### PR TITLE
feat(sdk): expose `execute` exit code in artifact

### DIFF
--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -763,11 +763,32 @@ class ExecuteResponse:
     exit_code: int | None = None
     """The process exit code.
 
-    0 indicates success, non-zero indicates failure.
+    0 indicates success, non-zero indicates failure. `None` means the exit code
+    could not be determined.
     """
 
     truncated: bool = False
     """Whether the output was truncated due to backend limitations."""
+
+
+class ExecuteArtifact(TypedDict):
+    """Machine-readable metadata attached to an `execute` tool result.
+
+    Carried on `ToolMessage.artifact` alongside the model-facing `content`, so
+    callers can react to shell failures. `artifact` is `None` instead when no
+    command ran -- a validation or unsupported-backend error, where
+    `ToolMessage.status` is `"error"`.
+
+    Note that `status` is `"success"` for any command that ran, including one
+    that exited non-zero: the model is expected to read the output and decide
+    what to do. Use `exit_code`, not `status`, to detect command failure.
+    """
+
+    exit_code: NotRequired[int]
+    """The command's exit status. 0 indicates success, non-zero indicates failure.
+
+    Omitted when the exit code could not be determined.
+    """
 
 
 @dataclass(frozen=True, slots=True)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -41,7 +41,9 @@ from deepagents.backends.protocol import (
     BackendProtocol,
     DeleteResult,
     EditResult,
+    ExecuteArtifact,
     ExecuteOffloadResult,
+    ExecuteResponse,
     FileData as FileData,  # Re-export for backwards compatibility
     FileInfo,
     GlobResult,
@@ -1538,7 +1540,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
     If the backend implements
     [`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol],
-    an `execute` tool is also added for running shell commands.
+    an `execute` tool is also added for running shell commands. Its results carry
+    [`ExecuteArtifact`][deepagents.backends.protocol.ExecuteArtifact] metadata on
+    `ToolMessage.artifact`.
 
     This middleware also automatically evicts large tool results to the file system when
     they exceed a token threshold, preventing context window saturation.
@@ -2763,6 +2767,17 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             parts.append("\n[Output was truncated due to size limits]")
         return "".join(parts)
 
+    @staticmethod
+    def _execute_artifact(response: ExecuteResponse) -> ExecuteArtifact:
+        """Build the `ExecuteArtifact` for an execute result.
+
+        See `ExecuteArtifact` for why an unknown exit code is omitted rather
+        than published as `None`.
+        """
+        if response.exit_code is None:
+            return {}
+        return {"exit_code": response.exit_code}
+
     def _interpret_capture_output(self, offload: ExecuteOffloadResult, capture_path: str, tool_call_id: str) -> str:
         """Build `ToolMessage` content from an `execute_with_offload` result."""
         response = offload.response
@@ -2871,7 +2886,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 content=content,
                 name="execute",
                 tool_call_id=runtime.tool_call_id,
-                artifact={"exit_code": response.exit_code},
+                artifact=self._execute_artifact(response),
                 status="success",
             )
 
@@ -2959,7 +2974,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 content=content,
                 name="execute",
                 tool_call_id=runtime.tool_call_id,
-                artifact={"exit_code": response.exit_code},
+                artifact=self._execute_artifact(response),
                 status="success",
             )
 

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -2847,10 +2847,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                         max_inline_bytes=NUM_CHARS_PER_TOKEN * cast("int", self._tool_token_limit_before_evict),
                         timeout=timeout,
                     )
+                    response = offload.response
                     content = self._interpret_capture_output(offload, capture_path, cast("str", runtime.tool_call_id))
                 else:
-                    result = executable.execute(command, timeout=timeout) if timeout is not None else executable.execute(command)
-                    content = self._format_execute_output(result.output, result.exit_code, truncated=result.truncated)
+                    response = executable.execute(command, timeout=timeout) if timeout is not None else executable.execute(command)
+                    content = self._format_execute_output(response.output, response.exit_code, truncated=response.truncated)
             except NotImplementedError as e:
                 return ToolMessage(
                     content=f"Error: Execution not available. {e}",
@@ -2870,6 +2871,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 content=content,
                 name="execute",
                 tool_call_id=runtime.tool_call_id,
+                artifact={"exit_code": response.exit_code},
                 status="success",
             )
 
@@ -2933,10 +2935,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                         max_inline_bytes=NUM_CHARS_PER_TOKEN * cast("int", self._tool_token_limit_before_evict),
                         timeout=timeout,
                     )
+                    response = offload.response
                     content = self._interpret_capture_output(offload, capture_path, cast("str", runtime.tool_call_id))
                 else:
-                    result = await executable.aexecute(command, timeout=timeout) if timeout is not None else await executable.aexecute(command)
-                    content = self._format_execute_output(result.output, result.exit_code, truncated=result.truncated)
+                    response = await executable.aexecute(command, timeout=timeout) if timeout is not None else await executable.aexecute(command)
+                    content = self._format_execute_output(response.output, response.exit_code, truncated=response.truncated)
             except NotImplementedError as e:
                 return ToolMessage(
                     content=f"Error: Execution not available. {e}",
@@ -2956,6 +2959,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 content=content,
                 name="execute",
                 tool_call_id=runtime.tool_call_id,
+                artifact={"exit_code": response.exit_code},
                 status="success",
             )
 

--- a/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
+++ b/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
@@ -22,11 +22,13 @@ import os
 import re
 import stat
 import subprocess
-from collections.abc import Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from pathlib import Path
 
 import pytest
 from langchain.tools import ToolRuntime
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import BaseTool
 
 from deepagents.backends import CompositeBackend
 from deepagents.backends.filesystem import _map_exception_to_standard_error
@@ -1647,13 +1649,32 @@ class TestExecuteCaptureOffload:
             config={},
         )
 
+    @pytest.fixture(params=["sync", "async"])
+    def invoke(self, request: pytest.FixtureRequest) -> Callable[[BaseTool, dict], Awaitable[ToolMessage]]:
+        """Drive a tool through either `invoke` or `ainvoke`.
+
+        The execute tool forks on sync/async well before the backend does:
+        `sync_execute` calls `execute_with_offload` while `async_execute` calls
+        `aexecute_with_offload`, so each branch builds its own `ToolMessage` and
+        neither covers the other. Running every case both ways closes that gap
+        for free -- `BaseSandbox.aexecute` delegates to `execute` in a thread,
+        so the async path needs no extra backend support.
+        """
+        if request.param == "async":
+            return lambda tool, payload: tool.ainvoke(payload)
+
+        async def invoke_sync(tool: BaseTool, payload: dict) -> ToolMessage:
+            return tool.invoke(payload)
+
+        return invoke_sync
+
     @staticmethod
     def _capture_path(tool_call_id: str) -> str:
         return f"{VIRTUAL_SANDBOX_ROOT}/large_tool_results/{tool_call_id}"
 
-    def test_small_output_returned_inline_and_leaves_no_file(self, tools: tuple, sandbox: LocalSubprocessSandbox) -> None:
+    async def test_small_output_returned_inline_and_leaves_no_file(self, tools: tuple, sandbox: LocalSubprocessSandbox, invoke: Callable) -> None:
         execute_tool, _ = tools
-        result = execute_tool.invoke({"command": "echo hello", "runtime": self._runtime("c_small")})
+        result = await invoke(execute_tool, {"command": "echo hello", "runtime": self._runtime("c_small")})
 
         assert "hello" in result.content
         assert "exit code 0" in result.content
@@ -1662,10 +1683,10 @@ class TestExecuteCaptureOffload:
         listing = sandbox.execute(f"ls {VIRTUAL_SANDBOX_ROOT}/large_tool_results/ 2>/dev/null | wc -l")
         assert listing.output.strip() == "0"
 
-    def test_large_output_offloads_and_full_content_roundtrips(self, tools: tuple) -> None:
+    async def test_large_output_offloads_and_full_content_roundtrips(self, tools: tuple, invoke: Callable) -> None:
         execute_tool, read_tool = tools
         rt = self._runtime("c_large")
-        result = execute_tool.invoke({"command": _BIG_OUTPUT_CMD, "runtime": rt})
+        result = await invoke(execute_tool, {"command": _BIG_OUTPUT_CMD, "runtime": rt})
 
         capture_path = self._capture_path("c_large")
         # Preview + pointer, not the full output inline.
@@ -1682,15 +1703,31 @@ class TestExecuteCaptureOffload:
         read = read_tool.invoke({"file_path": capture_path, "offset": 2499, "limit": 3, "runtime": rt})
         assert "line 2500:" in read.content
 
-    def test_nonzero_exit_code_preserved(self, tools: tuple) -> None:
+    async def test_nonzero_exit_code_preserved(self, tools: tuple, invoke: Callable) -> None:
         execute_tool, _ = tools
-        result = execute_tool.invoke({"command": "echo oops; exit 3", "runtime": self._runtime("c_ec")})
+        result = await invoke(execute_tool, {"command": "echo oops; exit 3", "runtime": self._runtime("c_ec")})
 
         assert "oops" in result.content
         assert "exit code 3" in result.content
         assert result.artifact == {"exit_code": 3}
 
-    def test_runaway_output_is_capped_and_flagged(self, tools: tuple, sandbox: LocalSubprocessSandbox, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_offloaded_result_carries_exit_code_artifact(self, tools: tuple, invoke: Callable) -> None:
+        # When the output is offloaded, `_interpret_capture_output` replaces the
+        # plain `[Command ... exit code N]` formatting with a `read_file` pointer,
+        # so the artifact is the only structured channel for the exit code.
+        execute_tool, _ = tools
+        result = await invoke(execute_tool, {"command": f"{_BIG_OUTPUT_CMD}; exit 3", "runtime": self._runtime("c_off_ec")})
+
+        assert self._capture_path("c_off_ec") in result.content  # actually offloaded
+        assert result.artifact == {"exit_code": 3}
+
+    async def test_runaway_output_is_capped_and_flagged(
+        self,
+        tools: tuple,
+        sandbox: LocalSubprocessSandbox,
+        monkeypatch: pytest.MonkeyPatch,
+        invoke: Callable,
+    ) -> None:
         # Cap must exceed the eviction budget so a capped result still offloads
         # (rather than fitting inline). Default budget is ~80 KB.
         cap = 100_000
@@ -1702,10 +1739,11 @@ class TestExecuteCaptureOffload:
         # the excess instead of SIGPIPE-killing the producer, so the command's real
         # exit code survives -- a regression guard: closing the pipe early would
         # report this successful command as failed.
-        result = execute_tool.invoke({"command": f"{_BIG_OUTPUT_CMD}; exit 0", "runtime": rt})
+        result = await invoke(execute_tool, {"command": f"{_BIG_OUTPUT_CMD}; exit 0", "runtime": rt})
 
         assert "exceeded the capture size limit" in result.content
         assert "succeeded with exit code 0" in result.content
+        assert result.artifact == {"exit_code": 0}
         # The on-disk capture file is bounded at the cap regardless of total output.
         size = sandbox.execute(f"wc -c < {self._capture_path('c_cap')}").output.strip()
         assert size == str(cap)

--- a/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
+++ b/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
@@ -1688,6 +1688,7 @@ class TestExecuteCaptureOffload:
 
         assert "oops" in result.content
         assert "exit code 3" in result.content
+        assert result.artifact == {"exit_code": 3}
 
     def test_runaway_output_is_capped_and_flagged(self, tools: tuple, sandbox: LocalSubprocessSandbox, monkeypatch: pytest.MonkeyPatch) -> None:
         # Cap must exceed the eviction budget so a capped result still offloads

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -2896,6 +2896,7 @@ class TestFilesystemMiddleware:
         assert "Hello world\nLine 2" in result.content
         assert "succeeded" in result.content
         assert "exit code 0" in result.content
+        assert result.artifact == {"exit_code": 0}
 
     def test_execute_tool_output_formatting_with_failure(self):
         """Test execute tool formats failure output correctly."""
@@ -2932,6 +2933,7 @@ class TestFilesystemMiddleware:
         assert "Error: command not found" in result.content
         assert "failed" in result.content
         assert "exit code 127" in result.content
+        assert result.artifact == {"exit_code": 127}
 
     def test_execute_tool_output_formatting_with_truncation(self):
         """Test execute tool formats truncated output correctly."""

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -2935,6 +2935,77 @@ class TestFilesystemMiddleware:
         assert "exit code 127" in result.content
         assert result.artifact == {"exit_code": 127}
 
+    def test_execute_tool_omits_artifact_exit_code_when_unknown(self):
+        """Test execute tool omits `exit_code` when the backend reports none."""
+
+        # Backends may leave exit_code unset, and the capture-offload parse falls
+        # back to None when the wrapper's meta line is unreadable. None must not be
+        # published as a value: it is falsy like a successful 0 but unequal to it, so
+        # both `!= 0` and `if not exit_code` would misclassify it.
+        class UnknownExitCodeMockSandboxBackend(SandboxBackendProtocol, StateBackend):
+            def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+                return ExecuteResponse(output="some output")
+
+            @property
+            def id(self):
+                return "unknown-exit-code-mock-sandbox-backend"
+
+        rt = ToolRuntime(
+            state=FilesystemState(messages=[], files={}),
+            context=None,
+            tool_call_id="test_unknown_ec",
+            store=InMemoryStore(),
+            stream_writer=lambda _: None,
+            config={},
+        )
+
+        middleware = FilesystemMiddleware(backend=UnknownExitCodeMockSandboxBackend())
+        execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
+        result = execute_tool.invoke({"command": "echo test", "runtime": rt})
+
+        # The content omits the status line entirely for an unknown exit code, so the
+        # artifact must not imply one either.
+        assert "exit code" not in result.content
+        assert result.artifact == {}
+
+    def test_execute_tool_error_paths_carry_no_artifact(self):
+        """Test execute tool returns no artifact when no command ran."""
+
+        # Errors raised before the command runs have no exit code to report, so
+        # `artifact` stays None. Consumers must therefore guard rather than index --
+        # inventing a sentinel exit code here would be indistinguishable from a real
+        # command that exited with it.
+        class ErrorPathMockSandboxBackend(SandboxBackendProtocol, StateBackend):
+            def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+                msg = "bad parameter"
+                raise ValueError(msg)
+
+            @property
+            def id(self):
+                return "error-path-mock-sandbox-backend"
+
+        rt = ToolRuntime(
+            state=FilesystemState(messages=[], files={}),
+            context=None,
+            tool_call_id="test_err_artifact",
+            store=InMemoryStore(),
+            stream_writer=lambda _: None,
+            config={},
+        )
+
+        middleware = FilesystemMiddleware(backend=ErrorPathMockSandboxBackend())
+        execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
+
+        # Validation error: rejected before the backend is reached.
+        rejected = execute_tool.invoke({"command": "echo test", "timeout": -1, "runtime": rt})
+        assert rejected.status == "error"
+        assert rejected.artifact is None
+
+        # Backend raised: the command was attempted but produced no exit code.
+        raised = execute_tool.invoke({"command": "echo test", "runtime": rt})
+        assert raised.status == "error"
+        assert raised.artifact is None
+
     def test_execute_tool_output_formatting_with_truncation(self):
         """Test execute tool formats truncated output correctly."""
 

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -937,6 +937,7 @@ class TestFilesystemMiddlewareAsync:
         assert "Async Hello world\nAsync Line 2" in result.content
         assert "succeeded" in result.content
         assert "exit code 0" in result.content
+        assert result.artifact == {"exit_code": 0}
 
     async def test_aexecute_tool_output_formatting_with_failure(self):
         """Test async execute tool formats failure output correctly."""
@@ -980,6 +981,7 @@ class TestFilesystemMiddlewareAsync:
         assert "Async Error: command not found" in result.content
         assert "failed" in result.content
         assert "exit code 127" in result.content
+        assert result.artifact == {"exit_code": 127}
 
     async def test_aexecute_tool_output_formatting_with_truncation(self):
         """Test async execute tool formats truncated output correctly."""

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -983,6 +983,75 @@ class TestFilesystemMiddlewareAsync:
         assert "exit code 127" in result.content
         assert result.artifact == {"exit_code": 127}
 
+    async def test_aexecute_tool_omits_artifact_exit_code_when_unknown(self):
+        """Test async execute tool omits `exit_code` when the backend reports none."""
+
+        # See the sync twin: None is falsy like a successful 0 but unequal to it, so
+        # publishing it as a value would misclassify under either comparison.
+        class UnknownExitCodeMockSandboxBackend(SandboxBackendProtocol, StateBackend):
+            def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+                return ExecuteResponse(output="sync output")
+
+            async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ASYNC109
+                return ExecuteResponse(output="async output")
+
+            @property
+            def id(self):
+                return "unknown-exit-code-mock-sandbox-backend"
+
+        rt = ToolRuntime(
+            state=FilesystemState(messages=[], files={}),
+            context=None,
+            tool_call_id="test_unknown_ec",
+            store=InMemoryStore(),
+            stream_writer=lambda _: None,
+            config={},
+        )
+
+        middleware = FilesystemMiddleware(backend=UnknownExitCodeMockSandboxBackend())
+        execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
+        result = await execute_tool.ainvoke({"command": "echo test", "runtime": rt})
+
+        assert "async output" in result.content
+        assert "exit code" not in result.content
+        assert result.artifact == {}
+
+    async def test_aexecute_tool_error_paths_carry_no_artifact(self):
+        """Test async execute tool returns no artifact when no command ran."""
+
+        class ErrorPathMockSandboxBackend(SandboxBackendProtocol, StateBackend):
+            def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+                msg = "bad parameter"
+                raise ValueError(msg)
+
+            async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ASYNC109
+                msg = "bad parameter"
+                raise ValueError(msg)
+
+            @property
+            def id(self):
+                return "error-path-mock-sandbox-backend"
+
+        rt = ToolRuntime(
+            state=FilesystemState(messages=[], files={}),
+            context=None,
+            tool_call_id="test_err_artifact",
+            store=InMemoryStore(),
+            stream_writer=lambda _: None,
+            config={},
+        )
+
+        middleware = FilesystemMiddleware(backend=ErrorPathMockSandboxBackend())
+        execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
+
+        rejected = await execute_tool.ainvoke({"command": "echo test", "timeout": -1, "runtime": rt})
+        assert rejected.status == "error"
+        assert rejected.artifact is None
+
+        raised = await execute_tool.ainvoke({"command": "echo test", "runtime": rt})
+        assert raised.status == "error"
+        assert raised.artifact is None
+
     async def test_aexecute_tool_output_formatting_with_truncation(self):
         """Test async execute tool formats truncated output correctly."""
 


### PR DESCRIPTION
`execute` tool results now expose the process exit code in `ToolMessage.artifact`.

---

This lets consumers distinguish shell failures without parsing model-facing content while preserving the existing `ToolMessage.status` behavior. Both synchronous and asynchronous execution, including capture/offload, attach the same JSON-serializable metadata.

Made by [Open SWE](https://openswe.vercel.app/agents/cd4daa3c-c4cd-1a1b-fe6b-a6fbe929a285)