### PR TITLE
fix(code): collapse finished dynamic subagents

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -15755,10 +15755,9 @@ class DeepAgentsApp(App):
             self._inflight_turn_start = time.monotonic()
             self._inflight_thread_id = self._lc_thread_id
 
-            # Arm the subagent fan-out panel for this turn, seeding the session
-            # model that labels each row. The panel persists across turns and only
-            # clears when this turn's first subagent actually starts, so a turn that
-            # spawns none leaves the previous workflow's results on screen.
+            # Clear the subagent fan-out panel from the previous turn and seed
+            # the session model that labels each row. A completed workflow's
+            # summary bar is cleared here rather than lingering into this turn.
             panel = self._get_subagent_panel()
             if panel is not None:
                 spec = self._effective_model_spec()

--- a/libs/code/deepagents_code/tui/widgets/subagent_panel.py
+++ b/libs/code/deepagents_code/tui/widgets/subagent_panel.py
@@ -356,10 +356,11 @@ class SubagentPanel(Vertical):
         self._refresh()
 
     def _handle_start(self, sub_id: str, eval_key: str, event: dict[str, Any]) -> None:
-        """Create/replace a running record and (re-)show the panel."""
+        """Create/replace a running record and expand a newly active workflow."""
         if self._pending_reset:
             # A new workflow is starting — drop the previous turn's fan-out now.
             self._clear()
+        should_expand = not self._any_running()
         phase = self._ensure_phase(eval_key)
         self._active_eval_id = eval_key
 
@@ -368,6 +369,8 @@ class SubagentPanel(Vertical):
             label=_sanitize(self._row_label(event), max_chars=200),
         )
         phase.add(record)
+        if should_expand:
+            self.expanded = True
         self._show()
         self._apply_body_height()
         self._ensure_timer()
@@ -403,7 +406,7 @@ class SubagentPanel(Vertical):
     def _handle_finish(
         self, sub_id: str, eval_key: str, outcome: str, event: dict[str, Any]
     ) -> None:
-        """Mark a record done/error, recording duration and stopping the timer.
+        """Mark a record done/error and collapse once the workflow is idle.
 
         An error with no matching `start` is adopted as a fresh row (see
         `_adopt_orphan_finish`) so a dropped-start failure still surfaces.
@@ -437,6 +440,7 @@ class SubagentPanel(Vertical):
             )
         if not self._any_running():
             self._stop_timer()
