### PR TITLE
feat(code): add Baseten built-in pricing overrides

### DIFF
--- a/libs/code/deepagents_code/bundled_prices.json
+++ b/libs/code/deepagents_code/bundled_prices.json
@@ -1,1 +1,21 @@
-[]
+[
+  {
+    "id": "baseten",
+    "name": "Baseten",
+    "api_pattern": "https://inference\\.baseten\\.co",
+    "models": [
+      { "id": "deepseek-ai/DeepSeek-V4-Pro", "match": { "equals": "deepseek-ai/DeepSeek-V4-Pro" }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 1.74, "cache_read_mtok": 0.145, "output_mtok": 3.48 } },
+      { "id": "deepseek-ai/DeepSeek-V4-Flash-0731", "match": { "equals": "deepseek-ai/DeepSeek-V4-Flash-0731" }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 0.13, "cache_read_mtok": 0.028, "output_mtok": 0.26 } },
+      { "id": "zai-org/GLM-4.7", "match": { "or": [{ "equals": "zai-org/GLM-4.7" }, { "equals": "glm-4-7" }] }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 0.6, "cache_read_mtok": 0.12, "output_mtok": 2.2 } },
+      { "id": "zai-org/GLM-5.2", "match": { "equals": "zai-org/GLM-5.2" }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 1.4, "cache_read_mtok": 0.14, "output_mtok": 4.4 } },
+      { "id": "zai-org/GLM-5.2-Fast", "match": { "equals": "zai-org/GLM-5.2-Fast" }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 2.1, "cache_read_mtok": 0.21, "output_mtok": 6.6 } },
+      { "id": "thinkingmachines/inkling", "match": { "or": [{ "equals": "thinkingmachines/inkling" }, { "equals": "inkling" }] }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 1.0, "cache_read_mtok": 0.17, "output_mtok": 4.05 } },
+      { "id": "thinkingmachines/inkling-small", "match": { "or": [{ "equals": "thinkingmachines/inkling-small" }, { "equals": "inkling-small" }] }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 0.5, "cache_read_mtok": 0.1, "output_mtok": 1.2 } },
+      { "id": "moonshotai/Kimi-K2.6", "match": { "equals": "moonshotai/Kimi-K2.6" }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 0.95, "cache_read_mtok": 0.16, "output_mtok": 4.0 } },
+      { "id": "moonshotai/Kimi-K2.7-Code", "match": { "equals": "moonshotai/Kimi-K2.7-Code" }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 0.95, "cache_read_mtok": 0.16, "output_mtok": 4.0 } },
+      { "id": "moonshotai/Kimi-K3", "match": { "equals": "moonshotai/Kimi-K3" }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 3.0, "cache_read_mtok": 0.3, "output_mtok": 15.0 } },
+      { "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B", "match": { "equals": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B" }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 0.6, "cache_read_mtok": 0.12, "output_mtok": 2.4 } },
+      { "id": "openai/gpt-oss-120b", "match": { "equals": "openai/gpt-oss-120b" }, "price_comments": "Stopgap pending pydantic/genai-prices#549; no cached-input rate published", "prices": { "input_mtok": 0.1, "output_mtok": 0.5 } }
+    ]
+  }
+]


### PR DESCRIPTION
Baseten model cost estimates now fall back to a built-in pricing catalog instead of showing `$0`. All 12 Baseten Model APIs models are priced at their published input / cached-input / output rates.

---

[Baseten Model APIs](https://docs.baseten.co/inference/model-apis/overview#supported-models) shipped models that genai-prices does not yet cover, so `estimate_cost` returned `None` for them and those requests dropped out of the session total. This adds a `baseten` provider block to `bundled_prices.json` (#5304's fallback-on-miss override), priced from the [Baseten pricing page](https://www.baseten.co/pricing).

This is a stopgap. Every entry carries `price_comments: "Stopgap pending pydantic/genai-prices#549"` per the `bundled_prices.README.md` policy, enforced by `test_every_bundled_override_entry_is_priced_and_links_upstream`. The upstream addition is open at pydantic/genai-prices#549; once that merges and the hourly auto-update picks it up, these entries go inert automatically (upstream always wins on a primary-catalog hit) and can be removed as housekeeping.

Rates per 1M tokens (input / cached input / output):

| Model | Slug | Input | Cache | Output |
|---|---|---|---|---|
| DeepSeek V4 Pro | `deepseek-ai/DeepSeek-V4-Pro` | 1.74 | 0.145 | 3.48 |
| DeepSeek V4 Flash 0731 | `deepseek-ai/DeepSeek-V4-Flash-0731` | 0.13 | 0.028 | 0.26 |
| GLM 4.7 | `zai-org/GLM-4.7` | 0.60 | 0.12 | 2.20 |
| GLM 5.2 | `zai-org/GLM-5.2` | 1.40 | 0.14 | 4.40 |
| GLM 5.2 Fast | `zai-org/GLM-5.2-Fast` | 2.10 | 0.21 | 6.60 |
| Inkling | `thinkingmachines/inkling` | 1.00 | 0.17 | 4.05 |
| Inkling Small | `thinkingmachines/inkling-small` | 0.50 | 0.10 | 1.20 |
| Kimi K2.6 | `moonshotai/Kimi-K2.6` | 0.95 | 0.16 | 4.00 |
| Kimi K2.7 Code | `moonshotai/Kimi-K2.7-Code` | 0.95 | 0.16 | 4.00 |
| Kimi K3 | `moonshotai/Kimi-K3` | 3.00 | 0.30 | 15.00 |
| NVIDIA Nemotron 3 Ultra | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B` | 0.60 | 0.12 | 2.40 |
| OpenAI GPT 120B | `openai/gpt-oss-120b` | 0.10 | — | 0.50 |

Notes:

- Cached input uses `cache_read_mtok`, matching Baseten's "Cache Input" KV-cache rate (applied automatically to every request).
- `openai/gpt-oss-120b` publishes no separate cached-input rate, so `cache_read_mtok` is omitted — cached tokens stay in the ordinary input total.
- Extra `match` aliases cover the bare slugs Baseten's pricing "Try" links use: `glm-4-7`, `inkling`, `inkling-small`.
