### PR TITLE
style(code): `/model` footer Ctrl+N hint follows display mode

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -265,7 +265,11 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             show=False,
             priority=True,
         ),
-        Binding("ctrl+n", "toggle_names", "Model IDs", show=False, priority=True),
+        # Description stays mode-neutral because the footer hint (see
+        # `_help_text`) flips with `_show_specs` while this string cannot.
+        Binding(
+            "ctrl+n", "toggle_names", "Toggle model IDs", show=False, priority=True
+        ),
         Binding("escape", "cancel", "Cancel", show=False, priority=True),
     ]
     """Key bindings for model navigation, selection, defaulting, and cancel.
@@ -432,6 +436,9 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         # to its raw `provider:model` spec (mirrors the `/theme` picker's
         # label/key toggle) so a user can read or copy the canonical id.
         self._show_specs = False
+        # True while the footer is displaying a Ctrl+S failure notice, so other
+        # footer writers (Ctrl+N) leave it alone until its restore timer fires.
+        self._help_error_shown = False
 
         self._unfiltered_models: list[tuple[str, str]] = []
         self._recent_specs: list[str] = []
@@ -1894,6 +1901,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                         f"bold {theme.get_theme_colors(self).error}",
                     )
                 )
+                self._help_error_shown = True
                 self.set_timer(3.0, self._restore_help_text)
         elif await asyncio.to_thread(save_default_model, model_spec):
             self._default_spec = model_spec
@@ -1911,10 +1919,17 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                     f"bold {theme.get_theme_colors(self).error}",
                 )
             )
+            self._help_error_shown = True
             self.set_timer(3.0, self._restore_help_text)
 
     def _restore_help_text(self) -> None:
-        """Restore the default help text after a temporary message."""
+        """Restore the default help text after a temporary message.
+
+        Recomputes `_help_text()` rather than replaying a captured string, so
+        a timer scheduled before a Ctrl+N press still restores the hint for the
+        display mode that is current when it fires.
+        """
+        self._help_error_shown = False
         help_widget = self.query_one(".model-selector-help", Static)
         help_widget.update(self._help_text())
 
@@ -1968,16 +1983,23 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         unnecessary — and stays available in curated/onboarding mode since it
         only affects presentation.
 
-        The footer hint is rewritten too so it always advertises the mode the
-        next press switches to. That also clears any transient Ctrl+S status
-        message early, which is harmless — the message is purely informational
-        and its restore timer replays the same help line.
+        In standard mode the footer hint is rewritten so it advertises the mode
+        the next press switches to; curated mode omits the hint entirely, so
+        the refresh is a no-op there.
+
+        The refresh is skipped while a Ctrl+S *error* notice is on the footer,
+        since that notice is the only signal a save failed and the user may not
+        have read it yet. Successful Ctrl+S messages are clobbered freely. The
+        pending restore timer is never cancelled, but it is idempotent — it
+        re-renders `_help_text()` for whatever mode is current when it fires,
+        so an orphaned timer cannot resurrect a stale hint.
         """
         if not self._loaded:
             return
         self._show_specs = not self._show_specs
         self._relabel_options()
-        self._restore_help_text()
+        if not self._help_error_shown:
+            self._restore_help_text()
 
     def _relabel_options(self) -> None:
         """Rebuild each mounted row's label for the current display mode.

--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -491,6 +491,10 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         width, so the help `Static` is sized to grow (auto height) and wraps to
         two rows rather than clipping the trailing hints.
 
+        The Ctrl+N hint names what the next press *does* rather than the
+        current mode, so it reads "Ctrl+N IDs" while friendly names are shown
+        and "Ctrl+N names" once rows are flipped to raw `provider:model` specs.
+
         Returns:
             The bullet-separated help line.
         """
@@ -501,7 +505,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             "Enter select",
         ]
         if not self._curated:
-            parts.extend(("Ctrl+S set default", "Ctrl+R recommended", "Ctrl+N IDs"))
+            names_hint = "Ctrl+N names" if self._show_specs else "Ctrl+N IDs"
+            parts.extend(("Ctrl+S set default", "Ctrl+R recommended", names_hint))
         sep = f" {glyphs.bullet} "
         return sep.join(parts)
 
@@ -1962,11 +1967,17 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         toggle changes neither ordering nor selection, so a full rebuild is
         unnecessary — and stays available in curated/onboarding mode since it
         only affects presentation.
+
+        The footer hint is rewritten too so it always advertises the mode the
+        next press switches to. That also clears any transient Ctrl+S status
+        message early, which is harmless — the message is purely informational
+        and its restore timer replays the same help line.
         """
         if not self._loaded:
             return
         self._show_specs = not self._show_specs
         self._relabel_options()
+        self._restore_help_text()
 
     def _relabel_options(self) -> None:
         """Rebuild each mounted row's label for the current display mode.

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -574,6 +574,39 @@ class TestNamesToggle:
             help_text = screen.query_one(".model-selector-help", Static)
             assert "Ctrl+N" in str(help_text.content)
 
