### PR TITLE
chore(code): surface update status, log path, and extras loss in installer

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -194,9 +194,10 @@ for _arg in "$@"; do
   esac
 done
 
-# Registry of temp files to clean up on exit or interrupt. Functions that
-# create tempfiles append their paths here; cleanup_on_signal removes them all.
+# Registry of temporary paths to clean up on exit or interrupt. Functions that
+# create them append their paths here; the signal handlers remove them all.
 TEMP_FILES=()
+TEMP_DIRS=()
 INSTALL_LOCK_KIND=""
 INSTALL_LOCK_DIR=""
 INSTALL_LOCK_TOKEN=""
@@ -209,9 +210,17 @@ INSTALL_LOCK_STALE_AFTER_SECS=600
 register_temp() {
   TEMP_FILES+=("$1")
 }
+register_temp_dir() {
+  TEMP_DIRS+=("$1")
+}
 cleanup_temp_files() {
   for f in "${TEMP_FILES[@]:-}"; do
     rm -f "$f" 2>/dev/null || true
+  done
+}
+cleanup_temp_dirs() {
+  for dir in "${TEMP_DIRS[@]:-}"; do
+    rm -rf "$dir" 2>/dev/null || true
   done
 }
 
@@ -272,6 +281,7 @@ log_signal_failure_hint() {
 cleanup_on_signal() {
   local exit_code=$?
   cleanup_temp_files
+  cleanup_temp_dirs
   if declare -F release_install_lock >/dev/null 2>&1; then
     release_install_lock
   fi
@@ -303,6 +313,7 @@ cleanup_on_interrupt() {
   echo "" >&2
   log_warn "Installation interrupted."
   cleanup_temp_files
+  cleanup_temp_dirs
   if declare -F release_install_lock >/dev/null 2>&1; then
     release_install_lock
   fi
@@ -568,6 +579,7 @@ copy_install_log() {
   # noclobber create below, which never follows a planted INSTALL_LOG symlink.
   local stage_dir staged
   stage_dir=$(mktemp -d "/tmp/deepagents-code-install-log.XXXXXX" 2>/dev/null) || return 2
+  register_temp_dir "$stage_dir"
   staged="${stage_dir}/install.log"
   if ! (cd "$stage_dir" && cp "$uv_stderr" install.log) 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -553,46 +553,53 @@ copy_install_log() {
   # than following it, so this guard is not what makes publishing safe. Keep it
   # anyway — it fails early and explicitly on an obviously tampered path.
   [ ! -L "$INSTALL_LOG" ] || return 1
-  # Publish the already-captured stderr with a same-directory rename, which
-  # never opens INSTALL_LOG: rename(2) swaps the directory entry atomically,
-  # so a symlink planted at that path is replaced, not followed. Stage inside
-  # install_log_dir (not the default TMPDIR) so the final `mv` is a true rename
-  # — a cross-filesystem `mv` degrades to copy+unlink, which does open the
-  # destination and follow links. mktemp creates the staged file with
-  # O_CREAT|O_EXCL, so a symlink pre-planted at the chosen name makes creation
-  # fail rather than be followed. Note that secrecy is *not* the protection: a
-  # target user who owns install_log_dir (possible after a prior root install
-  # handed it over) can readdir the name and swap the file between the mktemp
-  # and the cp. That residual window is accepted — the worst outcome is a
-  # failed publish or a write into a path that user already controls.
-  local staged
-  staged=$(mktemp "${install_log_dir}/.install.log.XXXXXX" 2>/dev/null) || return 2
-  register_temp "$staged"
-  if ! cp "$uv_stderr" "$staged" 2>/dev/null; then
+  # Stage inside a private directory. `mktemp` alone only protects creation:
+  # a user who owns install_log_dir could replace its resulting file before
+  # `cp` reopens it. The directory is mode 700, and copying via a relative
+  # pathname after entering it means the copy never follows such a replacement.
+  # Keeping the stage beneath install_log_dir also keeps the final move a
+  # same-filesystem rename, so it replaces a planted INSTALL_LOG symlink rather
+  # than degrading into a cross-filesystem copy that could follow one.
+  local stage_dir staged
+  stage_dir=$(mktemp -d "${install_log_dir}/.install.log.XXXXXX" 2>/dev/null) || return 2
+  staged="${stage_dir}/install.log"
+  if ! (cd "$stage_dir" && cp "$uv_stderr" install.log) 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true
+    rmdir "$stage_dir" 2>/dev/null || true
     return 2
   fi
-  # Defense in depth against a directory swap. The same-directory staging above
-  # already defeats it: both `mv` operands are built from install_log_dir, so if
-  # the directory is replaced by a symlink the *source* path resolves through
-  # that link too and no longer names the staged file, and the rename fails
-  # harmlessly. Re-validate anyway to fail early and explicitly. Note this is a
-  # check-then-rename, which narrows the window rather than closing it — the
-  # staging, not this guard, is what makes the operation safe.
+  [ -f "$staged" ] && [ ! -L "$staged" ] || {
+    rm -f "$staged" 2>/dev/null || true
+    rmdir "$stage_dir" 2>/dev/null || true
+    return 1
+  }
+  # Re-validate the parent immediately before publication so a directory swap
+  # is rejected explicitly rather than being mistaken for a write failure.
   [ -d "$install_log_dir" ] && [ ! -L "$install_log_dir" ] || {
     rm -f "$staged" 2>/dev/null || true
+    rmdir "$stage_dir" 2>/dev/null || true
     return 1
   }
   if [ "$(id -u)" -eq 0 ]; then
     path_is_under_home "$install_log_dir" || {
       rm -f "$staged" 2>/dev/null || true
+      rmdir "$stage_dir" 2>/dev/null || true
       return 1
     }
   fi
+  # `mv file directory` moves the file *into* the directory and reports
+  # success. Reject that state rather than publishing an undiscoverable log.
+  [ ! -d "$INSTALL_LOG" ] || {
+    rm -f "$staged" 2>/dev/null || true
+    rmdir "$stage_dir" 2>/dev/null || true
+    return 1
+  }
   if ! mv -f "$staged" "$INSTALL_LOG" 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true
+    rmdir "$stage_dir" 2>/dev/null || true
     return 2
   fi
+  rmdir "$stage_dir" 2>/dev/null || true
 }
 
 # Epoch mtime of the lock directory, used as a fallback reference time when the

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -546,10 +546,26 @@ copy_install_log() {
     path_is_under_home "$install_log_dir" || return 1
   fi
   [ ! -L "$INSTALL_LOG" ] || return 1
-  rm -f "$INSTALL_LOG" 2>/dev/null || return 1
-  # Publish the already-captured stderr without opening the destination for
-  # writing. `ln` fails if an attacker wins the race by creating install.log.
-  ln "$uv_stderr" "$INSTALL_LOG" 2>/dev/null
+  # Publish the already-captured stderr without opening the canonical path for
+  # writing. `ln` fails if an attacker wins the race by creating install.log,
+  # but it also fails with EXDEV whenever mktemp's TMPDIR and the cache dir sit
+  # on different filesystems — /tmp on tmpfs is the default on most Linux
+  # distros, so the hardlink alone would silently disable the log there. Fall
+  # back to a copy, staged under a sibling name: the destination is still never
+  # opened at the canonical path (and install_log_dir is a validated,
+  # non-symlink 0700 dir), and a failure leaves the previous run's log intact
+  # instead of deleting it before finding out.
+  local staged="${INSTALL_LOG}.$$"
+  rm -f "$staged" 2>/dev/null || return 1
+  if ! ln "$uv_stderr" "$staged" 2>/dev/null \
+    && ! cp "$uv_stderr" "$staged" 2>/dev/null; then
+    rm -f "$staged" 2>/dev/null || true
+    return 1
+  fi
+  if ! mv -f "$staged" "$INSTALL_LOG" 2>/dev/null; then
+    rm -f "$staged" 2>/dev/null || true
+    return 1
+  fi
 }
 
 # Epoch mtime of the lock directory, used as a fallback reference time when the
@@ -1381,21 +1397,49 @@ fi
 # the user re-runs this installer without DEEPAGENTS_CODE_EXTRAS, uv rebuilds
 # the environment against bare `deepagents-code` and silently drops those
 # extras' packages - warn before that happens so they can re-run with the
-# extras preserved. Only relevant on the default path (no explicit EXTRAS /
-# editable swap), where the user asked for nothing new.
+# extras preserved. Checked whenever the caller passed no EXTRAS and the
+# existing install isn't editable, which covers plain upgrades as well as the
+# same-version repair paths below (both re-run `uv tool install`).
 #
 # The receipt records every requirement in one array: the tool itself plus any
 # supplemental `--with` packages. Only parse extras from the `deepagents-code`
 # requirement - a `--with rich[jupyter]` entry must not surface as a tool
 # extra, since `DEEPAGENTS_CODE_EXTRAS` installs `deepagents-code[...]` and
 # cannot preserve supplemental packages.
+#
+# EXTRAS_UNREADABLE separates "this install has no extras" from "we could not
+# tell". Both would otherwise reach the rebuild silently, and a false negative
+# here costs the user the exact packages this check exists to protect - so an
+# unreadable or unparseable receipt warns rather than degrading to quiet.
 INSTALLED_EXTRAS=""
+EXTRAS_UNREADABLE=false
+receipt=""
 if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ] && [ -n "$UV_TOOL_DIR" ]; then
   receipt="${UV_TOOL_DIR}/deepagents-code/uv-receipt.toml"
-  if [ -f "$receipt" ] && [ ! -L "$receipt" ]; then
-    INSTALLED_EXTRAS=$(sed -nE 's/.*name = "deepagents-code"[^}]*extras = \[([^]]*)\].*/\1/p' "$receipt" \
-      | head -1 \
-      | tr -d ' "' || true)
+  if [ -L "$receipt" ]; then
+    # Refusing to read through a symlink matches the install-log hardening
+    # above, but the refusal must still be announced - staying silent here is
+    # indistinguishable from "no extras" to the user losing them.
+    EXTRAS_UNREADABLE=true
+  elif [ -f "$receipt" ] && [ ! -r "$receipt" ]; then
+    # A receipt written by a previous `sudo` run and re-read as a normal user.
+    EXTRAS_UNREADABLE=true
+  elif [ -f "$receipt" ]; then
+    # Isolate the deepagents-code inline table first ([^{}] cannot cross into a
+    # neighbouring requirement), then read extras out of that entry alone. uv
+    # keeps each inline table on one line; if a future formatter wraps it, the
+    # entry match fails while the package name is still present - that is the
+    # unparseable case, not an extras-free one.
+    receipt_entry=$(sed -nE \
+      's/.*(\{[^{}]*name = "deepagents-code"[^{}]*\}).*/\1/p' "$receipt" \
+      | head -1) || receipt_entry=""
+    if [ -n "$receipt_entry" ]; then
+      INSTALLED_EXTRAS=$(printf '%s\n' "$receipt_entry" \
+        | sed -nE 's/.*extras = \[([^]]*)\].*/\1/p' \
+        | tr -d ' "')
+    elif grep -q 'deepagents-code' "$receipt" 2>/dev/null; then
+      EXTRAS_UNREADABLE=true
+    fi
   fi
 fi
 
@@ -1516,22 +1560,33 @@ if [ -n "$cache_root" ]; then
     fi
   fi
 fi
-if [ -z "$INSTALL_LOCK_KIND" ]; then
-  acquire_install_lock
-fi
-if [ -n "$INSTALLED_EXTRAS" ]; then
-  log_warn "This install has extras that a bare upgrade will remove: ${INSTALLED_EXTRAS}"
+# Warn (and offer to back out) before the lock is taken: this block only reads
+# a file and asks a question, so holding the install lock across an unbounded
+# human wait would block a concurrent installer - which spins silently, since
+# it can't reclaim a lock whose owner is alive - for no reason.
+if [ "$EXTRAS_UNREADABLE" = true ]; then
+  log_warn "Could not read ${receipt} to check which extras this install was built with."
+  log_warn "  If it was built with DEEPAGENTS_CODE_EXTRAS, re-run with the same value or those packages will be removed."
+elif [ -n "$INSTALLED_EXTRAS" ]; then
+  log_warn "This install has extras that a bare re-run will remove: ${INSTALLED_EXTRAS}"
   log_warn "  To keep them, re-run with: DEEPAGENTS_CODE_EXTRAS=\"${INSTALLED_EXTRAS}\""
   # Give an interactive user the chance to back out before uv rebuilds the
-  # environment and drops those packages. Non-interactive runs (no TTY, or an
-  # unattended DEEPAGENTS_CODE_YES) can't answer, so they keep the warning
-  # only; an explicit YES is an instruction to proceed, not to abort.
+  # environment and drops those packages. No TTY means nobody can answer; an
+  # explicit DEEPAGENTS_CODE_YES means they already did. Both keep the warning
+  # and proceed - a pre-answered yes is an instruction to continue, not to
+  # abort.
   if [ "$ASSUME_YES" != "1" ] && can_prompt; then
     if ! prompt_yn "Continue anyway and remove them?"; then
-      log_info "Aborted. No changes made."
+      # This path can also skip a same-version PATH repair (the branches above
+      # that reinstall a current version), so name what was left undone rather
+      # than implying the run had nothing else to do.
+      log_info "Aborted. deepagents-code was left unchanged."
       exit 0
     fi
   fi
+fi
+if [ -z "$INSTALL_LOCK_KIND" ]; then
+  acquire_install_lock
 fi
 if [[ -z "$VERSION" ]]; then
   "$UV_BIN" tool install -U --python "$PYTHON_VERSION" \
@@ -2549,9 +2604,10 @@ elif [ -n "$NEW_VERSION" ] && [ "$PRE_VERSION" = "$NEW_VERSION" ]; then
   # the dep move entirely). UV_REPORTED_PACKAGE_CHANGES (set far above) is the
   # signal that the reinstall actually moved packages.
   if [ "$UV_REPORTED_PACKAGE_CHANGES" = true ]; then
-    # INSTALL_LOG_DISPLAY is empty exactly when no log was written, so the
-    # `:+` suffix appends the pointer only when there's a log to point at.
-    log_success "deepagents-code ${NEW_VERSION} was already up to date; dependencies were updated.${INSTALL_LOG_DISPLAY:+ Details: ${INSTALL_LOG_DISPLAY}}"
+    # No log pointer here: the "Full log:" line below prints it on every run
+    # that wrote one, and this branch would otherwise repeat the same path on
+    # consecutive lines.
+    log_success "deepagents-code ${NEW_VERSION} was already up to date; dependencies were updated."
   else
     log_success "deepagents-code ${NEW_VERSION} already up to date."
   fi
@@ -2561,10 +2617,13 @@ else
   log_success "deepagents-code installed."
 fi
 # The log captured uv's full stderr (dependency diff, warnings, rebuild
-# notice). Point at it on every run so users can inspect what changed -
-# non-verbose mode trims those lines from the terminal and piped
-# `curl | bash` runs lose scrollback.
-if [ -n "$INSTALL_LOG_DISPLAY" ]; then
+# notice). Point at it after any successful install so users can inspect what
+# changed - non-verbose mode trims those lines from the terminal, and a
+# non-TTY run (CI, `curl | bash` under a pipe) has no scrollback to go back
+# to. The failure path prints its own pointer and exits before reaching here.
+# Test on the file rather than the display name: uv writes nothing to stderr
+# on a clean no-op reinstall, and pointing at an empty log is a dead end.
+if [ -n "$INSTALL_LOG_DISPLAY" ] && [ -s "$INSTALL_LOG" ]; then
   log_info "Full log: ${INSTALL_LOG_DISPLAY}"
 fi
 
@@ -2789,8 +2848,15 @@ fi
 # Done — footer wording depends on what changed:
 #   - same app version + dependency changes → "Dependencies updated."
 #   - already up to date                    → "Already installed."
-#   - version actually moved                → "Upgrade complete."
-#   - fresh install / editable→PyPI swap    → "Setup complete."
+#   - unpinned run that moved version       → "Upgrade complete."
+#   - everything else                       → "Setup complete."
+#
+# The last branch is a catch-all, not an enumerated set. It covers a fresh
+# install and an editable→PyPI swap, but also a *pinned* version move (VERSION
+# set) — `bash -s -- 0.1.0` over an installed 0.2.0 is a downgrade, and the
+# script has no version comparison to tell the two apart, so only the unpinned
+# case (which always resolves to latest) may claim an upgrade. It also covers
+# an empty NEW_VERSION, i.e. the post-install `dcode -v` probe failed.
 # ---------------------------------------------------------------------------
 if [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] \
   && [ "$PRE_VERSION" = "$NEW_VERSION" ] && [ "$UV_REPORTED_PACKAGE_CHANGES" = true ]; then
@@ -2798,8 +2864,8 @@ if [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] 
 elif [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] \
   && [ "$PRE_VERSION" = "$NEW_VERSION" ]; then
   footer_msg="Already installed."
-elif [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] \
-  && [ "$PRE_VERSION" != "$NEW_VERSION" ]; then
+elif [ "$IS_EDITABLE" = false ] && [ -z "$VERSION" ] && [ -n "$PRE_VERSION" ] \
+  && [ -n "$NEW_VERSION" ] && [ "$PRE_VERSION" != "$NEW_VERSION" ]; then
   footer_msg="Upgrade complete."
 else
   footer_msg="Setup complete."

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -463,7 +463,11 @@ prompt_yn() {
     printf "%s [y/N] " "$question" > /dev/tty
     if ! read -r reply < /dev/tty 2>/dev/null; then
       log_warn "Could not read from /dev/tty — skipping prompt."
-      return 1
+      # 2, not 1: "nobody could answer" is not "the user said no". can_prompt
+      # only proves /dev/tty can be *opened*, so a detached session can reach
+      # here after passing that check. Callers for whom the distinction matters
+      # branch on 2; those that don't still see a non-zero status and decline.
+      return 2
     fi
   fi
   if [[ "$reply" =~ ^[Yy]$ ]]; then
@@ -545,27 +549,36 @@ copy_install_log() {
   if [ "$(id -u)" -eq 0 ]; then
     path_is_under_home "$install_log_dir" || return 1
   fi
+  # Belt-and-braces: the rename below replaces a symlink at INSTALL_LOG rather
+  # than following it, so this guard is not what makes publishing safe. Keep it
+  # anyway — it fails early and explicitly on an obviously tampered path.
   [ ! -L "$INSTALL_LOG" ] || return 1
   # Publish the already-captured stderr with a same-directory rename, which
   # never opens INSTALL_LOG: rename(2) swaps the directory entry atomically,
   # so a symlink planted at that path is replaced, not followed. Stage inside
   # install_log_dir (not the default TMPDIR) so the final `mv` is a true rename
   # — a cross-filesystem `mv` degrades to copy+unlink, which does open the
-  # destination and follow links. mktemp gives the staged file an unpredictable
-  # name, so the target user — who may own install_log_dir after a prior root
-  # install handed it over — cannot pre-place a link at the source path to make
-  # the copy overwrite it.
+  # destination and follow links. mktemp creates the staged file with
+  # O_CREAT|O_EXCL, so a symlink pre-planted at the chosen name makes creation
+  # fail rather than be followed. Note that secrecy is *not* the protection: a
+  # target user who owns install_log_dir (possible after a prior root install
+  # handed it over) can readdir the name and swap the file between the mktemp
+  # and the cp. That residual window is accepted — the worst outcome is a
+  # failed publish or a write into a path that user already controls.
   local staged
-  staged=$(mktemp "${install_log_dir}/.install.log.XXXXXX" 2>/dev/null) || return 1
+  staged=$(mktemp "${install_log_dir}/.install.log.XXXXXX" 2>/dev/null) || return 2
+  register_temp "$staged"
   if ! cp "$uv_stderr" "$staged" 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true
-    return 1
+    return 2
   fi
-  # Between the guard above and this rename, a target user who owns
-  # install_log_dir can rmdir the empty directory and symlink its path
-  # elsewhere; rename would then create install.log wherever the link points —
-  # with root's privileges during a sudo install. Re-validate the directory
-  # immediately before publishing.
+  # Defense in depth against a directory swap. The same-directory staging above
+  # already defeats it: both `mv` operands are built from install_log_dir, so if
+  # the directory is replaced by a symlink the *source* path resolves through
+  # that link too and no longer names the staged file, and the rename fails
+  # harmlessly. Re-validate anyway to fail early and explicitly. Note this is a
+  # check-then-rename, which narrows the window rather than closing it — the
+  # staging, not this guard, is what makes the operation safe.
   [ -d "$install_log_dir" ] && [ ! -L "$install_log_dir" ] || {
     rm -f "$staged" 2>/dev/null || true
     return 1
@@ -578,7 +591,7 @@ copy_install_log() {
   fi
   if ! mv -f "$staged" "$INSTALL_LOG" 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true
-    return 1
+    return 2
   fi
 }
 
@@ -1428,44 +1441,81 @@ fi
 INSTALLED_EXTRAS=""
 EXTRAS_UNREADABLE=false
 receipt=""
-if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ] && [ -n "$UV_TOOL_DIR" ]; then
-  receipt="${UV_TOOL_DIR}/deepagents-code/uv-receipt.toml"
-  if [ -L "$receipt" ]; then
-    # Refusing to read through a symlink matches the install-log hardening
-    # above, but the refusal must still be announced - staying silent here is
-    # indistinguishable from "no extras" to the user losing them.
-    EXTRAS_UNREADABLE=true
-  elif [ -f "$receipt" ] && [ ! -r "$receipt" ]; then
-    # A receipt written by a previous `sudo` run and re-read as a normal user.
-    EXTRAS_UNREADABLE=true
-  elif [ -f "$receipt" ]; then
-    # Isolate the deepagents-code inline table first ([^{}] cannot cross into a
-    # neighbouring requirement), then read extras out of that entry alone. uv
-    # keeps each inline table on one line; if a future formatter wraps it, the
-    # entry match fails while the package name is still present - that is the
-    # unparseable case, not an extras-free one.
-    receipt_entry=$(sed -nE \
-      's/.*(\{[^{}]*name = "deepagents-code"[^{}]*\}).*/\1/p' "$receipt" \
-      | head -1) || receipt_entry=""
-    if [ -n "$receipt_entry" ]; then
-      INSTALLED_EXTRAS=$(printf '%s\n' "$receipt_entry" \
-        | sed -nE 's/.*extras = \[([^]]*)\].*/\1/p' \
-        | tr -d ' "')
-      # INSTALLED_EXTRAS is echoed back inside a double-quoted, ready-to-paste
-      # shell command below; on a shared host a less-privileged writer of the
-      # receipt could plant `$(...)` and have it evaluated by whoever pastes
-      # the suggestion. Restrict to PEP 508 extra-name characters plus commas —
-      # anything else means the receipt was tampered with or written by a
-      # foreign tool, which is the unparseable case. An empty value is the
-      # normal no-extras receipt, not tampering.
-      case "$INSTALLED_EXTRAS" in
-        *[!A-Za-z0-9_,.-]*)
-          EXTRAS_UNREADABLE=true
-          INSTALLED_EXTRAS=""
-          ;;
-      esac
-    elif grep -q 'deepagents-code' "$receipt" 2>/dev/null; then
+receipt_install_dir=""
+if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ]; then
+  receipt_install_dir="${UV_TOOL_DIR:+${UV_TOOL_DIR}/deepagents-code}"
+  if [ -z "$UV_TOOL_DIR" ] || { [ -e "$UV_TOOL_DIR" ] && [ ! -x "$UV_TOOL_DIR" ]; }; then
+    # `uv tool dir` failed (a uv too old for the subcommand, a broken config),
+    # or its directory can't be searched. Either way we can't reach a receipt.
+    # Only a machine that already has an install can lose extras, so stay quiet
+    # when nothing is installed rather than warning every fresh run.
+    [ -z "$PRE_VERSION" ] || EXTRAS_UNREADABLE=true
+  elif [ -d "$receipt_install_dir" ]; then
+    receipt="${receipt_install_dir}/uv-receipt.toml"
+    if [ ! -r "$receipt_install_dir" ] || [ ! -x "$receipt_install_dir" ]; then
+      # A prior `sudo` run left the tool dir root-owned and mode 0700 (what a
+      # root umask of 077 produces). The receipt tests below would all report
+      # "absent" through an unsearchable parent, so check the directory first.
       EXTRAS_UNREADABLE=true
+    elif [ -L "$receipt" ]; then
+      # Refusing to read through a symlink matches the install-log hardening
+      # above, but the refusal must still be announced - staying silent here is
+      # indistinguishable from "no extras" to the user losing them.
+      EXTRAS_UNREADABLE=true
+    elif [ ! -f "$receipt" ]; then
+      # An install exists but has no receipt: a uv predating uv-receipt.toml, a
+      # future relocation of the file, or a partially-deleted tool dir. We
+      # cannot tell what extras it was built with, so say so.
+      EXTRAS_UNREADABLE=true
+    elif [ ! -r "$receipt" ]; then
+      # A receipt written by a previous `sudo` run and re-read as a normal user.
+      EXTRAS_UNREADABLE=true
+    else
+      # Narrow to the `requirements` assignment before looking for the entry. uv
+      # also writes an `entrypoints` array, and this package declares a console
+      # script literally named `deepagents-code` (see [project.scripts] in
+      # pyproject.toml), so an unscoped match would happily pick
+      #   { name = "deepagents-code", install-path = "...", from = "deepagents-code" }
+      # - an inline table that never carries extras. Matching it would report
+      # "no extras" for an install that has them, defeating the whole check. The
+      # range runs from the requirements line to the next top-level key, which
+      # covers both the single-line array uv writes today and a wrapped one.
+      receipt_requirements=$(sed -nE \
+        '/^requirements = /,$ { /^requirements = /!{ /^[A-Za-z_-]+ = /q; }; p; }' \
+        "$receipt" 2>/dev/null)
+      # Then isolate the deepagents-code inline table ([^{}] cannot cross into a
+      # neighbouring requirement) and read extras out of that entry alone. uv
+      # keeps each inline table on one line (observed through uv 0.9); if a
+      # future formatter wraps it, the entry match fails - handled below.
+      receipt_entry=$(printf '%s\n' "$receipt_requirements" \
+        | sed -nE 's/.*(\{[^{}]*name = "deepagents-code"[^{}]*\}).*/\1/p' \
+        | head -1)
+      if [ -n "$receipt_entry" ]; then
+        INSTALLED_EXTRAS=$(printf '%s\n' "$receipt_entry" \
+          | sed -nE 's/.*extras = \[([^]]*)\].*/\1/p' \
+          | tr -d ' "')
+        # INSTALLED_EXTRAS is echoed back inside a double-quoted, ready-to-paste
+        # shell command below; on a shared host a less-privileged writer of the
+        # receipt could plant `$(...)` and have it evaluated by whoever pastes
+        # the suggestion. Restrict to PEP 508 extra-name characters plus commas —
+        # anything else means the receipt was tampered with or written by a
+        # foreign tool, which is the unparseable case. An empty value is the
+        # normal no-extras receipt (uv omits the key entirely), not tampering.
+        case "$INSTALLED_EXTRAS" in
+          *[!A-Za-z0-9_,.-]*)
+            EXTRAS_UNREADABLE=true
+            INSTALLED_EXTRAS=""
+            ;;
+        esac
+      else
+        # No entry matched: either the receipt has no `requirements` section we
+        # recognise, or the requirement is wrapped across lines. Both are "we
+        # cannot tell" and never "no extras" - uv always records the tool's own
+        # requirement, so a miss here is a parse failure, not an empty install.
+        # (This also absorbs a failed read: sed's stderr is discarded, and an
+        # unreadable file yields no region and so no entry.)
+        EXTRAS_UNREADABLE=true
+      fi
     fi
   fi
 fi
@@ -1587,19 +1637,30 @@ if [ -n "$cache_root" ]; then
     fi
   fi
 fi
-# Warn (and offer to back out) before the lock is taken: this block only reads
-# a file and asks a question, so holding the install lock across an unbounded
-# human wait would block a concurrent installer - which spins silently, since
-# it can't reclaim a lock whose owner is alive - for no reason.
+# Warn (and offer to back out) before the lock is taken: this block only prints
+# a warning and asks a question - the receipt itself was read far above, also
+# outside the lock - so holding the install lock across an unbounded human wait
+# would block a concurrent installer (which spins silently, since it can't
+# reclaim a lock whose owner is alive) for no reason.
+#
+# `prompt_yn` returns 2 when it could not ask at all (a /dev/tty that opened for
+# can_prompt but failed to read, e.g. a detached session). That is not a "no":
+# treating it as one turns a broken terminal into a silent no-op exit, and it
+# would contradict the no-TTY branch above, which reasons that with no human to
+# ask the installer should complete the upgrade rather than stall.
+extras_prompt_rc=0
 if [ "$EXTRAS_UNREADABLE" = true ]; then
-  log_warn "Could not read ${receipt} to check which extras this install was built with."
+  log_warn "Could not read ${receipt:-the uv tool receipt} to check which extras this install was built with."
   log_warn "  If it was built with DEEPAGENTS_CODE_EXTRAS, re-run with the same value or those packages will be removed."
   # An unreadable receipt can still hide extras (e.g. one written by a prior
   # sudo run), so offer the same abort prompt as the known-extras case below:
   # the user is told their extras may be removed and must get the chance to
   # stop before the rebuild drops them.
   if [ "$ASSUME_YES" != "1" ] && can_prompt; then
-    if ! prompt_yn "Continue anyway?"; then
+    prompt_yn "Continue anyway?" || extras_prompt_rc=$?
+    if [ "$extras_prompt_rc" -eq 2 ]; then
+      log_warn "Could not ask — continuing; any extras this install has will be removed."
+    elif [ "$extras_prompt_rc" -ne 0 ]; then
       log_info "Aborted. deepagents-code was left unchanged."
       exit 0
     fi
@@ -1613,7 +1674,10 @@ elif [ -n "$INSTALLED_EXTRAS" ]; then
   # and proceed - a pre-answered yes is an instruction to continue, not to
   # abort.
   if [ "$ASSUME_YES" != "1" ] && can_prompt; then
-    if ! prompt_yn "Continue anyway and remove them?"; then
+    prompt_yn "Continue anyway and remove them?" || extras_prompt_rc=$?
+    if [ "$extras_prompt_rc" -eq 2 ]; then
+      log_warn "Could not ask — continuing; the extras above will be removed."
+    elif [ "$extras_prompt_rc" -ne 0 ]; then
       # This path can also skip a same-version PATH repair (the branches above
       # that reinstall a current version), so name what was left undone rather
       # than implying the run had nothing else to do.
@@ -1711,7 +1775,22 @@ if grep -Eq '^[[:space:]]+[-+][[:space:]]+[^=]+==' "$uv_stderr"; then
   UV_REPORTED_PACKAGE_CHANGES=true
 fi
 if [ -n "$INSTALL_LOG" ]; then
-  copy_install_log || { INSTALL_LOG=""; INSTALL_LOG_DISPLAY=""; }
+  # Return code 2 means the publish failed for an ordinary operational reason
+  # (no space, a cache dir left root-owned by an earlier sudo run) rather than
+  # because the path looked hostile. Say so: on a `curl | bash` run with no
+  # scrollback the log is the only way back to uv's output, and silently not
+  # having one is indistinguishable from a clean run. Rejected-path failures
+  # (return 1) stay quiet — the user cannot act on them and the noise would be
+  # alarming.
+  log_copy_rc=0
+  copy_install_log || log_copy_rc=$?
+  if [ "$log_copy_rc" -ne 0 ]; then
+    if [ "$log_copy_rc" -eq 2 ]; then
+      log_warn "Could not write the install log to ${INSTALL_LOG_DISPLAY} — continuing without it."
+    fi
+    INSTALL_LOG=""
+    INSTALL_LOG_DISPLAY=""
+  fi
 fi
 rm -f "$uv_stderr"
 if [ "$uv_rc" -ne 0 ]; then
@@ -1720,8 +1799,11 @@ if [ "$uv_rc" -ne 0 ]; then
   log_error "Failed to install ${PACKAGE}. See errors above."
   # The log captured uv's full stderr (copied just above, before this exit), so
   # point the user at it — non-verbose mode trims uv's lines from the terminal
-  # and piped `curl | bash` runs lose scrollback.
-  if [ -n "$INSTALL_LOG" ]; then
+  # and piped `curl | bash` runs lose scrollback. Require a non-empty file for
+  # the same reason the success path does: uv killed by a signal before writing
+  # anything leaves a zero-byte log, and sending a user whose install just
+  # failed to an empty file is a dead end.
+  if [ -n "$INSTALL_LOG" ] && [ -s "$INSTALL_LOG" ]; then
     log_error "Full install log: ${INSTALL_LOG_DISPLAY}"
   fi
   log_error "Common fixes: check your network, try a different Python version (DEEPAGENTS_CODE_PYTHON=3.12), or install manually."
@@ -2641,9 +2723,11 @@ elif [ -n "$NEW_VERSION" ] && [ "$PRE_VERSION" = "$NEW_VERSION" ]; then
   # the dep move entirely). UV_REPORTED_PACKAGE_CHANGES (set far above) is the
   # signal that the reinstall actually moved packages.
   if [ "$UV_REPORTED_PACKAGE_CHANGES" = true ]; then
-    # No log pointer here: the "Full log:" line below prints it on every run
-    # that wrote one, and this branch would otherwise repeat the same path on
-    # consecutive lines.
+    # No log pointer here: the "Full log:" line below prints it whenever uv
+    # wrote anything, which this branch guarantees (UV_REPORTED_PACKAGE_CHANGES
+    # is only true because a grep matched `- pkg==` / `+ pkg==` lines in the
+    # captured stderr, so the log is non-empty). Repeating it would print the
+    # same path on two consecutive lines.
     log_success "deepagents-code ${NEW_VERSION} was already up to date; dependencies were updated."
   else
     log_success "deepagents-code ${NEW_VERSION} already up to date."
@@ -2882,18 +2966,27 @@ if [ "$SKIP_OPTIONAL" != "1" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Done — footer wording depends on what changed:
+# Done — footer wording depends on what changed. All three named branches also
+# require a non-editable install (an editable one always falls through to the
+# catch-all, even when its reinstall moved dependencies):
 #   - same app version + dependency changes → "Dependencies updated."
 #   - already up to date                    → "Already installed."
-#   - unpinned run that moved version       → "Upgrade complete."
+#   - unpinned, default-prerelease run that moved version → "Upgrade complete."
 #   - everything else                       → "Setup complete."
 #
 # The last branch is a catch-all, not an enumerated set. It covers a fresh
-# install and an editable→PyPI swap, but also a *pinned* version move (VERSION
-# set) — `bash -s -- 0.1.0` over an installed 0.2.0 is a downgrade, and the
-# script has no version comparison to tell the two apart, so only the unpinned
-# case (which always resolves to latest) may claim an upgrade. It also covers
-# an empty NEW_VERSION, i.e. the post-install `dcode -v` probe failed.
+# install and an editable→PyPI swap, but also every version move the script
+# cannot prove went forward — it has no version comparison, so it can only rely
+# on resolution always picking the newest candidate. Two things break that, and
+# both are therefore excluded from the upgrade branch:
+#   - a *pinned* version (VERSION set): `bash -s -- 0.1.0` over an installed
+#     0.2.0 is a downgrade.
+#   - an explicit DEEPAGENTS_CODE_PRERELEASE (PRERELEASE_REQUESTED set): with
+#     `disallow` over an installed 0.3.0rc1, uv resolves to the latest *stable*,
+#     which can be older than what's there.
+# It also covers an empty NEW_VERSION — the post-install `dcode -v` probe
+# failed, was never run because DCODE_BIN didn't resolve, or exited 0 while
+# printing nothing.
 # ---------------------------------------------------------------------------
 if [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] \
   && [ "$PRE_VERSION" = "$NEW_VERSION" ] && [ "$UV_REPORTED_PACKAGE_CHANGES" = true ]; then
@@ -2901,8 +2994,8 @@ if [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] 
 elif [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] \
   && [ "$PRE_VERSION" = "$NEW_VERSION" ]; then
   footer_msg="Already installed."
-elif [ "$IS_EDITABLE" = false ] && [ -z "$VERSION" ] && [ -n "$PRE_VERSION" ] \
-  && [ -n "$NEW_VERSION" ] && [ "$PRE_VERSION" != "$NEW_VERSION" ]; then
+elif [ "$IS_EDITABLE" = false ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" ] \
+  && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] && [ "$PRE_VERSION" != "$NEW_VERSION" ]; then
   footer_msg="Upgrade complete."
 else
   footer_msg="Setup complete."

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -470,8 +470,10 @@ prompt_yn() {
   if [ -t 0 ]; then
     printf "%s [y/N] " "$question"
     if ! read -r reply; then
-      log_warn "Could not read from terminal — skipping prompt."
-      return 2
+      # An attached terminal can report EOF when the user presses Ctrl-D. This
+      # is an interactive response, so preserve the [y/N] default and decline.
+      log_warn "Could not read from terminal — declining prompt."
+      return 1
     fi
   else
     printf "%s [y/N] " "$question" > /dev/tty

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -553,15 +553,14 @@ copy_install_log() {
   # than following it, so this guard is not what makes publishing safe. Keep it
   # anyway — it fails early and explicitly on an obviously tampered path.
   [ ! -L "$INSTALL_LOG" ] || return 1
-  # Stage inside a private directory. `mktemp` alone only protects creation:
-  # a user who owns install_log_dir could replace its resulting file before
-  # `cp` reopens it. The directory is mode 700, and copying via a relative
-  # pathname after entering it means the copy never follows such a replacement.
-  # Keeping the stage beneath install_log_dir also keeps the final move a
-  # same-filesystem rename, so it replaces a planted INSTALL_LOG symlink rather
-  # than degrading into a cross-filesystem copy that could follow one.
+  # Do not stage beneath install_log_dir: when this runs as root, its parent can
+  # still be user-writable and the user could replace a freshly-created staging
+  # directory before `cp` enters it. `/tmp` is sticky, so a root-owned 0700
+  # directory created there cannot be renamed or replaced by another user.
+  # The final `mv` replaces a planted INSTALL_LOG symlink instead of following
+  # it.
   local stage_dir staged
-  stage_dir=$(mktemp -d "${install_log_dir}/.install.log.XXXXXX" 2>/dev/null) || return 2
+  stage_dir=$(mktemp -d "/tmp/deepagents-code-install-log.XXXXXX" 2>/dev/null) || return 2
   staged="${stage_dir}/install.log"
   if ! (cd "$stage_dir" && cp "$uv_stderr" install.log) 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -531,39 +531,22 @@ fix_install_log_owner() {
   [ "$(id -u)" -eq 0 ] || return 0
   [ -n "${TARGET_USER:-}" ] && [ "$TARGET_USER" != "root" ] || return 0
   [ -d "$install_log_dir" ] && [ ! -L "$install_log_dir" ] || return 0
-  path_is_under_home "$install_log_dir" || return 0
-  if ! chown -h "$TARGET_USER" "$install_log_dir" 2>&1; then
-    log_warn "Could not fix ownership of $install_log_dir for user ${TARGET_USER}."
-  fi
-  if [ -f "$INSTALL_LOG" ] && [ ! -L "$INSTALL_LOG" ]; then
-    if ! chown -h "$TARGET_USER" "$INSTALL_LOG" 2>&1; then
-      log_warn "Could not fix ownership of $INSTALL_LOG for user ${TARGET_USER}."
+  # Enter the directory before validating it, then use only relative paths.
+  # The target user owns its parent and can rename or replace this directory;
+  # keeping it as the subshell's cwd pins the validated inode throughout both
+  # chown calls instead of resolving an attacker-swappable parent as root.
+  (
+    cd "$install_log_dir" 2>/dev/null || exit 0
+    path_is_under_home "." || exit 0
+    if ! chown -h "$TARGET_USER" "." 2>&1; then
+      log_warn "Could not fix ownership of $install_log_dir for user ${TARGET_USER}."
     fi
-  fi
-}
-
-path_device() {
-  local device
-  # GNU and BSD `stat` use different format flags. The device number is enough
-  # here: `rename(2)` cannot cross a filesystem boundary.
-  device="$(stat -c %d "$1" 2>/dev/null || true)"
-  case "$device" in
-    ''|*[!0-9]*) ;;
-    *) printf '%s\n' "$device"; return 0 ;;
-  esac
-
-  device="$(stat -f %d "$1" 2>/dev/null || true)"
-  case "$device" in
-    ''|*[!0-9]*) return 1 ;;
-    *) printf '%s\n' "$device" ;;
-  esac
-}
-
-paths_share_filesystem() {
-  local first_device second_device
-  first_device="$(path_device "$1")" || return 1
-  second_device="$(path_device "$2")" || return 1
-  [ "$first_device" = "$second_device" ]
+    if [ -f "install.log" ] && [ ! -L "install.log" ]; then
+      if ! chown -h "$TARGET_USER" "install.log" 2>&1; then
+        log_warn "Could not fix ownership of $INSTALL_LOG for user ${TARGET_USER}."
+      fi
+    fi
+  )
 }
 
 copy_install_log() {
@@ -581,18 +564,11 @@ copy_install_log() {
   # still be user-writable and the user could replace a freshly-created staging
   # directory before `cp` enters it. `/tmp` is sticky, so a root-owned 0700
   # directory created there cannot be renamed or replaced by another user.
-  # Privileged publication uses an atomic hard link below, which never follows
-  # a planted INSTALL_LOG symlink.
+  # Privileged publication pins the destination directory and uses a
+  # noclobber create below, which never follows a planted INSTALL_LOG symlink.
   local stage_dir staged
   stage_dir=$(mktemp -d "/tmp/deepagents-code-install-log.XXXXXX" 2>/dev/null) || return 2
   staged="${stage_dir}/install.log"
-  # Do not persist a privileged log when `mv` would cross a filesystem
-  # boundary. Its copy-and-delete fallback could follow a symlink planted at
-  # INSTALL_LOG by the user who owns the cache directory.
-  if [ "$(id -u)" -eq 0 ] && ! paths_share_filesystem "$stage_dir" "$install_log_dir"; then
-    rmdir "$stage_dir" 2>/dev/null || true
-    return 1
-  fi
   if ! (cd "$stage_dir" && cp "$uv_stderr" install.log) 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true
     rmdir "$stage_dir" 2>/dev/null || true
@@ -617,29 +593,43 @@ copy_install_log() {
       return 1
     }
   fi
-  # `mv file directory` moves the file *into* the directory and reports
-  # success. Reject that state rather than publishing an undiscoverable log.
-  [ ! -d "$INSTALL_LOG" ] || {
-    rm -f "$staged" 2>/dev/null || true
-    rmdir "$stage_dir" 2>/dev/null || true
-    return 1
-  }
   if [ "$(id -u)" -eq 0 ]; then
-    # Unlinking a symlink removes the directory entry without following it.
-    # `ln` then atomically creates INSTALL_LOG only if the attacker has not
-    # replaced that entry in the meantime; unlike cross-device `mv`, it never
-    # copies through a planted symlink.
-    rm -f "$INSTALL_LOG" 2>/dev/null || true
-    if ! ln "$staged" "$INSTALL_LOG" 2>/dev/null; then
+    # Pin the validated directory as cwd before publishing. The target user can
+    # replace its path after any pathname check, so no privileged mutation may
+    # resolve that parent again. Noclobber makes the final create atomic: if the
+    # user races in a symlink, file, or directory after rm, the redirection
+    # fails instead of following it or treating it as a destination directory.
+    local publish_rc=0
+    (
+      cd "$install_log_dir" 2>/dev/null || exit 1
+      path_is_under_home "." || exit 1
+      [ ! -d "install.log" ] || exit 1
+      rm -f "install.log" 2>/dev/null || exit 2
+      set -o noclobber
+      if ! cat "$staged" > "install.log" 2>/dev/null; then
+        rm -f "install.log" 2>/dev/null || true
+        exit 2
+      fi
+    ) || publish_rc=$?
+    if [ "$publish_rc" -ne 0 ]; then
+      rm -f "$staged" 2>/dev/null || true
+      rmdir "$stage_dir" 2>/dev/null || true
+      return "$publish_rc"
+    fi
+    rm -f "$staged" 2>/dev/null || true
+  else
+    # `mv file directory` moves the file *into* the directory and reports
+    # success. Reject that state rather than publishing an undiscoverable log.
+    [ ! -d "$INSTALL_LOG" ] || {
+      rm -f "$staged" 2>/dev/null || true
+      rmdir "$stage_dir" 2>/dev/null || true
+      return 1
+    }
+    if ! mv -f "$staged" "$INSTALL_LOG" 2>/dev/null; then
       rm -f "$staged" 2>/dev/null || true
       rmdir "$stage_dir" 2>/dev/null || true
       return 2
     fi
-    rm -f "$staged" 2>/dev/null || true
-  elif ! mv -f "$staged" "$INSTALL_LOG" 2>/dev/null; then
-    rm -f "$staged" 2>/dev/null || true
-    rmdir "$stage_dir" 2>/dev/null || true
-    return 2
   fi
   rmdir "$stage_dir" 2>/dev/null || true
 }
@@ -3028,14 +3018,14 @@ fi
 # catch-all, even when its reinstall moved dependencies):
 #   - same app version + dependency changes → "Dependencies updated."
 #   - already up to date                    → "Already installed."
-#   - unpinned, default-prerelease run that moved version → "Upgrade complete."
+#   - unpinned, default-prerelease run that moved version → "Version changed."
 #   - everything else                       → "Setup complete."
 #
 # The last branch is a catch-all, not an enumerated set. It covers a fresh
-# install and an editable→PyPI swap, but also every version move the script
-# cannot prove went forward — it has no version comparison, so it can only rely
-# on resolution always picking the newest candidate. Two things break that, and
-# both are therefore excluded from the upgrade branch:
+# install and an editable→PyPI swap. The version-move branch stays neutral
+# because uv honors custom indexes and configuration whose newest available
+# package can be older than the installed version. Two other known downgrade
+# paths remain in the catch-all branch:
 #   - a *pinned* version (VERSION set): `bash -s -- 0.1.0` over an installed
 #     0.2.0 is a downgrade.
 #   - an explicit DEEPAGENTS_CODE_PRERELEASE (PRERELEASE_REQUESTED set): with
@@ -3053,7 +3043,7 @@ elif [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" 
   footer_msg="Already installed."
 elif [ "$IS_EDITABLE" = false ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" ] \
   && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] && [ "$PRE_VERSION" != "$NEW_VERSION" ]; then
-  footer_msg="Upgrade complete."
+  footer_msg="Version changed."
 else
   footer_msg="Setup complete."
 fi

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -546,35 +546,40 @@ copy_install_log() {
     path_is_under_home "$install_log_dir" || return 1
   fi
   [ ! -L "$INSTALL_LOG" ] || return 1
-  # Publish the already-captured stderr without opening the canonical path for
-  # writing. `ln` fails if an attacker wins the race by creating install.log,
-  # but it also fails with EXDEV whenever mktemp's TMPDIR and the cache dir sit
-  # on different filesystems — /tmp on tmpfs is the default on most Linux
-  # distros, so the hardlink alone would silently disable the log there. Fall
-  # back to a copy. The copy must not be staged next to INSTALL_LOG: a root
-  # installer may have handed that directory to TARGET_USER, who could replace
-  # a predictable sibling path with a symlink before `cp` opens it. Keep the
-  # staging file in a freshly-created root-owned 0700 directory instead.
-  local staging_dir
+  # Publish the already-captured stderr with a same-directory rename, which
+  # never opens INSTALL_LOG: rename(2) swaps the directory entry atomically,
+  # so a symlink planted at that path is replaced, not followed. Stage inside
+  # install_log_dir (not the default TMPDIR) so the final `mv` is a true rename
+  # — a cross-filesystem `mv` degrades to copy+unlink, which does open the
+  # destination and follow links. mktemp gives the staged file an unpredictable
+  # name, so the target user — who may own install_log_dir after a prior root
+  # install handed it over — cannot pre-place a link at the source path to make
+  # the copy overwrite it.
   local staged
-  staging_dir=$(mktemp -d /tmp/deepagents-code-install-log.XXXXXX 2>/dev/null) || return 1
-  [ -d "$staging_dir" ] && [ ! -L "$staging_dir" ] && [ -O "$staging_dir" ] || {
-    rmdir "$staging_dir" 2>/dev/null || true
+  staged=$(mktemp "${install_log_dir}/.install.log.XXXXXX" 2>/dev/null) || return 1
+  if ! cp "$uv_stderr" "$staged" 2>/dev/null; then
+    rm -f "$staged" 2>/dev/null || true
+    return 1
+  fi
+  # Between the guard above and this rename, a target user who owns
+  # install_log_dir can rmdir the empty directory and symlink its path
+  # elsewhere; rename would then create install.log wherever the link points —
+  # with root's privileges during a sudo install. Re-validate the directory
+  # immediately before publishing.
+  [ -d "$install_log_dir" ] && [ ! -L "$install_log_dir" ] || {
+    rm -f "$staged" 2>/dev/null || true
     return 1
   }
-  staged="${staging_dir}/install.log"
-  if ! ln "$uv_stderr" "$staged" 2>/dev/null \
-    && ! cp "$uv_stderr" "$staged" 2>/dev/null; then
-    rm -f "$staged" 2>/dev/null || true
-    rmdir "$staging_dir" 2>/dev/null || true
-    return 1
+  if [ "$(id -u)" -eq 0 ]; then
+    path_is_under_home "$install_log_dir" || {
+      rm -f "$staged" 2>/dev/null || true
+      return 1
+    }
   fi
   if ! mv -f "$staged" "$INSTALL_LOG" 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true
-    rmdir "$staging_dir" 2>/dev/null || true
     return 1
   fi
-  rmdir "$staging_dir" 2>/dev/null || true
 }
 
 # Epoch mtime of the lock directory, used as a fallback reference time when the

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1516,6 +1516,16 @@ fi
 if [ -n "$INSTALLED_EXTRAS" ]; then
   log_warn "This install has extras that a bare upgrade will remove: ${INSTALLED_EXTRAS}"
   log_warn "  To keep them, re-run with: DEEPAGENTS_CODE_EXTRAS=\"${INSTALLED_EXTRAS}\""
+  # Give an interactive user the chance to back out before uv rebuilds the
+  # environment and drops those packages. Non-interactive runs (no TTY, or an
+  # unattended DEEPAGENTS_CODE_YES) can't answer, so they keep the warning
+  # only; an explicit YES is an instruction to proceed, not to abort.
+  if [ "$ASSUME_YES" != "1" ] && can_prompt; then
+    if ! prompt_yn "Continue anyway and remove them?"; then
+      log_info "Aborted. No changes made."
+      exit 0
+    fi
+  fi
 fi
 if [[ -z "$VERSION" ]]; then
   "$UV_BIN" tool install -U --python "$PYTHON_VERSION" \

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1543,40 +1543,43 @@ if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ]; then
       # "no extras" for an install that has them, defeating the whole check. The
       # range runs from the requirements line to the next top-level key, which
       # covers both the single-line array uv writes today and a wrapped one.
-      receipt_requirements=$(sed -nE \
+      if receipt_requirements=$(sed -nE \
         '/^requirements = /,$ { /^requirements = /!{ /^[A-Za-z_-]+ = /q; }; p; }' \
-        "$receipt" 2>/dev/null)
-      # Then isolate the deepagents-code inline table ([^{}] cannot cross into a
-      # neighbouring requirement) and read extras out of that entry alone. uv
-      # keeps each inline table on one line (observed through uv 0.9); if a
-      # future formatter wraps it, the entry match fails - handled below.
-      receipt_entry=$(printf '%s\n' "$receipt_requirements" \
-        | sed -nE 's/.*(\{[^{}]*name = "deepagents-code"[^{}]*\}).*/\1/p' \
-        | head -1)
-      if [ -n "$receipt_entry" ]; then
-        INSTALLED_EXTRAS=$(printf '%s\n' "$receipt_entry" \
-          | sed -nE 's/.*extras = \[([^]]*)\].*/\1/p' \
-          | tr -d ' "')
-        # INSTALLED_EXTRAS is echoed back inside a double-quoted, ready-to-paste
-        # shell command below; on a shared host a less-privileged writer of the
-        # receipt could plant `$(...)` and have it evaluated by whoever pastes
-        # the suggestion. Restrict to PEP 508 extra-name characters plus commas —
-        # anything else means the receipt was tampered with or written by a
-        # foreign tool, which is the unparseable case. An empty value is the
-        # normal no-extras receipt (uv omits the key entirely), not tampering.
-        case "$INSTALLED_EXTRAS" in
-          *[!A-Za-z0-9_,.-]*)
-            EXTRAS_UNREADABLE=true
-            INSTALLED_EXTRAS=""
-            ;;
-        esac
+        "$receipt" 2>/dev/null); then
+        # Then isolate the deepagents-code inline table ([^{}] cannot cross into a
+        # neighbouring requirement) and read extras out of that entry alone. uv
+        # keeps each inline table on one line (observed through uv 0.9); if a
+        # future formatter wraps it, the entry match fails - handled below.
+        receipt_entry=$(printf '%s\n' "$receipt_requirements" \
+          | sed -nE 's/.*(\{[^{}]*name = "deepagents-code"[^{}]*\}).*/\1/p' \
+          | head -1)
+        if [ -n "$receipt_entry" ]; then
+          INSTALLED_EXTRAS=$(printf '%s\n' "$receipt_entry" \
+            | sed -nE 's/.*extras = \[([^]]*)\].*/\1/p' \
+            | tr -d ' "')
+          # INSTALLED_EXTRAS is echoed back inside a double-quoted, ready-to-paste
+          # shell command below; on a shared host a less-privileged writer of the
+          # receipt could plant `$(...)` and have it evaluated by whoever pastes
+          # the suggestion. Restrict to PEP 508 extra-name characters plus commas —
+          # anything else means the receipt was tampered with or written by a
+          # foreign tool, which is the unparseable case. An empty value is the
+          # normal no-extras receipt (uv omits the key entirely), not tampering.
+          case "$INSTALLED_EXTRAS" in
+            *[!A-Za-z0-9_,.-]*)
+              EXTRAS_UNREADABLE=true
+              INSTALLED_EXTRAS=""
+              ;;
+          esac
+        else
+          # No entry matched: either the receipt has no `requirements` section we
+          # recognise, or the requirement is wrapped across lines. Both are "we
+          # cannot tell" and never "no extras" - uv always records the tool's own
+          # requirement, so a miss here is a parse failure, not an empty install.
+          EXTRAS_UNREADABLE=true
+        fi
       else
-        # No entry matched: either the receipt has no `requirements` section we
-        # recognise, or the requirement is wrapped across lines. Both are "we
-        # cannot tell" and never "no extras" - uv always records the tool's own
-        # requirement, so a miss here is a parse failure, not an empty install.
-        # (This also absorbs a failed read: sed's stderr is discarded, and an
-        # unreadable file yields no region and so no entry.)
+        # The read failed after the checks above, so the receipt may have changed
+        # or disappeared while we were reading it. Treat that race as unreadable.
         EXTRAS_UNREADABLE=true
       fi
     fi

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -466,25 +466,46 @@ prompt_yn() {
   if [ "$IS_INTERACTIVE" = false ]; then
     return 1
   fi
-  local reply
+  local reply=""
   if [ -t 0 ]; then
     printf "%s [y/N] " "$question"
-    if ! read -r reply; then
-      # An attached terminal can report EOF when the user presses Ctrl-D. This
-      # is an interactive response, so preserve the [y/N] default and decline.
-      log_warn "Could not read from terminal — declining prompt."
+    # `read` reports failure on a final line with no trailing newline but still
+    # assigns what it did read, so an answer typed before Ctrl-D must not be
+    # thrown away. Only an empty read is a true "no answer": EOF on a terminal
+    # is an interactive response, so preserve the [y/N] default and decline.
+    if ! read -r reply && [ -z "$reply" ]; then
+      log_warn "No answer — declining prompt."
       return 1
     fi
   else
-    printf "%s [y/N] " "$question" > /dev/tty
-    if ! read -r reply < /dev/tty 2>/dev/null; then
-      log_warn "Could not read from /dev/tty — skipping prompt."
+    # Open the terminal before prompting, and keep that failure separate from a
+    # failed *read*. Conflating them is what makes a piped-stdin run (the
+    # documented `curl … | bash` path, where this branch always runs) treat a
+    # user's Ctrl-D as "nobody could answer" and proceed — the opposite of the
+    # printed [y/N] default, and the opposite of what the -t 0 branch does with
+    # the identical keystroke.
+    # Braces, not `exec 3<>/dev/tty 2>/dev/null`: a bare `exec` applies *every*
+    # redirection on it permanently, so that form would silence the script's
+    # own stderr for the rest of the run. A group is not a subshell, so fd 3
+    # still survives it.
+    if ! { exec 3<>/dev/tty; } 2>/dev/null; then
+      log_warn "Could not open /dev/tty — skipping prompt."
       # 2, not 1: "nobody could answer" is not "the user said no". can_prompt
-      # only proves /dev/tty can be *opened*, so a detached session can reach
-      # here after passing that check. Callers for whom the distinction matters
+      # only proves /dev/tty *could* be opened earlier, so a session that has
+      # since detached reaches here. Callers for whom the distinction matters
       # branch on 2; those that don't still see a non-zero status and decline.
       return 2
     fi
+    printf "%s [y/N] " "$question" >&3
+    if ! read -r reply <&3 && [ -z "$reply" ]; then
+      exec 3>&-
+      # The terminal opened, so there was somebody to ask; an empty read means
+      # they answered with EOF. That is a human declining, not an unanswerable
+      # prompt — return 1 so callers honour it instead of proceeding.
+      log_warn "No answer — declining prompt."
+      return 1
+    fi
+    exec 3>&-
   fi
   if [[ "$reply" =~ ^[Yy]$ ]]; then
     return 0
@@ -582,6 +603,21 @@ copy_install_log() {
   # directory created there cannot be renamed or replaced by another user.
   # Privileged publication pins the destination directory and uses a
   # noclobber create below, which never follows a planted INSTALL_LOG symlink.
+  #
+  # `/tmp` is hardcoded rather than honouring TMPDIR on purpose: an
+  # attacker-controlled TMPDIR would point staging at a directory with no
+  # sticky bit and void the guarantee above. Do not "fix" this for
+  # portability.
+  #
+  # Accepted cost: /tmp is usually a separate mount, so the unprivileged
+  # publication below is a cross-device `mv` - copy-then-unlink, not an atomic
+  # rename. A concurrent reader can therefore observe a half-written
+  # install.log, and a `mv` that fails partway can leave a truncated one in
+  # place of the previous run's. Both callers treat a failed copy_install_log
+  # as "no log this run", and the `-s`/`-f`/`-L` rechecks around publication
+  # cover the resulting window; the sticky-directory property is worth more
+  # than the atomicity, since only root can be attacked through the staging
+  # path and only the log's own contents are at stake through the other.
   local stage_dir staged
   stage_dir=$(mktemp -d "/tmp/deepagents-code-install-log.XXXXXX" 2>/dev/null) || return 2
   register_temp_dir "$stage_dir"
@@ -649,8 +685,12 @@ copy_install_log() {
     fi
     # `mv` accepts a directory destination by moving the staged file into it.
     # Check the result after publication so a directory created between the
-    # preflight check and `mv` is reported as a failed log write.
+    # preflight check and `mv` is reported as a failed log write. Take the
+    # staged copy back out of it: `mv` has already put uv's full stderr inside
+    # a directory this run did not create, and leaving it there is the same
+    # disclosure the failure paths above clean up.
     [ -f "$INSTALL_LOG" ] && [ ! -L "$INSTALL_LOG" ] || {
+      [ ! -d "$INSTALL_LOG" ] || rm -f "${INSTALL_LOG}/install.log" 2>/dev/null || true
       rmdir "$stage_dir" 2>/dev/null || true
       return 1
     }
@@ -1515,10 +1555,12 @@ if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ]; then
     [ -z "$PRE_VERSION" ] || EXTRAS_UNREADABLE=true
   elif [ -d "$receipt_install_dir" ]; then
     receipt="${receipt_install_dir}/uv-receipt.toml"
-    if [ ! -r "$receipt_install_dir" ] || [ ! -x "$receipt_install_dir" ]; then
+    if [ ! -x "$receipt_install_dir" ]; then
       # A prior `sudo` run left the tool dir root-owned and mode 0700 (what a
       # root umask of 077 produces). The receipt tests below would all report
       # "absent" through an unsearchable parent, so check the directory first.
+      # Only search permission matters: opening a known filename inside needs
+      # `x`, not `r`, so a `--x` directory is still perfectly readable here.
       EXTRAS_UNREADABLE=true
     elif [ -L "$receipt" ]; then
       # Refusing to read through a symlink matches the install-log hardening
@@ -1541,8 +1583,14 @@ if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ]; then
       #   { name = "deepagents-code", install-path = "...", from = "deepagents-code" }
       # - an inline table that never carries extras. Matching it would report
       # "no extras" for an install that has them, defeating the whole check. The
-      # range runs from the requirements line to the next top-level key, which
-      # covers both the single-line array uv writes today and a wrapped one.
+      # range runs from the requirements line to the next top-level key
+      # *assignment*, which covers both the single-line array uv writes today
+      # and a wrapped one. Note the terminator matches neither a table header
+      # (`[tool.options]`) nor a key containing digits, so a receipt that put
+      # either of those directly after `requirements` would run the range to
+      # EOF and let `entrypoints` back into the candidate region; that is safe
+      # against uv's current layout but is the thing to revisit if uv
+      # restructures the receipt.
       if receipt_requirements=$(sed -nE \
         '/^requirements = /,$ { /^requirements = /!{ /^[A-Za-z_-]+ = /q; }; p; }' \
         "$receipt" 2>/dev/null); then
@@ -1550,9 +1598,15 @@ if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ]; then
         # neighbouring requirement) and read extras out of that entry alone. uv
         # keeps each inline table on one line (observed through uv 0.9); if a
         # future formatter wraps it, the entry match fails - handled below.
+        # `|| receipt_entry=""`: under `set -o pipefail` a large enough matching
+        # region lets `head` close the pipe while `sed` is still writing, and
+        # the resulting SIGPIPE (141) would abort the whole installer before uv
+        # ever runs - surfaced only as the EXIT trap's generic exit-code line.
+        # An empty value falls through to the "cannot tell" branch below, which
+        # is the right answer for a receipt that large or that malformed.
         receipt_entry=$(printf '%s\n' "$receipt_requirements" \
           | sed -nE 's/.*(\{[^{}]*name = "deepagents-code"[^{}]*\}).*/\1/p' \
-          | head -1)
+          | head -1) || receipt_entry=""
         if [ -n "$receipt_entry" ]; then
           INSTALLED_EXTRAS=$(printf '%s\n' "$receipt_entry" \
             | sed -nE 's/.*extras = \[([^]]*)\].*/\1/p' \
@@ -1583,6 +1637,17 @@ if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ]; then
         EXTRAS_UNREADABLE=true
       fi
     fi
+  else
+    # `uv tool dir` resolved and is searchable, but this package has no
+    # directory under it. When the installed dcode came from uv's tool bin dir
+    # there must be a receipt somewhere, so not finding it here means the tool
+    # dir moved between installs (UV_TOOL_DIR, a changed `tool-dir` in uv.toml,
+    # a relocated XDG_DATA_HOME). The old install is still on PATH and the
+    # rebuild will still drop its extras, so this is "couldn't tell" exactly
+    # like the missing-receipt branch above - not "no extras". An install that
+    # did not come from uv (pipx, a manual venv) has no receipt to expect, so
+    # stay quiet there rather than warning about a file that was never written.
+    [ "$PRE_INSTALL_IS_TOOL" = false ] || EXTRAS_UNREADABLE=true
   fi
 fi
 
@@ -1711,17 +1776,28 @@ if [ -n "$cache_root" ]; then
     fi
   fi
 fi
-# Warn (and offer to back out) before the lock is taken: this block only prints
-# a warning and asks a question - the receipt itself was read far above, also
-# outside the lock - so holding the install lock across an unbounded human wait
-# would block a concurrent installer (which spins silently, since it can't
-# reclaim a lock whose owner is alive) for no reason.
+# Warn (and offer to back out) before *this* block would take the lock: it only
+# prints a warning and asks a question - the receipt itself was read far above,
+# also outside the lock - so holding the install lock across an unbounded human
+# wait would block a concurrent installer (which spins silently, since it can't
+# reclaim a lock whose owner is alive) for no reason. A run that had to
+# bootstrap uv first already holds the lock by now (see the acquire on the
+# uv-install path, which is why the acquire below is guarded), but such a run
+# has no prior install and so reaches neither branch here in practice.
 #
-# `prompt_yn` returns 2 when it could not ask at all (a /dev/tty that opened for
-# can_prompt but failed to read, e.g. a detached session). That is not a "no":
-# treating it as one turns a broken terminal into a silent no-op exit, and it
-# would contradict the no-TTY branch above, which reasons that with no human to
-# ask the installer should complete the upgrade rather than stall.
+# `prompt_yn` returns 2 only when it could not ask at all - /dev/tty opened for
+# can_prompt but no longer opens, e.g. a session that detached in between. That
+# is not a "no": treating it as one turns a broken terminal into a silent no-op
+# exit, and it would contradict the no-TTY branch above, which reasons that
+# with no human to ask the installer should complete the upgrade rather than
+# stall. An EOF on a terminal that *did* open is a human declining and arrives
+# as 1, so it aborts through the branches below like any other "n".
+#
+# Both branches end an abort with "Aborted. deepagents-code was left
+# unchanged." rather than a bare "Aborted.": this point is also reachable on a
+# same-version PATH repair (the branches above that reinstall a current
+# version), so the message names what was left undone instead of implying the
+# run had nothing else to do.
 extras_prompt_rc=0
 if [ "$EXTRAS_UNREADABLE" = true ]; then
   log_warn "Could not read ${receipt:-the uv tool receipt} to check which extras this install was built with."
@@ -1752,9 +1828,6 @@ elif [ -n "$INSTALLED_EXTRAS" ]; then
     if [ "$extras_prompt_rc" -eq 2 ]; then
       log_warn "Could not ask — continuing; the extras above will be removed."
     elif [ "$extras_prompt_rc" -ne 0 ]; then
-      # This path can also skip a same-version PATH repair (the branches above
-      # that reinstall a current version), so name what was left undone rather
-      # than implying the run had nothing else to do.
       log_info "Aborted. deepagents-code was left unchanged."
       exit 0
     fi
@@ -1878,7 +1951,7 @@ if [ "$uv_rc" -ne 0 ]; then
   # anything leaves a zero-byte log, and sending a user whose install just
   # failed to an empty file is a dead end.
   if [ -n "$INSTALL_LOG" ] && [ -s "$INSTALL_LOG" ]; then
-    log_error "Full install log: ${INSTALL_LOG_DISPLAY}"
+    log_error "Full log: ${INSTALL_LOG_DISPLAY}"
   fi
   log_error "Common fixes: check your network, try a different Python version (DEEPAGENTS_CODE_PYTHON=3.12), or install manually."
   exit "$uv_rc"
@@ -2797,11 +2870,13 @@ elif [ -n "$NEW_VERSION" ] && [ "$PRE_VERSION" = "$NEW_VERSION" ]; then
   # the dep move entirely). UV_REPORTED_PACKAGE_CHANGES (set far above) is the
   # signal that the reinstall actually moved packages.
   if [ "$UV_REPORTED_PACKAGE_CHANGES" = true ]; then
-    # No log pointer here: the "Full log:" line below prints it whenever uv
-    # wrote anything, which this branch guarantees (UV_REPORTED_PACKAGE_CHANGES
-    # is only true because a grep matched `- pkg==` / `+ pkg==` lines in the
-    # captured stderr, so the log is non-empty). Repeating it would print the
-    # same path on two consecutive lines.
+    # No log pointer here: the "Full log:" line below prints it whenever a log
+    # was successfully published *and* uv wrote something. This branch
+    # guarantees the second half (UV_REPORTED_PACKAGE_CHANGES is only true
+    # because a grep matched `- pkg==` / `+ pkg==` lines in the captured
+    # stderr), but publication can still have failed - copy_install_log clears
+    # INSTALL_LOG on failure - and then there is no log to point at from either
+    # site. Repeating it here would only print the same path on two lines.
     log_success "deepagents-code ${NEW_VERSION} was already up to date; dependencies were updated."
   else
     log_success "deepagents-code ${NEW_VERSION} already up to date."

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1383,11 +1383,17 @@ fi
 # extras' packages - warn before that happens so they can re-run with the
 # extras preserved. Only relevant on the default path (no explicit EXTRAS /
 # editable swap), where the user asked for nothing new.
+#
+# The receipt records every requirement in one array: the tool itself plus any
+# supplemental `--with` packages. Only parse extras from the `deepagents-code`
+# requirement - a `--with rich[jupyter]` entry must not surface as a tool
+# extra, since `DEEPAGENTS_CODE_EXTRAS` installs `deepagents-code[...]` and
+# cannot preserve supplemental packages.
 INSTALLED_EXTRAS=""
 if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ] && [ -n "$UV_TOOL_DIR" ]; then
   receipt="${UV_TOOL_DIR}/deepagents-code/uv-receipt.toml"
   if [ -f "$receipt" ] && [ ! -L "$receipt" ]; then
-    INSTALLED_EXTRAS=$(sed -nE 's/.*extras = \[([^]]*)\].*/\1/p' "$receipt" \
+    INSTALLED_EXTRAS=$(sed -nE 's/.*name = "deepagents-code"[^}]*extras = \[([^]]*)\].*/\1/p' "$receipt" \
       | head -1 \
       | tr -d ' "' || true)
   fi

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1574,8 +1574,16 @@ elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" 
     if prompt_yn "Install update?"; then
       log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}..."
     else
-      log_info "Keeping deepagents-code ${PRE_VERSION}. Re-run this installer anytime to update."
-      exit 0
+      update_prompt_rc=$?
+      if [ "$update_prompt_rc" -eq 2 ]; then
+        # `can_prompt` proved the terminal could be opened, but it may still
+        # detach before `prompt_yn` can read from it. As with no TTY at all,
+        # nobody declined the update, so warn and complete the install.
+        log_warn "Could not ask — continuing with the update."
+      else
+        log_info "Keeping deepagents-code ${PRE_VERSION}. Re-run this installer anytime to update."
+        exit 0
+      fi
     fi
   else
     # No TTY to prompt (cron, CI, Dockerfile RUN, systemd): there is no human to

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1377,6 +1377,22 @@ if [ -n "$UV_TOOL_DIR" ] && [ -d "${UV_TOOL_DIR}/deepagents-code" ]; then
   shopt -u nullglob
 fi
 
+# Read the extras the existing tool was installed with from uv's receipt. When
+# the user re-runs this installer without DEEPAGENTS_CODE_EXTRAS, uv rebuilds
+# the environment against bare `deepagents-code` and silently drops those
+# extras' packages - warn before that happens so they can re-run with the
+# extras preserved. Only relevant on the default path (no explicit EXTRAS /
+# editable swap), where the user asked for nothing new.
+INSTALLED_EXTRAS=""
+if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ] && [ -n "$UV_TOOL_DIR" ]; then
+  receipt="${UV_TOOL_DIR}/deepagents-code/uv-receipt.toml"
+  if [ -f "$receipt" ] && [ ! -L "$receipt" ]; then
+    INSTALLED_EXTRAS=$(sed -nE 's/.*extras = \[([^]]*)\].*/\1/p' "$receipt" \
+      | head -1 \
+      | tr -d ' "' || true)
+  fi
+fi
+
 if [ "$IS_EDITABLE" = true ]; then
   pre_label="${PRE_VERSION:-(version unknown)}"
   if [ -n "$EDITABLE_SRC" ]; then
