### PR TITLE
fix(code): bound Hooks v2 session-end teardown

### DIFF
--- a/libs/code/deepagents_code/_constants.py
+++ b/libs/code/deepagents_code/_constants.py
@@ -27,6 +27,9 @@ drift guards in `test_main_args` and `test_tool_catalog` pin it so a new or
 renamed SDK filesystem tool fails a test instead of silently diverging.
 """
 
+SESSION_END_DRAIN_TIMEOUT_SECONDS: Final[float] = 2.0
+"""Maximum time to drain Hooks v2 `SessionEnd` during session teardown."""
+
 SDK_DEFAULT_RUBRIC_MAX_ITERATIONS: Final[int] = 3
 """Default `RubricMiddleware.max_iterations`, shown without importing the SDK.
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -18366,7 +18366,11 @@ class DeepAgentsApp(App):
                     from deepagents_code.hooks.models.domain import SessionEndCause
 
                     client_session_end_task = asyncio.ensure_future(
-                        self._hooks.on_session_end(SessionEndCause.PROMPT_INPUT_EXIT)
+                        _wait_for_session_end(
+                            self._hooks.on_session_end(
+                                SessionEndCause.PROMPT_INPUT_EXIT
+                            )
+                        )
                     )
 
                 async def _drain_hooks() -> None:
@@ -18606,7 +18610,7 @@ class DeepAgentsApp(App):
                             )
                     if client_session_end_task is not None:
                         try:
