### PR TITLE
fix(sdk): resolve exact-file `delete` targets with first-match-wins ordering

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -47,6 +47,7 @@ from deepagents.backends.protocol import (
     GlobResult,
     GrepMatch,
     GrepResult,
+    LsResult,
     ReadResult,
     SandboxBackendProtocol,
     WriteResult,
@@ -342,15 +343,109 @@ def _wildcard_delete_overlap(pattern: str, anchor: str, target: str) -> bool:
     )
 
 
-def _find_delete_deny_patterns(rules: list[FilesystemPermission], target: str) -> list[str]:
+def _delete_target_may_have_descendants(backend: BackendProtocol, target: str, *, permissions_configured: bool) -> bool:
+    """Return whether `_find_delete_deny_patterns` should use the conservative recursive check for `target`.
+
+    Skips the `ls` probe entirely when no permission rules are configured
+    (nothing to resolve either way) or when the backend doesn't implement
+    `ls` (falls back to the pre-existing conservative behavior).
+
+    Args:
+        backend: Backend the delete will run against.
+        target: Absolute, validated path being deleted.
+        permissions_configured: Whether any `FilesystemPermission` rules exist.
+
+    Returns:
+        `True` unless permissions are configured and the backend confirms
+            `target` is a leaf with nothing beneath it.
+    """
+    if not permissions_configured:
+        return False
+    try:
+        return _delete_target_has_descendants(backend.ls(target))
+    except NotImplementedError:
+        return True
+
+
+async def _adelete_target_may_have_descendants(backend: BackendProtocol, target: str, *, permissions_configured: bool) -> bool:
+    """Async counterpart to `_delete_target_may_have_descendants`."""
+    if not permissions_configured:
+        return False
+    try:
+        return _delete_target_has_descendants(await backend.als(target))
+    except NotImplementedError:
+        return True
+
+
+def _delete_target_has_descendants(ls_result: LsResult) -> bool:
+    """Return whether a delete target could have entries nested under it.
+
+    A confirmed leaf -- a plain file (`ls` reporting `not_a_directory`) or an
+    existing location with no children -- can't have anything recursively
+    swept out from under a denied sibling, so `_find_delete_deny_patterns` can
+    resolve it with plain first-match-wins ordering instead of the
+    conservative recursive-overlap check. Any other outcome (a real
+    directory with children, or an error that doesn't confirm a leaf, e.g.
+    `path_not_found` or a backend being unavailable) is treated as "may have
+    descendants" so the conservative check still applies.
+
+    Args:
+        ls_result: Result of listing the delete target.
+
+    Returns:
+        `True` unless the target is a confirmed leaf with nothing beneath it.
+    """
+    if ls_result.entries:
+        return True
+    if ls_result.error is None:
+        return False
+    return "not_a_directory" not in ls_result.error
+
+
+def _find_delete_deny_patterns_for_leaf(rules: list[FilesystemPermission], target: str) -> list[str]:
+    """Resolve delete permission for a confirmed leaf using first-match-wins ordering.
+
+    Mirrors `_check_fs_permission`'s ordering, but also reports which
+    pattern(s) matched so the delete tool's error message can cite them.
+
+    Args:
+        rules: Filesystem permission rules.
+        target: Absolute, validated path being deleted.
+
+    Returns:
+        The matched deny patterns from the first matching rule, or an empty
+            list if the first matching rule allows the delete (or nothing matches).
+    """
+    for rule in rules:
+        if "write" not in rule.operations:
+            continue
+        matched = [pattern for pattern in rule.paths if wcglob.globmatch(target, pattern, flags=_FS_WCMATCH_FLAGS)]
+        if not matched:
+            continue
+        return matched if rule.mode == "deny" else []
+    return []
+
+
+def _find_delete_deny_patterns(
+    rules: list[FilesystemPermission],
+    target: str,
+    *,
+    has_descendants: bool = True,
+) -> list[str]:
     """Return deny-write patterns that block deleting `target`.
 
-    A recursive delete removes `target` and all descendants, so a deny-write
-    pattern blocks the operation when it could match `target` or anything in
-    its subtree. Sibling file globs that cannot match anything inside the
-    deleted subtree (e.g. deny `/work/*.log` when deleting `/work/notes.txt`)
-    do not block. The check is based only on permission rules and returns all
-    matching patterns.
+    A recursive delete removes `target` and all descendants, so when
+    `has_descendants` is `True` a deny-write pattern blocks the operation
+    when it could match `target` or anything in its subtree, regardless of
+    rule order -- an earlier allow rule can't guarantee every descendant is
+    safe, since a later, more specific deny could still apply to one of them.
+    Sibling file globs that cannot match anything inside the deleted subtree
+    (e.g. deny `/work/*.log` when deleting `/work/notes.txt`) do not block.
+
+    When `has_descendants` is `False` (a confirmed leaf, see
+    `_delete_target_has_descendants`), there's no subtree to protect, so
+    `target` is resolved the same way `write_file`/`edit_file` resolve
+    permissions: the first rule (in declaration order) that matches wins.
 
     Literal (wildcard-free) deny patterns use a subtree-overlap check: a deny
     on a directory blocks deleting anything inside it and blocks deleting an
@@ -363,10 +458,15 @@ def _find_delete_deny_patterns(rules: list[FilesystemPermission], target: str) -
     Args:
         rules: Filesystem permission rules.
         target: Absolute, validated path being deleted.
+        has_descendants: Whether `target` may have entries nested under it.
+            Pass `False` only once the backend has confirmed it's a leaf.
 
     Returns:
         Matching deny-write patterns, or an empty list if the delete is allowed.
     """
