### PR TITLE
feat(code): `dcode_term_program` trace metadata

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -1779,6 +1779,10 @@ def build_stream_config(
     metadata. This is a diagnostic key, not the contract-scoped `approval_policy`
     key (see above), so it is safe to stamp trace-wide.
 
+    Also records `dcode_term_program` from `TERM_PROGRAM` when set, so traces
+    are groupable by host terminal (e.g. "iTerm.app", "vscode"). This is a
+    diagnostic key, not part of the contract.
+
     Args:
         thread_id: The app session thread identifier. Set both on
             `configurable.thread_id` and as the top-level `metadata.thread_id`
@@ -1823,6 +1827,12 @@ def build_stream_config(
     # Mark auto-approve ("YOLO") runs so they are filterable in trace metadata.
     if auto_approve:
         metadata["dcode_auto_approve"] = True
+
+    # Record the host terminal (e.g. "iTerm.app", "vscode", "Apple_Terminal")
+    # so traces are groupable by launch environment. Not a contract key.
+    term_program = os.environ.get("TERM_PROGRAM")
+    if term_program:
+        metadata["dcode_term_program"] = term_program
 
     # Legacy / diagnostic keys preserved for backward-compatibility during the
     # coding-agent-v1 rollout (not part of the contract).

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -175,6 +175,7 @@ _PROJECT_DOTENV_DENIED_ENV_KEYS = frozenset(
         DISABLED_PROJECT_MCP_SERVERS,
         AUTO_CLASSIFIER_MODEL,
         AUTO_CLASSIFIER_TIMEOUT,
+        "TERM_PROGRAM",
     }
 )
 """Env keys a *project* `.env` must not inject, even though they are otherwise
@@ -204,6 +205,11 @@ batch up to the ceiling, or squeeze the budget until reviews time out and the
 session degrades into repeated denials and approval prompts.
 `[models].auto_classifier_timeout` in
 `~/.deepagents/config.toml` and the trusted env surfaces still set it.
+
+`TERM_PROGRAM` identifies the terminal from which the user launched Deep
+Agents Code and is included in trace metadata. A project `.env` must not
+replace it: python-dotenv expands environment-variable references, which could
+otherwise forward a launch-environment value to the trace backend.
 
 Unlike `_DOTENV_DENIED_ENV_KEYS` (denied from *any* `.env` because they turn
 `.env` loading into code execution), these are denied only from the *project*
@@ -1779,9 +1785,14 @@ def build_stream_config(
     metadata. This is a diagnostic key, not the contract-scoped `approval_policy`
     key (see above), so it is safe to stamp trace-wide.
 
-    Also records `dcode_term_program` from `TERM_PROGRAM` when set, so traces
-    are groupable by host terminal (e.g. "iTerm.app", "vscode"). This is a
-    diagnostic key, not part of the contract.
+    Also records `dcode_term_program` from `TERM_PROGRAM` when that is non-empty
+    after stripping, so traces are groupable by launch environment (e.g.
+    "iTerm.app", "vscode", "Apple_Terminal"). Blank values are treated as unset
+    to match every other reader of this variable — some shells export
+    `TERM_PROGRAM=""` rather than leaving it unset, and terminals that never set
+    it (Windows Terminal, ssh, the Linux console) omit the key entirely rather
+    than forming a junk grouping bucket. This is a diagnostic key, not part of
+    the contract.
 
     Args:
         thread_id: The app session thread identifier. Set both on
@@ -1828,9 +1839,9 @@ def build_stream_config(
     if auto_approve:
         metadata["dcode_auto_approve"] = True
 
-    # Record the host terminal (e.g. "iTerm.app", "vscode", "Apple_Terminal")
-    # so traces are groupable by launch environment. Not a contract key.
-    term_program = os.environ.get("TERM_PROGRAM")
+    # Record the launch environment so traces are groupable by terminal.
+    # Blank is treated as unset, matching the other readers. Not a contract key.
+    term_program = os.environ.get("TERM_PROGRAM", "").strip()
     if term_program:
         metadata["dcode_term_program"] = term_program
 

--- a/libs/code/tests/unit_tests/test_coding_agent_metadata.py
+++ b/libs/code/tests/unit_tests/test_coding_agent_metadata.py
@@ -223,22 +223,26 @@ class TestContractValueSemantics:
         assert isinstance(metadata["turn_number"], int)
 
 
-class TestDiagnosticKeys:
-    """Non-contract `dcode_*` diagnostic keys stamped by `build_stream_config`."""
+@pytest.mark.usefixtures("known_env")
+class TestDiagnosticKeysDoNotBreakContract:
+    """Non-contract `dcode_*` keys coexist with the contract on every run type.
 
-    def test_term_program_stamped_when_set(self) -> None:
+    Value-level behavior of these keys is covered by `TestBuildStreamConfig` in
+    `tui/test_textual_adapter.py`; what matters here is only that stamping them
+    trace-wide keeps the metadata block contract-valid. Without an explicit
+    `TERM_PROGRAM` this would depend on the developer's or CI runner's shell.
+    """
+
+    def test_term_program_does_not_break_validation(self, contract: dict) -> None:
         with patch.dict("os.environ", {"TERM_PROGRAM": "iTerm.app"}):
             config = build_stream_config(
-                "thread-123", assistant_id=None, turn_id=None, turn_number=None
+                "thread-123", assistant_id="agent", turn_id="turn-abc", turn_number=2
             )
-        assert config["metadata"]["dcode_term_program"] == "iTerm.app"
-
-    def test_term_program_omitted_when_unset(self) -> None:
-        with patch.dict("os.environ", {}, clear=True):
-            config = build_stream_config(
-                "thread-123", assistant_id=None, turn_id=None, turn_number=None
-            )
-        assert "dcode_term_program" not in config["metadata"]
+        metadata = config["metadata"]
+        assert metadata["dcode_term_program"] == "iTerm.app"
+        for run_type in _TRACE_WIDE_RUN_TYPES:
+            errors, _ = _validate(metadata, run_type, contract)
+            assert errors == [], f"{run_type}: {errors}"
 
 
 class TestUnknownKeysOmitted:

--- a/libs/code/tests/unit_tests/test_coding_agent_metadata.py
+++ b/libs/code/tests/unit_tests/test_coding_agent_metadata.py
@@ -223,6 +223,24 @@ class TestContractValueSemantics:
         assert isinstance(metadata["turn_number"], int)
 
 
+class TestDiagnosticKeys:
+    """Non-contract `dcode_*` diagnostic keys stamped by `build_stream_config`."""
+
+    def test_term_program_stamped_when_set(self) -> None:
+        with patch.dict("os.environ", {"TERM_PROGRAM": "iTerm.app"}):
+            config = build_stream_config(
+                "thread-123", assistant_id=None, turn_id=None, turn_number=None
+            )
+        assert config["metadata"]["dcode_term_program"] == "iTerm.app"
+
+    def test_term_program_omitted_when_unset(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            config = build_stream_config(
+                "thread-123", assistant_id=None, turn_id=None, turn_number=None
+            )
+        assert "dcode_term_program" not in config["metadata"]
+
+
 class TestUnknownKeysOmitted:
     """Keys with unknown values are omitted regardless of environment."""
 

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -201,7 +201,7 @@ class TestRuntimeDotenvReload:
 
 
 class TestProjectDotenvDeniedKeys:
-    """A cloned repo must not tune the Auto approval classifier."""
+    """A cloned repo must not set user-level environment values."""
 
     def test_project_dotenv_cannot_set_classifier_timeout(
         self,
@@ -242,6 +242,45 @@ class TestProjectDotenvDeniedKeys:
             assert AUTO_CLASSIFIER_MODEL not in os.environ
             # A non-denied key from the same file still loads, so the assertion
             # above cannot pass just because the `.env` was never read.
+            assert os.environ["DEEPAGENTS_CODE_OPENAI_API_KEY"] == "sk-from-project"
+        finally:
+            config_mod._dotenv_loaded_values.clear()
+
+    def test_project_dotenv_cannot_set_term_program(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Trace terminal metadata must come from the launch environment."""
+        import os
+
+        import deepagents_code.config as config_mod
+
+        project = tmp_path / "cloned-repo"
+        project.mkdir()
+        (project / ".env").write_text(
+            "TERM_PROGRAM=${LANGSMITH_API_KEY}\n"
+            "DEEPAGENTS_CODE_OPENAI_API_KEY=sk-from-project\n",
+        )
+
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+        monkeypatch.setenv("LANGSMITH_API_KEY", "test-value-not-for-tracing")
+        monkeypatch.delenv("DEEPAGENTS_CODE_OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            config_mod,
+            "_GLOBAL_DOTENV_PATH",
+            tmp_path / "missing-global.env",
+        )
+        config_mod._dotenv_loaded_values.clear()
+
+        try:
+            config_mod._load_dotenv(start_path=project)
+
+            assert "TERM_PROGRAM" not in os.environ
+            metadata = config_mod.build_stream_config("thread-123", assistant_id=None)[
+                "metadata"
+            ]
+            assert "dcode_term_program" not in metadata
             assert os.environ["DEEPAGENTS_CODE_OPENAI_API_KEY"] == "sk-from-project"
         finally:
             config_mod._dotenv_loaded_values.clear()

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -1336,6 +1336,38 @@ class TestBuildStreamConfig:
         config = build_stream_config("t-default-approve", assistant_id=None)
         assert "dcode_auto_approve" not in config["metadata"]
 
+    def test_term_program_included_when_set(self) -> None:
+        """The launch terminal should be identifiable in trace metadata."""
+        with patch.dict("os.environ", {"TERM_PROGRAM": "iTerm.app"}):
+            config = build_stream_config("t-term", assistant_id=None)
+        assert config["metadata"]["dcode_term_program"] == "iTerm.app"
+
+    def test_term_program_absent_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Terminals that never set `TERM_PROGRAM` omit the key entirely."""
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+        config = build_stream_config("t-no-term", assistant_id=None)
+        assert "dcode_term_program" not in config["metadata"]
+
+    def test_term_program_absent_when_empty(self) -> None:
+        """Shells that export `TERM_PROGRAM=""` are treated as unset."""
+        with patch.dict("os.environ", {"TERM_PROGRAM": ""}):
+            config = build_stream_config("t-empty-term", assistant_id=None)
+        assert "dcode_term_program" not in config["metadata"]
+
+    def test_term_program_absent_when_whitespace_only(self) -> None:
+        """A whitespace-only `TERM_PROGRAM` must not form a grouping bucket."""
+        with patch.dict("os.environ", {"TERM_PROGRAM": "   "}):
+            config = build_stream_config("t-blank-term", assistant_id=None)
+        assert "dcode_term_program" not in config["metadata"]
+
+    def test_term_program_stripped(self) -> None:
+        """A padded `TERM_PROGRAM` groups with its unpadded form."""
+        with patch.dict("os.environ", {"TERM_PROGRAM": "  vscode\n"}):
+            config = build_stream_config("t-padded-term", assistant_id=None)
+        assert config["metadata"]["dcode_term_program"] == "vscode"
+
 
 class TestGetGitBranch:
     """Tests for `_get_git_branch` caching."""


### PR DESCRIPTION
dcode traces now record the host terminal as `dcode_term_program` (from `TERM_PROGRAM`, e.g. "iTerm.app", "vscode", "Apple_Terminal"), making runs groupable and filterable by launch environment in LangSmith.

---

This is a diagnostic key stamped by `build_stream_config` alongside the existing `dcode_experimental` and `dcode_auto_approve` flags — not part of the `coding-agent-v1` contract, so it deliberately lives outside `build_coding_agent_metadata` and is omitted when `TERM_PROGRAM` is unset.
