### PR TITLE
ci(infra): fail on unexpected test warnings

### DIFF
--- a/.github/scripts/tests/release/test_build_release_notes.py
+++ b/.github/scripts/tests/release/test_build_release_notes.py
@@ -16,7 +16,7 @@ SCRIPT_DIR = REPO_ROOT / ".github" / "scripts" / "release"
 SCRIPT_PATH = SCRIPT_DIR / "build_release_notes.py"
 sys.path.insert(0, str(SCRIPT_DIR))
 
-import build_release_notes as brn
+import build_release_notes as brn  # noqa: E402  # import requires the script path above
 
 PACKAGE_PATH = Path("libs/example")
 REPOSITORY = "langchain-ai/deepagents"
@@ -1181,7 +1181,7 @@ class TestUnreachablePredecessorWarnings:
         _init_repo(tmp_path)
         _commit(tmp_path, PACKAGE_PATH / "module.py", "V = 0\n", "feat(example): base")
         _git(tmp_path, "tag", "example==1.0.0")
-        head = _commit(
+        _commit(
             tmp_path, PACKAGE_PATH / "module.py", "V = 1\n", "feat(example): a1"
         )
         _git(tmp_path, "tag", "example==1.1.0a1")

--- a/.github/scripts/tests/workflows/test_warnings_are_errors.py
+++ b/.github/scripts/tests/workflows/test_warnings_are_errors.py
@@ -1,0 +1,92 @@
+"""Static contract for the warnings-as-errors test policy.
+
+Every package under `libs/` opts in by putting `"error"` first in its pytest
+`filterwarnings`; `_test.yml` keeps the `bypass-warnings-check` label wiring
+that demotes the policy for a labeled PR.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[4]
+WORKFLOWS = ROOT / ".github" / "workflows"
+TEST_WORKFLOW = WORKFLOWS / "_test.yml"
+CI_WORKFLOW = WORKFLOWS / "ci.yml"
+
+_EXCLUDED_PARTS = frozenset({".venv", "node_modules", "build", "dist", ".tox"})
+
+
+def _discover_package_pyprojects() -> list[Path]:
+    """Return every package `pyproject.toml` under `libs/`, skipping build trees."""
+    return sorted(
+        path
+        for path in (ROOT / "libs").rglob("pyproject.toml")
+        if not _EXCLUDED_PARTS & set(path.parts)
+    )
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Parse a workflow YAML file."""
+    return yaml.safe_load(path.read_text())
+
+
+def _build_steps(workflow: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the steps of the `build` job in `_test.yml`."""
+    return workflow["jobs"]["build"]["steps"]
+
+
+@pytest.fixture(scope="module")
+def test_workflow() -> dict[str, Any]:
+    """Parse `_test.yml` once for all tests in this module."""
+    return _load_yaml(TEST_WORKFLOW)
+
+
+def test_discovery_finds_all_packages() -> None:
+    """Guard against vacuous passes if the discovery glob breaks."""
+    assert len(_discover_package_pyprojects()) >= 10
+
+
+@pytest.mark.parametrize(
+    "pyproject",
+    _discover_package_pyprojects(),
+    ids=lambda path: str(path.relative_to(ROOT)),
+)
+def test_package_promotes_warnings_to_errors(pyproject: Path) -> None:
+    """Each package's first `filterwarnings` entry is exactly `"error"`."""
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    filters = data["tool"]["pytest"]["ini_options"]["filterwarnings"]
+    assert filters[0] == "error"
+
+
+def test_label_bypass_step_is_wired(test_workflow: dict[str, Any]) -> None:
+    """The `warnings` step exists and checks for the bypass label."""
+    steps = [step for step in _build_steps(test_workflow) if step.get("id") == "warnings"]
+    assert len(steps) == 1
+    assert "bypass-warnings-check" in steps[0]["run"]
+
+
+def test_test_steps_consume_bypass_flag(test_workflow: dict[str, Any]) -> None:
+    """Both test steps export `WARNINGS_FLAG` from the step output and pass it to pytest."""
+    consumers = [
+        step
+        for step in _build_steps(test_workflow)
+        if "WARNINGS_FLAG" in (step.get("env") or {})
+    ]
+    assert len(consumers) == 2
+    for step in consumers:
+        assert step["env"]["WARNINGS_FLAG"] == "${{ steps.warnings.outputs.flag }}"
+        assert "$WARNINGS_FLAG" in step["run"]
+
+
+@pytest.mark.parametrize("workflow_path", [CI_WORKFLOW, TEST_WORKFLOW])
+def test_workflow_grants_label_read_permission(workflow_path: Path) -> None:
+    """Live label reads require `pull-requests: read` on the token."""
+    workflow = _load_yaml(workflow_path)
+    assert workflow["permissions"]["pull-requests"] == "read"

--- a/.github/scripts/tests/workflows/test_warnings_are_errors.py
+++ b/.github/scripts/tests/workflows/test_warnings_are_errors.py
@@ -1,12 +1,19 @@
-"""Static contract for the warnings-as-errors test policy.
+"""Contract for the warnings-as-errors test policy.
 
 Every package under `libs/` opts in by putting `"error"` first in its pytest
 `filterwarnings`; `_test.yml` keeps the `bypass-warnings-check` label wiring
 that demotes the policy for a labeled PR.
+
+The bypass step is the single switch that can disable the policy repo-wide, so
+it is not merely grepped for -- `test_bypass_step_behaviour` extracts its shell
+and runs it against a stubbed `gh` to pin the polarity and the fail-closed
+contract.
 """
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -20,6 +27,14 @@ TEST_WORKFLOW = WORKFLOWS / "_test.yml"
 CI_WORKFLOW = WORKFLOWS / "ci.yml"
 
 _EXCLUDED_PARTS = frozenset({".venv", "node_modules", "build", "dist", ".tox"})
+
+# Filter actions that re-demote warnings. An entry using one of these bare (no
+# message and no category) undoes the leading `"error"`, because later
+# `filterwarnings` entries take precedence over earlier ones.
+_DEMOTING_ACTIONS = frozenset({"default", "always", "module", "once", "ignore"})
+
+# Categories broad enough that ignoring them re-demotes essentially everything.
+_TOO_BROAD_CATEGORIES = frozenset({"Warning", "DeprecationWarning", "UserWarning"})
 
 
 def _discover_package_pyprojects() -> list[Path]:
@@ -41,15 +56,40 @@ def _build_steps(workflow: dict[str, Any]) -> list[dict[str, Any]]:
     return workflow["jobs"]["build"]["steps"]
 
 
+def _bypass_step(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the single `warnings` step that resolves the bypass label."""
+    steps = [step for step in _build_steps(workflow) if step.get("id") == "warnings"]
+    assert len(steps) == 1, f"expected exactly one `warnings` step, found {len(steps)}"
+    return steps[0]
+
+
+def _tested_working_directories() -> set[str]:
+    """Return the `working-directory` of every `ci.yml` job that calls `_test.yml`."""
+    jobs = _load_yaml(CI_WORKFLOW)["jobs"].values()
+    return {
+        job["with"]["working-directory"]
+        for job in jobs
+        if isinstance(job, dict) and str(job.get("uses", "")).endswith("_test.yml")
+    }
+
+
 @pytest.fixture(scope="module")
 def test_workflow() -> dict[str, Any]:
     """Parse `_test.yml` once for all tests in this module."""
     return _load_yaml(TEST_WORKFLOW)
 
 
-def test_discovery_finds_all_packages() -> None:
-    """Guard against vacuous passes if the discovery glob breaks."""
-    assert len(_discover_package_pyprojects()) >= 10
+def test_every_discovered_package_is_wired_into_ci() -> None:
+    """Discovery matches the packages `ci.yml` actually runs tests for.
+
+    Pins both directions: a broken glob cannot silently shrink the set this
+    module checks, and a package added under `libs/` without a `ci.yml` test job
+    cannot slip in unnoticed.
+    """
+    discovered = {
+        str(path.parent.relative_to(ROOT)) for path in _discover_package_pyprojects()
+    }
+    assert discovered == _tested_working_directories()
 
 
 @pytest.mark.parametrize(
@@ -62,18 +102,40 @@ def test_package_promotes_warnings_to_errors(pyproject: Path) -> None:
     with pyproject.open("rb") as f:
         data = tomllib.load(f)
     filters = data["tool"]["pytest"]["ini_options"]["filterwarnings"]
+    assert isinstance(filters, list), "`filterwarnings` must be a list, not a string"
     assert filters[0] == "error"
 
 
-def test_label_bypass_step_is_wired(test_workflow: dict[str, Any]) -> None:
-    """The `warnings` step exists and checks for the bypass label."""
-    steps = [step for step in _build_steps(test_workflow) if step.get("id") == "warnings"]
-    assert len(steps) == 1
-    assert "bypass-warnings-check" in steps[0]["run"]
+@pytest.mark.parametrize(
+    "pyproject",
+    _discover_package_pyprojects(),
+    ids=lambda path: str(path.relative_to(ROOT)),
+)
+def test_allowlist_does_not_re_demote_everything(pyproject: Path) -> None:
+    """No allowlist entry undoes the leading `"error"`.
+
+    `filters[0] == "error"` alone is satisfied by a list ending in `"ignore"` or
+    `"ignore::Warning"`, which would silently switch the whole policy back off.
+    """
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    for entry in data["tool"]["pytest"]["ini_options"]["filterwarnings"][1:]:
+        action, _, rest = entry.partition(":")
+        assert not (action in _DEMOTING_ACTIONS and not rest.strip(":")), (
+            f"{entry!r} is a bare {action!r} and re-demotes every warning"
+        )
+        # Spec is `action:message:category:module:lineno`.
+        fields = entry.split(":")
+        message, category = (fields + ["", ""])[1:3]
+        assert not (
+            action in _DEMOTING_ACTIONS
+            and not message
+            and category in _TOO_BROAD_CATEGORIES
+        ), f"{entry!r} matches every {category} and re-demotes the policy"
 
 
 def test_test_steps_consume_bypass_flag(test_workflow: dict[str, Any]) -> None:
-    """Both test steps export `WARNINGS_FLAG` from the step output and pass it to pytest."""
+    """Both test steps export `WARNINGS_FLAG` from the step output and pass it on."""
     consumers = [
         step
         for step in _build_steps(test_workflow)
@@ -85,8 +147,68 @@ def test_test_steps_consume_bypass_flag(test_workflow: dict[str, Any]) -> None:
         assert "$WARNINGS_FLAG" in step["run"]
 
 
+def test_bypass_step_runs_only_for_pull_requests(test_workflow: dict[str, Any]) -> None:
+    """`push`/`merge_group` runs must not be able to resolve a bypass flag."""
+    assert _bypass_step(test_workflow)["if"] == "github.event_name == 'pull_request'"
+
+
 @pytest.mark.parametrize("workflow_path", [CI_WORKFLOW, TEST_WORKFLOW])
 def test_workflow_grants_label_read_permission(workflow_path: Path) -> None:
     """Live label reads require `pull-requests: read` on the token."""
     workflow = _load_yaml(workflow_path)
     assert workflow["permissions"]["pull-requests"] == "read"
+
+
+@pytest.mark.parametrize(
+    ("labels", "gh_exit", "expected_flag", "expect_error_annotation"),
+    [
+        pytest.param("bypass-warnings-check", 0, "-W default", False, id="label-present"),
+        pytest.param("dependencies\nlgtm", 0, "", False, id="label-absent"),
+        pytest.param("", 0, "", False, id="no-labels"),
+        # A substring or superstring of the label must not trigger the bypass.
+        pytest.param("bypass-warnings-check-v2", 0, "", False, id="label-superstring"),
+        pytest.param("no-bypass-warnings-check", 0, "", False, id="label-prefixed"),
+        # Fail closed, and say so: an unreadable label list must enforce the
+        # policy *and* annotate, or a maintainer cannot tell why the label had
+        # no effect. Labels on stdout are ignored when the call itself failed.
+        pytest.param("bypass-warnings-check", 1, "", True, id="api-failure-fails-closed"),
+    ],
+)
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+def test_bypass_step_behaviour(
+    test_workflow: dict[str, Any],
+    tmp_path: Path,
+    labels: str,
+    gh_exit: int,
+    expected_flag: str,
+    expect_error_annotation: bool,
+) -> None:
+    """Run the step's real shell against a stubbed `gh` and pin its decisions."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh_stub = bin_dir / "gh"
+    gh_stub.write_text(f'#!/usr/bin/env bash\nprintf "%s\\n" "{labels}"\nexit {gh_exit}\n')
+    gh_stub.chmod(0o755)
+
+    script = tmp_path / "step.sh"
+    script.write_text(_bypass_step(test_workflow)["run"])
+    github_output = tmp_path / "github_output"
+    github_output.touch()
+
+    result = subprocess.run(  # noqa: S603
+        ["bash", str(script)],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "GITHUB_OUTPUT": str(github_output),
+            "GH_TOKEN": "stub-token",
+            "REPO": "langchain-ai/deepagents",
+            "PR": "1234",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert github_output.read_text().strip() == f"flag={expected_flag}"
+    assert ("::error::" in result.stdout) is expect_error_annotation

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -34,8 +34,12 @@ on:
         default: ""
         description: "Runner OS of the coverage leg; empty defaults to the primary 'os' input"
 
+# `pull-requests: read` lets the reusable workflow read live PR labels for the
+# warnings bypass below; a called workflow can only narrow the caller's token,
+# never widen it.
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   UV_NO_SYNC: "true"
@@ -115,6 +119,32 @@ jobs:
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y ripgrep
 
+      # Maintainer escape hatch: a PR labeled `bypass-warnings-check` runs
+      # pytest with `-W default`, demoting every warning filter (including
+      # the package-level "error" policy) for that run. Labels are read from
+      # the live GitHub API rather than `github.event.pull_request.labels`
+      # because re-running a job replays the original event payload, which
+      # would miss a label added after the fact. `push` and `merge_group`
+      # runs have no PR label context and always enforce warnings-as-errors.
+      - name: "🏷️ Resolve warnings bypass"
+        id: warnings
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+          # Fail closed: if the API call fails, enforce rather than bypass.
+          LABELS="$(gh api "repos/$REPO/issues/$PR/labels" --paginate --jq '.[].name' || true)"
+          if [[ $'\n'"$LABELS"$'\n' == *$'\n'bypass-warnings-check$'\n'* ]]; then
+            echo "flag=-W default" >> "$GITHUB_OUTPUT"
+            echo "::warning::'bypass-warnings-check' label present — test warnings will not fail this run"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: "🧪 Run Unit Tests"
         if: runner.os != 'Windows'
         shell: bash
@@ -124,12 +154,15 @@ jobs:
           PY_OS: ${{ matrix.os }}
           COV_PY: ${{ inputs.coverage-python-version }}
           COV_OS: ${{ inputs.coverage-os || inputs.os }}
+          # A command-line `-W` filter outranks every ini `filterwarnings`
+          # entry, so the bypass also demotes intentional `error:` filters.
+          WARNINGS_FLAG: ${{ steps.warnings.outputs.flag }}
         run: |
           if [ -n "$COV_PY" ] && [ "$PY" = "$COV_PY" ] && [ "$PY_OS" = "$COV_OS" ]; then
-            make test PYTEST_EXTRA=-q
+            make test PYTEST_EXTRA="-q $WARNINGS_FLAG"
           else
             echo "Coverage disabled for Python $PY / $PY_OS (target=$COV_PY / $COV_OS)"
-            make test COV_ARGS= PYTEST_EXTRA=-q
+            make test COV_ARGS= PYTEST_EXTRA="-q $WARNINGS_FLAG"
           fi
 
       # Windows cannot run `make test` because `LocalShellBackend` requires POSIX
@@ -146,12 +179,14 @@ jobs:
           PY_OS: ${{ matrix.os }}
           COV_PY: ${{ inputs.coverage-python-version }}
           COV_OS: ${{ inputs.coverage-os || inputs.os }}
+          # See the POSIX step: the command-line bypass outranks ini filters.
+          WARNINGS_FLAG: ${{ steps.warnings.outputs.flag }}
         run: |
           if [ -n "$COV_PY" ] && [ "$PY" = "$COV_PY" ] && [ "$PY_OS" = "$COV_OS" ]; then
-            uv run --group test pytest -n auto -vvv tests/unit_tests/ --cov=deepagents --cov-report=term-missing
+            uv run --group test pytest -n auto -vvv $WARNINGS_FLAG tests/unit_tests/ --cov=deepagents --cov-report=term-missing
           else
             echo "Coverage disabled for Python $PY / $PY_OS (target=$COV_PY / $COV_OS)"
-            uv run --group test pytest -n auto -vvv tests/unit_tests/
+            uv run --group test pytest -n auto -vvv $WARNINGS_FLAG tests/unit_tests/
           fi
 
       - name: "🧹 Verify Clean Working Directory"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -36,7 +36,9 @@ on:
 
 # `pull-requests: read` lets the reusable workflow read live PR labels for the
 # warnings bypass below; a called workflow can only narrow the caller's token,
-# never widen it.
+# never widen it. The bypass reads the issues labels endpoint, which accepts
+# either `issues: read` or `pull-requests: read` -- so unlike `release-please.yml`
+# (which grants `issues: read` for the same call), no `issues` grant is needed.
 permissions:
   contents: read
   pull-requests: read
@@ -120,12 +122,14 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       # Maintainer escape hatch: a PR labeled `bypass-warnings-check` runs
-      # pytest with `-W default`, demoting every warning filter (including
-      # the package-level "error" policy) for that run. Labels are read from
-      # the live GitHub API rather than `github.event.pull_request.labels`
-      # because re-running a job replays the original event payload, which
-      # would miss a label added after the fact. `push` and `merge_group`
-      # runs have no PR label context and always enforce warnings-as-errors.
+      # pytest with `-W default`, demoting the ini `filterwarnings` policy
+      # (including the package-level "error" entry) for that run. Per-test
+      # `@pytest.mark.filterwarnings` marks are applied after command-line
+      # filters, so those still take effect. Labels are read from the live
+      # GitHub API rather than `github.event.pull_request.labels` because
+      # re-running a job replays the original event payload, which would miss
+      # a label added after the fact. `push` and `merge_group` runs have no PR
+      # label context and always enforce warnings-as-errors.
       - name: "🏷️ Resolve warnings bypass"
         id: warnings
         if: github.event_name == 'pull_request'
@@ -136,9 +140,22 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
         run: |
           set -eu
-          # Fail closed: if the API call fails, enforce rather than bypass.
-          LABELS="$(gh api "repos/$REPO/issues/$PR/labels" --paginate --jq '.[].name' || true)"
-          if [[ $'\n'"$LABELS"$'\n' == *$'\n'bypass-warnings-check$'\n'* ]]; then
+          # `per_page=100` rather than `--paginate`: an issue caps at 100 labels,
+          # and `--paginate` streams each page as it arrives, so a failure on a
+          # later page would leave earlier pages in $LABELS while the nonzero exit
+          # is discarded -- i.e. it could bypass on the strength of a failed call.
+          # A single request makes the exit status an honest all-or-nothing signal.
+          rc=0
+          LABELS="$(gh api "repos/$REPO/issues/$PR/labels?per_page=100" --jq '.[].name')" || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            # Fail closed, but loudly: a silent fall-through here is
+            # indistinguishable from "label absent", so a maintainer would apply
+            # the label, re-run, and watch it fail again with no explanation.
+            echo "::error::Could not read labels for PR #$PR (gh api exit $rc); warnings-as-errors will be ENFORCED. The bypass label cannot take effect until this is resolved."
+            echo "flag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s\n' "$LABELS" | grep -Fxq "bypass-warnings-check"; then
             echo "flag=-W default" >> "$GITHUB_OUTPUT"
             echo "::warning::'bypass-warnings-check' label present — test warnings will not fail this run"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ concurrency:
 # `pull-requests: read` lets the called `_test.yml` reusable workflow read live
 # PR labels (re-runs replay the original event payload, so the API is the only
 # fresh source). A called workflow's token can only narrow the caller's grants.
+# The issues labels endpoint it uses accepts either `issues: read` or
+# `pull-requests: read`, so no `issues` grant is needed here.
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# `pull-requests: read` lets the called `_test.yml` reusable workflow read live
+# PR labels (re-runs replay the original event payload, so the API is the only
+# fresh source). A called workflow's token can only narrow the caller's grants.
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   UV_NO_SYNC: "true"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,14 +227,22 @@ Ensure the following:
 
 #### Warnings are errors
 
-Every package under `libs/` puts `"error"` first in its pytest `filterwarnings`, so any warning the repo has not explicitly accepted fails the test or collection. The entries after `"error"` are the reviewed allowlist.
+Every package under `libs/` puts `"error"` first in its pytest `filterwarnings`, so any warning the repo has not explicitly accepted fails the run. The entries after `"error"` are the reviewed allowlist.
 
 - Fix actionable warnings first; an allowlist entry is the last resort, not the default.
 - When one test deliberately emits a warning, scope the exception to it with `@pytest.mark.filterwarnings("ignore:<message>:<category>")` instead of a package-level entry.
-- Reserve package-level `ignore:` entries for categorical or third-party warnings nothing in the repo can act on. Each one needs a justification comment and a message prefix narrow enough to not swallow adjacent warnings.
+- Reserve package-level entries for categorical or third-party warnings nothing in the repo can act on. Each one needs a justification comment; when the filter is message-scoped, the prefix must be narrow enough to not swallow adjacent warnings.
+- Prefer `default::` over `ignore::` when the category is one that reports failures Python otherwise swallows (`PytestUnhandledThreadExceptionWarning`, `PytestUnraisableExceptionWarning`). `ignore` deletes the report, so an assertion failing inside a worker thread would pass silently; `default` keeps it printed without failing the run.
 - Warning filter specs split on `:`, so end the message prefix before the first colon that appears in the warning text.
+- In `filterwarnings` ini entries the message field is an **unescaped regex** (unlike a command-line `-W`, which escapes it). Escape any `.`, `(`, or `+` you mean literally — an unescaped metacharacter can produce a filter that silently never matches.
 - A filter can be version-specific (e.g. only firing on Python 3.14); a filter that does not match anything is harmless.
-- Maintainers can apply the `bypass-warnings-check` PR label and re-run failed jobs to run the suite with warnings demoted. This is an escape hatch for landing fixes under time pressure, not a permanent fix: merge queue runs enforce the policy again, so the warning must still be addressed or allowlisted.
+
+Three failure modes to expect: a warning inside a test fails that test, one during import fails collection, and one raised while pytest is *configuring* (typically from a plugin) aborts with `INTERNALERROR` — the last is the hardest to read from CI output. Warnings emitted while pytest loads its plugins, before the ini filters are installed, are not caught at all; do not assume a clean run proves a dependency is warning-free.
+
+Maintainers can apply the `bypass-warnings-check` PR label and re-run failed jobs to run the suite with warnings demoted. This is an escape hatch for landing fixes under time pressure, not a permanent fix: merge queue runs enforce the policy again, so the warning must still be addressed or allowlisted. Two caveats on its reach:
+
+- It applies only to jobs that go through `_test.yml`. The `test-quickjs-sdk-smoke` job in `ci.yml` invokes pytest directly and has no bypass path.
+- Release runs (`release.yml`) always enforce, so a warning that only appears against the built wheel cannot be labeled past.
 
 ### Security and risk assessment
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,17 @@ Ensure the following:
 - Edge cases and error conditions are tested
 - Tests are deterministic (no flaky tests)
 
+#### Warnings are errors
+
+Every package under `libs/` puts `"error"` first in its pytest `filterwarnings`, so any warning the repo has not explicitly accepted fails the test or collection. The entries after `"error"` are the reviewed allowlist.
+
+- Fix actionable warnings first; an allowlist entry is the last resort, not the default.
+- When one test deliberately emits a warning, scope the exception to it with `@pytest.mark.filterwarnings("ignore:<message>:<category>")` instead of a package-level entry.
+- Reserve package-level `ignore:` entries for categorical or third-party warnings nothing in the repo can act on. Each one needs a justification comment and a message prefix narrow enough to not swallow adjacent warnings.
+- Warning filter specs split on `:`, so end the message prefix before the first colon that appears in the warning text.
+- A filter can be version-specific (e.g. only firing on Python 3.14); a filter that does not match anything is harmless.
+- Maintainers can apply the `bypass-warnings-check` PR label and re-run failed jobs to run the suite with warnings demoted. This is an escape hatch for landing fixes under time pressure, not a permanent fix: merge queue runs enforce the policy again, so the warning must still be addressed or allowlisted.
+
 ### Security and risk assessment
 
 - No `eval()`, `exec()`, or `pickle` on user-controlled input

--- a/libs/acp/pyproject.toml
+++ b/libs/acp/pyproject.toml
@@ -126,4 +126,14 @@ ignore-var-parameters = true  # ignore missing documentation for *args and **kwa
 ]
 
 [tool.pytest.ini_options]
+filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
+    # `langchain_core` imports `pydantic.v1` during collection on Python 3.14+.
+    "ignore:Core Pydantic V1 functionality isn't compatible:UserWarning",
+    # `google.genai.types` builds a union alias out of `typing._UnionGenericAlias`
+    # at import time, which Python 3.14 deprecates. Nothing here can act on it --
+    # it fires before any of our code runs and is fixed by upgrading the SDK.
+    "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
+]
 asyncio_mode = "auto" # or "strict"

--- a/libs/acp/tests/chat_model.py
+++ b/libs/acp/tests/chat_model.py
@@ -16,18 +16,21 @@ from typing_extensions import override
 
 class GenericFakeChatModel(BaseChatModel):
     r"""Generic fake chat model that can be used to test the chat model interface.
+
     * Chat model should be usable in both sync and async tests
     * Invokes `on_llm_new_token` to allow for testing of callback related code for new
         tokens.
     * Includes configurable logic to break messages into chunks for streaming.
+
     Args:
         messages: An iterator over messages (use `iter()` to convert a list)
         stream_delimiter: How to chunk content when streaming. Options:
             - None (default): Return content in a single chunk (no streaming)
             - A string delimiter (e.g., " "): Split content on this delimiter,
-              preserving the delimiter as separate chunks
+                preserving the delimiter as separate chunks
             - A regex pattern (e.g., r"(\s)"): Split using the pattern with a capture
-              group to preserve delimiters
+                group to preserve delimiters
+
     Examples:
         # No streaming - single chunk
         model = GenericFakeChatModel(messages=iter([AIMessage(content="Hello world")]))
@@ -47,14 +50,17 @@ class GenericFakeChatModel(BaseChatModel):
 
     messages: Iterator[AIMessage | str]
     """Get an iterator over messages.
+
     This can be expanded to accept other types like Callables / dicts / strings
     to make the interface more generic if needed.
+
     !!! note
         if you want to pass a list, you can use `iter` to convert it to an iterator.
     """
 
     stream_delimiter: str | None = None
     """Delimiter for chunking content during streaming.
+
     - None (default): No chunking, returns content in a single chunk
     - String: Split content on this exact string, preserving delimiter as chunks
     - Regex pattern: Use re.split() with the pattern (use capture groups to preserve delimiters)

--- a/libs/acp/tests/chat_model.py
+++ b/libs/acp/tests/chat_model.py
@@ -15,7 +15,7 @@ from typing_extensions import override
 
 
 class GenericFakeChatModel(BaseChatModel):
-    """Generic fake chat model that can be used to test the chat model interface.
+    r"""Generic fake chat model that can be used to test the chat model interface.
     * Chat model should be usable in both sync and async tests
     * Invokes `on_llm_new_token` to allow for testing of callback related code for new
         tokens.
@@ -26,7 +26,7 @@ class GenericFakeChatModel(BaseChatModel):
             - None (default): Return content in a single chunk (no streaming)
             - A string delimiter (e.g., " "): Split content on this delimiter,
               preserving the delimiter as separate chunks
-            - A regex pattern (e.g., r"(\\s)"): Split using the pattern with a capture
+            - A regex pattern (e.g., r"(\s)"): Split using the pattern with a capture
               group to preserve delimiters
     Examples:
         # No streaming - single chunk

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -175,6 +175,10 @@ omit = ["tests/*"]
 
 [tool.pytest.ini_options]
 timeout = 30  # Default timeout for all tests (can be overridden per-test)
+filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
+]
 
 addopts = "--strict-markers --strict-config --durations=5"
 asyncio_mode = "auto"

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -344,7 +344,11 @@ timeout = 30  # Default timeout for all tests (can be overridden per-test)
 filterwarnings = [
     # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
     "error",
-    "ignore:Core Pydantic V1 functionality isn't compatible with Python 3\\.14 or greater\\.:UserWarning:langchain_core\\.utils\\.pydantic",
+    # `langchain_core` imports `pydantic.v1` during collection on Python 3.14+.
+    # Deliberately unqualified by module: `pydantic` warns with `stacklevel=2`, so
+    # the attributed module is whichever `langchain_core` module imports
+    # `pydantic.v1` first, which is import-order dependent.
+    "ignore:Core Pydantic V1 functionality isn't compatible:UserWarning",
     # `genai_prices.Usage` only warns for a usage key it does not recognize, then
     # drops it -- the request still prices, just without that bucket. A renamed
     # key anywhere in the allowed range would silently undercount, so fail
@@ -356,15 +360,25 @@ filterwarnings = [
     # at import time, which Python 3.14 deprecates. Nothing here can act on it --
     # it fires before any of our code runs and is fixed by upgrading the SDK.
     "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
-    # pytest-benchmark warns during pytest configuration when xdist is active.
+    # pytest-benchmark warns during pytest configuration when xdist is active and
+    # benchmarks are not already disabled. `make test` passes `--benchmark-disable`,
+    # which short-circuits it; this entry covers `make integration_test` and keeps
+    # a dropped `--benchmark-disable` from turning into an `INTERNALERROR`.
     "ignore:Benchmarks are automatically disabled:pytest_benchmark.logger.PytestBenchmarkWarning",
-    # TODO(mdrxy): the three ignores below are real nondeterministic test-hygiene
+    # TODO(mdrxy): the three entries below are real nondeterministic test-hygiene
     # bugs caused by leaked `_run_agent_task` coroutines and sqlite/aiosqlite
     # resources. They cannot be attached to one test because scheduling/GC
     # determines where they land. They should be fixed and deleted, not expanded.
     "ignore:coroutine 'DeepAgentsApp._run_agent_task' was never awaited:RuntimeWarning",
-    "ignore::pytest.PytestUnhandledThreadExceptionWarning",
-    "ignore::pytest.PytestUnraisableExceptionWarning",
+    # The two below are `default`, not `ignore`, and that distinction is
+    # load-bearing. These are the only categories through which pytest reports
+    # failures Python itself swallows: an exception in a worker thread, and one
+    # raised in a `__del__`/finalizer or during GC. `ignore` would delete them
+    # outright, so a test asserting inside a thread would pass silently -- a
+    # regression against the pre-policy behaviour, where they were at least
+    # printed. `default` keeps them printed without failing the run.
+    "default::pytest.PytestUnhandledThreadExceptionWarning",
+    "default::pytest.PytestUnraisableExceptionWarning",
 ]
 
 addopts = "--strict-markers --strict-config --durations=5"

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -342,6 +342,8 @@ omit = ["tests/*"]
 [tool.pytest.ini_options]
 timeout = 30  # Default timeout for all tests (can be overridden per-test)
 filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
     "ignore:Core Pydantic V1 functionality isn't compatible with Python 3\\.14 or greater\\.:UserWarning:langchain_core\\.utils\\.pydantic",
     # `genai_prices.Usage` only warns for a usage key it does not recognize, then
     # drops it -- the request still prices, just without that bucket. A renamed
@@ -354,6 +356,15 @@ filterwarnings = [
     # at import time, which Python 3.14 deprecates. Nothing here can act on it --
     # it fires before any of our code runs and is fixed by upgrading the SDK.
     "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
+    # pytest-benchmark warns during pytest configuration when xdist is active.
+    "ignore:Benchmarks are automatically disabled:pytest_benchmark.logger.PytestBenchmarkWarning",
+    # TODO(mdrxy): the three ignores below are real nondeterministic test-hygiene
+    # bugs caused by leaked `_run_agent_task` coroutines and sqlite/aiosqlite
+    # resources. They cannot be attached to one test because scheduling/GC
+    # determines where they land. They should be fixed and deleted, not expanded.
+    "ignore:coroutine 'DeepAgentsApp._run_agent_task' was never awaited:RuntimeWarning",
+    "ignore::pytest.PytestUnhandledThreadExceptionWarning",
+    "ignore::pytest.PytestUnraisableExceptionWarning",
 ]
 
 addopts = "--strict-markers --strict-config --durations=5"

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1337,7 +1337,7 @@ requires-dist = [
     { name = "langchain-together", marker = "extra == 'together'", specifier = ">=0.4.0,<2.0.0" },
     { name = "langchain-vercel-sandbox", marker = "extra == 'vercel'", editable = "../partners/vercel" },
     { name = "langchain-xai", marker = "extra == 'xai'", specifier = ">=1.3.0,<2.0.0" },
-    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.0,<4.0.0" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.1,<4.0.0" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.31,<1.0.0" },
     { name = "langgraph-runtime-inmem", specifier = ">=0.31.1,<1.0.0" },
     { name = "langgraph-sdk", specifier = ">=0.4.2,<1.0.0" },
@@ -3142,7 +3142,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.0,<4.0.0" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.1,<4.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4,<4.0.0" },
     { name = "pytest", specifier = ">=9.1.1,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
@@ -3325,16 +3325,16 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint-sqlite"
-version = "3.1.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "langgraph-checkpoint" },
     { name = "sqlite-vec" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/ea/83917c2369acf8a10a894d4247655fd063c07924ba5bc4e83c85d2eaeded/langgraph_checkpoint_sqlite-3.1.0.tar.gz", hash = "sha256:f926916ebc1b985d802cc9c820026036e84db9d910d62c97b57e4ba64f67d5ae", size = 147902, upload-time = "2026-05-12T03:34:52.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/b1/26fef7572c4fce0322740ef3fcee471510028355d4d4c1d800f0fd432d73/langgraph_checkpoint_sqlite-3.1.1.tar.gz", hash = "sha256:6fcb20db4c37ef7aad52f29b539eb98c38e2dad6fab7c2446a2a9db24f37a70e", size = 146805, upload-time = "2026-07-30T19:19:37.516Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/07/b342811a16327900af2747c752ea19676172fcddf9b592cc384031076623/langgraph_checkpoint_sqlite-3.1.0-py3-none-any.whl", hash = "sha256:cc9b40df0076feae8a9ad42ae713621b148b00ac23adc09dc1dc66090a46e5ad", size = 38587, upload-time = "2026-05-12T03:34:51.231Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b9/e458601a1718337839bcfeec9d1b27b8b16ce135be2bd50ed0395d33a878/langgraph_checkpoint_sqlite-3.1.1-py3-none-any.whl", hash = "sha256:8505c54c94a658080525d7e6780fdd4e0c078ff2566b30d399c02cc9f9af1c63", size = 40785, upload-time = "2026-07-30T19:19:36.424Z" },
 ]
 
 [[package]]

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -136,11 +136,21 @@ ignore-var-parameters = true
 asyncio_mode = "auto"
 addopts = "-m 'not benchmark'"
 filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
     "ignore:Passing `model=None` to `create_deep_agent`:DeprecationWarning",
     # `langsmith.sandbox` is alpha upstream; the FutureWarning fires on import.
     "ignore:langsmith.sandbox is in alpha:FutureWarning",
     # pytest-cov complains when invoked with `--no-cov` (used for fast runs).
     "ignore::pytest_cov.plugin.CovDisabledWarning",
+    # `langchain_core` imports `pydantic.v1` during collection on Python 3.14+.
+    "ignore:Core Pydantic V1 functionality isn't compatible:UserWarning",
+    # `google.genai.types` builds a union alias out of `typing._UnionGenericAlias`
+    # at import time, which Python 3.14 deprecates. Nothing here can act on it --
+    # it fires before any of our code runs and is fixed by upgrading the SDK.
+    "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
+    # pytest-benchmark warns during pytest configuration when xdist is active.
+    "ignore:Benchmarks are automatically disabled:pytest_benchmark.logger.PytestBenchmarkWarning",
 ]
 markers = [
     "benchmark: wall-time benchmarks for construction performance",

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -154,6 +154,7 @@ filterwarnings = [
 ]
 markers = [
     "benchmark: wall-time benchmarks for construction performance",
+    "requires(*packages): integration test dependencies required to run a test",
     "video_extra: pin the read_file video gate on to snapshot the [video]-extra variant",
 ]
 

--- a/libs/deepagents/tests/unit_tests/test_version.py
+++ b/libs/deepagents/tests/unit_tests/test_version.py
@@ -350,6 +350,9 @@ class TestIsEditableInstallAgainstRealMetadata:
         with patch("deepagents._version.distributions", return_value=[corrupt, editable]):
             assert _is_editable_install() is True
 
+    # The deliberately nameless `PathDistribution` below makes importlib.metadata
+    # emit this warning; only this test should tolerate it.
+    @pytest.mark.filterwarnings("ignore:Implicit None on return values is deprecated:DeprecationWarning")
     def test_metadata_less_dist_info_does_not_raise(self, tmp_path: Path, editable_root: Path) -> None:
         """A partial install leaves a `*.dist-info` whose real `.name` is `None`.
 

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -213,4 +213,8 @@ known-first-party = ["deepagents_evals", "deepagents_harbor"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
+]
 asyncio_mode = "auto"

--- a/libs/evals/tests/unit_tests/test_drbench_adapter.py
+++ b/libs/evals/tests/unit_tests/test_drbench_adapter.py
@@ -410,7 +410,8 @@ def test_generated_task_toml_validates_against_harbors_own_schema(
         qa=[_qa("IN1", "kept"), _qa("DI1", "planted", qa_type="distractor")],
     )
     task_dir = adapter.generate_task(output_dir=tmp_path / "dataset", task_id=_TASK_ID)
-    config = TaskConfig.model_validate(tomllib.load((task_dir / "task.toml").open("rb")))
+    with (task_dir / "task.toml").open("rb") as f:
+        config = TaskConfig.model_validate(tomllib.load(f))
 
     # Each of these is only meaningful if Harbor actually parsed it into the model.
     assert config.artifacts == ["/app/report.md"]
@@ -749,9 +750,7 @@ def test_pruning_leaves_directories_this_adapter_did_not_generate(
     assert (unrelated / "task.toml").is_file()
 
 
-def test_subset_verification_reports_a_vendored_copy_that_drifted(
-    vendor: Path, tmp_path: Path
-) -> None:
+def test_subset_verification_reports_a_vendored_copy_that_drifted(vendor: Path) -> None:
     """The vendored list is the denominator of every score, so it must match the pin."""
     upstream_subsets = adapter.ensure_upstream_checkout() / "drbench" / "data" / "subsets"
     upstream_subsets.mkdir(parents=True)

--- a/libs/evals/tests/unit_tests/test_drbench_judge.py
+++ b/libs/evals/tests/unit_tests/test_drbench_judge.py
@@ -19,7 +19,7 @@ import types
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import numpy
+import numpy as np
 import pytest
 
 if TYPE_CHECKING:
@@ -111,13 +111,13 @@ def _install_fake_drbench(
 
     utils: Any = types.ModuleType("drbench.agents.utils")
 
-    def get_embeddings(texts: list[str], *_a: Any, **_kw: Any) -> Any:
+    def get_embeddings(texts: list[str], *_a: Any, **_kw: Any) -> Any:  # noqa: ANN401  # stub for an untyped upstream function
         # Mirrors upstream exactly: a C-contiguous float32 ndarray. The caller reads
         # `.shape[1]` and passes it to `faiss.normalize_L2`, which mutates in place, so a
         # stub returning plain lists would hide a real type regression.
         recorded.setdefault("embed_batches", []).append(len(texts))
-        rows = numpy.array([[float(len(text)), 0.5] for text in texts])
-        return numpy.ascontiguousarray(rows, dtype=numpy.float32)
+        rows = np.array([[float(len(text)), 0.5] for text in texts])
+        return np.ascontiguousarray(rows, dtype=np.float32)
 
     utils.get_embeddings = get_embeddings
     utils.OPENAI_MODELS = (
@@ -128,7 +128,7 @@ def _install_fake_drbench(
     # in `OPENAI_MODELS` but not here -- which is why the judge takes the intersection.
     # The cited-URL guard wraps this; a bare pass-through unless a test replaces it.
     class SourceReader:
-        def parse_website(self, url: str) -> Any:
+        def parse_website(self, url: str) -> Any:  # noqa: ANN401  # stub for an untyped upstream method
             recorded.setdefault("fetched", []).append(url)
             return f"content of {url}"
 
@@ -178,15 +178,15 @@ def _install_fake_drbench(
         blocked host was never contacted rather than merely reported after the fact.
         """
 
-        def send(self, request: Any, **kwargs: Any) -> Any:
+        def send(self, request: Any, **kwargs: Any) -> Any:  # noqa: ANN401  # stub for untyped `requests` internals
             recorded.setdefault("sent", []).append((request.url, kwargs.get("timeout")))
             return type("R", (), {"url": request.url})()
 
-        def request(self, method: str, url: str, **kwargs: Any) -> Any:
+        def request(self, method: str, url: str, **kwargs: Any) -> Any:  # noqa: ANN401  # stub for untyped `requests` internals
             recorded.setdefault("requests", []).append((url, kwargs.get("timeout")))
             return self.send(type("P", (), {"url": url})(), **kwargs)
 
-        def resolve_redirects(self, resp: Any, req: Any, **kwargs: Any) -> Any:
+        def resolve_redirects(self, resp: Any, req: Any, **kwargs: Any) -> Any:  # noqa: ANN401  # stub for untyped `requests` internals
             for hop in recorded.get("hops", []):
                 yield self.send(type("P", (), {"url": hop.url})(), **kwargs)
 
@@ -287,7 +287,7 @@ def test_judge_model_raises_on_an_unsupported_request(
     _install_fake_drbench(monkeypatch, scores={})
     monkeypatch.setenv("DRBENCH_JUDGE_MODEL", "gpt-5.6-luna")
 
-    with pytest.raises(ValueError, match="openrouter/openai/gpt-5.6-luna") as excinfo:
+    with pytest.raises(ValueError, match=r"openrouter/openai/gpt-5\.6-luna") as excinfo:
         judge._judge_model()
 
     assert "gpt-5.6-luna" in str(excinfo.value)
@@ -301,7 +301,7 @@ def test_judge_model_rejects_a_model_in_only_one_registry(
     _install_fake_drbench(monkeypatch, scores={})
     monkeypatch.setenv("DRBENCH_JUDGE_MODEL", "gpt-4.1")
 
-    with pytest.raises(ValueError, match="gpt-4.1"):
+    with pytest.raises(ValueError, match=r"gpt-4\.1"):
         judge._judge_model()
 
 
@@ -343,7 +343,7 @@ def test_judge_model_rejects_a_malformed_openrouter_slug(
     _install_fake_drbench(monkeypatch, scores={})
     monkeypatch.setenv("DRBENCH_JUDGE_MODEL", slug)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="is not one upstream DRBench can drive"):
         judge._judge_model()
 
 
@@ -864,10 +864,10 @@ def test_embedding_batching_preserves_the_vectors_exactly(
     judge._install_embedding_batching()
     batched = utils.get_embeddings(texts)
 
-    assert numpy.array_equal(batched, unbatched)
+    assert np.array_equal(batched, unbatched)
     # Type fidelity matters as much as the values: the consumer reads `.shape[1]` and
     # calls `faiss.normalize_L2`, which needs a C-contiguous float32 array.
-    assert isinstance(batched, numpy.ndarray)
+    assert isinstance(batched, np.ndarray)
     assert batched.dtype == unbatched.dtype
     assert batched.flags["C_CONTIGUOUS"]
     assert batched.shape == unbatched.shape
@@ -1152,7 +1152,7 @@ def test_grade_reports_the_judges_verdicts(
 # unreachable citation therefore zeroed all four metrics for a task in a real run.
 
 
-def _fake_requests() -> Any:
+def _fake_requests() -> Any:  # noqa: ANN401  # the registered module stand-in is a dynamic ModuleType
     """The `requests` stand-in `_install_fake_drbench` registered."""
     return sys.modules["requests"]
 
@@ -1160,12 +1160,12 @@ def _fake_requests() -> Any:
 def test_url_guard_turns_a_failed_fetch_into_no_content(
     judge: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    calls: dict[str, Any] = {}
     _install_fake_drbench(monkeypatch, scores={})
     from drbench.agents import utils  # noqa: PLC0415  # ty: ignore[unresolved-import]
 
-    def boom(self: Any, url: str) -> Any:
-        raise OSError("name resolution failed")
+    def boom(_self: Any, _url: str) -> Any:  # noqa: ANN401  # stub for an untyped upstream method
+        msg = "name resolution failed"
+        raise OSError(msg)
 
     utils.SourceReader = type("SourceReader", (), {"parse_website": boom})
 

--- a/libs/partners/daytona/pyproject.toml
+++ b/libs/partners/daytona/pyproject.toml
@@ -89,7 +89,18 @@ markers = [
     "scheduled: mark tests to run in scheduled testing",
 ]
 asyncio_mode = "auto"
-filterwarnings = []
+filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
+    # `langchain_core` imports `pydantic.v1` during collection on Python 3.14+.
+    "ignore:Core Pydantic V1 functionality isn't compatible:UserWarning",
+    # `google.genai.types` builds a union alias out of `typing._UnionGenericAlias`
+    # at import time, which Python 3.14 deprecates. Nothing here can act on it --
+    # it fires before any of our code runs and is fixed by upgrading the SDK.
+    "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
+    # The `daytona` SDK's decorator still calls the deprecated API.
+    "ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning",
+]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/**/*.py" = ["D", "S101"]

--- a/libs/partners/modal/pyproject.toml
+++ b/libs/partners/modal/pyproject.toml
@@ -89,7 +89,16 @@ markers = [
     "scheduled: mark tests to run in scheduled testing",
 ]
 asyncio_mode = "auto"
-filterwarnings = []
+filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
+    # `langchain_core` imports `pydantic.v1` during collection on Python 3.14+.
+    "ignore:Core Pydantic V1 functionality isn't compatible:UserWarning",
+    # `google.genai.types` builds a union alias out of `typing._UnionGenericAlias`
+    # at import time, which Python 3.14 deprecates. Nothing here can act on it --
+    # it fires before any of our code runs and is fixed by upgrading the SDK.
+    "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
+]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/**/*.py" = ["D", "S101"]

--- a/libs/partners/quickjs/pyproject.toml
+++ b/libs/partners/quickjs/pyproject.toml
@@ -121,7 +121,10 @@ filterwarnings = [
     "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
     # This package intentionally tests its own beta surface.
     "ignore:The class `CodeInterpreterMiddleware` is in beta",
-    # pytest-benchmark warns during pytest configuration when xdist is active.
+    # pytest-benchmark warns during pytest configuration when xdist is active and
+    # benchmarks are not already disabled. `make test` runs without `-n`, so this
+    # covers `make integration_test` (which uses `-n auto`) and keeps the warning
+    # from turning into an `INTERNALERROR` if `-n` is added to `make test`.
     "ignore:Benchmarks are automatically disabled:pytest_benchmark.logger.PytestBenchmarkWarning",
 ]
 

--- a/libs/partners/quickjs/pyproject.toml
+++ b/libs/partners/quickjs/pyproject.toml
@@ -110,7 +110,20 @@ markers = [
     "throughput_benchmark: mark throughput benchmarks",
 ]
 asyncio_mode = "auto"
-filterwarnings = []
+filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
+    # `langchain_core` imports `pydantic.v1` during collection on Python 3.14+.
+    "ignore:Core Pydantic V1 functionality isn't compatible:UserWarning",
+    # `google.genai.types` builds a union alias out of `typing._UnionGenericAlias`
+    # at import time, which Python 3.14 deprecates. Nothing here can act on it --
+    # it fires before any of our code runs and is fixed by upgrading the SDK.
+    "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
+    # This package intentionally tests its own beta surface.
+    "ignore:The class `CodeInterpreterMiddleware` is in beta",
+    # pytest-benchmark warns during pytest configuration when xdist is active.
+    "ignore:Benchmarks are automatically disabled:pytest_benchmark.logger.PytestBenchmarkWarning",
+]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/**/*.py" = [

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -985,7 +985,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.0,<4.0.0" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.1,<4.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4,<4.0.0" },
     { name = "pytest", specifier = ">=9.1.1,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
@@ -1034,7 +1034,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint-postgres"
-version = "3.1.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langgraph-checkpoint" },
@@ -1042,9 +1042,9 @@ dependencies = [
     { name = "psycopg" },
     { name = "psycopg-pool" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/51/5a2dc42e8b5d5942b933b5b7237eae5a4dbc92508a04727c263dd383ad8a/langgraph_checkpoint_postgres-3.1.0.tar.gz", hash = "sha256:02bff4ab63d9dae8eab3a9640fce1d479da8965c9fba7b0dc04cb1f7c56f0a55", size = 148473, upload-time = "2026-05-12T03:40:10.599Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/92/1e8959f8cd1b56e672fde3227f6fd642be85af6c5fd662d73921074aa39d/langgraph_checkpoint_postgres-3.1.1.tar.gz", hash = "sha256:d320e147ddad8c374cd546df0b52b532dd54d0541dd9fd23fc738cbd5de76f41", size = 150413, upload-time = "2026-07-30T19:15:39.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/cd/eff9b82bc3b5f62d481b437099f44f3ef7b1d907f166fb4ee25e8f84a1e7/langgraph_checkpoint_postgres-3.1.0-py3-none-any.whl", hash = "sha256:814cce2ef35d792bf07b090a95eed004f1acac0724fe6605536b13f6d1e7032c", size = 48988, upload-time = "2026-05-12T03:40:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/03/32/ba457698a48a0e18d786caa770033067049fbe36d6846f8e50f13b594b51/langgraph_checkpoint_postgres-3.1.1-py3-none-any.whl", hash = "sha256:6e353aecd8150de144fef8e51a49076f58b7d6830d4cf51392b7ad4d79832ba7", size = 50778, upload-time = "2026-07-30T19:15:37.405Z" },
 ]
 
 [[package]]

--- a/libs/partners/runloop/pyproject.toml
+++ b/libs/partners/runloop/pyproject.toml
@@ -90,7 +90,16 @@ markers = [
     "scheduled: mark tests to run in scheduled testing",
 ]
 asyncio_mode = "auto"
-filterwarnings = []
+filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
+    # `langchain_core` imports `pydantic.v1` during collection on Python 3.14+.
+    "ignore:Core Pydantic V1 functionality isn't compatible:UserWarning",
+    # `google.genai.types` builds a union alias out of `typing._UnionGenericAlias`
+    # at import time, which Python 3.14 deprecates. Nothing here can act on it --
+    # it fires before any of our code runs and is fixed by upgrading the SDK.
+    "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
+]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/**/*.py" = ["D", "S101"]

--- a/libs/partners/vercel/pyproject.toml
+++ b/libs/partners/vercel/pyproject.toml
@@ -91,7 +91,16 @@ markers = [
     "scheduled: mark tests to run in scheduled testing",
 ]
 asyncio_mode = "auto"
-filterwarnings = []
+filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
+    # `langchain_core` imports `pydantic.v1` during collection on Python 3.14+.
+    "ignore:Core Pydantic V1 functionality isn't compatible:UserWarning",
+    # `google.genai.types` builds a union alias out of `typing._UnionGenericAlias`
+    # at import time, which Python 3.14 deprecates. Nothing here can act on it --
+    # it fires before any of our code runs and is fixed by upgrading the SDK.
+    "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
+]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/**/*.py" = ["D", "S101", "SLF001"]

--- a/libs/talon/pyproject.toml
+++ b/libs/talon/pyproject.toml
@@ -122,4 +122,12 @@ ignore-var-parameters = true
 ]
 
 [tool.pytest.ini_options]
+filterwarnings = [
+    # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
+    "error",
+    # `google.genai.types` builds a union alias out of `typing._UnionGenericAlias`
+    # at import time, which Python 3.14 deprecates. Nothing here can act on it --
+    # it fires before any of our code runs and is fixed by upgrading the SDK.
+    "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
+]
 asyncio_mode = "auto"

--- a/libs/talon/uv.lock
+++ b/libs/talon/uv.lock
@@ -881,7 +881,7 @@ requires-dist = [
     { name = "langchain-together", marker = "extra == 'together'", specifier = ">=0.4.0,<2.0.0" },
     { name = "langchain-vercel-sandbox", marker = "extra == 'vercel'", editable = "../partners/vercel" },
     { name = "langchain-xai", marker = "extra == 'xai'", specifier = ">=1.3.0,<2.0.0" },
-    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.0,<4.0.0" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.1,<4.0.0" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.31,<1.0.0" },
     { name = "langgraph-runtime-inmem", specifier = ">=0.31.1,<1.0.0" },
     { name = "langgraph-sdk", specifier = ">=0.4.2,<1.0.0" },
@@ -1736,7 +1736,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.0,<4.0.0" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.1,<4.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4,<4.0.0" },
     { name = "pytest", specifier = ">=9.1.1,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },


### PR DESCRIPTION
Every package under `libs/` now fails its test run on any warning the repo has not explicitly accepted. Each package's pytest `filterwarnings` opens with `"error"`, followed by a short reviewed allowlist of categorical third-party warnings (each with a justification comment). One test that deliberately emits a warning (`test_metadata_less_dist_info_does_not_raise`) scopes its exception with `pytest.mark.filterwarnings` instead of a package-level entry. A static contract test under `.github/scripts/tests/workflows/` asserts every package opts in and the workflow bypass wiring stays intact.

Applying the policy surfaced two real bugs, fixed at the source rather than allowlisted: a `SyntaxWarning` from a non-raw docstring in the ACP `GenericFakeChatModel`, and a `ResourceWarning` from an unclosed `task.toml` handle in the DRBench adapter test.

Maintainers can bypass the policy on a PR by applying the `bypass-warnings-check` label and re-running failed jobs: `_test.yml` reads live PR labels from the GitHub API (re-runs replay the original event payload, so `github.event.pull_request.labels` can be stale) and passes `-W default` on the pytest command line, which outranks every ini filter for that run. The step is fail-closed — an API error enforces rather than bypasses — and `push`/`merge_group` runs always enforce, so the label cannot smuggle warnings into the merge queue.