### PR TITLE
fix(sdk): handle `None` summary in `SummarizationMiddleware`

### DIFF
--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -639,12 +639,20 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
         """Partition messages into those to summarize and those to preserve."""
         return self._lc_helper._partition_messages(conversation_messages, cutoff_index)
 
-    def _create_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
-        """Generate summary for the given messages."""
+    def _create_summary(self, messages_to_summarize: list[AnyMessage]) -> str | None:
+        """Generate summary for the given messages.
+
+        Returns `None` if summary generation failed. Callers must treat a `None`
+        return as "skip compaction this turn," never as valid summary text.
+        """
         return self._lc_helper._create_summary(messages_to_summarize)
 
-    async def _acreate_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
-        """Generate summary for the given messages (async)."""
+    async def _acreate_summary(self, messages_to_summarize: list[AnyMessage]) -> str | None:
+        """Generate summary for the given messages (async).
+
+        Returns `None` if summary generation failed. Callers must treat a `None`
+        return as "skip compaction this turn," never as valid summary text.
+        """
         return await self._lc_helper._acreate_summary(messages_to_summarize)
 
     def _get_thread_id(self) -> str:
@@ -1427,6 +1435,12 @@ A condensed summary follows:
 
         # Generate summary
         summary = self._create_summary(offloaded_media_messages)
+        if summary is None:
+            # Summary generation failed (e.g. a transient model error). Never
+            # fabricate a summary from `None` - skip compaction this turn and
+            # retry once the underlying model recovers, the same way a missing
+            # safe cutoff is handled above.
+            return handler(request.override(messages=truncated_messages))
 
         # Build summary message with file path reference
         new_messages = self._build_new_messages_with_path(summary, file_path)
@@ -1562,6 +1576,13 @@ A condensed summary follows:
             )
             logger.warning(msg)
             warnings.warn(msg, stacklevel=2)
+
+        if summary is None:
+            # Summary generation failed (e.g. a transient model error). Never
+            # fabricate a summary from `None` - skip compaction this turn and
+            # retry once the underlying model recovers, the same way a missing
+            # safe cutoff is handled above.
+            return await handler(request.override(messages=truncated_messages))
 
         # Build summary message with file path reference
         new_messages = self._build_new_messages_with_path(summary, file_path)
@@ -2036,6 +2057,10 @@ class SummarizationToolMiddleware(AgentMiddleware):
         try:
             to_summarize, _ = s._partition_messages(effective, cutoff)
             summary = s._create_summary(to_summarize)
+            if summary is None:
+                # Never fabricate a summary from `None` - report the failure
+                # honestly instead of claiming the conversation was compacted.
+                return self._compact_error(tool_call_id, RuntimeError("the summarization model failed to generate a summary"))
             file_path = s._offload_to_backend(s._backend, to_summarize)
         except Exception as exc:  # tool must return a ToolMessage, not raise
             logger.exception("compact_conversation tool failed")
@@ -2069,6 +2094,10 @@ class SummarizationToolMiddleware(AgentMiddleware):
         try:
             to_summarize, _ = s._partition_messages(effective, cutoff)
             summary = await s._acreate_summary(to_summarize)
+            if summary is None:
+                # Never fabricate a summary from `None` - report the failure
+                # honestly instead of claiming the conversation was compacted.
+                return self._compact_error(tool_call_id, RuntimeError("the summarization model failed to generate a summary"))
             file_path = await s._aoffload_to_backend(s._backend, to_summarize)
         except Exception as exc:  # tool must return a ToolMessage, not raise
             logger.exception("compact_conversation tool failed")

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -1436,10 +1436,7 @@ A condensed summary follows:
         # Generate summary
         summary = self._create_summary(offloaded_media_messages)
         if summary is None:
