### PR TITLE
fix(code): send terminal escapes through the tmux passthrough

### DIFF
--- a/libs/code/README.md
+++ b/libs/code/README.md
@@ -55,7 +55,7 @@ A tmux pane is not the terminal you are looking at: tmux owns the pty and decide
 ```tmux
 # ~/.tmux.conf
 set -g focus-events on              # otherwise unfocused panes keep a blinking cursor
-set -g allow-passthrough on         # otherwise terminal progress and OSC 52 are dropped
+set -g allow-passthrough on         # otherwise progress, OSC 52, and the cursor guide are dropped
 set -g set-clipboard on             # otherwise /copy cannot reach the outer clipboard
 set -ga update-environment COLORTERM # otherwise themes are quantized to 256 colors
 ```

--- a/libs/code/README.md
+++ b/libs/code/README.md
@@ -50,14 +50,15 @@ Do not run `dcode` in a directory you do not trust without a sandbox backend. Fo
 
 ## 🪟 Running under tmux
 
-A tmux pane is not the terminal you are looking at: tmux owns the pty and decides which escape sequences reach the outer terminal. Four options are off by default and each disables something in `dcode`. Run `dcode doctor` to see which ones apply to your setup.
+A tmux pane is not the terminal you are looking at: tmux owns the pty and decides which escape sequences reach the outer terminal. Several options are off by default and each disables something in `dcode`. Run `dcode doctor` to see which ones apply to your setup.
 
 ```tmux
 # ~/.tmux.conf
-set -g focus-events on              # otherwise unfocused panes keep a blinking cursor
-set -g allow-passthrough on         # otherwise progress, OSC 52, and the cursor guide are dropped
-set -g set-clipboard on             # otherwise /copy cannot reach the outer clipboard
-set -ga update-environment COLORTERM # otherwise themes are quantized to 256 colors
+set -g focus-events on                  # otherwise unfocused panes keep a blinking cursor
+set -g allow-passthrough on             # otherwise progress, OSC 52, and the cursor guide are dropped
+set -g set-clipboard on                 # otherwise /copy cannot reach the outer clipboard
+set -ga update-environment COLORTERM    # otherwise themes are quantized to 256 colors
+set -ga update-environment ITERM_PROFILE # iTerm2 only: otherwise the cursor guide reads a stale profile
 ```
 
 Reload with `tmux source-file ~/.tmux.conf` (a new server is needed for `update-environment` to reach existing panes).

--- a/libs/code/deepagents_code/clipboard.py
+++ b/libs/code/deepagents_code/clipboard.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import base64
 import logging
-import os
-import pathlib
 from typing import TYPE_CHECKING, Literal
 
 from textual.dom import NoScreen
@@ -24,15 +22,26 @@ _PREVIEW_MAX_LENGTH = 40
 
 
 def _copy_osc52(text: str) -> None:
-    """Copy text using OSC 52 escape sequence (works over SSH/tmux)."""
-    encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
-    osc52_seq = f"\033]52;c;{encoded}\a"
-    if os.environ.get("TMUX"):
-        osc52_seq = f"\033Ptmux;\033{osc52_seq}\033\\"
+    """Copy text using an OSC 52 escape sequence (works over SSH and tmux).
 
-    with pathlib.Path("/dev/tty").open("w", encoding="utf-8") as tty:
-        tty.write(osc52_seq)
-        tty.flush()
+    Delegates to `terminal_escape.write_osc`, which owns the `/dev/tty`
+    fallbacks and the tmux passthrough wrapper, and therefore also honors
+    `DEEPAGENTS_CODE_NO_TERMINAL_ESCAPE`.
+
+    Args:
+        text: Text to place on the clipboard.
+
+    Raises:
+        RuntimeError: When no terminal could be written to, so
+            `copy_text_to_clipboard` reports the failure like any other
+            backend's.
+    """
+    from deepagents_code.terminal_escape import write_osc
+
+    encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    if not write_osc("52", f"c;{encoded}"):
+        msg = "no terminal available for an OSC 52 clipboard write"
+        raise RuntimeError(msg)
 
 
 def _shorten_preview(texts: list[str]) -> str:

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -627,7 +627,7 @@ def _tmux_items(status: TmuxStatus) -> list[DiagnosticItem]:
             "Passthrough",
             options,
             ALLOW_PASSTHROUGH,
