### PR TITLE
fix(ci): replace invalid Actions pin with the commit SHA it resolves to

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -784,7 +784,7 @@ jobs:
           ref: ${{ matrix.pr.headBranchName }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Update lockfiles
         id: update-lockfiles


### PR DESCRIPTION
## Problem

These workflow `uses:` pins are invalid as written. Each item below shows the current value, why it is wrong, and the correct ref that must be used instead.

### 1. `.github/workflows/release-please.yml`

**Current (invalid):**

```yaml
uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
```

**Why this is wrong:**

- `94527f2e458b27549849d47d273a16bec83a01e9` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v7`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v7` points to**: `37802adc94f370d6bfd71619e3f0bf239e1f3b78`.

**Correct pin:**

```yaml
uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
```

## Test plan

- [ ] Each updated `uses:` ref resolves as a commit via the GitHub Commits API
- [ ] Relevant CI jobs on this branch look healthy