@@ -1416,10 +1432,13 @@ elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" 
   elif [ "$LATEST_VERSION" = "$PRE_VERSION" ]; then
     log_info "deepagents-code ${PRE_VERSION} is current but is outside uv's configured tool bin — installing it there."
   elif [ "$ASSUME_YES" = "1" ]; then
+    log_info "Update available: deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}"
+    log_info "  What's new: ${RELEASE_TAG_URL_BASE}${LATEST_VERSION}"
     log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}..."
   elif can_prompt; then
-    log_info "What's new: ${RELEASE_TAG_URL_BASE}${LATEST_VERSION}"
-    if prompt_yn "Update deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}?"; then
+    log_info "Update available: deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}"
+    log_info "  What's new: ${RELEASE_TAG_URL_BASE}${LATEST_VERSION}"
+    if prompt_yn "Install update?"; then
       log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}..."
     else
       log_info "Keeping deepagents-code ${PRE_VERSION}. Re-run this installer anytime to update."
@@ -1430,7 +1449,7 @@ elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" 
     # ask, and an installer's job is to make the current version present, so
     # complete the upgrade rather than silently no-op. Callers that want a fixed
     # version pin DEEPAGENTS_CODE_VERSION, which skips this path entirely.
-    log_info "deepagents-code ${LATEST_VERSION} available — updating (no TTY to prompt)."
+    log_info "Update available: deepagents-code ${PRE_VERSION} → ${LATEST_VERSION} — updating (no TTY to prompt)."
   fi
 elif [ -n "$PRE_VERSION" ]; then
   log_info "dcode ${PRE_VERSION} found — checking for updates..."
