### PR TITLE
fix(code): route failures to `PostToolUseFailure`

### DIFF
--- a/libs/code/HOOKS.md
+++ b/libs/code/HOOKS.md
@@ -54,7 +54,8 @@ Native tools are matched by their wire names (for example `execute` → `Bash`, 
 | `PermissionRequest` | client | `tool_name` | The client is about to ask for tool permission |
 | `Notification` | client | `notification_type` | A client lifecycle notification is emitted |
 | `PreToolUse` | server | `tool_name` | Before a tool call runs |
-| `PostToolUse` | server | `tool_name` | After a tool call completes |
+| `PostToolUse` | server | `tool_name` | After a tool call succeeds |
+| `PostToolUseFailure` | server | `tool_name` | After a tool call fails |
 | `PreCompact` | server | `trigger` | Before conversation compaction |
 | `Stop` | server | _(none)_ | After an agent stop turn |
 | `SubagentStart` | server | `agent_name` | When a subagent starts |
@@ -127,7 +128,7 @@ Matchers use wire tool names. `execute` is exposed as `Bash`. Exit code `2` (or 
 
 Handlers communicate through:
 
-- **Exit code `2`**: treated as a synthetic `decision: "block"`. Interpretation depends on the event (for example deny on `PreToolUse` / `PermissionRequest`, block further processing on `UserPromptSubmit` / `PreCompact`, feedback on `PostToolUse`).
+- **Exit code `2`**: treated as a synthetic `decision: "block"`. Interpretation depends on the event (for example deny on `PreToolUse` / `PermissionRequest`, block further processing on `UserPromptSubmit` / `PreCompact`, feedback on `PostToolUse` / `PostToolUseFailure`).
 - **Other non-zero exits**: recorded as diagnostics; they do not apply a block decision.
 - **JSON stdout** (`HookWireOutput`): may set `continue` / `stopReason`, `systemMessage` (user-visible notice), `additionalContext` via `hookSpecificOutput`, and event-specific fields such as `permissionDecision` on `PreToolUse`.
 - **Non-JSON stdout**: becomes additional context for events whose plain-output policy is context (`SessionStart`, `UserPromptSubmit`); otherwise it is a diagnostic.

--- a/libs/code/deepagents_code/hooks/capabilities.py
+++ b/libs/code/deepagents_code/hooks/capabilities.py
@@ -16,6 +16,8 @@ from deepagents_code.hooks.models.domain import (
     PermissionRequestEvent,
     PostToolUseDecision,
     PostToolUseEvent,
+    PostToolUseFailureDecision,
+    PostToolUseFailureEvent,
     PreCompactDecision,
     PreCompactEvent,
     PreToolUseDecision,
@@ -183,6 +185,18 @@ _HOOK_EVENT_SPECS: Final[Mapping[HookEvent, HookEventSpec]] = MappingProxyType(
             aggregation_policy=AggregationPolicy.FEEDBACK_AND_CONTEXT,
             supported_handler_types=frozenset({HandlerType.COMMAND}),
         ),
+        HookEvent.POST_TOOL_USE_FAILURE: HookEventSpec(
+            event=HookEvent.POST_TOOL_USE_FAILURE,
+            owner=HookOwner.SERVER,
+            event_model=PostToolUseFailureEvent,
+            decision_model=PostToolUseFailureDecision,
+            matcher_field="tool_name",
+            default_timeout_seconds=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+            exit_code_policy=ExitCodePolicy.FEEDBACK,
+            plain_output_policy=PlainOutputPolicy.IGNORE,
+            aggregation_policy=AggregationPolicy.FEEDBACK_AND_CONTEXT,
+            supported_handler_types=frozenset({HandlerType.COMMAND}),
+        ),
         HookEvent.PRE_COMPACT: HookEventSpec(
             event=HookEvent.PRE_COMPACT,
             owner=HookOwner.SERVER,
@@ -259,6 +273,8 @@ def get_event_spec(event: HookEvent) -> HookEventSpec:
             return _HOOK_EVENT_SPECS[HookEvent.PRE_TOOL_USE]
         case HookEvent.POST_TOOL_USE:
             return _HOOK_EVENT_SPECS[HookEvent.POST_TOOL_USE]
+        case HookEvent.POST_TOOL_USE_FAILURE:
+            return _HOOK_EVENT_SPECS[HookEvent.POST_TOOL_USE_FAILURE]
         case HookEvent.PRE_COMPACT:
             return _HOOK_EVENT_SPECS[HookEvent.PRE_COMPACT]
         case HookEvent.STOP:

--- a/libs/code/deepagents_code/hooks/models/domain.py
+++ b/libs/code/deepagents_code/hooks/models/domain.py
@@ -43,6 +43,7 @@ class HookEvent(StrEnum):
     NOTIFICATION = "Notification"
     PRE_TOOL_USE = "PreToolUse"
     POST_TOOL_USE = "PostToolUse"
+    POST_TOOL_USE_FAILURE = "PostToolUseFailure"
     PRE_COMPACT = "PreCompact"
     STOP = "Stop"
     SUBAGENT_START = "SubagentStart"
@@ -251,6 +252,16 @@ class PostToolUseEvent(_DomainModel):
         )
 
 
+class PostToolUseFailureEvent(_DomainModel):
+    """Domain payload for `PostToolUseFailure`."""
+
+    event: Literal[HookEvent.POST_TOOL_USE_FAILURE]
+    call: ToolCallData
+    error: str
+    is_interrupt: bool = False
+    duration_ms: int | None = None
+
+
 class PreCompactEvent(_DomainModel):
     """Domain payload for `PreCompact`."""
 
@@ -304,6 +315,7 @@ HookDomainEvent: TypeAlias = Annotated[
     | NotificationEvent
     | PreToolUseEvent
     | PostToolUseEvent
+    | PostToolUseFailureEvent
     | PreCompactEvent
     | StopEvent
     | SubagentStartEvent
@@ -397,6 +409,14 @@ class PostToolUseDecision(BaseHookDecision):
     context: list[str] = Field(default_factory=list)
 
 
+class PostToolUseFailureDecision(BaseHookDecision):
+    """Decision returned for `PostToolUseFailure`."""
+
+    event: Literal[HookEvent.POST_TOOL_USE_FAILURE]
+    feedback: list[str] = Field(default_factory=list)
+    context: list[str] = Field(default_factory=list)
+
+
 class PreCompactDecision(BaseHookDecision):
     """Decision returned for `PreCompact`."""
 
@@ -433,6 +453,7 @@ HookDecision: TypeAlias = Annotated[
     | NotificationDecision
     | PreToolUseDecision
     | PostToolUseDecision
+    | PostToolUseFailureDecision
     | PreCompactDecision
     | StopDecision
     | SubagentStartDecision

--- a/libs/code/deepagents_code/hooks/models/wire.py
+++ b/libs/code/deepagents_code/hooks/models/wire.py
@@ -287,6 +287,18 @@ class PostToolUseWireInput(BaseHookWireInput):
     duration_ms: int | None = None
 
 
+class PostToolUseFailureWireInput(BaseHookWireInput):
+    """Wire input for `PostToolUseFailure`."""
+
+    hook_event_name: Literal[HookEvent.POST_TOOL_USE_FAILURE]
+    tool_name: str
+    tool_input: JsonObject
+    tool_use_id: str
+    error: str
+    is_interrupt: bool | None = None
+    duration_ms: int | None = None
+
+
 class PreCompactWireInput(BaseHookWireInput):
     """Wire input for `PreCompact`."""
 
@@ -334,6 +346,7 @@ HookWireInput: TypeAlias = Annotated[
     | NotificationWireInput
     | PreToolUseWireInput
     | PostToolUseWireInput
+    | PostToolUseFailureWireInput
     | PreCompactWireInput
     | StopWireInput
     | SubagentStartWireInput
@@ -425,6 +438,13 @@ class PostToolUseSpecificOutput(_WireModel):
     )
 
 
+class PostToolUseFailureSpecificOutput(_WireModel):
+    """Event-specific output for `PostToolUseFailure`."""
+
+    hook_event_name: Literal["PostToolUseFailure"] = Field(alias="hookEventName")
+    additional_context: str | None = Field(default=None, alias="additionalContext")
+
+
 class StopSpecificOutput(_WireModel):
     """Event-specific output for `Stop`."""
 
@@ -452,6 +472,7 @@ HookSpecificOutput: TypeAlias = Annotated[
     | PreToolUseSpecificOutput
     | PermissionRequestSpecificOutput
     | PostToolUseSpecificOutput
+    | PostToolUseFailureSpecificOutput
     | StopSpecificOutput
     | SubagentStartSpecificOutput
     | SubagentStopSpecificOutput,

--- a/libs/code/deepagents_code/hooks/projection.py
+++ b/libs/code/deepagents_code/hooks/projection.py
@@ -13,6 +13,7 @@ from deepagents_code.hooks.models.domain import (
     NotificationEvent,
     PermissionRequestEvent,
     PostToolUseEvent,
+    PostToolUseFailureEvent,
     PreCompactEvent,
     PreToolUseEvent,
     SessionEndEvent,
@@ -27,6 +28,7 @@ from deepagents_code.hooks.models.wire import (
     Effort,
     NotificationWireInput,
     PermissionRequestWireInput,
+    PostToolUseFailureWireInput,
     PostToolUseWireInput,
     PreCompactWireInput,
     PreToolUseWireInput,
@@ -215,6 +217,26 @@ def _project_post_tool_use(
         tool_input=tool_input,
         tool_response=event.result,
         tool_use_id=event.call.id,
+        duration_ms=event.duration_ms,
+    )
+
+
+@_project_event.register(PostToolUseFailureEvent)
+def _project_post_tool_use_failure(
+    event: PostToolUseFailureEvent,
+    invocation: HookInvocation,
+    transcript_path: Path,
+    _agent_transcript_path: Path | None,
+) -> HookWireInput:
+    tool_name, tool_input = to_wire_call(event.call)
+    return PostToolUseFailureWireInput(
+        **_base_fields(invocation, transcript_path),
+        hook_event_name=HookEvent.POST_TOOL_USE_FAILURE,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        tool_use_id=event.call.id,
+        error=event.error,
+        is_interrupt=event.is_interrupt,
         duration_ms=event.duration_ms,
     )
 

--- a/libs/code/deepagents_code/hooks/reducer.py
+++ b/libs/code/deepagents_code/hooks/reducer.py
@@ -20,6 +20,7 @@ from deepagents_code.hooks.models.domain import (
     PermissionEffect,
     PermissionRequestDecision,
     PostToolUseDecision,
+    PostToolUseFailureDecision,
     PreCompactDecision,
     PreToolUseDecision,
     SessionEndDecision,
@@ -35,6 +36,7 @@ from deepagents_code.hooks.models.wire import (
     HookSpecificOutput,
     PermissionAllow,
     PermissionRequestSpecificOutput,
+    PostToolUseFailureSpecificOutput,
     PostToolUseSpecificOutput,
     PreToolUseSpecificOutput,
     SessionStartSpecificOutput,
@@ -398,6 +400,16 @@ def _merge_post_tool_use(
 
 
 @_merge_specific.register
+def _merge_post_tool_use_failure(
+    specific: PostToolUseFailureSpecificOutput,
+    _invocation: HookInvocation,
+    state: _Reduction,
+    _handler_id: str,
+) -> None:
+    _append(state.context, specific.additional_context)
+
+
+@_merge_specific.register
 def _merge_stop(
     specific: StopSpecificOutput,
     invocation: HookInvocation,
@@ -506,6 +518,13 @@ def _decision(invocation: HookInvocation, state: _Reduction) -> HookDecision:
         )
     if event is HookEvent.POST_TOOL_USE:
         return PostToolUseDecision(
+            event=event,
+            feedback=state.feedback,
+            context=state.context,
+            **common,
+        )
+    if event is HookEvent.POST_TOOL_USE_FAILURE:
+        return PostToolUseFailureDecision(
             event=event,
             feedback=state.feedback,
             context=state.context,

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -1,8 +1,8 @@
 """Server-owned Hooks v2 lifecycle middleware.
 
-Emits `PreCompact`, `PreToolUse`, `PostToolUse`, `Stop`, `SubagentStart`, and
-`SubagentStop` through the LangGraph interrupt channel so the client runtime can
-execute matching handlers and return typed decisions.
+Emits `PreCompact`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `Stop`,
+`SubagentStart`, and `SubagentStop` through the LangGraph interrupt channel so the
+client runtime can execute matching handlers and return typed decisions.
 """
 
 from __future__ import annotations
@@ -62,6 +62,8 @@ from deepagents_code.hooks.models.domain import (
     PermissionEffect,
     PostToolUseDecision,
     PostToolUseEvent,
+    PostToolUseFailureDecision,
+    PostToolUseFailureEvent,
     PreCompactDecision,
     PreCompactEvent,
     PreToolUseDecision,
@@ -478,22 +480,39 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
         result: ToolMessage | Command[Any],
         duration_ms: int,
     ) -> ToolMessage | Command[Any]:
-        if not _event_enabled(gate, HookEvent.POST_TOOL_USE):
+        error = _tool_result_error(result, call)
+        event = (
+            HookEvent.POST_TOOL_USE_FAILURE
+            if error is not None
+            else HookEvent.POST_TOOL_USE
+        )
+        if not _event_enabled(gate, event):
             return result
-        if _tool_result_failed(result, call.id):
-            return result
-        decision = _invoke_hook(
-            context,
-            PostToolUseEvent.from_tool_result(
+        if error is not None:
+            hook_event = PostToolUseFailureEvent(
+                event=HookEvent.POST_TOOL_USE_FAILURE,
+                call=call,
+                error=error,
+                duration_ms=duration_ms,
+            )
+            decision_type = PostToolUseFailureDecision
+        else:
+            hook_event = PostToolUseEvent.from_tool_result(
                 result,
                 call=call,
                 duration_ms=duration_ms,
+            )
+            decision_type = PostToolUseDecision
+        decision = _require_decision(
+            _invoke_hook(
+                context,
+                hook_event,
+                gate=gate,
+                config=config,
+                deadline=self._default_deadline,
             ),
-            gate=gate,
-            config=config,
-            deadline=self._default_deadline,
+            decision_type,
         )
-        decision = _require_decision(decision, PostToolUseDecision)
         return _apply_post_tool_use(result, decision, call.id)
 
     def _maybe_subagent_stop(
@@ -653,6 +672,7 @@ def _invoke_hook(
     event: (
         PreToolUseEvent
         | PostToolUseEvent
+        | PostToolUseFailureEvent
         | PreCompactEvent
         | StopEvent
         | SubagentStartEvent
@@ -770,6 +790,7 @@ def _invocation_id(
     event: (
         PreToolUseEvent
         | PostToolUseEvent
+        | PostToolUseFailureEvent
         | PreCompactEvent
         | StopEvent
         | SubagentStartEvent
@@ -797,6 +818,7 @@ def _logical_event_identity(
     event: (
         PreToolUseEvent
         | PostToolUseEvent
+        | PostToolUseFailureEvent
         | PreCompactEvent
         | StopEvent
         | SubagentStartEvent
@@ -805,7 +827,10 @@ def _logical_event_identity(
     *,
     logical_event_id: str | None = None,
 ) -> str:
-    if isinstance(event, PreToolUseEvent | PostToolUseEvent):
+    if isinstance(
+        event,
+        PreToolUseEvent | PostToolUseEvent | PostToolUseFailureEvent,
+    ):
         return event.call.id
     if isinstance(event, PreCompactEvent):
         if logical_event_id:
@@ -954,7 +979,7 @@ def _append_message_text(
 
 def _apply_post_tool_use(
     result: ToolMessage | Command[Any],
-    decision: PostToolUseDecision,
+    decision: PostToolUseDecision | PostToolUseFailureDecision,
     call_id: str,
 ) -> ToolMessage | Command[Any]:
     extras: list[str] = []
@@ -1006,13 +1031,29 @@ def _append_tool_result_text(
     return replace(result, update={**update, "messages": messages})
 
 
-def _tool_result_failed(result: ToolMessage | Command[Any], call_id: str) -> bool:
-    if isinstance(result, ToolMessage):
-        return result.status == "error"
-    return any(
-        _is_call_result(message, call_id) and message.status == "error"
-        for message in _command_messages(result)
+def _tool_result_error(
+    result: ToolMessage | Command[Any],
+    call: ToolCallData,
+) -> str | None:
+    messages = (
+        [result] if isinstance(result, ToolMessage) else _command_messages(result)
     )
+    for message in messages:
+        if not _is_call_result(message, call.id):
+            continue
+        if message.status == "error":
+            return _tool_result_text(result, call.id)
+        artifact = message.artifact
+        if call.name != "execute" or not isinstance(artifact, Mapping):
+            continue
+        exit_code = artifact.get("exit_code")
+        if (
+            isinstance(exit_code, int)
+            and not isinstance(exit_code, bool)
+            and exit_code != 0
+        ):
+            return f"Command exited with non-zero status code {exit_code}"
+    return None
 
 
 def _command_messages(result: Command[Any]) -> Sequence[object]:

--- a/libs/code/deepagents_code/hooks/snapshot.py
+++ b/libs/code/deepagents_code/hooks/snapshot.py
@@ -16,6 +16,7 @@ from deepagents_code.hooks.models.domain import (
     NotificationEvent,
     PermissionRequestEvent,
     PostToolUseEvent,
+    PostToolUseFailureEvent,
     PreCompactEvent,
     PreToolUseEvent,
     SessionEndEvent,
@@ -256,7 +257,11 @@ def _match_target(
 ) -> str | None:
     event = invocation.event
     if matcher_field == "tool_name" and isinstance(
-        event, PermissionRequestEvent | PreToolUseEvent | PostToolUseEvent
+        event,
+        PermissionRequestEvent
+        | PreToolUseEvent
+        | PostToolUseEvent
+        | PostToolUseFailureEvent,
     ):
         return to_wire_tool_name(event.call.name, mcp_server=event.call.mcp_server)
     if matcher_field == "notification_type" and isinstance(event, NotificationEvent):

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "deepagents==0.7.1",
+    "deepagents==0.7.4",
     "langchain>=1.3.14,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.1.0,<4.0.0",
 

--- a/libs/code/tests/unit_tests/hooks/models/test_models.py
+++ b/libs/code/tests/unit_tests/hooks/models/test_models.py
@@ -87,16 +87,6 @@ _WIRE_INPUTS = [
     },
     {
         **_COMMON_WIRE_INPUT,
-        "hook_event_name": "PostToolUseFailure",
-        "tool_name": "Bash",
-        "tool_input": {"command": "exit 42"},
-        "tool_use_id": "call-3",
-        "error": "Command exited with non-zero status code 42",
-        "is_interrupt": False,
-        "duration_ms": 15,
-    },
-    {
-        **_COMMON_WIRE_INPUT,
         "hook_event_name": "PreCompact",
         "trigger": "manual",
         "custom_instructions": "Keep the implementation plan",
@@ -193,10 +183,6 @@ _SPECIFIC_OUTPUTS = [
         "hookEventName": "PostToolUse",
         "additionalContext": "Check the formatter output",
         "updatedMCPToolOutput": {"content": "deferred"},
-    },
-    {
-        "hookEventName": "PostToolUseFailure",
-        "additionalContext": "Try a different command",
     },
     {
         "hookEventName": "Stop",

--- a/libs/code/tests/unit_tests/hooks/models/test_models.py
+++ b/libs/code/tests/unit_tests/hooks/models/test_models.py
@@ -87,6 +87,16 @@ _WIRE_INPUTS = [
     },
     {
         **_COMMON_WIRE_INPUT,
+        "hook_event_name": "PostToolUseFailure",
+        "tool_name": "Bash",
+        "tool_input": {"command": "exit 42"},
+        "tool_use_id": "call-3",
+        "error": "Command exited with non-zero status code 42",
+        "is_interrupt": False,
+        "duration_ms": 15,
+    },
+    {
+        **_COMMON_WIRE_INPUT,
         "hook_event_name": "PreCompact",
         "trigger": "manual",
         "custom_instructions": "Keep the implementation plan",
@@ -183,6 +193,10 @@ _SPECIFIC_OUTPUTS = [
         "hookEventName": "PostToolUse",
         "additionalContext": "Check the formatter output",
         "updatedMCPToolOutput": {"content": "deferred"},
+    },
+    {
+        "hookEventName": "PostToolUseFailure",
+        "additionalContext": "Try a different command",
     },
     {
         "hookEventName": "Stop",

--- a/libs/code/tests/unit_tests/hooks/test_engine.py
+++ b/libs/code/tests/unit_tests/hooks/test_engine.py
@@ -33,6 +33,8 @@ from deepagents_code.hooks.models.domain import (
     PermissionRequestEvent,
     PostToolUseDecision,
     PostToolUseEvent,
+    PostToolUseFailureDecision,
+    PostToolUseFailureEvent,
     PreCompactDecision,
     PreCompactEvent,
     PreToolUseDecision,
@@ -451,6 +453,21 @@ def test_snapshot_rejects_matcher_for_unmatchable_event() -> None:
                 call=ToolCallData(id="call-2", name="Bash", args={}),
             ),
             {"hook_event_name": "PostToolUse", "tool_use_id": "call-2"},
+        ),
+        (
+            PostToolUseFailureEvent(
+                event=HookEvent.POST_TOOL_USE_FAILURE,
+                call=ToolCallData(id="call-3", name="Bash", args={}),
+                error="Command exited with non-zero status code 42",
+                duration_ms=15,
+            ),
+            {
+                "hook_event_name": "PostToolUseFailure",
+                "tool_use_id": "call-3",
+                "error": "Command exited with non-zero status code 42",
+                "is_interrupt": False,
+                "duration_ms": 15,
+            },
         ),
         (
             PreCompactEvent(
@@ -1205,6 +1222,21 @@ def test_reducer_covers_event_decision_shapes_and_loop_guards(tmp_path: Path) ->
             },
         ),
         (
+            PostToolUseFailureEvent(
+                event=HookEvent.POST_TOOL_USE_FAILURE,
+                call=ToolCallData(id="call", name="Bash", args={}),
+                error="failed",
+            ),
+            {
+                "decision": "block",
+                "reason": "failure feedback",
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUseFailure",
+                    "additionalContext": "failure context",
+                },
+            },
+        ),
+        (
             StopEvent(
                 event=HookEvent.STOP,
                 continuation_count=1,
@@ -1260,23 +1292,28 @@ def test_reducer_covers_event_decision_shapes_and_loop_guards(tmp_path: Path) ->
         HookEvent.NOTIFICATION,
         HookEvent.PERMISSION_REQUEST,
         HookEvent.POST_TOOL_USE,
+        HookEvent.POST_TOOL_USE_FAILURE,
         HookEvent.STOP,
         HookEvent.SUBAGENT_START,
         HookEvent.SUBAGENT_STOP,
     ]
     permission = decisions[2]
     post_tool = decisions[3]
-    stop = decisions[4]
-    subagent_start = decisions[5]
-    subagent_stop = decisions[6]
+    post_tool_failure = decisions[4]
+    stop = decisions[5]
+    subagent_start = decisions[6]
+    subagent_stop = decisions[7]
     assert isinstance(permission, PermissionRequestDecision)
     assert isinstance(post_tool, PostToolUseDecision)
+    assert isinstance(post_tool_failure, PostToolUseFailureDecision)
     assert isinstance(stop, StopDecision)
     assert isinstance(subagent_start, SubagentStartDecision)
     assert isinstance(subagent_stop, SubagentStopDecision)
     assert permission.permission.behavior == "deny"
     assert post_tool.feedback == ["feedback"]
     assert post_tool.context == ["context"]
+    assert post_tool_failure.feedback == ["failure feedback"]
+    assert post_tool_failure.context == ["failure context"]
     assert stop.continue_loop is True
     assert stop.feedback == ["continue"]
     assert subagent_start.context == ["focus"]

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -843,7 +843,6 @@ def test_failed_execute_routes_to_post_tool_use_failure(
     event = invoke.call_args.args[1]
     assert isinstance(event, PostToolUseFailureEvent)
     assert event.error == "Command exited with non-zero status code 42"
-    assert event.is_interrupt is False
     assert event.duration_ms == 5
 
 

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -49,6 +49,8 @@ from deepagents_code.hooks.models.domain import (
     HookInvocation,
     PermissionEffect,
     PostToolUseDecision,
+    PostToolUseFailureDecision,
+    PostToolUseFailureEvent,
     PreCompactDecision,
     PreCompactEvent,
     PreToolUseDecision,
@@ -76,7 +78,7 @@ from deepagents_code.hooks.server_middleware import (
     _invoke_hook,
     _merge_tool_message_content,
     _session_gate,
-    _tool_result_failed,
+    _tool_result_error,
     _tool_result_text,
 )
 from deepagents_code.hooks.snapshot import HooksSnapshot
@@ -787,24 +789,38 @@ def test_tool_result_text_reads_only_matching_call() -> None:
     assert _tool_result_text(_multi_result_command(), "c1") == "mine"
 
 
-def test_tool_result_failed_ignores_unrelated_failure() -> None:
+def test_tool_result_error_ignores_unrelated_failure() -> None:
     result = _multi_result_command()
 
-    assert _tool_result_failed(result, "c1") is False
-    assert _tool_result_failed(result, "c2") is True
+    assert (
+        _tool_result_error(result, ToolCallData(id="c1", name="execute", args={}))
+        is None
+    )
+    assert (
+        _tool_result_error(
+            result,
+            ToolCallData(id="c2", name="execute", args={}),
+        )
+        == "theirs"
+    )
 
 
-def test_post_tool_use_skips_failed_tool_message(
+def test_failed_execute_routes_to_post_tool_use_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     middleware = ServerHooksMiddleware(cwd=Path("/tmp"))
     result = ToolMessage(
-        content="failed",
+        content="[Command failed with exit code 42]",
         name="execute",
         tool_call_id="c1",
-        status="error",
+        artifact={"exit_code": 42},
+        status="success",
     )
-    invoke = MagicMock()
+    invoke = MagicMock(
+        return_value=PostToolUseFailureDecision(
+            event=HookEvent.POST_TOOL_USE_FAILURE,
+        )
+    )
     monkeypatch.setattr(
         "deepagents_code.hooks.server_middleware._invoke_hook",
         invoke,
@@ -817,14 +833,18 @@ def test_post_tool_use_skips_failed_tool_message(
             cwd=Path("/tmp"),
             approval_mode=ApprovalMode.MANUAL,
         ),
-        {"snapshot_id": "snap", "events": frozenset({"PostToolUse"})},
+        {"snapshot_id": "snap", "events": frozenset({"PostToolUseFailure"})},
         {"configurable": {"thread_id": "thread-1"}},
         result,
         5,
     )
 
     assert updated is result
-    invoke.assert_not_called()
+    event = invoke.call_args.args[1]
+    assert isinstance(event, PostToolUseFailureEvent)
+    assert event.error == "Command exited with non-zero status code 42"
+    assert event.is_interrupt is False
+    assert event.duration_ms == 5
 
 
 def test_append_pretool_context_to_result() -> None:

--- a/libs/code/tests/unit_tests/test_end_to_end.py
+++ b/libs/code/tests/unit_tests/test_end_to_end.py
@@ -397,7 +397,6 @@ class TestDeepAgentsCLIEndToEnd:
                 model=model,
                 assistant_id="test-agent",
                 tools=[sample_tool],
-                checkpointer=InMemorySaver(),
             )
 
             # Invoke the agent


### PR DESCRIPTION
Supersedes #5255

Failed tool calls now fire `PostToolUseFailure`; `PostToolUse` remains success-only.

---

Uses `artifact.exit_code` from `deepagents==0.7.4` for shell failures.
