### PR TITLE
chore(code): harden installer ripgrep gating and prompt semantics

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -3044,7 +3044,9 @@ check_sudo() {
 installed_rg_is_acceptable() {
   local ver
   command -v rg >/dev/null 2>&1 || return 1
-  ver=$(installed_rg_version)
+  if ! ver=$(installed_rg_version) || [ -z "$ver" ]; then
+    return 1
+  fi
   if version_too_old "$ver" "$MIN_RIPGREP_VERSION"; then
     log_warn "ripgrep ${ver} is older than the supported minimum (${MIN_RIPGREP_VERSION})."
     return 1
@@ -3166,15 +3168,18 @@ if [ "$SKIP_OPTIONAL" != "1" ]; then
       fi
     fi
   elif command -v rg >/dev/null 2>&1; then
-    rg_version=$(installed_rg_version)
-    if version_too_old "$rg_version" "$MIN_RIPGREP_VERSION"; then
+    if ! rg_version=$(installed_rg_version) || [ -z "$rg_version" ]; then
+      echo ""
+      log_warn "Could not determine the version of ripgrep on PATH."
+      ripgrep_manual_hint
+    elif version_too_old "$rg_version" "$MIN_RIPGREP_VERSION"; then
       echo ""
       log_warn "ripgrep ${rg_version} found, but the minimum supported is ${MIN_RIPGREP_VERSION} — the grep tool may misbehave."
       ripgrep_manual_hint
     elif [ "$VERBOSE" = "1" ]; then
       echo ""
       log_info "Checking optional tools..."
-      log_success "ripgrep ${rg_version:-(version unknown)} found"
+      log_success "ripgrep ${rg_version} found"
     fi
   else
     echo ""

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1311,72 +1311,14 @@ install_uv() {
     exit "$uv_install_rc"
   fi
 
-  # Verify the download against the SHA-256 manifest Astral publishes with each
-  # uv release. The shebang and parse checks below only prove the response is
-  # *shaped* like a shell script; a body that is tampered-with or truncated at
-  # a statement boundary passes both. The manifest entry binds the exact bytes
-  # we run to the released artifact.
+  # Astral does not publish a checksum that covers uv-installer.sh itself:
+  # the per-release sha256.sum and dist-manifest.json only list the platform
+  # archives, and the archives' digests are embedded in this script (which
+  # pins APP_VERSION and verifies them after download). The meaningful checks
+  # for the script fetch are therefore the shebang and parse checks below:
+  # they catch a captive-portal HTML page and a truncated body, which are the
+  # realistic failure modes for this URL.
   #
-  # Fail closed on any verification problem: a mismatch means the bytes are not
-  # what Astral released (supply-chain anomaly), and an unreachable manifest
-  # means we can no longer tell — continuing anyway would make the check
-  # silently optional. This runs for both the curl and wget paths; when curl
-  # exists it does the fetch, otherwise the already-resolved wget does.
-  local uv_sums uv_sums_rc=0
-  uv_sums=$(mktemp 2>/dev/null) || {
-    log_error "mktemp is required to create a secure temp file."
-    exit 1
-  }
-  register_temp "$uv_sums"
-  if command -v curl >/dev/null 2>&1 && ! is_snap_curl; then
-    curl -fsSL https://github.com/astral-sh/uv/releases/latest/download/sha256.sum \
-      --proto '=https' --proto-redir '=https' --max-redirs 3 \
-      -o "$uv_sums" 2>"$uv_install_out" || uv_sums_rc=$?
-  elif command -v wget >/dev/null 2>&1; then
-    wget_download "$uv_sums" https://github.com/astral-sh/uv/releases/latest/download/sha256.sum "" false \
-      2>"$uv_install_out" || uv_sums_rc=$?
-  else
-    uv_sums_rc=1
-  fi
-  if [ "$uv_sums_rc" -ne 0 ]; then
-    cat "$uv_install_out" >&2
-    rm -f "$uv_install_out" "$uv_script" "$uv_sums"
-    log_error "Could not download the uv release checksum manifest (exit ${uv_sums_rc})."
-    log_error "  Cannot verify the installer download — aborting rather than running unverified code."
-    log_error "  Try again, or install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
-    exit 1
-  fi
-  # The manifest lists every release artifact as `<hash> *<name>`; keep only
-  # the installer line so a renamed or missing entry fails closed below.
-  local uv_expected uv_actual
-  uv_expected=$(awk '$2 == "*uv-installer.sh" { print $1; exit }' "$uv_sums")
-  rm -f "$uv_sums"
-  if [ -z "$uv_expected" ]; then
-    rm -f "$uv_install_out" "$uv_script"
-    log_error "The uv release checksum manifest has no entry for uv-installer.sh."
-    log_error "  Cannot verify the installer download — aborting rather than running unverified code."
-    log_error "  Try again, or install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
-    exit 1
-  fi
-  if command -v sha256sum >/dev/null 2>&1; then
-    uv_actual=$(sha256sum "$uv_script" | awk '{print $1}')
-  elif command -v shasum >/dev/null 2>&1; then
-    uv_actual=$(shasum -a 256 "$uv_script" | awk '{print $1}')
-  else
-    rm -f "$uv_install_out" "$uv_script"
-    log_error "sha256sum or shasum is required to verify the uv installer download."
-    log_error "  Install one (coreutils / perl-Digest-SHA), or install uv manually:"
-    log_error "  https://docs.astral.sh/uv/getting-started/installation/"
-    exit 1
-  fi
-  if [ "$uv_actual" != "$uv_expected" ]; then
-    rm -f "$uv_install_out" "$uv_script"
-    log_error "uv installer checksum mismatch — the download does not match the released artifact."
-    log_error "  This can indicate a tampered or corrupted download; aborting."
-    log_error "  Try again, or install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
-    exit 1
-  fi
-
   # Verify the downloaded script starts with a shell shebang before executing
   # it. This catches a non-shell response — an HTML error page or JSON from a
   # proxy or captive portal that returned 200 — that would otherwise fail

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -67,8 +67,15 @@
 #   DEEPAGENTS_CODE_RIPGREP_INSTALLER — how to provision ripgrep:
 #     "managed" (default) eagerly installs the pinned, SHA-256-verified binary
 #     into ~/.deepagents/bin (no sudo) via `dcode tools install`; "system"
-#     keeps the interactive package-manager install (brew/apt/cargo/...). Set
-#     DEEPAGENTS_CODE_OFFLINE=1 to skip the managed download entirely.
+#     keeps the interactive package-manager install (brew/apt/cargo/...),
+#     which only counts as success when the resulting `rg` meets the minimum
+#     supported version. Set DEEPAGENTS_CODE_OFFLINE=1 to skip the managed
+#     download entirely.
+#
+# The uv bootstrap download is verified against the SHA-256 manifest Astral
+# publishes with each uv release before it is executed; a mismatch, an
+# unreachable manifest, or a host with no SHA-256 tool aborts the install
+# rather than running unverified code.
 #   DEEPAGENTS_CODE_SKIP_XCODE_CHECK — set to 1 to bypass the macOS Xcode
 #     Command Line Tools preflight check
 #   DEEPAGENTS_CODE_NO_MODIFY_PATH — set to 1 to skip PATH setup entirely
@@ -450,20 +457,33 @@ fi
 # ---------------------------------------------------------------------------
 # Prompt helper — reads from /dev/tty when stdin is piped
 # ---------------------------------------------------------------------------
+# prompt_yn QUESTION — three outcomes, so callers can tell a declined prompt
+# apart from one that could never be shown:
+#   0 — answered yes
+#   1 — answered no (or empty)
+#   2 — no terminal exists to ask on (non-interactive, or /dev/tty unusable)
+# Plain `if prompt_yn ...` keeps working unchanged: 0 is yes, anything else is
+# not-yes. Only callers that act differently on "no terminal" vs "no" check
+# for 2 explicitly.
 prompt_yn() {
   local question="$1"
   if [ "$IS_INTERACTIVE" = false ]; then
-    return 1
+    return 2
   fi
   local reply
   if [ -t 0 ]; then
     printf "%s [y/N] " "$question"
-    read -r reply
+    if ! read -r reply; then
+      return 2
+    fi
   else
+    if ! { : < /dev/tty; } 2>/dev/null; then
+      return 2
+    fi
     printf "%s [y/N] " "$question" > /dev/tty
     if ! read -r reply < /dev/tty 2>/dev/null; then
       log_warn "Could not read from /dev/tty — skipping prompt."
-      return 1
+      return 2
     fi
   fi
   if [[ "$reply" =~ ^[Yy]$ ]]; then
@@ -1150,6 +1170,72 @@ install_uv() {
     exit "$uv_install_rc"
   fi
 
+  # Verify the download against the SHA-256 manifest Astral publishes with each
+  # uv release. The shebang and parse checks below only prove the response is
+  # *shaped* like a shell script; a body that is tampered-with or truncated at
+  # a statement boundary passes both. The manifest entry binds the exact bytes
+  # we run to the released artifact.
+  #
+  # Fail closed on any verification problem: a mismatch means the bytes are not
+  # what Astral released (supply-chain anomaly), and an unreachable manifest
+  # means we can no longer tell — continuing anyway would make the check
+  # silently optional. This runs for both the curl and wget paths; when curl
+  # exists it does the fetch, otherwise the already-resolved wget does.
+  local uv_sums uv_sums_rc=0
+  uv_sums=$(mktemp 2>/dev/null) || {
+    log_error "mktemp is required to create a secure temp file."
+    exit 1
+  }
+  register_temp "$uv_sums"
+  if command -v curl >/dev/null 2>&1 && ! is_snap_curl; then
+    curl -fsSL https://github.com/astral-sh/uv/releases/latest/download/sha256.sum \
+      --proto '=https' --proto-redir '=https' --max-redirs 3 \
+      -o "$uv_sums" 2>"$uv_install_out" || uv_sums_rc=$?
+  elif command -v wget >/dev/null 2>&1; then
+    wget_download "$uv_sums" https://github.com/astral-sh/uv/releases/latest/download/sha256.sum "" false \
+      2>"$uv_install_out" || uv_sums_rc=$?
+  else
+    uv_sums_rc=1
+  fi
+  if [ "$uv_sums_rc" -ne 0 ]; then
+    cat "$uv_install_out" >&2
+    rm -f "$uv_install_out" "$uv_script" "$uv_sums"
+    log_error "Could not download the uv release checksum manifest (exit ${uv_sums_rc})."
+    log_error "  Cannot verify the installer download — aborting rather than running unverified code."
+    log_error "  Try again, or install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+  fi
+  # The manifest lists every release artifact as `<hash> *<name>`; keep only
+  # the installer line so a renamed or missing entry fails closed below.
+  local uv_expected uv_actual
+  uv_expected=$(awk '$2 == "*uv-installer.sh" { print $1; exit }' "$uv_sums")
+  rm -f "$uv_sums"
+  if [ -z "$uv_expected" ]; then
+    rm -f "$uv_install_out" "$uv_script"
+    log_error "The uv release checksum manifest has no entry for uv-installer.sh."
+    log_error "  Cannot verify the installer download — aborting rather than running unverified code."
+    log_error "  Try again, or install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    uv_actual=$(sha256sum "$uv_script" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    uv_actual=$(shasum -a 256 "$uv_script" | awk '{print $1}')
+  else
+    rm -f "$uv_install_out" "$uv_script"
+    log_error "sha256sum or shasum is required to verify the uv installer download."
+    log_error "  Install one (coreutils / perl-Digest-SHA), or install uv manually:"
+    log_error "  https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+  fi
+  if [ "$uv_actual" != "$uv_expected" ]; then
+    rm -f "$uv_install_out" "$uv_script"
+    log_error "uv installer checksum mismatch — the download does not match the released artifact."
+    log_error "  This can indicate a tampered or corrupted download; aborting."
+    log_error "  Try again, or install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+  fi
+
   # Verify the downloaded script starts with a shell shebang before executing
   # it. This catches a non-shell response — an HTML error page or JSON from a
   # proxy or captive portal that returned 200 — that would otherwise fail
@@ -1417,20 +1503,34 @@ elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" 
     log_info "deepagents-code ${PRE_VERSION} is current but is outside uv's configured tool bin — installing it there."
   elif [ "$ASSUME_YES" = "1" ]; then
     log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}..."
-  elif can_prompt; then
-    log_info "What's new: ${RELEASE_TAG_URL_BASE}${LATEST_VERSION}"
-    if prompt_yn "Update deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}?"; then
-      log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}..."
-    else
-      log_info "Keeping deepagents-code ${PRE_VERSION}. Re-run this installer anytime to update."
-      exit 0
-    fi
   else
-    # No TTY to prompt (cron, CI, Dockerfile RUN, systemd): there is no human to
-    # ask, and an installer's job is to make the current version present, so
-    # complete the upgrade rather than silently no-op. Callers that want a fixed
-    # version pin DEEPAGENTS_CODE_VERSION, which skips this path entirely.
-    log_info "deepagents-code ${LATEST_VERSION} available — updating (no TTY to prompt)."
+    # Print the release link only when a terminal is present to answer the
+    # prompt. prompt_yn's exit code then distinguishes the three outcomes:
+    # yes (0), a human's "no" (1), and "no terminal to ask on" (2, from cron /
+    # CI / a Dockerfile RUN / systemd) — which falls through to the upgrade.
+    if can_prompt; then
+      log_info "What's new: ${RELEASE_TAG_URL_BASE}${LATEST_VERSION}"
+    fi
+    # `|| prompt_rc=$?` keeps a "no" answer from tripping `set -e`: a bare
+    # failing command would abort the script before the case below runs.
+    prompt_rc=0
+    prompt_yn "Update deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}?" || prompt_rc=$?
+    case "$prompt_rc" in
+      0)
+        log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}..."
+        ;;
+      1)
+        log_info "Keeping deepagents-code ${PRE_VERSION}. Re-run this installer anytime to update."
+        exit 0
+        ;;
+      *)
+        # No human to ask, and an installer's job is to make the current
+        # version present, so complete the upgrade rather than silently no-op.
+        # Callers that want a fixed version pin DEEPAGENTS_CODE_VERSION, which
+        # skips this path entirely.
+        log_info "deepagents-code ${LATEST_VERSION} available — updating (no TTY to prompt)."
+        ;;
+    esac
   fi
 elif [ -n "$PRE_VERSION" ]; then
   log_info "dcode ${PRE_VERSION} found — checking for updates..."
