### PR TITLE
fix(code): handle malformed hook resumes

### DIFF
--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -689,9 +689,12 @@ def _invoke_hook(
             invocation_id=request.invocation_id,
             snapshot_id=request.snapshot_id,
         )
-    except (ValidationError, ValueError):
+    except ValidationError:
+        # Only shape errors degrade to a neutral decision. `ValueError` from an
+        # invocation_id or snapshot_id mismatch means the client answered a
+        # different request, so it must stay fatal rather than fail open.
         return reduce_hook_results(
-            HookInvocation(context=context, event=event),
+            request.invocation,
             (),
             diagnostics=(
                 HookDiagnostic(

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -690,20 +690,14 @@ def _invoke_hook(
             snapshot_id=request.snapshot_id,
         )
     except ValidationError:
-        # Only shape errors degrade to a neutral decision. `ValueError` from an
-        # invocation_id or snapshot_id mismatch means the client answered a
-        # different request, so it must stay fatal rather than fail open.
-        return reduce_hook_results(
-            request.invocation,
-            (),
-            diagnostics=(
-                HookDiagnostic(
-                    code="invalid_resume",
-                    severity="warning",
-                    message="Malformed hook resume value; treating it as no decision",
-                ),
-            ),
+        # Only shape errors degrade to a neutral decision. A plain `ValueError`
+        # means the client answered a different request, so it stays fatal.
+        diagnostic = HookDiagnostic(
+            code="invalid_resume",
+            severity="warning",
+            message="Malformed hook resume value; treating it as no decision",
         )
+        return reduce_hook_results(request.invocation, (), diagnostics=(diagnostic,))
     return response.decision
 
 

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -42,6 +42,7 @@ from langchain.agents.middleware.types import (
 )
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.types import Command, interrupt
+from pydantic import ValidationError
 from typing_extensions import TypedDict
 
 from deepagents_code.approval_mode import ApprovalMode, coerce_approval_mode
@@ -55,6 +56,7 @@ from deepagents_code.hooks.models.domain import (
     CompactTrigger,
     HookContext,
     HookDecision,
+    HookDiagnostic,
     HookEvent,
     HookInvocation,
     PermissionEffect,
@@ -73,6 +75,7 @@ from deepagents_code.hooks.models.domain import (
     ToolCallData,
 )
 from deepagents_code.hooks.models.transport import HookInvocationRequest
+from deepagents_code.hooks.reducer import reduce_hook_results
 from deepagents_code.hooks.tools import to_wire_tool_name
 
 if TYPE_CHECKING:
@@ -680,11 +683,24 @@ def _invoke_hook(
         deadline=datetime.now(UTC) + deadline,
     )
     raw = interrupt(build_hook_interrupt_payload(request))
-    response = parse_hook_resume_value(
-        raw,
-        invocation_id=request.invocation_id,
-        snapshot_id=request.snapshot_id,
-    )
+    try:
+        response = parse_hook_resume_value(
+            raw,
+            invocation_id=request.invocation_id,
+            snapshot_id=request.snapshot_id,
+        )
+    except (ValidationError, ValueError):
+        return reduce_hook_results(
+            HookInvocation(context=context, event=event),
+            (),
+            diagnostics=(
+                HookDiagnostic(
+                    code="invalid_resume",
+                    severity="warning",
+                    message="Malformed hook resume value; treating it as no decision",
+                ),
+            ),
+        )
     return response.decision
 
 

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -467,7 +467,14 @@ def test_hook_resume_value_validates_identity() -> None:
         )
 
 
-def _invoke_pre_tool_hook(request: HookInvocationRequest) -> HookDecision:
+def _invoke_pre_tool_hook(
+    monkeypatch: pytest.MonkeyPatch,
+    request: HookInvocationRequest,
+    resume: object,
+) -> HookDecision:
+    monkeypatch.setattr(
+        "deepagents_code.hooks.server_middleware.interrupt", lambda _payload: resume
+    )
     event = request.invocation.event
     assert isinstance(event, PreToolUseEvent)
     gate = _session_gate(
@@ -486,25 +493,15 @@ def _invoke_pre_tool_hook(request: HookInvocationRequest) -> HookDecision:
     )
 
 
-def test_malformed_hook_resume_fails_open(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    request = _request()
-    monkeypatch.setattr(
-        "deepagents_code.hooks.server_middleware.interrupt",
-        lambda _payload: {"invalid": True},
-    )
-
-    decision = _invoke_pre_tool_hook(request)
+def test_malformed_hook_resume_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    decision = _invoke_pre_tool_hook(monkeypatch, _request(), {"invalid": True})
 
     assert isinstance(decision, PreToolUseDecision)
     assert decision.permission.behavior == "none"
     assert [item.code for item in decision.diagnostics] == ["invalid_resume"]
 
 
-def test_mismatched_hook_resume_stays_fatal(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_mismatched_hook_resume_stays_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
     """A well-formed response for another request must not fail open."""
     request = _request()
     resume = build_hook_resume_value(
@@ -518,13 +515,9 @@ def test_mismatched_hook_resume_stays_fatal(
             ),
         )
     )
-    monkeypatch.setattr(
-        "deepagents_code.hooks.server_middleware.interrupt",
-        lambda _payload: resume,
-    )
 
     with pytest.raises(ValueError, match="invocation_id mismatch"):
-        _invoke_pre_tool_hook(request)
+        _invoke_pre_tool_hook(monkeypatch, request, resume)
 
 
 def test_real_checkpointer_resume_replays_stable_hook_identity() -> None:

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -466,6 +466,35 @@ def test_hook_resume_value_validates_identity() -> None:
         )
 
 
+def test_malformed_hook_resume_fails_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request()
+    gate = _session_gate(
+        {
+            "hooks_snapshot_id": request.snapshot_id,
+            "hooks_server_events": [HookEvent.PRE_TOOL_USE.value],
+        }
+    )
+    assert gate is not None
+    monkeypatch.setattr(
+        "deepagents_code.hooks.server_middleware.interrupt",
+        lambda _payload: {"invalid": True},
+    )
+
+    decision = _invoke_hook(
+        request.invocation.context,
+        request.invocation.event,
+        gate=gate,
+        config={"configurable": {"thread_id": request.invocation.context.thread_id}},
+        deadline=timedelta(seconds=1),
+    )
+
+    assert isinstance(decision, PreToolUseDecision)
+    assert decision.permission.behavior == "none"
+    assert [item.code for item in decision.diagnostics] == ["invalid_resume"]
+
+
 def test_real_checkpointer_resume_replays_stable_hook_identity() -> None:
     context = HookContext(
         thread_id="thread-1",

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -44,6 +44,7 @@ from deepagents_code.hooks.models.config import HooksConfig
 from deepagents_code.hooks.models.domain import (
     CompactTrigger,
     HookContext,
+    HookDecision,
     HookEvent,
     HookInvocation,
     PermissionEffect,
@@ -466,10 +467,9 @@ def test_hook_resume_value_validates_identity() -> None:
         )
 
 
-def test_malformed_hook_resume_fails_open(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    request = _request()
+def _invoke_pre_tool_hook(request: HookInvocationRequest) -> HookDecision:
+    event = request.invocation.event
+    assert isinstance(event, PreToolUseEvent)
     gate = _session_gate(
         {
             "hooks_snapshot_id": request.snapshot_id,
@@ -477,22 +477,54 @@ def test_malformed_hook_resume_fails_open(
         }
     )
     assert gate is not None
-    monkeypatch.setattr(
-        "deepagents_code.hooks.server_middleware.interrupt",
-        lambda _payload: {"invalid": True},
-    )
-
-    decision = _invoke_hook(
+    return _invoke_hook(
         request.invocation.context,
-        request.invocation.event,
+        event,
         gate=gate,
         config={"configurable": {"thread_id": request.invocation.context.thread_id}},
         deadline=timedelta(seconds=1),
     )
 
+
+def test_malformed_hook_resume_fails_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request()
+    monkeypatch.setattr(
+        "deepagents_code.hooks.server_middleware.interrupt",
+        lambda _payload: {"invalid": True},
+    )
+
+    decision = _invoke_pre_tool_hook(request)
+
     assert isinstance(decision, PreToolUseDecision)
     assert decision.permission.behavior == "none"
     assert [item.code for item in decision.diagnostics] == ["invalid_resume"]
+
+
+def test_mismatched_hook_resume_stays_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A well-formed response for another request must not fail open."""
+    request = _request()
+    resume = build_hook_resume_value(
+        HookInvocationResponse(
+            protocol_version=1,
+            invocation_id=uuid4(),
+            snapshot_id=request.snapshot_id,
+            decision=PreToolUseDecision(
+                event=HookEvent.PRE_TOOL_USE,
+                permission=PermissionEffect(behavior="allow"),
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        "deepagents_code.hooks.server_middleware.interrupt",
+        lambda _payload: resume,
+    )
+
+    with pytest.raises(ValueError, match="invocation_id mismatch"):
+        _invoke_pre_tool_hook(request)
 
 
 def test_real_checkpointer_resume_replays_stable_hook_identity() -> None:


### PR DESCRIPTION
Malformed server-owned hook resume payloads raised a validation error through `_invoke_hook`, which could fail the graph instead of allowing the tool lifecycle to continue. Normalize invalid resume data through the existing reducer as a neutral event decision and retain an `invalid_resume` warning diagnostic.

Added a focused regression test and verified the full hooks suite (207 tests).