### PR TITLE
fix(code): route failures to `PostToolUseFailure`

### DIFF
--- a/libs/code/deepagents_code/hooks/capabilities.py
+++ b/libs/code/deepagents_code/hooks/capabilities.py
@@ -16,6 +16,8 @@ from deepagents_code.hooks.models.domain import (
     PermissionRequestEvent,
     PostToolUseDecision,
     PostToolUseEvent,
+    PostToolUseFailureDecision,
+    PostToolUseFailureEvent,
     PreCompactDecision,
     PreCompactEvent,
     PreToolUseDecision,
@@ -183,6 +185,18 @@ _HOOK_EVENT_SPECS: Final[Mapping[HookEvent, HookEventSpec]] = MappingProxyType(
             aggregation_policy=AggregationPolicy.FEEDBACK_AND_CONTEXT,
             supported_handler_types=frozenset({HandlerType.COMMAND}),
         ),
+        HookEvent.POST_TOOL_USE_FAILURE: HookEventSpec(
+            event=HookEvent.POST_TOOL_USE_FAILURE,
+            owner=HookOwner.SERVER,
+            event_model=PostToolUseFailureEvent,
+            decision_model=PostToolUseFailureDecision,
+            matcher_field="tool_name",
+            default_timeout_seconds=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+            exit_code_policy=ExitCodePolicy.FEEDBACK,
+            plain_output_policy=PlainOutputPolicy.IGNORE,
+            aggregation_policy=AggregationPolicy.FEEDBACK_AND_CONTEXT,
+            supported_handler_types=frozenset({HandlerType.COMMAND}),
+        ),
         HookEvent.PRE_COMPACT: HookEventSpec(
             event=HookEvent.PRE_COMPACT,
             owner=HookOwner.SERVER,
@@ -259,6 +273,8 @@ def get_event_spec(event: HookEvent) -> HookEventSpec:
             return _HOOK_EVENT_SPECS[HookEvent.PRE_TOOL_USE]
         case HookEvent.POST_TOOL_USE:
             return _HOOK_EVENT_SPECS[HookEvent.POST_TOOL_USE]
+        case HookEvent.POST_TOOL_USE_FAILURE:
+            return _HOOK_EVENT_SPECS[HookEvent.POST_TOOL_USE_FAILURE]
         case HookEvent.PRE_COMPACT:
             return _HOOK_EVENT_SPECS[HookEvent.PRE_COMPACT]
         case HookEvent.STOP:

--- a/libs/code/deepagents_code/hooks/models/domain.py
+++ b/libs/code/deepagents_code/hooks/models/domain.py
@@ -43,6 +43,7 @@ class HookEvent(StrEnum):
     NOTIFICATION = "Notification"
     PRE_TOOL_USE = "PreToolUse"
     POST_TOOL_USE = "PostToolUse"
+    POST_TOOL_USE_FAILURE = "PostToolUseFailure"
     PRE_COMPACT = "PreCompact"
     STOP = "Stop"
     SUBAGENT_START = "SubagentStart"
@@ -253,6 +254,16 @@ class PostToolUseEvent(_DomainModel):
         )
 
 
+class PostToolUseFailureEvent(_DomainModel):
+    """Domain payload for `PostToolUseFailure`."""
+
+    event: Literal[HookEvent.POST_TOOL_USE_FAILURE]
+    call: ToolCallData
+    error: str
+    is_interrupt: bool = False
+    duration_ms: int | None = None
+
+
 class PreCompactEvent(_DomainModel):
     """Domain payload for `PreCompact`."""
 
@@ -306,6 +317,7 @@ HookDomainEvent: TypeAlias = Annotated[
     | NotificationEvent
     | PreToolUseEvent
     | PostToolUseEvent
+    | PostToolUseFailureEvent
     | PreCompactEvent
     | StopEvent
     | SubagentStartEvent
@@ -399,6 +411,14 @@ class PostToolUseDecision(BaseHookDecision):
     context: list[str] = Field(default_factory=list)
 
 
+class PostToolUseFailureDecision(BaseHookDecision):
+    """Decision returned for `PostToolUseFailure`."""
+
+    event: Literal[HookEvent.POST_TOOL_USE_FAILURE]
+    feedback: list[str] = Field(default_factory=list)
+    context: list[str] = Field(default_factory=list)
+
+
 class PreCompactDecision(BaseHookDecision):
     """Decision returned for `PreCompact`."""
 
@@ -435,6 +455,7 @@ HookDecision: TypeAlias = Annotated[
     | NotificationDecision
     | PreToolUseDecision
     | PostToolUseDecision
+    | PostToolUseFailureDecision
     | PreCompactDecision
     | StopDecision
     | SubagentStartDecision

--- a/libs/code/deepagents_code/hooks/models/wire.py
+++ b/libs/code/deepagents_code/hooks/models/wire.py
@@ -287,6 +287,18 @@ class PostToolUseWireInput(BaseHookWireInput):
     duration_ms: int | None = None
 
 
+class PostToolUseFailureWireInput(BaseHookWireInput):
+    """Wire input for `PostToolUseFailure`."""
+
+    hook_event_name: Literal[HookEvent.POST_TOOL_USE_FAILURE]
+    tool_name: str
+    tool_input: JsonObject
+    tool_use_id: str
+    error: str
+    is_interrupt: bool | None = None
+    duration_ms: int | None = None
+
+
 class PreCompactWireInput(BaseHookWireInput):
     """Wire input for `PreCompact`."""
 
@@ -334,6 +346,7 @@ HookWireInput: TypeAlias = Annotated[
     | NotificationWireInput
     | PreToolUseWireInput
     | PostToolUseWireInput
+    | PostToolUseFailureWireInput
     | PreCompactWireInput
     | StopWireInput
     | SubagentStartWireInput
@@ -425,6 +438,13 @@ class PostToolUseSpecificOutput(_WireModel):
     )
 
 
+class PostToolUseFailureSpecificOutput(_WireModel):
+    """Event-specific output for `PostToolUseFailure`."""
+
+    hook_event_name: Literal["PostToolUseFailure"] = Field(alias="hookEventName")
+    additional_context: str | None = Field(default=None, alias="additionalContext")
+
+
 class StopSpecificOutput(_WireModel):
     """Event-specific output for `Stop`."""
 
@@ -452,6 +472,7 @@ HookSpecificOutput: TypeAlias = Annotated[
     | PreToolUseSpecificOutput
     | PermissionRequestSpecificOutput
     | PostToolUseSpecificOutput
+    | PostToolUseFailureSpecificOutput
     | StopSpecificOutput
     | SubagentStartSpecificOutput
     | SubagentStopSpecificOutput,

--- a/libs/code/deepagents_code/hooks/projection.py
+++ b/libs/code/deepagents_code/hooks/projection.py
@@ -13,6 +13,7 @@ from deepagents_code.hooks.models.domain import (
     NotificationEvent,
     PermissionRequestEvent,
     PostToolUseEvent,
+    PostToolUseFailureEvent,
     PreCompactEvent,
     PreToolUseEvent,
     SessionEndEvent,
@@ -27,6 +28,7 @@ from deepagents_code.hooks.models.wire import (
     Effort,
     NotificationWireInput,
     PermissionRequestWireInput,
+    PostToolUseFailureWireInput,
     PostToolUseWireInput,
     PreCompactWireInput,
     PreToolUseWireInput,
@@ -215,6 +217,26 @@ def _project_post_tool_use(
         tool_input=tool_input,
         tool_response=event.result,
         tool_use_id=event.call.id,
+        duration_ms=event.duration_ms,
+    )
+
+
+@_project_event.register(PostToolUseFailureEvent)
+def _project_post_tool_use_failure(
+    event: PostToolUseFailureEvent,
+    invocation: HookInvocation,
+    transcript_path: Path,
+    _agent_transcript_path: Path | None,
+) -> HookWireInput:
+    tool_name, tool_input = to_wire_call(event.call)
+    return PostToolUseFailureWireInput(
+        **_base_fields(invocation, transcript_path),
+        hook_event_name=HookEvent.POST_TOOL_USE_FAILURE,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        tool_use_id=event.call.id,
+        error=event.error,
+        is_interrupt=event.is_interrupt,
         duration_ms=event.duration_ms,
     )
 

--- a/libs/code/deepagents_code/hooks/reducer.py
+++ b/libs/code/deepagents_code/hooks/reducer.py
@@ -20,6 +20,7 @@ from deepagents_code.hooks.models.domain import (
     PermissionEffect,
     PermissionRequestDecision,
     PostToolUseDecision,
+    PostToolUseFailureDecision,
     PreCompactDecision,
     PreToolUseDecision,
     SessionEndDecision,
@@ -35,6 +36,7 @@ from deepagents_code.hooks.models.wire import (
     HookSpecificOutput,
     PermissionAllow,
     PermissionRequestSpecificOutput,
+    PostToolUseFailureSpecificOutput,
     PostToolUseSpecificOutput,
     PreToolUseSpecificOutput,
     SessionStartSpecificOutput,
@@ -398,6 +400,16 @@ def _merge_post_tool_use(
 
 
 @_merge_specific.register
+def _merge_post_tool_use_failure(
+    specific: PostToolUseFailureSpecificOutput,
+    _invocation: HookInvocation,
+    state: _Reduction,
+    _handler_id: str,
+) -> None:
+    _append(state.context, specific.additional_context)
+
+
+@_merge_specific.register
 def _merge_stop(
     specific: StopSpecificOutput,
     invocation: HookInvocation,
@@ -506,6 +518,13 @@ def _decision(invocation: HookInvocation, state: _Reduction) -> HookDecision:
         )
     if event is HookEvent.POST_TOOL_USE:
         return PostToolUseDecision(
+            event=event,
+            feedback=state.feedback,
+            context=state.context,
+            **common,
+        )
+    if event is HookEvent.POST_TOOL_USE_FAILURE:
+        return PostToolUseFailureDecision(
             event=event,
             feedback=state.feedback,
             context=state.context,

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -1,7 +1,7 @@
 """Server-owned Hooks v2 lifecycle middleware.
 
-Emits `PreCompact`, `PreToolUse`, `PostToolUse`, `Stop`, `SubagentStart`, and
-`SubagentStop` through the LangGraph interrupt channel so the client runtime can
+Emits tool, compaction, stop, and subagent lifecycle events through the LangGraph
+interrupt channel so the client runtime can
 execute matching handlers and return typed decisions.
 """
 
@@ -62,6 +62,8 @@ from deepagents_code.hooks.models.domain import (
     PermissionEffect,
     PostToolUseDecision,
     PostToolUseEvent,
+    PostToolUseFailureDecision,
+    PostToolUseFailureEvent,
     PreCompactDecision,
     PreCompactEvent,
     PreToolUseDecision,
@@ -478,22 +480,38 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
         result: ToolMessage | Command[Any],
         duration_ms: int,
     ) -> ToolMessage | Command[Any]:
-        if not _event_enabled(gate, HookEvent.POST_TOOL_USE):
+        failed = _tool_result_failed(result, call)
+        event = HookEvent.POST_TOOL_USE_FAILURE if failed else HookEvent.POST_TOOL_USE
+        if not _event_enabled(gate, event):
             return result
-        if _tool_result_failed(result, call.id):
-            return result
-        decision = _invoke_hook(
-            context,
-            PostToolUseEvent.from_tool_result(
-                result,
-                call=call,
-                duration_ms=duration_ms,
-            ),
-            gate=gate,
-            config=config,
-            deadline=self._default_deadline,
-        )
-        decision = _require_decision(decision, PostToolUseDecision)
+        if failed:
+            decision = _invoke_hook(
+                context,
+                PostToolUseFailureEvent(
+                    event=HookEvent.POST_TOOL_USE_FAILURE,
+                    call=call,
+                    error=_tool_result_text(result, call.id),
+                    is_interrupt=False,
+                    duration_ms=duration_ms,
+                ),
+                gate=gate,
+                config=config,
+                deadline=self._default_deadline,
+            )
+            decision = _require_decision(decision, PostToolUseFailureDecision)
+        else:
+            decision = _invoke_hook(
+                context,
+                PostToolUseEvent.from_tool_result(
+                    result,
+                    call=call,
+                    duration_ms=duration_ms,
+                ),
+                gate=gate,
+                config=config,
+                deadline=self._default_deadline,
+            )
+            decision = _require_decision(decision, PostToolUseDecision)
         return _apply_post_tool_use(result, decision, call.id)
 
     def _maybe_subagent_stop(
@@ -653,6 +671,7 @@ def _invoke_hook(
     event: (
         PreToolUseEvent
         | PostToolUseEvent
+        | PostToolUseFailureEvent
         | PreCompactEvent
         | StopEvent
         | SubagentStartEvent
@@ -770,6 +789,7 @@ def _invocation_id(
     event: (
         PreToolUseEvent
         | PostToolUseEvent
+        | PostToolUseFailureEvent
         | PreCompactEvent
         | StopEvent
         | SubagentStartEvent
@@ -797,6 +817,7 @@ def _logical_event_identity(
     event: (
         PreToolUseEvent
         | PostToolUseEvent
+        | PostToolUseFailureEvent
         | PreCompactEvent
         | StopEvent
         | SubagentStartEvent
@@ -805,7 +826,7 @@ def _logical_event_identity(
     *,
     logical_event_id: str | None = None,
 ) -> str:
-    if isinstance(event, PreToolUseEvent | PostToolUseEvent):
+    if isinstance(event, PreToolUseEvent | PostToolUseEvent | PostToolUseFailureEvent):
         return event.call.id
     if isinstance(event, PreCompactEvent):
         if logical_event_id:
@@ -954,7 +975,7 @@ def _append_message_text(
 
 def _apply_post_tool_use(
     result: ToolMessage | Command[Any],
-    decision: PostToolUseDecision,
+    decision: PostToolUseDecision | PostToolUseFailureDecision,
     call_id: str,
 ) -> ToolMessage | Command[Any]:
     extras: list[str] = []
@@ -1006,12 +1027,20 @@ def _append_tool_result_text(
     return replace(result, update={**update, "messages": messages})
 
 
-def _tool_result_failed(result: ToolMessage | Command[Any], call_id: str) -> bool:
-    if isinstance(result, ToolMessage):
-        return result.status == "error"
+def _tool_result_failed(result: ToolMessage | Command[Any], call: ToolCallData) -> bool:
+    messages = (
+        [result] if isinstance(result, ToolMessage) else _command_messages(result)
+    )
     return any(
-        _is_call_result(message, call_id) and message.status == "error"
-        for message in _command_messages(result)
+        _is_call_result(message, call.id)
+        and (
+            message.status == "error"
+            or (
+                call.name == "execute"
+                and "[Command failed with exit code " in str(message.content)
+            )
+        )
+        for message in messages
     )
 
 

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -1,8 +1,8 @@
 """Server-owned Hooks v2 lifecycle middleware.
 
-Emits tool, compaction, stop, and subagent lifecycle events through the LangGraph
-interrupt channel so the client runtime can
-execute matching handlers and return typed decisions.
+Emits `PreCompact`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `Stop`,
+`SubagentStart`, and `SubagentStop` through the LangGraph interrupt channel so the
+client runtime can execute matching handlers and return typed decisions.
 """
 
 from __future__ import annotations
@@ -485,33 +485,30 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
         if not _event_enabled(gate, event):
             return result
         if failed:
-            decision = _invoke_hook(
-                context,
-                PostToolUseFailureEvent(
-                    event=HookEvent.POST_TOOL_USE_FAILURE,
-                    call=call,
-                    error=_tool_result_text(result, call.id),
-                    is_interrupt=False,
-                    duration_ms=duration_ms,
-                ),
-                gate=gate,
-                config=config,
-                deadline=self._default_deadline,
+            event = PostToolUseFailureEvent(
+                event=HookEvent.POST_TOOL_USE_FAILURE,
+                call=call,
+                error=_tool_result_text(result, call.id),
+                duration_ms=duration_ms,
             )
-            decision = _require_decision(decision, PostToolUseFailureDecision)
+            expected = PostToolUseFailureDecision
         else:
-            decision = _invoke_hook(
+            event = PostToolUseEvent.from_tool_result(
+                result,
+                call=call,
+                duration_ms=duration_ms,
+            )
+            expected = PostToolUseDecision
+        decision = _require_decision(
+            _invoke_hook(
                 context,
-                PostToolUseEvent.from_tool_result(
-                    result,
-                    call=call,
-                    duration_ms=duration_ms,
-                ),
+                event,
                 gate=gate,
                 config=config,
                 deadline=self._default_deadline,
-            )
-            decision = _require_decision(decision, PostToolUseDecision)
+            ),
+            expected,
+        )
         return _apply_post_tool_use(result, decision, call.id)
 
     def _maybe_subagent_stop(

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import time
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
@@ -98,6 +99,11 @@ _PRE_TOOL_STATE_KEY = "_hooks_pre_tool_outcomes"
 _TASK_TOOL_NAME = "task"
 _COMPACT_TOOL_NAME = "compact_conversation"
 _INVOCATION_NAMESPACE = UUID("f2896d18-cf2a-4e7d-b11a-d5b10fc0e335")
+_EXECUTE_STATUS_RE = re.compile(
+    r"^\[Command (?P<outcome>failed|succeeded) with exit code -?\d+\]$",
+    re.MULTILINE,
+)
+_OFFLOADED_TOOL_RESULT_PREFIX = "Tool result too large, the result of this tool call "
 
 PreToolBehavior: TypeAlias = Literal["allow", "deny", "none"]
 _DEFAULT_DENY_REASON = "Blocked by PreToolUse hook"
@@ -281,9 +287,16 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
         with _subagent_transcript_config(call, request.runtime.config):
             result = handler(request)
         duration_ms = int((time.perf_counter() - started) * 1000)
+        failed = _tool_result_failed(result, call)
         result = _append_message_text(result, pre.context, call.id)
         result = self._maybe_post_tool_use(
-            call, context, gate, request.runtime.config, result, duration_ms
+            call,
+            context,
+            gate,
+            request.runtime.config,
+            result,
+            duration_ms,
+            failed=failed,
         )
         return self._maybe_subagent_stop(
             call, context, gate, request.runtime.config, result
@@ -315,9 +328,16 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
         with _subagent_transcript_config(call, request.runtime.config):
             result = await handler(request)
         duration_ms = int((time.perf_counter() - started) * 1000)
+        failed = _tool_result_failed(result, call)
         result = _append_message_text(result, pre.context, call.id)
         result = self._maybe_post_tool_use(
-            call, context, gate, request.runtime.config, result, duration_ms
+            call,
+            context,
+            gate,
+            request.runtime.config,
+            result,
+            duration_ms,
+            failed=failed,
         )
         return self._maybe_subagent_stop(
             call, context, gate, request.runtime.config, result
@@ -479,8 +499,9 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
         config: Mapping[str, Any] | None,
         result: ToolMessage | Command[Any],
         duration_ms: int,
+        *,
+        failed: bool,
     ) -> ToolMessage | Command[Any]:
-        failed = _tool_result_failed(result, call)
         event = HookEvent.POST_TOOL_USE_FAILURE if failed else HookEvent.POST_TOOL_USE
         if not _event_enabled(gate, event):
             return result
@@ -1034,11 +1055,25 @@ def _tool_result_failed(result: ToolMessage | Command[Any], call: ToolCallData) 
             message.status == "error"
             or (
                 call.name == "execute"
-                and "[Command failed with exit code " in str(message.content)
+                and _execute_result_failed(message.content, call.id)
             )
         )
         for message in messages
     )
+
+
+def _execute_result_failed(content: object, call_id: str) -> bool:
+    if not isinstance(content, str):
+        return False
+    statuses = list(_EXECUTE_STATUS_RE.finditer(content))
+    if not statuses:
+        return False
+    offloaded_prefix = (
+        f"{_OFFLOADED_TOOL_RESULT_PREFIX}{call_id} was saved in the filesystem"
+        " at this path: "
+    )
+    status = statuses[0] if content.startswith(offloaded_prefix) else statuses[-1]
+    return status["outcome"] == "failed"
 
 
 def _command_messages(result: Command[Any]) -> Sequence[object]:

--- a/libs/code/deepagents_code/hooks/snapshot.py
+++ b/libs/code/deepagents_code/hooks/snapshot.py
@@ -16,6 +16,7 @@ from deepagents_code.hooks.models.domain import (
     NotificationEvent,
     PermissionRequestEvent,
     PostToolUseEvent,
+    PostToolUseFailureEvent,
     PreCompactEvent,
     PreToolUseEvent,
     SessionEndEvent,
@@ -256,7 +257,11 @@ def _match_target(
 ) -> str | None:
     event = invocation.event
     if matcher_field == "tool_name" and isinstance(
-        event, PermissionRequestEvent | PreToolUseEvent | PostToolUseEvent
+        event,
+        PermissionRequestEvent
+        | PreToolUseEvent
+        | PostToolUseEvent
+        | PostToolUseFailureEvent,
     ):
         return to_wire_tool_name(event.call.name, mcp_server=event.call.mcp_server)
     if matcher_field == "notification_type" and isinstance(event, NotificationEvent):

--- a/libs/code/tests/unit_tests/hooks/models/test_models.py
+++ b/libs/code/tests/unit_tests/hooks/models/test_models.py
@@ -87,6 +87,16 @@ _WIRE_INPUTS = [
     },
     {
         **_COMMON_WIRE_INPUT,
+        "hook_event_name": "PostToolUseFailure",
+        "tool_name": "Bash",
+        "tool_input": {"command": "exit 42"},
+        "tool_use_id": "call-3",
+        "error": "Command exited with non-zero status code 42",
+        "is_interrupt": False,
+        "duration_ms": 15,
+    },
+    {
+        **_COMMON_WIRE_INPUT,
         "hook_event_name": "PreCompact",
         "trigger": "manual",
         "custom_instructions": "Keep the implementation plan",
@@ -183,6 +193,10 @@ _SPECIFIC_OUTPUTS = [
         "hookEventName": "PostToolUse",
         "additionalContext": "Check the formatter output",
         "updatedMCPToolOutput": {"content": "deferred"},
+    },
+    {
+        "hookEventName": "PostToolUseFailure",
+        "additionalContext": "Try a different command",
     },
     {
         "hookEventName": "Stop",

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -743,6 +743,7 @@ def test_post_tool_use_updates_successful_command_result(
         {"configurable": {"thread_id": "thread-1"}},
         result,
         5,
+        failed=False,
     )
 
     assert isinstance(updated, Command)
@@ -802,6 +803,22 @@ def test_tool_result_failed_ignores_unrelated_failure() -> None:
     )
 
 
+def test_successful_execute_ignores_failure_marker_in_stdout() -> None:
+    result = ToolMessage(
+        content=(
+            "[Command failed with exit code 42]\n[Command succeeded with exit code 0]"
+        ),
+        name="execute",
+        tool_call_id="c1",
+        status="success",
+    )
+
+    assert (
+        _tool_result_failed(result, ToolCallData(id="c1", name="execute", args={}))
+        is False
+    )
+
+
 def test_failed_execute_routes_to_post_tool_use_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -836,6 +853,7 @@ def test_failed_execute_routes_to_post_tool_use_failure(
         {"configurable": {"thread_id": "thread-1"}},
         result,
         5,
+        failed=True,
     )
 
     invoke.assert_called_once()

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -822,8 +822,8 @@ def test_failed_execute_routes_to_post_tool_use_failure(
         invoke,
     )
 
-    updated = middleware._maybe_post_tool_use(
-        ToolCallData(id="c1", name="execute", args={"command": "bash -c 'exit 42'"}),
+    middleware._maybe_post_tool_use(
+        ToolCallData(id="c1", name="execute", args={}),
         HookContext(
             thread_id="thread-1",
             cwd=Path("/tmp"),
@@ -831,18 +831,17 @@ def test_failed_execute_routes_to_post_tool_use_failure(
         ),
         {
             "snapshot_id": "snap",
-            "events": frozenset({"PostToolUse", "PostToolUseFailure"}),
+            "events": frozenset({"PostToolUseFailure"}),
         },
         {"configurable": {"thread_id": "thread-1"}},
         result,
         5,
     )
 
-    assert updated is result
+    invoke.assert_called_once()
     event = invoke.call_args.args[1]
     assert isinstance(event, PostToolUseFailureEvent)
     assert event.error == result.content
-    assert event.is_interrupt is False
     assert event.duration_ms == 5
 
 

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -49,6 +49,8 @@ from deepagents_code.hooks.models.domain import (
     HookInvocation,
     PermissionEffect,
     PostToolUseDecision,
+    PostToolUseFailureDecision,
+    PostToolUseFailureEvent,
     PreCompactDecision,
     PreCompactEvent,
     PreToolUseDecision,
@@ -790,41 +792,58 @@ def test_tool_result_text_reads_only_matching_call() -> None:
 def test_tool_result_failed_ignores_unrelated_failure() -> None:
     result = _multi_result_command()
 
-    assert _tool_result_failed(result, "c1") is False
-    assert _tool_result_failed(result, "c2") is True
+    assert (
+        _tool_result_failed(result, ToolCallData(id="c1", name="execute", args={}))
+        is False
+    )
+    assert (
+        _tool_result_failed(result, ToolCallData(id="c2", name="execute", args={}))
+        is True
+    )
 
 
-def test_post_tool_use_skips_failed_tool_message(
+def test_failed_execute_routes_to_post_tool_use_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     middleware = ServerHooksMiddleware(cwd=Path("/tmp"))
     result = ToolMessage(
-        content="failed",
+        content="<no output>\n[Command failed with exit code 42]",
         name="execute",
         tool_call_id="c1",
-        status="error",
+        status="success",
     )
-    invoke = MagicMock()
+    invoke = MagicMock(
+        return_value=PostToolUseFailureDecision(
+            event=HookEvent.POST_TOOL_USE_FAILURE,
+        )
+    )
     monkeypatch.setattr(
         "deepagents_code.hooks.server_middleware._invoke_hook",
         invoke,
     )
 
     updated = middleware._maybe_post_tool_use(
-        ToolCallData(id="c1", name="execute", args={}),
+        ToolCallData(id="c1", name="execute", args={"command": "bash -c 'exit 42'"}),
         HookContext(
             thread_id="thread-1",
             cwd=Path("/tmp"),
             approval_mode=ApprovalMode.MANUAL,
         ),
-        {"snapshot_id": "snap", "events": frozenset({"PostToolUse"})},
+        {
+            "snapshot_id": "snap",
+            "events": frozenset({"PostToolUse", "PostToolUseFailure"}),
+        },
         {"configurable": {"thread_id": "thread-1"}},
         result,
         5,
     )
 
     assert updated is result
-    invoke.assert_not_called()
+    event = invoke.call_args.args[1]
+    assert isinstance(event, PostToolUseFailureEvent)
+    assert event.error == result.content
+    assert event.is_interrupt is False
+    assert event.duration_ms == 5
 
 
 def test_append_pretool_context_to_result() -> None:


### PR DESCRIPTION
Failed tool calls now emit `PostToolUseFailure` with top-level error metadata, while `PostToolUse` remains success-only.

---

This matches Claude Code routing and handles nonzero `execute` results from the pinned SDK.

<details>
<summary>Test plan</summary>

- `make lint`
- 150 focused hook tests

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/019fc8bb-156a-74a8-aa5a-6050b62a94a8)