### PR TITLE
style(code): explain why to use `/offload` in the startup tip

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -19,7 +19,7 @@ _TIP_SHIFT_TAB_WITHOUT_YOLO = "Press Shift+Tab to toggle Manual and Auto modes"
 _TIPS: dict[str, int] = {
     "Use @ to reference files and / for commands": 3,
     "Try /threads to resume a previous conversation": 2,
-    "Use /offload when your conversation gets long": 2,
+    "Use /offload to summarize older messages and free up the context window": 2,
     "Use /copy to copy the latest message": 3,
     "Use /cost to see a breakdown of estimated spend": 1,
     "Use /tools to list the tools available to the agent": 1,


### PR DESCRIPTION
The startup tip for `/offload` now explains what the command does and why it helps — it summarizes older messages to free up the context window — instead of only saying to run it once the conversation gets long.

---

Startup tips exist for feature discovery, so a tip that names a command without saying what it gains the user does not do its job. The new wording keeps the short, action-oriented format of the other tips while stating the benefit.

Made by [Open SWE](https://openswe.vercel.app/agents/985d7cc1-7fab-ad75-7dff-86588a73b73a)