@@ -2326,7 +2426,12 @@ ensure_path_setup() {
     done
   fi
   if [ "$IS_INTERACTIVE" = true ] && can_prompt; then
-    if ! prompt_yn "Add ~/.local/bin to your PATH in ${prompt_targets}?"; then
+    # Only an explicit "no" (rc=1) declines; rc=2 (no usable terminal) leaves
+    # the auto-add default in place, matching the non-interactive behavior.
+    # `|| prompt_rc=$?` keeps "no" from tripping `set -e`.
+    prompt_rc=0
+    prompt_yn "Add ~/.local/bin to your PATH in ${prompt_targets}?" || prompt_rc=$?
+    if [ "$prompt_rc" -eq 1 ]; then
       should_add=false
     fi
   fi
@@ -2576,6 +2681,46 @@ fi
 # ---------------------------------------------------------------------------
 # Optional tools — ripgrep
 # ---------------------------------------------------------------------------
+# Oldest ripgrep the agent's grep tool is expected to work with. The managed
+# installer pins a newer upstream release; this floor only guards the system
+# path (brew/apt/...) so an ancient distro package doesn't install
+# "successfully" and then behave differently at runtime.
+MIN_RIPGREP_VERSION="12.0.0"
+
+# version_at_least HAVE WANT — dotted numeric compare (12.0.0 >= 11.0.0). The
+# installer runs before Python exists, so this stays in pure shell.
+version_at_least() {
+  local have="$1" want="$2" IFS_save="$IFS"
+  case "$have" in ''|*[!0-9.]*) return 1 ;; esac
+  IFS=.
+  # shellcheck disable=SC2086  # word-splitting on '.' is the point
+  set -- $have
+  IFS="$IFS_save"
+  local have_major="${1:-0}" have_minor="${2:-0}" have_patch="${3:-0}"
+  IFS=.
+  # shellcheck disable=SC2086
+  set -- $want
+  IFS="$IFS_save"
+  local want_major="${1:-0}" want_minor="${2:-0}" want_patch="${3:-0}"
+  [ "$have_major" -gt "$want_major" ] && return 0
+  [ "$have_major" -lt "$want_major" ] && return 1
+  [ "$have_minor" -gt "$want_minor" ] && return 0
+  [ "$have_minor" -lt "$want_minor" ] && return 1
+  [ "$have_patch" -ge "$want_patch" ]
+}
+
+# version_older_than_have IS MIN — true when IS is present but below MIN.
+version_too_old() {
+  local is="$1" min="$2"
+  [ -n "$is" ] || return 1
+  ! version_at_least "$is" "$min"
+}
+
+# Print the version of `rg` on PATH, or nothing when it can't be determined.
+installed_rg_version() {
+  rg --version 2>/dev/null | head -1 | awk '{print $2}'
+}
+
 
 # Pre-check: verify sudo is usable before running sudo commands.
 # Returns 0 if sudo is available (cached or passwordless), 1 otherwise.
