### PR TITLE
feat(code): complete the `dcode config` surface

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -369,6 +369,17 @@ Defaults to enabled; set to a falsy value (`0`, `false`, `no`, `off`, or empty)
 to hide replica tracing details from the splash while leaving tracing active.
 """
 
+SHOW_MESSAGE_TIMESTAMPS = "DEEPAGENTS_CODE_SHOW_MESSAGE_TIMESTAMPS"
+"""Show the timestamp footer under each chat message when enabled.
+
+Off by default; use the `/timestamps` slash command or
+`[ui].show_message_timestamps` in config.toml to toggle. Parsed by
+`classify_env_bool` (an unrecognized or empty value falls through to the config
+value rather than forcing the default). While this env var is set it outranks
+the persisted value, so a `/timestamps` toggle will not appear to "stick"
+across restarts.
+"""
+
 SHOW_SCROLLBAR = "DEEPAGENTS_CODE_SHOW_SCROLLBAR"
 """Show the vertical scrollbar in the chat area when enabled.
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -995,150 +995,79 @@ def _load_theme_preference() -> str:
     return theme.DEFAULT_THEME
 
 
-def _load_message_timestamps_visible() -> bool:
-    """Load the saved message-timestamp-footer visibility preference.
+def _load_bool_display_preference(key: str, *, fallback: bool) -> bool:
+    """Resolve a boolean `Display` option through the config manifest.
 
-    Reads `[ui].show_message_timestamps` from `~/.deepagents/config.toml`.
+    Precedence follows `resolve_scalar`: the option's `DEEPAGENTS_CODE_*` env
+    var wins, then its `[ui]` key in `~/.deepagents/config.toml`, then the
+    option's declared default. Resolution is intentionally forgiving — an
+    unreadable config, a non-table `[ui]`, or a wrong-typed value is logged by
+    the resolver and falls through, so a typo in a cosmetic setting never
+    breaks startup.
+
+    Args:
+        key: Manifest key of the option, e.g. `"display.cursor_blink"`.
+        fallback: Value to use when `key` is not in the manifest at all, which
+            only happens if a caller and the manifest disagree.
 
     Returns:
-        The saved preference, or `False` when it is unset or unreadable.
+        The resolved value.
     """
-    import tomllib
+    from deepagents_code.config_manifest import (
+        get_option,
+        load_config_toml,
+        resolve_scalar,
+    )
 
-    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
+    option = get_option(key)
+    if option is None:
+        logger.warning("Unknown config option %r; falling back to %r", key, fallback)
+        return fallback
+    value, _ = resolve_scalar(option, toml_data=load_config_toml())
+    return bool(value)
 
-    if not DEFAULT_CONFIG_PATH.exists():
-        return False
-    try:
-        with DEFAULT_CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
-        logger.warning("Could not read config for timestamp preference: %s", exc)
-        return False
 
-    ui = data.get("ui", {})
-    if not isinstance(ui, dict):
-        logger.warning(
-            "[ui] should be a table; got %s while loading timestamp preference",
-            type(ui).__name__,
-        )
-        return False
+def _load_message_timestamps_visible() -> bool:
+    """Resolve whether chat messages show a timestamp footer.
 
-    value = ui.get("show_message_timestamps")
-    if isinstance(value, bool):
-        return value
-    if value is not None:
-        logger.warning(
-            "[ui].show_message_timestamps should be a boolean; got %s",
-            type(value).__name__,
-        )
-    return False
+    Toggled in-app with `/timestamps`, or preset with
+    `DEEPAGENTS_CODE_SHOW_MESSAGE_TIMESTAMPS` / `[ui].show_message_timestamps`.
+
+    Returns:
+        The resolved preference, or `False` when unset, unreadable, or
+        malformed.
+    """
+    return _load_bool_display_preference(
+        "display.show_message_timestamps", fallback=False
+    )
 
 
 def _load_show_scrollbar() -> bool:
-    """Load the chat scrollbar visibility preference.
+    """Resolve whether the chat area shows a vertical scrollbar.
 
-    Reads `DEEPAGENTS_CODE_SHOW_SCROLLBAR` env var, falling back to
-    `[ui].show_scrollbar` from `~/.deepagents/config.toml`, and finally `False`.
+    Toggled in-app with `/scrollbar`, or preset with
+    `DEEPAGENTS_CODE_SHOW_SCROLLBAR` / `[ui].show_scrollbar`.
 
     Returns:
-        The resolved preference.
+        The resolved preference, or `False` when unset, unreadable, or
+        malformed.
     """
