### PR TITLE
feat(code): add Fireworks built-in pricing overrides

### DIFF
--- a/libs/code/deepagents_code/bundled_prices.json
+++ b/libs/code/deepagents_code/bundled_prices.json
@@ -17,5 +17,15 @@
       { "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B", "match": { "equals": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B" }, "price_comments": "Stopgap pending pydantic/genai-prices#549", "prices": { "input_mtok": 0.6, "cache_read_mtok": 0.12, "output_mtok": 2.4 } },
       { "id": "openai/gpt-oss-120b", "match": { "equals": "openai/gpt-oss-120b" }, "price_comments": "Stopgap pending pydantic/genai-prices#549; no cached-input rate published", "prices": { "input_mtok": 0.1, "output_mtok": 0.5 } }
     ]
+  },
+  {
+    "id": "fireworks",
+    "name": "Fireworks",
+    "api_pattern": "https://api\\.fireworks\\.ai",
+    "models": [
+      { "id": "kimi-k3", "match": { "equals": "accounts/fireworks/models/kimi-k3" }, "price_comments": "Stopgap pending pydantic/genai-prices#550", "prices": { "input_mtok": 3.0, "cache_read_mtok": 0.3, "output_mtok": 15.0 } },
+      { "id": "inkling", "match": { "equals": "accounts/fireworks/models/inkling" }, "price_comments": "Stopgap pending pydantic/genai-prices#550", "prices": { "input_mtok": 1.0, "cache_read_mtok": 0.17, "output_mtok": 4.05 } },
+      { "id": "deepseek-v4-flash-0731", "match": { "equals": "accounts/fireworks/models/deepseek-v4-flash-0731" }, "price_comments": "Stopgap pending pydantic/genai-prices#550", "prices": { "input_mtok": 0.14, "cache_read_mtok": 0.028, "output_mtok": 0.28 } }
+    ]
   }
 ]


### PR DESCRIPTION
Fireworks cost estimates for three new serverless models now fall back to built-in pricing instead of showing `$0`: `accounts/fireworks/models/kimi-k3` ($3.00 / $0.30 / $15.00), `accounts/fireworks/models/inkling` ($1.00 / $0.17 / $4.05), and `accounts/fireworks/models/deepseek-v4-flash-0731` ($0.14 / $0.028 / $0.28) per 1M input / cached-input / output tokens.

---

These models shipped on [Fireworks serverless](https://fireworks.ai/models) without genai-prices coverage, so `estimate_cost` returned `None` for them and those requests dropped out of the session total. This adds a `fireworks` provider block to `bundled_prices.json` (#5304's fallback-on-miss override), priced from each model's pricing page: [Kimi K3](https://fireworks.ai/models/fireworks/kimi-k3), [Inkling](https://fireworks.ai/models/fireworks/inkling), [DeepSeek-V4-Flash-0731](https://fireworks.ai/models/deepseek-ai/deepseek-v4-flash-0731).

This is a stopgap. Every entry carries `price_comments: "Stopgap pending pydantic/genai-prices#550"` per the `bundled_prices.README.md` policy, enforced by `test_every_bundled_override_entry_is_priced_and_links_upstream`. The upstream addition is open at pydantic/genai-prices#550; once that merges and the hourly auto-update picks it up, these entries go inert automatically (upstream always wins on a primary-catalog hit) and can be removed as housekeeping.

Rates per 1M tokens (input / cached input / output):

| Model | Slug | Input | Cache | Output |
|---|---|---|---|---|
| Kimi K3 | `accounts/fireworks/models/kimi-k3` | 3.00 | 0.30 | 15.00 |
| Inkling | `accounts/fireworks/models/inkling` | 1.00 | 0.17 | 4.05 |
| DeepSeek-V4-Flash-0731 | `accounts/fireworks/models/deepseek-v4-flash-0731` | 0.14 | 0.028 | 0.28 |

Notes:

- `deepseek-v4-flash-0731` is the official release of DeepSeek-V4-Flash at the same rates as the existing `deepseek-v4-flash` preview.
- All other Fireworks models with published serverless prices are already covered by upstream `fireworks.yml`, so no other entries are needed.