@@ -1493,6 +1512,10 @@ if [ -n "$cache_root" ]; then
 fi
 if [ -z "$INSTALL_LOCK_KIND" ]; then
   acquire_install_lock
+fi
+if [ -n "$INSTALLED_EXTRAS" ]; then
+  log_warn "This install has extras that a bare upgrade will remove: ${INSTALLED_EXTRAS}"
+  log_warn "  To keep them, re-run with: DEEPAGENTS_CODE_EXTRAS=\"${INSTALLED_EXTRAS}\""
 fi
 if [[ -z "$VERSION" ]]; then
   "$UV_BIN" tool install -U --python "$PYTHON_VERSION" \
@@ -2521,6 +2544,13 @@ elif [ -n "$NEW_VERSION" ]; then
 else
   log_success "deepagents-code installed."
 fi
+# The log captured uv's full stderr (dependency diff, warnings, rebuild
+# notice). Point at it on every run so users can inspect what changed -
+# non-verbose mode trims those lines from the terminal and piped
+# `curl | bash` runs lose scrollback.
+if [ -n "$INSTALL_LOG_DISPLAY" ]; then
+  log_info "Full log: ${INSTALL_LOG_DISPLAY}"
+fi
 
 if [ "$VERBOSE" = "1" ] && [ -n "$DCODE_BIN_DISPLAY" ]; then
   printf "  Location: %s\n" "$DCODE_BIN_DISPLAY"
@@ -2741,9 +2771,10 @@ fi
 
 # ---------------------------------------------------------------------------
 # Done — footer wording depends on what changed:
-#   - same app version + dependency changes → "Dependencies updated"
-#   - already up to date                    → "Already installed"
-#   - fresh install / upgrade / editable→PyPI swap → "Setup complete"
+#   - same app version + dependency changes → "Dependencies updated."
+#   - already up to date                    → "Already installed."
+#   - version actually moved                → "Upgrade complete."
+#   - fresh install / editable→PyPI swap    → "Setup complete."
 # ---------------------------------------------------------------------------
 if [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] \
   && [ "$PRE_VERSION" = "$NEW_VERSION" ] && [ "$UV_REPORTED_PACKAGE_CHANGES" = true ]; then
@@ -2751,6 +2782,9 @@ if [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] 
 elif [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] \
   && [ "$PRE_VERSION" = "$NEW_VERSION" ]; then
   footer_msg="Already installed."