-            consequence="terminal progress and OSC 52 are dropped",
+            consequence="progress, OSC 52, and the cursor guide are dropped",
             remedy="set -g allow-passthrough on",
         ),
         _tmux_option_item(

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -564,7 +564,21 @@ def _annotated_item(
     """
     if value == healthy:
         return DiagnosticItem(label, value)
-    return DiagnosticItem(label, f"{value} - {consequence}; {remedy}")
+    return DiagnosticItem(label, _annotated_value(value, consequence, remedy))
+
+
+def _annotated_value(value: str, consequence: str, remedy: str) -> str:
+    """Render a value alongside what it costs and the line that fixes it.
+
+    Args:
+        value: The state tmux or the terminal reported.
+        consequence: What breaks while `value` stands.
+        remedy: The `~/.tmux.conf` line that fixes it.
+
+    Returns:
+        The annotated value shown in a diagnostic row.
+    """
+    return f"{value} - {consequence}; {remedy}"
 
 
 def _tmux_option_item(
@@ -598,6 +612,46 @@ def _tmux_option_item(
     )
 
 
+def _iterm_profile_item(status: TmuxStatus) -> DiagnosticItem | None:
+    """Build the row describing whether the inherited iTerm2 profile is current.
+
+    The cursor-guide workaround reads `ITERM_PROFILE` to decide whether the
+    guide was on before launch. tmux does not refresh that variable on attach
+    unless it is listed in `update-environment`, so a pane inherits whichever
+    profile the window that started the server happened to be using — and the
+    workaround then reads the wrong profile's preference.
+
+    Args:
+        status: Facts probed from the tmux server hosting this pane.
+
+    Returns:
+        A diagnostic item, or `None` when iTerm2 is not the outer terminal and
+        the row would be noise.
+    """
+    import os
+
+    from deepagents_code.multiplexer import ITERM_PROFILE_VAR, UPDATE_ENVIRONMENT
+    from deepagents_code.terminal_capabilities import is_iterm2
+
+    label = "iTerm2 profile"
+    if not is_iterm2():
+        return None
+    updates = status.environment_updates
+    if updates is None:
+        return DiagnosticItem(label, "could not query tmux")
+    value = os.environ.get(ITERM_PROFILE_VAR, "").strip() or "not inherited"
+    if ITERM_PROFILE_VAR in updates:
+        return DiagnosticItem(label, value)
+    return DiagnosticItem(
+        label,
+        _annotated_value(
+            value,
+            "frozen at server start, so the cursor guide may read the wrong one",
+            f"set -ga {UPDATE_ENVIRONMENT} {ITERM_PROFILE_VAR}",
+        ),
+    )
+
+
 def _tmux_items(status: TmuxStatus) -> list[DiagnosticItem]:
     """Build the tmux-specific rows of the `Terminal` section.
 
@@ -614,7 +668,7 @@ def _tmux_items(status: TmuxStatus) -> list[DiagnosticItem]:
     )
 
     options = status.options
-    return [
+    items = [
         DiagnosticItem("Multiplexer", status.version or "tmux (version unknown)"),
         _tmux_option_item(
             "Focus events",
@@ -646,6 +700,10 @@ def _tmux_items(status: TmuxStatus) -> list[DiagnosticItem]:
         ),
         _kitty_keyboard_item(),
     ]
+    profile = _iterm_profile_item(status)
+    if profile is not None:
+        items.append(profile)
+    return items
 
 
 def _collect_terminal() -> DiagnosticSection:

--- a/libs/code/deepagents_code/iterm_cursor_guide.py
+++ b/libs/code/deepagents_code/iterm_cursor_guide.py
@@ -2,27 +2,20 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
+
+from deepagents_code.terminal_capabilities import is_iterm2
+
+logger = logging.getLogger(__name__)
 
 # iTerm2's cursor guide (highlight cursor line) causes visual artifacts when
 # Textual takes over the terminal in alternate screen mode. We disable it at
 # module load and restore it on exit only if the active/default iTerm2 profile
 # had cursor guide enabled before launch.
 
-# Detection: check env vars AND that stderr is a TTY (avoids false positives
-# when env vars are inherited but running in non-TTY context like CI).
-# Inherited env vars are the right signal here even inside tmux: the command
-# is forwarded to the outer terminal, which really is iTerm2. Contrast key
-# encodings, where a pane must not trust the terminal it is hosted in.
-_IS_ITERM = (
-    (
-        os.environ.get("LC_TERMINAL", "") == "iTerm2"
-        or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
-    )
-    and hasattr(os, "isatty")
-    and os.isatty(2)
-)
+_IS_ITERM = is_iterm2()
 
 _CURSOR_GUIDE_OSC = "1337"
 """iTerm2's proprietary OSC command number."""
@@ -148,6 +141,13 @@ def _iterm_profile_cursor_guide_enabled() -> bool:
     name = os.environ.get("ITERM_PROFILE", "").strip()
     guid = str(prefs.get("Default Bookmark Guid", ""))
     profile = _find_iterm_profile(profiles, name=name, guid=guid)
+    # Inside tmux `ITERM_PROFILE` is only as current as the server's start,
+    # so record what was matched; `dcode doctor` reports the same hazard.
+    logger.debug(
+        "cursor guide: ITERM_PROFILE=%r matched profile %r",
+        name,
+        profile.get("Name") if profile else None,
+    )
     if profile is None:
         return False
     return _profile_uses_cursor_guide(profile)

--- a/libs/code/deepagents_code/iterm_cursor_guide.py
+++ b/libs/code/deepagents_code/iterm_cursor_guide.py
@@ -12,6 +12,9 @@ from pathlib import Path
 
 # Detection: check env vars AND that stderr is a TTY (avoids false positives
 # when env vars are inherited but running in non-TTY context like CI).
+# Inherited env vars are the right signal here even inside tmux: the command
+# is forwarded to the outer terminal, which really is iTerm2. Contrast key
+# encodings, where a pane must not trust the terminal it is hosted in.
 _IS_ITERM = (
     (
         os.environ.get("LC_TERMINAL", "") == "iTerm2"
@@ -21,31 +24,36 @@ _IS_ITERM = (
     and os.isatty(2)
 )
 
-# iTerm2 cursor guide escape sequences (OSC 1337)
-# Format: OSC 1337 ; HighlightCursorLine=<yes|no> ST
-# Where OSC = ESC ] (0x1b 0x5d) and ST = ESC \ (0x1b 0x5c)
-_ITERM_CURSOR_GUIDE_OFF = "\x1b]1337;HighlightCursorLine=no\x1b\\"
-_ITERM_CURSOR_GUIDE_ON = "\x1b]1337;HighlightCursorLine=yes\x1b\\"
+_CURSOR_GUIDE_OSC = "1337"
+"""iTerm2's proprietary OSC command number."""
+
+# Payloads for `OSC 1337 ; HighlightCursorLine=<yes|no> ST`.
+_CURSOR_GUIDE_OFF = "HighlightCursorLine=no"
+_CURSOR_GUIDE_ON = "HighlightCursorLine=yes"
 _ITERM_PREFS_PATH = Path("~/Library/Preferences/com.googlecode.iterm2.plist")
 
 
-def _write_iterm_escape(sequence: str) -> None:
-    """Write an iTerm2 escape sequence to stderr.
+def _write_cursor_guide(payload: str) -> None:
+    """Send a cursor-guide `OSC 1337` command to the terminal.
 
-    Silently fails if the terminal is unavailable (redirected, closed, broken
-    pipe). This is a cosmetic feature, so failures should never crash the app.
+    Delegates to the shared escape writer, which prefers `/dev/tty` and wraps
+    the sequence in tmux's passthrough envelope. tmux only forwards the
+    handful of operating-system commands it understands and drops the rest, so
+    writing `OSC 1337` straight to stderr is a silent no-op in every pane —
+    the outer terminal is still iTerm2, but nothing reaches it.
+
+    Failures are swallowed by the shared writer: this is cosmetic, so it must
+    never crash the app.
+
+    Args:
+        payload: The `OSC 1337` command body, such as `HighlightCursorLine=no`.
     """
     if not _IS_ITERM:
         return
-    try:
-        import sys
 
-        if sys.__stderr__ is not None:
-            sys.__stderr__.write(sequence)
-            sys.__stderr__.flush()
-    except OSError:
-        # Terminal may be unavailable (redirected, closed, broken pipe).
-        pass
+    from deepagents_code.terminal_escape import write_osc
+
+    write_osc(_CURSOR_GUIDE_OSC, payload, st=True)
 
 
 def _plist_bool(value: object) -> bool | None:
@@ -156,14 +164,14 @@ def restore_iterm_cursor_guide() -> None:
     if not _RESTORE_ITERM_CURSOR_GUIDE or _ITERM_CURSOR_GUIDE_RESTORED:
         return
     _ITERM_CURSOR_GUIDE_RESTORED = True
-    _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+    _write_cursor_guide(_CURSOR_GUIDE_ON)
 
 
 def _disable_iterm_cursor_guide() -> None:
     """Disable iTerm2 cursor guide only when the module has a restore path."""
     if not _RESTORE_ITERM_CURSOR_GUIDE:
         return
-    _write_iterm_escape(_ITERM_CURSOR_GUIDE_OFF)
+    _write_cursor_guide(_CURSOR_GUIDE_OFF)
 
 
 # Disable cursor guide at module load (before Textual takes over), but only

--- a/libs/code/deepagents_code/multiplexer.py
+++ b/libs/code/deepagents_code/multiplexer.py
@@ -35,7 +35,7 @@ REPORTED_OPTIONS: tuple[str, ...] = (FOCUS_EVENTS, ALLOW_PASSTHROUGH, SET_CLIPBO
 - `focus-events` gates `FocusIn`/`FocusOut` delivery, without which an
   unfocused pane keeps drawing a blinking cursor.
 - `allow-passthrough` gates the `DCS tmux;` wrapper, without which terminal
-  progress and OSC 52 clipboard writes are dropped.
+  progress, OSC 52 clipboard writes, and the iTerm2 cursor guide are dropped.
 - `set-clipboard` must be `on` for an application's OSC 52 to reach the
   outer terminal's clipboard.
 """

--- a/libs/code/deepagents_code/multiplexer.py
+++ b/libs/code/deepagents_code/multiplexer.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -40,14 +41,32 @@ REPORTED_OPTIONS: tuple[str, ...] = (FOCUS_EVENTS, ALLOW_PASSTHROUGH, SET_CLIPBO
   outer terminal's clipboard.
 """
 
-_SHOW_OPTIONS_ARGS: tuple[str, ...] = ("show-options", "-s", ";", "show-options", "-gw")
-"""Read both scopes in one invocation.
+UPDATE_ENVIRONMENT = "update-environment"
+"""Session option naming the variables tmux refreshes from the client."""
 
-`focus-events` and `set-clipboard` are server options while
-`allow-passthrough` is a window option, so a single `show-options -g` (session
-scope) returns none of them. `;` is passed as its own argument, which tmux
-reads as a command separator.
+ITERM_PROFILE_VAR = "ITERM_PROFILE"
+"""Variable iTerm2 exports to name the profile a window is using."""
+
+_SHOW_OPTIONS_ARGS: tuple[str, ...] = (
+    "show-options",
+    "-s",
+    ";",
+    "show-options",
+    "-gw",
+    ";",
+    "show-options",
+    "-g",
+)
+"""Read all three scopes in one invocation.
+
+`focus-events` and `set-clipboard` are server options, `allow-passthrough` is
+a window option, and `update-environment` is a session option, so no single
+scope returns them all. `;` is passed as its own argument, which tmux reads as
+a command separator.
 """
+
+_UPDATE_ENVIRONMENT_ENTRY = re.compile(rf"{UPDATE_ENVIRONMENT}(?:\[\d+\])?")
+"""Matches both the array form tmux 3.x prints and the older single-line form."""
 
 
 @dataclass(frozen=True)
@@ -63,6 +82,13 @@ class TmuxStatus:
     A present mapping missing a key means tmux answered but does not know that
     option — an older server without `allow-passthrough`, say. That is a
     different fact from a failed probe, so the two must not collapse.
+    """
+
+    environment_updates: frozenset[str] | None = None
+    """Variables `update-environment` refreshes, or `None` when the query failed.
+
+    Anything absent here is frozen at whatever value the tmux server started
+    with, however long ago that was.
     """
 
 
@@ -134,6 +160,30 @@ def parse_tmux_options(output: str) -> dict[str, str]:
     return options
 
 
+def parse_tmux_environment_updates(output: str) -> frozenset[str]:
+    """Extract the variables `update-environment` refreshes on attach.
+
+    tmux 3.x prints an array option one index per line
+    (`update-environment[0] DISPLAY`); older servers print the whole list on a
+    single quoted line. Both shapes are accepted so the answer does not depend
+    on the server's age.
+
+    Args:
+        output: Raw stdout from `tmux show-options`.
+
+    Returns:
+        The variable names tmux copies from the attaching client. Empty when
+        the option is absent from `output`.
+    """
+    names: set[str] = set()
+    for line in output.splitlines():
+        name, separator, value = line.partition(" ")
+        if not separator or not _UPDATE_ENVIRONMENT_ENTRY.fullmatch(name):
+            continue
+        names.update(value.strip().strip("'\"").split())
+    return frozenset(names)
+
+
 def query_tmux_status() -> TmuxStatus | None:
     """Probe the tmux server hosting this pane.
 
@@ -150,6 +200,9 @@ def query_tmux_status() -> TmuxStatus | None:
     return TmuxStatus(
         version=version_output.strip() if version_output else None,
         options=parse_tmux_options(options_output)
+        if options_output is not None
+        else None,
+        environment_updates=parse_tmux_environment_updates(options_output)
         if options_output is not None
         else None,
     )

--- a/libs/code/deepagents_code/terminal_capabilities.py
+++ b/libs/code/deepagents_code/terminal_capabilities.py
@@ -26,6 +26,31 @@ logger = logging.getLogger(__name__)
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _FALSE_VALUES = frozenset({"0", "false", "no", "off"})
 _KNOWN_KITTY_KEYBOARD_TERMS = frozenset({"xterm-ghostty", "xterm-kitty"})
+_STDERR_FD = 2
+
+
+def is_iterm2(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether the terminal the user is looking at is iTerm2.
+
+    Unlike the kitty-keyboard check this stays true inside a multiplexer. The
+    callers care about sequences tmux forwards to the outer terminal, and that
+    terminal really is iTerm2, so the inherited markers are the right signal.
+
+    Requiring a TTY keeps the markers from producing a false positive when they
+    are inherited into a non-interactive context such as CI.
+
+    Args:
+        env: Environment mapping to read. Defaults to the process environment.
+
+    Returns:
+        `True` when iTerm2 is hosting this process and stderr is a terminal.
+    """
+    source = env if env is not None else os.environ
+    identified = (
+        source.get("LC_TERMINAL", "") == "iTerm2"
+        or source.get("TERM_PROGRAM", "") == "iTerm.app"
+    )
+    return identified and hasattr(os, "isatty") and os.isatty(_STDERR_FD)
 
 
 def _override_supports_kitty_keyboard_protocol(

--- a/libs/code/deepagents_code/terminal_escape.py
+++ b/libs/code/deepagents_code/terminal_escape.py
@@ -1,10 +1,14 @@
 """Best-effort writer for terminal escape/control sequences.
 
 Centralizes the "fire and forget" pattern the app uses for cosmetic terminal
-control (OSC 9;4 taskbar progress today; eventually OSC 52 clipboard and the
-iTerm2 cursor guide). Writes prefer `/dev/tty` so output reaches the terminal
-even when stdout/stderr are redirected, fall back to `sys.__stderr__`, and
-never raise — cosmetic control output must not crash the app.
+control (OSC 9;4 taskbar progress, OSC 11 background, OSC 52 clipboard).
+Writes prefer `/dev/tty` so output reaches the terminal even when stdout/stderr
+are redirected, fall back to `sys.__stderr__`, and never raise — cosmetic
+control output must not crash the app.
+
+It is also the single place that knows a terminal multiplexer may be in the
+way: `write_osc` wraps its sequence for tmux, which otherwise drops every OSC
+its panes emit.
 
 Set `DEEPAGENTS_CODE_NO_TERMINAL_ESCAPE=1` to disable all output (useful for
 unsupported terminals or noisy logs).
@@ -23,9 +27,16 @@ from typing import TYPE_CHECKING
 from deepagents_code._env_vars import NO_TERMINAL_ESCAPE, is_env_truthy
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from typing import TextIO
 
 logger = logging.getLogger(__name__)
+
+_TMUX_PASSTHROUGH_PREFIX = "\x1bPtmux;"
+"""Device Control String that tells tmux to forward the payload verbatim."""
+
+_TMUX_PASSTHROUGH_SUFFIX = "\x1b\\"
+"""String Terminator closing the passthrough DCS."""
 
 _PROGRESS_MIN = 0
 """Lower clamp bound for determinate `OSC 9;4` progress percentages."""
@@ -119,8 +130,35 @@ def write_terminal_escape(sequence: str) -> bool:
     return False
 
 
+def wrap_for_multiplexer(sequence: str, env: Mapping[str, str] | None = None) -> str:
+    r"""Wrap `sequence` so tmux forwards it to the terminal it is hosted in.
+
+    tmux swallows operating-system commands from its panes: an unwrapped
+    `OSC 9;4` or `OSC 52` never reaches the outer terminal. Wrapping in tmux's
+    passthrough DCS forwards the payload verbatim — provided the user has
+    turned on `allow-passthrough`, which `dcode doctor` reports. Every escape
+    inside the payload has to be doubled or tmux ends the DCS early.
+
+    Args:
+        sequence: Raw escape sequence intended for the outer terminal.
+        env: Environment mapping to read. Defaults to the process environment.
+
+    Returns:
+        The wrapped sequence inside tmux, otherwise `sequence` unchanged.
+    """
+    from deepagents_code.multiplexer import inside_tmux
+
+    if not sequence or not inside_tmux(env):
+        return sequence
+    doubled = sequence.replace("\x1b", "\x1b\x1b")
+    return f"{_TMUX_PASSTHROUGH_PREFIX}{doubled}{_TMUX_PASSTHROUGH_SUFFIX}"
+
+
 def write_osc(command: str, payload: str = "", *, st: bool = False) -> bool:
     r"""Write an `OSC <command>;<payload>` sequence.
+
+    Every OSC the app emits addresses the terminal the user is looking at, so
+    the sequence is wrapped for a multiplexer when one is in the way.
 
     Args:
         command: The numeric OSC command (e.g. `"9;4"` for taskbar progress).
@@ -136,7 +174,7 @@ def write_osc(command: str, payload: str = "", *, st: bool = False) -> bool:
     """
     body = f"{command};{payload}" if payload else command
     terminator = "\x1b\\" if st else "\a"
-    return write_terminal_escape(f"\x1b]{body}{terminator}")
+    return write_terminal_escape(wrap_for_multiplexer(f"\x1b]{body}{terminator}"))
 
 
 _progress_active = False

--- a/libs/code/tests/unit_tests/test_clipboard.py
+++ b/libs/code/tests/unit_tests/test_clipboard.py
@@ -14,6 +14,7 @@ import sys
 from typing import TYPE_CHECKING, Self
 from unittest.mock import MagicMock, patch
 
+import pytest
 from textual.app import App, ComposeResult
 from textual.screen import ModalScreen
 from textual.widgets import Static
@@ -27,6 +28,8 @@ from deepagents_code.clipboard import (
 )
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from textual.pilot import Pilot
 
 _BASE_TEXT = "hello base world"
@@ -291,62 +294,74 @@ class TestCopyTextWithFeedback:
 class TestCopyOsc52:
     """Direct coverage of the OSC 52 escape sequence (`_copy_osc52`)."""
 
+    class _FakeTTY(io.StringIO):
+        """`StringIO` whose context manager does not truncate on close."""
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: TracebackType | None,
+        ) -> None:
+            pass
+
+    def _capture(self, monkeypatch) -> _FakeTTY:
+        """Point the escape writer at an in-memory tty and return it."""
+        from deepagents_code import terminal_escape
+
+        fake = self._FakeTTY()
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: fake)
+        monkeypatch.delenv(terminal_escape.NO_TERMINAL_ESCAPE, raising=False)
+        return fake
+
     def test_emits_escape_envelope(self, monkeypatch) -> None:
-        r"""Emits `\x1b]52;c;<base64>\a` written to `/dev/tty`."""
-        captured = io.StringIO()
-
-        class _DummyTTY:
-            def __init__(self) -> None:
-                self.buffer = captured
-
-            def __enter__(self) -> Self:
-                return self
-
-            def __exit__(self, *_: object) -> None:
-                pass
-
-            def write(self, s: str) -> int:
-                self.buffer.write(s)
-                return len(s)
-
-            def flush(self) -> None:
-                pass
-
+        r"""Emits `\x1b]52;c;<base64>\a` to the terminal."""
         monkeypatch.delenv("TMUX", raising=False)
+        fake = self._capture(monkeypatch)
+
         text = "hello world"
-        with patch("pathlib.Path.open", return_value=_DummyTTY()):
-            _copy_osc52(text)
+        _copy_osc52(text)
 
         encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
-        assert captured.getvalue() == f"\033]52;c;{encoded}\a"
+        assert fake.getvalue() == f"\033]52;c;{encoded}\a"
 
     def test_wraps_envelope_for_tmux_passthrough(self, monkeypatch) -> None:
         """Inside tmux, the OSC 52 sequence must be wrapped in DCS passthrough."""
-        captured = io.StringIO()
-
-        class _DummyTTY:
-            def __enter__(self) -> Self:
-                return self
-
-            def __exit__(self, *_: object) -> None:
-                pass
-
-            def write(self, s: str) -> int:
-                captured.write(s)
-                return len(s)
-
-            def flush(self) -> None:
-                pass
-
         monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+        fake = self._capture(monkeypatch)
+
         text = "hi"
-        with patch("pathlib.Path.open", return_value=_DummyTTY()):
-            _copy_osc52(text)
+        _copy_osc52(text)
 
         encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
         inner = f"\033]52;c;{encoded}\a"
-        expected = f"\033Ptmux;\033{inner}\033\\"
-        assert captured.getvalue() == expected
+        assert fake.getvalue() == f"\033Ptmux;\033{inner}\033\\"
+
+    def test_raises_when_no_terminal_is_reachable(self, monkeypatch) -> None:
+        """A failed write must raise so the backend chain reports it."""
+        from deepagents_code import terminal_escape
+
+        monkeypatch.delenv("TMUX", raising=False)
+        monkeypatch.delenv(terminal_escape.NO_TERMINAL_ESCAPE, raising=False)
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: None)
+        monkeypatch.setattr(terminal_escape.sys, "__stderr__", None)
+
+        with pytest.raises(RuntimeError, match="OSC 52"):
+            _copy_osc52("hello")
+
+    def test_respects_terminal_escape_opt_out(self, monkeypatch) -> None:
+        """`DEEPAGENTS_CODE_NO_TERMINAL_ESCAPE` now covers the clipboard too."""
+        from deepagents_code import terminal_escape
+
+        monkeypatch.delenv("TMUX", raising=False)
+        monkeypatch.setenv(terminal_escape.NO_TERMINAL_ESCAPE, "1")
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: self._FakeTTY())
+
+        with pytest.raises(RuntimeError, match="OSC 52"):
+            _copy_osc52("hello")
 
 
 class TestCopySelectionToClipboard:

--- a/libs/code/tests/unit_tests/test_doctor.py
+++ b/libs/code/tests/unit_tests/test_doctor.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import pytest
 from rich.console import Console
 
+from deepagents_code import terminal_capabilities
 from deepagents_code.doctor import (
     DiagnosticItem,
     DiagnosticSection,
@@ -258,7 +259,9 @@ class TestCollectTerminal:
     def _tmux_status(self, **options: str) -> object:
         from deepagents_code.multiplexer import TmuxStatus
 
-        return TmuxStatus(version="tmux 3.5a", options=options)
+        return TmuxStatus(
+            version="tmux 3.5a", options=options, environment_updates=frozenset()
+        )
 
     def test_outside_tmux_reports_terminal_identity(
         self, monkeypatch: pytest.MonkeyPatch
@@ -333,6 +336,64 @@ class TestCollectTerminal:
             )
         )
         assert section.ok is True
+
+    def test_iterm_profile_row_is_absent_on_other_terminals(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The row would be noise for a pane that is not hosted by iTerm2."""
+        monkeypatch.setattr(terminal_capabilities, "is_iterm2", lambda: False)
+        assert "iTerm2 profile" not in self._labels(self._tmux_status())
+
+    def test_stale_iterm_profile_carries_consequence_and_remedy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unrefreshed `ITERM_PROFILE` silently misreports the cursor guide."""
+        monkeypatch.setattr(terminal_capabilities, "is_iterm2", lambda: True)
+        monkeypatch.setenv("ITERM_PROFILE", "Work")
+
+        value = self._labels(self._tmux_status())["iTerm2 profile"]
+
+        assert value.startswith("Work - ")
+        assert "frozen at server start" in value
+        assert "set -ga update-environment ITERM_PROFILE" in value
+
+    def test_refreshed_iterm_profile_renders_bare(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Listing the variable in `update-environment` is the whole fix."""
+        from deepagents_code.multiplexer import ITERM_PROFILE_VAR, TmuxStatus
+
+        monkeypatch.setattr(terminal_capabilities, "is_iterm2", lambda: True)
+        monkeypatch.setenv("ITERM_PROFILE", "Work")
+        status = TmuxStatus(
+            version="tmux 3.5a",
+            options={},
+            environment_updates=frozenset({ITERM_PROFILE_VAR}),
+        )
+
+        assert self._labels(status)["iTerm2 profile"] == "Work"
+
+    def test_uninherited_iterm_profile_is_named_as_such(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing variable is a different fact from a stale one."""
+        monkeypatch.setattr(terminal_capabilities, "is_iterm2", lambda: True)
+        monkeypatch.delenv("ITERM_PROFILE", raising=False)
+
+        value = self._labels(self._tmux_status())["iTerm2 profile"]
+
+        assert value.startswith("not inherited - ")
+
+    def test_iterm_profile_row_reports_a_failed_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without an answer from tmux the row must not guess."""
+        from deepagents_code.multiplexer import TmuxStatus
+
+        monkeypatch.setattr(terminal_capabilities, "is_iterm2", lambda: True)
+        labels = self._labels(TmuxStatus(version=None, options=None))
+
+        assert labels["iTerm2 profile"] == "could not query tmux"
 
 
 class TestCollectTracing:

--- a/libs/code/tests/unit_tests/test_iterm_cursor_guide.py
+++ b/libs/code/tests/unit_tests/test_iterm_cursor_guide.py
@@ -5,84 +5,98 @@ from __future__ import annotations
 import io
 import os
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
+import pytest
 from textual.app import App
 
-from deepagents_code import iterm_cursor_guide
+from deepagents_code import iterm_cursor_guide, terminal_escape
 from deepagents_code.app import DeepAgentsApp
 from deepagents_code.iterm_cursor_guide import (
-    _ITERM_CURSOR_GUIDE_OFF,
-    _ITERM_CURSOR_GUIDE_ON,
+    _CURSOR_GUIDE_OFF,
+    _CURSOR_GUIDE_ON,
     _disable_iterm_cursor_guide,
     _iterm_profile_cursor_guide_enabled,
-    _write_iterm_escape,
+    _write_cursor_guide,
     restore_iterm_cursor_guide,
 )
 
 if TYPE_CHECKING:
-    import pytest
+    from types import TracebackType
+
+
+class _FakeTTY(io.StringIO):
+    """`StringIO` with a context-manager that doesn't truncate on close."""
+
+    def __enter__(self) -> _FakeTTY:  # noqa: PYI034  # _FakeTTY is a test helper
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        pass
+
+
+@pytest.fixture
+def tty(monkeypatch: pytest.MonkeyPatch) -> _FakeTTY:
+    """Capture what the shared escape writer sends to the terminal."""
+    fake = _FakeTTY()
+    monkeypatch.setattr(terminal_escape, "_open_tty", lambda: fake)
+    monkeypatch.delenv(terminal_escape.NO_TERMINAL_ESCAPE, raising=False)
+    # A developer running the suite from inside a pane would otherwise see
+    # every expected sequence gain a passthrough DCS.
+    monkeypatch.delenv("TMUX", raising=False)
+    return fake
 
 
 class TestITerm2CursorGuide:
     """Test iTerm2 cursor guide handling."""
 
-    def test_escape_sequences_are_valid(self) -> None:
-        """Escape sequences should be properly formatted OSC 1337 commands.
+    def test_write_cursor_guide_does_nothing_when_not_iterm(
+        self, tty: _FakeTTY
+    ) -> None:
+        """`_write_cursor_guide` should no-op when `_IS_ITERM` is `False`."""
+        with patch.object(iterm_cursor_guide, "_IS_ITERM", False):
+            _write_cursor_guide(_CURSOR_GUIDE_ON)
 
-        Format: OSC (ESC ]) + "1337;" + command + ST (ESC backslash)
-        """
-        assert _ITERM_CURSOR_GUIDE_OFF.startswith("\x1b]1337;")
-        assert _ITERM_CURSOR_GUIDE_OFF.endswith("\x1b\\")
-        assert "HighlightCursorLine=no" in _ITERM_CURSOR_GUIDE_OFF
+        assert tty.getvalue() == ""
 
-        assert _ITERM_CURSOR_GUIDE_ON.startswith("\x1b]1337;")
-        assert _ITERM_CURSOR_GUIDE_ON.endswith("\x1b\\")
-        assert "HighlightCursorLine=yes" in _ITERM_CURSOR_GUIDE_ON
+    def test_write_cursor_guide_emits_osc_1337(self, tty: _FakeTTY) -> None:
+        """The command goes out as `OSC 1337 ; <payload> ST`."""
+        with patch.object(iterm_cursor_guide, "_IS_ITERM", True):
+            _write_cursor_guide(_CURSOR_GUIDE_ON)
 
-    def test_write_iterm_escape_does_nothing_when_not_iterm(self) -> None:
-        """_write_iterm_escape should no-op when `_IS_ITERM` is `False`."""
-        mock_stderr = MagicMock()
-        with (
-            patch.object(iterm_cursor_guide, "_IS_ITERM", False),
-            patch("sys.__stderr__", mock_stderr),
-        ):
-            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
-            mock_stderr.write.assert_not_called()
+        assert tty.getvalue() == "\x1b]1337;HighlightCursorLine=yes\x1b\\"
 
-    def test_write_iterm_escape_writes_sequence_when_iterm(self) -> None:
-        """_write_iterm_escape should write sequence when in iTerm2."""
-        mock_stderr = io.StringIO()
-        with (
-            patch.object(iterm_cursor_guide, "_IS_ITERM", True),
-            patch("sys.__stderr__", mock_stderr),
-        ):
-            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
-            assert mock_stderr.getvalue() == _ITERM_CURSOR_GUIDE_ON
+    def test_write_cursor_guide_wraps_for_tmux(
+        self, tty: _FakeTTY, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tmux drops a bare `OSC 1337`, so a pane must send it wrapped."""
+        monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+        with patch.object(iterm_cursor_guide, "_IS_ITERM", True):
+            _write_cursor_guide(_CURSOR_GUIDE_OFF)
 
-    def test_write_iterm_escape_handles_oserror_gracefully(self) -> None:
-        """_write_iterm_escape should not raise on `OSError`."""
-        mock_stderr = MagicMock()
-        mock_stderr.write.side_effect = OSError("Broken pipe")
-        with (
-            patch.object(iterm_cursor_guide, "_IS_ITERM", True),
-            patch("sys.__stderr__", mock_stderr),
-        ):
-            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+        assert tty.getvalue() == (
+            "\x1bPtmux;\x1b\x1b]1337;HighlightCursorLine=no\x1b\x1b\\\x1b\\"
+        )
 
-    def test_write_iterm_escape_handles_none_stderr(self) -> None:
-        """_write_iterm_escape should handle `None` `__stderr__` gracefully."""
-        with (
-            patch.object(iterm_cursor_guide, "_IS_ITERM", True),
-            patch("sys.__stderr__", None),
-        ):
-            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+    def test_write_cursor_guide_survives_an_unwritable_terminal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cosmetic write must never propagate a terminal failure."""
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: None)
+        monkeypatch.setattr(terminal_escape.sys, "__stderr__", None)
+        with patch.object(iterm_cursor_guide, "_IS_ITERM", True):
+            _write_cursor_guide(_CURSOR_GUIDE_ON)
 
     def test_disable_cursor_guide_noops_without_restore_path(self) -> None:
         """Cursor guide should not be disabled when startup state is unknown."""
         with (
             patch.object(iterm_cursor_guide, "_RESTORE_ITERM_CURSOR_GUIDE", False),
-            patch.object(iterm_cursor_guide, "_write_iterm_escape") as write_escape,
+            patch.object(iterm_cursor_guide, "_write_cursor_guide") as write_escape,
         ):
             _disable_iterm_cursor_guide()
 
@@ -92,11 +106,11 @@ class TestITerm2CursorGuide:
         """Cursor guide may be disabled only when cleanup will restore it."""
         with (
             patch.object(iterm_cursor_guide, "_RESTORE_ITERM_CURSOR_GUIDE", True),
-            patch.object(iterm_cursor_guide, "_write_iterm_escape") as write_escape,
+            patch.object(iterm_cursor_guide, "_write_cursor_guide") as write_escape,
         ):
             _disable_iterm_cursor_guide()
 
-        write_escape.assert_called_once_with(_ITERM_CURSOR_GUIDE_OFF)
+        write_escape.assert_called_once_with(_CURSOR_GUIDE_OFF)
 
     def test_app_exit_does_not_reenable_cursor_guide(self) -> None:
         """App exit should not restore when cursor guide was off before launch."""
@@ -116,23 +130,23 @@ class TestITerm2CursorGuide:
         with (
             patch.object(iterm_cursor_guide, "_RESTORE_ITERM_CURSOR_GUIDE", True),
             patch.object(iterm_cursor_guide, "_ITERM_CURSOR_GUIDE_RESTORED", False),
-            patch.object(iterm_cursor_guide, "_write_iterm_escape") as write_escape,
+            patch.object(iterm_cursor_guide, "_write_cursor_guide") as write_escape,
         ):
             restore_iterm_cursor_guide()
 
-        write_escape.assert_called_once_with(_ITERM_CURSOR_GUIDE_ON)
+        write_escape.assert_called_once_with(_CURSOR_GUIDE_ON)
 
     def test_restore_cursor_guide_is_idempotent(self) -> None:
         """The direct exit path and atexit fallback should not double-restore."""
         with (
             patch.object(iterm_cursor_guide, "_RESTORE_ITERM_CURSOR_GUIDE", True),
             patch.object(iterm_cursor_guide, "_ITERM_CURSOR_GUIDE_RESTORED", False),
-            patch.object(iterm_cursor_guide, "_write_iterm_escape") as write_escape,
+            patch.object(iterm_cursor_guide, "_write_cursor_guide") as write_escape,
         ):
             restore_iterm_cursor_guide()
             restore_iterm_cursor_guide()
 
-        write_escape.assert_called_once_with(_ITERM_CURSOR_GUIDE_ON)
+        write_escape.assert_called_once_with(_CURSOR_GUIDE_ON)
 
     def test_profile_cursor_guide_enabled_from_iterm_profile(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_multiplexer.py
+++ b/libs/code/tests/unit_tests/test_multiplexer.py
@@ -9,8 +9,10 @@ from deepagents_code import multiplexer
 from deepagents_code.multiplexer import (
     ALLOW_PASSTHROUGH,
     FOCUS_EVENTS,
+    ITERM_PROFILE_VAR,
     SET_CLIPBOARD,
     inside_tmux,
+    parse_tmux_environment_updates,
     parse_tmux_options,
     query_tmux_status,
 )
@@ -24,6 +26,8 @@ focus-events off
 set-clipboard external
 default-command ''
 allow-passthrough off
+update-environment[0] DISPLAY
+update-environment[1] SSH_AUTH_SOCK
 """
 
 
@@ -67,6 +71,37 @@ class TestParseTmuxOptions:
         """An empty answer is a valid answer with nothing in it."""
         assert parse_tmux_options("") == {}
 
+    def test_array_entries_are_not_mistaken_for_options(self) -> None:
+        """`update-environment[0]` is an array entry, not an option value."""
+        assert "update-environment" not in parse_tmux_options(_SHOW_OPTIONS_OUTPUT)
+
+
+class TestParseTmuxEnvironmentUpdates:
+    """Tests for reading which variables tmux refreshes on attach."""
+
+    def test_collects_array_entries(self) -> None:
+        """Tmux 3.x prints one indexed line per variable."""
+        assert parse_tmux_environment_updates(_SHOW_OPTIONS_OUTPUT) == frozenset(
+            {"DISPLAY", "SSH_AUTH_SOCK"}
+        )
+
+    def test_accepts_the_older_single_line_form(self) -> None:
+        """An older server prints the whole quoted list on one line."""
+        parsed = parse_tmux_environment_updates(
+            'update-environment "DISPLAY ITERM_PROFILE"\n'
+        )
+        assert parsed == frozenset({"DISPLAY", ITERM_PROFILE_VAR})
+
+    def test_absent_option_yields_nothing(self) -> None:
+        """No `update-environment` means no variable is refreshed."""
+        assert parse_tmux_environment_updates("focus-events on\n") == frozenset()
+
+    def test_ignores_similarly_named_options(self) -> None:
+        """A prefix match would wrongly harvest an unrelated option's value."""
+        assert parse_tmux_environment_updates("update-environment-x FOO\n") == (
+            frozenset()
+        )
+
 
 class TestQueryTmuxStatus:
     """Tests for the end-to-end probe."""
@@ -93,6 +128,7 @@ class TestQueryTmuxStatus:
             SET_CLIPBOARD: "external",
             ALLOW_PASSTHROUGH: "off",
         }
+        assert status.environment_updates == frozenset({"DISPLAY", "SSH_AUTH_SOCK"})
 
     def test_failed_probe_reports_none_options(
         self, monkeypatch: pytest.MonkeyPatch
@@ -105,6 +141,7 @@ class TestQueryTmuxStatus:
         assert status is not None
         assert status.version is None
         assert status.options is None
+        assert status.environment_updates is None
 
 
 class TestRunTmux:

--- a/libs/code/tests/unit_tests/test_terminal_capabilities.py
+++ b/libs/code/tests/unit_tests/test_terminal_capabilities.py
@@ -12,6 +12,7 @@ from deepagents_code._env_vars import KITTY_KEYBOARD
 from deepagents_code.terminal_capabilities import (
     _override_supports_kitty_keyboard_protocol,
     _terminal_identity_supports_kitty_keyboard_protocol,
+    is_iterm2,
     supports_kitty_keyboard_protocol,
 )
 
@@ -123,6 +124,44 @@ class TestTerminalIdentitySupportsKittyKeyboardProtocol:
             )
             is False
         )
+
+
+class TestIsIterm2:
+    """Tests for iTerm2 terminal identification."""
+
+    def test_detects_lc_terminal(self) -> None:
+        """`LC_TERMINAL` survives an SSH hop, so it is checked first."""
+        with patch.object(os, "isatty", return_value=True):
+            assert is_iterm2({"LC_TERMINAL": "iTerm2"}) is True
+
+    def test_detects_term_program(self) -> None:
+        """A local iTerm2 window exports `TERM_PROGRAM`."""
+        with patch.object(os, "isatty", return_value=True):
+            assert is_iterm2({"TERM_PROGRAM": "iTerm.app"}) is True
+
+    def test_rejects_other_terminals(self) -> None:
+        """Another terminal must not inherit iTerm2's workarounds."""
+        with patch.object(os, "isatty", return_value=True):
+            assert is_iterm2({"TERM_PROGRAM": "Ghostty"}) is False
+
+    def test_requires_a_tty(self) -> None:
+        """Inherited markers in CI would otherwise look like a live iTerm2."""
+        with patch.object(os, "isatty", return_value=False):
+            assert is_iterm2({"TERM_PROGRAM": "iTerm.app"}) is False
+
+    def test_stays_true_inside_a_multiplexer(self) -> None:
+        """A forwarded escape is interpreted by the outer terminal, not the pane."""
+        with patch.object(os, "isatty", return_value=True):
+            assert (
+                is_iterm2(
+                    {
+                        "TERM_PROGRAM": "iTerm.app",
+                        "TERM": "tmux-256color",
+                        "TMUX": "/tmp/tmux-0/default,1,0",
+                    }
+                )
+                is True
+            )
 
 
 class TestSupportsKittyKeyboardProtocolShortCircuits:

--- a/libs/code/tests/unit_tests/test_terminal_escape.py
+++ b/libs/code/tests/unit_tests/test_terminal_escape.py
@@ -20,6 +20,7 @@ from deepagents_code.terminal_escape import (
     reset_terminal_background,
     set_terminal_background,
     set_terminal_progress,
+    wrap_for_multiplexer,
     write_osc,
     write_terminal_escape,
 )
@@ -32,6 +33,9 @@ def _reset_active_state(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(terminal_escape, "_terminal_background_active", False)
     monkeypatch.setattr(terminal_escape, "_atexit_registered", False)
     monkeypatch.delenv(terminal_escape.NO_TERMINAL_ESCAPE, raising=False)
+    # `write_osc` now wraps for tmux, so a developer running the suite from
+    # inside a pane would otherwise see every expected sequence gain a DCS.
+    monkeypatch.delenv("TMUX", raising=False)
 
 
 class _FakeTTY(io.StringIO):
@@ -140,8 +144,38 @@ class TestWriteTerminalEscape:
         assert fake.getvalue() == "\x1b]9;4;テスト\a"
 
 
+class TestWrapForMultiplexer:
+    """Tests for the tmux passthrough envelope."""
+
+    def test_no_op_outside_tmux(self) -> None:
+        """A sequence reaches the terminal directly when nothing is in the way."""
+        assert wrap_for_multiplexer("\x1b]9;4;3;0\a", {}) == "\x1b]9;4;3;0\a"
+
+    def test_wraps_and_doubles_escapes_inside_tmux(self) -> None:
+        """Tmux ends the DCS at the first raw escape, so payload escapes double."""
+        wrapped = wrap_for_multiplexer("\x1b]9;4;3;0\a", {"TMUX": "/tmp/s,1,0"})
+        assert wrapped == "\x1bPtmux;\x1b\x1b]9;4;3;0\a\x1b\\"
+
+    def test_doubles_every_escape_in_the_payload(self) -> None:
+        """An ST-terminated sequence carries a second escape that also doubles."""
+        wrapped = wrap_for_multiplexer("\x1b]11;#112233\x1b\\", {"TMUX": "/tmp/s,1,0"})
+        assert wrapped == "\x1bPtmux;\x1b\x1b]11;#112233\x1b\x1b\\\x1b\\"
+
+    def test_empty_sequence_is_returned_unchanged(self) -> None:
+        """Wrapping nothing would emit a stray DCS."""
+        assert wrap_for_multiplexer("", {"TMUX": "/tmp/s,1,0"}) == ""
+
+
 class TestWriteOsc:
     """Tests for `write_osc`."""
+
+    def test_wraps_for_tmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inside a pane the sequence must go out wrapped or tmux drops it."""
+        fake = _FakeTTY()
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: fake)
+        monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+        write_osc("9;4", "3;0")
+        assert fake.getvalue() == "\x1bPtmux;\x1b\x1b]9;4;3;0\a\x1b\\"
 
     def test_default_terminator_is_bel(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fake = _FakeTTY()


### PR DESCRIPTION
Depends on #5222

Terminal progress, the dynamic background color, and the iTerm2 cursor guide now work inside tmux, for panes whose server has `allow-passthrough` enabled. `dcode doctor` also warns when a pane's inherited `ITERM_PROFILE` is too stale for the cursor guide to trust.

---

tmux swallows operating-system commands emitted by its panes, so an unwrapped `OSC 9;4`, `OSC 11`, or `OSC 1337` never reached the outer terminal. That made the `[ui].terminal_progress` option a no-op for every tmux user. The clipboard already knew this and carried its own copy of tmux's passthrough envelope; the shared escape writer did not.

Wrapping now lives in `terminal_escape` beside the writer that needs it, and the two callers that had grown their own escape writers — `_copy_osc52` and the iTerm2 cursor guide — drop them and delegate. Verified against tmux 3.5a by capturing what an attached client actually receives: wrapped sequences arrive, unwrapped ones never do.

Getting the escape through only fixes half of the cursor guide. It decides whether to restore the guide on exit by reading the active profile's preference out of iTerm2's plist, keyed by `ITERM_PROFILE` — and tmux does not refresh that variable on attach unless `update-environment` lists it. A pane therefore inherits whichever profile the window that started the server was using, and can restore a cursor guide the user never had. There is no way to ask iTerm2 for the current profile without reading from the tty, which this codebase deliberately never does, so the remaining fix is the user's: `doctor` gains a row naming the inherited profile and the `~/.tmux.conf` line that keeps it current. This is the same shape as the existing `COLORTERM` row.

Points worth a careful look:

- **Wrapping is unconditional inside tmux.** Knowing whether `allow-passthrough` is on would cost a subprocess on a cosmetic hot path, and a wrapped sequence that tmux drops is harmless — the same outcome as today. #5222's `Terminal` section is what tells the user to turn the option on. Wrapping is applied in `write_osc` rather than `write_terminal_escape` so a future caller that wants tmux *itself* to interpret a sequence is not forced through the envelope.
- **Behavior change:** because `_copy_osc52` and the cursor guide now go through the shared writer, both honor `DEEPAGENTS_CODE_NO_TERMINAL_ESCAPE`. That matches the variable's documented meaning ("disable all terminal escape output"), but it is new. Impact is limited — pyperclip and Textual's clipboard are both tried first, and OSC 52 is the last-resort backend.
- **The cursor guide still trusts inherited environment variables**, which may look wrong next to #5221, where a pane is told not to trust `KITTY_WINDOW_ID`. The two cases differ: key encodings are decided by the pane, but a passed-through OSC is interpreted by the outer terminal, which really is iTerm2. The identity check moves to `terminal_capabilities.is_iterm2` with that reasoning recorded, so it is not "fixed" by symmetry — and so `doctor` can ask the question without importing the cursor-guide module, which disables the guide as an import side effect.
- **`update-environment` needed a third option scope.** It is a *session* option, so the existing server (`-s`) and window (`-gw`) reads returned nothing; the probe now chains `show-options -g` as well. It is also an array option, printed one indexed line per entry by tmux 3.x and as a single quoted line by older servers, so the parser accepts both rather than silently reporting an empty list to anyone on the wrong version.

Made by [Open SWE](https://openswe.vercel.app/agents/b7873d59-2127-2dd1-cf5b-9bf5b500a25e)

## References
- Plan: https://openswe.vercel.app/agents/1c22682d-7700-26b5-b84e-a99ca14124e7/plan