-    from deepagents_code._env_vars import SHOW_SCROLLBAR, classify_env_bool
-
-    raw = os.environ.get(SHOW_SCROLLBAR)
-    if raw is not None and raw.strip():
-        env = classify_env_bool(raw)
-        if env is not None:
-            return env
-
-    import tomllib
-
-    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
-
-    if not DEFAULT_CONFIG_PATH.exists():
-        return False
-    try:
-        with DEFAULT_CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
-        logger.warning("Could not read config for scrollbar preference: %s", exc)
-        return False
-
-    ui = data.get("ui", {})
-    if not isinstance(ui, dict):
-        logger.warning(
-            "[ui] should be a table; got %s while loading scrollbar preference",
-            type(ui).__name__,
-        )
-        return False
-
-    value = ui.get("show_scrollbar")
-    if isinstance(value, bool):
-        return value
-    if value is not None:
-        logger.warning(
-            "[ui].show_scrollbar should be a boolean; got %s",
-            type(value).__name__,
-        )
-    return False
+    return _load_bool_display_preference("display.show_scrollbar", fallback=False)
 
 
 def _load_debug_console_click_to_copy() -> bool:
-    r"""Load the `Ctrl+\` Debug Console click-to-copy preference.
+    r"""Resolve whether the `Ctrl+\` Debug Console copies a row on click.
 
-    Reads `DEEPAGENTS_CODE_DEBUG_CONSOLE_CLICK_TO_COPY` env var, falling back to
-    `[ui].debug_console_click_to_copy` from `~/.deepagents/config.toml`, and
-    finally `False` (click-to-copy off; Enter-to-copy is always available).
+    Preset with `DEEPAGENTS_CODE_DEBUG_CONSOLE_CLICK_TO_COPY` or
+    `[ui].debug_console_click_to_copy`. Enter-to-copy is always available.
 
     Returns:
-        The resolved preference.
+        The resolved preference, or `False` when unset, unreadable, or
+        malformed.
     """
-    from deepagents_code._env_vars import (
-        DEBUG_CONSOLE_CLICK_TO_COPY,
-        classify_env_bool,
+    return _load_bool_display_preference(
+        "display.debug_console_click_to_copy", fallback=False
     )
-
-    raw = os.environ.get(DEBUG_CONSOLE_CLICK_TO_COPY)
-    if raw is not None and raw.strip():
-        env = classify_env_bool(raw)
-        if env is not None:
-            return env
-
-    import tomllib
-
-    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
-
-    if not DEFAULT_CONFIG_PATH.exists():
-        return False
-    try:
-        with DEFAULT_CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
-        logger.warning(
-            "Could not read config for debug console click-to-copy preference: %s",
-            exc,
-        )
-        return False
-
-    ui = data.get("ui", {})
-    if not isinstance(ui, dict):
-        logger.warning(
-            "[ui] should be a table; got %s while loading debug console "
-            "click-to-copy preference",
-            type(ui).__name__,
-        )
-        return False
-
-    value = ui.get("debug_console_click_to_copy")
-    if isinstance(value, bool):
-        return value
-    if value is not None:
-        logger.warning(
-            "[ui].debug_console_click_to_copy should be a boolean; got %s",
-            type(value).__name__,
-        )
-    return False
 
 
 def _replace_malformed_ui(
@@ -1239,35 +1168,6 @@ def save_theme_preference(name: str) -> bool:
     return _save_theme_preference_result(name).ok
 
 
-def _load_bool_display_preference(key: str) -> bool:
-    """Resolve a boolean `Display` option that defaults to on.
-
-    Precedence follows `resolve_scalar`: the option's `DEEPAGENTS_CODE_*` env
-    var wins, then its `[ui]` key in `~/.deepagents/config.toml`. Resolution is
-    intentionally forgiving — an unreadable config, a non-table `[ui]`, or a
-    wrong-typed value is logged by the resolver and falls back to `True` (the
-    feature stays on), so a typo in a cosmetic setting never breaks startup.
-
-    Args:
-        key: Manifest key of the option, e.g. `"display.cursor_blink"`.
-
-    Returns:
-        The resolved value, or `True` when unset, unreadable, or malformed.
-    """
-    from deepagents_code.config_manifest import (
-        get_option,
-        load_config_toml,
-        resolve_scalar,
-    )
-
-    option = get_option(key)
-    if option is None:
-        logger.warning("Unknown config option %r; leaving it enabled", key)
-        return True
-    value, _ = resolve_scalar(option, toml_data=load_config_toml())
-    return bool(value)
-
-
 def _load_cursor_blink_preference() -> bool:
     """Resolve whether the chat input cursor should blink.
 
@@ -1278,7 +1178,7 @@ def _load_cursor_blink_preference() -> bool:
         The resolved cursor-blink preference, or `True` (blink on) when unset,
         unreadable, or malformed.
     """
-    return _load_bool_display_preference("display.cursor_blink")
+    return _load_bool_display_preference("display.cursor_blink", fallback=True)
 
 
 def _load_cursor_style_preference() -> CursorStyle:
@@ -1321,7 +1221,7 @@ def _load_terminal_progress_preference() -> bool:
         The resolved terminal-progress preference, or `True` (progress on) when
         unset, unreadable, or malformed.
     """
-    return _load_bool_display_preference("display.terminal_progress")
+    return _load_bool_display_preference("display.terminal_progress", fallback=True)
 
 
 def _save_terminal_theme_mapping_result(

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -647,8 +647,9 @@ def resolve_scalar(
         `(value, source)`, where `source` is `env (<name>)`, `config.toml`, or
         `default`. A malformed `int`/`float`/list/PTC value, an unrecognized
         boolean token, or any TOML value of the wrong type is logged and skipped
-        so the next layer (or the typed default) applies. An empty env value is
-        normally treated as unset (mirroring `resolve_env_var`), so it falls
+        so the next layer (or the typed default) applies. An empty or
+        whitespace-only env value is
+        treated as unset (mirroring `resolve_env_var`), so it falls
         through to the next env var, then `config.toml`/`default`, rather than
         counting as set. Options declaring `empty_env_is_false` instead resolve
         an explicitly present empty value to `False`. Theme resolution
@@ -673,7 +674,10 @@ def resolve_scalar(
             raw = os.environ.get(name)
             if raw is None:
                 continue
-            if not raw:
+            # Whitespace counts as empty: `FOO=` and `FOO=" "` are the same
+            # intent, and without the strip the latter would slip past this
+            # guard and be classified as a falsy boolean token.
+            if not raw.strip():
                 if option.empty_env_is_false:
                     return False, f"env ({name})"
                 continue
@@ -990,6 +994,29 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         toml_keys=("ui", "terminal_progress"),
     ),
     ConfigOption(
+        key="display.show_message_timestamps",
+        group="Display",
+        summary="Show the timestamp footer under each chat message.",
+        kind=OptionKind.BOOL,
+        default=False,
+        env_var=_env_vars.SHOW_MESSAGE_TIMESTAMPS,
+        toml_keys=("ui", "show_message_timestamps"),
+    ),
+    ConfigOption(
+        key="display.themes",
+        group="Display",
+        summary="User-defined themes, each a table of theme colors.",
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("themes",),
+    ),
+    ConfigOption(
+        key="display.terminal_themes",
+        group="Display",
+        summary="Per-`TERM_PROGRAM` default theme, written by the theme picker.",
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("ui", "terminal_themes"),
+    ),
+    ConfigOption(
         key="display.show_header",
         group="Display",
         summary="Show Textual's native header bar at the top of the TUI.",
@@ -1135,6 +1162,66 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         summary="Most recently switched-to model (managed by the app).",
         kind=OptionKind.STR,
         toml_keys=("models", "recent"),
+    ),
+    ConfigOption(
+        key="models.providers",
+        group="Models",
+        summary=(
+            "Custom chat-model providers. A `class_path` entry is imported at "
+            "model creation, so its module runs with your privileges."
+        ),
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("models", "providers"),
+    ),
+    ConfigOption(
+        key="retries.max_retries",
+        group="Models",
+        summary=(
+            "Default provider retry count; override per provider with "
+            "`[retries.<provider>]`."
+        ),
+        kind=OptionKind.INT,
+        toml_keys=("retries", "max_retries"),
+    ),
+    # --- Agents ---------------------------------------------------------
+    ConfigOption(
+        key="agents.default",
+        group="Agents",
+        summary="Agent used at launch when `--agent` is omitted.",
+        kind=OptionKind.STR,
+        toml_keys=("agents", "default"),
+    ),
+    ConfigOption(
+        key="agents.recent",
+        group="Agents",
+        summary="Most recently switched-to agent (managed by the app).",
+        kind=OptionKind.STR,
+        toml_keys=("agents", "recent"),
+    ),
+    ConfigOption(
+        key="agents.async_subagents",
+        group="Agents",
+        summary="Remote LangGraph deployments exposed to the agent as subagents.",
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("async_subagents",),
+    ),
+    # --- Sandboxes ------------------------------------------------------
+    ConfigOption(
+        key="sandboxes.default",
+        group="Sandboxes",
+        summary="Sandbox backend used when none is named on the command line.",
+        kind=OptionKind.STR,
+        toml_keys=("sandboxes", "default"),
+    ),
+    ConfigOption(
+        key="sandboxes.providers",
+        group="Sandboxes",
+        summary=(
+            "Custom sandbox backends. A `class_path` entry is imported at "
+            "sandbox creation, so its module runs with your privileges."
+        ),
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("sandboxes", "providers"),
     ),
     # --- Tracing -------------------------------------------------------
     ConfigOption(

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -14516,25 +14516,22 @@ class TestScrollbarToggle:
         config = tmp_path / "config.toml"
         config.write_text("this is = = not valid toml [[[\n")
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
-        with caplog.at_level("WARNING", logger="deepagents_code.app"):
+        with caplog.at_level("WARNING", logger="deepagents_code.config_manifest"):
             assert _load_show_scrollbar() is False
-        assert any("scrollbar" in record.getMessage() for record in caplog.records)
+        assert any("Could not read config" in r.getMessage() for r in caplog.records)
 
     def test_load_ignores_non_table_ui(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A scalar `[ui]` value is ignored with a warning on load."""
+        """A scalar `[ui]` value reads as unset rather than raising."""
         from deepagents_code.app import _load_show_scrollbar
 
         config = tmp_path / "config.toml"
         config.write_text('ui = "oops"\n')
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
-        with caplog.at_level("WARNING", logger="deepagents_code.app"):
-            assert _load_show_scrollbar() is False
-        assert any("ui" in record.getMessage() for record in caplog.records)
+        assert _load_show_scrollbar() is False
 
     def test_save_repairs_malformed_ui_table(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -14701,7 +14698,6 @@ class TestDebugConsoleClickToCopyPreference:
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """A `[ui]` value that is not a table degrades to the off default."""
         from deepagents_code.app import _load_debug_console_click_to_copy
@@ -14709,9 +14705,7 @@ class TestDebugConsoleClickToCopyPreference:
         config = tmp_path / "config.toml"
         config.write_text('ui = "not-a-table"\n')
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
-        with caplog.at_level("WARNING", logger="deepagents_code.app"):
-            assert _load_debug_console_click_to_copy() is False
-        assert any("[ui]" in record.getMessage() for record in caplog.records)
+        assert _load_debug_console_click_to_copy() is False
 
     def test_load_handles_unreadable_config(
         self,
@@ -14725,9 +14719,9 @@ class TestDebugConsoleClickToCopyPreference:
         config = tmp_path / "config.toml"
         config.write_text("[ui]\ndebug_console_click_to_copy = tru\n")  # invalid TOML
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
-        with caplog.at_level("WARNING", logger="deepagents_code.app"):
+        with caplog.at_level("WARNING", logger="deepagents_code.config_manifest"):
             assert _load_debug_console_click_to_copy() is False
-        assert any("click-to-copy" in record.getMessage() for record in caplog.records)
+        assert any("Could not read config" in r.getMessage() for r in caplog.records)
 
     def test_save_round_trips(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -79,6 +79,107 @@ def test_manifest_covers_every_provider_credential() -> None:
     )
 
 
+_UI_READER_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Theme resolution predates the manifest and keeps bespoke semantics
+        # (terminal-program mapping, unknown-name fallback), so these read
+        # `[ui]` directly rather than through `resolve_scalar`.
+        "app.py:_load_terminal_default",
+        "app.py:_load_theme_preference",
+        "config_manifest.py:_resolve_theme",
+        # Reads `[ui]` only to repair and rewrite it; not a value reader.
+        "app.py:_replace_malformed_ui",
+    }
+)
+"""Functions permitted to read the `[ui]` table without using the manifest."""
+
+
+def test_no_hand_rolled_ui_config_readers() -> None:
+    """`[ui]` scalars must be read through the manifest, not re-parsed by hand.
+
+    A bespoke loader re-implements env parsing, the `[ui]` lookup, the type
+    check, and the fallback — which is how the app came to read values that
+    `dcode config` did not report, and vice versa.
+    """
+    import ast
+    from pathlib import Path
+
+    from deepagents_code import config_manifest
+
+    package_root = Path(config_manifest.__file__).parent
+    readers: set[str] = set()
+    for source in sorted(package_root.rglob("*.py")):
+        text = source.read_text(encoding="utf-8")
+        if '.get("ui"' not in text:
+            continue
+        hits = [
+            number
+            for number, line in enumerate(text.splitlines(), start=1)
+            if '.get("ui"' in line
+        ]
+        functions = [
+            node
+            for node in ast.walk(ast.parse(text))
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        for hit in hits:
+            # Smallest enclosing span, so a nested helper is not attributed to
+            # the function it happens to live in.
+            enclosing = min(
+                (
+                    node
+                    for node in functions
+                    if node.lineno <= hit <= (node.end_lineno or node.lineno)
+                ),
+                key=lambda node: (node.end_lineno or node.lineno) - node.lineno,
+                default=None,
+            )
+            name = enclosing.name if enclosing else "<module>"
+            readers.add(f"{source.name}:{name}")
+
+    assert readers == _UI_READER_ALLOWLIST, (
+        f"Unexpected `[ui]` readers: {sorted(readers - _UI_READER_ALLOWLIST)}. "
+        "Register the option in config_manifest.py and resolve it with "
+        "`resolve_scalar` instead of parsing config.toml by hand."
+    )
+
+
+@pytest.mark.parametrize(
+    ("key", "toml_keys"),
+    [
+        ("display.show_message_timestamps", ("ui", "show_message_timestamps")),
+        ("display.themes", ("themes",)),
+        ("display.terminal_themes", ("ui", "terminal_themes")),
+        ("models.providers", ("models", "providers")),
+        ("retries.max_retries", ("retries", "max_retries")),
+        ("agents.default", ("agents", "default")),
+        ("agents.recent", ("agents", "recent")),
+        ("agents.async_subagents", ("async_subagents",)),
+        ("sandboxes.default", ("sandboxes", "default")),
+        ("sandboxes.providers", ("sandboxes", "providers")),
+    ],
+)
+def test_config_toml_sections_are_discoverable(
+    key: str, toml_keys: tuple[str, ...]
+) -> None:
+    """Every `config.toml` section the app reads must be listed by `dcode config`."""
+    option = get_option(key)
+    assert option is not None, f"{key} is missing from the manifest"
+    assert option.toml_keys == toml_keys
+
+
+def test_show_message_timestamps_env_overrides_config(monkeypatch) -> None:
+    """The env var must outrank a persisted `/timestamps` toggle."""
+    option = get_option("display.show_message_timestamps")
+    assert option is not None
+    monkeypatch.setenv(_env_vars.SHOW_MESSAGE_TIMESTAMPS, "1")
+    value, source = resolve_scalar(
+        option, toml_data={"ui": {"show_message_timestamps": False}}
+    )
+    assert value is True
+    assert source == f"env ({_env_vars.SHOW_MESSAGE_TIMESTAMPS})"
+
+
 def test_option_keys_unique() -> None:
     """Manifest keys must be unique so `config get` lookups are unambiguous."""
     keys = option_keys()


### PR DESCRIPTION
Depends on #5219

`dcode config` now lists every `config.toml` section the app reads, including the custom-provider, custom-sandbox, remote-subagent, and user-theme tables that were previously invisible, and the message-timestamp toggle gains a `DEEPAGENTS_CODE_SHOW_MESSAGE_TIMESTAMPS` override.

---

Auditing the config surface after #5219 turned up two related problems.

Some options were simply missing: `[ui].show_message_timestamps`, `[agents].default`/`.recent`, `[sandboxes].default`, `[retries].max_retries`, and the structured tables `[models.providers]`, `[sandboxes.providers]`, `[async_subagents]`, `[themes]`, and `[ui.terminal_themes]`. The first three structured ones matter most: each can import user-named Python or reach a remote endpoint, and nothing in the CLI told you they were set.

Others were listed but not actually read through the manifest. `show_scrollbar` and `debug_console_click_to_copy` had bespoke loaders re-implementing env parsing, the `[ui]` lookup, the type check, and the fallback, so `dcode config` could report a value the app did not use. Those loaders are gone, and a drift test now fails if a new `[ui]` reader appears outside the manifest — the existing check only covered `DEEPAGENTS_CODE_*` env vars, which is exactly how three TOML-only keys slipped through in the first place.

Worth a careful look:

- **`resolve_scalar` now treats a whitespace-only env value as unset**, matching how it already treated an empty one. Without this, folding the old loaders in would have silently changed `FOO="   "` from "ignored" to "false", because `classify_env_bool` strips before matching and the empty string is a falsy token. This affects every manifest option, not just the ones moved here.
- **Two tests lost a log assertion.** The old loaders warned when `[ui]` was not a table; the shared resolver treats an unusable path as "not set" and stays quiet, because warning per option would emit one line per lookup. The tests now assert the resulting value instead.
- **Per-provider retry tables** (`[retries.<provider>]`) share the `[retries]` table with `max_retries`, so a second structured entry would print the same TOML twice. They are named in the `retries.max_retries` summary instead, which `dcode config --verbose` shows.
- Theme resolution still reads `[ui]` directly and is explicitly allowlisted in the drift test; its terminal-mapping and unknown-name fallback semantics do not fit the generic resolver, and converting it is a larger change than this PR should carry.

Made by [Open SWE](https://openswe.vercel.app/agents/1c22682d-7700-26b5-b84e-a99ca14124e7)

## References
- Plan: https://openswe.vercel.app/agents/1c22682d-7700-26b5-b84e-a99ca14124e7/plan