-            # Summary generation failed (e.g. a transient model error). Never
-            # fabricate a summary from `None` - skip compaction this turn and
-            # retry once the underlying model recovers, the same way a missing
-            # safe cutoff is handled above.
+            # Summary generation failed; skip compaction this turn and retry later.
             return handler(request.override(messages=truncated_messages))
 
         # Build summary message with file path reference
@@ -1578,10 +1575,7 @@ A condensed summary follows:
             warnings.warn(msg, stacklevel=2)
 
         if summary is None:
-            # Summary generation failed (e.g. a transient model error). Never
-            # fabricate a summary from `None` - skip compaction this turn and
-            # retry once the underlying model recovers, the same way a missing
-            # safe cutoff is handled above.
+            # Summary generation failed; skip compaction this turn and retry later.
             return await handler(request.override(messages=truncated_messages))
 
         # Build summary message with file path reference
@@ -2058,8 +2052,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
             to_summarize, _ = s._partition_messages(effective, cutoff)
             summary = s._create_summary(to_summarize)
             if summary is None:
-                # Never fabricate a summary from `None` - report the failure
-                # honestly instead of claiming the conversation was compacted.
+                # Summary generation failed; return an error instead of reporting false success.
                 return self._compact_error(tool_call_id, RuntimeError("the summarization model failed to generate a summary"))
             file_path = s._offload_to_backend(s._backend, to_summarize)
         except Exception as exc:  # tool must return a ToolMessage, not raise
@@ -2095,8 +2088,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
             to_summarize, _ = s._partition_messages(effective, cutoff)
             summary = await s._acreate_summary(to_summarize)
             if summary is None:
-                # Never fabricate a summary from `None` - report the failure
-                # honestly instead of claiming the conversation was compacted.
+                # Summary generation failed; return an error instead of reporting false success.
                 return self._compact_error(tool_call_id, RuntimeError("the summarization model failed to generate a summary"))
             file_path = await s._aoffload_to_backend(s._backend, to_summarize)
         except Exception as exc:  # tool must return a ToolMessage, not raise

--- a/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
@@ -410,6 +410,68 @@ class TestCompactErrorHandling:
         assert "Compaction failed" in msg.content
         assert "_summarization_event" not in result.update
 
+    def test_sync_none_summary_returns_error_tool_message(self) -> None:
+        """Sync: a `None` summary must not be fabricated into a fake success.
+
+        Unlike the RuntimeError-raising case above, this covers the failure
+        signal langchain's `SummarizationMiddleware` actually uses: a `None`
+        return, not a raised exception.
+        """
+        mw = _make_middleware()
+        messages = _make_messages(10)
+        runtime = _make_runtime(messages)
+
+        with (
+            patch.object(mw._summarization, "_determine_cutoff_index", return_value=4),
+            patch.object(
+                mw._summarization,
+                "_partition_messages",
+                side_effect=lambda msgs, idx: (msgs[:idx], msgs[idx:]),
+            ),
+            patch.object(mw._summarization, "_offload_to_backend", return_value=None) as offload_mock,
+            patch.object(mw._summarization, "_create_summary", return_value=None),
+        ):
+            result = mw._run_compact(runtime)
+
+        assert isinstance(result, Command)
+        assert result.update is not None
+        msg = result.update["messages"][0]
+        assert "Compaction failed" in msg.content
+        assert "None" not in msg.content
+        # Should NOT have a _summarization_event (state not modified) and must not
+        # have reported "Conversation compacted" success text.
+        assert "_summarization_event" not in result.update
+        assert "Conversation compacted" not in msg.content
+        # Must not proceed to offload once the summary is known to have failed.
+        offload_mock.assert_not_called()
+
+    async def test_async_none_summary_returns_error_tool_message(self) -> None:
+        """Async: a `None` summary must return an error `ToolMessage`, not a fake success."""
+        mw = _make_middleware()
+        messages = _make_messages(10)
+        runtime = _make_runtime(messages)
+
+        with (
+            patch.object(mw._summarization, "_determine_cutoff_index", return_value=4),
+            patch.object(
+                mw._summarization,
+                "_partition_messages",
+                side_effect=lambda msgs, idx: (msgs[:idx], msgs[idx:]),
+            ),
+            patch.object(mw._summarization, "_aoffload_to_backend", return_value=None) as offload_mock,
+            patch.object(mw._summarization, "_acreate_summary", return_value=None),
+        ):
+            result = await mw._arun_compact(runtime)
+
+        assert isinstance(result, Command)
+        assert result.update is not None
+        msg = result.update["messages"][0]
+        assert "Compaction failed" in msg.content
+        assert "None" not in msg.content
+        assert "_summarization_event" not in result.update
+        assert "Conversation compacted" not in msg.content
+        offload_mock.assert_not_called()
+
     def test_offload_failure_returns_error_tool_message(self) -> None:
         """Offload failure should return an error ToolMessage."""
         mw = _make_middleware()

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
@@ -1977,6 +1977,67 @@ class TestCutoffIndexEdgeCases:
         assert len(backend.write_calls) == 0
 
 
