### PR TITLE
fix(code): return Ctrl+C status from CLI startup

### DIFF
--- a/libs/code/deepagents_code/__init__.py
+++ b/libs/code/deepagents_code/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str) -> Callable[[], None]:
+def __getattr__(name: str) -> Callable[[], int | None]:
     """Lazy import for `cli_main` to avoid loading `main.py` at package import.
 
     `main.py` pulls in `argparse`, signal handling, and other startup machinery

--- a/libs/code/deepagents_code/__main__.py
+++ b/libs/code/deepagents_code/__main__.py
@@ -3,4 +3,4 @@
 from deepagents_code.main import cli_main
 
 if __name__ == "__main__":
-    cli_main()
+    raise SystemExit(cli_main())

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3700,8 +3700,12 @@ def _verify_interpreter_or_exit() -> None:
         sys.exit(1)
 
 
-def cli_main() -> None:
-    """Entry point for console script."""
+def cli_main() -> int | None:
+    """Run the command-line entry point.
+
+    Returns:
+        An explicit exit status when startup is interrupted, otherwise `None`.
+    """
     # Fix for gRPC fork issue on macOS
     # https://github.com/grpc/grpc/issues/37642
     if sys.platform == "darwin":
@@ -3740,7 +3744,7 @@ def cli_main() -> None:
         )
 
         if _show_bare_command_group_help(args):
-            return
+            return None
 
         # Keep self-contained commands that do not need global settings here, before
         # state migration and settings bootstrap. If a future command only reads
@@ -4613,13 +4617,13 @@ def cli_main() -> None:
                     "[dim]Aborted; no project MCP servers loaded.[/dim]",
                     highlight=False,
                 )
-                return
+                return None
 
             hook_trust = _check_project_hooks_trust(
                 trust_flag=getattr(args, "trust_project_hooks", False),
             )
             if hook_trust is _TrustPromptOutcome.INTERRUPTED:
-                sys.exit(130)
+                return 130
             if hook_trust is _TrustPromptOutcome.CANCELLED:
                 from rich.console import Console as _Console
 
@@ -4627,7 +4631,7 @@ def cli_main() -> None:
                     "[dim]Aborted; project hooks not loaded.[/dim]",
                     highlight=False,
                 )
-                return
+                return None
 
             # Run Textual TUI
             return_code = 0
@@ -4763,7 +4767,7 @@ def cli_main() -> None:
             console.print("\n\n[yellow]Interrupted[/yellow]")
         except NameError:
             sys.stderr.write("\n\nInterrupted\n")
-        sys.exit(130)
+        return 130
 
 
 if __name__ == "__main__":

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -1017,6 +1017,33 @@ class TestStartupAutoUpdate:
         assert exc_info.value.code == 130
         launch.assert_not_called()
 
+    def test_project_hooks_prompt_interrupt_returns_exit_code(
+        self,
+    ) -> None:
+        """An interrupted project-hook prompt returns 130 to the console wrapper."""
+        from deepagents_code.main import _TrustPromptOutcome
+
+        launch = AsyncMock(return_value=AppResult(return_code=0, thread_id="thread"))
+        with (
+            patch("sys.argv", ["dcode"]),
+            patch("sys.stdin", SimpleNamespace(isatty=lambda: True)),
+            patch("deepagents_code.main._run_startup_auto_update"),
+            patch("deepagents_code.main._resolve_agent_arg", return_value="agent"),
+            patch(
+                "deepagents_code.main._resolve_interpreter_enabled", return_value=False
+            ),
+            patch("deepagents_code.main._check_mcp_project_trust", return_value=None),
+            patch(
+                "deepagents_code.main._check_project_hooks_trust",
+                return_value=_TrustPromptOutcome.INTERRUPTED,
+            ),
+            patch("deepagents_code.main.run_textual_cli_async", launch),
+        ):
+            result = cli_main()
+
+        assert result == 130
+        launch.assert_not_called()
+
     def test_yolo_acknowledgement_interrupt_aborts_before_tui(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -1042,11 +1069,10 @@ class TestStartupAutoUpdate:
                 side_effect=KeyboardInterrupt,
             ),
             patch("deepagents_code.main.run_textual_cli_async", launch),
-            pytest.raises(SystemExit) as exc_info,
         ):
-            cli_main()
+            result = cli_main()
 
-        assert exc_info.value.code == 130
+        assert result == 130
         launch.assert_not_called()
         captured = capsys.readouterr()
         assert "Interrupted" in captured.out + captured.err


### PR DESCRIPTION
Ctrl+C at the project-hooks trust prompt printed Interrupted but exited 0 instead of conventional status 130. Return the explicit status from `cli_main` and propagate it through the module entrypoint so both launch paths preserve the interruption status.

Verified with the targeted startup tests and the hooks/main test suites (402 tests).