### PR TITLE
fix(code): keep MCP shutdown-race traceback off the terminal

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -558,23 +558,85 @@ _QUIET_SDK_LOGGER_NAMES = (
     "genai-prices",
     "langchain",
     "langsmith",
-    "mcp",
 )
+
+_MCP_STREAMABLE_HTTP_LOGGER_NAME = "mcp.client.streamable_http"
+
+
+class _McpShutdownRaceFilter(logging.Filter):
+    """Drop the MCP streamable-HTTP transport's shutdown-race record.
+
+    When the app quits while an HTTP MCP response is in flight, the
+    transport's response task finds the session stream already closed and
+    logs `logger.exception("Error parsing JSON response")` with the closed-
+    resource exception. The record is redundant: the transport also sends the
+    exception into the read stream, so the caller already surfaces the error.
+    Dropping it here keeps the traceback off the terminal without quieting
+    the rest of the `mcp` hierarchy -- OAuth failures, SSE parse errors, and
+    other diagnostics users actually troubleshoot with stay on stderr.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return `False` for shutdown-race records, `True` for everything else."""
+        if record.exc_info is None or record.exc_info[1] is None:
+            return True
+        return not self._is_closed_resource(record.exc_info[1])
+
+    @classmethod
+    def _is_closed_resource(cls, exc: BaseException) -> bool:
+        """Check for anyio closed/broken-resource errors, including grouped ones.
+
+        Args:
+            exc: The exception from the log record's `exc_info`.
+
+        Returns:
+            `True` if *exc* is (or wraps, via `BaseExceptionGroup`) an anyio
+            closed/broken-resource error, `False` otherwise.
+        """
+        import anyio
+
+        if isinstance(exc, (anyio.ClosedResourceError, anyio.BrokenResourceError)):
+            return True
+        # Task-group cancellation can wrap the closed-resource error in an
+        # `ExceptionGroup`; anyio 4.x also exposes `BaseExceptionGroup` itself.
+        if isinstance(exc, BaseExceptionGroup):
+            return any(cls._is_closed_resource(sub) for sub in exc.exceptions)
+        return False
+
+
+def _install_mcp_shutdown_race_filter() -> None:
+    """Filter the MCP shutdown-race record unless debug logging is on.
+
+    The filter must live on the `mcp.client.streamable_http` logger itself:
+    logger-level filters only run for records logged directly on that logger,
+    so attaching it to the `mcp` root would never see the transport's records.
+    With `DEEPAGENTS_CODE_DEBUG` set, no filter is installed so the race (and
+    everything else) still lands in the debug log.
+    """
+    from deepagents_code._env_vars import DEBUG, is_env_truthy
+
+    transport_logger = logging.getLogger(_MCP_STREAMABLE_HTTP_LOGGER_NAME)
+    existing = [
+        f for f in transport_logger.filters if isinstance(f, _McpShutdownRaceFilter)
+    ]
+    if is_env_truthy(DEBUG):
+        for f in existing:
+            transport_logger.removeFilter(f)
+        return
+    if not existing:
+        transport_logger.addFilter(_McpShutdownRaceFilter())
 
 
 def _quiet_sdk_logging() -> None:
     """Keep non-actionable SDK diagnostics off the terminal.
 
-    The harness-profile resolver, tracing SDKs, the `genai-prices` price
-    updater, and the MCP SDK emit diagnostics on their own logger hierarchies.
-    With no handler attached, warnings reach Python's last-resort stderr handler
-    and can bleed into command output or the alternate-screen TUI -- the price
-    updater logs at ERROR from a background thread once an hour, and the MCP
-    streamable-HTTP transport logs `logger.exception("Error parsing JSON
-    response")` when its response-handling task races a quick exit and finds
-    the session stream already closed (`anyio.ClosedResourceError`), so an
-    offline, proxied, or quickly-quit session would otherwise get a stderr
-    traceback over the TUI. Route them to the debug log when
+    The harness-profile resolver, tracing SDKs, and the `genai-prices` price
+    updater emit diagnostics on their own logger hierarchies. With no handler
+    attached, warnings reach Python's last-resort stderr handler and can bleed
+    into command output or the alternate-screen TUI -- the price updater logs
+    at ERROR from a background thread once an hour, so an offline or
+    proxied session would otherwise get a stderr line over the TUI on every
+    failed refresh. Route them to the debug log when
     `DEEPAGENTS_CODE_DEBUG` is set, otherwise attach a `NullHandler` so they stay
     off the terminal. Other Deep Agents loggers remain untouched so actionable
     runtime warnings are still visible.
@@ -582,6 +644,7 @@ def _quiet_sdk_logging() -> None:
     from deepagents_code._debug import configure_debug_logging
     from deepagents_code._env_vars import DEBUG, is_env_truthy
 
+    _install_mcp_shutdown_race_filter()
     debug_enabled = is_env_truthy(DEBUG)
     for name in _QUIET_SDK_LOGGER_NAMES:
         sdk_logger = logging.getLogger(name)

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -558,19 +558,23 @@ _QUIET_SDK_LOGGER_NAMES = (
     "genai-prices",
     "langchain",
     "langsmith",
+    "mcp",
 )
 
 
 def _quiet_sdk_logging() -> None:
     """Keep non-actionable SDK diagnostics off the terminal.
 
