### PR TITLE
docs(code): orient hooks package docstrings toward v2, banner legacy

### DIFF
--- a/libs/code/deepagents_code/hooks/__init__.py
+++ b/libs/code/deepagents_code/hooks/__init__.py
@@ -1,4 +1,16 @@
-"""Hook contracts and compatibility dispatch."""
+"""Hook contracts and compatibility dispatch.
+
+This package contains two hook systems: Hooks v2 (current) and legacy hooks
+(deprecated, removal September 1, 2026).
+
+To write a new hook integration, use the v2 config format — see
+`deepagents_code.hooks.loading` for file locations and precedence, and
+`deepagents_code.hooks.models.config` + `deepagents_code.hooks.models.wire`
+for the schema and stdin payload shapes.
+
+`deepagents_code.hooks.legacy` exists only for backward compatibility; new
+integrations should not target it.
+"""
 
 from deepagents_code.hooks.legacy import (
     HOOK_SUBPROCESS_TIMEOUT,

--- a/libs/code/deepagents_code/hooks/legacy.py
+++ b/libs/code/deepagents_code/hooks/legacy.py
@@ -1,5 +1,11 @@
 """Lightweight hook dispatch for external tool integration.
 
+DEPRECATED: This is the legacy hook system, kept for backward compatibility
+until September 1, 2026. New integrations should use Hooks v2 — see
+`deepagents_code.hooks.loading` for config locations and
+`deepagents_code.hooks.models` for the schema. Legacy documents are migrated
+to v2 at load time (`deepagents_code.hooks.migration`).
+
 Loads hook configuration from `~/.deepagents/hooks.json` and fires matching
 commands with JSON payloads on stdin. Subprocess work is offloaded to a
 background thread so the caller's event loop is never stalled. Failures are

--- a/libs/code/deepagents_code/hooks/loading.py
+++ b/libs/code/deepagents_code/hooks/loading.py
@@ -10,6 +10,17 @@ Sources are concatenated per event. Precedence is reduction order, not execution
 order: every matching handler runs, and the first one that stops processing
 decides the event.
 
+A minimal v2 config with one event and one command handler:
+
+```json
+{"hooks": {"Notification": [{"matcher": "agent_completed",
+  "hooks": [{"type": "command", "command": "bash notify.sh"}]}]}}
+```
+
+Hook stdin payloads are the Claude-compatible envelope (`hook_event_name` +
+`session_id` + event-specific fields), defined in
+`deepagents_code.hooks.models.wire`.
+
 Legacy list-shaped documents are migrated only for events whose lifecycle
 semantics genuinely match Hooks v2.
 """

--- a/libs/code/deepagents_code/hooks/migration.py
+++ b/libs/code/deepagents_code/hooks/migration.py
@@ -2,6 +2,10 @@
 
 Legacy documents are converted by the loader so lifecycle call sites dispatch
 only canonical events and do not duplicate old dotted-event hooks.
+
+`_LEGACY_EVENT_MAP` is the authoritative list of which legacy events still
+work; events absent from it (e.g. `permission.request`, `tool.use`,
+`tool.result`) are silently dropped during migration.
 """
 
 from __future__ import annotations

--- a/libs/code/deepagents_code/hooks/migration.py
+++ b/libs/code/deepagents_code/hooks/migration.py
@@ -3,9 +3,11 @@
 Legacy documents are converted by the loader so lifecycle call sites dispatch
 only canonical events and do not duplicate old dotted-event hooks.
 
-`_LEGACY_EVENT_MAP` is the authoritative list of which legacy events still
-work; events absent from it (e.g. `permission.request`, `tool.use`,
-`tool.result`) are silently dropped during migration.
+`_LEGACY_EVENT_MAP` is the authoritative list of legacy events migrated into
+Hooks v2. Events absent from it (e.g. `permission.request`, `tool.use`,
+`tool.result`) are dropped from the migrated configuration only; they continue
+to fire through the legacy dispatcher (`deepagents_code.hooks.legacy`) until
+the legacy system is removed.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Agents and developers landing on any hook-related file now get immediate orientation on which hook system is current: the `hooks` package docstring names Hooks v2 as current and legacy as deprecated (removal September 1, 2026) and points to the canonical v2 references, `hooks/legacy.py` opens with a `DEPRECATED:` banner before its format documentation, `hooks/loading.py` includes a copy-pasteable minimal v2 config example plus a pointer to the stdin payload envelope in `hooks/models/wire.py`, and `hooks/migration.py` notes that `_LEGACY_EVENT_MAP` is the authoritative list of legacy events still migrated (unmapped events are silently dropped).

---

Motivation: an agent searching for "hooks" previously landed on `legacy.py` first — its ~70-line module docstring reads like the canonical format reference — and could build against the legacy list-shaped config without ever discovering Hooks v2. Meanwhile the package entry point docstring gave no orientation at all.

Docstring-only change; no behavior modified. Where details already live elsewhere (precedence, schema, wire envelope), the docstrings point to the canonical module instead of restating them.