+    async def test_help_text_names_toggle_hint_follows_display_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Ctrl+N footer hint advertises what the next press switches to."""
+        from deepagents_code.tui.widgets import model_selector
+
+        monkeypatch.setattr(
+            model_selector,
+            "get_available_models",
+            lambda: {"anthropic": ["claude-sonnet-5"]},
+        )
+        monkeypatch.setattr(model_selector, "load_recent_models", list)
+
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            screen = ModelSelectorScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+
+            help_widget = screen.query_one(".model-selector-help", Static)
+            assert "Ctrl+N IDs" in str(help_widget.content)
+
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+
+            assert "Ctrl+N names" in str(help_widget.content)
+            assert "Ctrl+N IDs" not in str(help_widget.content)
+
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+
+            assert "Ctrl+N IDs" in str(help_widget.content)
+
     async def test_help_text_omits_names_toggle_in_curated_mode(self) -> None:
         """Onboarding's curated help footer should not mention Ctrl+N."""
         app = ModelSelectorTestApp()

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -606,6 +606,85 @@ class TestNamesToggle:
             await pilot.pause()
 
             assert "Ctrl+N IDs" in str(help_widget.content)
+            assert "Ctrl+N names" not in str(help_widget.content)
+
+    async def test_names_toggle_clobbers_ctrl_s_success_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pending Ctrl+S restore timer must not resurrect a stale hint.
+
+        Ctrl+N and Ctrl+S both write the footer. Toggling while a success
+        message is up replaces it immediately, and the message's uncancelled
+        3s timer must then restore the hint for the *new* mode — which only
+        holds because `_restore_help_text` recomputes rather than replaying a
+        string captured when the message was set.
+        """
+        from deepagents_code.tui.widgets import model_selector
+
+        monkeypatch.setattr(
+            model_selector,
+            "get_available_models",
+            lambda: {"anthropic": ["claude-sonnet-5"]},
+        )
+        monkeypatch.setattr(model_selector, "load_recent_models", list)
+        monkeypatch.setattr(model_selector, "save_default_model", lambda _spec: True)
+
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            screen = ModelSelectorScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            screen._default_spec = None
+
+            help_widget = screen.query_one(".model-selector-help", Static)
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            assert "Default set to" in str(help_widget.content)
+
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+            assert "Ctrl+N names" in str(help_widget.content)
+
+            # Stand in for the 3s timer the Ctrl+S message left pending.
+            screen._restore_help_text()
+            assert "Ctrl+N names" in str(help_widget.content)
+
+    async def test_names_toggle_preserves_ctrl_s_error_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ctrl+N must not wipe the only notice that saving the default failed."""
+        from deepagents_code.tui.widgets import model_selector
+
+        monkeypatch.setattr(
+            model_selector,
+            "get_available_models",
+            lambda: {"anthropic": ["claude-sonnet-5"]},
+        )
+        monkeypatch.setattr(model_selector, "load_recent_models", list)
+        monkeypatch.setattr(model_selector, "save_default_model", lambda _spec: False)
+
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            screen = ModelSelectorScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            screen._default_spec = None
+
+            help_widget = screen.query_one(".model-selector-help", Static)
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            assert "Failed to save default" in str(help_widget.content)
+
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+
+            # Rows still flip; only the footer refresh is held back.
+            assert screen._show_specs
+            assert "anthropic:claude-sonnet-5" in str(screen._option_widgets[0].content)
+            assert "Failed to save default" in str(help_widget.content)
+
+            screen._restore_help_text()
+            assert "Ctrl+N names" in str(help_widget.content)
 
     async def test_help_text_omits_names_toggle_in_curated_mode(self) -> None:
         """Onboarding's curated help footer should not mention Ctrl+N."""
@@ -642,6 +721,10 @@ class TestNamesToggle:
 
             assert screen._show_specs
             assert "anthropic:claude-sonnet-5" in str(screen._option_widgets[0].content)
+            # The toggle refreshes the footer, but curated mode advertises no
+            # Ctrl+N hint to begin with — the press must not leak one in.
+            help_widget = screen.query_one(".model-selector-help", Static)
+            assert "Ctrl+N" not in str(help_widget.content)
 
     async def test_show_specs_persists_across_filter_rebuild(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
`/model` selector footer now toggles its Ctrl+N hint between "IDs" and "names" to match the current row display mode.

---

The `/model` selector footer always read "Ctrl+N IDs", even once rows were flipped to raw `provider:model` specs, so the hint no longer described what the next press does. The hint is now derived from `_show_specs` ("Ctrl+N IDs" while friendly names show, "Ctrl+N names" while specs show) and the footer is refreshed when the toggle fires.

Made by [Open SWE](https://openswe.vercel.app/agents/d455c068-331f-2953-88b0-d3751f58b63e)