### PR TITLE
feat(infra): acknowledge accepted `@release-bot` commands with a reply comment

### DIFF
--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -624,6 +624,18 @@ async function validateTrigger({ github, context, core, botLogin = null, botId =
       }
       return { shouldRun: false };
     }
+    // A manual command passes silently into a queued GitHub Actions run that can
+    // take minutes to publish the override/applied comment, leaving the
+    // maintainer unsure whether the command even registered. Acknowledge it so a
+    // valid command always gets an immediate bot reply, matching the feedback
+    // every rejected command already gets.
+    await createComment(
+      github,
+      owner,
+      repo,
+      number,
+      `Running \`${command}\` for the \`${target.component}\` release PR; the result will be posted as a follow-up comment.`,
+    );
   }
 
   const result = {

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -628,14 +628,20 @@ async function validateTrigger({ github, context, core, botLogin = null, botId =
     // take minutes to publish the override/applied comment, leaving the
     // maintainer unsure whether the command even registered. Acknowledge it so a
     // valid command always gets an immediate bot reply, matching the feedback
-    // every rejected command already gets.
-    await createComment(
-      github,
-      owner,
-      repo,
-      number,
-      `Running \`${command}\` for the \`${target.component}\` release PR; the result will be posted as a follow-up comment.`,
-    );
+    // every rejected command already gets. The acknowledgment is best-effort:
+    // a transient createComment failure (e.g. secondary rate limit) must not
+    // fail validation and skip a command that already passed every check.
+    try {
+      await createComment(
+        github,
+        owner,
+        repo,
+        number,
+        `Running \`${command}\` for the \`${target.component}\` release PR; the result will be posted as a follow-up comment.`,
+      );
+    } catch (error) {
+      core.warning(`Failed to post acknowledgment comment for ${command} on PR #${number}: ${error.message}`);
+    }
   }
 
   const result = {

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -624,23 +624,25 @@ async function validateTrigger({ github, context, core, botLogin = null, botId =
       }
       return { shouldRun: false };
     }
-    // A manual command passes silently into a queued GitHub Actions run that can
-    // take minutes to publish the override/applied comment, leaving the
-    // maintainer unsure whether the command even registered. Acknowledge it so a
-    // valid command always gets an immediate bot reply, matching the feedback
-    // every rejected command already gets. The acknowledgment is best-effort:
-    // a transient createComment failure (e.g. secondary rate limit) must not
-    // fail validation and skip a command that already passed every check.
+    // A manual command otherwise passes silently into a queued Actions run,
+    // leaving the maintainer unsure whether it registered at all. Unlike the
+    // rejection replies above this is not gated on `canNotify`: clearing the
+    // write-permission check already proves the commenter is an insider.
+    // Best-effort by design — a createComment failure (e.g. secondary rate
+    // limit) must not fail validation and drop a command that passed every
+    // check. Never include COMMAND_MENTION here, or the ack re-triggers us.
     try {
       await createComment(
         github,
         owner,
         repo,
         number,
-        `Running \`${command}\` for the \`${target.component}\` release PR; the result will be posted as a follow-up comment.`,
+        `Running \`${command}\` for the \`${target.component}\` release PR; the release-notes comment on this PR will be created or updated when the run finishes.`,
       );
     } catch (error) {
-      core.warning(`Failed to post acknowledgment comment for ${command} on PR #${number}: ${error.message}`);
+      core.warning(
+        `Failed to post acknowledgment comment for ${command} on PR #${number}: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -99,7 +99,7 @@ function makeCore() {
   };
 }
 
-function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adminFlag = permission === 'admin', appUser = BOT, files = new Map(), comparison = 'ahead', malformedContent = false, onGetPr = null, onListComments = null } = {}) {
+function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adminFlag = permission === 'admin', appUser = BOT, files = new Map(), comparison = 'ahead', malformedContent = false, onGetPr = null, onListComments = null, onCreateComment = null } = {}) {
   const calls = {
     createBlob: [],
     createComment: [],
@@ -139,6 +139,7 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
         },
         createComment: async params => {
           calls.createComment.push(params);
+          if (onCreateComment) onCreateComment({ count: calls.createComment.length, params });
           const comment = { id: 100 + calls.createComment.length, updated_at: APPLIED_UPDATED_AT, user: BOT, body: params.body };
           comments.push(comment);
           return { data: comment };
@@ -406,16 +407,53 @@ test('an accepted manual command is acknowledged immediately', async () => {
   assert.equal(result.command, 'draft');
   assert.equal(run.calls.createComment.length, 1);
   assert.match(run.calls.createComment[0].body, /Running `draft` for the `deepagents-code` release PR/);
+  // The ack must land on the PR that carried the command, not merely somewhere.
+  assert.equal(run.calls.createComment[0].owner, 'langchain-ai');
+  assert.equal(run.calls.createComment[0].repo, 'deepagents');
+  assert.equal(run.calls.createComment[0].issue_number, 123);
+  // A mention would make the ack re-trigger the workflow on itself.
+  assert.doesNotMatch(run.calls.createComment[0].body, /@release-bot/);
+});
+
+test('a failed acknowledgment still runs the command', async () => {
+  const context = {
+    eventName: 'issue_comment',
+    repo: { owner: 'langchain-ai', repo: 'deepagents' },
+    payload: {
+      action: 'created',
+      issue: { number: 123, pull_request: {} },
+      comment: { body: '@release-bot apply', user: { login: 'maintainer' }, author_association: 'MEMBER' },
+    },
+  };
+  // A non-Error rejection is the sharp case: reading `.message` off it unguarded
+  // throws out of the catch and drops a command that passed every gate.
+  for (const thrown of [new Error('secondary rate limit'), 'secondary rate limit']) {
+    const run = makeGithub({
+      permission: 'write',
+      onCreateComment: () => { throw thrown; },
+    });
+    const core = makeCore();
+    const result = await releaseNotes.validateTrigger({ github: run.github, context, core });
+    assert.equal(result.shouldRun, true);
+    assert.equal(result.command, 'apply');
+    assert.equal(core.warnings.length, 1);
+    assert.match(core.warnings[0], /Failed to post acknowledgment comment for apply on PR #123: secondary rate limit/);
+  }
 });
 
 test('ready_for_review automatically validates as draft command', async () => {
-  const { github } = makeGithub();
+  const { github, calls } = makeGithub();
   const context = {
     eventName: 'pull_request_target',
     repo: { owner: 'langchain-ai', repo: 'deepagents' },
     payload: { action: 'ready_for_review', pull_request: { number: 123 } },
   };
-  const result = await releaseNotes.validateTrigger({ github, context, core: makeCore() });
+  const core = makeCore();
+  const result = await releaseNotes.validateTrigger({ github, context, core });
+  // The automatic trigger fires on every release PR becoming ready, so it must
+  // stay silent; only manual commands are acknowledged.
+  assert.equal(calls.createComment.length, 0);
+  assert.equal(core.warnings.length, 0);
   assert.deepEqual(result, {
     shouldRun: true,
     command: 'draft',
@@ -1362,7 +1400,8 @@ test('manual commands run for maintainers and admins', async () => {
   const maintainResult = await releaseNotes.validateTrigger({ github: maintain.github, context, core: makeCore() });
   assert.equal(maintainResult.shouldRun, true);
   assert.equal(maintainResult.command, 'apply');
-  // Accepted commands are acknowledged with exactly one reply.
+  // This payload carries no `author_association`, so `canNotify` is false: the
+  // ack fires on write permission alone, unlike every rejection reply.
   assert.equal(maintain.calls.createComment.length, 1);
   assert.match(maintain.calls.createComment[0].body, /Running `apply`/);
 
@@ -1393,9 +1432,11 @@ test('validateTrigger surfaces draft instructions and drops apply instructions',
   assert.equal(draftResult.shouldRun, true);
   assert.equal(draftResult.command, 'draft');
   assert.equal(draftResult.instructions, 'emphasize the breaking SDK change');
-  // The ack is a plain reply; instructions ride along in the result, not the comment.
+  // The ack is a plain reply; instructions ride along in the result, not the
+  // comment, so untrusted text never gets echoed back onto the PR.
   assert.equal(draftRun.calls.createComment.length, 1);
   assert.match(draftRun.calls.createComment[0].body, /Running `draft`/);
+  assert.doesNotMatch(draftRun.calls.createComment[0].body, /emphasize the breaking SDK change/);
 
   // Instructions after `apply` never reach the workflow: apply republishes the
   // stored draft, so the gate reports no instructions for it.

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -390,6 +390,24 @@ test('manual commands ignore comments authored by the configured bot', async () 
   assert.equal(run.calls.createComment.length, 0);
 });
 
+test('an accepted manual command is acknowledged immediately', async () => {
+  const context = {
+    eventName: 'issue_comment',
+    repo: { owner: 'langchain-ai', repo: 'deepagents' },
+    payload: {
+      action: 'created',
+      issue: { number: 123, pull_request: {} },
+      comment: { body: '@release-bot draft', user: { login: 'maintainer' }, author_association: 'MEMBER' },
+    },
+  };
+  const run = makeGithub({ permission: 'write' });
+  const result = await releaseNotes.validateTrigger({ github: run.github, context, core: makeCore() });
+  assert.equal(result.shouldRun, true);
+  assert.equal(result.command, 'draft');
+  assert.equal(run.calls.createComment.length, 1);
+  assert.match(run.calls.createComment[0].body, /Running `draft` for the `deepagents-code` release PR/);
+});
+
 test('ready_for_review automatically validates as draft command', async () => {
   const { github } = makeGithub();
   const context = {
@@ -1344,7 +1362,9 @@ test('manual commands run for maintainers and admins', async () => {
   const maintainResult = await releaseNotes.validateTrigger({ github: maintain.github, context, core: makeCore() });
   assert.equal(maintainResult.shouldRun, true);
   assert.equal(maintainResult.command, 'apply');
-  assert.equal(maintain.calls.createComment.length, 0);
+  // Accepted commands are acknowledged with exactly one reply.
+  assert.equal(maintain.calls.createComment.length, 1);
+  assert.match(maintain.calls.createComment[0].body, /Running `apply`/);
 
   // The admin flag grants access even when the permission string is not in the set.
   const admin = makeGithub({ permission: 'read', adminFlag: true });
@@ -1373,6 +1393,9 @@ test('validateTrigger surfaces draft instructions and drops apply instructions',
   assert.equal(draftResult.shouldRun, true);
   assert.equal(draftResult.command, 'draft');
   assert.equal(draftResult.instructions, 'emphasize the breaking SDK change');
+  // The ack is a plain reply; instructions ride along in the result, not the comment.
+  assert.equal(draftRun.calls.createComment.length, 1);
+  assert.match(draftRun.calls.createComment[0].body, /Running `draft`/);
 
   // Instructions after `apply` never reach the workflow: apply republishes the
   // stored draft, so the gate reports no instructions for it.


### PR DESCRIPTION
Running `@release-bot draft` or `@release-bot apply` on a release-please PR now gets an immediate reply confirming the command was accepted, instead of silence until the drafted or applied comment appears minutes later.

---

Manual release-bot commands go through several validation gates in `validateTrigger` — the PR must be a release-please branch, it must be ready for review, and the commenter must have write access. Every rejection path already posted an explanatory comment, but the success path returned `shouldRun: true` without saying anything, leaving the maintainer staring at an unchanged PR wondering whether the command registered, whether the workflow is queued, or whether they mistyped the mention.

The acknowledgment comment is posted only after all gates pass and only for manual `issue_comment` commands; the automatic `ready_for_review` draft trigger stays silent to avoid adding noise to every release PR. The reply names the command and component (e.g. "Running `draft` for the `deepagents-code` release PR...") so it's clear what was accepted, and notes that the result arrives as a follow-up comment.
