### PR TITLE
fix(code): remove undispatched `SessionEndCause` members

### DIFF
--- a/libs/code/HOOKS.md
+++ b/libs/code/HOOKS.md
@@ -50,7 +50,7 @@ Native tools are matched by their wire names (for example `execute` → `Bash`, 
 | --- | --- | --- | --- |
 | `SessionStart` | client | `cause` | A session starts (`startup`, `resume`, `clear`, `compact`) |
 | `UserPromptSubmit` | client | _(none)_ | The user submits a prompt |
-| `SessionEnd` | client | `cause` | A session ends |
+| `SessionEnd` | client | `cause` | A session ends (`clear`, `resume`, `prompt_input_exit`, `other`) |
 | `PermissionRequest` | client | `tool_name` | The client is about to ask for tool permission |
 | `Notification` | client | `notification_type` | A client lifecycle notification is emitted |
 | `PreToolUse` | server | `tool_name` | Before a tool call runs |

--- a/libs/code/deepagents_code/hooks/models/domain.py
+++ b/libs/code/deepagents_code/hooks/models/domain.py
@@ -70,9 +70,7 @@ class SessionEndCause(StrEnum):
 
     CLEAR = "clear"
     RESUME = "resume"
-    LOGOUT = "logout"
     PROMPT_INPUT_EXIT = "prompt_input_exit"
-    BYPASS_PERMISSIONS_DISABLED = "bypass_permissions_disabled"
     OTHER = "other"
 
 

--- a/libs/code/tests/unit_tests/hooks/test_engine.py
+++ b/libs/code/tests/unit_tests/hooks/test_engine.py
@@ -350,7 +350,7 @@ def test_snapshot_rejects_invalid_matcher_at_compile_time(tmp_path: Path) -> Non
                         "hooks": [{"type": "command", "command": "bad"}],
                     },
                     {
-                        "matcher": "logout",
+                        "matcher": "clear",
                         "hooks": [{"type": "command", "command": "good"}],
                     },
                     {
@@ -415,8 +415,8 @@ def test_snapshot_rejects_matcher_for_unmatchable_event() -> None:
             },
         ),
         (
-            SessionEndEvent(event=HookEvent.SESSION_END, cause=SessionEndCause.LOGOUT),
-            {"hook_event_name": "SessionEnd", "reason": "logout"},
+            SessionEndEvent(event=HookEvent.SESSION_END, cause=SessionEndCause.CLEAR),
+            {"hook_event_name": "SessionEnd", "reason": "clear"},
         ),
         (
             PermissionRequestEvent(


### PR DESCRIPTION
Session-end hooks now expose only causes with real lifecycle dispatch sites.

---
Removes the two unreachable `SessionEndCause` members, retargets matcher/projection coverage to `clear`, and documents every valid end cause.
<details><summary>Test plan</summary>

- `make lint` (passed)
- `make test TEST_FILE=tests/unit_tests/hooks/test_engine.py` (61 passed)
- `make test` (11,647 passed; 24 environment-sensitive failures outside hooks)
</details>

Made by [Open SWE](https://openswe.vercel.app/agents/1e46818c-518d-e42a-8b9d-a429513d88ab)