+class TestSummaryGenerationFailure:
+    """Test that a failed summary (`None`) never gets fabricated into a fake compaction.
+
+    `_create_summary`/`_acreate_summary` on the underlying LangChain
+    `SummarizationMiddleware` return `None` (instead of a fabricated error
+    string) when the summary model call fails. `wrap_model_call`/`awrap_model_call`
+    must treat that as "skip compaction this turn," not build a `_summarization_event`
+    or interpolate `None` into a fake summary message.
+    """
+
+    def test_sync_skips_compaction_when_summary_is_none(self) -> None:
+        """A `None` summary must skip compaction and fall through to a plain handler call."""
+        backend = MockBackend()
+        mock_model = make_mock_model()
+
+        middleware = SummarizationMiddleware(
+            model=mock_model,
+            backend=backend,
+            trigger=("messages", 3),
+            keep=("messages", 2),
+        )
+
+        messages = make_conversation_messages(num_old=6, num_recent=3)
+        state = cast("AgentState[Any]", {"messages": messages})
+        runtime = make_mock_runtime()
+
+        with mock_get_config(), patch.object(middleware, "_create_summary", return_value=None):
+            result, captured_request = call_wrap_model_call(middleware, state, runtime)
+
+        # No _summarization_event should be created - a plain ModelResponse instead.
+        assert not isinstance(result, ExtendedModelResponse)
+        # The handler must have received the original (untouched) messages, not a
+        # fabricated summary built from `None`.
+        assert captured_request is not None
+        assert captured_request.messages == messages
+
+    @pytest.mark.anyio
+    async def test_async_skips_compaction_when_summary_is_none(self) -> None:
+        """Async: a `None` summary must skip compaction and fall through to the handler."""
+        backend = MockBackend()
+        mock_model = make_mock_model()
+
+        middleware = SummarizationMiddleware(
+            model=mock_model,
+            backend=backend,
+            trigger=("messages", 3),
+            keep=("messages", 2),
+        )
+
+        messages = make_conversation_messages(num_old=6, num_recent=3)
+        state = cast("AgentState[Any]", {"messages": messages})
+        runtime = make_mock_runtime()
+
+        with mock_get_config(), patch.object(middleware, "_acreate_summary", return_value=None):
+            result, captured_request = await call_awrap_model_call(middleware, state, runtime)
+
+        assert not isinstance(result, ExtendedModelResponse)
+        assert captured_request is not None
+        assert captured_request.messages == messages
+
+
 # -----------------------------------------------------------------------------
 # Argument truncation tests
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Handles summary generation failures in DeepAgents after [#langchain-ai/langchain#39268](https://github.com/langchain-ai/langchain/pull/39268)

- Automatic summarization now skips compaction when summary generation returns `None`.
- `compact_conversation` returns an error instead of reporting a false success.

This is forward-compatible with the upcoming LangChain change and has no behavior change with current versions.