### PR TITLE
fix(sdk): configure private state on installed `SubAgentMiddleware`

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -895,7 +895,14 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     state_schemas.extend(mw.state_schema for mw in deepagent_middleware if getattr(mw, "state_schema", None) is not None)
     private_state_keys = private_state_field_names(*state_schemas)
     if sub_agent_middleware is not None:
-        sub_agent_middleware.private_state_keys = private_state_keys
+        installed_subagent_middleware = cast(
+            "SubAgentMiddleware",
+            next(
+                (mw for mw in deepagent_middleware if mw.name == sub_agent_middleware.name),
+                sub_agent_middleware,
+            ),
+        )
+        installed_subagent_middleware.private_state_keys = private_state_keys | installed_subagent_middleware.private_state_keys
     # Verify every main-profile exclusion matched at least one middleware in
     # either the main agent stack or the GP subagent stack. An entry that
     # matched nothing across both is almost certainly a typo or a stale

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -8,14 +8,15 @@ import subprocess
 import sys
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain.agents.middleware import TodoListMiddleware
-from langchain.agents.middleware.types import AgentMiddleware
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, PrivateStateAttr
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, SystemMessage
+from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import BaseTool, StructuredTool
 
 from deepagents._api.deprecation import LangChainDeprecationWarning
@@ -37,7 +38,7 @@ from deepagents.middleware._prompt_caching import (
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
 from deepagents.middleware.async_subagents import AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
-from deepagents.middleware.subagents import SubAgent, SubAgentMiddleware, create_sub_agent
+from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware, create_sub_agent
 from deepagents.middleware.summarization import SummarizationMiddleware, _DeepAgentsSummarizationMiddleware
 from deepagents.profiles import GeneralPurposeSubagentProfile, HarnessProfile, register_harness_profile
 from deepagents.profiles.harness.harness_profiles import (
@@ -2635,6 +2636,31 @@ class TestUserMiddlewareOverride:
 
         default_index = next(i for i, m in enumerate(stack) if isinstance(m, _DeepAgentsSummarizationMiddleware))
         assert stack[default_index] is custom
+
+    def test_subagent_replacement_receives_private_state_keys(self) -> None:
+        """A user-supplied subagent middleware receives derived private keys."""
+
+        class _PrivateState(AgentState):
+            derived_private: Annotated[str | None, PrivateStateAttr]
+
+        class _PrivateMiddleware(AgentMiddleware[_PrivateState, Any, Any]):
+            state_schema = _PrivateState
+
+        subagent: CompiledSubAgent = {
+            "name": "custom",
+            "description": "Custom subagent.",
+            "runnable": RunnableLambda(lambda _state: {"messages": [AIMessage(content="done")]}),
+        }
+        custom = SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[subagent],
+            private_state_keys=frozenset({"caller_private"}),
+        )
+
+        stack = self._run([_PrivateMiddleware(), custom])
+
+        assert next(m for m in stack if isinstance(m, SubAgentMiddleware)) is custom
+        assert {"caller_private", "derived_private"} <= custom.private_state_keys
 
     def test_subagent_middleware_replaces_default(self) -> None:
         """SubAgent middleware= field also replaces same-named defaults in that subagent's stack."""


### PR DESCRIPTION
Closes #5189

Caller-supplied `SubAgentMiddleware` instances now receive all private state keys derived from the final middleware stack, preventing private state from crossing subagent boundaries.

---

`create_deep_agent` previously configured the internal default instance after `_apply_custom_middleware` could replace it by name. The installed replacement therefore kept only its constructor-provided keys.

This change resolves the installed instance from the finalized middleware stack and combines the derived keys with any keys explicitly supplied by the caller. The regression test covers both the replacement identity and preservation of caller-provided keys.

<details>
<summary>Test plan</summary>

- Full SDK unit suite: 2432 passed, 96 skipped, 4 xfailed
- Related graph and subagent tests: 165 passed, 1 skipped, 1 xfailed
- Ruff lint and format checks
- `ty` type checking

</details>