-                            await _wait_for_session_end(client_session_end_task)
+                            await client_session_end_task
                         except BaseException:
                             logger.debug(
                                 "SessionEnd await interrupted during teardown",

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -60,6 +60,7 @@ from deepagents_code._constants import (
     DEFAULT_AGENT_NAME as DEFAULT_ASSISTANT_ID,
     MCP_REENABLED_PENDING_ERROR,
     SDK_DEFAULT_RUBRIC_MAX_ITERATIONS,
+    SESSION_END_DRAIN_TIMEOUT_SECONDS,
 )
 from deepagents_code._git import (
     read_git_branch_from_filesystem,
@@ -132,6 +133,33 @@ from deepagents_code.tui.widgets.welcome import WelcomeBanner
 logger = logging.getLogger(__name__)
 _GRACEFUL_EXIT_WAIT_SECONDS = 2.0
 _monotonic = time.monotonic
+
+
+async def _wait_for_session_end(
+    session_end: Awaitable[None],
+    *,
+    timeout_seconds: float | None = None,
+) -> None:
+    """Bound Hooks v2 `SessionEnd` while a client session is torn down.
+
+    Args:
+        session_end: Session-end invocation or its already-running task.
+        timeout_seconds: Optional timeout override for deterministic tests.
+    """
+    timeout = (
+        SESSION_END_DRAIN_TIMEOUT_SECONDS
+        if timeout_seconds is None
+        else timeout_seconds
+    )
+    try:
+        await asyncio.wait_for(session_end, timeout=timeout)
+    except TimeoutError:
+        logger.warning(
+            "SessionEnd hook drain did not finish within %ss; continuing session "
+            "teardown",
+            timeout,
+        )
+
 
 _DEFERRED_START_NOTICE = (
     "No model is configured yet. Run `/model` to choose one. "
@@ -13684,7 +13712,9 @@ class DeepAgentsApp(App):
 
             if cmd == "/force-clear":
                 self._force_interrupt_active_work()
-            await self._hooks.on_session_end(SessionEndCause.CLEAR)
+            await _wait_for_session_end(
+                self._hooks.on_session_end(SessionEndCause.CLEAR)
+            )
             self._pending_messages.clear()
             self._queued_widgets.clear()
             self._sync_status_queued()
@@ -18576,7 +18606,7 @@ class DeepAgentsApp(App):
                             )
                     if client_session_end_task is not None:
                         try:
-                            await client_session_end_task
+                            await _wait_for_session_end(client_session_end_task)
                         except BaseException:
                             logger.debug(
                                 "SessionEnd await interrupted during teardown",
@@ -20218,9 +20248,11 @@ class DeepAgentsApp(App):
                         if resume_thread_id is not None
                         else SessionEndCause.OTHER
                     )
-                    await self._hooks.on_session_end(
-                        end_cause,
-                        thread_id=previous_thread_id,
+                    await _wait_for_session_end(
+                        self._hooks.on_session_end(
+                            end_cause,
+                            thread_id=previous_thread_id,
+                        )
                     )
                     if resume_thread_id is None:
                         next_thread_id = self._session_state.reset_thread()
@@ -24625,7 +24657,9 @@ class DeepAgentsApp(App):
                     SessionStartCause,
                 )
 
-                await self._hooks.on_session_end(SessionEndCause.RESUME)
+                await _wait_for_session_end(
+                    self._hooks.on_session_end(SessionEndCause.RESUME)
+                )
                 await self._reload_hooks()
                 if not await self._run_session_start_hook(SessionStartCause.RESUME):
                     return
@@ -24667,9 +24701,11 @@ class DeepAgentsApp(App):
                 SessionStartCause,
             )
 
-            await self._hooks.on_session_end(
-                SessionEndCause.RESUME,
-                thread_id=prev_session_thread,
+            await _wait_for_session_end(
+                self._hooks.on_session_end(
+                    SessionEndCause.RESUME,
+                    thread_id=prev_session_thread,
+                )
             )
             outgoing_ended = True
 

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -40,6 +40,7 @@ from rich.style import Style
 from rich.text import Text
 
 from deepagents_code._cli_context import CLIContext
+from deepagents_code._constants import SESSION_END_DRAIN_TIMEOUT_SECONDS
 from deepagents_code._session_stats import (
     RecordedRequest,
     SessionStats,
@@ -1304,11 +1305,33 @@ async def _after_headless_compact(state: StreamState) -> None:
         )
 
 
-async def _end_headless_session(state: StreamState, cause: SessionEndCause) -> None:
+async def _end_headless_session(
+    state: StreamState,
+    cause: SessionEndCause,
+    *,
+    timeout_seconds: float = SESSION_END_DRAIN_TIMEOUT_SECONDS,
+) -> None:
+    """End a headless session without letting Hooks v2 stall process exit.
+
+    Args:
+        state: Active headless stream state.
+        cause: Reason the session ended.
+        timeout_seconds: Maximum time to wait for `SessionEnd` handlers.
+    """
     if state.session_end_fired:
         return
     state.session_end_fired = True
-    await state.hooks.on_session_end(cause)
+    try:
+        await asyncio.wait_for(
+            state.hooks.on_session_end(cause),
+            timeout=timeout_seconds,
+        )
+    except TimeoutError:
+        logger.warning(
+            "SessionEnd hook drain did not finish within %ss; continuing session "
+            "teardown",
+            timeout_seconds,
+        )
 
 
 def _dispatch_orphaned_tool_result_hooks(state: StreamState, tool_output: str) -> None:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -18777,6 +18777,7 @@ class TestExitGracefulWorkerHandoff:
 
         calls = 0
         cancelled = asyncio.Event()
+        drain_observed_cancellation = asyncio.Event()
 
         async def invoke(_invocation: object) -> SessionEndDecision:
             nonlocal calls
@@ -18787,6 +18788,13 @@ class TestExitGracefulWorkerHandoff:
                 cancelled.set()
                 raise
             return SessionEndDecision(event=HookEvent.SESSION_END)
+
+        async def drain_pending() -> None:
+            try:
+                await asyncio.wait_for(cancelled.wait(), timeout=0.1)
+            except TimeoutError:
+                return
+            drain_observed_cancellation.set()
 
         runtime = MagicMock()
         runtime.cwd = Path.cwd()
@@ -18815,6 +18823,8 @@ class TestExitGracefulWorkerHandoff:
                     "deepagents_code.app.SESSION_END_DRAIN_TIMEOUT_SECONDS",
                     0.01,
                 ),
+                patch("deepagents_code.hooks.has_pending_hooks", return_value=True),
+                patch("deepagents_code.hooks.drain_pending_hooks", new=drain_pending),
                 patch.object(App, "exit") as super_exit,
             ):
                 started = loop.time()
@@ -18828,6 +18838,7 @@ class TestExitGracefulWorkerHandoff:
 
         assert elapsed < 0.5
         assert cancelled.is_set()
+        assert drain_observed_cancellation.is_set()
         assert calls == 1
         assert any(
             record.levelno == logging.WARNING

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -18763,6 +18763,78 @@ class TestExitGracefulWorkerHandoff:
             for record in caplog.records
         )
 