+            self.expanded = False
 
     def _adopt_orphan_finish(
         self, sub_id: str, eval_key: str, event: dict[str, Any]
@@ -598,7 +602,7 @@ class SubagentPanel(Vertical):
         self.remove_class("-visible")
 
     def finalize_running(self) -> None:
-        """Mark any still-running subagents as cancelled and stop ticking.
+        """Cancel still-running subagents and collapse the completed workflow.
 
         Called when a turn is interrupted: the QuickJS bridge does not emit
         terminal events for `asyncio.CancelledError` (a BaseException, so it
@@ -616,6 +620,7 @@ class SubagentPanel(Vertical):
         if not changed:
             return
         self._stop_timer()
+        self.expanded = False
         self._refresh()
 
     def _show(self) -> None:
@@ -623,7 +628,7 @@ class SubagentPanel(Vertical):
         self.add_class("-visible")
 
     def toggle(self) -> None:
-        """Toggle the body open/closed. This is the only thing that changes it."""
+        """Toggle the body open or closed for manual inspection."""
         self.expanded = not self.expanded
 
     def watch_expanded(self, expanded: bool) -> None:
@@ -752,7 +757,7 @@ class SubagentPanel(Vertical):
         parts: list[Content] = [Content.styled(lead_text, tint)]
         left_len = len(lead_text)
 
-        if self.expanded and total:
+        if total:
             meta = self._header_meta_parts(done, total, failed, cancelled, colors)
             parts.extend(meta)
             left_len += sum(len(p.plain) for p in meta)
@@ -773,7 +778,7 @@ class SubagentPanel(Vertical):
         cancelled: int,
         colors: Any,  # noqa: ANN401 — ThemeColors
     ) -> list[Content]:
-        """Whole-turn totals (phase count, failures, cancellations) when expanded.
+        """Whole-turn totals, including phase count, failures, and cancellations.
 
         Returns:
             The styled `Content` pieces appended after the header label.

--- a/libs/code/deepagents_code/tui/widgets/subagent_panel.py
+++ b/libs/code/deepagents_code/tui/widgets/subagent_panel.py
@@ -215,8 +215,8 @@ class SubagentPanel(Vertical):
     Hidden until the first spawn event. Phases (one per `js_eval`) list on the
     left and the selected phase's subagents render as a scrollable table on the
     right. Focus the panel and use up/down to revisit finished phases. Expands
-    while any phase runs, collapses to the header when the turn goes idle, and
-    re-expands when a new phase starts.
+    while any phase runs, collapses to a summary header once the workflow goes
+    idle, and hides when the user submits the next turn.
     """
 
     can_focus = True
@@ -291,10 +291,6 @@ class SubagentPanel(Vertical):
         self._last_render: dict[str, str] = {}
         self._spinner = Spinner()
         self._timer: Timer | None = None
-        # When True, the next subagent `start` clears the previous workflow's
-        # fan-out before adding the new row (armed by `prepare_turn`). Lets the
-        # panel persist across turns until a new workflow actually begins.
-        self._pending_reset = False
 
     def compose(self) -> ComposeResult:  # noqa: PLR6301 — Textual widget method
         """Yield the header line and the two-pane body (phases | agents)."""
@@ -357,9 +353,6 @@ class SubagentPanel(Vertical):
 
     def _handle_start(self, sub_id: str, eval_key: str, event: dict[str, Any]) -> None:
         """Create/replace a running record and expand a newly active workflow."""
-        if self._pending_reset:
-            # A new workflow is starting — drop the previous turn's fan-out now.
-            self._clear()
         should_expand = not self._any_running()
         phase = self._ensure_phase(eval_key)
         self._active_eval_id = eval_key
@@ -453,10 +446,6 @@ class SubagentPanel(Vertical):
         Returns:
             The newly created record, already inserted into its phase.
         """
-        if self._pending_reset:
-            # A dropped-start error is still evidence that a new workflow
-            # started, so clear the previous turn before surfacing it.
-            self._clear()
         phase = self._ensure_phase(eval_key)
         self._active_eval_id = eval_key
         record = _SubagentRecord(
@@ -558,25 +547,18 @@ class SubagentPanel(Vertical):
         self._refresh()
 
     def prepare_turn(self, *, model_label: str | None = None) -> None:
-        """Arm a deferred clear for a new turn without touching the panel yet.
+        """Clear the previous workflow's fan-out for a new turn.
 
-        The visible fan-out persists across turns; it is cleared lazily when the
-        next workflow actually starts a subagent (see `_handle_start`), so a turn
-        that spawns none leaves the previous results on screen. Refreshes the
-        session model used to label rows.
+        A completed workflow's collapsed summary is relevant only while the
+        user can still act on it — once they submit a new message the bar is
+        stale, so the panel hides now instead of lingering until the next
+        workflow starts. Also drops rows stuck "running" from an interrupted
+        turn. Refreshes the session model used to label rows.
         """
         self._model_label = (
             _sanitize(model_label, max_chars=_MODEL_COL) if model_label else None
         )
-        # If the previous turn left rows stuck "running" — e.g. it was cancelled
-        # before the bridge emitted terminal events (CancelledError is a
-        # BaseException, so it bypasses the bridge's `except Exception`) — clear
-        # now instead of persisting a stale, still-spinning fan-out. Otherwise
-        # defer the clear so a completed workflow survives no-subagent turns.
-        if self._any_running():
-            self._clear()
-        else:
-            self._pending_reset = True
+        self._clear()
 
     def reset(self, *, model_label: str | None = None, **_kwargs: Any) -> None:
         """Clear all phases and hide the panel immediately (e.g. on `/clear`)."""
@@ -597,7 +579,6 @@ class SubagentPanel(Vertical):
         self._selected_eval_id = None
         self._applied_height = None
         self._last_render.clear()
-        self._pending_reset = False
         self._stop_timer()
         self.remove_class("-visible")
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_subagent_panel.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_subagent_panel.py
@@ -120,10 +120,13 @@ class TestLifecycle:
             await pilot.pause()
             assert panel._any_running() is True
             panel.on_subagent_event(_complete("a", "E1"))
+            await pilot.pause()
+            assert panel.expanded is True
             panel.on_subagent_event(_complete("b", "E1"))
             await pilot.pause()
             assert panel._any_running() is False
             assert panel._counts() == (2, 2)
+            assert panel.expanded is False
 
     async def test_missing_label_falls_back_to_short_description(self) -> None:
         async with PanelApp().run_test(size=(200, 24)) as pilot:
@@ -342,16 +345,26 @@ class TestHeaderToggle:
             await pilot.pause()
             assert panel.expanded is False
 
-    async def test_user_collapse_persists_across_turn_reset(self) -> None:
+    async def test_new_workflow_reopens_after_manual_collapse(self) -> None:
         async with PanelApp().run_test(size=(160, 24)) as pilot:
             panel = pilot.app.query_one("#panel", SubagentPanel)
             panel.on_subagent_event(_start("a", "E1"))
             await pilot.pause()
-            panel.toggle()  # user closes it
-            panel.reset()  # new user turn
+            panel.toggle()
+            panel.reset()
             panel.on_subagent_event(_start("b", "E2"))
             await pilot.pause()
-            assert panel.expanded is False  # preference persists
+            assert panel.expanded is True
+
+    async def test_manual_collapse_survives_concurrent_start(self) -> None:
+        async with PanelApp().run_test(size=(160, 24)) as pilot:
+            panel = pilot.app.query_one("#panel", SubagentPanel)
+            panel.on_subagent_event(_start("a", "E1"))
+            await pilot.pause()
+            panel.toggle()
+            panel.on_subagent_event(_start("b", "E1"))
+            await pilot.pause()
+            assert panel.expanded is False
 
     async def test_header_shows_turn_totals_and_failed(self) -> None:
         async with PanelApp().run_test(size=(200, 24)) as pilot:
@@ -400,6 +413,7 @@ class TestReset:
             panel.on_subagent_event(_complete("a", "E1"))
             await pilot.pause()
             assert panel.has_class("-visible")
+            assert panel.expanded is False
             # A new turn begins but spawns no subagents — results persist.
             panel.prepare_turn()
             await pilot.pause()
@@ -410,6 +424,7 @@ class TestReset:
             await pilot.pause()
             assert panel._phase_order == ["E2"]
             assert panel._find_record("a") is None
+            assert panel.expanded is True
 
     async def test_finalize_running_marks_cancelled(self) -> None:
         async with PanelApp().run_test(size=(200, 24)) as pilot:
@@ -428,6 +443,7 @@ class TestReset:
             assert rec_b is not None
             assert rec_a.status == "cancelled"
             assert rec_b.status == "cancelled"
+            assert panel.expanded is False
             header = _render(pilot.app.query_one("#subagent-header", Static))
             assert "2 cancelled" in header
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_subagent_panel.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_subagent_panel.py
@@ -168,19 +168,21 @@ class TestLifecycle:
             rows = _render(pilot.app.query_one("#subagent-agents", Static))
             assert "dropped boom" in rows
 
-    async def test_orphan_error_after_prepare_turn_replaces_prior_turn(self) -> None:
+    async def test_orphan_error_in_new_turn_starts_fresh_panel(self) -> None:
         async with PanelApp().run_test(size=(200, 24)) as pilot:
             panel = pilot.app.query_one("#panel", SubagentPanel)
             panel.on_subagent_event(_start("a", "E1", label="old work"))
             panel.on_subagent_event(_complete("a", "E1"))
             panel.prepare_turn()
             panel.on_subagent_event(_error("orphan", "E2", message="dropped boom"))
-            panel.on_subagent_event(_start("b", "E3", label="later work"))
             await pilot.pause()
-            assert panel._phase_order == ["E2", "E3"]
+            assert panel.has_class("-visible")
+            assert panel._phase_order == ["E2"]
             assert panel._find_record("a") is None
-            assert panel._find_record("orphan") is not None
-            assert panel._find_record("b") is not None
+            record = panel._find_record("orphan")
+            assert record is not None
+            assert record.status == "error"
+            assert record.error == "dropped boom"
 
     async def test_orphan_error_becomes_active_phase(self) -> None:
         async with PanelApp().run_test(size=(200, 24)) as pilot:
@@ -406,7 +408,7 @@ class TestReset:
             assert panel._phase_order == []
             assert panel._counts() == (0, 0)
 
-    async def test_panel_persists_until_next_workflow(self) -> None:
+    async def test_prepare_turn_clears_completed_workflow(self) -> None:
         async with PanelApp().run_test() as pilot:
             panel = pilot.app.query_one("#panel", SubagentPanel)
             panel.on_subagent_event(_start("a", "E1"))
@@ -414,14 +416,15 @@ class TestReset:
             await pilot.pause()
             assert panel.has_class("-visible")
             assert panel.expanded is False
-            # A new turn begins but spawns no subagents — results persist.
+            # A new turn begins — the previous workflow's summary is stale.
             panel.prepare_turn()
             await pilot.pause()
-            assert panel.has_class("-visible")
-            assert panel._phase_order == ["E1"]
-            # The next workflow's first subagent clears the prior fan-out.
+            assert not panel.has_class("-visible")
+            assert panel._phase_order == []
+            # The next workflow starts fresh and expands.
             panel.on_subagent_event(_start("b", "E2"))
             await pilot.pause()
+            assert panel.has_class("-visible")
             assert panel._phase_order == ["E2"]
             assert panel._find_record("a") is None
             assert panel.expanded is True


### PR DESCRIPTION
Dynamic subagent panels now collapse to a compact status header when the final task ends, hide when the next turn begins, and automatically reopen for a later workflow.

---

The expanded panel can consume a large part of the terminal after its work is complete. Completion, failure, and cancellation totals remain visible in the header, while a manual collapse stays respected during the current workflow.

The collapsed summary is only relevant while the user can still act on it, so the panel clears eagerly at the next turn boundary (`prepare_turn`) instead of lingering until another workflow starts. This replaces the deferred `_pending_reset` clear, which no longer has a purpose once the panel collapses itself.

Made by [Open SWE](https://openswe.vercel.app/agents/f0ce2762-8448-3d73-edff-e3dd83696f6f)