### PR TITLE
fix(infra): push pin bump branch without origin refspec

### DIFF
--- a/.github/workflows/bump_code_sdk_pin.yml
+++ b/.github/workflows/bump_code_sdk_pin.yml
@@ -201,7 +201,7 @@ jobs:
           git checkout -b "$BRANCH"
           git add "$code_pyproject" "$lockfile"
           git commit -m "chore(deps): bump deepagents pin in deepagents-code to $SDK_VERSION"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" --set-upstream origin "$BRANCH"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH:$BRANCH"
 
           body_file="$(mktemp)"
           {


### PR DESCRIPTION
Fixes the auto-opened SDK pin bump workflow failing at its final push with `error: src refspec origin does not match any`, so the `chore(deps):` pin bump PR can be opened again after a `deepagents` release.

---

The `Open pin bump PR` step pushed with the remote as a URL literal plus `--set-upstream origin "$BRANCH"`. With an unnamed URL remote, git parses `origin` as the source ref of the refspec; no local ref named `origin` exists, so the push failed after the branch had already been committed. `--set-upstream` is also meaningless against a URL remote. The step now pushes `"$BRANCH:$BRANCH"` — local branch to the same-named remote branch, no `origin` refspec, no `--set-upstream`.

The earlier `git push <url> --delete "$BRANCH"` in the same step is unaffected and intentionally untouched: `--delete` takes only a destination ref, so that form was already correct. The sibling `bump_uv_pin.yml` workflow pushes via the named `origin` remote and was already correct.