+    async def test_client_session_end_timeout_is_bounded_and_at_most_once(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A slow Hooks v2 `SessionEnd` cannot stall or fire twice on TUI exit."""
+        from deepagents_code.approval_mode import ApprovalMode
+        from deepagents_code.hooks.manager import HookSessionIdentity
+        from deepagents_code.hooks.models.domain import (
+            HookEvent,
+            SessionEndDecision,
+        )
+
+        calls = 0
+        cancelled = asyncio.Event()
+
+        async def invoke(_invocation: object) -> SessionEndDecision:
+            nonlocal calls
+            calls += 1
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            return SessionEndDecision(event=HookEvent.SESSION_END)
+
+        runtime = MagicMock()
+        runtime.cwd = Path.cwd()
+        runtime.configured_events.return_value = frozenset({HookEvent.SESSION_END})
+        runtime.invoke = invoke
+        hooks = HooksManager.adopting(
+            runtime,
+            identity=lambda: HookSessionIdentity(
+                thread_id="t1",
+                approval_mode=ApprovalMode.MANUAL,
+            ),
+        )
+        app = DeepAgentsApp()
+        loop = asyncio.get_running_loop()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            if app._session_state is None:
+                app._detached_hooks = hooks
+            else:
+                app._session_state.hooks = hooks
+
+            with (
+                caplog.at_level(logging.WARNING, logger="deepagents_code.app"),
+                patch(
+                    "deepagents_code.app.SESSION_END_DRAIN_TIMEOUT_SECONDS",
+                    0.01,
+                ),
+                patch.object(App, "exit") as super_exit,
+            ):
+                started = loop.time()
+                app.exit()
+                assert app._graceful_exit_task is not None
+                await app._graceful_exit_task
+                elapsed = loop.time() - started
+                app.exit()
+
+                assert super_exit.call_count == 2
+
+        assert elapsed < 0.5
+        assert cancelled.is_set()
+        assert calls == 1
+        assert any(
+            record.levelno == logging.WARNING
+            and "SessionEnd hook drain did not finish" in record.message
+            for record in caplog.records
+        )
+
     async def test_second_exit_force_quits_pending_graceful_exit(self) -> None:
         """A second exit() during a pending graceful exit force-quits.
 

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import io
+import logging
 import signal
 import sys
 from collections.abc import AsyncIterator, Iterator, Sequence
@@ -36,6 +37,7 @@ from deepagents_code.client.non_interactive import (
     _collect_action_request_warnings,
     _compaction_result_id,
     _dispatch_orphaned_tool_result_hooks,
+    _end_headless_session,
     _make_hitl_decision,
     _make_stdio_encoding_safe,
     _process_ai_message,
@@ -59,6 +61,7 @@ from deepagents_code.hooks.models.domain import (
     HookEvent,
     PermissionEffect,
     PermissionRequestDecision,
+    SessionEndCause,
     SessionEndDecision,
     SessionStartDecision,
     UserPromptSubmitDecision,
@@ -1420,6 +1423,58 @@ def _manager(runtime: MagicMock) -> HooksManager:
             thread_id="t1",
             approval_mode=ApprovalMode.MANUAL,
         ),
+    )
+
+
+async def test_headless_session_end_timeout_is_bounded_and_at_most_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A slow Hooks v2 `SessionEnd` cannot stall or fire twice on exit."""
+    calls = 0
+    cancelled = asyncio.Event()
+
+    async def invoke(_invocation: object) -> SessionEndDecision:
+        nonlocal calls
+        calls += 1
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return SessionEndDecision(event=HookEvent.SESSION_END)
+
+    runtime = MagicMock()
+    runtime.cwd = Path.cwd()
+    runtime.configured_events.return_value = frozenset({HookEvent.SESSION_END})
+    runtime.invoke = invoke
+    state = StreamState(hooks=_manager(runtime))
+    loop = asyncio.get_running_loop()
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="deepagents_code.client.non_interactive",
+    ):
+        started = loop.time()
+        await _end_headless_session(
+            state,
+            SessionEndCause.PROMPT_INPUT_EXIT,
+            timeout_seconds=0.01,
+        )
+        elapsed = loop.time() - started
+        await _end_headless_session(
+            state,
+            SessionEndCause.PROMPT_INPUT_EXIT,
+            timeout_seconds=0.01,
+        )
+
+    assert elapsed < 0.5
+    assert cancelled.is_set()
+    assert calls == 1
+    assert state.session_end_fired
+    assert any(
+        record.levelno == logging.WARNING
+        and "SessionEnd hook drain did not finish" in record.message
+        for record in caplog.records
     )
 
 


### PR DESCRIPTION
Hooks v2 `SessionEnd` handlers now have a two-second teardown budget in headless and interactive sessions, preventing slow handlers from delaying process exit.

---

The generic hook timeout remains unchanged. Session boundaries use a dedicated bounded wait, log overruns, and preserve at-most-once delivery.

<details><summary>Test plan</summary>

- Focused headless and TUI timeout tests, plus the complete graceful-exit test class
- Ruff formatting/lint and `ty` checks for all modified files

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/8af65704-7778-df84-0c27-ad718a80ea7f)

## References
- Plan: https://openswe.vercel.app/agents/8af65704-7778-df84-0c27-ad718a80ea7f/plan