### PR TITLE
feat(code): tri-state `DEEPAGENTS_CODE_ONBOARDING` env var

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -143,12 +143,6 @@ Does not auto-open the update modal (use `DEEPAGENTS_CODE_DEBUG_UPDATE` for that
 Any non-empty value enables the flag (including `"0"` or `"false"`).
 """
 
-DEBUG_ONBOARDING = "DEEPAGENTS_CODE_DEBUG_ONBOARDING"
-"""Force the onboarding flow to open on every interactive startup.
-
-Parsed by `is_env_truthy`: accepts `1`, `true`, `yes`, `on` as enabled.
-"""
-
 DEBUG_UPDATE = "DEEPAGENTS_CODE_DEBUG_UPDATE"
 """Inject a sample update-available notification and auto-open the update modal
 at launch so the update-available flow can be exercised without waiting for a
@@ -301,6 +295,22 @@ offline or the probe latency is undesirable. The probe is lazy and never
 runs on the startup hot path. When enabled, discovery may call `/api/tags`
 and `/api/show`. See `_ollama_discovery_enabled` for accepted truthy/falsy
 values.
+"""
+
+ONBOARDING = "DEEPAGENTS_CODE_ONBOARDING"
+"""Override whether the first-run onboarding flow opens at interactive startup.
+
+Three-state, parsed by `classify_env_bool`:
+
+- Unset (or an unrecognized token): keep the default first-run behavior, i.e.
+  run onboarding until the completion marker exists.
+- Falsy (`0`, `false`, `no`, `off`, or empty): never open onboarding, even on a
+  fresh install with no completion marker.
+- Truthy (`1`, `true`, `yes`, `on`): force onboarding to open on every
+  interactive startup, ignoring the completion marker.
+
+Read by `should_run_onboarding`; skipping the flow this way does not write the
+completion marker, so unsetting the variable restores first-run behavior.
 """
 
 ONBOARDING_INTEGRATIONS_SCREEN = "DEEPAGENTS_CODE_ONBOARDING_INTEGRATIONS_SCREEN"

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1492,6 +1492,7 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         ),
         kind=OptionKind.BOOL,
         env_var=_env_vars.ONBOARDING,
+        empty_env_is_false=True,
     ),
     ConfigOption(
         key="startup.mode",

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1484,6 +1484,16 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
     ),
     # --- Startup --------------------------------------------------------
     ConfigOption(
+        key="startup.onboarding",
+        group="Startup",
+        summary=(
+            "Force the first-run onboarding flow to open on every interactive "
+            "startup, or disable it entirely; unset follows the completion marker."
+        ),
+        kind=OptionKind.BOOL,
+        env_var=_env_vars.ONBOARDING,
+    ),
+    ConfigOption(
         key="startup.mode",
         group="Startup",
         summary="Default approval mode at launch ('manual', 'auto', or 'yolo').",
@@ -1531,14 +1541,6 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         ),
         kind=OptionKind.LOG_LEVEL_DELEGATE,
         env_var=_env_vars.LOG_LEVEL,
-    ),
-    ConfigOption(
-        key="debug.onboarding",
-        group="Debug",
-        summary="Force the onboarding flow to open on every interactive startup.",
-        kind=OptionKind.BOOL,
-        default=False,
-        env_var=_env_vars.DEBUG_ONBOARDING,
     ),
     ConfigOption(
         key="debug.notifications",

--- a/libs/code/deepagents_code/onboarding.py
+++ b/libs/code/deepagents_code/onboarding.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import TYPE_CHECKING
 
-from deepagents_code._env_vars import DEBUG_ONBOARDING, is_env_truthy
+from deepagents_code._env_vars import ONBOARDING, classify_env_bool
 from deepagents_code.model_config import DEFAULT_STATE_DIR
 
 if TYPE_CHECKING:
@@ -266,12 +267,24 @@ def strip_onboarding_name_markers(text: str) -> str:
 def should_run_onboarding(state_dir: Path | None = None) -> bool:
     """Return whether onboarding should open at interactive startup.
 
+    `DEEPAGENTS_CODE_ONBOARDING` overrides the marker in both directions: a
+    truthy value forces the flow open on every startup, and a falsy value keeps
+    it closed even on a fresh install. An unset or unrecognized value leaves the
+    marker in charge, so the override never has to be unset to get first-run
+    behavior back.
+
     Args:
         state_dir: Optional state directory override for tests.
 
     Returns:
-        `True` when the debug override is enabled or no completion marker exists.
+        `True` when the env override is truthy, or when it does not apply and no
+            completion marker exists.
     """
-    if is_env_truthy(DEBUG_ONBOARDING):
-        return True
+    raw = os.environ.get(ONBOARDING)
+    if raw is not None:
+        override = classify_env_bool(raw)
+        if override is None:
+            logger.warning("Ignoring %s=%r (expected bool)", ONBOARDING, raw)
+        else:
+            return override
     return not has_completed_onboarding(state_dir)

--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -245,8 +245,8 @@ def _clear_provider_base_url_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(autouse=True)
 def _clear_onboarding_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Prevent local debug onboarding env vars from affecting tests."""
-    monkeypatch.delenv("DEEPAGENTS_CODE_DEBUG_ONBOARDING", raising=False)
+    """Prevent local onboarding env overrides from affecting tests."""
+    monkeypatch.delenv("DEEPAGENTS_CODE_ONBOARDING", raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -1127,6 +1127,23 @@ def test_langsmith_project_empty_bare_is_default(monkeypatch) -> None:
     assert resolve_scalar(opt, toml_data={}) == (LANGSMITH_PROJECT_DEFAULT, "default")
 
 
+def test_onboarding_empty_env_reports_env_opt_out(monkeypatch) -> None:
+    """An explicitly empty `DEEPAGENTS_CODE_ONBOARDING` resolves as an env opt-out.
+
+    `should_run_onboarding` treats an empty value as falsy and suppresses the
+    flow, so `config` must report the option as set by the environment rather
+    than unset/default.
+    """
+    from deepagents_code.onboarding import should_run_onboarding
+
+    opt = get_option("startup.onboarding")
+    assert opt is not None
+    monkeypatch.setenv("DEEPAGENTS_CODE_ONBOARDING", "")
+    value, source = resolve_scalar(opt, toml_data={})
+    assert (value, source) == (False, "env (DEEPAGENTS_CODE_ONBOARDING)")
+    assert should_run_onboarding() is False
+
+
 def test_fallback_env_vars_yield_to_toml_when_env_unset(monkeypatch) -> None:
     """A synthetic option exercises the empty-fallback → `config.toml` path.
 

--- a/libs/code/tests/unit_tests/test_onboarding.py
+++ b/libs/code/tests/unit_tests/test_onboarding.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from deepagents_code._env_vars import DEBUG_ONBOARDING
+import pytest
+
+from deepagents_code._env_vars import ONBOARDING
 from deepagents_code.onboarding import (
     GOAL_AUTO_ACCEPT_PROMPT_MARKER_FILENAME,
     ONBOARDING_MARKER_FILENAME,
@@ -24,11 +26,9 @@ from deepagents_code.onboarding import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-
 
 class TestOnboardingState:
-    """Tests for the onboarding completion marker and debug override."""
+    """Tests for the onboarding completion marker and env override."""
 
     def test_missing_marker_runs_onboarding(self, tmp_path) -> None:
         """Onboarding should run before the marker exists."""
@@ -41,16 +41,43 @@ class TestOnboardingState:
         assert has_completed_onboarding(tmp_path) is True
         assert should_run_onboarding(tmp_path) is False
 
-    def test_debug_override_runs_even_with_marker(
+    def test_truthy_override_runs_even_with_marker(
         self,
         tmp_path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Debug override should force onboarding every startup."""
+        """A truthy override should force onboarding every startup."""
         onboarding_marker_path(tmp_path).write_text("1\n", encoding="utf-8")
-        monkeypatch.setenv(DEBUG_ONBOARDING, "1")
+        monkeypatch.setenv(ONBOARDING, "1")
 
         assert should_run_onboarding(tmp_path) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    def test_falsy_override_skips_onboarding_without_marker(
+        self,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+        value: str,
+    ) -> None:
+        """A falsy override should skip onboarding on a fresh install."""
+        monkeypatch.setenv(ONBOARDING, value)
+
+        assert should_run_onboarding(tmp_path) is False
+        assert has_completed_onboarding(tmp_path) is False
+
+    def test_unrecognized_override_falls_back_to_marker(
+        self,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An unparseable override should leave the marker in charge."""
+        monkeypatch.setenv(ONBOARDING, "maybe")
+
+        assert should_run_onboarding(tmp_path) is True
+
+        onboarding_marker_path(tmp_path).write_text("1\n", encoding="utf-8")
+
+        assert should_run_onboarding(tmp_path) is False
 
     def test_mark_onboarding_complete_creates_marker(self, tmp_path) -> None:
         """Completion should create the marker under the state directory."""


### PR DESCRIPTION
`DEEPAGENTS_CODE_DEBUG_ONBOARDING` is now `DEEPAGENTS_CODE_ONBOARDING`, and it works in both directions: set it to a falsy value to skip the first-run onboarding flow entirely (useful for fresh containers, CI, and provisioned machines), a truthy value to force it open on every interactive startup, or leave it unset for the existing first-run behavior.

---

Previously the only knob was a debug-only override that could force onboarding *on*. There was no supported way to turn it off, so anyone provisioning a fresh instance had to pre-seed the internal completion marker file — an implementation detail that is not part of the documented surface.

`should_run_onboarding` now reads the variable through the existing `classify_env_bool` helper so it resolves three ways: truthy forces the flow, falsy suppresses it, and unset (or an unrecognized token, which is logged) defers to the completion marker as before. Suppressing the flow does not write the marker, so removing the variable restores first-run behavior rather than silently consuming it.

The config manifest entry moves from `debug.onboarding` to `startup.onboarding` and drops its static default, so `config` reports it as unset rather than implying a hardcoded `false`. It stays env-only, matching what the runtime actually reads.

The old variable name is removed rather than aliased: it was documented as a debug-only knob, and keeping a second spelling would leave two names with different semantics.

Made by [Open SWE](https://openswe.vercel.app/agents/44ba60bf-19f1-3a82-77ba-6def983ff352)