### PR TITLE
fix(code): fire `PreCompact` before auto-compaction

### DIFF
--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -808,7 +808,10 @@ def _logical_event_identity(
     if isinstance(event, PreToolUseEvent | PostToolUseEvent):
         return event.call.id
     if isinstance(event, PreCompactEvent):
-        return logical_event_id or event.trigger.value
+        if logical_event_id:
+            return logical_event_id
+        msg = "PreCompact requires a stable tool-call identity"
+        raise ValueError(msg)
     if isinstance(event, SubagentStartEvent):
         return event.agent.id
     if isinstance(event, SubagentStopEvent):

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -808,10 +808,7 @@ def _logical_event_identity(
     if isinstance(event, PreToolUseEvent | PostToolUseEvent):
         return event.call.id
     if isinstance(event, PreCompactEvent):
-        if logical_event_id:
-            return logical_event_id
-        msg = "PreCompact requires a stable tool-call identity"
-        raise ValueError(msg)
+        return logical_event_id or event.trigger.value
     if isinstance(event, SubagentStartEvent):
         return event.agent.id
     if isinstance(event, SubagentStopEvent):

--- a/libs/code/deepagents_code/offload_middleware.py
+++ b/libs/code/deepagents_code/offload_middleware.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, NamedTuple, cast
 
 from deepagents.backends.protocol import FILE_NOT_FOUND
@@ -20,9 +22,22 @@ from langchain_core.tools import InjectedToolArg, StructuredTool
 from langgraph.types import Command
 
 from deepagents_code._cli_context import CLIContextSchema
+from deepagents_code.hooks.models.domain import (
+    CompactTrigger,
+    HookEvent,
+    PreCompactDecision,
+    PreCompactEvent,
+)
+from deepagents_code.hooks.server_middleware import (
+    _event_enabled,
+    _hook_context,
+    _invoke_hook,
+    _require_decision,
+    _session_gate,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Mapping
 
     from deepagents.backends.protocol import (
         BackendProtocol,
@@ -31,6 +46,7 @@ if TYPE_CHECKING:
         WriteResult,
     )
     from deepagents.middleware.summarization import SummarizationMiddleware
+    from langchain.agents.middleware.types import ModelRequest, ModelResponse
     from langchain.chat_models import BaseChatModel
     from langgraph.prebuilt.tool_node import ToolCallRequest
 
@@ -319,6 +335,88 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
     which must compact whenever messages exceed the retention window even when
     the conversation has not reached the SDK's proactive eligibility gate.
     """
+
+    @staticmethod
+    def _hook_config() -> Mapping[str, Any] | None:
+        """Return the current runnable config when available."""
+        from langgraph.config import get_config
+
+        try:
+            return get_config()
+        except RuntimeError:
+            return None
+
+    def _pre_auto_compact(self, request: ModelRequest) -> bool:
+        """Run `PreCompact` before automatic summarization.
+
+        Returns:
+            Whether automatic summarization may continue.
+        """
+        runtime = request.runtime
+        gate = _session_gate(runtime.context)
+        if not _event_enabled(gate, HookEvent.PRE_COMPACT):
+            return True
+        config = self._hook_config()
+        decision = _invoke_hook(
+            _hook_context(runtime.context, config, Path.cwd()),
+            PreCompactEvent(
+                event=HookEvent.PRE_COMPACT,
+                trigger=CompactTrigger.AUTO,
+            ),
+            gate=gate,
+            config=config,
+            deadline=timedelta(seconds=600),
+        )
+        decision = _require_decision(decision, PreCompactDecision)
+        return decision.continue_processing
+
+    def _auto_compaction_request(self, request: ModelRequest) -> ModelRequest | None:
+        """Return the prepared request when threshold compaction will run."""
+        summarization = self._summarization
+        messages = summarization._get_effective_messages(request)
+        tokens = summarization._count_tokens(
+            messages, request.system_message, request.tools
+        )
+        messages, modified = summarization._truncate_args(messages, tokens)
+        if modified:
+            tokens = summarization._count_tokens(
+                messages, request.system_message, request.tools
+            )
+        if not summarization._should_summarize(messages, tokens):
+            return None
+        if summarization._determine_cutoff_index(messages) <= 0:
+            return None
+        return request.override(messages=messages)
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        """Run `PreCompact` before synchronous threshold summarization.
+
+        Returns:
+            The model response from the handler.
+        """
+        prepared = self._auto_compaction_request(request)
+        if prepared is not None and not self._pre_auto_compact(request):
+            return handler(prepared)
+        return super().wrap_model_call(request, handler)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        """Run `PreCompact` before asynchronous threshold summarization.
+
+        Returns:
+            The model response from the handler.
+        """
+        prepared = self._auto_compaction_request(request)
+        if prepared is not None and not self._pre_auto_compact(request):
+            return await handler(prepared)
+        return await super().awrap_model_call(request, handler)
 
     @staticmethod
     def _offload_rejection(request: ToolCallRequest) -> ToolMessage | None:

--- a/libs/code/deepagents_code/offload_middleware.py
+++ b/libs/code/deepagents_code/offload_middleware.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-from datetime import timedelta
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, NamedTuple, cast
 
@@ -31,6 +31,7 @@ from deepagents_code.hooks.models.domain import (
     PreCompactEvent,
 )
 from deepagents_code.hooks.server_middleware import (
+    _DEFAULT_DEADLINE,
     _event_enabled,
     _hook_context,
     _invoke_hook,
@@ -39,7 +40,7 @@ from deepagents_code.hooks.server_middleware import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Mapping
+    from collections.abc import Awaitable, Callable
 
     from deepagents.backends.protocol import (
         BackendProtocol,
@@ -48,7 +49,11 @@ if TYPE_CHECKING:
         WriteResult,
     )
     from deepagents.middleware.summarization import SummarizationMiddleware
-    from langchain.agents.middleware.types import ModelRequest, ModelResponse
+    from langchain.agents.middleware.types import (
+        ExtendedModelResponse,
+        ModelRequest,
+        ModelResponse,
+    )
     from langchain.chat_models import BaseChatModel
     from langgraph.prebuilt.tool_node import ToolCallRequest
 
@@ -338,7 +343,7 @@ class _ArchiveReadGuard:
 
 
 class CLICompactionMiddleware(SummarizationToolMiddleware):
-    """Add explicit forced compaction and runtime model selection for dcode.
+    """Add hook-aware automatic and explicit forced compaction for dcode.
 
     The SDK tool's normal, model-initiated behavior remains unchanged. The
     private `force` input is used only by the user-initiated `/offload` path,
@@ -346,31 +351,18 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
     the conversation has not reached the SDK's proactive eligibility gate.
     """
 
-    @staticmethod
-    def _hook_config() -> Mapping[str, Any] | None:
-        """Return the current runnable config when available."""
-        from langgraph.config import get_config
-
-        try:
-            return get_config()
-        except RuntimeError:
-            return None
+    @property
+    def name(self) -> str:
+        """Replace the SDK auto-summarizer while retaining the compact tool."""
+        return self._summarization.name
 
     @staticmethod
     def _auto_compaction_id(request: ModelRequest) -> str:
-        """Identify one model-input snapshot across interrupt replays.
-
-        Returns:
-            A stable identity that changes when the model input advances.
-        """
+        """Return a stable identity for one model-input snapshot."""
         messages = request.messages
-        if not messages:
-            return "0"
         last = messages[-1]
         identity = (
-            str(last.id)
-            if last.id
-            else hashlib.sha256(last.model_dump_json().encode()).hexdigest()
+            last.id or hashlib.sha256(last.model_dump_json().encode()).hexdigest()
         )
         return f"{len(messages)}:{identity}"
 
@@ -378,26 +370,27 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
         """Run `PreCompact` before automatic summarization.
 
         Returns:
-            Whether automatic summarization may continue.
+            Whether summarization may continue.
         """
+        from langgraph.config import get_config
+
         runtime = request.runtime
         gate = _session_gate(runtime.context)
         if not _event_enabled(gate, HookEvent.PRE_COMPACT):
             return True
-        config = self._hook_config()
+        try:
+            config = get_config()
+        except RuntimeError:
+            config = None
         decision = _invoke_hook(
             _hook_context(runtime.context, config, Path.cwd()),
-            PreCompactEvent(
-                event=HookEvent.PRE_COMPACT,
-                trigger=CompactTrigger.AUTO,
-            ),
+            PreCompactEvent(event=HookEvent.PRE_COMPACT, trigger=CompactTrigger.AUTO),
             gate=gate,
             config=config,
-            deadline=timedelta(seconds=600),
+            deadline=_DEFAULT_DEADLINE,
             logical_event_id=self._auto_compaction_id(request),
         )
-        decision = _require_decision(decision, PreCompactDecision)
-        return decision.continue_processing
+        return _require_decision(decision, PreCompactDecision).continue_processing
 
     def _auto_compaction_request(self, request: ModelRequest) -> ModelRequest | None:
         """Return the prepared request when threshold compaction will run."""
@@ -411,9 +404,10 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
             tokens = summarization._count_tokens(
                 messages, request.system_message, request.tools
             )
-        if not summarization._should_summarize(messages, tokens):
-            return None
-        if summarization._determine_cutoff_index(messages) <= 0:
+        if (
+            not summarization._should_summarize(messages, tokens)
+            or summarization._determine_cutoff_index(messages) <= 0
+        ):
             return None
         return request.override(messages=messages)
 
@@ -422,38 +416,39 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
         request: ModelRequest,
         overflow: ContextOverflowError,
     ) -> None:
-        """Gate the SDK fallback when the overflowing input can be compacted.
+        """Gate a provider-overflow fallback before it compacts.
 
         Raises:
-            _AutoCompactionBlockedError: If `PreCompact` blocks the fallback.
+            _AutoCompactionBlockedError: If the hook blocks compaction.
         """
         if self._summarization._determine_cutoff_index(
             request.messages
         ) > 0 and not self._pre_auto_compact(request):
             raise _AutoCompactionBlockedError(overflow) from overflow
 
-    def wrap_model_call(
+    def wrap_model_call(  # ty: ignore[invalid-method-override]  # delegates auto summarizer
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ModelResponse:
+    ) -> ModelResponse | ExtendedModelResponse:
         """Run `PreCompact` before synchronous automatic summarization.
 
         Returns:
-            The model response from the handler.
+            The model response.
         """
+        call_model = partial(super().wrap_model_call, handler=handler)
         prepared = self._auto_compaction_request(request)
         if prepared is not None:
             if not self._pre_auto_compact(prepared):
-                return handler(prepared)
-            return super().wrap_model_call(request, handler)
+                return call_model(prepared)
+            return self._summarization.wrap_model_call(request, call_model)
 
         overflow_gated = False
 
         def gated_handler(next_request: ModelRequest) -> ModelResponse:
             nonlocal overflow_gated
             try:
-                return handler(next_request)
+                return call_model(next_request)
             except ContextOverflowError as overflow:
                 if not overflow_gated:
                     overflow_gated = True
@@ -461,32 +456,33 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
                 raise
 
         try:
-            return super().wrap_model_call(request, gated_handler)
+            return self._summarization.wrap_model_call(request, gated_handler)
         except _AutoCompactionBlockedError as blocked:
             raise blocked.overflow from None
 
-    async def awrap_model_call(
+    async def awrap_model_call(  # ty: ignore[invalid-method-override]  # delegates auto summarizer
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
-    ) -> ModelResponse:
+    ) -> ModelResponse | ExtendedModelResponse:
         """Run `PreCompact` before asynchronous automatic summarization.
 
         Returns:
-            The model response from the handler.
+            The model response.
         """
+        call_model = partial(super().awrap_model_call, handler=handler)
         prepared = self._auto_compaction_request(request)
         if prepared is not None:
             if not self._pre_auto_compact(prepared):
-                return await handler(prepared)
-            return await super().awrap_model_call(request, handler)
+                return await call_model(prepared)
+            return await self._summarization.awrap_model_call(request, call_model)
 
         overflow_gated = False
 
         async def gated_handler(next_request: ModelRequest) -> ModelResponse:
             nonlocal overflow_gated
             try:
-                return await handler(next_request)
+                return await call_model(next_request)
             except ContextOverflowError as overflow:
                 if not overflow_gated:
                     overflow_gated = True
@@ -494,7 +490,7 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
                 raise
 
         try:
-            return await super().awrap_model_call(request, gated_handler)
+            return await self._summarization.awrap_model_call(request, gated_handler)
         except _AutoCompactionBlockedError as blocked:
             raise blocked.overflow from None
 

--- a/libs/code/deepagents_code/offload_middleware.py
+++ b/libs/code/deepagents_code/offload_middleware.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 from datetime import timedelta
 from pathlib import Path
@@ -17,6 +18,7 @@ from deepagents.middleware.summarization import (
 from langchain.tools import (
     ToolRuntime,  # noqa: TC002  # inspected for runtime injection
 )
+from langchain_core.exceptions import ContextOverflowError
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import InjectedToolArg, StructuredTool
 from langgraph.types import Command
@@ -71,6 +73,14 @@ Only the *prefix position* is load-bearing; wording after it is free to change.
 """
 
 _OFFLOAD_SEED_ID_PREFIX = "offload-seed-"
+
+
+class _AutoCompactionBlockedError(Exception):
+    """Carry a blocked provider overflow past the SDK fallback handler."""
+
+    def __init__(self, overflow: ContextOverflowError) -> None:
+        super().__init__(str(overflow))
+        self.overflow = overflow
 
 
 def _offload_seed_message_id(tool_call_id: str) -> str:
@@ -346,6 +356,24 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
         except RuntimeError:
             return None
 
+    @staticmethod
+    def _auto_compaction_id(request: ModelRequest) -> str:
+        """Identify one model-input snapshot across interrupt replays.
+
+        Returns:
+            A stable identity that changes when the model input advances.
+        """
+        messages = request.messages
+        if not messages:
+            return "0"
+        last = messages[-1]
+        identity = (
+            str(last.id)
+            if last.id
+            else hashlib.sha256(last.model_dump_json().encode()).hexdigest()
+        )
+        return f"{len(messages)}:{identity}"
+
     def _pre_auto_compact(self, request: ModelRequest) -> bool:
         """Run `PreCompact` before automatic summarization.
 
@@ -366,6 +394,7 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
             gate=gate,
             config=config,
             deadline=timedelta(seconds=600),
+            logical_event_id=self._auto_compaction_id(request),
         )
         decision = _require_decision(decision, PreCompactDecision)
         return decision.continue_processing
@@ -388,35 +417,86 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
             return None
         return request.override(messages=messages)
 
+    def _pre_overflow_compact(
+        self,
+        request: ModelRequest,
+        overflow: ContextOverflowError,
+    ) -> None:
+        """Gate the SDK fallback when the overflowing input can be compacted.
+
+        Raises:
+            _AutoCompactionBlockedError: If `PreCompact` blocks the fallback.
+        """
+        if self._summarization._determine_cutoff_index(
+            request.messages
+        ) > 0 and not self._pre_auto_compact(request):
+            raise _AutoCompactionBlockedError(overflow) from overflow
+
     def wrap_model_call(
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], ModelResponse],
     ) -> ModelResponse:
-        """Run `PreCompact` before synchronous threshold summarization.
+        """Run `PreCompact` before synchronous automatic summarization.
 
         Returns:
             The model response from the handler.
         """
         prepared = self._auto_compaction_request(request)
-        if prepared is not None and not self._pre_auto_compact(request):
-            return handler(prepared)
-        return super().wrap_model_call(request, handler)
+        if prepared is not None:
+            if not self._pre_auto_compact(prepared):
+                return handler(prepared)
+            return super().wrap_model_call(request, handler)
+
+        overflow_gated = False
+
+        def gated_handler(next_request: ModelRequest) -> ModelResponse:
+            nonlocal overflow_gated
+            try:
+                return handler(next_request)
+            except ContextOverflowError as overflow:
+                if not overflow_gated:
+                    overflow_gated = True
+                    self._pre_overflow_compact(next_request, overflow)
+                raise
+
+        try:
+            return super().wrap_model_call(request, gated_handler)
+        except _AutoCompactionBlockedError as blocked:
+            raise blocked.overflow from None
 
     async def awrap_model_call(
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        """Run `PreCompact` before asynchronous threshold summarization.
+        """Run `PreCompact` before asynchronous automatic summarization.
 
         Returns:
             The model response from the handler.
         """
         prepared = self._auto_compaction_request(request)
-        if prepared is not None and not self._pre_auto_compact(request):
-            return await handler(prepared)
-        return await super().awrap_model_call(request, handler)
+        if prepared is not None:
+            if not self._pre_auto_compact(prepared):
+                return await handler(prepared)
+            return await super().awrap_model_call(request, handler)
+
+        overflow_gated = False
+
+        async def gated_handler(next_request: ModelRequest) -> ModelResponse:
+            nonlocal overflow_gated
+            try:
+                return await handler(next_request)
+            except ContextOverflowError as overflow:
+                if not overflow_gated:
+                    overflow_gated = True
+                    self._pre_overflow_compact(next_request, overflow)
+                raise
+
+        try:
+            return await super().awrap_model_call(request, gated_handler)
+        except _AutoCompactionBlockedError as blocked:
+            raise blocked.overflow from None
 
     @staticmethod
     def _offload_rejection(request: ToolCallRequest) -> ToolMessage | None:

--- a/libs/code/tests/unit_tests/test_compact_tool.py
+++ b/libs/code/tests/unit_tests/test_compact_tool.py
@@ -7,13 +7,13 @@ Core compact tool logic tests live in the SDK at
 from __future__ import annotations
 
 import warnings
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from deepagents.backends.protocol import FileDownloadResponse, WriteResult
-from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelRequest
 from langchain_core.exceptions import ContextOverflowError
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.runtime import Runtime
@@ -139,36 +139,38 @@ class TestCLICompactionMiddleware:
         summarization._compute_state_cutoff.return_value = 2
         return summarization
 
-    @staticmethod
-    def _model_request(summarization: MagicMock) -> ModelRequest:
-        """Build a model request whose summarizer crosses the auto threshold."""
-        messages = [HumanMessage("one"), HumanMessage("two")]
+    @pytest.mark.parametrize("overflow", [False, True])
+    async def test_auto_compaction_runs_precompact_hook(self, overflow: bool) -> None:
+        """Every automatic compaction must ask `PreCompact` before summarizing."""
+        from deepagents.middleware.summarization import SummarizationMiddleware
+
+        from deepagents_code.hooks.models.domain import (
+            HookEvent,
+            PreCompactDecision,
+        )
+
+        messages: list[AnyMessage] = [HumanMessage("one"), HumanMessage("two")]
+        summarization = self._summarization()
         summarization._get_effective_messages.return_value = messages
         summarization._count_tokens.return_value = 2
         summarization._truncate_args.return_value = (messages, False)
-        summarization._should_summarize.return_value = True
+        summarization._should_summarize.return_value = not overflow
         summarization._determine_cutoff_index.return_value = 1
-        return ModelRequest(
+        if overflow:
+            summarization.awrap_model_call = MethodType(
+                SummarizationMiddleware.awrap_model_call, summarization
+            )
+
+        middleware = CLICompactionMiddleware(summarization)
+        request: ModelRequest[None] = ModelRequest(
             model=MagicMock(),
             messages=messages,
             state={"messages": messages},
             runtime=Runtime(context=None),
         )
-
-    async def test_auto_compaction_runs_precompact_hook(self) -> None:
-        """Threshold compaction must ask `PreCompact` before summarizing."""
-        from deepagents_code.hooks.models.domain import (
-            HookEvent,
-            PreCompactDecision,
+        handler = AsyncMock(
+            side_effect=ContextOverflowError("too large") if overflow else None
         )
-
-        summarization = self._summarization()
-        middleware = CLICompactionMiddleware(summarization)
-        request = self._model_request(summarization)
-        logical_id = middleware._auto_compaction_id(request)
-        later = request.override(messages=[*request.messages, HumanMessage("three")])
-        expected = ModelResponse(result=[AIMessage(content="ok")])
-        handler = AsyncMock(return_value=expected)
         invoke = MagicMock(
             return_value=PreCompactDecision(
                 event=HookEvent.PRE_COMPACT,
@@ -179,57 +181,23 @@ class TestCLICompactionMiddleware:
 
         with (
             patch(
-                "deepagents_code.offload_middleware._session_gate",
-                return_value={
-                    "snapshot_id": "snapshot",
-                    "events": frozenset({"PreCompact"}),
-                },
+                "deepagents_code.offload_middleware._event_enabled", return_value=True
             ),
             patch("deepagents_code.offload_middleware._invoke_hook", invoke),
         ):
-            result = await middleware.awrap_model_call(request, handler)
+            if overflow:
+                with pytest.raises(ContextOverflowError, match="too large"):
+                    await middleware.awrap_model_call(request, handler)
+            else:
+                await middleware.awrap_model_call(request, handler)
 
         event = invoke.call_args.args[1]
         assert event.trigger.value == "auto"
-        assert invoke.call_args.kwargs["logical_event_id"] == logical_id
-        assert middleware._auto_compaction_id(request) == logical_id
-        assert middleware._auto_compaction_id(later) != logical_id
-        assert result is expected
-        handler.assert_awaited_once_with(request)
-
-    async def test_overflow_compaction_runs_precompact_hook(self) -> None:
-        """Overflow fallback must ask `PreCompact` before summarizing."""
-        from deepagents_code.hooks.models.domain import (
-            HookEvent,
-            PreCompactDecision,
+        logical_id = invoke.call_args.kwargs["logical_event_id"]
+        assert logical_id == middleware._auto_compaction_id(request)
+        assert logical_id != middleware._auto_compaction_id(
+            request.override(messages=[*messages, HumanMessage("three")])
         )
-
-        summarization = self._summarization()
-        middleware = CLICompactionMiddleware(summarization)
-        request = self._model_request(summarization)
-        summarization._should_summarize.return_value = False
-        handler = AsyncMock(side_effect=ContextOverflowError("too large"))
-        invoke = MagicMock(
-            return_value=PreCompactDecision(
-                event=HookEvent.PRE_COMPACT,
-                continue_processing=False,
-                stop_reason="preserve context",
-            )
-        )
-
-        with (
-            patch(
-                "deepagents_code.offload_middleware._session_gate",
-                return_value={
-                    "snapshot_id": "snapshot",
-                    "events": frozenset({"PreCompact"}),
-                },
-            ),
-            patch("deepagents_code.offload_middleware._invoke_hook", invoke),
-            pytest.raises(ContextOverflowError, match="too large"),
-        ):
-            await middleware.awrap_model_call(request, handler)
-
         invoke.assert_called_once()
         handler.assert_awaited_once()
         summarization._aoffload_to_backend.assert_not_awaited()
@@ -646,6 +614,7 @@ class TestCLICompactionMiddleware:
 
         sdk = MagicMock()
         sdk._summarization = MagicMock()
+        sdk._summarization.name = "SummarizationMiddleware"
         sdk.system_prompt = "SYSTEM PROMPT"
         backend: Any = object()
         with patch.object(
@@ -655,6 +624,7 @@ class TestCLICompactionMiddleware:
 
         factory.assert_called_once()
         assert isinstance(result, om.CLICompactionMiddleware)
+        assert result.name == "SummarizationMiddleware"
         assert result.system_prompt == "SYSTEM PROMPT"
         assert result._summarization is sdk._summarization
 

--- a/libs/code/tests/unit_tests/test_compact_tool.py
+++ b/libs/code/tests/unit_tests/test_compact_tool.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from deepagents.backends.protocol import FileDownloadResponse, WriteResult
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.exceptions import ContextOverflowError
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.runtime import Runtime
 
@@ -164,6 +165,8 @@ class TestCLICompactionMiddleware:
         summarization = self._summarization()
         middleware = CLICompactionMiddleware(summarization)
         request = self._model_request(summarization)
+        logical_id = middleware._auto_compaction_id(request)
+        later = request.override(messages=[*request.messages, HumanMessage("three")])
         expected = ModelResponse(result=[AIMessage(content="ok")])
         handler = AsyncMock(return_value=expected)
         invoke = MagicMock(
@@ -188,8 +191,49 @@ class TestCLICompactionMiddleware:
 
         event = invoke.call_args.args[1]
         assert event.trigger.value == "auto"
+        assert invoke.call_args.kwargs["logical_event_id"] == logical_id
+        assert middleware._auto_compaction_id(request) == logical_id
+        assert middleware._auto_compaction_id(later) != logical_id
         assert result is expected
         handler.assert_awaited_once_with(request)
+
+    async def test_overflow_compaction_runs_precompact_hook(self) -> None:
+        """Overflow fallback must ask `PreCompact` before summarizing."""
+        from deepagents_code.hooks.models.domain import (
+            HookEvent,
+            PreCompactDecision,
+        )
+
+        summarization = self._summarization()
+        middleware = CLICompactionMiddleware(summarization)
+        request = self._model_request(summarization)
+        summarization._should_summarize.return_value = False
+        handler = AsyncMock(side_effect=ContextOverflowError("too large"))
+        invoke = MagicMock(
+            return_value=PreCompactDecision(
+                event=HookEvent.PRE_COMPACT,
+                continue_processing=False,
+                stop_reason="preserve context",
+            )
+        )
+
+        with (
+            patch(
+                "deepagents_code.offload_middleware._session_gate",
+                return_value={
+                    "snapshot_id": "snapshot",
+                    "events": frozenset({"PreCompact"}),
+                },
+            ),
+            patch("deepagents_code.offload_middleware._invoke_hook", invoke),
+            pytest.raises(ContextOverflowError, match="too large"),
+        ):
+            await middleware.awrap_model_call(request, handler)
+
+        invoke.assert_called_once()
+        handler.assert_awaited_once()
+        summarization._aoffload_to_backend.assert_not_awaited()
+        summarization._acreate_summary.assert_not_awaited()
 
     async def test_force_bypasses_sdk_eligibility_gate(self) -> None:
         """Forced compaction partitions directly even below the proactive gate."""

--- a/libs/code/tests/unit_tests/test_compact_tool.py
+++ b/libs/code/tests/unit_tests/test_compact_tool.py
@@ -13,7 +13,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from deepagents.backends.protocol import FileDownloadResponse, WriteResult
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.runtime import Runtime
 
 from deepagents_code._cli_context import CLIContextSchema
 from deepagents_code.offload_middleware import (
@@ -135,6 +137,59 @@ class TestCLICompactionMiddleware:
         ]
         summarization._compute_state_cutoff.return_value = 2
         return summarization
+
+    @staticmethod
+    def _model_request(summarization: MagicMock) -> ModelRequest:
+        """Build a model request whose summarizer crosses the auto threshold."""
+        messages = [HumanMessage("one"), HumanMessage("two")]
+        summarization._get_effective_messages.return_value = messages
+        summarization._count_tokens.return_value = 2
+        summarization._truncate_args.return_value = (messages, False)
+        summarization._should_summarize.return_value = True
+        summarization._determine_cutoff_index.return_value = 1
+        return ModelRequest(
+            model=MagicMock(),
+            messages=messages,
+            state={"messages": messages},
+            runtime=Runtime(context=None),
+        )
+
+    async def test_auto_compaction_runs_precompact_hook(self) -> None:
+        """Threshold compaction must ask `PreCompact` before summarizing."""
+        from deepagents_code.hooks.models.domain import (
+            HookEvent,
+            PreCompactDecision,
+        )
+
+        summarization = self._summarization()
+        middleware = CLICompactionMiddleware(summarization)
+        request = self._model_request(summarization)
+        expected = ModelResponse(result=[AIMessage(content="ok")])
+        handler = AsyncMock(return_value=expected)
+        invoke = MagicMock(
+            return_value=PreCompactDecision(
+                event=HookEvent.PRE_COMPACT,
+                continue_processing=False,
+                stop_reason="preserve context",
+            )
+        )
+
+        with (
+            patch(
+                "deepagents_code.offload_middleware._session_gate",
+                return_value={
+                    "snapshot_id": "snapshot",
+                    "events": frozenset({"PreCompact"}),
+                },
+            ),
+            patch("deepagents_code.offload_middleware._invoke_hook", invoke),
+        ):
+            result = await middleware.awrap_model_call(request, handler)
+
+        event = invoke.call_args.args[1]
+        assert event.trigger.value == "auto"
+        assert result is expected
+        handler.assert_awaited_once_with(request)
 
     async def test_force_bypasses_sdk_eligibility_gate(self) -> None:
         """Forced compaction partitions directly even below the proactive gate."""


### PR DESCRIPTION
Automatic threshold compaction now runs `PreCompact` with `trigger="auto"` before summarizing context.

---

The dcode compaction middleware mirrors the SDK eligibility check and invokes the existing server hook gate before the inner summarizer runs. Blocking the hook skips that compaction attempt without dropping argument truncation.

Made by [Open SWE](https://openswe.vercel.app/agents/019fc9ab-d293-72b0-9272-72dd41023214)