-    The harness-profile resolver, tracing SDKs, and the `genai-prices` price
-    updater emit diagnostics on their own logger hierarchies. With no handler
-    attached, warnings reach Python's last-resort stderr handler and can bleed
-    into command output or the alternate-screen TUI -- the price updater logs
-    at ERROR from a background thread once an hour, so an offline or
-    proxied session would otherwise get a stderr line over the TUI on every
-    failed refresh. Route them to the debug log when
+    The harness-profile resolver, tracing SDKs, the `genai-prices` price
+    updater, and the MCP SDK emit diagnostics on their own logger hierarchies.
+    With no handler attached, warnings reach Python's last-resort stderr handler
+    and can bleed into command output or the alternate-screen TUI -- the price
+    updater logs at ERROR from a background thread once an hour, and the MCP
+    streamable-HTTP transport logs `logger.exception("Error parsing JSON
+    response")` when its response-handling task races a quick exit and finds
+    the session stream already closed (`anyio.ClosedResourceError`), so an
+    offline, proxied, or quickly-quit session would otherwise get a stderr
+    traceback over the TUI. Route them to the debug log when
     `DEEPAGENTS_CODE_DEBUG` is set, otherwise attach a `NullHandler` so they stay
     off the terminal. Other Deep Agents loggers remain untouched so actionable
     runtime warnings are still visible.

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -578,6 +578,8 @@ class _McpShutdownRaceFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Return `False` for shutdown-race records, `True` for everything else."""
+        if record.msg != "Error parsing JSON response":
+            return True
         if record.exc_info is None or record.exc_info[1] is None:
             return True
         return not self._is_closed_resource(record.exc_info[1])
@@ -646,6 +648,8 @@ def _quiet_sdk_logging() -> None:
 
     _install_mcp_shutdown_race_filter()
     debug_enabled = is_env_truthy(DEBUG)
+    if debug_enabled:
+        configure_debug_logging(logging.getLogger(_MCP_STREAMABLE_HTTP_LOGGER_NAME))
     for name in _QUIET_SDK_LOGGER_NAMES:
         sdk_logger = logging.getLogger(name)
         if debug_enabled:

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import importlib
 import json
 import keyword
@@ -561,26 +562,92 @@ _QUIET_SDK_LOGGER_NAMES = (
 )
 
 _MCP_STREAMABLE_HTTP_LOGGER_NAME = "mcp.client.streamable_http"
+_MCP_SSE_LOGGER_NAME = "mcp.client.sse"
+
+_MCP_SHUTDOWN_RACE_MESSAGES: Mapping[str, frozenset[str]] = {
+    _MCP_STREAMABLE_HTTP_LOGGER_NAME: frozenset(
+        {"Error parsing JSON response", "Error parsing SSE message"}
+    ),
+    _MCP_SSE_LOGGER_NAME: frozenset({"Error in sse_reader"}),
+}
+"""MCP transport log messages whose `try` block writes to the session stream.
+
+Keyed by the logger that emits them. Every listed `except` clause wraps an
+`await read_stream_writer.send(session_message)`, so a closed/broken-resource
+error reaching one of them means the session's streams are already torn down —
+the app is quitting — and the record says nothing actionable.
+
+Both streamable-HTTP messages are needed: a server that answers with a single
+JSON body takes `_handle_json_response`, while one that streams its response
+takes `_handle_sse_event`, and both send into the read stream from inside the
+logging `try`. `Error in post_writer` is deliberately absent — it wraps the
+entire write loop, so a closed stream there can also mean the transport was
+orphaned while the session was still live, which is worth seeing.
+"""
+
+
+@functools.cache
+def _closed_resource_error_types() -> tuple[type[BaseException], ...]:
+    """Return anyio's closed/broken-resource exception types.
+
+    Imported lazily and cached rather than at module scope: nothing has pulled
+    in `anyio` by the time `_quiet_sdk_logging` runs, so importing it there
+    would add work to the startup path of every invocation.
+
+    The import is guarded because this runs on the logging path. `logging`
+    swallows exceptions raised by `Handler.emit`, but *not* those raised by
+    `Logger.filter` — they propagate into the `except` block that called
+    `logger.exception`. Returning an empty tuple degrades to keeping the record.
+    In practice the import always succeeds: the transports that emit these
+    records import `anyio` themselves.
+    """
+    try:
+        import anyio
+    except ImportError:  # pragma: no cover
+        return ()
+    return (anyio.ClosedResourceError, anyio.BrokenResourceError)
 
 
 class _McpShutdownRaceFilter(logging.Filter):
-    """Drop the MCP streamable-HTTP transport's shutdown-race record.
+    """Drop an MCP client transport's shutdown-race records.
 
-    When the app quits while an HTTP MCP response is in flight, the
-    transport's response task finds the session stream already closed and
-    logs `logger.exception("Error parsing JSON response")` with the closed-
-    resource exception. The record is redundant: the transport also sends the
-    exception into the read stream, so the caller already surfaces the error.
-    Dropping it here keeps the traceback off the terminal without quieting
-    the rest of the `mcp` hierarchy -- OAuth failures, SSE parse errors, and
-    other diagnostics users actually troubleshoot with stay on stderr.
+    When the app quits while an MCP response is in flight, the transport's
+    reader task sends the parsed message into a session stream that is already
+    closed, and the surrounding `except` logs the resulting closed-resource
+    error with a full traceback. Nothing downstream can act on that record: the
+    `send` that raised *is* the transport's only channel back to the caller, so
+    the follow-up `await read_stream_writer.send(exc)` raises the same error
+    instead of delivering it. The in-flight request still fails loudly by
+    another route — the session's receive loop hands every pending response
+    stream an `ErrorData(CONNECTION_CLOSED)` on its way out, so the waiting
+    `send_request` raises `McpError("Connection closed")`.
+
+    Matching is deliberately narrow — a per-logger message list, and only anyio
+    stream errors — so real transport faults stay on stderr. A network-level
+    drop cannot reach this filter: `httpcore` remaps anyio's
+    `BrokenResourceError`/`ClosedResourceError` onto `httpx.ReadError` and
+    friends before httpx re-raises, and this filter never walks `__cause__`, so
+    those records are kept. What remains matches only the teardown of an
+    in-process memory stream.
     """
