### PR TITLE
fix(code): surface hook stops without agent errors

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -15702,6 +15702,7 @@ class DeepAgentsApp(App):
         self._agent_turn_started = True
 
         from deepagents_code.config import settings
+        from deepagents_code.hooks.client_lifecycle import ClientHookStopError
         from deepagents_code.resume_state import RUBRIC_RESULT_VALUES
         from deepagents_code.tui.textual_adapter import (
             RubricEvaluationEnd,
@@ -15882,6 +15883,13 @@ class DeepAgentsApp(App):
             except Exception:
                 logger.exception("Failed to close/regroup tool group at turn end")
             task_succeeded = True
+        except ClientHookStopError as exc:
+            message = f"Operation stopped by hook: {exc}"
+            logger.info("Operation stopped by hook: %s", exc)
+            if self._ui_adapter:
+                self._ui_adapter.finalize_pending_tools_as_rejected(str(exc))
+            with suppress(Exception):
+                await self._mount_message(AppMessage(message))
         except Exception as e:  # Resilient tool rendering
             if not streaming_started:
                 # Nothing was ever sent to the agent, so this is a local TUI or

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -15703,6 +15703,7 @@ class DeepAgentsApp(App):
 
         from deepagents_code.config import settings
         from deepagents_code.hooks.client_lifecycle import ClientHookStopError
+        from deepagents_code.hooks.presenter import format_hook_stop_message
         from deepagents_code.resume_state import RUBRIC_RESULT_VALUES
         from deepagents_code.tui.textual_adapter import (
             RubricEvaluationEnd,
@@ -15884,8 +15885,8 @@ class DeepAgentsApp(App):
                 logger.exception("Failed to close/regroup tool group at turn end")
             task_succeeded = True
         except ClientHookStopError as exc:
-            message = f"Operation stopped by hook: {exc}"
-            logger.info("Operation stopped by hook: %s", exc)
+            message = format_hook_stop_message(exc)
+            logger.info("%s", message)
             if self._ui_adapter:
                 self._ui_adapter.finalize_pending_tools_as_rejected(str(exc))
             with suppress(Exception):

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -15703,7 +15703,6 @@ class DeepAgentsApp(App):
 
         from deepagents_code.config import settings
         from deepagents_code.hooks.client_lifecycle import ClientHookStopError
-        from deepagents_code.hooks.presenter import format_hook_stop_message
         from deepagents_code.resume_state import RUBRIC_RESULT_VALUES
         from deepagents_code.tui.textual_adapter import (
             RubricEvaluationEnd,
@@ -15885,12 +15884,10 @@ class DeepAgentsApp(App):
                 logger.exception("Failed to close/regroup tool group at turn end")
             task_succeeded = True
         except ClientHookStopError as exc:
-            message = format_hook_stop_message(exc)
-            logger.info("%s", message)
-            if self._ui_adapter:
-                self._ui_adapter.finalize_pending_tools_as_rejected(str(exc))
             with suppress(Exception):
-                await self._mount_message(AppMessage(message))
+                await self._mount_message(
+                    AppMessage(f"Operation stopped by hook: {exc}")
+                )
         except Exception as e:  # Resilient tool rendering
             if not streaming_started:
                 # Nothing was ever sent to the agent, so this is a local TUI or

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -2048,6 +2048,7 @@ async def run_non_interactive(
 
     from deepagents_code.client.launch.server_manager import server_session
     from deepagents_code.hooks.client_lifecycle import ClientHookStopError
+    from deepagents_code.hooks.presenter import format_hook_stop_message
 
     # Launch MCP preload concurrently with server startup
     mcp_task: asyncio.Task[Any] | None = None
@@ -2201,11 +2202,9 @@ async def run_non_interactive(
         console.print("\n[yellow]Interrupted[/yellow]")
         return 130
     except ClientHookStopError as exc:
-        logger.info("Operation stopped by hook: %s", exc)
-        console.print(
-            Text(f"\nOperation stopped by hook: {exc}", style="yellow"),
-            highlight=False,
-        )
+        message = format_hook_stop_message(exc)
+        logger.info("%s", message)
+        console.print(Text(f"\n{message}", style="yellow"), highlight=False)
         return 0
     except HITLIterationLimitError as e:
         console.print(f"\n[red]{escape_markup(str(e))}[/red]")

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -2201,10 +2201,7 @@ async def run_non_interactive(
         console.print("\n[yellow]Interrupted[/yellow]")
         return 130
     except ClientHookStopError as exc:
-        console.print(
-            Text(f"\nOperation stopped by hook: {exc}", style="yellow"),
-            highlight=False,
-        )
+        console.print(Text(f"\nOperation stopped by hook: {exc}", style="yellow"))
         return 0
     except HITLIterationLimitError as e:
         console.print(f"\n[red]{escape_markup(str(e))}[/red]")

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -2048,7 +2048,6 @@ async def run_non_interactive(
 
     from deepagents_code.client.launch.server_manager import server_session
     from deepagents_code.hooks.client_lifecycle import ClientHookStopError
-    from deepagents_code.hooks.presenter import format_hook_stop_message
 
     # Launch MCP preload concurrently with server startup
     mcp_task: asyncio.Task[Any] | None = None
@@ -2202,9 +2201,10 @@ async def run_non_interactive(
         console.print("\n[yellow]Interrupted[/yellow]")
         return 130
     except ClientHookStopError as exc:
-        message = format_hook_stop_message(exc)
-        logger.info("%s", message)
-        console.print(Text(f"\n{message}", style="yellow"), highlight=False)
+        console.print(
+            Text(f"\nOperation stopped by hook: {exc}", style="yellow"),
+            highlight=False,
+        )
         return 0
     except HITLIterationLimitError as e:
         console.print(f"\n[red]{escape_markup(str(e))}[/red]")

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -1912,9 +1912,9 @@ async def run_non_interactive(
             commands without an explicit `--trust-project-hooks` opt-in.
 
     Returns:
-        Exit code: 0 for success, 1 for error, 124 when the `--max-turns`
-            budget was exceeded (matching GNU `timeout`), 130 for keyboard
-            interrupt.
+        Exit code: 0 for success or an intentional hook stop, 1 for error, 124
+            when the `--max-turns` budget was exceeded (matching GNU `timeout`),
+            130 for keyboard interrupt.
     """
     _make_stdio_encoding_safe()
 
@@ -2047,6 +2047,7 @@ async def run_non_interactive(
         console.print(header)
 
     from deepagents_code.client.launch.server_manager import server_session
+    from deepagents_code.hooks.client_lifecycle import ClientHookStopError
 
     # Launch MCP preload concurrently with server startup
     mcp_task: asyncio.Task[Any] | None = None
@@ -2199,6 +2200,13 @@ async def run_non_interactive(
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted[/yellow]")
         return 130
+    except ClientHookStopError as exc:
+        logger.info("Operation stopped by hook: %s", exc)
+        console.print(
+            Text(f"\nOperation stopped by hook: {exc}", style="yellow"),
+            highlight=False,
+        )
+        return 0
     except HITLIterationLimitError as e:
         console.print(f"\n[red]{escape_markup(str(e))}[/red]")
         console.print(

--- a/libs/code/deepagents_code/hooks/presenter.py
+++ b/libs/code/deepagents_code/hooks/presenter.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from deepagents_code.hooks.client_lifecycle import ClientHookStopError
     from deepagents_code.hooks.models.domain import (
         HookDecision,
         HookDiagnostic,
@@ -27,6 +28,18 @@ logger = logging.getLogger(__name__)
 
 HookNoticeSeverity: TypeAlias = Literal["information", "warning", "error"]
 DiagnosticKey: TypeAlias = tuple[str, str, str, str | None, str | None]
+
+
+def format_hook_stop_message(error: ClientHookStopError) -> str:
+    """Distinguish an intentional hook stop from an agent failure.
+
+    Args:
+        error: Hook stop carrying the user-facing reason.
+
+    Returns:
+        Neutral hook-stop text shared by interactive and headless clients.
+    """
+    return f"Operation stopped by hook: {error}"
 
 
 class HookNoticeCallback(Protocol):

--- a/libs/code/deepagents_code/hooks/presenter.py
+++ b/libs/code/deepagents_code/hooks/presenter.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from deepagents_code.hooks.client_lifecycle import ClientHookStopError
     from deepagents_code.hooks.models.domain import (
         HookDecision,
         HookDiagnostic,
@@ -28,18 +27,6 @@ logger = logging.getLogger(__name__)
 
 HookNoticeSeverity: TypeAlias = Literal["information", "warning", "error"]
 DiagnosticKey: TypeAlias = tuple[str, str, str, str | None, str | None]
-
-
-def format_hook_stop_message(error: ClientHookStopError) -> str:
-    """Distinguish an intentional hook stop from an agent failure.
-
-    Args:
-        error: Hook stop carrying the user-facing reason.
-
-    Returns:
-        Neutral hook-stop text shared by interactive and headless clients.
-    """
-    return f"Operation stopped by hook: {error}"
 
 
 class HookNoticeCallback(Protocol):

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -437,11 +437,9 @@ def _reject_tracked_rows(
     """
     rejected = _pop_rows_not_awaiting_deferred_result(adapter._current_tool_messages)
     for tool_msg in rejected.values():
-        try:
+        with contextlib.suppress(Exception):
             tool_msg.set_rejected(reason=reason)
             adapter._sync_tool_widget(tool_msg)
-        except Exception:
-            logger.exception("Failed to mark tool row rejected during cleanup")
     return _dispatch_terminal_tool_result_hooks(rejected, "Tool approval rejected")
 
 

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -437,8 +437,11 @@ def _reject_tracked_rows(
     """
     rejected = _pop_rows_not_awaiting_deferred_result(adapter._current_tool_messages)
     for tool_msg in rejected.values():
-        tool_msg.set_rejected(reason=reason)
-        adapter._sync_tool_widget(tool_msg)
+        try:
+            tool_msg.set_rejected(reason=reason)
+            adapter._sync_tool_widget(tool_msg)
+        except Exception:
+            logger.exception("Failed to mark tool row rejected during cleanup")
     return _dispatch_terminal_tool_result_hooks(rejected, "Tool approval rejected")
 
 

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -437,6 +437,7 @@ def _reject_tracked_rows(
     """
     rejected = _pop_rows_not_awaiting_deferred_result(adapter._current_tool_messages)
     for tool_msg in rejected.values():
+        # DOM teardown may fail; cleanup must not mask the originating exception.
         with contextlib.suppress(Exception):
             tool_msg.set_rejected(reason=reason)
             adapter._sync_tool_widget(tool_msg)

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -1212,6 +1212,7 @@ async def execute_task_textual(
     from deepagents_code.auto_mode import USER_PROMPT_METADATA_KEY, user_prompt_metadata
     from deepagents_code.hooks.client_lifecycle import ClientHookStopError
     from deepagents_code.hooks.models.domain import HookEvent
+    from deepagents_code.hooks.presenter import format_hook_stop_message
 
     hitl_request_adapter = _get_hitl_request_adapter(HITLRequest)
     ask_user_adapter = _get_ask_user_adapter()
@@ -3072,7 +3073,7 @@ async def execute_task_textual(
                     )
                 except ClientHookStopError as exc:
                     await adapter._mount_message(
-                        AppMessage(f"Operation stopped by hook: {exc}")
+                        AppMessage(format_hook_stop_message(exc))
                     )
                 if not hooks.has_handlers(HookEvent.NOTIFICATION):
                     await dispatch_hook("task.complete", {"thread_id": thread_id})

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -820,26 +820,6 @@ class TextualUIAdapter:
         if self._set_active_message:
             self._set_active_message(None)
 
-    def finalize_pending_tools_as_rejected(self, reason: str) -> None:
-        """Reject pending tool widgets after an intentional hook stop.
-
-        Args:
-            reason: Hook stop reason rendered in each pending tool widget.
-        """
-        _dispatch_terminal_tool_result_hooks(self._current_tool_messages, reason)
-        for tool_msg in list(self._current_tool_messages.values()):
-            try:
-                tool_msg.set_rejected(reason=reason)
-                self._sync_tool_widget(tool_msg)
-            except Exception:
-                logger.exception(
-                    "Failed to finalize pending %s row as rejected",
-                    tool_msg.tool_name,
-                )
-        self._current_tool_messages.clear()
-        if self._set_active_message:
-            self._set_active_message(None)
-
 
 def _build_interrupted_ai_message(
     pending_text_by_namespace: dict[tuple, str],
@@ -1212,7 +1192,6 @@ async def execute_task_textual(
     from deepagents_code.auto_mode import USER_PROMPT_METADATA_KEY, user_prompt_metadata
     from deepagents_code.hooks.client_lifecycle import ClientHookStopError
     from deepagents_code.hooks.models.domain import HookEvent
-    from deepagents_code.hooks.presenter import format_hook_stop_message
 
     hitl_request_adapter = _get_hitl_request_adapter(HITLRequest)
     ask_user_adapter = _get_ask_user_adapter()
@@ -3073,14 +3052,14 @@ async def execute_task_textual(
                     )
                 except ClientHookStopError as exc:
                     await adapter._mount_message(
-                        AppMessage(format_hook_stop_message(exc))
+                        AppMessage(f"Operation stopped by hook: {exc}")
                     )
                 if not hooks.has_handlers(HookEvent.NOTIFICATION):
                     await dispatch_hook("task.complete", {"thread_id": thread_id})
                 break
 
-    except ClientHookStopError as exc:
-        adapter.finalize_pending_tools_as_rejected(str(exc))
+    except ClientHookStopError:
+        _reject_tracked_rows(adapter)
         raise
     except (asyncio.CancelledError, KeyboardInterrupt):
         await _handle_interrupt_cleanup(

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -820,6 +820,26 @@ class TextualUIAdapter:
         if self._set_active_message:
             self._set_active_message(None)
 
+    def finalize_pending_tools_as_rejected(self, reason: str) -> None:
+        """Reject pending tool widgets after an intentional hook stop.
+
+        Args:
+            reason: Hook stop reason rendered in each pending tool widget.
+        """
+        _dispatch_terminal_tool_result_hooks(self._current_tool_messages, reason)
+        for tool_msg in list(self._current_tool_messages.values()):
+            try:
+                tool_msg.set_rejected(reason=reason)
+                self._sync_tool_widget(tool_msg)
+            except Exception:
+                logger.exception(
+                    "Failed to finalize pending %s row as rejected",
+                    tool_msg.tool_name,
+                )
+        self._current_tool_messages.clear()
+        if self._set_active_message:
+            self._set_active_message(None)
+
 
 def _build_interrupted_ai_message(
     pending_text_by_namespace: dict[tuple, str],
@@ -1190,6 +1210,7 @@ async def execute_task_textual(
 
     from deepagents_code.approval_mode import ApprovalMode, awrite_approval_mode
     from deepagents_code.auto_mode import USER_PROMPT_METADATA_KEY, user_prompt_metadata
+    from deepagents_code.hooks.client_lifecycle import ClientHookStopError
     from deepagents_code.hooks.models.domain import HookEvent
 
     hitl_request_adapter = _get_hitl_request_adapter(HITLRequest)
@@ -3044,14 +3065,22 @@ async def execute_task_textual(
                     DcodeNotificationKind,
                 )
 
-                await hooks.notify(
-                    DcodeNotificationKind.AGENT_COMPLETED,
-                    "Agent completed",
-                )
+                try:
+                    await hooks.notify(
+                        DcodeNotificationKind.AGENT_COMPLETED,
+                        "Agent completed",
+                    )
+                except ClientHookStopError as exc:
+                    await adapter._mount_message(
+                        AppMessage(f"Operation stopped by hook: {exc}")
+                    )
                 if not hooks.has_handlers(HookEvent.NOTIFICATION):
                     await dispatch_hook("task.complete", {"thread_id": thread_id})
                 break
 
+    except ClientHookStopError as exc:
+        adapter.finalize_pending_tools_as_rejected(str(exc))
+        raise
     except (asyncio.CancelledError, KeyboardInterrupt):
         await _handle_interrupt_cleanup(
             adapter=adapter,

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -66,6 +66,7 @@ from deepagents_code.tui.textual_adapter import (
     _is_auto_mode_classifier_chunk,
     _is_summarization_chunk,
     _read_mentioned_file,
+    _reject_tracked_rows,
     _session_cost_pricing_ok,
     _session_cost_thread_id,
     _session_cost_total,
@@ -6037,6 +6038,29 @@ def _make_tool_widget(
     widget.deferred_success_output = deferred_success_output
     widget.is_awaiting_deferred_result = deferred_success_output is not None
     return widget
+
+
+class TestRejectTrackedRows:
+    """Tests for best-effort terminal rejection cleanup."""
+
+    def test_widget_failure_does_not_suppress_terminal_hooks(self) -> None:
+        """A widget failure must not suppress its terminal tool hooks."""
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+        tool_widget = _make_tool_widget("read_file", {"path": "notes.txt"})
+        tool_widget.set_rejected.side_effect = RuntimeError("widget teardown failed")
+        adapter._current_tool_messages = {"call-1": tool_widget}
+
+        with patch(
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
+        ) as dispatch:
+            assert _reject_tracked_rows(adapter) == ["call-1"]
+
+        assert dispatch.call_count == 2
+        assert adapter._current_tool_messages == {}
 
 
 class TestAskUserHookBodySanitization:

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -66,7 +66,6 @@ from deepagents_code.tui.textual_adapter import (
     _is_auto_mode_classifier_chunk,
     _is_summarization_chunk,
     _read_mentioned_file,
-    _reject_tracked_rows,
     _session_cost_pricing_ok,
     _session_cost_thread_id,
     _session_cost_total,
@@ -1839,20 +1838,17 @@ class TestExecuteTaskTextualStreamCompletion:
     """Report only clean stream endings to the app."""
 
     async def test_hook_stop_after_clean_stream_calls_completion_callback(self) -> None:
-        mounted: list[object] = []
+        mount_message = AsyncMock()
         adapter = TextualUIAdapter(
-            mount_message=AsyncMock(side_effect=mounted.append),
+            mount_message=mount_message,
             update_status=_noop_status,
             request_approval=_mock_approval,
         )
         callback = MagicMock()
         adapter._on_stream_complete = callback
 
-        with patch.object(
-            HooksManager,
-            "notify",
-            AsyncMock(side_effect=ClientHookStopError("intentional stop")),
-        ):
+        stop = ClientHookStopError("intentional stop")
+        with patch.object(HooksManager, "notify", side_effect=stop):
             await execute_task_textual(
                 user_input="hello",
                 agent=_FakeAgent([]),
@@ -1861,9 +1857,8 @@ class TestExecuteTaskTextualStreamCompletion:
                 adapter=adapter,
             )
 
-        assert [
-            str(widget._content) for widget in mounted if isinstance(widget, AppMessage)
-        ] == ["Operation stopped by hook: intentional stop"]
+        message = mount_message.await_args_list[0].args[0]
+        assert str(message._content) == f"Operation stopped by hook: {stop}"
         callback.assert_called_once_with()
 
     async def test_interrupted_stream_skips_completion_callback(self) -> None:
@@ -6040,29 +6035,6 @@ def _make_tool_widget(
     return widget
 
 
-class TestRejectTrackedRows:
-    """Tests for best-effort terminal rejection cleanup."""
-
-    def test_widget_failure_does_not_suppress_terminal_hooks(self) -> None:
-        """A widget failure must not suppress its terminal tool hooks."""
-        adapter = TextualUIAdapter(
-            mount_message=_mock_mount,
-            update_status=_noop_status,
-            request_approval=_mock_approval,
-        )
-        tool_widget = _make_tool_widget("read_file", {"path": "notes.txt"})
-        tool_widget.set_rejected.side_effect = RuntimeError("widget teardown failed")
-        adapter._current_tool_messages = {"call-1": tool_widget}
-
-        with patch(
-            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
-        ) as dispatch:
-            assert _reject_tracked_rows(adapter) == ["call-1"]
-
-        assert dispatch.call_count == 2
-        assert adapter._current_tool_messages == {}
-
-
 class TestAskUserHookBodySanitization:
     """`tool.result` for `ask_user` can never carry the answer transcript.
 
@@ -7282,6 +7254,7 @@ class TestToolHooksTextual:
         )
 
         with (
+            patch.object(ToolCallMessage, "set_rejected", side_effect=RuntimeError),
             patch(
                 "deepagents_code.tui.textual_adapter.dispatch_hook",
                 new_callable=AsyncMock,

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -47,7 +47,6 @@ from deepagents_code.config import ASCII_GLYPHS, UNICODE_GLYPHS, build_stream_co
 from deepagents_code.hooks.client_lifecycle import ClientHookStopError
 from deepagents_code.hooks.manager import HooksManager, PromptOutcome
 from deepagents_code.hooks.models.domain import (
-    DcodeNotificationKind,
     HookEvent,
     PermissionEffect,
     PermissionRequestDecision,
@@ -1838,41 +1837,20 @@ class _FailingApprovalStoreAgent(_SequencedAgent):
 class TestExecuteTaskTextualStreamCompletion:
     """Report only clean stream endings to the app."""
 
-    async def test_clean_stream_calls_completion_callback(self) -> None:
-        adapter = TextualUIAdapter(
-            mount_message=_mock_mount,
-            update_status=_noop_status,
-            request_approval=_mock_approval,
-        )
-        callback = MagicMock()
-        adapter._on_stream_complete = callback
-
-        await execute_task_textual(
-            user_input="hello",
-            agent=_FakeAgent([]),
-            assistant_id="assistant",
-            session_state=_session_state(auto_approve=False),
-            adapter=adapter,
-        )
-
-        callback.assert_called_once_with()
-
-    async def test_completed_notification_stop_is_not_an_agent_error(self) -> None:
+    async def test_hook_stop_after_clean_stream_calls_completion_callback(self) -> None:
         mounted: list[object] = []
-        mount_message = AsyncMock(side_effect=mounted.append)
-
         adapter = TextualUIAdapter(
-            mount_message=mount_message,
+            mount_message=AsyncMock(side_effect=mounted.append),
             update_status=_noop_status,
             request_approval=_mock_approval,
         )
         callback = MagicMock()
         adapter._on_stream_complete = callback
-        notify = AsyncMock(side_effect=ClientHookStopError("intentional stop"))
 
-        with (
-            _handlers_for(HookEvent.NOTIFICATION),
-            patch.object(HooksManager, "notify", notify),
+        with patch.object(
+            HooksManager,
+            "notify",
+            AsyncMock(side_effect=ClientHookStopError("intentional stop")),
         ):
             await execute_task_textual(
                 user_input="hello",
@@ -1882,10 +1860,6 @@ class TestExecuteTaskTextualStreamCompletion:
                 adapter=adapter,
             )
 
-        notify.assert_awaited_once_with(
-            DcodeNotificationKind.AGENT_COMPLETED,
-            "Agent completed",
-        )
         assert [
             str(widget._content) for widget in mounted if isinstance(widget, AppMessage)
         ] == ["Operation stopped by hook: intentional stop"]

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -44,8 +44,10 @@ from deepagents_code.client.non_interactive import (
     _process_message_chunk,
 )
 from deepagents_code.config import ASCII_GLYPHS, UNICODE_GLYPHS, build_stream_config
+from deepagents_code.hooks.client_lifecycle import ClientHookStopError
 from deepagents_code.hooks.manager import HooksManager, PromptOutcome
 from deepagents_code.hooks.models.domain import (
+    DcodeNotificationKind,
     HookEvent,
     PermissionEffect,
     PermissionRequestDecision,
@@ -1853,6 +1855,40 @@ class TestExecuteTaskTextualStreamCompletion:
             adapter=adapter,
         )
 
+        callback.assert_called_once_with()
+
+    async def test_completed_notification_stop_is_not_an_agent_error(self) -> None:
+        mounted: list[object] = []
+        mount_message = AsyncMock(side_effect=mounted.append)
+
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+        callback = MagicMock()
+        adapter._on_stream_complete = callback
+        notify = AsyncMock(side_effect=ClientHookStopError("intentional stop"))
+
+        with (
+            _handlers_for(HookEvent.NOTIFICATION),
+            patch.object(HooksManager, "notify", notify),
+        ):
+            await execute_task_textual(
+                user_input="hello",
+                agent=_FakeAgent([]),
+                assistant_id="assistant",
+                session_state=_session_state(auto_approve=False),
+                adapter=adapter,
+            )
+
+        notify.assert_awaited_once_with(
+            DcodeNotificationKind.AGENT_COMPLETED,
+            "Agent completed",
+        )
+        assert [
+            str(widget._content) for widget in mounted if isinstance(widget, AppMessage)
+        ] == ["Operation stopped by hook: intentional stop"]
         callback.assert_called_once_with()
 
     async def test_interrupted_stream_skips_completion_callback(self) -> None:


### PR DESCRIPTION
Intentional hook stops now render as hook-stop notices instead of agent errors in interactive and headless runs.

---

`ClientHookStopError` bypasses generic agent-failure handling while preserving completion cleanup and rejecting pending tool rows.