@@ -2595,19 +2740,34 @@ check_sudo() {
   return 1
 }
 
+# True when the `rg` on PATH is present and at least MIN_RIPGREP_VERSION.
+# An install that produced a too-old binary does not count as success: an
+# ancient distro package would otherwise satisfy `command -v rg` while behaving
+# differently from what the grep tool expects.
+installed_rg_is_acceptable() {
+  local ver
+  command -v rg >/dev/null 2>&1 || return 1
+  ver=$(installed_rg_version)
+  if version_too_old "$ver" "$MIN_RIPGREP_VERSION"; then
+    log_warn "ripgrep ${ver} is older than the supported minimum (${MIN_RIPGREP_VERSION})."
+    return 1
+  fi
+  return 0
+}
+
 install_ripgrep_via_pkg() {
   case "$OS" in
     macos)
       if command -v brew >/dev/null 2>&1; then
         log_info "Installing ripgrep via Homebrew (this may take a moment)..."
         if HOMEBREW_NO_AUTO_UPDATE=1 brew install ripgrep; then
-          command -v rg >/dev/null 2>&1 && return 0
+          installed_rg_is_acceptable && return 0
         fi
       fi
       if command -v port >/dev/null 2>&1 && check_sudo; then
         log_info "Installing ripgrep via MacPorts..."
         if sudo port install ripgrep; then
-          command -v rg >/dev/null 2>&1 && return 0
+          installed_rg_is_acceptable && return 0
         fi
       fi
       ;;
