### PR TITLE
fix(code): open `/auto model` selector immediately while connecting

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10225,8 +10225,11 @@ class DeepAgentsApp(App):
             # which opens the classifier picker). Other argument forms do a
             # direct action that shouldn't race the agent (e.g. `/model <name>`
             # switches models, `/threads -r <id>` resumes a thread,
-            # `/auto model <spec>` mutates classifier state).
-            return value == cmd or value in IMMEDIATE_UI_ARG_FORMS
+            # `/auto model <spec>` mutates classifier state). Whitespace is
+            # canonicalized for the whitelist check because `_handle_command`
+            # strips and reparses the same way — `/auto  model` (double space,
+            # tab) reaches the selector branch once processed.
+            return value == cmd or " ".join(value.split()) in IMMEDIATE_UI_ARG_FORMS
         return cmd in SIDE_EFFECT_FREE
 
     async def _submit_input(

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10192,6 +10192,7 @@ class DeepAgentsApp(App):
         from deepagents_code.command_registry import (
             BYPASS_WHEN_CONNECTING,
             IMMEDIATE_UI,
+            IMMEDIATE_UI_ARG_FORMS,
             SIDE_EFFECT_FREE,
             STARTUP_RECOVERY_COMMANDS,
         )
@@ -10219,11 +10220,13 @@ class DeepAgentsApp(App):
                 or self._modal_command_running()
             )
         if cmd in IMMEDIATE_UI:
-            # Only bare form (no args) bypasses — the selector-opening form is
-            # safe, but an argument form does a direct action that shouldn't
-            # race the agent (e.g. `/model <name>` switches models, `/threads
-            # -r <id>` resumes a thread).
-            return value == cmd
+            # Only UI-opening forms bypass: the bare command, or an argument
+            # form whitelisted in IMMEDIATE_UI_ARG_FORMS (e.g. `/auto model`,
+            # which opens the classifier picker). Other argument forms do a
+            # direct action that shouldn't race the agent (e.g. `/model <name>`
+            # switches models, `/threads -r <id>` resumes a thread,
+            # `/auto model <spec>` mutates classifier state).
+            return value == cmd or value in IMMEDIATE_UI_ARG_FORMS
         return cmd in SIDE_EFFECT_FREE
 
     async def _submit_input(

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -85,8 +85,10 @@ COMMANDS: tuple[SlashCommand, ...] = (
             "this session"
         ),
         # Bare `/auto` still switches mode immediately (the switcher must work
-        # mid-turn); `/auto model ...` opens UI or resolves a model, so it waits
-        # for idle like every other argument form.
+        # mid-turn). `/auto model` with no further arguments only opens the
+        # classifier picker, so it also bypasses (via IMMEDIATE_UI_ARG_FORMS);
+        # `/auto model <spec>` and `/auto model clear` mutate classifier state
+        # and wait for idle like every other argument form.
         bypass_tier=BypassTier.IMMEDIATE_UI,
         hidden_keywords=(
             "approval mode classifier automatic auto-approve shift+tab model"
@@ -355,6 +357,21 @@ BYPASS_WHEN_CONNECTING: frozenset[str] = _build_bypass_set(BypassTier.CONNECTING
 
 IMMEDIATE_UI: frozenset[str] = _build_bypass_set(BypassTier.IMMEDIATE_UI)
 """Commands that open modal UI immediately, deferring real work."""
+
+IMMEDIATE_UI_ARG_FORMS: frozenset[str] = frozenset({"/auto model"})
+"""Argument forms of `IMMEDIATE_UI` commands that are still pure selector opens.
+
+The bare-form check in `_can_bypass_queue` (`value == cmd`) parks every
+argument form behind the queue because most of them act directly (e.g.
+`/model <name>` switches models). Entries here are the exceptions: their
+handler routes straight to a modal open and defers all real work (validation,
+mutation) to the dismiss callback, exactly like the bare form. `/auto model`
+with no further arguments qualifies — it only pushes the classifier-model
+picker — while `/auto model <spec>` and `/auto model clear` validate and
+mutate classifier state, so they stay queue-bound. Each entry must be an
+exact lowered command-plus-subcommand string with no further arguments; the
+bypass compares the full submitted value against it.
+"""
 
 SIDE_EFFECT_FREE: frozenset[str] = _build_bypass_set(BypassTier.SIDE_EFFECT_FREE)
 """Commands whose side effect fires immediately; chat output deferred until idle."""

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -368,9 +368,10 @@ handler routes straight to a modal open and defers all real work (validation,
 mutation) to the dismiss callback, exactly like the bare form. `/auto model`
 with no further arguments qualifies — it only pushes the classifier-model
 picker — while `/auto model <spec>` and `/auto model clear` validate and
-mutate classifier state, so they stay queue-bound. Each entry must be an
-exact lowered command-plus-subcommand string with no further arguments; the
-bypass compares the full submitted value against it.
+mutate classifier state, so they stay queue-bound. Each entry must be an exact
+lowered command-plus-subcommand string with single-space separators and no
+further arguments; the bypass canonicalizes the submitted value's whitespace
+before comparing against it.
 """
 
 SIDE_EFFECT_FREE: frozenset[str] = _build_bypass_set(BypassTier.SIDE_EFFECT_FREE)

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -22842,19 +22842,54 @@ class TestDeferredActions:
             assert app._can_bypass_queue("/model --default foo") is False
 
     async def test_can_bypass_queue_bare_auto_bypasses(self) -> None:
-        """Bare `/auto` must bypass the queue; `/auto model ...` must not.
+        """Bare `/auto` and `/auto model` bypass; the mutating forms must not.
 
         `/auto` is the mid-turn approval-mode switch, so parking it behind a busy
-        queue would break the "stop auto-approving right now" escape. Its
-        argument form resolves a classifier model and can wait for idle. Pins
-        both sides of `BypassTier.IMMEDIATE_UI` for this command.
+        queue would break the "stop auto-approving right now" escape. `/auto
+        model` with no further arguments only opens the classifier picker, so it
+        is bare-equivalent; `/auto model <spec>` and `/auto model clear` resolve
+        or mutate classifier state and can wait for idle.
         """
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             assert app._can_bypass_queue("/auto") is True
+            assert app._can_bypass_queue("/auto model") is True
             assert app._can_bypass_queue("/auto model openai:gpt-5.5-mini") is False
             assert app._can_bypass_queue("/auto model clear") is False
+
+    async def test_auto_model_opens_selector_while_busy(self) -> None:
+        """`/auto model` opens the selector instead of queueing when busy."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            with patch.object(
+                app,
+                "_show_auto_classifier_model_selector",
+                new_callable=AsyncMock,
+            ) as show_selector:
+                app.post_message(ChatInput.Submitted("/auto model", "command"))
+                await pilot.pause()
+
+            show_selector.assert_awaited_once()
+            assert len(app._pending_messages) == 0
+
+    async def test_auto_model_with_spec_still_queues(self) -> None:
+        """`/auto model <spec>` mutates classifier state, so it must queue."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            app.post_message(
+                ChatInput.Submitted("/auto model openai:gpt-5.5-mini", "command")
+            )
+            await pilot.pause()
+
+            assert len(app._pending_messages) == 1
+            assert app._pending_messages[0].text == "/auto model openai:gpt-5.5-mini"
 
     async def test_model_with_args_still_queues(self) -> None:
         """/model gpt-4 should be queued when busy, not bypass."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -22855,6 +22855,11 @@ class TestDeferredActions:
             await pilot.pause()
             assert app._can_bypass_queue("/auto") is True
             assert app._can_bypass_queue("/auto model") is True
+            # `_handle_auto_command` strips and reparses the remainder, so
+            # whitespace-variant spellings reach the same selector branch and
+            # must bypass too.
+            assert app._can_bypass_queue("/auto  model") is True
+            assert app._can_bypass_queue("/auto\tmodel") is True
             assert app._can_bypass_queue("/auto model openai:gpt-5.5-mini") is False
             assert app._can_bypass_queue("/auto model clear") is False
 

--- a/libs/code/tests/unit_tests/test_command_registry.py
+++ b/libs/code/tests/unit_tests/test_command_registry.py
@@ -13,6 +13,7 @@ from deepagents_code.command_registry import (
     COMMANDS,
     HIDDEN_COMMANDS,
     IMMEDIATE_UI,
+    IMMEDIATE_UI_ARG_FORMS,
     QUEUE_BOUND,
     SIDE_EFFECT_FREE,
     STARTUP_RECOVERY_COMMANDS,
@@ -98,6 +99,21 @@ class TestBypassTiers:
     def test_startup_recovery_commands_are_known(self) -> None:
         names = {cmd.name for cmd in COMMANDS}
         assert names >= STARTUP_RECOVERY_COMMANDS
+
+    def test_immediate_ui_arg_forms_extend_immediate_ui_commands(self) -> None:
+        """Every whitelisted argument form must name an IMMEDIATE_UI command.
+
+        `_can_bypass_queue` checks these forms only after the base command
+        matches `IMMEDIATE_UI`; an entry under a command in any other tier
+        would be dead config. The whitelist must also stay narrow — every
+        entry is an exact no-further-arguments form whose handler defers all
+        mutation to the modal's dismiss callback.
+        """
+        for form in IMMEDIATE_UI_ARG_FORMS:
+            base = form.split(maxsplit=1)[0]
+            assert base in IMMEDIATE_UI, (
+                f"{form!r} is whitelisted but {base!r} is not IMMEDIATE_UI"
+            )
 
 
 class TestSlashCommands:


### PR DESCRIPTION
Typing `/auto model` during startup (or mid-turn) now opens the Auto classifier model selector immediately, matching bare `/model`, instead of being parked behind the message queue until the app finishes connecting.

---

`_can_bypass_queue` previously treated every argument form of an `IMMEDIATE_UI` command as queue-bound, because most of them act directly (`/model <name>` switches models). But `/auto model` with no further arguments routes straight to the classifier picker — a modal that defers all validation and mutation (`_set_auto_classifier_model`, install-extra flow) to its dismiss callback, exactly like bare `/model`. There is no server dependency at open time.

The fix adds an `IMMEDIATE_UI_ARG_FORMS` frozenset in `command_registry.py` next to the derived tier sets, so the bypass is data-driven and extensible rather than an inline string special case. `_can_bypass_queue` now bypasses when the submitted value is the bare command or one of these whitelisted forms. The mutating forms — `/auto model <spec>` and `/auto model clear` — stay queue-bound, as does every other command's argument form.