+
+    def __init__(self, messages: frozenset[str]) -> None:
+        """Build a filter for one transport logger's shutdown-race messages.
+
+        Args:
+            messages: Exact `logger.exception` messages to drop when they carry
+                a closed/broken-resource error.
+        """
+        super().__init__()
+        self._messages = messages
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Return `False` for shutdown-race records, `True` for everything else."""
-        if record.msg != "Error parsing JSON response":
+        if record.msg not in self._messages:
             return True
         if record.exc_info is None or record.exc_info[1] is None:
+            # `logger.exception()` outside an active exception yields
+            # `(None, None, None)` — there is no error to classify.
             return True
         return not self._is_closed_resource(record.exc_info[1])
 
@@ -592,41 +659,48 @@ class _McpShutdownRaceFilter(logging.Filter):
             exc: The exception from the log record's `exc_info`.
 
         Returns:
-            `True` if *exc* is (or wraps, via `BaseExceptionGroup`) an anyio
-            closed/broken-resource error, `False` otherwise.
+            `True` if *exc* is an anyio closed/broken-resource error, or a
+            `BaseExceptionGroup` whose every leaf is one, `False` otherwise.
         """
-        import anyio
-
-        if isinstance(exc, (anyio.ClosedResourceError, anyio.BrokenResourceError)):
+        if isinstance(exc, _closed_resource_error_types()):
             return True
-        # Task-group cancellation can wrap the closed-resource error in an
-        # `ExceptionGroup`; anyio 4.x also exposes `BaseExceptionGroup` itself.
         if isinstance(exc, BaseExceptionGroup):
-            return any(cls._is_closed_resource(sub) for sub in exc.exceptions)
+            # Defensive: no current call site logs from a task-group boundary,
+            # but if one ever does, the error arrives wrapped. Every leaf must
+            # be a stream teardown — a group that also carries a real fault
+            # stays visible rather than being suppressed wholesale.
+            return bool(exc.exceptions) and all(
+                cls._is_closed_resource(sub) for sub in exc.exceptions
+            )
         return False
 
 
-def _install_mcp_shutdown_race_filter() -> None:
-    """Filter the MCP shutdown-race record unless debug logging is on.
+def _install_mcp_shutdown_race_filter(*, debug_enabled: bool) -> None:
+    """Filter the MCP transports' shutdown-race records unless debug is on.
 
-    The filter must live on the `mcp.client.streamable_http` logger itself:
-    logger-level filters only run for records logged directly on that logger,
-    so attaching it to the `mcp` root would never see the transport's records.
-    With `DEEPAGENTS_CODE_DEBUG` set, no filter is installed so the race (and
-    everything else) still lands in the debug log.
+    Each filter must live on the logger that emits the records: logger-level
+    filters only run for records logged directly on that logger, so attaching
+    one to the `mcp` root would never see the transports' records.
+
+    With `DEEPAGENTS_CODE_DEBUG` set, an already-installed filter is *removed*
+    rather than merely not added. A logger-level filter drops the record for
+    every handler, including the debug file handler `_quiet_sdk_logging`
+    attaches, so leaving one in place would keep the race out of the debug log.
+
+    Args:
+        debug_enabled: Whether `DEEPAGENTS_CODE_DEBUG` is truthy.
     """
-    from deepagents_code._env_vars import DEBUG, is_env_truthy
-
-    transport_logger = logging.getLogger(_MCP_STREAMABLE_HTTP_LOGGER_NAME)
-    existing = [
-        f for f in transport_logger.filters if isinstance(f, _McpShutdownRaceFilter)
-    ]
-    if is_env_truthy(DEBUG):
-        for f in existing:
-            transport_logger.removeFilter(f)
-        return
-    if not existing:
-        transport_logger.addFilter(_McpShutdownRaceFilter())
+    for name, messages in _MCP_SHUTDOWN_RACE_MESSAGES.items():
+        transport_logger = logging.getLogger(name)
+        existing = [
+            f for f in transport_logger.filters if isinstance(f, _McpShutdownRaceFilter)
+        ]
+        if debug_enabled:
+            for f in existing:
+                transport_logger.removeFilter(f)
+            continue
+        if not existing:
+            transport_logger.addFilter(_McpShutdownRaceFilter(messages))
 
 
 def _quiet_sdk_logging() -> None:
@@ -642,14 +716,21 @@ def _quiet_sdk_logging() -> None:
     `DEEPAGENTS_CODE_DEBUG` is set, otherwise attach a `NullHandler` so they stay
     off the terminal. Other Deep Agents loggers remain untouched so actionable
     runtime warnings are still visible.
+
+    The `mcp` hierarchy is handled differently: it gets no `NullHandler`, so its
+    diagnostics stay on stderr, and only the shutdown-race records named in
+    `_MCP_SHUTDOWN_RACE_MESSAGES` are filtered out. Under debug those transport
+    loggers get the file handler instead, so the filtered records are still
+    recorded rather than reaching last-resort stderr over the TUI.
     """
     from deepagents_code._debug import configure_debug_logging
     from deepagents_code._env_vars import DEBUG, is_env_truthy
 
