### PR TITLE
fix(sdk): identify file-capable provider classes

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -90,6 +90,20 @@ from deepagents.middleware._video import (
     video_dependencies_available,
 )
 
+try:
+    from langchain_openai import AzureChatOpenAI as _AzureChatOpenAI, ChatOpenAI as _ChatOpenAI
+except ImportError:
+    _OPENAI_FILE_MODEL_TYPES: tuple[type[Any], ...] = ()
+else:
+    _OPENAI_FILE_MODEL_TYPES = (_AzureChatOpenAI, _ChatOpenAI)
+
+try:
+    from langchain_google_genai import ChatGoogleGenerativeAI as _ChatGoogleGenerativeAI
+except ImportError:
+    _GOOGLE_FILE_MODEL_TYPES: tuple[type[Any], ...] = ()
+else:
+    _GOOGLE_FILE_MODEL_TYPES = (_ChatGoogleGenerativeAI,)
+
 if TYPE_CHECKING:
     from langchain.chat_models import BaseChatModel
 
@@ -127,17 +141,6 @@ since it's `_get_file_type`'s default for unmapped extensions).
 """
 
 _PDF_MIME_TYPE: Final = "application/pdf"
-
-_NON_PDF_FILE_TOLERANT_LLM_TYPES: Final = frozenset({"openai-chat", "azure-openai-chat", "chat-google-generative-ai"})
-"""Exact `_llm_type` values for chat models known to accept non-PDF `file`
-blocks (e.g. `.docx`, `.pptx`) today: `ChatOpenAI`, `AzureChatOpenAI`, and
-`ChatGoogleGenerativeAI`.
-
-[`ModelProfile`][langchain_core.language_models.model_profile.ModelProfile] only
-encodes PDF support (`pdf_inputs`/`pdf_tool_message`); it has no field yet for
-other office/document formats. Until it does, these providers get a hard-coded
-pass for non-PDF `file` blocks instead of being blocked by that profile gap.
-"""
 
 
 def _tool_error(name: str, tool_call_id: str | None, content: str) -> ToolMessage:
@@ -183,20 +186,15 @@ def _move_media_results_after_tool_results(messages: list[AnyMessage]) -> list[A
 
 _PROFILE_FIELD_BY_BLOCK_TYPE: Final = {"image": "image_inputs", "audio": "audio_inputs", "video": "video_inputs", "file": "pdf_inputs"}
 """`ModelProfile` field gating each block type. `file` only applies to PDF `mime_type`; other
-file types have no field yet and are handled separately via `_NON_PDF_FILE_TOLERANT_LLM_TYPES`."""
+file types have no field yet and are handled separately via provider class checks."""
 
 _TOOL_MESSAGE_FIELD_BY_BLOCK_TYPE: Final = {"image": "image_tool_message", "file": "pdf_tool_message"}
 """Extra `ModelProfile` field that can gate a block type specifically within a `ToolMessage`."""
 
 
 def _model_tolerates_non_pdf_files(model: "BaseChatModel | None") -> bool:
-    """Whether `model` is known to accept non-PDF `file` blocks.
-
-    Checks `_llm_type`, a property every `BaseChatModel` implements
-    """
-    if model is None:
-        return False
-    return model._llm_type in _NON_PDF_FILE_TOLERANT_LLM_TYPES
+    """Whether `model` is a provider class known to accept non-PDF `file` blocks."""
+    return isinstance(model, _OPENAI_FILE_MODEL_TYPES + _GOOGLE_FILE_MODEL_TYPES)
 
 
 def _multimodal_block_supported(

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -90,6 +90,10 @@ from deepagents.middleware._video import (
     video_dependencies_available,
 )
 
+# `ChatOpenAI`, `AzureChatOpenAI`, and `ChatGoogleGenerativeAI` accept non-PDF
+# `file` blocks such as `.docx` and `.pptx`. `ModelProfile` only encodes PDF
+# support today, so these providers get a hard-coded pass until profiles can
+# describe support for other office and document formats.
 try:
     from langchain_openai import AzureChatOpenAI as _AzureChatOpenAI, ChatOpenAI as _ChatOpenAI
 except ImportError:

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -20,6 +20,8 @@ from langchain_core.messages.content import ContentBlock
 from langchain_core.outputs import ChatResult
 from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool, tool
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_openai import AzureChatOpenAI, ChatOpenAI
 from langgraph.channels.delta import DeltaChannel
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.graph import END, START, StateGraph
@@ -146,6 +148,24 @@ class FixedGenericFakeChatModel(GenericFakeChatModel):
     ) -> ChatResult:
         self.captured_messages.append(messages)
         return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+