+elif [ "$IS_EDITABLE" = false ] && [ -n "$PRE_VERSION" ] && [ -n "$NEW_VERSION" ] \
+  && [ "$PRE_VERSION" != "$NEW_VERSION" ]; then
+  footer_msg="Upgrade complete."
 else
   footer_msg="Setup complete."
 fi

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -469,7 +469,10 @@ prompt_yn() {
   local reply
   if [ -t 0 ]; then
     printf "%s [y/N] " "$question"
-    read -r reply
+    if ! read -r reply; then
+      log_warn "Could not read from terminal — skipping prompt."
+      return 2
+    fi
   else
     printf "%s [y/N] " "$question" > /dev/tty
     if ! read -r reply < /dev/tty 2>/dev/null; then
@@ -642,6 +645,13 @@ copy_install_log() {
       rmdir "$stage_dir" 2>/dev/null || true
       return 2
     fi
+    # `mv` accepts a directory destination by moving the staged file into it.
+    # Check the result after publication so a directory created between the
+    # preflight check and `mv` is reported as a failed log write.
+    [ -f "$INSTALL_LOG" ] && [ ! -L "$INSTALL_LOG" ] || {
+      rmdir "$stage_dir" 2>/dev/null || true
+      return 1
+    }
   fi
   rmdir "$stage_dir" 2>/dev/null || true
 }

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -542,6 +542,30 @@ fix_install_log_owner() {
   fi
 }
 
+path_device() {
+  local device
+  # GNU and BSD `stat` use different format flags. The device number is enough
+  # here: `rename(2)` cannot cross a filesystem boundary.
+  device="$(stat -c %d "$1" 2>/dev/null || true)"
+  case "$device" in
+    ''|*[!0-9]*) ;;
+    *) printf '%s\n' "$device"; return 0 ;;
+  esac
+
+  device="$(stat -f %d "$1" 2>/dev/null || true)"
+  case "$device" in
+    ''|*[!0-9]*) return 1 ;;
+    *) printf '%s\n' "$device" ;;
+  esac
+}
+
+paths_share_filesystem() {
+  local first_device second_device
+  first_device="$(path_device "$1")" || return 1
+  second_device="$(path_device "$2")" || return 1
+  [ "$first_device" = "$second_device" ]
+}
+
 copy_install_log() {
   [ -n "${INSTALL_LOG:-}" ] || return 1
   [ -n "${install_log_dir:-}" ] || return 1
@@ -549,19 +573,26 @@ copy_install_log() {
   if [ "$(id -u)" -eq 0 ]; then
     path_is_under_home "$install_log_dir" || return 1
   fi
-  # Belt-and-braces: the rename below replaces a symlink at INSTALL_LOG rather
-  # than following it, so this guard is not what makes publishing safe. Keep it
+  # Belt-and-braces: the publication below never follows a symlink at
+  # INSTALL_LOG, so this guard is not what makes publishing safe. Keep it
   # anyway — it fails early and explicitly on an obviously tampered path.
   [ ! -L "$INSTALL_LOG" ] || return 1
   # Do not stage beneath install_log_dir: when this runs as root, its parent can
   # still be user-writable and the user could replace a freshly-created staging
   # directory before `cp` enters it. `/tmp` is sticky, so a root-owned 0700
   # directory created there cannot be renamed or replaced by another user.
-  # The final `mv` replaces a planted INSTALL_LOG symlink instead of following
-  # it.
+  # Privileged publication uses an atomic hard link below, which never follows
+  # a planted INSTALL_LOG symlink.
   local stage_dir staged
   stage_dir=$(mktemp -d "/tmp/deepagents-code-install-log.XXXXXX" 2>/dev/null) || return 2
   staged="${stage_dir}/install.log"
+  # Do not persist a privileged log when `mv` would cross a filesystem
+  # boundary. Its copy-and-delete fallback could follow a symlink planted at
+  # INSTALL_LOG by the user who owns the cache directory.
+  if [ "$(id -u)" -eq 0 ] && ! paths_share_filesystem "$stage_dir" "$install_log_dir"; then
+    rmdir "$stage_dir" 2>/dev/null || true
+    return 1
+  fi
   if ! (cd "$stage_dir" && cp "$uv_stderr" install.log) 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true
     rmdir "$stage_dir" 2>/dev/null || true
@@ -593,7 +624,19 @@ copy_install_log() {
     rmdir "$stage_dir" 2>/dev/null || true
     return 1
   }
-  if ! mv -f "$staged" "$INSTALL_LOG" 2>/dev/null; then
+  if [ "$(id -u)" -eq 0 ]; then
+    # Unlinking a symlink removes the directory entry without following it.
+    # `ln` then atomically creates INSTALL_LOG only if the attacker has not
+    # replaced that entry in the meantime; unlike cross-device `mv`, it never
+    # copies through a planted symlink.
+    rm -f "$INSTALL_LOG" 2>/dev/null || true
+    if ! ln "$staged" "$INSTALL_LOG" 2>/dev/null; then
+      rm -f "$staged" 2>/dev/null || true
+      rmdir "$stage_dir" 2>/dev/null || true
+      return 2
+    fi
+    rm -f "$staged" 2>/dev/null || true
+  elif ! mv -f "$staged" "$INSTALL_LOG" 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true
     rmdir "$stage_dir" 2>/dev/null || true
     return 2

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -969,7 +969,7 @@ if [[ -n "$EXTRAS" ]]; then
   # Strip brackets if the user passed them anyway
   EXTRAS="${EXTRAS#[}"
   EXTRAS="${EXTRAS%]}"
-  if [[ ! "$EXTRAS" =~ ^[-a-zA-Z0-9,]+$ ]]; then
+  if [[ ! "$EXTRAS" =~ ^[-a-zA-Z0-9,._]+$ ]]; then
     log_error "DEEPAGENTS_CODE_EXTRAS must be comma-separated extra names, e.g. 'anthropic,groq' or 'daytona'"
     exit 1
   fi

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -551,21 +551,30 @@ copy_install_log() {
   # but it also fails with EXDEV whenever mktemp's TMPDIR and the cache dir sit
   # on different filesystems — /tmp on tmpfs is the default on most Linux
   # distros, so the hardlink alone would silently disable the log there. Fall
-  # back to a copy, staged under a sibling name: the destination is still never
-  # opened at the canonical path (and install_log_dir is a validated,
-  # non-symlink 0700 dir), and a failure leaves the previous run's log intact
-  # instead of deleting it before finding out.
-  local staged="${INSTALL_LOG}.$$"
-  rm -f "$staged" 2>/dev/null || return 1
+  # back to a copy. The copy must not be staged next to INSTALL_LOG: a root
+  # installer may have handed that directory to TARGET_USER, who could replace
+  # a predictable sibling path with a symlink before `cp` opens it. Keep the
+  # staging file in a freshly-created root-owned 0700 directory instead.
+  local staging_dir
+  local staged
+  staging_dir=$(mktemp -d /tmp/deepagents-code-install-log.XXXXXX 2>/dev/null) || return 1
+  [ -d "$staging_dir" ] && [ ! -L "$staging_dir" ] && [ -O "$staging_dir" ] || {
+    rmdir "$staging_dir" 2>/dev/null || true
+    return 1
+  }
+  staged="${staging_dir}/install.log"
   if ! ln "$uv_stderr" "$staged" 2>/dev/null \
     && ! cp "$uv_stderr" "$staged" 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true
+    rmdir "$staging_dir" 2>/dev/null || true
     return 1
   fi
   if ! mv -f "$staged" "$INSTALL_LOG" 2>/dev/null; then
     rm -f "$staged" 2>/dev/null || true
+    rmdir "$staging_dir" 2>/dev/null || true
     return 1
   fi
+  rmdir "$staging_dir" 2>/dev/null || true
 }
 
 # Epoch mtime of the lock directory, used as a fallback reference time when the

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1576,6 +1576,16 @@ fi
 if [ "$EXTRAS_UNREADABLE" = true ]; then
   log_warn "Could not read ${receipt} to check which extras this install was built with."
   log_warn "  If it was built with DEEPAGENTS_CODE_EXTRAS, re-run with the same value or those packages will be removed."
+  # An unreadable receipt can still hide extras (e.g. one written by a prior
+  # sudo run), so offer the same abort prompt as the known-extras case below:
+  # the user is told their extras may be removed and must get the chance to
+  # stop before the rebuild drops them.
+  if [ "$ASSUME_YES" != "1" ] && can_prompt; then
+    if ! prompt_yn "Continue anyway?"; then
+      log_info "Aborted. deepagents-code was left unchanged."
+      exit 0
+    fi
+  fi
 elif [ -n "$INSTALLED_EXTRAS" ]; then
   log_warn "This install has extras that a bare re-run will remove: ${INSTALLED_EXTRAS}"
   log_warn "  To keep them, re-run with: DEEPAGENTS_CODE_EXTRAS=\"${INSTALLED_EXTRAS}\""

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1451,6 +1451,19 @@ if [ -z "$EXTRAS" ] && [ "$IS_EDITABLE" = false ] && [ -n "$UV_TOOL_DIR" ]; then
       INSTALLED_EXTRAS=$(printf '%s\n' "$receipt_entry" \
         | sed -nE 's/.*extras = \[([^]]*)\].*/\1/p' \
         | tr -d ' "')
+      # INSTALLED_EXTRAS is echoed back inside a double-quoted, ready-to-paste
+      # shell command below; on a shared host a less-privileged writer of the
+      # receipt could plant `$(...)` and have it evaluated by whoever pastes
+      # the suggestion. Restrict to PEP 508 extra-name characters plus commas —
+      # anything else means the receipt was tampered with or written by a
+      # foreign tool, which is the unparseable case. An empty value is the
+      # normal no-extras receipt, not tampering.
+      case "$INSTALLED_EXTRAS" in
+        *[!A-Za-z0-9_,.-]*)
+          EXTRAS_UNREADABLE=true
+          INSTALLED_EXTRAS=""
+          ;;
+      esac
     elif grep -q 'deepagents-code' "$receipt" 2>/dev/null; then
       EXTRAS_UNREADABLE=true
     fi

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1427,6 +1427,37 @@ def test_install_script_warns_when_receipt_is_unparseable(tmp_path: Path) -> Non
     assert "re-run with the same value" in proc.stderr
 
 
+def test_install_script_receipt_extras_with_metacharacters_warns(
+    tmp_path: Path,
+) -> None:
+    """Shell metacharacters in receipt extras must not reach the printed hint.
+
+    The extras value is echoed inside a double-quoted `DEEPAGENTS_CODE_EXTRAS`
+    suggestion the user may paste; a tampered receipt could otherwise smuggle
+    `$(...)` into that paste. Anything outside `[A-Za-z0-9_,.-]` is treated as
+    an unparseable receipt — the run warns and omits the paste-ready hint.
+    """
+    receipt = _write_uv_receipt(tmp_path / "tools", ["$(touch /tmp/pwned)"])
+    # Keep the file plausible TOML but with the payload as the extra name.
+    receipt.write_text(
+        '[tool]\nrequirements = [{ name = "deepagents-code",'
+        ' extras = ["$(touch /tmp/pwned)"], specifier = "==0.1.0" }]\n'
+    )
+
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "Could not read" in proc.stderr
+    assert "DEEPAGENTS_CODE_EXTRAS=" not in proc.stderr
+    assert "$(touch" not in proc.stderr
+    assert not Path("/tmp/pwned").exists()
+
+
 def test_install_script_warns_when_receipt_is_symlinked(tmp_path: Path) -> None:
     """A symlinked receipt is refused, but the refusal is announced.
 

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1588,6 +1588,86 @@ def test_install_script_extras_assume_yes_skips_interrupt(tmp_path: Path) -> Non
     assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
 
 
+def test_install_script_unreadable_receipt_interrupt_decline_aborts_before_uv(
+    tmp_path: Path,
+) -> None:
+    """Answering 'n' to the unreadable-receipt prompt exits before uv runs.
+
+    An unreadable receipt can still hide extras, so the unknown-extras case must
+    offer the same abort prompt as the known-extras one: the user is told their
+    extras may be removed and gets the chance to stop before the rebuild drops
+    them. Two prompts fire on this path — the update prompt, then the
+    unreadable-receipt interrupt — so both answers are fed.
+    """
+    receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+    receipt.chmod(0o000)
+
+    try:
+        code, output, args_path = _invoke_interactive(
+            tmp_path,
+            {},
+            answer=["y", "n"],
+            installed_version="0.1.0",
+            latest_version="0.2.0",
+        )
+    finally:
+        receipt.chmod(0o644)
+
+    assert code == 0
+    assert "Continue anyway?" in output
+    assert "Aborted. deepagents-code was left unchanged." in output
+    assert not args_path.exists()
+
+
+def test_install_script_unreadable_receipt_interrupt_accept_proceeds(
+    tmp_path: Path,
+) -> None:
+    """Answering 'y' to the unreadable-receipt prompt continues the upgrade."""
+    receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+    receipt.chmod(0o000)
+
+    try:
+        code, output, args_path = _invoke_interactive(
+            tmp_path,
+            {},
+            answer=["y", "y"],
+            installed_version="0.1.0",
+            latest_version="0.2.0",
+        )
+    finally:
+        receipt.chmod(0o644)
+
+    assert code == 0
+    assert "Continue anyway?" in output
+    assert "Aborted. deepagents-code was left unchanged." not in output
+    args = args_path.read_text().splitlines()
+    assert args[:3] == ["tool", "install", "-U"]
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permissions")
+def test_install_script_unreadable_receipt_assume_yes_skips_interrupt(
+    tmp_path: Path,
+) -> None:
+    """`DEEPAGENTS_CODE_YES=1` proceeds past the unreadable-receipt prompt."""
+    receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+    receipt.chmod(0o000)
+
+    try:
+        proc, args_path = _invoke(
+            tmp_path,
+            {"DEEPAGENTS_CODE_YES": "1"},
+            installed_version="0.1.0",
+            latest_version="0.2.0",
+        )
+    finally:
+        receipt.chmod(0o644)
+
+    assert proc.returncode == 0
+    assert "Could not read" in proc.stderr
+    assert "Aborted. deepagents-code was left unchanged." not in proc.stderr
+    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
+
+
 def test_install_script_refuses_symlinked_log_file(tmp_path: Path) -> None:
     """A pre-existing log-file symlink disables the persistent install log."""
     cache = tmp_path / "cache"

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1239,8 +1239,8 @@ def _write_uv_receipt(
     return receipt
 
 
-def test_install_script_upgrade_footer_says_upgrade_complete(tmp_path: Path) -> None:
-    """A version move ends with `Upgrade complete.`, not `Setup complete.`."""
+def test_install_script_upgrade_footer_says_version_changed(tmp_path: Path) -> None:
+    """A version move gets a useful footer without assuming its direction."""
     proc, _ = _invoke(
         tmp_path,
         {
@@ -1255,16 +1255,37 @@ def test_install_script_upgrade_footer_says_upgrade_complete(tmp_path: Path) -> 
     )
 
     assert proc.returncode == 0
-    assert "✔ Upgrade complete. Run: dcode" in proc.stdout
+    assert "✔ Version changed. Run: dcode" in proc.stdout
+    assert "Upgrade complete" not in proc.stdout
     assert "Setup complete" not in proc.stdout
+
+
+def test_install_script_custom_index_downgrade_footer_is_neutral(
+    tmp_path: Path,
+) -> None:
+    """An unpinned custom index can resolve an older available version."""
+    proc, _ = _invoke(
+        tmp_path,
+        {
+            "UV_INDEX_URL": "https://packages.example.invalid/simple",
+            "FAKE_UV_CREATE_LOCAL_DCODE": "1",
+            "FAKE_LOCAL_DCODE_VERSION": "0.1.18",
+        },
+        installed_version="0.1.19",
+        latest_version="0.1.20",
+    )
+
+    assert proc.returncode == 0
+    assert "✔ Version changed. Run: dcode" in proc.stdout
+    assert "Upgrade complete" not in proc.stdout
 
 
 def test_install_script_pinned_downgrade_footer_is_not_upgrade(tmp_path: Path) -> None:
     """Pinning an older version must not claim an upgrade.
 
     `bash -s -- 0.1.0` over an installed 0.1.19 moves the version but downwards.
-    The script has no semantic version comparison available in shell, so only an
-    unpinned run — which always resolves to latest — may say "Upgrade complete."
+    The pinned path retains the general setup footer rather than the neutral
+    unpinned-version-change footer.
     """
     proc, _ = _invoke(
         tmp_path,
@@ -1971,8 +1992,6 @@ def _run_copy_install_log(
         "TEMP_FILES=()\n"
         'register_temp() { TEMP_FILES+=("$1"); }\n'
         f"{_extract_shell_function('path_is_under_home')}\n"
-        f"{_extract_shell_function('path_device')}\n"
-        f"{_extract_shell_function('paths_share_filesystem')}\n"
         f"{_extract_shell_function('copy_install_log')}\n"
         f"HOME={str(home)!r}\n"
         f"install_log_dir={str(install_log_dir)!r}\n"
@@ -2032,27 +2051,6 @@ def test_copy_install_log_stages_outside_user_writable_log_dir(
     assert published.read_text() == "captured uv stderr\n"
 
 
-def test_copy_install_log_skips_privileged_cross_device_publication(
-    tmp_path: Path,
-) -> None:
-    """A root install never lets `mv` fall back to a symlink-following copy."""
-    rc, _log_dir, published = _run_copy_install_log(
-        tmp_path,
-        race_hook=(
-            'id() { printf "0\\n"; }\n'
-            "path_device() {\n"
-            '  case "$1" in\n'
-            '    "$install_log_dir") printf "destination\\n" ;;\n'
-            '    *) printf "staging\\n" ;;\n'
-            "  esac\n"
-            "}\n"
-        ),
-    )
-
-    assert rc == 1
-    assert not published.exists()
-
-
 def test_copy_install_log_replaces_symlink_planted_during_the_race(
     tmp_path: Path,
 ) -> None:
@@ -2100,6 +2098,34 @@ def test_copy_install_log_refuses_publish_when_log_dir_is_swapped(
     assert list(elsewhere.glob(".install.log.*")) == []
 
 
+def test_copy_install_log_pins_parent_during_privileged_publication(
+    tmp_path: Path,
+) -> None:
+    """A parent swap after validation cannot redirect root's rm or create."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    rc, log_dir, _published = _run_copy_install_log(
+        tmp_path,
+        race_hook=(
+            'id() { printf "0\\n"; }\n'
+            "rm() {\n"
+            '  if [ "${1:-}" = "-f" ] && [ "${2:-}" = "install.log" ]; then\n'
+            '    mv "$install_log_dir" "${install_log_dir}.moved"\n'
+            f'    command ln -s {str(elsewhere)!r} "$install_log_dir"\n'
+            "  fi\n"
+            '  command rm "$@"\n'
+            "}\n"
+        ),
+    )
+
+    assert rc == 0
+    assert log_dir.is_symlink()
+    assert not (elsewhere / "install.log").exists()
+    assert (log_dir.with_name(f"{log_dir.name}.moved") / "install.log").read_text() == (
+        "captured uv stderr\n"
+    )
+
+
 def test_copy_install_log_refuses_directory_target(tmp_path: Path) -> None:
     """A directory at the publication path is not treated as a successful move."""
     log_dir = tmp_path / "home" / "cache"