-    _install_mcp_shutdown_race_filter()
     debug_enabled = is_env_truthy(DEBUG)
+    _install_mcp_shutdown_race_filter(debug_enabled=debug_enabled)
     if debug_enabled:
-        configure_debug_logging(logging.getLogger(_MCP_STREAMABLE_HTTP_LOGGER_NAME))
+        for mcp_logger_name in _MCP_SHUTDOWN_RACE_MESSAGES:
+            configure_debug_logging(logging.getLogger(mcp_logger_name))
     for name in _QUIET_SDK_LOGGER_NAMES:
         sdk_logger = logging.getLogger(name)
         if debug_enabled:

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -14,6 +14,8 @@ from deepagents_code import _git as git_module, model_config
 from deepagents_code._env_vars import SERVER_ENV_PREFIX
 from deepagents_code._version import __version__
 from deepagents_code.config import (
+    _MCP_SHUTDOWN_RACE_MESSAGES,
+    _MCP_SSE_LOGGER_NAME,
     _MCP_STREAMABLE_HTTP_LOGGER_NAME,
     _QUIET_SDK_LOGGER_NAMES,
     CLI_MAX_RETRIES_KEY,
@@ -3753,84 +3755,141 @@ class TestQuietSdkLogging:
 
         assert genai_prices.update_prices.logger.name in _QUIET_SDK_LOGGER_NAMES
 
-    def test_covers_the_logger_mcp_actually_uses(self) -> None:
-        """The shutdown-race filter targets the transport's real logger.
+    @staticmethod
+    def _mcp_record(
+        logger_name: str,
+        message: str,
+        exc: BaseException,
+    ) -> logging.LogRecord:
+        """Build the record `logger.exception(message)` would emit for *exc*."""
+        return logging.LogRecord(
+            logger_name, logging.ERROR, __file__, 0, message, (), (type(exc), exc, None)
+        )
 
-        When the app quits while an HTTP MCP response is in flight, the
-        transport's response task finds the session stream already closed and
-        logs `logger.exception("Error parsing JSON response")` with an
-        `anyio.ClosedResourceError` traceback. The filter must sit on that
-        exact logger -- logger-level filters do not run for records propagated
-        from children, so filtering the `mcp` root would miss these records.
-        Reading the name off the module pins the coupling, so an upstream
-        rename fails here rather than in a user's terminal.
+    @staticmethod
+    def _filter_for(logger_name: str) -> _McpShutdownRaceFilter:
+        """Build the filter that gets installed on *logger_name*."""
+        return _McpShutdownRaceFilter(_MCP_SHUTDOWN_RACE_MESSAGES[logger_name])
+
+    def test_covers_the_loggers_mcp_actually_uses(self) -> None:
+        """The shutdown-race filters target the transports' real loggers.
+
+        When the app quits while an MCP response is in flight, the transport's
+        reader task finds the session stream already closed and logs the
+        resulting `anyio.ClosedResourceError` with a full traceback. Each filter
+        must sit on the exact logger that emits it — logger-level filters do not
+        run for records propagated from children, so filtering the `mcp` root
+        would miss these records. Reading the names off the modules pins the
+        coupling, so an upstream rename fails here rather than in a user's
+        terminal.
         """
+        import mcp.client.sse
         import mcp.client.streamable_http
 
         assert (
             mcp.client.streamable_http.logger.name == _MCP_STREAMABLE_HTTP_LOGGER_NAME
         )
+        assert mcp.client.sse.logger.name == _MCP_SSE_LOGGER_NAME
+        assert set(_MCP_SHUTDOWN_RACE_MESSAGES) == {
+            _MCP_STREAMABLE_HTTP_LOGGER_NAME,
+            _MCP_SSE_LOGGER_NAME,
+        }
 
-    def test_mcp_shutdown_race_record_is_dropped(self) -> None:
-        """The targeted JSON-response closed-resource record is filtered out."""
+    def test_mcp_hierarchy_is_not_quieted(self) -> None:
+        """The `mcp` loggers must never get a `NullHandler`.
+
+        The whole point of the targeted filter is that everything else the
+        transports report — OAuth failures, unexpected content types, real
+        parse errors — keeps reaching the terminal. Quieting `mcp` (or any
+        ancestor) would attach a handler to the hierarchy, so `lastResort` is
+        skipped and those diagnostics vanish instead. Without this guard,
+        someone chasing more MCP noise can add `mcp` to the tuple and every
+        other test here still passes.
+        """
+        for name in _QUIET_SDK_LOGGER_NAMES:
+            assert name != "mcp"
+            assert not name.startswith("mcp.")
+
+    @pytest.mark.parametrize(
+        ("logger_name", "message"),
+        [
+            (_MCP_STREAMABLE_HTTP_LOGGER_NAME, "Error parsing JSON response"),
+            (_MCP_STREAMABLE_HTTP_LOGGER_NAME, "Error parsing SSE message"),
+            (_MCP_SSE_LOGGER_NAME, "Error in sse_reader"),
+        ],
+    )
+    def test_mcp_shutdown_race_record_is_dropped(
+        self, logger_name: str, message: str
+    ) -> None:
+        """Every send-into-a-closed-stream record is filtered out.
+
+        A server answering with one JSON body races in `_handle_json_response`,
+        one streaming its answer races in `_handle_sse_event`, and the plain SSE
+        transport races in `sse_reader`. All three wrap the read-stream `send`
+        in the `try` that logs, so all three must be covered.
+        """
         import anyio
 
-        f = _McpShutdownRaceFilter()
+        f = self._filter_for(logger_name)
         for exc in (anyio.ClosedResourceError(), anyio.BrokenResourceError()):
-            record = logging.LogRecord(
-                _MCP_STREAMABLE_HTTP_LOGGER_NAME,
-                logging.ERROR,
-                __file__,
-                0,
-                "Error parsing JSON response",
-                (),
-                (type(exc), exc, None),
-            )
-            assert f.filter(record) is False
+            assert f.filter(self._mcp_record(logger_name, message, exc)) is False
 
     def test_mcp_shutdown_race_filter_unwraps_exception_groups(self) -> None:
-        """Task-group cancellation wraps the closed-resource error in a group."""
+        """A group of nothing but stream teardowns is dropped, at any depth."""
         import anyio
 
-        f = _McpShutdownRaceFilter()
+        f = self._filter_for(_MCP_STREAMABLE_HTTP_LOGGER_NAME)
+        grouped = BaseExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [
+                anyio.BrokenResourceError(),
+                BaseExceptionGroup("nested", [anyio.ClosedResourceError()]),
+            ],
+        )
+        record = self._mcp_record(
+            _MCP_STREAMABLE_HTTP_LOGGER_NAME, "Error parsing JSON response", grouped
+        )
+
+        assert f.filter(record) is False
+
+    def test_mcp_shutdown_race_filter_keeps_mixed_exception_groups(self) -> None:
+        """A group carrying a real fault alongside the teardown stays visible.
+
+        Suppressing on *any* matching leaf would hide the `ValueError` here,
+        which is the only thing in the group a user could act on.
+        """
+        import anyio
+
+        f = self._filter_for(_MCP_STREAMABLE_HTTP_LOGGER_NAME)
         grouped = BaseExceptionGroup(
             "unhandled errors in a TaskGroup",
             [ValueError("other"), anyio.ClosedResourceError()],
         )
-        record = logging.LogRecord(
-            _MCP_STREAMABLE_HTTP_LOGGER_NAME,
-            logging.ERROR,
-            __file__,
-            0,
-            "Error parsing JSON response",
-            (),
-            (type(grouped), grouped, None),
-        )
-        assert f.filter(record) is False
-
-    def test_mcp_shutdown_race_filter_keeps_other_closed_resource_records(
-        self,
-    ) -> None:
-        """Closed streams do not hide unrelated transport diagnostics."""
-        import anyio
-
-        f = _McpShutdownRaceFilter()
-        exc = anyio.ClosedResourceError()
-        record = logging.LogRecord(
-            _MCP_STREAMABLE_HTTP_LOGGER_NAME,
-            logging.ERROR,
-            __file__,
-            0,
-            "Error parsing SSE message",
-            (),
-            (type(exc), exc, None),
+        record = self._mcp_record(
+            _MCP_STREAMABLE_HTTP_LOGGER_NAME, "Error parsing JSON response", grouped
         )
 
         assert f.filter(record) is True
 
+    def test_mcp_shutdown_race_filter_keeps_unlisted_messages(self) -> None:
+        """A closed stream does not hide records outside the listed messages.
+
+        `Error in post_writer` wraps the whole write loop, so a closed stream
+        there can mean the transport was orphaned while the session was still
+        live — a real fault, not the quit-time race.
+        """
+        import anyio
+
+        for logger_name in (_MCP_STREAMABLE_HTTP_LOGGER_NAME, _MCP_SSE_LOGGER_NAME):
+            f = self._filter_for(logger_name)
+            record = self._mcp_record(
+                logger_name, "Error in post_writer", anyio.ClosedResourceError()
+            )
+            assert f.filter(record) is True
+
     def test_mcp_shutdown_race_filter_keeps_other_records(self) -> None:
-        """Other transport diagnostics -- OAuth, SSE, parse errors -- pass through."""
-        f = _McpShutdownRaceFilter()
+        """Records with no exception, or an unrelated one, pass through."""
+        f = self._filter_for(_MCP_STREAMABLE_HTTP_LOGGER_NAME)
         no_exc = logging.LogRecord(
             _MCP_STREAMABLE_HTTP_LOGGER_NAME,
             logging.WARNING,
@@ -3842,43 +3901,109 @@ class TestQuietSdkLogging:
         )
         assert f.filter(no_exc) is True
 
-        err = ValueError("boom")
-        with_exc = logging.LogRecord(
+        record = self._mcp_record(
+            _MCP_STREAMABLE_HTTP_LOGGER_NAME, "Error parsing SSE message", ValueError()
+        )
+        assert f.filter(record) is True
+
+    def test_mcp_shutdown_race_filter_keeps_bare_exception_calls(self) -> None:
+        """`logger.exception()` with no active exception has nothing to classify.
+
+        That call yields `exc_info=(None, None, None)` rather than `None`, so
+        the record must survive on the strength of having no exception at all.
+        `filter`'s `exc_info[1] is None` check is what keeps
+        `_is_closed_resource`'s `BaseException` parameter honest; the kept-record
+        outcome here holds either way.
+        """
+        f = self._filter_for(_MCP_STREAMABLE_HTTP_LOGGER_NAME)
+        record = logging.LogRecord(
             _MCP_STREAMABLE_HTTP_LOGGER_NAME,
             logging.ERROR,
             __file__,
             0,
-            "Error parsing SSE message",
+            "Error parsing JSON response",
             (),
-            (type(err), err, None),
+            (None, None, None),
         )
-        assert f.filter(with_exc) is True
+
+        assert f.filter(record) is True
+
+    def test_mcp_shutdown_race_is_suppressed_end_to_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Logging the real race through the real logger emits nothing.
+
+        The unit tests above hand-build records; this one drives the actual
+        `logger.exception` path so a filter installed on the wrong logger, or a
+        mismatch in how `exc_info` is shaped, still fails.
+        """
+        import anyio
+        import mcp.client.streamable_http
+
+        from deepagents_code._env_vars import DEBUG
+
+        monkeypatch.delenv(DEBUG, raising=False)
+        transport_logger = mcp.client.streamable_http.logger
+        monkeypatch.setattr(transport_logger, "filters", [])
+        monkeypatch.setattr(transport_logger, "handlers", [])
+        captured: list[str] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record.getMessage())
+
+        transport_logger.addHandler(_Capture())
+        _quiet_sdk_logging()
+
+        def _raise(exc: BaseException) -> None:
+            raise exc
+
+        # The race is dropped; the same message carrying a real parse failure
+        # is kept, so exactly one record reaches the handler.
+        for exc in (anyio.ClosedResourceError(), ValueError("bad json")):
+            try:
+                _raise(exc)
+            except (anyio.ClosedResourceError, ValueError):
+                transport_logger.exception("Error parsing JSON response")
+
+        assert captured == ["Error parsing JSON response"]
 
     def test_mcp_shutdown_race_filter_installation(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The filter is installed once without debug, removed with debug on."""
+        """The filter is installed once per transport, removed with debug on."""
         from deepagents_code._env_vars import DEBUG
 
-        transport_logger = logging.getLogger(_MCP_STREAMABLE_HTTP_LOGGER_NAME)
-        for f in list(transport_logger.filters):
-            transport_logger.removeFilter(f)
+        transport_loggers = [
+            logging.getLogger(name) for name in _MCP_SHUTDOWN_RACE_MESSAGES
+        ]
+        for transport_logger in transport_loggers:
+            # `setattr` (rather than `removeFilter`) so monkeypatch restores the
+            # original list on teardown; these are process-global loggers and
+            # `mcp_auth` installs its own filter on a sibling at import time.
+            monkeypatch.setattr(transport_logger, "filters", [])
         monkeypatch.delenv(DEBUG, raising=False)
 
         _quiet_sdk_logging()
         _quiet_sdk_logging()
 
-        installed = [
-            f for f in transport_logger.filters if isinstance(f, _McpShutdownRaceFilter)
-        ]
-        assert len(installed) == 1
+        for transport_logger in transport_loggers:
+            installed = [
+                f
+                for f in transport_logger.filters
+                if isinstance(f, _McpShutdownRaceFilter)
+            ]
+            assert len(installed) == 1
 
         monkeypatch.setenv(DEBUG, "1")
         _quiet_sdk_logging()
 
-        assert not [
-            f for f in transport_logger.filters if isinstance(f, _McpShutdownRaceFilter)
-        ]
+        for transport_logger in transport_loggers:
+            assert not [
+                f
+                for f in transport_logger.filters
+                if isinstance(f, _McpShutdownRaceFilter)
+            ]
 
     def test_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Repeated calls do not stack duplicate handlers."""
@@ -3917,21 +4042,30 @@ class TestQuietSdkLogging:
     def test_routes_mcp_diagnostics_to_debug_log(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Debug mode configures a file handler for MCP transport diagnostics."""
+        """Debug mode configures a file handler for MCP transport diagnostics.
+
+        Without this, removing the filter under debug would only move the
+        traceback back to `logging.lastResort` — i.e. straight over the
+        alternate-screen TUI — instead of into the debug log.
+        """
         from deepagents_code._env_vars import DEBUG
 
         monkeypatch.setenv(DEBUG, "1")
-        transport_logger = logging.getLogger(_MCP_STREAMABLE_HTTP_LOGGER_NAME)
-        transport_logger.handlers.clear()
-        monkeypatch.setattr(transport_logger, "propagate", True)
+        transport_loggers = [
+            logging.getLogger(name) for name in _MCP_SHUTDOWN_RACE_MESSAGES
+        ]
+        for transport_logger in transport_loggers:
+            monkeypatch.setattr(transport_logger, "handlers", [])
+            monkeypatch.setattr(transport_logger, "propagate", True)
 
         with patch("deepagents_code._debug.configure_debug_logging") as configure:
             _quiet_sdk_logging()
 
-        assert any(
-            call.args == (transport_logger,) for call in configure.call_args_list
-        )
-        assert transport_logger.propagate is True
+        for transport_logger in transport_loggers:
+            assert any(
+                call.args == (transport_logger,) for call in configure.call_args_list
+            )
+            assert transport_logger.propagate is True
 
     def test_leaves_other_deepagents_loggers_untouched(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -3772,7 +3772,7 @@ class TestQuietSdkLogging:
         )
 
     def test_mcp_shutdown_race_record_is_dropped(self) -> None:
-        """A closed/broken-resource exception record is filtered out."""
+        """The targeted JSON-response closed-resource record is filtered out."""
         import anyio
 
         f = _McpShutdownRaceFilter()
@@ -3807,6 +3807,26 @@ class TestQuietSdkLogging:
             (type(grouped), grouped, None),
         )
         assert f.filter(record) is False
+
+    def test_mcp_shutdown_race_filter_keeps_other_closed_resource_records(
+        self,
+    ) -> None:
+        """Closed streams do not hide unrelated transport diagnostics."""
+        import anyio
+
+        f = _McpShutdownRaceFilter()
+        exc = anyio.ClosedResourceError()
+        record = logging.LogRecord(
+            _MCP_STREAMABLE_HTTP_LOGGER_NAME,
+            logging.ERROR,
+            __file__,
+            0,
+            "Error parsing SSE message",
+            (),
+            (type(exc), exc, None),
+        )
+
+        assert f.filter(record) is True
 
     def test_mcp_shutdown_race_filter_keeps_other_records(self) -> None:
         """Other transport diagnostics -- OAuth, SSE, parse errors -- pass through."""
@@ -3893,6 +3913,25 @@ class TestQuietSdkLogging:
 
         assert any(call.args == (harness_logger,) for call in configure.call_args_list)
         assert harness_logger.propagate is True
+
+    def test_routes_mcp_diagnostics_to_debug_log(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Debug mode configures a file handler for MCP transport diagnostics."""
+        from deepagents_code._env_vars import DEBUG
+
+        monkeypatch.setenv(DEBUG, "1")
+        transport_logger = logging.getLogger(_MCP_STREAMABLE_HTTP_LOGGER_NAME)
+        transport_logger.handlers.clear()
+        monkeypatch.setattr(transport_logger, "propagate", True)
+
+        with patch("deepagents_code._debug.configure_debug_logging") as configure:
+            _quiet_sdk_logging()
+
+        assert any(
+            call.args == (transport_logger,) for call in configure.call_args_list
+        )
+        assert transport_logger.propagate is True
 
     def test_leaves_other_deepagents_loggers_untouched(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -3751,6 +3751,24 @@ class TestQuietSdkLogging:
 
         assert genai_prices.update_prices.logger.name in _QUIET_SDK_LOGGER_NAMES
 
+    def test_covers_the_logger_mcp_actually_uses(self) -> None:
+        """The MCP streamable-HTTP transport's logger must be quieted.
+
+        When the app quits while an HTTP MCP response is in flight, the
+        transport's response task finds the session stream already closed and
+        logs `logger.exception("Error parsing JSON response")` with an
+        `anyio.ClosedResourceError` traceback. Unhandled, that clears
+        `logging.lastResort`'s WARNING threshold and prints over the terminal.
+        The transport logs under `mcp.client.streamable_http`, a child of the
+        quieted `mcp` logger. Reading the name off the module pins the
+        coupling, so an upstream rename fails here rather than in a user's
+        terminal.
+        """
+        import mcp.client.streamable_http
+
+        assert mcp.client.streamable_http.logger.name.startswith("mcp")
+        assert "mcp" in _QUIET_SDK_LOGGER_NAMES
+
     def test_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Repeated calls do not stack duplicate handlers."""
         from deepagents_code._env_vars import DEBUG

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -14,6 +14,7 @@ from deepagents_code import _git as git_module, model_config
 from deepagents_code._env_vars import SERVER_ENV_PREFIX
 from deepagents_code._version import __version__
 from deepagents_code.config import (
+    _MCP_STREAMABLE_HTTP_LOGGER_NAME,
     _QUIET_SDK_LOGGER_NAMES,
     CLI_MAX_RETRIES_KEY,
     LANGSMITH_EU_ENDPOINT,
@@ -31,6 +32,7 @@ from deepagents_code.config import (
     _create_model_via_init,
     _disable_orphaned_tracing,
     _get_provider_kwargs,
+    _McpShutdownRaceFilter,
     _quiet_sdk_logging,
     _read_config_toml_retries,
     _resolve_retry_kwargs,
@@ -3752,22 +3754,111 @@ class TestQuietSdkLogging:
         assert genai_prices.update_prices.logger.name in _QUIET_SDK_LOGGER_NAMES
 
     def test_covers_the_logger_mcp_actually_uses(self) -> None:
-        """The MCP streamable-HTTP transport's logger must be quieted.
+        """The shutdown-race filter targets the transport's real logger.
 
         When the app quits while an HTTP MCP response is in flight, the
         transport's response task finds the session stream already closed and
         logs `logger.exception("Error parsing JSON response")` with an
-        `anyio.ClosedResourceError` traceback. Unhandled, that clears
-        `logging.lastResort`'s WARNING threshold and prints over the terminal.
-        The transport logs under `mcp.client.streamable_http`, a child of the
-        quieted `mcp` logger. Reading the name off the module pins the
-        coupling, so an upstream rename fails here rather than in a user's
-        terminal.
+        `anyio.ClosedResourceError` traceback. The filter must sit on that
+        exact logger -- logger-level filters do not run for records propagated
+        from children, so filtering the `mcp` root would miss these records.
+        Reading the name off the module pins the coupling, so an upstream
+        rename fails here rather than in a user's terminal.
         """
         import mcp.client.streamable_http
 
-        assert mcp.client.streamable_http.logger.name.startswith("mcp")
-        assert "mcp" in _QUIET_SDK_LOGGER_NAMES
+        assert (
+            mcp.client.streamable_http.logger.name == _MCP_STREAMABLE_HTTP_LOGGER_NAME
+        )
+
+    def test_mcp_shutdown_race_record_is_dropped(self) -> None:
+        """A closed/broken-resource exception record is filtered out."""
+        import anyio
+
+        f = _McpShutdownRaceFilter()
+        for exc in (anyio.ClosedResourceError(), anyio.BrokenResourceError()):
+            record = logging.LogRecord(
+                _MCP_STREAMABLE_HTTP_LOGGER_NAME,
+                logging.ERROR,
+                __file__,
+                0,
+                "Error parsing JSON response",
+                (),
+                (type(exc), exc, None),
+            )
+            assert f.filter(record) is False
+
+    def test_mcp_shutdown_race_filter_unwraps_exception_groups(self) -> None:
+        """Task-group cancellation wraps the closed-resource error in a group."""
+        import anyio
+
+        f = _McpShutdownRaceFilter()
+        grouped = BaseExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ValueError("other"), anyio.ClosedResourceError()],
+        )
+        record = logging.LogRecord(
+            _MCP_STREAMABLE_HTTP_LOGGER_NAME,
+            logging.ERROR,
+            __file__,
+            0,
+            "Error parsing JSON response",
+            (),
+            (type(grouped), grouped, None),
+        )
+        assert f.filter(record) is False
+
+    def test_mcp_shutdown_race_filter_keeps_other_records(self) -> None:
+        """Other transport diagnostics -- OAuth, SSE, parse errors -- pass through."""
+        f = _McpShutdownRaceFilter()
+        no_exc = logging.LogRecord(
+            _MCP_STREAMABLE_HTTP_LOGGER_NAME,
+            logging.WARNING,
+            __file__,
+            0,
+            "Unknown SSE event: ping",
+            (),
+            None,
+        )
+        assert f.filter(no_exc) is True
+
+        err = ValueError("boom")
+        with_exc = logging.LogRecord(
+            _MCP_STREAMABLE_HTTP_LOGGER_NAME,
+            logging.ERROR,
+            __file__,
+            0,
+            "Error parsing SSE message",
+            (),
+            (type(err), err, None),
+        )
+        assert f.filter(with_exc) is True
+
+    def test_mcp_shutdown_race_filter_installation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The filter is installed once without debug, removed with debug on."""
+        from deepagents_code._env_vars import DEBUG
+
+        transport_logger = logging.getLogger(_MCP_STREAMABLE_HTTP_LOGGER_NAME)
+        for f in list(transport_logger.filters):
+            transport_logger.removeFilter(f)
+        monkeypatch.delenv(DEBUG, raising=False)
+
+        _quiet_sdk_logging()
+        _quiet_sdk_logging()
+
+        installed = [
+            f for f in transport_logger.filters if isinstance(f, _McpShutdownRaceFilter)
+        ]
+        assert len(installed) == 1
+
+        monkeypatch.setenv(DEBUG, "1")
+        _quiet_sdk_logging()
+
+        assert not [
+            f for f in transport_logger.filters if isinstance(f, _McpShutdownRaceFilter)
+        ]
 
     def test_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Repeated calls do not stack duplicate handlers."""


### PR DESCRIPTION
Quitting `dcode` while an MCP response is in flight no longer prints an `anyio.ClosedResourceError` traceback to the terminal on exit.

---

An MCP transport's reader task can still be running while the session stream is torn down. Its `read_stream_writer.send(...)` raises `anyio.ClosedResourceError`, the SDK's surrounding `except` calls `logger.exception(...)`, and since nothing handles the `mcp` hierarchy the record clears `logging.lastResort`'s WARNING threshold and prints a full traceback — alarming-looking but harmless, since the app was already exiting.

A `logging.Filter` on each transport's own logger drops those records. It has to live on the emitting logger: logger-level filters never run for records propagated up from children.

`_MCP_SHUTDOWN_RACE_MESSAGES` lists the messages whose `try` block wraps a read-stream `send`, and a record is dropped only if it carries an anyio closed/broken-resource error:

| Logger | Message |
| --- | --- |
| `mcp.client.streamable_http` | `Error parsing JSON response` (single JSON body) |
| `mcp.client.streamable_http` | `Error parsing SSE message` (streamed response) |
| `mcp.client.sse` | `Error in sse_reader` |

`Error in post_writer` is excluded — it wraps the entire write loop, so a closed stream there can also mean the transport was orphaned while the session was live.

**Why this is safe.** The in-flight request still fails loudly: the session's receive loop hands pending response streams an `ErrorData(CONNECTION_CLOSED)` on its way out, so `send_request` raises `McpError("Connection closed")`. A network-level drop can't reach the filter — `httpcore` remaps anyio's stream errors onto `httpx.ReadError` and friends before httpx re-raises, and the filter never walks `__cause__`. For a `BaseExceptionGroup`, every leaf must be a teardown, so a group carrying a real fault stays visible. The `mcp` hierarchy gets no `NullHandler` (pinned by a test), so everything else reaches stderr.

**Debug mode.** With `DEEPAGENTS_CODE_DEBUG` set, an installed filter is *removed* and the transport loggers are routed to the debug log. Both halves matter: the filter would otherwise suppress the record for the debug file handler too, and without that handler it would fall through to `lastResort` and print over the TUI.

Drift-pin tests read the logger names off the installed `mcp` modules — mirroring the existing `genai-prices` pin — so an upstream rename fails in CI rather than in a user's terminal.