+class MaskedChatOpenAI(ChatOpenAI):
+    @property
+    def _llm_type(self) -> str:
+        return "langchain-chat"
+
+
+class MaskedAzureChatOpenAI(AzureChatOpenAI):
+    @property
+    def _llm_type(self) -> str:
+        return "langchain-chat"
+
+
+class MaskedChatGoogleGenerativeAI(ChatGoogleGenerativeAI):
+    @property
+    def _llm_type(self) -> str:
+        return "langchain-chat"
 
 
 class TestDeepAgentEndToEnd:
@@ -4657,11 +4677,7 @@ class TestMultimodalProfileScrubProfileGatedBlocks:
 
 
 class TestMultimodalProfileScrubNonPdfFileProviderGate:
-    """Non-PDF `file` blocks (`.docx`, ...) have no `ModelProfile` field yet.
-
-    Support is hard-coded per exact `_llm_type` regardless of whether
-    `profile` itself is present.
-    """
+    """Non-PDF `file` blocks (`.docx`, ...) have no `ModelProfile` field yet."""
 
     def test_docx_stripped_for_anthropic(self) -> None:
         model = FixedGenericFakeChatModel(messages=iter([]), llm_type="anthropic-chat")
@@ -4670,31 +4686,34 @@ class TestMultimodalProfileScrubNonPdfFileProviderGate:
         tool_message = _second_call_tool_message(model)
         assert _is_placeholder_block(tool_message.content_blocks[0], path="/report.docx")
 
-    def test_docx_passes_for_openai(self) -> None:
-        model = FixedGenericFakeChatModel(messages=iter([]), llm_type="openai-chat")
-        _read_file_agent(model=model, file_path="/report.docx", file_base64=_docx_base64())
+    @pytest.mark.parametrize(
+        "model",
+        [
+            MaskedChatOpenAI.model_construct(),
+            MaskedAzureChatOpenAI.model_construct(),
+            MaskedChatGoogleGenerativeAI.model_construct(),
+        ],
+    )
+    def test_provider_class_tolerates_docx_when_llm_type_is_masked(self, model: ChatOpenAI | ChatGoogleGenerativeAI) -> None:
+        message = ToolMessage(
+            content_blocks=[
+                {
+                    "type": "file",
+                    "base64": _docx_base64(),
+                    "mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                }
+            ],
+            tool_call_id="docx-read-1",
+            additional_kwargs={"read_file_path": "/report.docx"},
+        )
 
-        tool_message = _second_call_tool_message(model)
-        blocks = tool_message.content_blocks
-        assert blocks[0]["type"] == "file"
-        assert blocks[0]["base64"] == _docx_base64()
+        assert model._llm_type == "langchain-chat"
+        scrubbed = filesystem_middleware._scrub_unsupported_multimodal_content([message], model)
+        assert scrubbed[0].content_blocks[0]["base64"] == _docx_base64()
 
-    def test_docx_passes_for_gemini(self) -> None:
-        model = FixedGenericFakeChatModel(messages=iter([]), llm_type="chat-google-generative-ai")
-        _read_file_agent(model=model, file_path="/report.docx", file_base64=_docx_base64())
-
-        tool_message = _second_call_tool_message(model)
-        assert tool_message.content_blocks[0]["type"] == "file"
-        assert tool_message.content_blocks[0]["base64"] == _docx_base64()
-
-    def test_openai_mantle_style_llm_type_is_not_treated_as_openai(self) -> None:
-        """Regression: a substring match on `_llm_type` would misclassify this.
-
-        A third-party `_llm_type` that merely *contains* `"openai"` (e.g. a
-        Bedrock-hosted model inheriting from `ChatOpenAI`) isn't genuine OpenAI
-        and shouldn't get the non-PDF-file pass.
-        """
-        model = FixedGenericFakeChatModel(messages=iter([]), llm_type="openai-mantle-chat")
+    @pytest.mark.parametrize("llm_type", ["openai-chat", "azure-openai-chat", "chat-google-generative-ai", "openai-mantle-chat"])
+    def test_llm_type_does_not_grant_docx_support(self, llm_type: str) -> None:
+        model = FixedGenericFakeChatModel(messages=iter([]), llm_type=llm_type)
         _read_file_agent(model=model, file_path="/report.docx", file_base64=_docx_base64())
 
         tool_message = _second_call_tool_message(model)


### PR DESCRIPTION
Related #4397

`FilesystemMiddleware` now identifies OpenAI, Azure OpenAI, and Google GenAI models by provider class, preserving non-PDF file inputs when `_llm_type` is masked.

---

This avoids coupling file capability checks to tracing metadata while conditional imports keep OpenAI optional. Focused tests cover masked provider subclasses and reject spoofed `_llm_type` values.

Made by [Open SWE](https://openswe.vercel.app/agents/3e054eb4-7d94-3018-900f-72e67aa287a3)