@@ -2122,11 +2148,10 @@ def test_copy_install_log_cleans_up_staged_file_when_publish_fails(
     The staged file holds the full captured stderr, so an orphan is both litter
     and a disclosure; repeated failures would accumulate them.
     """
-    # Fail the root-safe hard-link publication itself, leaving the staged file
-    # in place for the cleanup to find. Contriving a filesystem state that
-    # breaks `ln` is unreliable.
+    # Fail the root-safe publication copy after noclobber creates the target,
+    # leaving both files in place for the cleanup to find.
     rc, log_dir, published = _run_copy_install_log(
-        tmp_path, race_hook='id() { printf "0\\n"; }\nln() { return 1; }\n'
+        tmp_path, race_hook='id() { printf "0\\n"; }\ncat() { return 1; }\n'
     )
 
     assert rc == 2

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -76,7 +76,9 @@ def _write_fake_tools(
     tools = tmp_path / "tools"
     bin_dir.mkdir()
     home.mkdir()
-    tools.mkdir()
+    # exist_ok: a test may stage a uv tool receipt under `tools/deepagents-code`
+    # before invoking, which creates `tools` as a side effect.
+    tools.mkdir(exist_ok=True)
 
     # Raw f-string: the embedded bash must keep `\n` as the two literal
     # characters (an f-string would otherwise turn `\n` into a newline). `{{ }}`
@@ -751,7 +753,10 @@ def test_install_script_interactive_decline_keeps_current(tmp_path: Path) -> Non
 
     assert code == 0
     assert not args_path.exists()
-    assert "0.1.0 → 0.2.0" in output
+    # The headline must lead with the verdict, not the changelog link.
+    assert output.index(
+        "Update available: deepagents-code 0.1.0 → 0.2.0"
+    ) < output.index("What's new:")
     assert (
         "What's new: https://github.com/langchain-ai/deepagents/releases/tag/"
         "deepagents-code%3D%3D0.2.0" in output
@@ -770,10 +775,12 @@ def test_install_script_interactive_accept_updates(tmp_path: Path) -> None:
     # paths, so assert the "Updating ..." line to prove the prompt was shown and
     # answered yes rather than bypassed.
     assert "Updating deepagents-code 0.1.0 → 0.2.0" in output
+    assert "Update available: deepagents-code 0.1.0 → 0.2.0\n" in output
     assert (
         "What's new: https://github.com/langchain-ai/deepagents/releases/tag/"
         "deepagents-code%3D%3D0.2.0" in output
     )
+    assert "Install update?" in output
     args = args_path.read_text().splitlines()
     assert args[:3] == ["tool", "install", "-U"]
     assert args[-1] == "deepagents-code"
@@ -1121,6 +1128,158 @@ def test_install_script_refuses_symlinked_log_dir(tmp_path: Path) -> None:
     )
     assert "Details:" not in proc.stdout
     assert not (target / "install.log").exists()
+
+
+def _write_uv_receipt(tools: Path, extras: list[str]) -> None:
+    """Stage a uv tool receipt recording the extras the install was built with.
+
+    The install script reads `uv-receipt.toml` to detect extras that a bare
+    re-run would drop; the fake `uv tool dir` points at `tmp_path / "tools"`,
+    so the receipt belongs under `tools/deepagents-code/`. Only the
+    `deepagents-code` subdir is created here — `_write_fake_tools` creates
+    `tools` itself and would fail if it already existed.
+    """
+    receipt_dir = tools / "deepagents-code"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    quoted = ", ".join(f'"{extra}"' for extra in extras)
+    (receipt_dir / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        f'requirements = [{{ name = "deepagents-code", extras = [{quoted}], '
+        'specifier = "==0.1.0" }]\n'
+    )
+
+
+def test_install_script_upgrade_footer_says_upgrade_complete(tmp_path: Path) -> None:
+    """A version move ends with `Upgrade complete.`, not `Setup complete.`."""
+    proc, _ = _invoke(
+        tmp_path,
+        {
+            "FAKE_UV_INSTALL_STDERR": _UPGRADE_DIFF,
+            # Post-install `dcode -v` must report the new version, otherwise
+            # PRE_VERSION == NEW_VERSION and the same-version branch fires.
+            "FAKE_UV_CREATE_LOCAL_DCODE": "1",
+            "FAKE_LOCAL_DCODE_VERSION": "0.1.19",
+        },
+        installed_version="0.1.18",
+        latest_version="0.1.19",
+    )
+
+    assert proc.returncode == 0
+    assert "✔ Upgrade complete. Run: dcode" in proc.stdout
+    assert "Setup complete" not in proc.stdout
+
+
+def test_install_script_fresh_install_footer_says_setup_complete(
+    tmp_path: Path,
+) -> None:
+    """A fresh install keeps the `Setup complete.` footer.
+
+    The host `PATH` must be scrubbed of the test venv's real `dcode` —
+    otherwise the pre-install probe finds it and the run becomes a same-version
+    no-op instead of a fresh install. No post-install `dcode` is staged either,
+    so `PRE_VERSION`/`NEW_VERSION` stay empty and the footer holds the
+    fresh-install branch.
+    """
+    env = _env(tmp_path, {}, installed_version=None)
+    env["PATH"] = (
+        f"{env['PATH'].split(os.pathsep)[0]}{os.pathsep}{_path_without_dcode()}"
+    )
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    assert proc.returncode == 0
+    assert "✔ Setup complete. Run: dcode" in proc.stdout
+
+
+def test_install_script_upgrade_prints_full_log_pointer(tmp_path: Path) -> None:
+    """Every run surfaces the persistent uv log, not just failures/dep bumps."""
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.18",
+        latest_version="0.1.19",
+    )
+
+    assert proc.returncode == 0
+    assert "Full log: ~/.cache/deepagents-code/install.log" in proc.stdout
+
+
+def test_install_script_warns_when_upgrade_drops_receipt_extras(tmp_path: Path) -> None:
+    """A bare re-run warns when the existing install was built with extras.
+
+    Without `DEEPAGENTS_CODE_EXTRAS`, `uv tool install -U deepagents-code`
+    rebuilds the environment against the bare package and silently removes the
+    extras' packages. The script must read the extras off uv's receipt and warn
+    (with the re-run hint) before that rebuild happens.
+    """
+    _write_uv_receipt(tmp_path / "tools", ["anthropic", "openai"])
+
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert (
+        "This install has extras that a bare upgrade will remove: anthropic,openai"
+        in proc.stderr
+    )
+    assert (
+        'To keep them, re-run with: DEEPAGENTS_CODE_EXTRAS="anthropic,openai"'
+        in proc.stderr
+    )
+
+
+def test_install_script_no_extras_warning_when_receipt_has_none(tmp_path: Path) -> None:
+    """An empty extras list in the receipt stays silent."""
+    _write_uv_receipt(tmp_path / "tools", [])
+
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "extras that a bare upgrade will remove" not in proc.stderr
+
+
+def test_install_script_no_extras_warning_when_receipt_missing(tmp_path: Path) -> None:
+    """No receipt (older uv / non-tool install) degrades quietly."""
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "extras that a bare upgrade will remove" not in proc.stderr
+
+
+def test_install_script_no_extras_warning_when_extras_explicit(tmp_path: Path) -> None:
+    """Passing `DEEPAGENTS_CODE_EXTRAS` is explicit intent — no warning."""
+    _write_uv_receipt(tmp_path / "tools", ["anthropic", "openai"])
+
+    proc, _ = _invoke(
+        tmp_path,
+        {"DEEPAGENTS_CODE_EXTRAS": "anthropic,openai"},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "extras that a bare upgrade will remove" not in proc.stderr
 
 
 def test_install_script_refuses_symlinked_log_file(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1974,6 +1974,35 @@ def test_copy_install_log_publishes_captured_stderr(tmp_path: Path) -> None:
     assert list(log_dir.glob(".install.log.*")) == []
 
 
+def test_copy_install_log_stages_outside_user_writable_log_dir(
+    tmp_path: Path,
+) -> None:
+    """The copied log is staged in sticky `/tmp`, not below the cache path.
+
+    A root installer cannot safely reopen a staging directory whose parent is
+    user-writable: that user can rename the directory and replace it with a
+    symlink before `cp` runs. Pin the `mktemp` template so the staging parent
+    remains independent of the cache directory.
+    """
+    mktemp_args = tmp_path / "mktemp-args.txt"
+    rc, _log_dir, published = _run_copy_install_log(
+        tmp_path,
+        race_hook=(
+            "mktemp() {\n"
+            f"  printf '%s\\n' \"$@\" > {str(mktemp_args)!r}\n"
+            '  command mktemp "$@"\n'
+            "}\n"
+        ),
+    )
+
+    assert rc == 0
+    assert mktemp_args.read_text().splitlines() == [
+        "-d",
+        "/tmp/deepagents-code-install-log.XXXXXX",
+    ]
+    assert published.read_text() == "captured uv stderr\n"
+
+
 def test_copy_install_log_replaces_symlink_planted_during_the_race(
     tmp_path: Path,
 ) -> None:

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -665,25 +665,42 @@ def test_install_script_latest_version_with_python_rebuilds_tool_env(
 
 def test_install_script_out_of_date_auto_updates_without_tty(tmp_path: Path) -> None:
     """Out of date with no TTY to prompt: upgrade automatically (legacy path)."""
-    args = _run_install_script(
+    proc, args_path = _invoke(
         tmp_path, {}, installed_version="0.1.0", latest_version="0.2.0"
     )
 
+    args = args_path.read_text().splitlines()
     assert args[:3] == ["tool", "install", "-U"]
     assert args[-1] == "deepagents-code"
+    # This path can't prompt, so the headline is the only notice the user gets
+    # that a version move is about to happen — it must still lead with the
+    # verdict rather than only explaining why no prompt appeared.
+    assert (
+        "Update available: deepagents-code 0.1.0 → 0.2.0 — updating (no TTY to prompt)."
+        in proc.stdout
+    )
 
 
 def test_install_script_assume_yes_updates_without_prompt(tmp_path: Path) -> None:
     """`DEEPAGENTS_CODE_YES=1` upgrades an out-of-date install without asking."""
-    args = _run_install_script(
+    proc, args_path = _invoke(
         tmp_path,
         {"DEEPAGENTS_CODE_YES": "1"},
         installed_version="0.1.0",
         latest_version="0.2.0",
     )
 
+    args = args_path.read_text().splitlines()
     assert args[:3] == ["tool", "install", "-U"]
     assert args[-1] == "deepagents-code"
+    # Unattended runs get the same verdict-first headline and changelog link as
+    # the interactive path; only the prompt is skipped.
+    output = proc.stdout + proc.stderr
+    assert "Update available: deepagents-code 0.1.0 → 0.2.0" in output
+    assert (
+        "What's new: https://github.com/langchain-ai/deepagents/releases/tag/"
+        "deepagents-code%3D%3D0.2.0" in output
+    )
 
 
 @pytest.mark.parametrize("assume_yes", ["true", "TRUE", "yes", " YES "])
@@ -756,7 +773,11 @@ def test_install_script_interactive_decline_keeps_current(tmp_path: Path) -> Non
 
     assert code == 0
     assert not args_path.exists()
-    # The headline must lead with the verdict, not the changelog link.
+    # The headline must lead with the verdict, not the changelog link. Assert
+    # presence before ordering: `.index` raises ValueError rather than failing
+    # as an assertion when a string is missing entirely.
+    assert "Update available: deepagents-code 0.1.0 → 0.2.0" in output
+    assert "What's new:" in output
     assert output.index(
         "Update available: deepagents-code 0.1.0 → 0.2.0"
     ) < output.index("What's new:")
@@ -960,8 +981,8 @@ def test_install_script_same_version_with_dependency_updates_says_dependencies_u
     The fake `dcode -v` reports the same version before and after install, so
     `PRE_VERSION == NEW_VERSION` and the same-version branch fires; the `± pkg==`
     diff in stderr must steer it away from the flat "already up to date" message.
-    Also verifies the raw uv diff is persisted to the cache install log and that
-    the success line points the user at it via the `Details:` suffix.
+    Also verifies the raw uv diff is persisted to the cache install log, which
+    the shared `Full log:` line points the user at.
     """
     proc, _ = _invoke(
         tmp_path,
@@ -972,9 +993,9 @@ def test_install_script_same_version_with_dependency_updates_says_dependencies_u
 
     assert proc.returncode == 0
     assert (
-        "deepagents-code 0.1.8 was already up to date; dependencies were updated. "
-        "Details: ~/.cache/deepagents-code/install.log"
+        "deepagents-code 0.1.8 was already up to date; dependencies were updated."
     ) in proc.stdout
+    assert "Full log: ~/.cache/deepagents-code/install.log" in proc.stdout
     assert "deepagents-code 0.1.8 already up to date" not in proc.stdout
     assert (tmp_path / "home/.cache/deepagents-code/install.log").read_text() == (
         f"{_DEPENDENCY_UPDATE_DIFF}\n"
@@ -992,8 +1013,8 @@ def test_install_script_same_version_no_dependency_changes_says_up_to_date(
     nothing (only timing/summary noise), the flag must stay false so the plain
     "already up to date" message is emitted. Guards against the flag defaulting
     on, the conditional inverting, or the grep matching uv's noise lines. The
-    log is still written (the no-op stderr) but the `Details:` suffix is
-    suppressed, since there's no dependency change worth pointing at.
+    log is still written (the no-op stderr), so the shared `Full log:` pointer
+    still fires — only the dependency-change wording is suppressed.
     """
     proc, _ = _invoke(
         tmp_path,
@@ -1005,7 +1026,7 @@ def test_install_script_same_version_no_dependency_changes_says_up_to_date(
     assert proc.returncode == 0
     assert "deepagents-code 0.1.8 already up to date." in proc.stdout
     assert "dependencies were updated" not in proc.stdout
-    assert "Details: ~/.cache/deepagents-code/install.log" not in proc.stdout
+    assert "Full log: ~/.cache/deepagents-code/install.log" in proc.stdout
     assert (tmp_path / "home/.cache/deepagents-code/install.log").read_text() == (
         f"{_NO_PACKAGE_CHANGE_STDERR}\n"
     )
@@ -1031,23 +1052,23 @@ def test_install_script_same_version_with_new_dependency_says_dependencies_updat
 
     assert proc.returncode == 0
     assert (
-        "deepagents-code 0.1.8 was already up to date; dependencies were updated. "
-        "Details: ~/.cache/deepagents-code/install.log"
+        "deepagents-code 0.1.8 was already up to date; dependencies were updated."
     ) in proc.stdout
+    assert "Full log: ~/.cache/deepagents-code/install.log" in proc.stdout
     assert (tmp_path / "home/.cache/deepagents-code/install.log").read_text() == (
         f"{_DEPENDENCY_ADDITION_DIFF}\n"
     )
 
 
-def test_install_script_dependency_update_without_writable_log_omits_details(
+def test_install_script_dependency_update_without_writable_log_omits_log_pointer(
     tmp_path: Path,
 ) -> None:
-    """When the log dir can't be created, the message drops the `Details:` suffix.
+    """When the log dir can't be created, no `Full log:` pointer is printed.
 
     Points `XDG_CACHE_HOME` under a regular file so `mkdir -p` fails, leaving
     `INSTALL_LOG` empty. The dependency-update message must still fire, just
     without a pointer to a log that was never written — guards against the
-    suffix being appended unconditionally.
+    pointer being printed unconditionally.
     """
     blocker = tmp_path / "blocker"
     blocker.write_text("")  # regular file; mkdir -p underneath must fail
@@ -1067,14 +1088,14 @@ def test_install_script_dependency_update_without_writable_log_omits_details(
         "deepagents-code 0.1.8 was already up to date; dependencies were updated."
         in proc.stdout
     )
-    assert "Details:" not in proc.stdout
+    assert "Full log:" not in proc.stdout
     assert not (blocker / "cache").exists()
 
 
-def test_install_script_dependency_update_with_failed_log_copy_omits_details(
+def test_install_script_dependency_update_with_failed_log_copy_omits_log_pointer(
     tmp_path: Path,
 ) -> None:
-    """When log creation succeeds but copying fails, the message omits `Details:`."""
+    """When log creation succeeds but copying fails, no `Full log:` pointer."""
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         pytest.skip("root can write through directory permissions")
 
@@ -1101,7 +1122,7 @@ def test_install_script_dependency_update_with_failed_log_copy_omits_details(
         "deepagents-code 0.1.8 was already up to date; dependencies were updated."
         in proc.stdout
     )
-    assert "Details:" not in proc.stdout
+    assert "Full log:" not in proc.stdout
     assert not (install_log_dir / "install.log").exists()
 
 
@@ -1129,27 +1150,40 @@ def test_install_script_refuses_symlinked_log_dir(tmp_path: Path) -> None:
         "deepagents-code 0.1.8 was already up to date; dependencies were updated."
         in proc.stdout
     )
-    assert "Details:" not in proc.stdout
+    assert "Full log:" not in proc.stdout
     assert not (target / "install.log").exists()
 
 
-def _write_uv_receipt(tools: Path, extras: list[str]) -> None:
+def _write_uv_receipt(
+    tools: Path, extras: list[str], *, with_packages: dict[str, list[str]] | None = None
+) -> Path:
     """Stage a uv tool receipt recording the extras the install was built with.
 
     The install script reads `uv-receipt.toml` to detect extras that a bare
     re-run would drop; the fake `uv tool dir` points at `tmp_path / "tools"`,
-    so the receipt belongs under `tools/deepagents-code/`. Only the
-    `deepagents-code` subdir is created here — `_write_fake_tools` creates
-    `tools` itself and would fail if it already existed.
+    so the receipt belongs under `tools/deepagents-code/`. `parents=True`
+    creates `tools` as a side effect, which is why `_write_fake_tools` tolerates
+    a pre-existing `tools` — the two helpers may run in either order.
+
+    `with_packages` maps supplemental `uv tool install --with` package names to
+    their own extras. uv records these in the *same* `requirements` array as the
+    tool itself, so a receipt with them is what distinguishes a parser scoped to
+    the `deepagents-code` entry from one that grabs any `extras = [...]`.
+
+    Returns the receipt path so tests can mangle its permissions or contents.
     """
     receipt_dir = tools / "deepagents-code"
     receipt_dir.mkdir(parents=True, exist_ok=True)
     quoted = ", ".join(f'"{extra}"' for extra in extras)
-    (receipt_dir / "uv-receipt.toml").write_text(
-        "[tool]\n"
-        f'requirements = [{{ name = "deepagents-code", extras = [{quoted}], '
-        'specifier = "==0.1.0" }]\n'
-    )
+    entries = [
+        f'{{ name = "deepagents-code", extras = [{quoted}], specifier = "==0.1.0" }}'
+    ]
+    for name, pkg_extras in (with_packages or {}).items():
+        pkg_quoted = ", ".join(f'"{extra}"' for extra in pkg_extras)
+        entries.append(f'{{ name = "{name}", extras = [{pkg_quoted}] }}')
+    receipt = receipt_dir / "uv-receipt.toml"
+    receipt.write_text("[tool]\nrequirements = [" + ", ".join(entries) + "]\n")
+    return receipt
 
 
 def test_install_script_upgrade_footer_says_upgrade_complete(tmp_path: Path) -> None:
@@ -1170,6 +1204,29 @@ def test_install_script_upgrade_footer_says_upgrade_complete(tmp_path: Path) -> 
     assert proc.returncode == 0
     assert "✔ Upgrade complete. Run: dcode" in proc.stdout
     assert "Setup complete" not in proc.stdout
+
+
+def test_install_script_pinned_downgrade_footer_is_not_upgrade(tmp_path: Path) -> None:
+    """Pinning an older version must not claim an upgrade.
+
+    `bash -s -- 0.1.0` over an installed 0.1.19 moves the version but downwards.
+    The script has no semantic version comparison available in shell, so only an
+    unpinned run — which always resolves to latest — may say "Upgrade complete."
+    """
+    proc, _ = _invoke(
+        tmp_path,
+        {
+            "DEEPAGENTS_CODE_VERSION": "0.1.0",
+            "FAKE_UV_CREATE_LOCAL_DCODE": "1",
+            "FAKE_LOCAL_DCODE_VERSION": "0.1.0",
+        },
+        installed_version="0.1.19",
+        latest_version="0.1.19",
+    )
+
+    assert proc.returncode == 0
+    assert "Upgrade complete" not in proc.stdout
+    assert "✔ Setup complete. Run: dcode" in proc.stdout
 
 
 def test_install_script_fresh_install_footer_says_setup_complete(
@@ -1202,7 +1259,47 @@ def test_install_script_fresh_install_footer_says_setup_complete(
 
 
 def test_install_script_upgrade_prints_full_log_pointer(tmp_path: Path) -> None:
-    """Every run surfaces the persistent uv log, not just failures/dep bumps."""
+    """A successful upgrade surfaces the persistent uv log, not just failures."""
+    proc, _ = _invoke(
+        tmp_path,
+        {"FAKE_UV_INSTALL_STDERR": _UPGRADE_DIFF},
+        installed_version="0.1.18",
+        latest_version="0.1.19",
+    )
+
+    assert proc.returncode == 0
+    assert "Full log: ~/.cache/deepagents-code/install.log" in proc.stdout
+
+
+def test_install_script_dependency_bump_prints_log_pointer_once(
+    tmp_path: Path,
+) -> None:
+    """The dep-bump success line defers to `Full log:` instead of repeating it."""
+    proc, _ = _invoke(
+        tmp_path,
+        {"FAKE_UV_INSTALL_STDERR": _DEPENDENCY_UPDATE_DIFF},
+        installed_version="0.1.8",
+        latest_version="0.1.20",
+    )
+
+    assert proc.returncode == 0
+    assert "dependencies were updated." in proc.stdout
+    assert "Full log: ~/.cache/deepagents-code/install.log" in proc.stdout
+    # The success line used to carry its own `Details:` copy of the same path,
+    # printing it twice on consecutive lines.
+    assert "Details:" not in proc.stdout
+    assert proc.stdout.count("~/.cache/deepagents-code/install.log") == 1
+
+
+def test_install_script_omits_log_pointer_when_uv_wrote_nothing(
+    tmp_path: Path,
+) -> None:
+    """An empty log is a dead end — don't send the user to a zero-byte file.
+
+    uv writes nothing to stderr on a clean reinstall, so the log file exists but
+    holds nothing. The pointer is guarded on the file's size rather than on the
+    display name being set.
+    """
     proc, _ = _invoke(
         tmp_path,
         {},
@@ -1211,7 +1308,7 @@ def test_install_script_upgrade_prints_full_log_pointer(tmp_path: Path) -> None:
     )
 
     assert proc.returncode == 0
-    assert "Full log: ~/.cache/deepagents-code/install.log" in proc.stdout
+    assert "Full log:" not in proc.stdout
 
 
 def test_install_script_warns_when_upgrade_drops_receipt_extras(tmp_path: Path) -> None:
@@ -1233,7 +1330,7 @@ def test_install_script_warns_when_upgrade_drops_receipt_extras(tmp_path: Path) 
 
     assert proc.returncode == 0
     assert (
-        "This install has extras that a bare upgrade will remove: anthropic,openai"
+        "This install has extras that a bare re-run will remove: anthropic,openai"
         in proc.stderr
     )
     assert (
@@ -1254,7 +1351,124 @@ def test_install_script_no_extras_warning_when_receipt_has_none(tmp_path: Path) 
     )
 
     assert proc.returncode == 0
-    assert "extras that a bare upgrade will remove" not in proc.stderr
+    assert "extras that a bare re-run will remove" not in proc.stderr
+
+
+def test_install_script_extras_ignores_supplemental_with_packages(
+    tmp_path: Path,
+) -> None:
+    """A `--with rich[jupyter]` entry is not reported as a deepagents-code extra.
+
+    uv records `--with` requirements in the same `requirements` array as the
+    tool. Suggesting `DEEPAGENTS_CODE_EXTRAS="jupyter"` would resolve to
+    `deepagents-code[jupyter]` — an extra that does not exist — while still
+    dropping the supplemental package, so the parse must be scoped to the
+    `deepagents-code` entry.
+    """
+    _write_uv_receipt(
+        tmp_path / "tools", ["anthropic"], with_packages={"rich": ["jupyter"]}
+    )
+
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert (
+        "This install has extras that a bare re-run will remove: anthropic"
+        in proc.stderr
+    )
+    assert "jupyter" not in proc.stderr
+
+
+def test_install_script_no_extras_warning_when_only_with_package_has_extras(
+    tmp_path: Path,
+) -> None:
+    """A supplemental package's extras alone must not trigger the warning."""
+    _write_uv_receipt(tmp_path / "tools", [], with_packages={"rich": ["jupyter"]})
+
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "extras that a bare re-run will remove" not in proc.stderr
+    assert "Could not read" not in proc.stderr
+
+
+def test_install_script_warns_when_receipt_is_unparseable(tmp_path: Path) -> None:
+    """A receipt uv wrapped across lines warns instead of degrading to silence.
+
+    uv currently keeps each requirement's inline table on one line. If a future
+    formatter wraps it, the extras are unreadable — but the rebuild still drops
+    them, so "couldn't tell" must not be reported the same way as "none".
+    """
+    receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+    receipt.write_text(
+        '[tool]\nrequirements = [\n    { name = "deepagents-code", extras = [\n'
+        '        "anthropic",\n    ] },\n]\n'
+    )
+
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "Could not read" in proc.stderr
+    assert "re-run with the same value" in proc.stderr
+
+
+def test_install_script_warns_when_receipt_is_symlinked(tmp_path: Path) -> None:
+    """A symlinked receipt is refused, but the refusal is announced.
+
+    Reading through the symlink is the security problem; staying quiet about it
+    is the usability one — the run still rebuilds and still drops the extras.
+    """
+    receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+    target = tmp_path / "elsewhere-receipt.toml"
+    target.write_text(receipt.read_text())
+    receipt.unlink()
+    receipt.symlink_to(target)
+
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "Could not read" in proc.stderr
+    assert "extras that a bare re-run will remove" not in proc.stderr
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permissions")
+def test_install_script_warns_when_receipt_is_unreadable(tmp_path: Path) -> None:
+    """An unreadable receipt (e.g. written by a prior `sudo` run) warns."""
+    receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+    receipt.chmod(0o000)
+
+    try:
+        proc, _ = _invoke(
+            tmp_path,
+            {},
+            installed_version="0.1.0",
+            latest_version="0.2.0",
+        )
+    finally:
+        receipt.chmod(0o644)
+
+    assert proc.returncode == 0
+    assert "Could not read" in proc.stderr
 
 
 def test_install_script_no_extras_warning_when_receipt_missing(tmp_path: Path) -> None:
@@ -1267,7 +1481,7 @@ def test_install_script_no_extras_warning_when_receipt_missing(tmp_path: Path) -
     )
 
     assert proc.returncode == 0
-    assert "extras that a bare upgrade will remove" not in proc.stderr
+    assert "extras that a bare re-run will remove" not in proc.stderr
 
 
 def test_install_script_no_extras_warning_when_extras_explicit(tmp_path: Path) -> None:
@@ -1282,7 +1496,7 @@ def test_install_script_no_extras_warning_when_extras_explicit(tmp_path: Path) -
     )
 
     assert proc.returncode == 0
-    assert "extras that a bare upgrade will remove" not in proc.stderr
+    assert "extras that a bare re-run will remove" not in proc.stderr
 
 
 def test_install_script_extras_interrupt_decline_aborts_before_uv(
@@ -1306,7 +1520,7 @@ def test_install_script_extras_interrupt_decline_aborts_before_uv(
 
     assert code == 0
     assert "Continue anyway and remove them?" in output
-    assert "Aborted. No changes made." in output
+    assert "Aborted. deepagents-code was left unchanged." in output
     assert not args_path.exists()
 
 
@@ -1324,9 +1538,37 @@ def test_install_script_extras_interrupt_accept_proceeds(tmp_path: Path) -> None
 
     assert code == 0
     assert "Continue anyway and remove them?" in output
-    assert "Aborted. No changes made." not in output
+    assert "Aborted. deepagents-code was left unchanged." not in output
     args = args_path.read_text().splitlines()
     assert args[:3] == ["tool", "install", "-U"]
+
+
+def test_install_script_extras_assume_yes_skips_interrupt_with_tty(
+    tmp_path: Path,
+) -> None:
+    """`DEEPAGENTS_CODE_YES=1` skips the extras prompt even on an attached TTY.
+
+    The non-pty sibling below can't prove this: without a TTY `can_prompt` is
+    already false, so it passes whether or not the `ASSUME_YES` half of the
+    guard exists. A terminal *and* a pre-answered yes (tmux, `docker run -t`, a
+    CI runner that allocates a pty) is the combination where dropping that half
+    would hang the run forever. No answers are fed, so a prompt would block
+    until `_invoke_interactive`'s timeout.
+    """
+    _write_uv_receipt(tmp_path / "tools", ["anthropic", "openai"])
+
+    code, output, args_path = _invoke_interactive(
+        tmp_path,
+        {"DEEPAGENTS_CODE_YES": "1"},
+        answer=[],
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert code == 0
+    assert "extras that a bare re-run will remove" in output
+    assert "Continue anyway and remove them?" not in output
+    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
 
 
 def test_install_script_extras_assume_yes_skips_interrupt(tmp_path: Path) -> None:
@@ -1341,8 +1583,8 @@ def test_install_script_extras_assume_yes_skips_interrupt(tmp_path: Path) -> Non
     )
 
     assert proc.returncode == 0
-    assert "extras that a bare upgrade will remove" in proc.stderr
-    assert "Aborted. No changes made." not in proc.stderr
+    assert "extras that a bare re-run will remove" in proc.stderr
+    assert "Aborted. deepagents-code was left unchanged." not in proc.stderr
     assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
 
 
@@ -1370,7 +1612,7 @@ def test_install_script_refuses_symlinked_log_file(tmp_path: Path) -> None:
         "deepagents-code 0.1.8 was already up to date; dependencies were updated."
         in proc.stdout
     )
-    assert "Details:" not in proc.stdout
+    assert "Full log:" not in proc.stdout
     assert target.read_text() == "keep me\n"
 
 
@@ -1395,9 +1637,9 @@ def test_install_script_unset_xdg_cache_home_falls_back_to_home_cache(
 
     assert proc.returncode == 0
     assert (
-        "deepagents-code 0.1.8 was already up to date; dependencies were updated. "
-        "Details: ~/.cache/deepagents-code/install.log"
+        "deepagents-code 0.1.8 was already up to date; dependencies were updated."
     ) in proc.stdout
+    assert "Full log: ~/.cache/deepagents-code/install.log" in proc.stdout
     assert (tmp_path / "home/.cache/deepagents-code/install.log").read_text() == (
         f"{_DEPENDENCY_UPDATE_DIFF}\n"
     )
@@ -1407,7 +1649,7 @@ def test_install_script_log_path_outside_home_stays_absolute(tmp_path: Path) -> 
     """A log path outside `$HOME` is shown verbatim, not tilde-collapsed.
 
     The `~` collapse only fires for paths under `$HOME`; an `XDG_CACHE_HOME`
-    elsewhere must surface the absolute path in the `Details:` suffix.
+    elsewhere must surface the absolute path in the `Full log:` pointer.
     """
     external = tmp_path / "external-cache"
 
@@ -1423,8 +1665,8 @@ def test_install_script_log_path_outside_home_stays_absolute(tmp_path: Path) -> 
 
     assert proc.returncode == 0
     expected_log = external / "deepagents-code" / "install.log"
-    assert f"Details: {expected_log}" in proc.stdout
-    assert "Details: ~/" not in proc.stdout
+    assert f"Full log: {expected_log}" in proc.stdout
+    assert "Full log: ~/" not in proc.stdout
     assert expected_log.read_text() == f"{_DEPENDENCY_UPDATE_DIFF}\n"
 
 

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1677,6 +1677,43 @@ def test_install_script_warns_when_receipt_is_absent(tmp_path: Path) -> None:
     assert "re-run with the same value" in proc.stderr
 
 
+def test_install_script_warns_when_receipt_read_races(tmp_path: Path) -> None:
+    """A receipt removed after preflight checks does not abort the installer."""
+    receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+    env = _env(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+    sed = tmp_path / "bin" / "sed"
+    sed.write_text(
+        f"""#!/usr/bin/env bash
+for argument in "$@"; do
+  if [ "$argument" = {str(receipt)!r} ]; then
+    exit 1
+  fi
+done
+exec /usr/bin/sed "$@"
+"""
+    )
+    _make_executable(sed)
+
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    assert proc.returncode == 0
+    assert "Could not read" in proc.stderr
+    assert (tmp_path / "uv-args.txt").is_file()
+
+
 @pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses directory permissions")
 def test_install_script_warns_when_tool_dir_is_unsearchable(tmp_path: Path) -> None:
     """A tool dir left root-owned and 0700 by a prior sudo run must warn.

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1990,7 +1990,9 @@ def _run_copy_install_log(
     harness.write_text(
         "set -uo pipefail\n"
         "TEMP_FILES=()\n"
+        "TEMP_DIRS=()\n"
         'register_temp() { TEMP_FILES+=("$1"); }\n'
+        'register_temp_dir() { TEMP_DIRS+=("$1"); }\n'
         f"{_extract_shell_function('path_is_under_home')}\n"
         f"{_extract_shell_function('copy_install_log')}\n"
         f"HOME={str(home)!r}\n"
@@ -2058,7 +2060,8 @@ def test_copy_install_log_replaces_symlink_planted_during_the_race(
 
     The `-L` guard runs before staging, so it cannot cover a link planted after
     it. Privileged publication unlinks that directory entry and atomically
-    creates a hard link instead, so the attacker's target remains untouched.
+    creates a new regular file instead, so the attacker's target remains
+    untouched.
     """
     outside = tmp_path / "outside.txt"
     outside.write_text("do not clobber\n")
@@ -2138,6 +2141,33 @@ def test_copy_install_log_refuses_directory_target(tmp_path: Path) -> None:
     assert published.is_dir()
     assert list(published.glob(".install.log.*")) == []
     assert list(log_dir.glob(".install.log.*")) == []
+
+
+def test_copy_install_log_rejects_directory_created_during_publication(
+    tmp_path: Path,
+) -> None:
+    """A directory created after removal makes privileged publication fail.
+
+    `rm -f` does not remove directories. The noclobber redirection must reject
+    one that appears after removal rather than treating it as a destination and
+    publishing `install.log/install.log`.
+    """
+    rc, _log_dir, published = _run_copy_install_log(
+        tmp_path,
+        race_hook=(
+            'id() { printf "0\\n"; }\n'
+            "rm() {\n"
+            '  if [ "${1:-}" = "-f" ] && [ "${2:-}" = "install.log" ]; then\n'
+            '    command mkdir "install.log"\n'
+            "  fi\n"
+            '  command rm "$@"\n'
+            "}\n"
+        ),
+    )
+
+    assert rc == 2
+    assert published.is_dir()
+    assert not (published / "install.log").exists()
 
 
 def test_copy_install_log_cleans_up_staged_file_when_publish_fails(
@@ -3502,7 +3532,7 @@ def test_install_uv_downloads_via_busybox_wget(tmp_path: Path) -> None:
 
 
 def _run_signal_traps(
-    tmp_path: Path, *, interrupt: bool
+    tmp_path: Path, *, interrupt: bool, temp_dir: Path | None = None
 ) -> subprocess.CompletedProcess[str]:
     """Wire the real EXIT + INT/TERM traps from `install.sh` and trip one.
 
@@ -3514,14 +3544,26 @@ def _run_signal_traps(
     """
     script = tmp_path / "signal_trap_harness.sh"
     body = "kill -INT $$\nsleep 5\n" if interrupt else "exit 2\n"
+    setup = ""
+    if temp_dir is not None:
+        setup = (
+            f"mkdir -p {str(temp_dir)!r}\n"
+            f"printf 'stderr\\n' > {str(temp_dir / 'install.log')!r}\n"
+            f"register_temp_dir {str(temp_dir)!r}\n"
+        )
     script.write_text(
         "set -uo pipefail\n"
         'log_warn()  { printf "%s\\n" "$*" >&2; }\n'
         'log_error() { printf "%s\\n" "$*" >&2; }\n'
-        "cleanup_temp_files() { :; }\n"
         # cleanup_on_signal now calls these unconditionally; extract the real
         # implementations so the harness exercises shipped code without emitting
         # "command not found" noise (which would otherwise pass tests by luck).
+        "TEMP_FILES=()\n"
+        "TEMP_DIRS=()\n"
+        f"{_extract_shell_function('register_temp')}\n"
+        f"{_extract_shell_function('register_temp_dir')}\n"
+        f"{_extract_shell_function('cleanup_temp_files')}\n"
+        f"{_extract_shell_function('cleanup_temp_dirs')}\n"
         f"{_extract_shell_function('is_linux_os')}\n"
         f"{_extract_shell_function('restore_terminal_after_signal')}\n"
         f"{_extract_shell_function('log_signal_failure_hint')}\n"
@@ -3533,6 +3575,7 @@ def _run_signal_traps(
         "trap 'cleanup_on_interrupt 2' INT\n"
         "trap 'cleanup_on_interrupt 15' TERM\n"
         "trap 'cleanup_on_interrupt 1' HUP\n"
+        f"{setup}"
         f"{body}",
         encoding="utf-8",
     )
@@ -3572,6 +3615,16 @@ def test_interrupt_shows_notice_without_failure_message(tmp_path: Path) -> None:
     # The harness must define every helper cleanup_on_signal calls; a missing
     # one would still pass the asserts above but corrupt the exercised path.
     assert "command not found" not in stderr
+
+
+def test_interrupt_removes_registered_staging_directory(tmp_path: Path) -> None:
+    """An interrupted installer removes its registered log staging directory."""
+    stage_dir = tmp_path / "deepagents-code-install-log"
+
+    proc = _run_signal_traps(tmp_path, interrupt=True, temp_dir=stage_dir)
+
+    assert proc.returncode == 130
+    assert not stage_dir.exists()
 
 
 def test_exit_trap_reports_failure_on_ordinary_error(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1971,6 +1971,8 @@ def _run_copy_install_log(
         "TEMP_FILES=()\n"
         'register_temp() { TEMP_FILES+=("$1"); }\n'
         f"{_extract_shell_function('path_is_under_home')}\n"
+        f"{_extract_shell_function('path_device')}\n"
+        f"{_extract_shell_function('paths_share_filesystem')}\n"
         f"{_extract_shell_function('copy_install_log')}\n"
         f"HOME={str(home)!r}\n"
         f"install_log_dir={str(install_log_dir)!r}\n"
@@ -2030,16 +2032,35 @@ def test_copy_install_log_stages_outside_user_writable_log_dir(
     assert published.read_text() == "captured uv stderr\n"
 
 
+def test_copy_install_log_skips_privileged_cross_device_publication(
+    tmp_path: Path,
+) -> None:
+    """A root install never lets `mv` fall back to a symlink-following copy."""
+    rc, _log_dir, published = _run_copy_install_log(
+        tmp_path,
+        race_hook=(
+            'id() { printf "0\\n"; }\n'
+            "path_device() {\n"
+            '  case "$1" in\n'
+            '    "$install_log_dir") printf "destination\\n" ;;\n'
+            '    *) printf "staging\\n" ;;\n'
+            "  esac\n"
+            "}\n"
+        ),
+    )
+
+    assert rc == 1
+    assert not published.exists()
+
+
 def test_copy_install_log_replaces_symlink_planted_during_the_race(
     tmp_path: Path,
 ) -> None:
     """A symlink planted at the publish path is replaced, never written through.
 
-    This is the property that made the implementation switch from `ln` to a
-    same-directory `mv`. The `-L` guard runs before staging, so it cannot cover
-    a link planted after it — only `rename(2)` swapping the directory entry
-    can. Plant the link in the race window and assert the attacker's target is
-    untouched.
+    The `-L` guard runs before staging, so it cannot cover a link planted after
+    it. Privileged publication unlinks that directory entry and atomically
+    creates a hard link instead, so the attacker's target remains untouched.
     """
     outside = tmp_path / "outside.txt"
     outside.write_text("do not clobber\n")
@@ -2101,11 +2122,11 @@ def test_copy_install_log_cleans_up_staged_file_when_publish_fails(
     The staged file holds the full captured stderr, so an orphan is both litter
     and a disclosure; repeated failures would accumulate them.
     """
-    # Fail the rename itself, leaving the staged file in place for the cleanup
-    # to find. Contriving a filesystem state that breaks `mv` is unreliable —
-    # `mv file dir/` moves *into* the directory rather than failing.
+    # Fail the root-safe hard-link publication itself, leaving the staged file
+    # in place for the cleanup to find. Contriving a filesystem state that
+    # breaks `ln` is unreliable.
     rc, log_dir, published = _run_copy_install_log(
-        tmp_path, race_hook="mv() { return 1; }\n"
+        tmp_path, race_hook='id() { printf "0\\n"; }\nln() { return 1; }\n'
     )
 
     assert rc == 2

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1696,13 +1696,19 @@ def test_install_script_refuses_symlinked_log_file(tmp_path: Path) -> None:
     assert target.read_text() == "keep me\n"
 
 
-def test_install_script_stages_log_copy_outside_user_cache() -> None:
-    """The cross-filesystem fallback stages logs in a root-owned temp directory."""
+def test_install_script_stages_log_copy_inside_log_dir() -> None:
+    """The log copy is staged inside the log dir so the publish is a rename.
+
+    A cross-filesystem `mv` degrades to copy+unlink, which opens the
+    destination path and follows symlinks planted there; staging under a
+    mktemp name inside `install_log_dir` keeps the publish an atomic rename
+    that replaces a planted symlink instead of following it.
+    """
     script = SCRIPT.read_text()
 
-    assert "mktemp -d /tmp/deepagents-code-install-log.XXXXXX" in script
-    assert 'staged="${staging_dir}/install.log"' in script
-    assert 'local staged="${INSTALL_LOG}.$$"' not in script
+    assert 'staged=$(mktemp "${install_log_dir}/.install.log.XXXXXX"' in script
+    assert "mktemp -d /tmp/deepagents-code-install-log.XXXXXX" not in script
+    assert 'staged="${INSTALL_LOG}.$$"' not in script
 
 
 def test_install_script_unset_xdg_cache_home_falls_back_to_home_cache(

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -815,6 +815,28 @@ def test_install_script_prompt_read_failure_continues_update(
     assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
 
 
+def test_install_script_attached_tty_read_failure_continues_update(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An EOF on an attached terminal must not be treated as declining."""
+    script = tmp_path / "install.sh"
+    source = SCRIPT.read_text(encoding="utf-8").replace(
+        "    if ! read -r reply; then\n", "    if ! false; then\n", 1
+    )
+    script.write_text(source, encoding="utf-8")
+    _make_executable(script)
+    monkeypatch.setitem(globals(), "SCRIPT", script)
+
+    code, output, args_path = _invoke_interactive(
+        tmp_path, {}, answer="n", installed_version="0.1.0", latest_version="0.2.0"
+    )
+
+    assert code == 0
+    assert "Could not read from terminal — skipping prompt." in output
+    assert "Keeping deepagents-code 0.1.0" not in output
+    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
+
+
 def test_install_script_interactive_accept_updates(tmp_path: Path) -> None:
     """Answering 'y' to the update prompt runs `uv tool install -U`."""
     code, output, args_path = _invoke_interactive(
@@ -2168,6 +2190,20 @@ def test_copy_install_log_rejects_directory_created_during_publication(
     assert rc == 2
     assert published.is_dir()
     assert not (published / "install.log").exists()
+
+
+def test_copy_install_log_rejects_directory_created_before_nonroot_move(
+    tmp_path: Path,
+) -> None:
+    """A non-root `mv` into a raced directory must not report success."""
+    rc, _log_dir, published = _run_copy_install_log(
+        tmp_path,
+        race_hook=('mv() {\n  command mkdir "$INSTALL_LOG"\n  command mv "$@"\n}\n'),
+    )
+
+    assert rc != 0
+    assert published.is_dir()
+    assert (published / "install.log").read_text() == "captured uv stderr\n"
 
 
 def test_copy_install_log_cleans_up_staged_file_when_publish_fails(

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -788,6 +788,33 @@ def test_install_script_interactive_decline_keeps_current(tmp_path: Path) -> Non
     assert "Keeping deepagents-code 0.1.0" in output
 
 
+def test_install_script_prompt_read_failure_continues_update(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A prompt that becomes unreadable after probing must not decline the update."""
+    script = tmp_path / "install.sh"
+    source = SCRIPT.read_text(encoding="utf-8")
+    source = source.replace(
+        _extract_shell_function("can_prompt"),
+        "can_prompt() {\n  return 0\n}",
+    ).replace(
+        _extract_shell_function("prompt_yn"),
+        "prompt_yn() {\n  return 2\n}",
+    )
+    script.write_text(source, encoding="utf-8")
+    _make_executable(script)
+    monkeypatch.setitem(globals(), "SCRIPT", script)
+
+    proc, args_path = _invoke(
+        tmp_path, {}, installed_version="0.1.0", latest_version="0.2.0"
+    )
+
+    assert proc.returncode == 0
+    assert "Could not ask — continuing with the update." in proc.stderr
+    assert "Keeping deepagents-code 0.1.0" not in proc.stdout
+    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
+
+
 def test_install_script_interactive_accept_updates(tmp_path: Path) -> None:
     """Answering 'y' to the update prompt runs `uv tool install -U`."""
     code, output, args_path = _invoke_interactive(

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -2011,8 +2011,7 @@ def test_copy_install_log_refuses_publish_when_log_dir_is_swapped(
         race_hook=(
             "cp() {\n"
             '  command cp "$@"\n'
-            '  rm -f "$1" "$2"\n'
-            '  rmdir "$install_log_dir"\n'
+            '  mv "$install_log_dir" "${install_log_dir}.moved"\n'
             f'  ln -s {str(elsewhere)!r} "$install_log_dir"\n'
             "}\n"
         ),
@@ -2022,6 +2021,20 @@ def test_copy_install_log_refuses_publish_when_log_dir_is_swapped(
     assert not (elsewhere / "install.log").exists()
     assert log_dir.is_symlink()
     assert list(elsewhere.glob(".install.log.*")) == []
+
+
+def test_copy_install_log_refuses_directory_target(tmp_path: Path) -> None:
+    """A directory at the publication path is not treated as a successful move."""
+    log_dir = tmp_path / "home" / "cache"
+    log_dir.mkdir(parents=True)
+    (log_dir / "install.log").mkdir()
+
+    rc, _log_dir, published = _run_copy_install_log(tmp_path, log_dir=log_dir)
+
+    assert rc == 1
+    assert published.is_dir()
+    assert list(published.glob(".install.log.*")) == []
+    assert list(log_dir.glob(".install.log.*")) == []
 
 
 def test_copy_install_log_cleans_up_staged_file_when_publish_fails(

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -406,6 +406,16 @@ def test_install_script_supports_exact_version_with_extras(tmp_path: Path) -> No
     assert "--prerelease" not in args
 
 
+def test_install_script_accepts_pep_508_extra_name_characters(tmp_path: Path) -> None:
+    """Extras with underscores and dots can be reused from a uv receipt."""
+    args = _run_install_script(
+        tmp_path,
+        {"DEEPAGENTS_CODE_EXTRAS": "provider_name.provider"},
+    )
+
+    assert args[-1] == "deepagents-code[provider_name.provider]"
+
+
 def test_install_script_supports_exact_version_without_extras(tmp_path: Path) -> None:
     """The version spec appends directly to the package name when no extras."""
     args = _run_install_script(tmp_path, {"DEEPAGENTS_CODE_VERSION": "0.1.0rc1"})

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1155,7 +1155,10 @@ def test_install_script_refuses_symlinked_log_dir(tmp_path: Path) -> None:
 
 
 def _write_uv_receipt(
-    tools: Path, extras: list[str], *, with_packages: dict[str, list[str]] | None = None
+    tools: Path,
+    extras: list[str] | None,
+    *,
+    with_packages: dict[str, list[str]] | None = None,
 ) -> Path:
     """Stage a uv tool receipt recording the extras the install was built with.
 
@@ -1165,24 +1168,47 @@ def _write_uv_receipt(
     creates `tools` as a side effect, which is why `_write_fake_tools` tolerates
     a pre-existing `tools` — the two helpers may run in either order.
 
+    `extras=None` omits the `extras` key entirely, which is what uv actually
+    writes for an install that has none — the shape every ordinary user has.
+    Passing `[]` writes an explicit `extras = []` instead; both are exercised,
+    since a parser can easily handle one and not the other.
+
     `with_packages` maps supplemental `uv tool install --with` package names to
     their own extras. uv records these in the *same* `requirements` array as the
     tool itself, so a receipt with them is what distinguishes a parser scoped to
     the `deepagents-code` entry from one that grabs any `extras = [...]`.
 
+    The `entrypoints` array is always emitted, and always includes the console
+    script literally named `deepagents-code` that this package declares. That
+    inline table's `name` matches the same pattern the requirements entry does
+    but never carries extras, so omitting it from the fixture would hide a
+    parser that matches it instead of the real requirement.
+
     Returns the receipt path so tests can mangle its permissions or contents.
     """
     receipt_dir = tools / "deepagents-code"
     receipt_dir.mkdir(parents=True, exist_ok=True)
-    quoted = ", ".join(f'"{extra}"' for extra in extras)
-    entries = [
-        f'{{ name = "deepagents-code", extras = [{quoted}], specifier = "==0.1.0" }}'
-    ]
+    if extras is None:
+        entries = ['{ name = "deepagents-code", specifier = "==0.1.0" }']
+    else:
+        quoted = ", ".join(f'"{extra}"' for extra in extras)
+        entry = f'{{ name = "deepagents-code", extras = [{quoted}], '
+        entries = [entry + 'specifier = "==0.1.0" }']
     for name, pkg_extras in (with_packages or {}).items():
         pkg_quoted = ", ".join(f'"{extra}"' for extra in pkg_extras)
         entries.append(f'{{ name = "{name}", extras = [{pkg_quoted}] }}')
     receipt = receipt_dir / "uv-receipt.toml"
-    receipt.write_text("[tool]\nrequirements = [" + ", ".join(entries) + "]\n")
+    receipt.write_text(
+        "[tool]\n"
+        "requirements = [" + ", ".join(entries) + "]\n"
+        'python = "3.13"\n'
+        "entrypoints = [\n"
+        '    { name = "dcode", install-path = "/h/bin/dcode",'
+        ' from = "deepagents-code" },\n'
+        '    { name = "deepagents-code",'
+        ' install-path = "/h/bin/deepagents-code", from = "deepagents-code" },\n'
+        "]\n"
+    )
     return receipt
 
 
@@ -1222,6 +1248,33 @@ def test_install_script_pinned_downgrade_footer_is_not_upgrade(tmp_path: Path) -
         },
         installed_version="0.1.19",
         latest_version="0.1.19",
+    )
+
+    assert proc.returncode == 0
+    assert "Upgrade complete" not in proc.stdout
+    assert "✔ Setup complete. Run: dcode" in proc.stdout
+
+
+def test_install_script_prerelease_downgrade_footer_is_not_upgrade(
+    tmp_path: Path,
+) -> None:
+    """An explicit prerelease strategy must not claim an upgrade either.
+
+    The version pin is not the only way an unpinned-looking run moves backwards.
+    `DEEPAGENTS_CODE_PRERELEASE=disallow` over an installed `0.2.0rc1` resolves
+    to the latest *stable*, which can be older than what is there — so the
+    footer's "resolution always picks the newest candidate" assumption only
+    holds when no prerelease strategy was requested.
+    """
+    proc, _ = _invoke(
+        tmp_path,
+        {
+            "DEEPAGENTS_CODE_PRERELEASE": "disallow",
+            "FAKE_UV_CREATE_LOCAL_DCODE": "1",
+            "FAKE_LOCAL_DCODE_VERSION": "0.1.9",
+        },
+        installed_version="0.2.0rc1",
+        latest_version="0.1.9",
     )
 
     assert proc.returncode == 0
@@ -1408,11 +1461,25 @@ def test_install_script_warns_when_receipt_is_unparseable(tmp_path: Path) -> Non
     uv currently keeps each requirement's inline table on one line. If a future
     formatter wraps it, the extras are unreadable — but the rebuild still drops
     them, so "couldn't tell" must not be reported the same way as "none".
+
+    The `entrypoints` array is the trap here, and it is why this receipt is
+    written out in full rather than mangling only the requirements line. uv
+    records one entry per console script, and this package declares one named
+    `deepagents-code` — an inline table that matches the requirement pattern on
+    a single line but carries no extras. A parser that isn't scoped to the
+    `requirements` assignment matches it once the real requirement wraps, reads
+    "no extras" off it, and drops the user's packages in total silence.
     """
     receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
     receipt.write_text(
-        '[tool]\nrequirements = [\n    { name = "deepagents-code", extras = [\n'
+        "[tool]\n"
+        'requirements = [\n    { name = "deepagents-code", extras = [\n'
         '        "anthropic",\n    ] },\n]\n'
+        'python = "3.13"\n'
+        "entrypoints = [\n"
+        '    { name = "deepagents-code",'
+        ' install-path = "/h/bin/deepagents-code", from = "deepagents-code" },\n'
+        "]\n"
     )
 
     proc, _ = _invoke(
@@ -1456,6 +1523,125 @@ def test_install_script_receipt_extras_with_metacharacters_warns(
     assert "DEEPAGENTS_CODE_EXTRAS=" not in proc.stderr
     assert "$(touch" not in proc.stderr
     assert not Path("/tmp/pwned").exists()
+
+
+def test_install_script_no_extras_warning_when_receipt_omits_extras_key(
+    tmp_path: Path,
+) -> None:
+    """The receipt shape uv writes for a plain install stays silent.
+
+    uv omits the `extras` key entirely rather than writing `extras = []`, so
+    this — not the explicit-empty form — is the receipt every ordinary user
+    has. A parser that only recognises the explicit form would fall through to
+    the unreadable branch and warn on every single re-run.
+    """
+    _write_uv_receipt(tmp_path / "tools", None)
+
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "extras that a bare re-run will remove" not in proc.stderr
+    assert "Could not read" not in proc.stderr
+
+
+def test_install_script_warns_when_receipt_is_absent(tmp_path: Path) -> None:
+    """An install with no receipt at all is "couldn't tell", not "no extras".
+
+    uv predating `uv-receipt.toml`, a future relocation of the file, or a
+    partially-deleted tool dir all leave the install present but unexplained.
+    Treating that as extras-free drops the packages silently — the exact
+    outcome the warning exists to prevent.
+    """
+    (tmp_path / "tools" / "deepagents-code").mkdir(parents=True, exist_ok=True)
+
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "Could not read" in proc.stderr
+    assert "re-run with the same value" in proc.stderr
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses directory permissions")
+def test_install_script_warns_when_tool_dir_is_unsearchable(tmp_path: Path) -> None:
+    """A tool dir left root-owned and 0700 by a prior sudo run must warn.
+
+    This is the common shape of the sudo-then-user case (a root umask of 077
+    produces it), and it defeats every test on the receipt file itself: `-f`
+    reports false through an unsearchable parent, which is indistinguishable
+    from an absent receipt and, without a directory check, from no extras.
+    """
+    receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+    install_dir = receipt.parent
+    install_dir.chmod(0o000)
+    try:
+        proc, _ = _invoke(
+            tmp_path,
+            {},
+            installed_version="0.1.0",
+            latest_version="0.2.0",
+        )
+    finally:
+        install_dir.chmod(0o755)
+
+    assert proc.returncode == 0
+    assert "Could not read" in proc.stderr
+    assert "re-run with the same value" in proc.stderr
+
+
+def test_install_script_extras_without_tty_proceeds_with_install(
+    tmp_path: Path,
+) -> None:
+    """With no TTY the extras warning is printed and the install still runs.
+
+    `prompt_yn` returns non-zero whenever it cannot ask, so a guard that lost
+    its `can_prompt` half would read "nobody can answer" as "the user said no"
+    and turn every CI job, Dockerfile, and piped `curl | bash` upgrade of an
+    extras install into a silent no-op that still exits 0. Asserting the exit
+    code alone cannot see that: abort and proceed both return 0. Assert uv was
+    actually invoked.
+    """
+    _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+
+    proc, args_path = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "extras that a bare re-run will remove: anthropic" in proc.stderr
+    assert "Aborted." not in proc.stdout
+    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
+
+
+def test_install_script_unreadable_receipt_without_tty_proceeds_with_install(
+    tmp_path: Path,
+) -> None:
+    """The unreadable-receipt branch must also proceed when it cannot ask."""
+    (tmp_path / "tools" / "deepagents-code").mkdir(parents=True, exist_ok=True)
+
+    proc, args_path = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "Could not read" in proc.stderr
+    assert "Aborted." not in proc.stdout
+    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
 
 
 def test_install_script_warns_when_receipt_is_symlinked(tmp_path: Path) -> None:
@@ -1727,19 +1913,204 @@ def test_install_script_refuses_symlinked_log_file(tmp_path: Path) -> None:
     assert target.read_text() == "keep me\n"
 
 
-def test_install_script_stages_log_copy_inside_log_dir() -> None:
-    """The log copy is staged inside the log dir so the publish is a rename.
+def _run_copy_install_log(
+    tmp_path: Path, *, race_hook: str = "", log_dir: Path | None = None
+) -> tuple[int, Path, Path]:
+    """Run the real `copy_install_log` from `install.sh` in isolation.
 
-    A cross-filesystem `mv` degrades to copy+unlink, which opens the
-    destination path and follows symlinks planted there; staging under a
-    mktemp name inside `install_log_dir` keeps the publish an atomic rename
-    that replaces a planted symlink instead of following it.
+    Whole-script runs cannot reach most of this function: the only way they can
+    make the publish fail is by making the log dir unwritable, which fails at
+    the very first `mktemp` and leaves the staging, re-validation, and rename
+    paths unexercised. Driving the function directly lets a test stand in the
+    race window instead.
+
+    `race_hook` is shell injected as a `cp` override, so it runs *after* the
+    staged file exists and *before* the rename — exactly where an attacker who
+    owns the log dir would act. It must copy the file itself (`command cp`) if
+    it wants the publish to get that far.
+
+    Returns the function's exit status, the log dir, and the publish path.
     """
-    script = SCRIPT.read_text()
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    install_log_dir = log_dir if log_dir is not None else home / "cache"
+    install_log_dir.mkdir(parents=True, exist_ok=True)
+    source = tmp_path / "uv-stderr.txt"
+    source.write_text("captured uv stderr\n")
 
-    assert 'staged=$(mktemp "${install_log_dir}/.install.log.XXXXXX"' in script
-    assert "mktemp -d /tmp/deepagents-code-install-log.XXXXXX" not in script
-    assert 'staged="${INSTALL_LOG}.$$"' not in script
+    harness = tmp_path / "copy_install_log_harness.sh"
+    harness.write_text(
+        "set -uo pipefail\n"
+        "TEMP_FILES=()\n"
+        'register_temp() { TEMP_FILES+=("$1"); }\n'
+        f"{_extract_shell_function('path_is_under_home')}\n"
+        f"{_extract_shell_function('copy_install_log')}\n"
+        f"HOME={str(home)!r}\n"
+        f"install_log_dir={str(install_log_dir)!r}\n"
+        # `${install_log_dir}` below is shell, not a Python f-string.
+        'INSTALL_LOG="${install_log_dir}/install.log"\n'  # noqa: RUF027
+        f"uv_stderr={str(source)!r}\n"
+        f"{race_hook}\n"
+        "copy_install_log\n"
+        'printf "rc=%s\\n" "$?"\n'
+    )
+    proc = subprocess.run(
+        ["bash", str(harness)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    match = re.search(r"rc=(\d+)", proc.stdout)
+    assert match is not None, f"harness produced no status: {proc.stdout!r}"
+    return int(match.group(1)), install_log_dir, install_log_dir / "install.log"
+
+
+def test_copy_install_log_publishes_captured_stderr(tmp_path: Path) -> None:
+    """The happy path publishes the content and leaves no staged file behind."""
+    rc, log_dir, published = _run_copy_install_log(tmp_path)
+
+    assert rc == 0
+    assert published.read_text() == "captured uv stderr\n"
+    assert list(log_dir.glob(".install.log.*")) == []
+
+
+def test_copy_install_log_replaces_symlink_planted_during_the_race(
+    tmp_path: Path,
+) -> None:
+    """A symlink planted at the publish path is replaced, never written through.
+
+    This is the property that made the implementation switch from `ln` to a
+    same-directory `mv`. The `-L` guard runs before staging, so it cannot cover
+    a link planted after it — only `rename(2)` swapping the directory entry
+    can. Plant the link in the race window and assert the attacker's target is
+    untouched.
+    """
+    outside = tmp_path / "outside.txt"
+    outside.write_text("do not clobber\n")
+    rc, _log_dir, published = _run_copy_install_log(
+        tmp_path,
+        race_hook=(
+            f'cp() {{\n  command cp "$@"\n  ln -s {str(outside)!r} "$INSTALL_LOG"\n}}\n'
+        ),
+    )
+
+    assert rc == 0
+    assert outside.read_text() == "do not clobber\n"
+    assert not published.is_symlink()
+    assert published.read_text() == "captured uv stderr\n"
+
+
+def test_copy_install_log_refuses_publish_when_log_dir_is_swapped(
+    tmp_path: Path,
+) -> None:
+    """Swapping the log dir for a symlink mid-run must not publish through it."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    rc, log_dir, _published = _run_copy_install_log(
+        tmp_path,
+        race_hook=(
+            "cp() {\n"
+            '  command cp "$@"\n'
+            '  rm -f "$1" "$2"\n'
+            '  rmdir "$install_log_dir"\n'
+            f'  ln -s {str(elsewhere)!r} "$install_log_dir"\n'
+            "}\n"
+        ),
+    )
+
+    assert rc != 0
+    assert not (elsewhere / "install.log").exists()
+    assert log_dir.is_symlink()
+    assert list(elsewhere.glob(".install.log.*")) == []
+
+
+def test_copy_install_log_cleans_up_staged_file_when_publish_fails(
+    tmp_path: Path,
+) -> None:
+    """A failed publish leaves no staged copy of uv's stderr in the log dir.
+
+    The staged file holds the full captured stderr, so an orphan is both litter
+    and a disclosure; repeated failures would accumulate them.
+    """
+    # Fail the rename itself, leaving the staged file in place for the cleanup
+    # to find. Contriving a filesystem state that breaks `mv` is unreliable —
+    # `mv file dir/` moves *into* the directory rather than failing.
+    rc, log_dir, published = _run_copy_install_log(
+        tmp_path, race_hook="mv() { return 1; }\n"
+    )
+
+    assert rc == 2
+    assert list(log_dir.glob(".install.log.*")) == []
+    assert not published.exists()
+
+
+def test_copy_install_log_reports_operational_failure_distinctly(
+    tmp_path: Path,
+) -> None:
+    """Failures the user can act on return 2; rejected paths return 1.
+
+    The caller only warns on 2. Collapsing the two would either go silent on a
+    full disk and a root-owned cache dir — leaving a `curl | bash` user with no
+    log and no reason why — or cry wolf on every hostile path it correctly
+    refused.
+    """
+    # A read-only log dir: staging cannot be created. Operational → 2.
+    readonly_dir = tmp_path / "home" / "readonly"
+    readonly_dir.mkdir(parents=True)
+    readonly_dir.chmod(0o500)
+    try:
+        rc_operational, _, _ = _run_copy_install_log(tmp_path, log_dir=readonly_dir)
+    finally:
+        readonly_dir.chmod(0o755)
+
+    # A symlinked log dir is refused outright, and the user cannot act on it.
+    rc_rejected, _, _ = _run_copy_install_log(
+        tmp_path,
+        race_hook=(
+            "cp() {\n"
+            '  command cp "$@"\n'
+            '  rm -f "$1" "$2"\n'
+            '  rmdir "$install_log_dir"\n'
+            f'  ln -s {str(tmp_path / "swap")!r} "$install_log_dir"\n'
+            "}\n"
+        ),
+    )
+
+    assert rc_operational == 2
+    assert rc_rejected == 1
+
+
+def test_install_script_warns_when_the_install_log_cannot_be_written(
+    tmp_path: Path,
+) -> None:
+    """An unwritable cache dir is reported, not silently dropped.
+
+    `prepare_install_log_dir` only checks that the path is a real directory, so
+    one left root-owned by an earlier sudo run passes and the failure surfaces
+    later at staging. Without a warning the user cannot tell a run that logged
+    nothing from one whose logging broke.
+    """
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    log_dir = cache / "deepagents-code"
+    log_dir.mkdir()
+    log_dir.chmod(0o500)
+    try:
+        proc, _ = _invoke(
+            tmp_path,
+            {
+                "XDG_CACHE_HOME": str(cache),
+                "FAKE_UV_INSTALL_STDERR": _UPGRADE_DIFF,
+            },
+            installed_version="0.1.0",
+            latest_version="0.2.0",
+        )
+    finally:
+        log_dir.chmod(0o755)
+
+    assert proc.returncode == 0
+    assert "Could not write the install log" in proc.stderr
+    assert "Full log:" not in proc.stdout
 
 
 def test_install_script_unset_xdg_cache_home_falls_back_to_home_cache(

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -258,15 +258,16 @@ def _invoke_interactive(
     tmp_path: Path,
     extra_env: dict[str, str],
     *,
-    answer: str,
+    answer: str | list[str],
     installed_version: str | None = "0.0.1",
     latest_version: str | None = None,
 ) -> tuple[int, str, Path]:
     """Run `install.sh` with a pty stdin and feed `answer` to its prompt.
 
     A pty makes `[ -t 0 ]` true, so the script treats the run as interactive and
-    reads the y/n answer from stdin. Returns the exit code, combined output
-    (ANSI stripped), and the uv-argv path.
+    reads the y/n answer from stdin. `answer` may be a single line or a list of
+    lines (fed in order) when the script prompts more than once. Returns the
+    exit code, combined output (ANSI stripped), and the uv-argv path.
     """
     env = _env(
         tmp_path,
@@ -274,6 +275,7 @@ def _invoke_interactive(
         installed_version=installed_version,
         latest_version=latest_version,
     )
+    answers = [answer] if isinstance(answer, str) else answer
     primary, secondary = pty.openpty()
     proc = subprocess.Popen(
         ["bash", str(SCRIPT)],
@@ -284,7 +286,8 @@ def _invoke_interactive(
         text=True,
     )
     os.close(secondary)
-    os.write(primary, f"{answer}\n".encode())
+    for line in answers:
+        os.write(primary, f"{line}\n".encode())
     output = proc.stdout.read() if proc.stdout else ""
     proc.wait(timeout=30)
     os.close(primary)
@@ -1280,6 +1283,67 @@ def test_install_script_no_extras_warning_when_extras_explicit(tmp_path: Path) -
 
     assert proc.returncode == 0
     assert "extras that a bare upgrade will remove" not in proc.stderr
+
+
+def test_install_script_extras_interrupt_decline_aborts_before_uv(
+    tmp_path: Path,
+) -> None:
+    """Answering 'n' to the extras prompt exits before uv runs.
+
+    Two prompts fire on this path — the update prompt, then the extras-loss
+    interrupt — so both answers are fed. Declining the second must abort
+    cleanly (exit 0, no uv invocation, no environment rebuild).
+    """
+    _write_uv_receipt(tmp_path / "tools", ["anthropic", "openai"])
+
+    code, output, args_path = _invoke_interactive(
+        tmp_path,
+        {},
+        answer=["y", "n"],
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert code == 0
+    assert "Continue anyway and remove them?" in output
+    assert "Aborted. No changes made." in output
+    assert not args_path.exists()
+
+
+def test_install_script_extras_interrupt_accept_proceeds(tmp_path: Path) -> None:
+    """Answering 'y' to the extras prompt continues the upgrade."""
+    _write_uv_receipt(tmp_path / "tools", ["anthropic", "openai"])
+
+    code, output, args_path = _invoke_interactive(
+        tmp_path,
+        {},
+        answer=["y", "y"],
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert code == 0
+    assert "Continue anyway and remove them?" in output
+    assert "Aborted. No changes made." not in output
+    args = args_path.read_text().splitlines()
+    assert args[:3] == ["tool", "install", "-U"]
+
+
+def test_install_script_extras_assume_yes_skips_interrupt(tmp_path: Path) -> None:
+    """`DEEPAGENTS_CODE_YES=1` proceeds past the extras interrupt unattended."""
+    _write_uv_receipt(tmp_path / "tools", ["anthropic", "openai"])
+
+    proc, args_path = _invoke(
+        tmp_path,
+        {"DEEPAGENTS_CODE_YES": "1"},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "extras that a bare upgrade will remove" in proc.stderr
+    assert "Aborted. No changes made." not in proc.stderr
+    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
 
 
 def test_install_script_refuses_symlinked_log_file(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1616,6 +1616,15 @@ def test_install_script_refuses_symlinked_log_file(tmp_path: Path) -> None:
     assert target.read_text() == "keep me\n"
 
 
+def test_install_script_stages_log_copy_outside_user_cache() -> None:
+    """The cross-filesystem fallback stages logs in a root-owned temp directory."""
+    script = SCRIPT.read_text()
+
+    assert "mktemp -d /tmp/deepagents-code-install-log.XXXXXX" in script
+    assert 'staged="${staging_dir}/install.log"' in script
+    assert 'local staged="${INSTALL_LOG}.$$"' not in script
+
+
 def test_install_script_unset_xdg_cache_home_falls_back_to_home_cache(
     tmp_path: Path,
 ) -> None:

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -815,10 +815,10 @@ def test_install_script_prompt_read_failure_continues_update(
     assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
 
 
-def test_install_script_attached_tty_read_failure_continues_update(
+def test_install_script_attached_tty_read_failure_declines_update(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An EOF on an attached terminal must not be treated as declining."""
+    """An EOF on an attached terminal must decline the update prompt."""
     script = tmp_path / "install.sh"
     source = SCRIPT.read_text(encoding="utf-8").replace(
         "    if ! read -r reply; then\n", "    if ! false; then\n", 1
@@ -832,9 +832,45 @@ def test_install_script_attached_tty_read_failure_continues_update(
     )
 
     assert code == 0
-    assert "Could not read from terminal — skipping prompt." in output
-    assert "Keeping deepagents-code 0.1.0" not in output
-    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
+    assert "Could not read from terminal — declining prompt." in output
+    assert "Keeping deepagents-code 0.1.0" in output
+    assert not args_path.exists()
+
+
+def test_install_script_attached_tty_read_failure_declines_extras_removal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An EOF on an attached terminal must preserve installed extras."""
+    _write_uv_receipt(tmp_path / "tools", ["anthropic", "openai"])
+    script = tmp_path / "install.sh"
+    source = SCRIPT.read_text(encoding="utf-8").replace(
+        _extract_shell_function("prompt_yn"),
+        """prompt_yn() {
+  PROMPT_CALLS=${PROMPT_CALLS:-0}
+  PROMPT_CALLS=$((PROMPT_CALLS + 1))
+  if [ "$PROMPT_CALLS" -eq 1 ]; then
+    return 0
+  fi
+  log_warn "Could not read from terminal — declining prompt."
+  return 1
+}""",
+    )
+    script.write_text(source, encoding="utf-8")
+    _make_executable(script)
+    monkeypatch.setitem(globals(), "SCRIPT", script)
+
+    code, output, args_path = _invoke_interactive(
+        tmp_path,
+        {},
+        answer=[],
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert code == 0
+    assert "Could not read from terminal — declining prompt." in output
+    assert "Aborted. deepagents-code was left unchanged." in output
+    assert not args_path.exists()
 
 
 def test_install_script_interactive_accept_updates(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -17,6 +17,20 @@ if TYPE_CHECKING:
 
 SCRIPT = Path(__file__).parents[2] / "scripts" / "install.sh"
 
+# Sentinel answer for `_invoke_interactive`: send a bare EOT (Ctrl-D) rather
+# than a line. Identity-compared, so it cannot collide with a real answer.
+_CTRL_D = "<ctrl-d>"
+
+# Where `copy_install_log` stages the log before publishing it. Mirrors the
+# `mktemp -d` template in install.sh; kept here so the cleanup assertion looks
+# in the same place the script writes.
+_STAGE_ROOT = Path("/tmp")
+_STAGE_GLOB = "deepagents-code-install-log.*"
+
+# Root bypasses the permission bits several tests rely on. `hasattr` because
+# `os.geteuid` does not exist on Windows, where these tests are skipped whole.
+_RUNNING_AS_ROOT = hasattr(os, "geteuid") and os.geteuid() == 0
+
 PRERELEASE_STRATEGIES = (
     "disallow",
     "allow",
@@ -52,6 +66,26 @@ def _clean_environ() -> dict[str, str]:
     }
 
 
+def _host_path_without_dcode() -> str:
+    """The host `PATH` with any directory holding a real `dcode` dropped.
+
+    The fake tools shadow `dcode` only when the fixture stages one; a run
+    configured as a fresh machine otherwise finds whatever the developer has
+    installed and reports it as a pre-existing install. That makes
+    `PRE_VERSION` — and every branch keyed on it — depend on who is running
+    the suite.
+    """
+    kept = []
+    for entry in os.environ["PATH"].split(os.pathsep):
+        if not entry:
+            continue
+        directory = Path(entry)
+        if any((directory / name).exists() for name in ("dcode", "deepagents-code")):
+            continue
+        kept.append(entry)
+    return os.pathsep.join(kept)
+
+
 def _write_fake_tools(
     tmp_path: Path,
     *,
@@ -61,6 +95,7 @@ def _write_fake_tools(
     curl_failures_before_success: int = 0,
     dcode_verify_fails: bool = False,
     mktemp_fails: bool = False,
+    stage_uv_receipt: bool = True,
 ) -> tuple[Path, Path, Path]:
     """Stage fake `uv`, `curl`, and (optionally) `dcode` binaries on `PATH`.
 
@@ -70,6 +105,14 @@ def _write_fake_tools(
     the script's offline fallback can be exercised. `dcode_verify_fails` makes
     `dcode -v` exit non-zero (`VERIFY_OK=false`) so the eager managed-ripgrep
     guard can be exercised against a present-but-broken binary.
+
+    An existing install also gets a bare `uv-receipt.toml`, because that is
+    what a real `uv tool install` leaves behind: the script treats a uv-managed
+    install whose receipt it cannot find as "couldn't tell which extras this
+    has" and warns, so a fixture without one would put every unrelated test on
+    that warning path. A test that staged its own receipt keeps it, and
+    `stage_uv_receipt=False` opts out to reach the missing-receipt branches
+    deliberately.
     """
     bin_dir = tmp_path / "bin"
     home = tmp_path / "home"
@@ -79,6 +122,12 @@ def _write_fake_tools(
     # exist_ok: a test may stage a uv tool receipt under `tools/deepagents-code`
     # before invoking, which creates `tools` as a side effect.
     tools.mkdir(exist_ok=True)
+    if (
+        stage_uv_receipt
+        and installed_version is not None
+        and not (tools / "deepagents-code").exists()
+    ):
+        _write_uv_receipt(tools, None)
 
     # Raw f-string: the embedded bash must keep `\n` as the two literal
     # characters (an f-string would otherwise turn `\n` into a newline). `{{ }}`
@@ -96,6 +145,9 @@ if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "dir" ]; then
     fi
     printf '%s\n' "${{FAKE_UV_TOOL_BIN_DIR:-$default_tool_bin}}"
   else
+    if [ "${{FAKE_UV_TOOL_DIR_UNSUPPORTED:-}}" = "1" ]; then
+      exit 2
+    fi
     printf '%s\n' {str(tools)!r}
   fi
   exit 0
@@ -193,6 +245,7 @@ def _env(
     curl_failures_before_success: int = 0,
     dcode_verify_fails: bool = False,
     mktemp_fails: bool = False,
+    stage_uv_receipt: bool = True,
 ) -> dict[str, str]:
     bin_dir, home, uv = _write_fake_tools(
         tmp_path,
@@ -202,12 +255,13 @@ def _env(
         curl_failures_before_success=curl_failures_before_success,
         dcode_verify_fails=dcode_verify_fails,
         mktemp_fails=mktemp_fails,
+        stage_uv_receipt=stage_uv_receipt,
     )
     return {
         **_clean_environ(),
         "HOME": str(home),
         "XDG_CACHE_HOME": str(home / ".cache"),
-        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "PATH": f"{bin_dir}{os.pathsep}{_host_path_without_dcode()}",
         "UV_BIN": str(uv),
         "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
         **extra_env,
@@ -224,6 +278,7 @@ def _invoke(
     curl_failures_before_success: int = 0,
     dcode_verify_fails: bool = False,
     mktemp_fails: bool = False,
+    stage_uv_receipt: bool = True,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     """Run `install.sh` non-interactively with the fake tools on `PATH`.
 
@@ -241,6 +296,7 @@ def _invoke(
         curl_failures_before_success=curl_failures_before_success,
         dcode_verify_fails=dcode_verify_fails,
         mktemp_fails=mktemp_fails,
+        stage_uv_receipt=stage_uv_receipt,
     )
     proc = subprocess.run(
         ["bash", str(SCRIPT)],
@@ -266,8 +322,10 @@ def _invoke_interactive(
 
     A pty makes `[ -t 0 ]` true, so the script treats the run as interactive and
     reads the y/n answer from stdin. `answer` may be a single line or a list of
-    lines (fed in order) when the script prompts more than once. Returns the
-    exit code, combined output (ANSI stripped), and the uv-argv path.
+    lines (fed in order) when the script prompts more than once; the sentinel
+    `_CTRL_D` sends a bare EOT instead, which the terminal delivers as a real
+    end-of-file to whichever `read` is waiting. Returns the exit code, combined
+    output (ANSI stripped), and the uv-argv path.
     """
     env = _env(
         tmp_path,
@@ -287,7 +345,8 @@ def _invoke_interactive(
     )
     os.close(secondary)
     for line in answers:
-        os.write(primary, f"{line}\n".encode())
+        payload = b"\x04" if line is _CTRL_D else f"{line}\n".encode()
+        os.write(primary, payload)
     output = proc.stdout.read() if proc.stdout else ""
     proc.wait(timeout=30)
     os.close(primary)
@@ -352,6 +411,74 @@ def _eval_can_prompt(
         start_new_session=True,
     )
     return proc.returncode == 0
+
+
+def _write_prompt_yn_harness(
+    tmp_path: Path, name: str = "prompt_yn_harness.sh"
+) -> Path:
+    """Write a script that runs the real `prompt_yn` and reports its status.
+
+    Extracts the shipped function (bash 3.2 on macOS cannot `source <(...)`)
+    alongside the `log_warn` it calls, then prints `rc=<status>` so a caller
+    can tell the three outcomes apart: accepted (0), declined (1), and
+    unaskable (2). The status is the whole contract — every caller in the
+    script branches on exactly these three values.
+    """
+    script = tmp_path / name
+    script.write_text(
+        "log_warn() { printf 'WARN %s\\n' \"$1\" >&2; }\n"
+        f"{_extract_shell_function('prompt_yn')}\n"
+        "IS_INTERACTIVE=true\n"
+        "rc=0\n"
+        'prompt_yn "Continue?" || rc=$?\n'
+        'printf "[rc=%s]\\n" "$rc" >&2\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    return script
+
+
+def _run_prompt_yn_on_tty(
+    tmp_path: Path, keystrokes: bytes, *, stdin_is_tty: bool
+) -> str:
+    r"""Drive the real `prompt_yn` against a controlling terminal.
+
+    Forks with the pty as the child's controlling terminal, so `/dev/tty` opens
+    in both configurations. `stdin_is_tty` selects the branch under test: True
+    leaves the pty on stdin (`[ -t 0 ]`), False redirects stdin from
+    `/dev/null` — the shape of the documented `curl … | bash` install, where
+    the script's own stdin is a pipe but a terminal is still reachable.
+
+    `keystrokes` goes to the pty verbatim, so `b"\\x04"` is a real Ctrl-D.
+    Note a terminal needs *two* EOTs to end a line that has text on it: the
+    first only flushes the pending characters to the reader, and the second —
+    on a now-empty buffer — is what makes `read(2)` return 0. Returns the
+    child's combined output.
+    """
+    script = _write_prompt_yn_harness(tmp_path)
+    pid, primary = pty.fork()
+    if pid == 0:  # pragma: no cover - child process never returns
+        try:
+            if not stdin_is_tty:
+                devnull = os.open(os.devnull, os.O_RDONLY)
+                os.dup2(devnull, 0)
+            os.execvp("bash", ["bash", str(script)])
+        finally:
+            os._exit(127)
+    os.write(primary, keystrokes)
+    chunks = []
+    try:
+        while True:
+            chunk = os.read(primary, 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    except OSError:
+        # The pty reports EIO rather than EOF once the child side is gone.
+        pass
+    os.waitpid(pid, 0)
+    os.close(primary)
+    return b"".join(chunks).decode(errors="replace")
 
 
 def _run_install_script(
@@ -825,60 +952,162 @@ def test_install_script_prompt_read_failure_continues_update(
     assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
 
 
-def test_install_script_attached_tty_read_failure_declines_update(
+def _invoke_with_unaskable_prompt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """An EOF on an attached terminal must decline the update prompt."""
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Run the script with a terminal that probes open but cannot be asked.
+
+    `can_prompt` succeeds and `prompt_yn` returns 2 — the detached-session
+    shape, where the branches under test must complete the install rather than
+    read the silence as a refusal. Stubbing is the only way in: a genuinely
+    unaskable terminal cannot be produced from inside a whole-script run, and
+    `prompt_yn`'s own 1-vs-2 contract is pinned separately by the harness
+    tests above.
+    """
     script = tmp_path / "install.sh"
-    source = SCRIPT.read_text(encoding="utf-8").replace(
-        "    if ! read -r reply; then\n", "    if ! false; then\n", 1
+    source = (
+        SCRIPT.read_text(encoding="utf-8")
+        .replace(_extract_shell_function("can_prompt"), "can_prompt() {\n  return 0\n}")
+        .replace(_extract_shell_function("prompt_yn"), "prompt_yn() {\n  return 2\n}")
     )
     script.write_text(source, encoding="utf-8")
     _make_executable(script)
     monkeypatch.setitem(globals(), "SCRIPT", script)
-
-    code, output, args_path = _invoke_interactive(
-        tmp_path, {}, answer="n", installed_version="0.1.0", latest_version="0.2.0"
-    )
-
-    assert code == 0
-    assert "Could not read from terminal — declining prompt." in output
-    assert "Keeping deepagents-code 0.1.0" in output
-    assert not args_path.exists()
+    return _invoke(tmp_path, {}, installed_version="0.1.0", latest_version="0.2.0")
 
 
-def test_install_script_attached_tty_read_failure_declines_extras_removal(
+def test_install_script_unaskable_prompt_continues_past_known_extras(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An EOF on an attached terminal must preserve installed extras."""
-    _write_uv_receipt(tmp_path / "tools", ["anthropic", "openai"])
-    script = tmp_path / "install.sh"
-    source = SCRIPT.read_text(encoding="utf-8").replace(
-        _extract_shell_function("prompt_yn"),
-        """prompt_yn() {
-  PROMPT_CALLS=${PROMPT_CALLS:-0}
-  PROMPT_CALLS=$((PROMPT_CALLS + 1))
-  if [ "$PROMPT_CALLS" -eq 1 ]; then
-    return 0
-  fi
-  log_warn "Could not read from terminal — declining prompt."
-  return 1
-}""",
-    )
-    script.write_text(source, encoding="utf-8")
-    _make_executable(script)
-    monkeypatch.setitem(globals(), "SCRIPT", script)
+    """An unanswerable extras prompt completes the install and says extras will go.
 
+    Collapsing this into the abort arm would turn a broken terminal into a
+    silent `exit 0` that looks exactly like success, leaving the user on the
+    old version with no idea why.
+    """
+    _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+
+    proc, args_path = _invoke_with_unaskable_prompt(tmp_path, monkeypatch)
+
+    assert proc.returncode == 0
+    assert (
+        "Could not ask — continuing; the extras above will be removed." in proc.stderr
+    )
+    assert "Aborted." not in proc.stdout
+    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
+
+
+def test_install_script_unaskable_prompt_continues_past_unreadable_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same holds when the receipt could not be read at all."""
+    receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
+    receipt.write_text("[tool]\nnot-a-requirements-array\n")
+
+    proc, args_path = _invoke_with_unaskable_prompt(tmp_path, monkeypatch)
+
+    assert proc.returncode == 0
+    assert (
+        "Could not ask — continuing; any extras this install has will be removed."
+        in proc.stderr
+    )
+    assert "Aborted." not in proc.stdout
+    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
+
+
+@pytest.mark.parametrize("stdin_is_tty", [True, False])
+def test_prompt_yn_eof_on_an_open_terminal_declines(
+    tmp_path: Path, *, stdin_is_tty: bool
+) -> None:
+    """Ctrl-D at the prompt is a human declining (1), not an unaskable prompt (2).
+
+    Both branches of `prompt_yn` must agree: the terminal opened, so somebody
+    was there to ask, and the printed default is N. Returning 2 here would make
+    callers proceed — installing an update and removing extras that the user
+    just refused. Parametrised over stdin because the `/dev/tty` branch (the
+    `curl | bash` shape) is the one whose callers act on the distinction, and
+    it was previously reachable only through stubs.
+    """
+    output = _run_prompt_yn_on_tty(tmp_path, b"\x04", stdin_is_tty=stdin_is_tty)
+
+    assert "[rc=1]" in output
+    assert "WARN No answer — declining prompt." in output
+
+
+@pytest.mark.parametrize("stdin_is_tty", [True, False])
+def test_prompt_yn_keeps_an_answer_submitted_without_a_newline(
+    tmp_path: Path, *, stdin_is_tty: bool
+) -> None:
+    """An answer terminated by Ctrl-D rather than Enter is still the user's answer.
+
+    `read` reports failure on an unterminated final line but has already
+    assigned what it read, so keying on the status alone discards a real "y"
+    or "n". Accepting (rc 0) is only reachable if the assigned reply survived
+    the failed status, which is what separates this from the EOF case above.
+    """
+    output = _run_prompt_yn_on_tty(tmp_path, b"y\x04\x04", stdin_is_tty=stdin_is_tty)
+
+    assert "[rc=0]" in output
+    assert "declining prompt" not in output
+
+
+def test_prompt_yn_without_a_terminal_reports_unaskable(tmp_path: Path) -> None:
+    """No controlling terminal is 2 — "nobody could answer", not "the user said no".
+
+    The complement of the EOF tests above: here `/dev/tty` cannot be opened at
+    all (detached session, cron, systemd), so there is genuinely no human, and
+    callers are meant to complete the install rather than treat the silence as
+    a refusal.
+    """
+    script = _write_prompt_yn_harness(tmp_path)
+    proc = subprocess.run(
+        ["bash", str(script)],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        check=False,
+        start_new_session=True,
+    )
+
+    assert "[rc=2]" in proc.stderr
+    assert "Could not open /dev/tty" in proc.stderr
+
+
+def test_install_script_attached_tty_eof_declines_update(tmp_path: Path) -> None:
+    """A real Ctrl-D at the update prompt keeps the installed version."""
     code, output, args_path = _invoke_interactive(
         tmp_path,
         {},
-        answer=[],
+        answer=_CTRL_D,
         installed_version="0.1.0",
         latest_version="0.2.0",
     )
 
     assert code == 0
-    assert "Could not read from terminal — declining prompt." in output
+    assert "No answer — declining prompt." in output
+    assert "Keeping deepagents-code 0.1.0" in output
+    assert not args_path.exists()
+
+
+def test_install_script_attached_tty_eof_preserves_extras(tmp_path: Path) -> None:
+    """A real Ctrl-D at the extras prompt aborts before uv rebuilds the environment.
+
+    Two prompts fire here, so the update is accepted first and the extras-loss
+    interrupt is answered with EOF. Declining that second prompt must leave the
+    install — and its extras — untouched.
+    """
+    _write_uv_receipt(tmp_path / "tools", ["anthropic", "openai"])
+
+    code, output, args_path = _invoke_interactive(
+        tmp_path,
+        {},
+        answer=["y", _CTRL_D],
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert code == 0
+    assert "No answer — declining prompt." in output
     assert "Aborted. deepagents-code was left unchanged." in output
     assert not args_path.exists()
 
@@ -1099,6 +1328,84 @@ def test_install_script_same_version_with_dependency_updates_says_dependencies_u
     assert "✔ Already installed. Run: dcode" not in proc.stdout
 
 
+def _make_editable(tmp_path: Path, *, version: str = "0.1.0") -> Path:
+    """Mark the staged uv tool install as an editable one.
+
+    Mirrors what `uv tool install -e <path>` leaves behind: a `direct_url.json`
+    in the dist-info recording `"editable": true` plus the source it points at.
+    The script globs for exactly this file, so nothing else needs to change.
+
+    Returns the source directory named in the marker.
+    """
+    src = tmp_path / "src" / "deepagents"
+    src.mkdir(parents=True, exist_ok=True)
+    dist_info = (
+        tmp_path
+        / "tools"
+        / "deepagents-code"
+        / "lib"
+        / "python3.13"
+        / "site-packages"
+        / f"deepagents_code-{version}.dist-info"
+    )
+    dist_info.mkdir(parents=True, exist_ok=True)
+    (dist_info / "direct_url.json").write_text(
+        f'{{"url": "file://{src}", "dir_info": {{"editable": true}}}}\n'
+    )
+    return src
+
+
+def test_install_script_editable_install_skips_the_extras_check(
+    tmp_path: Path,
+) -> None:
+    """An editable install never gets the extras-loss warning.
+
+    Its receipt can carry extras like any other, but an editable reinstall is
+    a developer rebuilding from local source on purpose. Warning here — and
+    offering to abort — would fire on every dev re-run.
+    """
+    _write_uv_receipt(tmp_path / "tools", ["anthropic", "openai"])
+    _make_editable(tmp_path)
+
+    proc, _ = _invoke(
+        tmp_path,
+        {},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "editable install" in proc.stdout
+    assert "extras that a bare re-run will remove" not in proc.stderr
+    assert "which extras this install was built with" not in proc.stderr
+
+
+def test_install_script_editable_install_keeps_the_neutral_footer(
+    tmp_path: Path,
+) -> None:
+    """An editable rebuild falls through to `Setup complete.` even when deps moved.
+
+    The same-version-plus-dependency-diff shape would otherwise report
+    `Dependencies updated.`; the editable guard on that branch is what keeps a
+    rebuild from local source out of the wording reserved for a PyPI install
+    whose dependencies actually moved.
+    """
+    _make_editable(tmp_path, version="0.1.8")
+
+    proc, _ = _invoke(
+        tmp_path,
+        {"FAKE_UV_INSTALL_STDERR": _DEPENDENCY_UPDATE_DIFF},
+        installed_version="0.1.8",
+        latest_version="0.1.20",
+    )
+
+    assert proc.returncode == 0
+    assert "editable install" in proc.stdout
+    assert "✔ Setup complete. Run: dcode" in proc.stdout
+    assert "Dependencies updated." not in proc.stdout
+    assert "Already installed." not in proc.stdout
+
+
 def test_install_script_same_version_no_dependency_changes_says_up_to_date(
     tmp_path: Path,
 ) -> None:
@@ -1191,7 +1498,7 @@ def test_install_script_dependency_update_with_failed_log_copy_omits_log_pointer
     tmp_path: Path,
 ) -> None:
     """When log creation succeeds but copying fails, no `Full log:` pointer."""
-    if hasattr(os, "geteuid") and os.geteuid() == 0:
+    if _RUNNING_AS_ROOT:
         pytest.skip("root can write through directory permissions")
 
     cache = tmp_path / "cache"
@@ -1620,11 +1927,16 @@ def test_install_script_receipt_extras_with_metacharacters_warns(
     `$(...)` into that paste. Anything outside `[A-Za-z0-9_,.-]` is treated as
     an unparseable receipt — the run warns and omits the paste-ready hint.
     """
-    receipt = _write_uv_receipt(tmp_path / "tools", ["$(touch /tmp/pwned)"])
+    # Sentinel under tmp_path, not a fixed system path: a shared target would
+    # make this test fail (or pass) for reasons that have nothing to do with
+    # the script, and it would leave litter behind.
+    sentinel = tmp_path / "pwned"
+    payload = f"$(touch {sentinel})"
+    receipt = _write_uv_receipt(tmp_path / "tools", [payload])
     # Keep the file plausible TOML but with the payload as the extra name.
     receipt.write_text(
         '[tool]\nrequirements = [{ name = "deepagents-code",'
-        ' extras = ["$(touch /tmp/pwned)"], specifier = "==0.1.0" }]\n'
+        f' extras = ["{payload}"], specifier = "==0.1.0" }}]\n'
     )
 
     proc, _ = _invoke(
@@ -1638,7 +1950,7 @@ def test_install_script_receipt_extras_with_metacharacters_warns(
     assert "Could not read" in proc.stderr
     assert "DEEPAGENTS_CODE_EXTRAS=" not in proc.stderr
     assert "$(touch" not in proc.stderr
-    assert not Path("/tmp/pwned").exists()
+    assert not sentinel.exists()
 
 
 def test_install_script_no_extras_warning_when_receipt_omits_extras_key(
@@ -1724,7 +2036,7 @@ exec /usr/bin/sed "$@"
     assert (tmp_path / "uv-args.txt").is_file()
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses directory permissions")
+@pytest.mark.skipif(_RUNNING_AS_ROOT, reason="root bypasses directory permissions")
 def test_install_script_warns_when_tool_dir_is_unsearchable(tmp_path: Path) -> None:
     """A tool dir left root-owned and 0700 by a prior sudo run must warn.
 
@@ -1821,7 +2133,7 @@ def test_install_script_warns_when_receipt_is_symlinked(tmp_path: Path) -> None:
     assert "extras that a bare re-run will remove" not in proc.stderr
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permissions")
+@pytest.mark.skipif(_RUNNING_AS_ROOT, reason="root bypasses file permissions")
 def test_install_script_warns_when_receipt_is_unreadable(tmp_path: Path) -> None:
     """An unreadable receipt (e.g. written by a prior `sudo` run) warns."""
     receipt = _write_uv_receipt(tmp_path / "tools", ["anthropic"])
@@ -1841,16 +2153,130 @@ def test_install_script_warns_when_receipt_is_unreadable(tmp_path: Path) -> None
     assert "Could not read" in proc.stderr
 
 
-def test_install_script_no_extras_warning_when_receipt_missing(tmp_path: Path) -> None:
-    """No receipt (older uv / non-tool install) degrades quietly."""
+def test_install_script_warns_when_the_tool_dir_has_no_package_dir(
+    tmp_path: Path,
+) -> None:
+    """A uv-managed install with nothing under `uv tool dir` is "couldn't tell".
+
+    The tool dir resolves and is searchable but holds no `deepagents-code`
+    directory — what a moved tool dir looks like (`UV_TOOL_DIR`, a changed
+    `tool-dir` in uv.toml, a relocated `XDG_DATA_HOME`). The old install is
+    still on `PATH`, so the rebuild really will drop whatever extras it has,
+    and its receipt is simply somewhere this run cannot see. Reporting "no
+    extras" here would silently delete the packages this check exists to
+    protect.
+    """
     proc, _ = _invoke(
         tmp_path,
         {},
         installed_version="0.1.0",
         latest_version="0.2.0",
+        stage_uv_receipt=False,
     )
 
     assert proc.returncode == 0
+    assert "Could not read" in proc.stderr
+    assert "which extras this install was built with" in proc.stderr
+    # "Couldn't tell", never a positive claim about which extras exist.
+    assert "extras that a bare re-run will remove" not in proc.stderr
+
+
+def test_install_script_warns_when_uv_tool_dir_fails_over_an_install(
+    tmp_path: Path,
+) -> None:
+    """`uv tool dir` failing over an existing install is "couldn't tell".
+
+    A uv too old for the subcommand or a broken config leaves no way to reach
+    the receipt, and the rebuild would still drop whatever extras the install
+    has.
+    """
+    proc, _ = _invoke(
+        tmp_path,
+        {"FAKE_UV_TOOL_DIR_UNSUPPORTED": "1"},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "which extras this install was built with" in proc.stderr
+
+
+def test_install_script_silent_when_uv_tool_dir_fails_on_a_fresh_machine(
+    tmp_path: Path,
+) -> None:
+    """The same failure stays silent when nothing is installed yet.
+
+    Only a machine that already has an install can lose extras. Losing this
+    guard would print "could not read the uv tool receipt" on every fresh
+    install anywhere `uv tool dir` does not work.
+    """
+    proc, _ = _invoke(
+        tmp_path,
+        {"FAKE_UV_TOOL_DIR_UNSUPPORTED": "1"},
+        installed_version=None,
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "which extras this install was built with" not in proc.stderr
+
+
+def test_install_script_warns_about_extras_on_a_same_version_repair(
+    tmp_path: Path,
+) -> None:
+    """The extras check also guards the same-version repair path.
+
+    An install that is current but is not the one selected on PATH gets
+    reinstalled, and that reinstall drops extras exactly as an upgrade
+    would. Every other extras test moves the version, which would leave the
+    "covers the same-version repair paths" claim unverified. (The plain
+    same-version no-op exits before this point and reinstalls nothing, so it
+    needs no warning.)
+    """
+    tool_bin = tmp_path / "tool-bin"
+    tool_bin.mkdir()
+    dcode = tool_bin / "dcode"
+    dcode.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = "-v" ]; then printf "deepagents-code 0.2.0\\n"; exit 0; fi\n'
+        "exit 0\n"
+    )
+    _make_executable(dcode)
+    _write_uv_receipt(tmp_path / "tools", ["anthropic", "daytona"])
+
+    proc, args_path = _invoke(
+        tmp_path,
+        {"FAKE_UV_TOOL_BIN_DIR": str(tool_bin)},
+        installed_version="0.2.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "is current but is not selected on PATH" in proc.stdout
+    assert "extras that a bare re-run will remove: anthropic,daytona" in proc.stderr
+    assert 'DEEPAGENTS_CODE_EXTRAS="anthropic,daytona"' in proc.stderr
+    assert args_path.exists()
+
+
+def test_install_script_no_extras_warning_for_a_non_uv_install(tmp_path: Path) -> None:
+    """An install that did not come from uv has no receipt to miss.
+
+    `dcode` resolves on `PATH` but not from uv's tool bin dir (pipx, a manual
+    venv, a distro package), so uv never wrote a receipt for it and its absence
+    says nothing. Warning here would fire on every run for those users, which
+    is why the branch above is gated on the install being uv-managed rather
+    than on merely having a version.
+    """
+    proc, _ = _invoke(
+        tmp_path,
+        {"FAKE_UV_TOOL_BIN_DIR": str(tmp_path / "empty-tool-bin")},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+        stage_uv_receipt=False,
+    )
+
+    assert proc.returncode == 0
+    assert "which extras this install was built with" not in proc.stderr
     assert "extras that a bare re-run will remove" not in proc.stderr
 
 
@@ -2014,7 +2440,7 @@ def test_install_script_unreadable_receipt_interrupt_accept_proceeds(
     assert args[:3] == ["tool", "install", "-U"]
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permissions")
+@pytest.mark.skipif(_RUNNING_AS_ROOT, reason="root bypasses file permissions")
 def test_install_script_unreadable_receipt_assume_yes_skips_interrupt(
     tmp_path: Path,
 ) -> None:
@@ -2071,16 +2497,22 @@ def _run_copy_install_log(
 ) -> tuple[int, Path, Path]:
     """Run the real `copy_install_log` from `install.sh` in isolation.
 
-    Whole-script runs cannot reach most of this function: the only way they can
-    make the publish fail is by making the log dir unwritable, which fails at
-    the very first `mktemp` and leaves the staging, re-validation, and rename
-    paths unexercised. Driving the function directly lets a test stand in the
-    race window instead.
+    Whole-script runs can only ever fail the publish step, and never observe
+    the staged file mid-flight. Driving the function directly lets a test stand
+    in the race window instead.
 
-    `race_hook` is shell injected as a `cp` override, so it runs *after* the
-    staged file exists and *before* the rename — exactly where an attacker who
-    owns the log dir would act. It must copy the file itself (`command cp`) if
-    it wants the publish to get that far.
+    `race_hook` is arbitrary shell evaluated before the call — in practice a
+    function override (`cp`, `mv`, `rm`, `mktemp`, `id`, `cat`) that acts
+    inside the window. An override shadowing a command the publish depends on
+    must delegate with `command …` if the publish is expected to get that far.
+
+    Every exit path of `copy_install_log` is supposed to remove its staging
+    directory, so this asserts that centrally: the staged file holds uv's full
+    captured stderr, and an orphan is both litter and a disclosure that
+    repeated failures would accumulate. Staging lives in `/tmp` (see the
+    function's own comment), so the check is a before/after diff of that
+    directory rather than a glob of the log dir — it assumes the suite is not
+    running copies of itself concurrently.
 
     Returns the function's exit status, the log dir, and the publish path.
     """
@@ -2109,12 +2541,15 @@ def _run_copy_install_log(
         "copy_install_log\n"
         'printf "rc=%s\\n" "$?"\n'
     )
+    before = set(_STAGE_ROOT.glob(_STAGE_GLOB))
     proc = subprocess.run(
         ["bash", str(harness)],
         check=False,
         capture_output=True,
         text=True,
     )
+    leaked = set(_STAGE_ROOT.glob(_STAGE_GLOB)) - before
+    assert leaked == set(), f"copy_install_log left staging behind: {sorted(leaked)}"
     match = re.search(r"rc=(\d+)", proc.stdout)
     assert match is not None, f"harness produced no status: {proc.stdout!r}"
     return int(match.group(1)), install_log_dir, install_log_dir / "install.log"
@@ -2122,11 +2557,10 @@ def _run_copy_install_log(
 
 def test_copy_install_log_publishes_captured_stderr(tmp_path: Path) -> None:
     """The happy path publishes the content and leaves no staged file behind."""
-    rc, log_dir, published = _run_copy_install_log(tmp_path)
+    rc, _log_dir, published = _run_copy_install_log(tmp_path)
 
     assert rc == 0
     assert published.read_text() == "captured uv stderr\n"
-    assert list(log_dir.glob(".install.log.*")) == []
 
 
 def test_copy_install_log_stages_outside_user_writable_log_dir(
@@ -2151,11 +2585,27 @@ def test_copy_install_log_stages_outside_user_writable_log_dir(
     )
 
     assert rc == 0
-    assert mktemp_args.read_text().splitlines() == [
-        "-d",
-        "/tmp/deepagents-code-install-log.XXXXXX",
-    ]
+    template = mktemp_args.read_text().splitlines()
+    assert template[0] == "-d"
+    # The invariant is the location, not the exact template: staging must not
+    # sit under the log dir, whose parent the target user may control.
+    assert not template[1].startswith(str(tmp_path))
+    assert template[1].startswith(f"{_STAGE_ROOT}/")
     assert published.read_text() == "captured uv stderr\n"
+
+
+def test_copy_install_log_reports_a_failure_to_create_staging(tmp_path: Path) -> None:
+    """`mktemp -d` failing is operational (2), so the caller warns about it.
+
+    A full or read-only `/tmp` is something the user can act on, and it leaves
+    the run with no log at all — exactly the case the rc-2 warning exists for.
+    """
+    rc, _log_dir, published = _run_copy_install_log(
+        tmp_path, race_hook="mktemp() { return 1; }\n"
+    )
+
+    assert rc == 2
+    assert not published.exists()
 
 
 def test_copy_install_log_replaces_symlink_planted_during_the_race(
@@ -2164,9 +2614,11 @@ def test_copy_install_log_replaces_symlink_planted_during_the_race(
     """A symlink planted at the publish path is replaced, never written through.
 
     The `-L` guard runs before staging, so it cannot cover a link planted after
-    it. Privileged publication unlinks that directory entry and atomically
-    creates a new regular file instead, so the attacker's target remains
-    untouched.
+    it. This runs unprivileged, where publication is a `mv`: that replaces the
+    symlink's directory entry rather than writing through it, so the
+    attacker's target remains untouched. (The privileged branch reaches the
+    same result through `rm` plus a noclobber create; it is covered by the
+    tests below that stub `id`.)
     """
     outside = tmp_path / "outside.txt"
     outside.write_text("do not clobber\n")
@@ -2203,7 +2655,6 @@ def test_copy_install_log_refuses_publish_when_log_dir_is_swapped(
     assert rc != 0
     assert not (elsewhere / "install.log").exists()
     assert log_dir.is_symlink()
-    assert list(elsewhere.glob(".install.log.*")) == []
 
 
 def test_copy_install_log_pins_parent_during_privileged_publication(
@@ -2244,8 +2695,6 @@ def test_copy_install_log_refuses_directory_target(tmp_path: Path) -> None:
 
     assert rc == 1
     assert published.is_dir()
-    assert list(published.glob(".install.log.*")) == []
-    assert list(log_dir.glob(".install.log.*")) == []
 
 
 def test_copy_install_log_rejects_directory_created_during_publication(
@@ -2278,7 +2727,13 @@ def test_copy_install_log_rejects_directory_created_during_publication(
 def test_copy_install_log_rejects_directory_created_before_nonroot_move(
     tmp_path: Path,
 ) -> None:
-    """A non-root `mv` into a raced directory must not report success."""
+    """A non-root `mv` into a raced directory must not report success.
+
+    `mv` moves the file *into* a directory destination and exits 0, so the
+    status alone would read as a published log. The post-move check catches
+    that, and the captured stderr must not be left sitting inside the
+    attacker's directory afterwards.
+    """
     rc, _log_dir, published = _run_copy_install_log(
         tmp_path,
         race_hook=('mv() {\n  command mkdir "$INSTALL_LOG"\n  command mv "$@"\n}\n'),
@@ -2286,25 +2741,26 @@ def test_copy_install_log_rejects_directory_created_before_nonroot_move(
 
     assert rc != 0
     assert published.is_dir()
-    assert (published / "install.log").read_text() == "captured uv stderr\n"
+    assert not (published / "install.log").exists()
 
 
 def test_copy_install_log_cleans_up_staged_file_when_publish_fails(
     tmp_path: Path,
 ) -> None:
-    """A failed publish leaves no staged copy of uv's stderr in the log dir.
+    """A failed publish leaves neither a half-written target nor its staging.
 
-    The staged file holds the full captured stderr, so an orphan is both litter
-    and a disclosure; repeated failures would accumulate them.
+    The staging half is asserted by `_run_copy_install_log` for every case;
+    this one drives the branch where cleanup has the most to do — the target
+    was already created before the write failed, so both files exist when the
+    failure path runs.
     """
     # Fail the root-safe publication copy after noclobber creates the target,
     # leaving both files in place for the cleanup to find.
-    rc, log_dir, published = _run_copy_install_log(
+    rc, _log_dir, published = _run_copy_install_log(
         tmp_path, race_hook='id() { printf "0\\n"; }\ncat() { return 1; }\n'
     )
 
     assert rc == 2
-    assert list(log_dir.glob(".install.log.*")) == []
     assert not published.exists()
 
 
@@ -2318,7 +2774,8 @@ def test_copy_install_log_reports_operational_failure_distinctly(
     log and no reason why — or cry wolf on every hostile path it correctly
     refused.
     """
-    # A read-only log dir: staging cannot be created. Operational → 2.
+    # A read-only log dir: staging succeeds in /tmp, but publishing into the
+    # log dir fails. Operational → 2.
     readonly_dir = tmp_path / "home" / "readonly"
     readonly_dir.mkdir(parents=True)
     readonly_dir.chmod(0o500)
@@ -2450,7 +2907,7 @@ def test_install_script_failed_install_points_to_log(tmp_path: Path) -> None:
 
     assert proc.returncode != 0
     assert "Failed to install" in proc.stderr
-    assert "Full install log: ~/.cache/deepagents-code/install.log" in proc.stderr
+    assert "Full log: ~/.cache/deepagents-code/install.log" in proc.stderr
     assert (tmp_path / "home/.cache/deepagents-code/install.log").read_text() == (
         f"{_DEPENDENCY_UPDATE_DIFF}\n"
     )
@@ -2475,6 +2932,10 @@ def test_install_script_propagates_uv_exit_code(tmp_path: Path) -> None:
     # Portable across macOS/Linux: both the generic and the Linux-OOM hint begin
     # with this phrase, so the assertion holds regardless of the test host's OS.
     assert "killed before it could finish" in proc.stderr
+    # No FAKE_UV_INSTALL_STDERR here, so uv was killed before writing anything
+    # and the log is zero bytes. Sending a user whose install just failed to an
+    # empty file is a dead end, so the pointer must be withheld.
+    assert "Full log:" not in proc.stderr
 
 
 def _run_signal_failure_hint(
@@ -3017,7 +3478,7 @@ def test_install_script_reclaims_stale_mkdir_lock(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(
-    os.geteuid() == 0, reason="root bypasses the directory permission bits"
+    _RUNNING_AS_ROOT, reason="root bypasses the directory permission bits"
 )
 def test_install_script_aborts_on_unremovable_stale_lock(tmp_path: Path) -> None:
     """An unremovable stale lock aborts loudly instead of spinning forever.
@@ -3746,6 +4207,21 @@ def test_interrupt_removes_registered_staging_directory(tmp_path: Path) -> None:
     assert not stage_dir.exists()
 
 
+def test_exit_trap_removes_registered_staging_directory(tmp_path: Path) -> None:
+    """An ordinary failure exit clears the staging directory too.
+
+    `cleanup_on_signal` runs on EXIT as well as on a signal, and the staged
+    file holds uv's full captured stderr — a failed install that leaves it
+    behind is the same disclosure an interrupted one would be.
+    """
+    stage_dir = tmp_path / "deepagents-code-install-log"
+
+    proc = _run_signal_traps(tmp_path, interrupt=False, temp_dir=stage_dir)
+
+    assert proc.returncode == 2
+    assert not stage_dir.exists()
+
+
 def test_exit_trap_reports_failure_on_ordinary_error(tmp_path: Path) -> None:
     """A non-signal, non-zero exit still fires the EXIT trap's failure message.
 
@@ -4186,6 +4662,11 @@ def _invoke_with_local_dcode_not_on_path(
         "exit 0\n"
     )
     _make_executable(dcode)
+    # This dcode sits in uv's tool bin dir, so the script sees a uv-managed
+    # install and expects a receipt for it. These tests are about PATH and
+    # profile selection; without the receipt every one of them would divert
+    # into the "couldn't tell which extras this has" warning and its prompt.
+    _write_uv_receipt(tmp_path / "tools", None)
     if create_env_file:
         (local_bin / "env").write_text('export PATH="$HOME/.local/bin:$PATH"\n')
 


### PR DESCRIPTION
The install script now leads an available update with an explicit `Update available: deepagents-code X → Y` verdict before the changelog link, prints the persistent uv install log path on every run (not just on failure), ends a real upgrade with `Upgrade complete.` instead of `Setup complete.`, and warns before a bare re-run silently drops extras the existing install was built with — including the `DEEPAGENTS_CODE_EXTRAS` re-run command that preserves them.

---

Before / after:

**Update prompt** — the changelog link previously appeared without first stating that an update exists:

```console
# Before
▸ What's new: https://github.com/langchain-ai/deepagents/releases/tag/deepagents-code%3D%3D0.2.0
Update deepagents-code 0.1.0 → 0.2.0? [y/N]

# After
▸ Update available: deepagents-code 0.1.0 → 0.2.0
▸   What's new: https://github.com/langchain-ai/deepagents/releases/tag/deepagents-code%3D%3D0.2.0
Install update? [y/N]
```

**Extras loss** — re-running the installer without `DEEPAGENTS_CODE_EXTRAS` rebuilds the environment against the bare package and silently removes every extra the install was built with (model providers, sandbox backends, etc.). The extras are now read off uv's own `uv-receipt.toml` and called out, with the exact re-run command, before that happens. An interactive user can also back out; explicitly passing extras or doing an editable→PyPI swap already expresses intent, so those skip the warning:

```console
# Before
(no output; the extras are gone after the reinstall)

# After
⚠ This install has extras that a bare re-run will remove: anthropic,daytona
⚠   To keep them, re-run with: DEEPAGENTS_CODE_EXTRAS="anthropic,daytona"
Continue anyway and remove them? [y/N]
```

A receipt that exists but can't be read or parsed (symlink, unreadable permissions, unexpected format) warns too — a false negative here costs the user the exact packages this check protects.

**Footer** — the footer now distinguishes a version move from a fresh install:

```console
# Before (any successful run)
✔ Setup complete. Run: dcode

# After (unpinned run that moved version)
✔ Upgrade complete. Run: dcode
```

Other outcomes get their own wording: `Dependencies updated.` for a same-version dependency bump and `Already installed.` for a no-op. A pinned move (`bash -s -- 0.1.0` over 0.2.0 is a downgrade, and there's no version comparison to tell) keeps `Setup complete.`

**Log path** — uv's full stderr (dependency diff, rebuild notice) is captured to a persistent log, but the script only mentioned it on failure or a same-version dependency bump, so on a normal upgrade the details scrolled away with no way back. It's now printed after any successful install that wrote a log:

```console
# After
✔ deepagents-code upgraded to 0.2.0.
▸ Full log: ~/.cache/deepagents/install.log
```

The log stays under `~/.cache` (not `~/.deepagents/.state`) because it's ephemeral output, not application state.