+    if not has_descendants:
+        return _find_delete_deny_patterns_for_leaf(rules, target)
+
     denying: list[str] = []
     seen: set[str] = set()
     for rule in rules:
@@ -1965,7 +2065,8 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path)
+            has_descendants = _delete_target_may_have_descendants(resolved_backend, validated_path, permissions_configured=bool(self._permissions))
+            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path, has_descendants=has_descendants)
             if denying_patterns:
                 return ToolMessage(
                     content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
@@ -2004,7 +2105,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path)
+            has_descendants = await _adelete_target_may_have_descendants(
+                resolved_backend, validated_path, permissions_configured=bool(self._permissions)
+            )
+            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path, has_descendants=has_descendants)
             if denying_patterns:
                 return ToolMessage(
                     content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -12,7 +12,7 @@ from langgraph.store.memory import InMemoryStore
 from deepagents.backends import StateBackend, StoreBackend
 from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.filesystem import FilesystemBackend
-from deepagents.backends.protocol import EditResult, ExecuteResponse, GlobResult, ReadResult, SandboxBackendProtocol, WriteResult
+from deepagents.backends.protocol import EditResult, ExecuteResponse, GlobResult, LsResult, ReadResult, SandboxBackendProtocol, WriteResult
 from deepagents.backends.utils import _glob_anchor, _paths_overlap
 from deepagents.graph import create_deep_agent
 from deepagents.middleware import filesystem as filesystem_module
@@ -22,6 +22,7 @@ from deepagents.middleware.filesystem import (
     FilesystemPermission,
     _all_paths_scoped_to_routes,
     _check_fs_permission,
+    _delete_target_has_descendants,
     _filter_paths_by_permission,
     _find_delete_deny_patterns,
 )
@@ -216,6 +217,57 @@ class TestRecursiveDeletePermissions:
         assert "Deleted" in result
         assert not (tmp_path / "work" / "a.txt").exists()
 
+    def test_exact_file_delete_allowed_under_workspace_isolation(self, tmp_path):
+        """Regression for #5113.
+
+        An earlier, more specific allow rule must win for an exact-file
+        delete, even with a later catch-all deny -- the same first-match-wins
+        ordering `write_file`/`edit_file` already use.
+        """
+        backend = self._fs_backend(tmp_path)
+        rules = [
+            FilesystemPermission(operations=["read", "write"], paths=["/work/**"], mode="allow"),
+            FilesystemPermission(operations=["read", "write"], paths=["/**"], mode="deny"),
+        ]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/a.txt"}, rules, backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work" / "a.txt").exists()
+
+    def test_recursive_delete_still_blocked_under_workspace_isolation(self, tmp_path):
+        """The catch-all deny still protects an actual recursive delete.
+
+        Unlike the exact-file case above, `/work` has descendants not
+        covered by the narrower allow rule, so the all-or-nothing check
+        still applies.
+        """
+        backend = self._fs_backend(tmp_path)
+        rules = [
+            FilesystemPermission(operations=["read", "write"], paths=["/work/logs/**"], mode="allow"),
+            FilesystemPermission(operations=["read", "write"], paths=["/**"], mode="deny"),
+        ]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "a.txt").exists()
+
+    async def test_exact_file_delete_allowed_under_workspace_isolation_async(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [
+            FilesystemPermission(operations=["read", "write"], paths=["/work/**"], mode="allow"),
+            FilesystemPermission(operations=["read", "write"], paths=["/**"], mode="deny"),
+        ]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = await _ainvoke_with_permissions(tool, {"file_path": "/work/a.txt"}, rules, backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work" / "a.txt").exists()
+
     async def test_recursive_delete_refused_async(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
@@ -345,6 +397,66 @@ class TestFindDeleteDenyPatterns:
     def test_multiple_rule_aggregation(self, rule_paths, target, expected):
         rules = [_deny(*paths) for paths in rule_paths]
         assert _find_delete_deny_patterns(rules, target) == expected
+
+
+class TestFindDeleteDenyPatternsExactFile:
+    """`has_descendants=False` resolves the target via first-match-wins ordering.
+
+    Regression coverage for #5113: with no subtree to protect, a confirmed
+    leaf is resolved exactly like `write_file`/`edit_file` -- the first
+    matching rule (in declaration order) wins -- instead of the conservative
+    any-overlapping-deny-blocks check used for recursive deletes.
+    """
+
+    def test_earlier_allow_wins_over_later_catch_all_deny(self):
+        rules = [
+            FilesystemPermission(operations=["write"], paths=["/work/**"], mode="allow"),
+            FilesystemPermission(operations=["write"], paths=["/**"], mode="deny"),
+        ]
+        assert _find_delete_deny_patterns(rules, "/work/a.txt", has_descendants=False) == []
+
+    def test_deny_still_blocks_when_it_matches_first(self):
+        rules = [
+            FilesystemPermission(operations=["write"], paths=["/**"], mode="deny"),
+            FilesystemPermission(operations=["write"], paths=["/work/**"], mode="allow"),
+        ]
+        assert _find_delete_deny_patterns(rules, "/work/a.txt", has_descendants=False) == ["/**"]
+
+    def test_default_has_descendants_preserves_conservative_behavior(self):
+        # Without an explicit has_descendants=False, callers keep the
+        # pre-existing conservative recursive-delete overlap check.
+        rules = [
+            FilesystemPermission(operations=["write"], paths=["/work/**"], mode="allow"),
+            FilesystemPermission(operations=["write"], paths=["/**"], mode="deny"),
+        ]
+        assert _find_delete_deny_patterns(rules, "/work/a.txt") == ["/**"]
+
+    def test_non_matching_rule_allows(self):
+        rules = [FilesystemPermission(operations=["write"], paths=["/other/**"], mode="deny")]
+        assert _find_delete_deny_patterns(rules, "/work/a.txt", has_descendants=False) == []
+
+    def test_interrupt_rule_is_not_a_denial(self):
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/**"], mode="interrupt")]
+        assert _find_delete_deny_patterns(rules, "/work/a.txt", has_descendants=False) == []
+
+
+class TestDeleteTargetHasDescendants:
+    """`_delete_target_has_descendants` gates which delete permission check applies."""
+
+    def test_confirmed_leaf_file_has_no_descendants(self):
+        ls_result = LsResult(entries=None, error="Path '/work/a.txt': not_a_directory")
+        assert _delete_target_has_descendants(ls_result) is False
+
+    def test_empty_location_has_no_descendants(self):
+        assert _delete_target_has_descendants(LsResult(entries=[])) is False
+
+    def test_directory_with_children_has_descendants(self):
+        ls_result = LsResult(entries=[{"path": "/work/a.txt", "is_dir": False}])
+        assert _delete_target_has_descendants(ls_result) is True
+
+    def test_unresolved_error_is_treated_conservatively(self):
+        ls_result = LsResult(entries=None, error="Path '/work': path_not_found")
+        assert _delete_target_has_descendants(ls_result) is True
 
 
 class TestFilesystemPermission:


### PR DESCRIPTION
Closes #5113

`delete`'s permission check now resolves a confirmed leaf target (a plain file, or an existing location with nothing beneath it) with the same first-match-wins ordering `write_file`/`edit_file` already use, instead of the conservative any-overlapping-deny-blocks check. This makes the documented workspace-isolation pattern (allow `/workspace/**`, then deny `/**`) usable for deleting files inside the workspace.

---

Previously, `delete` treated any overlapping `deny` rule as blocking regardless of rule order, even when an earlier, more specific `allow` rule would have won for the same path under `write_file`/`edit_file`. That conservative check still exists and is unchanged for anything that could have descendants (a real directory, or a path the backend can't rule out), preserving the recursive all-or-nothing safety net -- deleting `/` or a directory with a denied descendant still fails.

To tell the two cases apart without a new backend capability, the delete tool now calls the backend's existing `ls` to check whether the target has anything nested under it (`not_a_directory` or empty entries confirm a leaf; anything else falls back to the old conservative behavior).

<details>
<summary>Test plan</summary>

- Reproduced the exact scenario from #5113 against `FilesystemBackend` and `StoreBackend`; the delete now succeeds and the earlier-blocked behavior is gone.
- Added unit tests covering the ordering resolution for confirmed leaves, the unchanged conservative behavior for real directories/descendants, and the `ls`-based leaf-detection helper.
- Confirmed deleting `/` (a real directory with descendants) is still refused.

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/17cfcfab-ea19-1545-668d-6b6415ccda3f)