@@ -2615,32 +2775,32 @@ install_ripgrep_via_pkg() {
       if command -v apt-get >/dev/null 2>&1 && check_sudo; then
         log_info "Installing ripgrep via apt-get..."
         if sudo apt-get install -y ripgrep; then
-          command -v rg >/dev/null 2>&1 && return 0
+          installed_rg_is_acceptable && return 0
         fi
       elif command -v dnf >/dev/null 2>&1 && check_sudo; then
         log_info "Installing ripgrep via dnf..."
         if sudo dnf install -y ripgrep; then
-          command -v rg >/dev/null 2>&1 && return 0
+          installed_rg_is_acceptable && return 0
         fi
       elif command -v pacman >/dev/null 2>&1 && check_sudo; then
         log_info "Installing ripgrep via pacman..."
         if sudo pacman -S --noconfirm ripgrep; then
-          command -v rg >/dev/null 2>&1 && return 0
+          installed_rg_is_acceptable && return 0
         fi
       elif command -v zypper >/dev/null 2>&1 && check_sudo; then
         log_info "Installing ripgrep via zypper..."
         if sudo zypper install -y ripgrep; then
-          command -v rg >/dev/null 2>&1 && return 0
+          installed_rg_is_acceptable && return 0
         fi
       elif command -v apk >/dev/null 2>&1 && check_sudo; then
         log_info "Installing ripgrep via apk..."
         if sudo apk add ripgrep; then
-          command -v rg >/dev/null 2>&1 && return 0
+          installed_rg_is_acceptable && return 0
         fi
       elif command -v nix-env >/dev/null 2>&1; then
         log_info "Installing ripgrep via nix..."
         if nix-env -iA nixpkgs.ripgrep; then
-          command -v rg >/dev/null 2>&1 && return 0
+          installed_rg_is_acceptable && return 0
         fi
       fi
       ;;
@@ -2653,8 +2813,8 @@ install_ripgrep_via_cargo() {
     log_info "Installing ripgrep via cargo (no sudo needed)..."
     if cargo install ripgrep; then
       fix_owner "${HOME}/.cargo"
-      command -v rg >/dev/null 2>&1 && return 0
-      log_warn "cargo install succeeded but rg not found in PATH."
+      installed_rg_is_acceptable && return 0
+      log_warn "cargo install succeeded but rg not found in PATH or too old."
     fi
   fi
   return 1
@@ -2709,11 +2869,15 @@ if [ "$SKIP_OPTIONAL" != "1" ]; then
       fi
     fi
   elif command -v rg >/dev/null 2>&1; then
-    if [ "$VERBOSE" = "1" ]; then
+    rg_version=$(installed_rg_version)
+    if version_too_old "$rg_version" "$MIN_RIPGREP_VERSION"; then
+      echo ""
+      log_warn "ripgrep ${rg_version} found, but the minimum supported is ${MIN_RIPGREP_VERSION} — the grep tool may misbehave."
+      ripgrep_manual_hint
+    elif [ "$VERBOSE" = "1" ]; then
       echo ""
       log_info "Checking optional tools..."
-      rg_version=$(rg --version 2>/dev/null | head -1 | awk '{print $2}') || rg_version="(version unknown)"
-      log_success "ripgrep ${rg_version} found"
+      log_success "ripgrep ${rg_version:-(version unknown)} found"
     fi
   else
     echo ""

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -72,10 +72,9 @@
 #     supported version. Set DEEPAGENTS_CODE_OFFLINE=1 to skip the managed
 #     download entirely.
 #
-# The uv bootstrap download is verified against the SHA-256 manifest Astral
-# publishes with each uv release before it is executed; a mismatch, an
-# unreachable manifest, or a host with no SHA-256 tool aborts the install
-# rather than running unverified code.
+# Before execution, the downloaded uv bootstrap script is checked for a shell
+# shebang and valid shell syntax. These structural checks help catch error
+# pages and some truncated downloads, but do not verify its integrity.
 #   DEEPAGENTS_CODE_SKIP_XCODE_CHECK — set to 1 to bypass the macOS Xcode
 #     Command Line Tools preflight check
 #   DEEPAGENTS_CODE_NO_MODIFY_PATH — set to 1 to skip PATH setup entirely

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import pty
 import re
+import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -824,6 +826,106 @@ def test_can_prompt_false_without_usable_tty(tmp_path: Path) -> None:
     wrongly report the unanswerable cron/systemd/CI case as promptable.
     """
     assert _eval_can_prompt(tmp_path, is_interactive=True, stdin_is_tty=False) is False
+
+
+def _eval_prompt_yn(tmp_path: Path, *, is_interactive: bool, answer: str | None) -> int:
+    """Run the real `prompt_yn` and report its raw exit code.
+
+    `answer=None` detaches the controlling terminal (stdin from `/dev/null`,
+    `start_new_session`), so there is no terminal to prompt on — the rc=2
+    path. Otherwise stdin is a real pty with the answer written in, so the
+    `[ -t 0 ]` branch reads it and rc distinguishes yes (0) from no (1).
+    """
+    script = tmp_path / "prompt_yn_harness.sh"
+    script.write_text(
+        f"{_extract_shell_function('prompt_yn')}\n"
+        f"IS_INTERACTIVE={'true' if is_interactive else 'false'}\n"
+        "prompt_yn 'Proceed?'\n",
+        encoding="utf-8",
+    )
+    if answer is None:
+        proc = subprocess.run(
+            ["bash", str(script)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            start_new_session=True,
+        )
+        return proc.returncode
+    primary, secondary = pty.openpty()
+    try:
+        # Write the answer before the child reads, so `read` sees it on the
+        # pty's input queue rather than blocking.
+        os.write(primary, (answer + "\n").encode())
+        proc = subprocess.run(
+            ["bash", str(script)],
+            stdin=secondary,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    finally:
+        os.close(secondary)
+        os.close(primary)
+    return proc.returncode
+
+
+def test_prompt_yn_yes_returns_zero(tmp_path: Path) -> None:
+    """An affirmative answer is rc=0."""
+    assert _eval_prompt_yn(tmp_path, is_interactive=True, answer="y") == 0
+
+
+def test_prompt_yn_no_returns_one(tmp_path: Path) -> None:
+    """A declined answer is rc=1, distinct from the no-terminal case."""
+    assert _eval_prompt_yn(tmp_path, is_interactive=True, answer="n") == 1
+
+
+def test_prompt_yn_no_terminal_returns_two(tmp_path: Path) -> None:
+    """No usable terminal is rc=2, so callers can default instead of decline."""
+    assert _eval_prompt_yn(tmp_path, is_interactive=True, answer=None) == 2
+
+
+def test_prompt_yn_non_interactive_returns_two(tmp_path: Path) -> None:
+    """`IS_INTERACTIVE=false` is rc=2 — unaskable, not a "no"."""
+    assert _eval_prompt_yn(tmp_path, is_interactive=False, answer="y") == 2
+
+
+def _eval_version_at_least(tmp_path: Path, have: str, want: str) -> bool:
+    """Run the real `version_at_least` from install.sh, reporting its verdict."""
+    script = tmp_path / "version_harness.sh"
+    script.write_text(
+        f"{_extract_shell_function('version_at_least')}\n"
+        f"if version_at_least {have!r} {want!r}; then echo YES; else echo NO; fi\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip() == "YES"
+
+
+@pytest.mark.parametrize(
+    ("have", "want", "expected"),
+    [
+        ("14.1.1", "12.0.0", True),  # current managed pin clears the floor
+        ("12.0.0", "12.0.0", True),  # boundary: equal is acceptable
+        ("12.0.1", "12.0.0", True),  # patch above
+        ("13.0.0", "12.0.0", True),  # minor above
+        ("11.9.9", "12.0.0", False),  # minor below
+        ("0.10.0", "12.0.0", False),  # ancient distro package
+        ("", "12.0.0", False),  # empty is never acceptable
+        ("abc", "12.0.0", False),  # unparseable is never acceptable
+    ],
+)
+def test_version_at_least(tmp_path: Path, have: str, want: str, expected: bool) -> None:
+    """Dotted-version comparison gates the system ripgrep floor."""
+    assert _eval_version_at_least(tmp_path, have, want) is expected
 
 
 _FRESH_INSTALL_DIFF = (
@@ -1962,6 +2064,10 @@ def _run_install_uv(
     use_wget: bool = False,
     busybox_wget: bool = False,
     truncated: bool = False,
+    sum_fails: bool = False,
+    sum_missing_entry: bool = False,
+    sum_mismatch: bool = False,
+    no_sha_tool: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Run the real `install_uv` from `install.sh` against a fake uv installer.
 
@@ -1982,29 +2088,68 @@ def _run_install_uv(
     """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    first_line = "'<html>error</html>'" if no_shebang else "'#!/bin/sh'"
-    installer = first_line
+    first_line = "<html>error</html>" if no_shebang else "#!/bin/sh"
+    installer = first_line + "\n"
     if truncated:
         # A body cut mid-`if`: the shebang is intact, so only a parse check
         # rejects this. Exactly the shape a dropped connection leaves behind.
-        installer += " 'if [ 1 = 1 ]; then'"
-    installer += " 'echo UV_INSTALLER_NOISE'"
+        installer += "if [ 1 = 1 ]; then\n"
+    installer += "echo UV_INSTALLER_NOISE\n"
     if fails:
-        installer += " 'exit 3'"
+        installer += "exit 3\n"
 
-    # The fake downloader must handle its output flag (curl ``-o`` / wget ``-O``)
-    # and write the installer content there instead of stdout. With
+    # The fake installer is served as a real file (not shell-quoted inline) so
+    # its digest can be computed and served alongside it. install_uv fetches
+    # two URLs through the same downloader: the installer
+    # (astral.sh/uv/install.sh) and the checksum manifest
+    # (github.com/astral-sh/uv/releases/latest/download/sha256.sum). The URL
+    # stays visible in argv, so the fake routes each to its payload. The
+    # manifest's `uv-installer.sh` entry carries the real digest of the
+    # fixture, computed here with Python's hashlib, so the fixture is
+    # self-consistent on any platform and verification passes.
+    installer_fixture = tmp_path / "fake-uv-installer.sh"
+    installer_fixture.write_text(installer, encoding="utf-8")
+    good_digest = hashlib.sha256(installer.encode()).hexdigest()
+    sum_fixture = tmp_path / "fake-sha256.sum"
+    if sum_missing_entry:
+        sum_fixture.write_text(
+            "0" * 64 + " *uv-aarch64-apple-darwin.tar.gz\n", encoding="utf-8"
+        )
+    elif sum_mismatch:
+        sum_fixture.write_text("0" * 64 + " *uv-installer.sh\n", encoding="utf-8")
+    else:
+        sum_fixture.write_text(f"{good_digest} *uv-installer.sh\n", encoding="utf-8")
+
+    # The fake downloader must handle its output flag (curl ``-o`` / wget
+    # ``-O``) and copy the right fixture there based on the URL in argv. With
     # ``download_fails`` it instead emits an error to stderr and exits non-zero
-    # without creating the file, so install_uv sees a failed download.
+    # without creating the file, so install_uv sees a failed download. With
+    # ``sum_fails`` the installer serves fine but the manifest fetch fails.
     downloader_name = "wget" if use_wget else "curl"
     out_flag = "-O" if use_wget else "-o"
+    sum_fail_guard = ""
+    if sum_fails:
+        sum_fail_guard = (
+            "  printf 'DOWNLOADER_ERROR: could not resolve host\\n' >&2\n  exit 7\n"
+        )
+
     if download_fails:
         write_body = (
             "printf 'DOWNLOADER_ERROR: could not resolve host\\n' >&2\nexit 7\n"
         )
     elif download_failures_before_success:
+        # The retry counter must key on the installer fetch only — the checksum
+        # manifest is a separate request that must keep routing to its fixture
+        # (and succeed) so verification can run once the installer download
+        # recovers.
         attempts = tmp_path / "uv-download-attempts.txt"
         write_body = (
+            'case "$all_args" in\n'
+            "  *sha256.sum*)\n"
+            f'    cat {str(sum_fixture)!r} >"${{out:-/dev/stdout}}"\n'
+            "    exit 0\n"
+            "    ;;\n"
+            "esac\n"
             "count=0\n"
             f"if [ -f {str(attempts)!r} ]; then read -r count < {str(attempts)!r}; fi\n"
             "count=$((count + 1))\n"
@@ -2013,10 +2158,20 @@ def _run_install_uv(
             "  printf 'DOWNLOADER_ERROR: transient failure\\n' >&2\n"
             "  exit 7\n"
             "fi\n"
-            f"printf '%s\\n' {installer} >\"${{out:-/dev/stdout}}\"\n"
+            f'cat {str(installer_fixture)!r} >"${{out:-/dev/stdout}}"\n'
         )
     else:
-        write_body = f"printf '%s\\n' {installer} >\"${{out:-/dev/stdout}}\"\n"
+        write_body = (
+            'case "$all_args" in\n'
+            "  *sha256.sum*)\n"
+            f"{sum_fail_guard}"
+            f'    cat {str(sum_fixture)!r} >"${{out:-/dev/stdout}}"\n'
+            "    ;;\n"
+            "  *)\n"
+            f'    cat {str(installer_fixture)!r} >"${{out:-/dev/stdout}}"\n'
+            "    ;;\n"
+            "esac\n"
+        )
     downloader = bin_dir / downloader_name
     # `wget_download` probes `wget --help` to decide which hardening flags this
     # wget implements. Answer those probes *before* any counting or output, so
@@ -2061,6 +2216,9 @@ def _run_install_uv(
     record_argv = f"printf '%s\\n' \"$*\" >> {str(argv_log)!r}\n"
     downloader.write_text(
         "#!/usr/bin/env bash\n" + help_handler + record_argv + "out=''\n"
+        # Capture the full argv *before* the parsing loop shifts it away — the
+        # body routes on the URL, which is gone from `$*` once the loop runs.
+        'all_args="$*"\n'
         "while [ $# -gt 0 ]; do\n"
         '  case "$1" in\n'
         f'    {out_flag}) out="$2"; shift 2 ;;\n'
@@ -2076,7 +2234,6 @@ def _run_install_uv(
         mktemp = bin_dir / "mktemp"
         mktemp.write_text("#!/usr/bin/env bash\nexit 1\n")
         _make_executable(mktemp)
-
     # install_uv branches on is_snap_curl. For the curl path, stub it to the
     # non-snap answer so the normal curl branch runs (and no stray "command not
     # found" hits stderr). For the wget path, report curl as a snap so install_uv
@@ -2098,6 +2255,36 @@ def _run_install_uv(
         encoding="utf-8",
     )
     env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+    if no_sha_tool:
+        # `command -v` only checks PATH presence (it never runs the tool), so
+        # hiding the host's sha256sum/shasum requires a PATH that genuinely
+        # lacks them. Rebuild PATH from scratch: bin_dir (fakes) plus symlinks
+        # to just the core utilities install_uv and the fakes invoke.
+        tools_dir = tmp_path / "bare-tools"
+        tools_dir.mkdir()
+        needed = (
+            "awk",
+            "bash",
+            "cat",
+            "chmod",
+            "env",
+            "grep",
+            "head",
+            "ls",
+            "mkdir",
+            "mktemp",
+            "mv",
+            "rm",
+            "sh",
+            "sleep",
+            "tr",
+            "uname",
+        )
+        for tool_name in needed:
+            resolved = shutil.which(tool_name)
+            if resolved:
+                (tools_dir / tool_name).symlink_to(resolved)
+        env["PATH"] = f"{bin_dir}{os.pathsep}{tools_dir}"
     return subprocess.run(
         ["bash", str(script)],
         env=env,
@@ -2174,6 +2361,69 @@ def test_install_uv_rejects_truncated_download(tmp_path: Path) -> None:
 
     assert proc.returncode != 0
     assert "failed a shell syntax check" in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stdout
+
+
+def test_install_uv_verifies_checksum_and_runs(tmp_path: Path) -> None:
+    """A download whose digest matches the manifest is verified, then run.
+
+    The fake manifest carries the real SHA-256 of the fixture installer, so a
+    passing run proves the verification step is wired end-to-end: manifest
+    fetched, entry selected, digest compared, payload executed.
+    """
+    proc = _run_install_uv(tmp_path, verbose=False)
+
+    assert proc.returncode == 0
+    # The installer body only runs when verification succeeded.
+    argv = (tmp_path / "downloader-argv.txt").read_text()
+    assert "sha256.sum" in argv
+
+
+def test_install_uv_checksum_mismatch_aborts_before_exec(tmp_path: Path) -> None:
+    """A digest that disagrees with the manifest fails closed, never executing.
+
+    A mismatch is a supply-chain anomaly (tampered mirror, CDN poisoning), so
+    the payload must not run even though it is a valid shell script.
+    """
+    proc = _run_install_uv(tmp_path, verbose=False, sum_mismatch=True)
+
+    assert proc.returncode != 0
+    assert "checksum mismatch" in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stdout
+
+
+def test_install_uv_unfetchable_checksum_aborts(tmp_path: Path) -> None:
+    """A manifest that cannot be downloaded fails closed rather than skipping.
+
+    Verification that silently becomes optional when the network hiccups is
+    not verification; the installer must stop and say why.
+    """
+    proc = _run_install_uv(tmp_path, verbose=False, sum_fails=True)
+
+    assert proc.returncode != 0
+    assert "Could not download the uv release checksum manifest" in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stdout
+
+
+def test_install_uv_manifest_missing_installer_entry_aborts(tmp_path: Path) -> None:
+    """A manifest without a uv-installer.sh line fails closed."""
+    proc = _run_install_uv(tmp_path, verbose=False, sum_missing_entry=True)
+
+    assert proc.returncode != 0
+    assert "no entry for uv-installer.sh" in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stdout
+
+
+def test_install_uv_requires_a_sha256_tool(tmp_path: Path) -> None:
+    """A host with neither sha256sum nor shasum cannot verify, so it aborts."""
+    proc = _run_install_uv(tmp_path, verbose=False, no_sha_tool=True)
+
+    assert proc.returncode != 0
+    assert "sha256sum or shasum is required" in proc.stderr
     assert "UV_INSTALLER_NOISE" not in proc.stderr
     assert "UV_INSTALLER_NOISE" not in proc.stdout
 

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import hashlib
 import os
 import pty
 import re
-import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -3751,10 +3749,6 @@ def _run_install_uv(
     use_wget: bool = False,
     busybox_wget: bool = False,
     truncated: bool = False,
-    sum_fails: bool = False,
-    sum_missing_entry: bool = False,
-    sum_mismatch: bool = False,
-    no_sha_tool: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Run the real `install_uv` from `install.sh` against a fake uv installer.
 
@@ -3785,58 +3779,25 @@ def _run_install_uv(
     if fails:
         installer += "exit 3\n"
 
-    # The fake installer is served as a real file (not shell-quoted inline) so
-    # its digest can be computed and served alongside it. install_uv fetches
-    # two URLs through the same downloader: the installer
-    # (astral.sh/uv/install.sh) and the checksum manifest
-    # (github.com/astral-sh/uv/releases/latest/download/sha256.sum). The URL
-    # stays visible in argv, so the fake routes each to its payload. The
-    # manifest's `uv-installer.sh` entry carries the real digest of the
-    # fixture, computed here with Python's hashlib, so the fixture is
-    # self-consistent on any platform and verification passes.
+    # The fake installer is served as a real file (not shell-quoted inline)
+    # so the downloader can copy it to the output path install_uv passes.
     installer_fixture = tmp_path / "fake-uv-installer.sh"
     installer_fixture.write_text(installer, encoding="utf-8")
-    good_digest = hashlib.sha256(installer.encode()).hexdigest()
-    sum_fixture = tmp_path / "fake-sha256.sum"
-    if sum_missing_entry:
-        sum_fixture.write_text(
-            "0" * 64 + " *uv-aarch64-apple-darwin.tar.gz\n", encoding="utf-8"
-        )
-    elif sum_mismatch:
-        sum_fixture.write_text("0" * 64 + " *uv-installer.sh\n", encoding="utf-8")
-    else:
-        sum_fixture.write_text(f"{good_digest} *uv-installer.sh\n", encoding="utf-8")
 
     # The fake downloader must handle its output flag (curl ``-o`` / wget
-    # ``-O``) and copy the right fixture there based on the URL in argv. With
-    # ``download_fails`` it instead emits an error to stderr and exits non-zero
-    # without creating the file, so install_uv sees a failed download. With
-    # ``sum_fails`` the installer serves fine but the manifest fetch fails.
+    # ``-O``) and copy the fixture there. With ``download_fails`` it instead
+    # emits an error to stderr and exits non-zero without creating the file,
+    # so install_uv sees a failed download.
     downloader_name = "wget" if use_wget else "curl"
     out_flag = "-O" if use_wget else "-o"
-    sum_fail_guard = ""
-    if sum_fails:
-        sum_fail_guard = (
-            "  printf 'DOWNLOADER_ERROR: could not resolve host\\n' >&2\n  exit 7\n"
-        )
 
     if download_fails:
         write_body = (
             "printf 'DOWNLOADER_ERROR: could not resolve host\\n' >&2\nexit 7\n"
         )
     elif download_failures_before_success:
-        # The retry counter must key on the installer fetch only — the checksum
-        # manifest is a separate request that must keep routing to its fixture
-        # (and succeed) so verification can run once the installer download
-        # recovers.
         attempts = tmp_path / "uv-download-attempts.txt"
         write_body = (
-            'case "$all_args" in\n'
-            "  *sha256.sum*)\n"
-            f'    cat {str(sum_fixture)!r} >"${{out:-/dev/stdout}}"\n'
-            "    exit 0\n"
-            "    ;;\n"
-            "esac\n"
             "count=0\n"
             f"if [ -f {str(attempts)!r} ]; then read -r count < {str(attempts)!r}; fi\n"
             "count=$((count + 1))\n"
@@ -3848,17 +3809,7 @@ def _run_install_uv(
             f'cat {str(installer_fixture)!r} >"${{out:-/dev/stdout}}"\n'
         )
     else:
-        write_body = (
-            'case "$all_args" in\n'
-            "  *sha256.sum*)\n"
-            f"{sum_fail_guard}"
-            f'    cat {str(sum_fixture)!r} >"${{out:-/dev/stdout}}"\n'
-            "    ;;\n"
-            "  *)\n"
-            f'    cat {str(installer_fixture)!r} >"${{out:-/dev/stdout}}"\n'
-            "    ;;\n"
-            "esac\n"
-        )
+        write_body = f'cat {str(installer_fixture)!r} >"${{out:-/dev/stdout}}"\n'
     downloader = bin_dir / downloader_name
     # `wget_download` probes `wget --help` to decide which hardening flags this
     # wget implements. Answer those probes *before* any counting or output, so
@@ -3942,36 +3893,6 @@ def _run_install_uv(
         encoding="utf-8",
     )
     env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
-    if no_sha_tool:
-        # `command -v` only checks PATH presence (it never runs the tool), so
-        # hiding the host's sha256sum/shasum requires a PATH that genuinely
-        # lacks them. Rebuild PATH from scratch: bin_dir (fakes) plus symlinks
-        # to just the core utilities install_uv and the fakes invoke.
-        tools_dir = tmp_path / "bare-tools"
-        tools_dir.mkdir()
-        needed = (
-            "awk",
-            "bash",
-            "cat",
-            "chmod",
-            "env",
-            "grep",
-            "head",
-            "ls",
-            "mkdir",
-            "mktemp",
-            "mv",
-            "rm",
-            "sh",
-            "sleep",
-            "tr",
-            "uname",
-        )
-        for tool_name in needed:
-            resolved = shutil.which(tool_name)
-            if resolved:
-                (tools_dir / tool_name).symlink_to(resolved)
-        env["PATH"] = f"{bin_dir}{os.pathsep}{tools_dir}"
     return subprocess.run(
         ["bash", str(script)],
         env=env,
@@ -4052,67 +3973,16 @@ def test_install_uv_rejects_truncated_download(tmp_path: Path) -> None:
     assert "UV_INSTALLER_NOISE" not in proc.stdout
 
 
-def test_install_uv_verifies_checksum_and_runs(tmp_path: Path) -> None:
-    """A download whose digest matches the manifest is verified, then run.
+def test_install_uv_verifies_and_runs(tmp_path: Path) -> None:
+    """A well-formed installer passes the shebang and parse checks, then runs.
 
-    The fake manifest carries the real SHA-256 of the fixture installer, so a
-    passing run proves the verification step is wired end-to-end: manifest
-    fetched, entry selected, digest compared, payload executed.
+    Upstream does not publish a checksum for ``uv-installer.sh``, so there is
+    no digest comparison to wire up here — this test simply proves the payload
+    executes once the structural checks pass.
     """
     proc = _run_install_uv(tmp_path, verbose=False)
 
     assert proc.returncode == 0
-    # The installer body only runs when verification succeeded.
-    argv = (tmp_path / "downloader-argv.txt").read_text()
-    assert "sha256.sum" in argv
-
-
-def test_install_uv_checksum_mismatch_aborts_before_exec(tmp_path: Path) -> None:
-    """A digest that disagrees with the manifest fails closed, never executing.
-
-    A mismatch is a supply-chain anomaly (tampered mirror, CDN poisoning), so
-    the payload must not run even though it is a valid shell script.
-    """
-    proc = _run_install_uv(tmp_path, verbose=False, sum_mismatch=True)
-
-    assert proc.returncode != 0
-    assert "checksum mismatch" in proc.stderr
-    assert "UV_INSTALLER_NOISE" not in proc.stderr
-    assert "UV_INSTALLER_NOISE" not in proc.stdout
-
-
-def test_install_uv_unfetchable_checksum_aborts(tmp_path: Path) -> None:
-    """A manifest that cannot be downloaded fails closed rather than skipping.
-
-    Verification that silently becomes optional when the network hiccups is
-    not verification; the installer must stop and say why.
-    """
-    proc = _run_install_uv(tmp_path, verbose=False, sum_fails=True)
-
-    assert proc.returncode != 0
-    assert "Could not download the uv release checksum manifest" in proc.stderr
-    assert "UV_INSTALLER_NOISE" not in proc.stderr
-    assert "UV_INSTALLER_NOISE" not in proc.stdout
-
-
-def test_install_uv_manifest_missing_installer_entry_aborts(tmp_path: Path) -> None:
-    """A manifest without a uv-installer.sh line fails closed."""
-    proc = _run_install_uv(tmp_path, verbose=False, sum_missing_entry=True)
-
-    assert proc.returncode != 0
-    assert "no entry for uv-installer.sh" in proc.stderr
-    assert "UV_INSTALLER_NOISE" not in proc.stderr
-    assert "UV_INSTALLER_NOISE" not in proc.stdout
-
-
-def test_install_uv_requires_a_sha256_tool(tmp_path: Path) -> None:
-    """A host with neither sha256sum nor shasum cannot verify, so it aborts."""
-    proc = _run_install_uv(tmp_path, verbose=False, no_sha_tool=True)
-
-    assert proc.returncode != 0
-    assert "sha256sum or shasum is required" in proc.stderr
-    assert "UV_INSTALLER_NOISE" not in proc.stderr
-    assert "UV_INSTALLER_NOISE" not in proc.stdout
 
 
 def test_install_uv_curl_pins_https_for_request_and_redirects(

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -94,6 +94,7 @@ def _write_fake_tools(
     curl_fails: bool = False,
     curl_failures_before_success: int = 0,
     dcode_verify_fails: bool = False,
+    rg_version_fails: bool = False,
     mktemp_fails: bool = False,
     stage_uv_receipt: bool = True,
 ) -> tuple[Path, Path, Path]:
@@ -105,6 +106,7 @@ def _write_fake_tools(
     the script's offline fallback can be exercised. `dcode_verify_fails` makes
     `dcode -v` exit non-zero (`VERIFY_OK=false`) so the eager managed-ripgrep
     guard can be exercised against a present-but-broken binary.
+    `rg_version_fails` stages an `rg` that fails its version probe.
 
     An existing install also gets a bare `uv-receipt.toml`, because that is
     what a real `uv tool install` leaves behind: the script treats a uv-managed
@@ -208,6 +210,11 @@ printf '%s' '{payload}'
     sleep.write_text("#!/usr/bin/env bash\nexit 0\n")
     _make_executable(sleep)
 
+    if rg_version_fails:
+        rg = bin_dir / "rg"
+        rg.write_text("#!/usr/bin/env bash\nexit 1\n")
+        _make_executable(rg)
+
     if mktemp_fails:
         mktemp = bin_dir / "mktemp"
         mktemp.write_text("#!/usr/bin/env bash\nexit 1\n")
@@ -244,6 +251,7 @@ def _env(
     curl_fails: bool = False,
     curl_failures_before_success: int = 0,
     dcode_verify_fails: bool = False,
+    rg_version_fails: bool = False,
     mktemp_fails: bool = False,
     stage_uv_receipt: bool = True,
 ) -> dict[str, str]:
@@ -254,6 +262,7 @@ def _env(
         curl_fails=curl_fails,
         curl_failures_before_success=curl_failures_before_success,
         dcode_verify_fails=dcode_verify_fails,
+        rg_version_fails=rg_version_fails,
         mktemp_fails=mktemp_fails,
         stage_uv_receipt=stage_uv_receipt,
     )
@@ -277,6 +286,7 @@ def _invoke(
     curl_fails: bool = False,
     curl_failures_before_success: int = 0,
     dcode_verify_fails: bool = False,
+    rg_version_fails: bool = False,
     mktemp_fails: bool = False,
     stage_uv_receipt: bool = True,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
@@ -295,6 +305,7 @@ def _invoke(
         curl_fails=curl_fails,
         curl_failures_before_success=curl_failures_before_success,
         dcode_verify_fails=dcode_verify_fails,
+        rg_version_fails=rg_version_fails,
         mktemp_fails=mktemp_fails,
         stage_uv_receipt=stage_uv_receipt,
     )
@@ -5905,6 +5916,27 @@ def test_install_script_system_ripgrep_skips_tools_install(tmp_path: Path) -> No
 
     assert proc.returncode == 0, proc.stderr
     assert not (tmp_path / "dcode-tools.txt").exists()
+
+
+def test_install_script_system_ripgrep_failed_version_probe_warns(
+    tmp_path: Path,
+) -> None:
+    """A broken system `rg` is optional and must not abort the installer."""
+    proc, _ = _invoke(
+        tmp_path,
+        {
+            "DEEPAGENTS_CODE_SKIP_OPTIONAL": "0",
+            "DEEPAGENTS_CODE_RIPGREP_INSTALLER": "system",
+        },
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+        rg_version_fails=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    combined = proc.stdout + proc.stderr
+    assert "Could not determine the version of ripgrep on PATH" in combined
+    assert "slower fallback" in combined
 
 
 def test_install_script_skip_optional_skips_tools_install(tmp_path: Path) -> None:

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1337,7 +1337,7 @@ requires-dist = [
     { name = "langchain-together", marker = "extra == 'together'", specifier = ">=0.4.0,<2.0.0" },
     { name = "langchain-vercel-sandbox", marker = "extra == 'vercel'", editable = "../partners/vercel" },
     { name = "langchain-xai", marker = "extra == 'xai'", specifier = ">=1.3.0,<2.0.0" },
-    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.0,<4.0.0" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.1,<4.0.0" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.31,<1.0.0" },
     { name = "langgraph-runtime-inmem", specifier = ">=0.31.1,<1.0.0" },
     { name = "langgraph-sdk", specifier = ">=0.4.2,<1.0.0" },
@@ -3142,7 +3142,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.0,<4.0.0" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.1,<4.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4,<4.0.0" },
     { name = "pytest", specifier = ">=9.1.1,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
@@ -3325,16 +3325,16 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint-sqlite"
-version = "3.1.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "langgraph-checkpoint" },
     { name = "sqlite-vec" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/ea/83917c2369acf8a10a894d4247655fd063c07924ba5bc4e83c85d2eaeded/langgraph_checkpoint_sqlite-3.1.0.tar.gz", hash = "sha256:f926916ebc1b985d802cc9c820026036e84db9d910d62c97b57e4ba64f67d5ae", size = 147902, upload-time = "2026-05-12T03:34:52.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/b1/26fef7572c4fce0322740ef3fcee471510028355d4d4c1d800f0fd432d73/langgraph_checkpoint_sqlite-3.1.1.tar.gz", hash = "sha256:6fcb20db4c37ef7aad52f29b539eb98c38e2dad6fab7c2446a2a9db24f37a70e", size = 146805, upload-time = "2026-07-30T19:19:37.516Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/07/b342811a16327900af2747c752ea19676172fcddf9b592cc384031076623/langgraph_checkpoint_sqlite-3.1.0-py3-none-any.whl", hash = "sha256:cc9b40df0076feae8a9ad42ae713621b148b00ac23adc09dc1dc66090a46e5ad", size = 38587, upload-time = "2026-05-12T03:34:51.231Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b9/e458601a1718337839bcfeec9d1b27b8b16ce135be2bd50ed0395d33a878/langgraph_checkpoint_sqlite-3.1.1-py3-none-any.whl", hash = "sha256:8505c54c94a658080525d7e6780fdd4e0c078ff2566b30d399c02cc9f9af1c63", size = 40785, upload-time = "2026-07-30T19:19:36.424Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hardens the `dcode` install script (`curl ... | bash`) in two ways, adapted from patterns in Prime's installer.

---

## Gate system ripgrep on a minimum version

The `system` ripgrep path (brew/apt/dnf/pacman/zypper/apk/nix/cargo) used to count any `command -v rg` after install as success — an ancient distro package would satisfy it and then behave differently at runtime. Each branch now checks the resulting `rg --version` against a floor (12.0.0, below the 14.1.1 the managed installer pins) and only succeeds when it clears it; a too-old or unprobeable pre-existing `rg` warns instead of silently passing, and a failed version probe no longer aborts the installer.

## Three-valued `prompt_yn`

`prompt_yn` returned the same code for "user said no" and "no terminal exists to ask on," forcing callers to guess. It now returns 0 (yes), 1 (no), or 2 (no usable terminal). The upgrade prompt completes the update on the no-terminal case (cron/CI/systemd) rather than conflating it with a decline, the PATH-setup prompt declines only on an explicit "no," and the extras-removal prompts continue (with a warning) when nobody could be asked.