### PR TITLE
feat(code): make Hooks v2 generally available

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -2474,21 +2474,17 @@ def create_cli_agent(
         # Server-owned hooks must wrap subagent tools too; otherwise Pre/Post
         # ToolUse only fire on the parent graph. Disable Stop so finishing a
         # subagent does not emit the main-agent Stop event (SubagentStop still
-        # fires from the parent wrap around `task`). Hooks v2 stays off unless
-        # experimental mode is on.
-        from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+        # fires from the parent wrap around `task`).
+        from deepagents_code.hooks.server_middleware import ServerHooksMiddleware
 
-        if is_env_truthy(EXPERIMENTAL):
-            from deepagents_code.hooks.server_middleware import ServerHooksMiddleware
-
-            hooks_cwd = Path(effective_cwd) if effective_cwd is not None else Path.cwd()
-            middleware.append(
-                ServerHooksMiddleware(
-                    cwd=hooks_cwd,
-                    emit_stop=False,
-                    mcp_tools=mcp_tools,
-                )
+        hooks_cwd = Path(effective_cwd) if effective_cwd is not None else Path.cwd()
+        middleware.append(
+            ServerHooksMiddleware(
+                cwd=hooks_cwd,
+                emit_stop=False,
+                mcp_tools=mcp_tools,
             )
+        )
         # Subagents share the on-disk filesystem backend and can edit the user
         # AGENTS.md, so they get the same managed onboarding-name block guard as
         # the main agent. Gated on memory because the block only exists when
@@ -2883,19 +2879,13 @@ def create_cli_agent(
         agent_middleware.append(AsyncApprovalHITLMiddleware(resolved_interrupt_on))
 
     # Server-owned Hooks v2 lifecycle events (Pre/Post tool, Stop, subagent).
-    # Mounted only in experimental mode; when mounted, also gated at runtime by
-    # `hooks_server_events` on the per-run context so idle sessions without
-    # configured handlers pay no interrupt round-trip. Appended after the HITL
-    # middleware so `PreToolUse` resolves before approval routing.
-    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+    # Gated at runtime by `hooks_server_events` on the per-run context so idle
+    # sessions without configured handlers pay no interrupt round-trip. Appended
+    # after the HITL middleware so `PreToolUse` resolves before approval routing.
+    from deepagents_code.hooks.server_middleware import ServerHooksMiddleware
 
-    if is_env_truthy(EXPERIMENTAL):
-        from deepagents_code.hooks.server_middleware import ServerHooksMiddleware
-
-        hooks_cwd = Path(effective_cwd) if effective_cwd is not None else Path.cwd()
-        agent_middleware.append(
-            ServerHooksMiddleware(cwd=hooks_cwd, mcp_tools=mcp_tools)
-        )
+    hooks_cwd = Path(effective_cwd) if effective_cwd is not None else Path.cwd()
+    agent_middleware.append(ServerHooksMiddleware(cwd=hooks_cwd, mcp_tools=mcp_tools))
 
     if fs_tools is not None:
         # `fs_tools` is an explicit allowlist here (`--allow-fs-tools all` and an

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4746,11 +4746,6 @@ class DeepAgentsApp(App):
                 immediately. In-session resumes defer activation until the outgoing
                 runtime has received `SessionEnd`.
         """
-        from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
-
-        if not is_env_truthy(EXPERIMENTAL):
-            return
-
         from deepagents_code.hooks.loading import project_hooks_path
         from deepagents_code.hooks.trust import project_root_for, trust_project_hooks
         from deepagents_code.tui.widgets.cwd_switch import HookTrustScreen

--- a/libs/code/deepagents_code/hooks/manager.py
+++ b/libs/code/deepagents_code/hooks/manager.py
@@ -135,10 +135,6 @@ class HooksManager:
     ) -> HooksManager:
         """Load hook configuration and return a ready manager.
 
-        Hooks v2 is in progress, so it stays off unless
-        `DEEPAGENTS_CODE_EXPERIMENTAL` is truthy; without it the manager is
-        inert and no hook (client- or server-owned) fires.
-
         Never raises: a failed load yields an inert manager whose lifecycle
         methods are all no-ops.
 
@@ -614,16 +610,12 @@ def _load_runtime(
         plugins: Already-discovered plugins, or `None` to discover them.
 
     Returns:
-        The loaded runtime, `None` when configuration could not be loaded, and
-        `None` whenever `DEEPAGENTS_CODE_EXPERIMENTAL` is not truthy.
+        The loaded runtime, or `None` when configuration could not be loaded.
     """
-    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
     from deepagents_code.hooks.runtime import HooksRuntime
     from deepagents_code.plugins.adapters.hooks import discover_plugin_hook_sources
     from deepagents_code.project_utils import ProjectContext
 
-    if not is_env_truthy(EXPERIMENTAL):
-        return None
     try:
         project_context = ProjectContext.from_user_cwd(cwd)
         plugin_sources, plugin_diagnostics = discover_plugin_hook_sources(

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3714,14 +3714,11 @@ def _check_project_hooks_trust(
     Returns:
         The trust policy to run the session under, `INTERRUPTED` when the user
         presses Ctrl+C, or `CANCELLED` when the user presses Esc or Ctrl+D to
-        abort startup. Nothing is trusted, and no prompt is shown, unless
-        `DEEPAGENTS_CODE_EXPERIMENTAL` is truthy, since hooks stay off without
-        it.
+        abort startup.
     """
     from rich.console import Console
     from rich.text import Text
 
-    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
     from deepagents_code.hooks.loading import project_hooks_path
     from deepagents_code.hooks.trust import (
         WorkspaceTrust,
@@ -3730,8 +3727,6 @@ def _check_project_hooks_trust(
     )
     from deepagents_code.project_utils import ProjectContext
 
-    if not is_env_truthy(EXPERIMENTAL):
-        return WorkspaceTrust.none()
     try:
         context = ProjectContext.from_user_cwd(Path.cwd())
         project_root = context.project_root or context.user_cwd

--- a/libs/code/tests/unit_tests/hooks/test_manager.py
+++ b/libs/code/tests/unit_tests/hooks/test_manager.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
-import pytest
-
-from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.approval_mode import ApprovalMode
 from deepagents_code.hooks.manager import HookSessionIdentity, HooksManager
 from deepagents_code.hooks.models.domain import PermissionEffect
@@ -15,13 +12,9 @@ from deepagents_code.hooks.models.domain import PermissionEffect
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
     from deepagents_code.hooks.presenter import HookNoticeSeverity, HookPresenter
-
-
-@pytest.fixture(autouse=True)
-def _enable_hooks_v2(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Hooks v2 only loads in experimental mode, which these tests exercise."""
-    monkeypatch.setenv(EXPERIMENTAL, "1")
 
 
 def _write_project_hooks(root: Path) -> Path:

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -911,12 +911,7 @@ def test_pre_tool_allow_bypasses_hitl_and_preserves_context(
     handler.assert_called_once_with(request)
 
 
-def test_server_pre_tool_node_runs_before_stock_hitl(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    from deepagents_code._env_vars import EXPERIMENTAL
-
-    monkeypatch.setenv(EXPERIMENTAL, "1")
+def test_server_pre_tool_node_runs_before_stock_hitl(tmp_path: Path) -> None:
     model = GenericFakeChatModel(messages=iter([AIMessage(content="done")]))
     model.profile = {"max_input_tokens": 200000}
     graph, _backend = create_cli_agent(

--- a/libs/code/tests/unit_tests/hooks/test_trust.py
+++ b/libs/code/tests/unit_tests/hooks/test_trust.py
@@ -11,7 +11,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.approval_mode import ApprovalMode
 from deepagents_code.hooks.manager import HookSessionIdentity, HooksManager
 from deepagents_code.hooks.models.domain import (
@@ -31,12 +30,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from deepagents_code.app import DeepAgentsApp
-
-
-@pytest.fixture(autouse=True)
-def _enable_hooks_v2(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Hooks v2 only loads in experimental mode, which these tests exercise."""
-    monkeypatch.setenv(EXPERIMENTAL, "1")
 
 
 def _write_project_hooks(root: Path, *, event: str = "Stop") -> Path:

--- a/libs/code/tests/unit_tests/plugins/test_plugin_hooks.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugin_hooks.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.approval_mode import ApprovalMode
 from deepagents_code.hooks.manager import HookSessionIdentity, HooksManager
 from deepagents_code.hooks.models.domain import HookEvent, SessionStartCause
@@ -39,7 +38,6 @@ def _stage_plugins(
     monkeypatch: pytest.MonkeyPatch,
     documents: Mapping[str, dict[str, object] | bytes],
 ) -> tuple[Path, Path]:
-    monkeypatch.setenv(EXPERIMENTAL, "1")
     user_dir = tmp_path / "config"
     user_dir.mkdir(parents=True, exist_ok=True)
     for module in ("model_config", "hooks.loading", "hooks.runtime"):

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -3544,7 +3544,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
             ), f"Unexpected shell middleware on subagent {name!r}"
 
     def test_subagent_middleware_combines_shell_configurable_model_and_cost(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path
     ) -> None:
         """Restrictive shell + implicit model should yield shell, model, and cost.
 
@@ -3552,13 +3552,11 @@ class TestCreateCliAgentShellMiddlewareWiring:
         must not gain `ConfigurableModelMiddleware`, which would let a runtime
         `/model` switch clobber the pinned model.
         """
-        from deepagents_code._env_vars import EXPERIMENTAL
         from deepagents_code.agent import ShellAllowListMiddleware
         from deepagents_code.configurable_model import ConfigurableModelMiddleware
         from deepagents_code.cost_tracking import CostTrackingMiddleware
         from deepagents_code.hooks.server_middleware import ServerHooksMiddleware
 
-        monkeypatch.setenv(EXPERIMENTAL, "1")
         mock_settings = self._build_mock_settings(tmp_path)
         mock_agent = Mock()
         mock_agent.with_config.return_value = mock_agent
@@ -4957,7 +4955,6 @@ class TestCreateCliAgentInterpreterWiring:
     def test_single_hitl_slot_precedes_server_hooks(
         self,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
         *,
         auto_mode_enabled: bool,
     ) -> None:
@@ -4969,10 +4966,8 @@ class TestCreateCliAgentInterpreterWiring:
         stay behind whichever one is installed so its `after_model` `PreToolUse`
         pass resolves before approval routing.
         """
-        from deepagents_code._env_vars import EXPERIMENTAL
         from deepagents_code.hooks.server_middleware import ServerHooksMiddleware
 
-        monkeypatch.setenv(EXPERIMENTAL, "1")
         middleware = self._capture_middleware(
             tmp_path, auto_mode_enabled=auto_mode_enabled
         )

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -27660,15 +27660,9 @@ class TestLiveApprovalModeWrites:
         assert app._session_state.approval_mode is ApprovalMode.MANUAL
         assert app._approval_mode_blocked is False
 
-    async def test_session_init_keeps_mode_changed_during_construction(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        from deepagents_code._env_vars import EXPERIMENTAL
+    async def test_session_init_keeps_mode_changed_during_construction(self) -> None:
         from deepagents_code.approval_mode import ApprovalMode
 
-        # `HooksRuntime.create` is the construction seam probed below, and it
-        # only runs in experimental mode.
-        monkeypatch.setenv(EXPERIMENTAL, "1")
         app = DeepAgentsApp(approval_mode=ApprovalMode.MANUAL)
 
         def change_mode_during_construction(**_kwargs: object) -> None:
@@ -27683,19 +27677,12 @@ class TestLiveApprovalModeWrites:
         assert app._session_state is not None
         assert app._session_state.approval_mode is ApprovalMode.AUTO
 
-    async def test_session_init_builds_one_state_for_concurrent_callers(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_session_init_builds_one_state_for_concurrent_callers(self) -> None:
         """The startup worker and the inline startup fallback must not race.
 
         Idempotency rests on construction staying free of `await`; reintroducing
         one would let both callers pass the guard and build two states.
         """
-        from deepagents_code._env_vars import EXPERIMENTAL
-
-        # `HooksRuntime.create` is the construction seam counted below, and it
-        # only runs in experimental mode.
-        monkeypatch.setenv(EXPERIMENTAL, "1")
         app = DeepAgentsApp()
         creations = 0
 

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
 from rich.style import Style
 from rich.text import Text
 
-from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code._tool_stream import (
     TOOL_OUTPUT_TRUNCATION_MARKER,
     UNRENDERABLE_TOOL_OUTPUT,
@@ -381,11 +380,8 @@ class TestSandboxTypeForwarding:
         assert kwargs["profile_overrides"] == {"max_input_tokens": 32_000}
         assert kwargs["enable_interpreter"] is None
 
-    async def test_permission_hooks_override_headless_yolo_bypass(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_permission_hooks_override_headless_yolo_bypass(self) -> None:
         """Permission hooks force client resolution while retaining YOLO context."""
-        monkeypatch.setenv(EXPERIMENTAL, "1")
         runtime = MagicMock()
         runtime.configured_events.return_value = frozenset(
             {HookEvent.PERMISSION_REQUEST}
@@ -1679,7 +1675,6 @@ class TestMaxTurns:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """`--trust-project-hooks` loads repository hook handlers."""
-        monkeypatch.setenv(EXPERIMENTAL, "1")
         monkeypatch.chdir(tmp_path)
         project_hooks = tmp_path / ".deepagents"
         project_hooks.mkdir()


### PR DESCRIPTION
Hooks v2 now loads by default across interactive and headless sessions.

---

Removes the runtime, trust, cwd-switch, and main/subagent server middleware experimental gates while preserving workspace trust and configured-event runtime gating.

Made by [Open SWE](https://openswe.vercel.app/agents/019fcdad-507a-778b-9ab6-f3741f9cdf80)