### PR TITLE
fix(sdk): disambiguate `read_file` gutter separator from source inden…

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -206,16 +206,18 @@ _SUCCESS_EXIT_RE = re.compile(r"\n?\[Command succeeded with exit code 0\]\s*$")
 """Strip the SDK's `[Command succeeded with exit code 0]` trailer from tool output."""
 
 
-_READ_FILE_GUTTER_RE = re.compile(r"^ *(\d+(?:\.\d+)?)(?:  |\t)(.*)$")
+_READ_FILE_GUTTER_RE = re.compile(r"^ *(\d+(?:\.\d+)?)(?: \| |  |\t)(.*)$")
 """Match a `read_file` gutter row into (marker, source).
 
 The marker is a bare `N` or `N.M` (the latter a wrapped-line continuation) —
 both sides of the dot required, so a stray `.5` head is not a gutter. The
-separator is exactly two spaces (current format) or a single tab (legacy
-`cat -n`). Only the separator is consumed and leading padding is spaces-only, so
-source indentation — including leading tabs — after the gutter stays put. Kept in
-sync with the separator emitted by deepagents' `format_content_with_line_numbers`
-(the authoritative producer). See `ToolCallMessage._compact_line_gutter`.
+separator is ` | ` (current format), or a legacy separator — two spaces, or a
+single tab (`cat -n`) — from output persisted by an older deepagents version.
+Only the separator is consumed and leading padding is spaces-only, so source
+indentation — including leading tabs and spaces — after the gutter stays put.
+Kept in sync with the separator emitted by deepagents'
+`format_content_with_line_numbers` (the authoritative producer). See
+`ToolCallMessage._compact_line_gutter`.
 """
 
 
@@ -2667,13 +2669,14 @@ class ToolCallMessage(Vertical):
         r"""Tighten `read_file`'s line-number gutter for display.
 
         `read_file` prefixes each row with a right-justified line marker — `N`,
-        or `N.M` for a wrapped-line continuation — then two spaces, then the
-        original source content. (Output from deepagents versions predating the
-        gutter disambiguation in #4561 used the older `cat -n` gutter — a wide
-        right-justified number and a tab — which may still surface from cached or
+        or `N.M` for a wrapped-line continuation — then ` | `, then the original
+        source content. (Output from deepagents versions predating the gutter
+        disambiguation in #5343 used a two-space separator, and versions
+        predating #4561 used the older `cat -n` gutter — a wide right-justified
+        number and a tab — either of which may still surface from cached or
         persisted transcripts.) The model needs the raw gutter for edits, but the
-        TUI re-justifies markers to the widest marker actually present, then two
-        spaces, mirroring how grep/glob results sit flush left. Source
+        TUI re-justifies markers to the widest marker actually present, then
+        ` | `, mirroring how grep/glob results sit flush left. Source
         indentation after the gutter is preserved untouched.
 
         The gutter shape is `_READ_FILE_GUTTER_RE`. Lines that don't match a
@@ -2705,7 +2708,7 @@ class ToolCallMessage(Vertical):
                 compacted.append(line)
             else:
                 marker, source = row
-                compacted.append(f"{marker:>{width}}  {source}")
+                compacted.append(f"{marker:>{width}} | {source}")
         return "\n".join(compacted)
 
     def _format_edit_file_output(

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -5509,8 +5509,8 @@ class TestCreateCliAgentInterpreterWiring:
             runtime=runtime,
         )
 
-        assert "1  first" in allowed.content
-        assert "2  second" in allowed.content
+        assert "1 | first" in allowed.content
+        assert "2 | second" in allowed.content
         assert "can only read" in denied
 
     def test_rubric_grader_prefix_tracks_artifacts_root(self, tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -3666,33 +3666,50 @@ class TestToolCallMessageFileOutput:
         line numbers and (when the first row's padding was stripped) misaligned.
         Such output may still surface from cached or persisted transcripts. The
         TUI recomputes a compact gutter: numbers right-justified to the widest
-        number present, two spaces, then the original source indentation.
+        number present, ` | `, then the original source indentation.
         """
         msg = ToolCallMessage("read_file", {"path": "/tmp/a.py"})
         # cat -n style: 6-wide right-justified number + tab + source line.
         output = '     1\t"""doc"""\n     2\t\n     3\t    indented'
         result = msg._format_output(output, is_preview=False)
 
-        # No tab, no 6-wide pad: `{num}  ` gutter, then the original source
+        # No tab, no 6-wide pad: `{num} | ` gutter, then the original source
         # indentation (the 4 spaces on line 3) preserved verbatim.
-        assert result.content.plain == '1  """doc"""\n2  \n3      indented'
+        assert result.content.plain == '1 | """doc"""\n2 | \n3 |     indented'
 
-    def test_format_output_leaves_current_two_space_gutter_intact(self) -> None:
-        r"""The current SDK gutter is already compact, so compaction is a no-op.
+    def test_format_output_compacts_legacy_two_space_gutter(self) -> None:
+        r"""A legacy two-space gutter (predating #5343) is normalized to ` | `.
 
-        `read_file` now emits `f"{marker:>width}  {line}"` — a right-justified
-        marker, two spaces, then source. Re-justifying to the widest marker
-        reproduces the same string, and crucially a tab-indented source line
-        keeps its leading tab (the two-space separator, not the source tab, is
-        consumed). Regression guard: the old tab-splitting gutter dropped that
-        indentation, re-introducing the ambiguity this format fixes.
+        deepagents versions between #4561 and #5343 emitted
+        `f"{marker:>width}  {line}"` — a right-justified marker, two spaces,
+        then source — which is ambiguous with space-indented source. Such
+        output may still surface from cached or persisted transcripts; the TUI
+        recompacts it to the current, unambiguous ` | ` separator rather than
+        leaving it as-is.
         """
         msg = ToolCallMessage("read_file", {"path": "/tmp/a.py"})
         # Two-digit max marker => width 2; line 2 is tab-indented source.
         output = " 9  def build_config():\n10  \treturn {}"
         result = msg._format_output(output, is_preview=False)
 
-        assert result.content.plain == " 9  def build_config():\n10  \treturn {}"
+        assert result.content.plain == " 9 | def build_config():\n10 | \treturn {}"
+
+    def test_format_output_leaves_current_pipe_gutter_intact(self) -> None:
+        r"""The current SDK gutter is already compact, so compaction is a no-op.
+
+        `read_file` now emits `f"{marker:>width} | {line}"` — a right-justified
+        marker, ` | `, then source. Re-justifying to the widest marker
+        reproduces the same string, and crucially a tab-indented source line
+        keeps its leading tab (only the ` | ` separator, not the source tab, is
+        consumed). Regression guard: an earlier tab-splitting gutter dropped
+        that indentation, which is the ambiguity this format fixes.
+        """
+        msg = ToolCallMessage("read_file", {"path": "/tmp/a.py"})
+        # Two-digit max marker => width 2; line 2 is tab-indented source.
+        output = " 9 | def build_config():\n10 | \treturn {}"
+        result = msg._format_output(output, is_preview=False)
+
+        assert result.content.plain == " 9 | def build_config():\n10 | \treturn {}"
 
     def test_compact_line_gutter_right_justifies_to_widest_number(self) -> None:
         r"""Multi-digit line numbers set a uniform, right-justified gutter."""
@@ -3700,7 +3717,7 @@ class TestToolCallMessageFileOutput:
         output = "     9\tnine\n    10\tten"
         compacted = ToolCallMessage._compact_line_gutter(output)
 
-        assert compacted == " 9  nine\n10  ten"
+        assert compacted == " 9 | nine\n10 | ten"
 
     def test_compact_line_gutter_handles_continuation_markers(self) -> None:
         r"""`N.M` wrapped-line markers are gutters and drive the column width.
@@ -3712,7 +3729,7 @@ class TestToolCallMessageFileOutput:
         output = "     1\tfirst\n   1.1\twrapped"
         compacted = ToolCallMessage._compact_line_gutter(output)
 
-        assert compacted == "  1  first\n1.1  wrapped"
+        assert compacted == "  1 | first\n1.1 | wrapped"
 
     def test_compact_line_gutter_preserves_source_tabs_legacy(self) -> None:
         r"""Only the gutter tab is consumed; a legacy row's source tab stays put.
@@ -3723,23 +3740,23 @@ class TestToolCallMessageFileOutput:
         output = "     1\t\tdef foo():"
         compacted = ToolCallMessage._compact_line_gutter(output)
 
-        assert compacted == "1  \tdef foo():"
+        assert compacted == "1 | \tdef foo():"
 
     def test_compact_line_gutter_preserves_source_tabs_current(self) -> None:
         r"""A current-format row's leading source tab (and a blank row) survive.
 
-        The current gutter separator is two spaces, so a tab-indented source
-        line reads as `"N  \tsource"`. Only the two spaces are consumed; the
-        source tab must remain. This is the regression guard for the tab-
-        splitting gutter that used to drop it. A blank source line (`"N  "` —
-        marker, separator, empty source) round-trips unchanged too; the
+        The current gutter separator is ` | `, so a tab-indented source line
+        reads as `"N | \tsource"`. Only the ` | ` is consumed; the source tab
+        must remain. This is the regression guard for the tab-splitting gutter
+        that used to drop it. A blank source line (`"N | "` — marker,
+        separator, empty source) round-trips unchanged too; the
         `_compact_line_gutter` return preserves its trailing separator (the
         display path may later strip trailing space, but the compactor does not).
         """
-        output = "1  def foo():\n2  \treturn 1\n3  "
+        output = "1 | def foo():\n2 | \treturn 1\n3 | "
         compacted = ToolCallMessage._compact_line_gutter(output)
 
-        assert compacted == "1  def foo():\n2  \treturn 1\n3  "
+        assert compacted == "1 | def foo():\n2 | \treturn 1\n3 | "
 
     def test_compact_line_gutter_parses_real_producer_output(self) -> None:
         r"""Round-trip guard against producer/consumer separator drift.
@@ -3756,7 +3773,7 @@ class TestToolCallMessageFileOutput:
         )
         compacted = ToolCallMessage._compact_line_gutter(output)
 
-        assert compacted == "1  def f():\n2  \treturn 1"
+        assert compacted == "1 | def f():\n2 | \treturn 1"
 
     def test_compact_line_gutter_round_trips_continuation_and_padding(self) -> None:
         r"""Real-producer round-trip exercising continuation + multi-digit padding.
@@ -3776,25 +3793,26 @@ class TestToolCallMessageFileOutput:
         compacted = ToolCallMessage._compact_line_gutter(output)
 
         lines = compacted.split("\n")
-        assert lines[0] == "   9  short"  # width 4, driven by the "10.1" marker
-        assert lines[2].startswith("10.1  ")
-        assert lines[-1] == "  11  \treturn 1"  # tab-indented source survives
+        assert lines[0] == "   9 | short"  # width 4, driven by the "10.1" marker
+        assert lines[2].startswith("10.1 | ")
+        assert lines[-1] == "  11 | \treturn 1"  # tab-indented source survives
 
     def test_compact_line_gutter_preserves_double_spaced_source(self) -> None:
         r"""Only the first separator is consumed; the rest of the source is verbatim.
 
         A source line whose own text starts with digits and two spaces
         (`"42  meaning"`) must survive intact: the regex captures the leading
-        gutter marker and emits everything after the first two-space separator
-        untouched, including the embedded double space. Guards the `(.*)` capture
+        gutter marker and emits everything after the first ` | ` separator
+        untouched, including the embedded double space that could otherwise be
+        mistaken for a legacy gutter separator. Guards the `(.*)` capture
         against a future separator group that might reprocess or collapse
-        interior spacing (e.g. widening `(?:  |\t)` to `\s+`).
+        interior spacing.
         """
         # width 2 (max marker "10"); row 5's source begins with digits + 2 spaces.
-        output = "5  42  meaning\n10  ok"
+        output = "5 | 42  meaning\n10 | ok"
         compacted = ToolCallMessage._compact_line_gutter(output)
 
-        assert compacted == " 5  42  meaning\n10  ok"
+        assert compacted == " 5 | 42  meaning\n10 | ok"
 
     def test_compact_line_gutter_passes_through_non_numbered(self) -> None:
         """Output without a gutter is returned unchanged."""
@@ -3805,16 +3823,17 @@ class TestToolCallMessageFileOutput:
         r"""Heads that aren't a bare `N`/`N.M` are treated as source, not gutter.
 
         Guards against corrupting data whose first column merely resembles a
-        number (leading/trailing dot, multiple dots) — in both the legacy tab
-        and current two-space forms, since a malformed head fails the marker
-        pattern before the separator alternation is ever reached.
+        number (leading/trailing dot, multiple dots) — across the legacy tab,
+        legacy two-space, and current pipe forms, since a malformed head fails
+        the marker pattern before the separator alternation is ever reached.
         """
         # Leading dot, trailing dot, and multi-dot heads must all pass through,
         # whichever separator follows. All lines are non-gutter, so nothing
         # matches and the whole output is returned verbatim.
         output = (
             "   .5\tweird\n   5.\talso\n 1.2.3\tnope\n"
-            ".5  two-space\n5.  two-space\n1.2.3  two-space"
+            ".5  two-space\n5.  two-space\n1.2.3  two-space\n"
+            ".5 | pipe\n5. | pipe\n1.2.3 | pipe"
         )
         assert ToolCallMessage._compact_line_gutter(output) == output
 
@@ -3832,7 +3851,7 @@ class TestToolCallMessageFileOutput:
         result = msg._format_file_output(output, is_preview=True)
 
         rendered = result.content.plain.split("\n")
-        assert rendered[0] == " 1  line 1"  # width 2 (max line number is 20)
+        assert rendered[0] == " 1 | line 1"  # width 2 (max line number is 20)
         assert result.truncation == "16 more lines"
 
     def test_compact_line_gutter_empty_output(self) -> None:

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -199,8 +199,9 @@ def format_content_with_line_numbers(
     """Format file content with line numbers.
 
     Chunks lines longer than `MAX_LINE_LENGTH` with continuation markers
-    (e.g., `5.1`, `5.2`). Line markers are separated from source content
-    with two spaces so source tabs cannot be confused with a gutter separator.
+    (e.g., `5.1`, `5.2`). Line markers are separated from source content with
+    ` | ` so the gutter can never be confused with source indentation,
+    whether the source uses tabs or spaces.
 
     Args:
         content: File content as string or list of lines
@@ -230,19 +231,24 @@ def format_content_with_line_numbers(
             rows.append((marker, chunk))
             marker_width = max(marker_width, len(marker))
 
-    # The two-space marker/source separator is a load-bearing contract shared by
-    # two downstream parsers that must stay in sync with the separator emitted
+    # The ` | ` marker/source separator is a load-bearing contract shared by
+    # downstream parsers that must stay in sync with the separator emitted
     # here:
+    #   - `_truncate_paginated_read` (middleware/filesystem.py, same package)
+    #     extracts the leading line number from each rendered row to compute
+    #     truncation boundaries.
     #   - `ReadFileContinuationNoticeMiddleware._is_numbered_read_file_row`
     #     (profiles/harness/_nvidia_nemotron_3_ultra.py) counts source rows to
     #     decide whether to append the continuation notice.
     #   - `ToolCallMessage._compact_line_gutter` (the deepagents-code TUI, in a
     #     separate package: libs/code/.../tui/widgets/messages.py) re-justifies
     #     the gutter for display.
-    # Both also tolerate the legacy `cat -n` tab. Shrinking this separator below
-    # two spaces (or otherwise diverging) would silently break them; the
-    # producer->consumer round-trip tests in both packages guard against that.
-    return "\n".join(f"{marker:>{marker_width}}  {line}" for marker, line in rows)
+    # The latter two also tolerate the legacy two-space separator and the
+    # original `cat -n` tab, since they may parse content persisted by an older
+    # deepagents version. Changing this separator (or otherwise diverging) would
+    # silently break them; the producer->consumer round-trip tests in both
+    # packages guard against that.
+    return "\n".join(f"{marker:>{marker_width}} | {line}" for marker, line in rows)
 
 
 def check_empty_content(content: str) -> str | None:

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -923,7 +923,7 @@ def _truncate_paginated_read(
 
     Args:
         content: Line-numbered content produced by
-            `format_content_with_line_numbers` (a marker followed by two spaces
+            `format_content_with_line_numbers` (a marker followed by ` | `
             and the source content).
         file_path: Path used to format the truncation message.
         read_result: Backend read result carrying the window metadata; the
@@ -964,7 +964,7 @@ def _truncate_paginated_read(
         boundaries: list[tuple[int, int]] = []
         for index, row in enumerate(rows):
             position += len(row)
-            marker = row.lstrip().partition("  ")[0].partition(".")[0]
+            marker = row.lstrip().partition(" | ")[0].partition(".")[0]
             source_line = int(marker)
             # Rows numbered past the window's last source line are not file
             # content: a byte-capped backend page appends its own truncation
@@ -978,7 +978,7 @@ def _truncate_paginated_read(
                 break
             next_source_line = None
             if index + 1 < len(rows):
-                next_marker = rows[index + 1].lstrip().partition("  ")[0].partition(".")[0]
+                next_marker = rows[index + 1].lstrip().partition(" | ")[0].partition(".")[0]
                 next_source_line = int(next_marker)
             if next_source_line != source_line:
                 boundaries.append((position, source_line))

--- a/libs/deepagents/deepagents/profiles/harness/_nvidia_nemotron_3_ultra.py
+++ b/libs/deepagents/deepagents/profiles/harness/_nvidia_nemotron_3_ultra.py
@@ -141,14 +141,15 @@ class ReadFileContinuationNoticeMiddleware(AgentMiddleware):
         """Return whether `row` looks like a formatted `read_file` source line.
 
         Matches a primary source marker (`N`), optional spaces-only right-justify
-        padding in front of it, then the current two-space separator (emitted by
-        `format_content_with_line_numbers`) or the legacy `cat -n` tab.
-        Continuation rows (`N.M`) fail — the `.` follows the digits, so they are
-        not counted toward the source-line limit. The separator clause is matched
-        exactly (two spaces or a tab), in lockstep with the producer and with the
-        TUI `_compact_line_gutter` parser.
+        padding in front of it, then the current ` | ` separator (emitted by
+        `format_content_with_line_numbers`) or a legacy separator (the two-space
+        gutter, or the original `cat -n` tab) from content persisted by an older
+        deepagents version. Continuation rows (`N.M`) fail — the `.` follows the
+        digits, so they are not counted toward the source-line limit. The
+        separator clause is matched exactly, in lockstep with the producer and
+        with the TUI `_compact_line_gutter` parser.
         """
-        return re.match(r"^ *\d+(?:  |\t)", row) is not None
+        return re.match(r"^ *\d+(?: \| |  |\t)", row) is not None
 
     @staticmethod
     def _annotate(

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -524,7 +524,7 @@ class TestDeepAgentEndToEnd:
         assert "short line 0" in file_content
         assert "xxx" in file_content
         # All four wrapped chunks of source line 2 render in order.
-        for marker in ("  2  ", "2.1  ", "2.2  ", "2.3  "):
+        for marker in ("  2 | ", "2.1 | ", "2.2 | ", "2.3 | "):
             assert marker in file_content, f"missing continuation marker {marker!r}"
         # Source line 3 is the third source line and must be included.
         assert "short line 2" in file_content
@@ -1262,11 +1262,11 @@ class TestDeepAgentEndToEnd:
         # The primary row and both continuation chunks of the wrapped line 2
         # must render in order, before `important instruction`, with nothing
         # dropped at the page boundary.
-        for marker in ("  2  ", "2.1  ", "2.2  "):
+        for marker in ("  2 | ", "2.1 | ", "2.2 | "):
             assert marker in combined, f"missing continuation marker {marker!r}"
-        idx_first = combined.index("  2  ")
-        idx_cont1 = combined.index("2.1  ")
-        idx_cont2 = combined.index("2.2  ")
+        idx_first = combined.index("  2 | ")
+        idx_cont1 = combined.index("2.1 | ")
+        idx_cont2 = combined.index("2.2 | ")
         idx_next = combined.index("important instruction")
         assert idx_first < idx_cont1 < idx_cont2 < idx_next
 

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1368,43 +1368,44 @@ class TestFilesystemMiddleware:
         result = format_content_with_line_numbers(content, start_line=1)
 
         assert result.split("\n") == [
-            "1  short line 1",
-            "2  short line 2",
-            "3  short line 3",
+            "1 | short line 1",
+            "2 | short line 2",
+            "3 | short line 3",
         ]
 
     def test_format_content_with_line_numbers_empty_and_single(self):
         """Empty content yields an empty string; a single line needs no padding."""
         assert format_content_with_line_numbers("") == ""
         assert format_content_with_line_numbers([]) == ""
-        assert format_content_with_line_numbers(["only"]) == "1  only"
+        assert format_content_with_line_numbers(["only"]) == "1 | only"
 
     def test_format_content_with_line_numbers_blank_line_in_middle(self):
         """A blank source line keeps its own gutter row, ending at the separator.
 
-        The row is `marker + "  "` with empty content — trailing whitespace that
-        a careless refactor could strip or drop entirely. Exact equality guards
-        the row's presence and shape.
+        The row is `marker + " | "` with empty content — trailing whitespace
+        that a careless refactor could strip or drop entirely. Exact equality
+        guards the row's presence and shape.
         """
         result = format_content_with_line_numbers(["code", "", "more"], start_line=1)
 
-        assert result.split("\n") == ["1  code", "2  ", "3  more"]
+        assert result.split("\n") == ["1 | code", "2 | ", "3 | more"]
 
     def test_format_content_with_line_numbers_aligns_across_magnitude(self):
         """Markers right-justify to a shared width when line counts cross 9->10.
 
-        The gutter is exactly `marker_width + 2` spaces, so an over-wide gutter
-        (a `marker_width` bug) is caught here that substring checks would miss.
+        The gutter is exactly `marker_width` spaces plus ` | `, so an over-wide
+        gutter (a `marker_width` bug) is caught here that substring checks
+        would miss.
         """
         content = [f"line{i}" for i in range(12)]
         result = format_content_with_line_numbers(content, start_line=1)
 
         lines = result.split("\n")
         # Widest marker is "12" (width 2), so single-digit markers get one pad.
-        assert lines[0] == " 1  line0"
-        assert lines[8] == " 9  line8"
-        assert lines[9] == "10  line9"
-        assert lines[11] == "12  line11"
+        assert lines[0] == " 1 | line0"
+        assert lines[8] == " 9 | line8"
+        assert lines[9] == "10 | line9"
+        assert lines[11] == "12 | line11"
 
     def test_format_content_with_line_numbers_offset_crosses_magnitude(self):
         """A `start_line` offset that pushes numbers past 9 widens the gutter."""
@@ -1412,11 +1413,11 @@ class TestFilesystemMiddleware:
         result = format_content_with_line_numbers(content, start_line=8)
 
         assert result.split("\n") == [
-            " 8  a",
-            " 9  b",
-            "10  c",
-            "11  d",
-            "12  e",
+            " 8 | a",
+            " 9 | b",
+            "10 | c",
+            "11 | d",
+            "12 | e",
         ]
 
     def test_format_content_with_line_numbers_preserves_source_tabs(self):
@@ -1424,19 +1425,20 @@ class TestFilesystemMiddleware:
         content = ["\tif config:", "\t\tbilling_cfg = {}"]
         result = format_content_with_line_numbers(content, start_line=1)
 
-        assert result.split("\n") == ["1  \tif config:", "2  \t\tbilling_cfg = {}"]
+        assert result.split("\n") == ["1 | \tif config:", "2 | \t\tbilling_cfg = {}"]
 
     def test_format_content_with_line_numbers_preserves_source_spaces(self):
-        """Leading source spaces survive intact after the two-space gutter.
+        """Leading source spaces survive intact and unambiguous after the gutter.
 
-        The gutter itself is spaces, so this documents that space-indented
-        source is preserved byte-for-byte even though the boundary is not
-        marked by a distinct separator character.
+        The ` | ` separator is a non-whitespace boundary, so space-indented
+        source is both preserved byte-for-byte and unambiguous to a reader (or
+        a model) trying to tell gutter padding apart from source indentation —
+        the bug this format fixes (#5343).
         """
         content = ["    def foo():", "        return 1"]
         result = format_content_with_line_numbers(content, start_line=1)
 
-        assert result.split("\n") == ["1      def foo():", "2          return 1"]
+        assert result.split("\n") == ["1 |     def foo():", "2 |         return 1"]
 
     def test_format_content_with_line_numbers_long_line_with_continuation(self):
         """Test that long lines (>5000 chars) are split with continuation markers."""
@@ -1446,18 +1448,18 @@ class TestFilesystemMiddleware:
 
         lines = result.split("\n")
         assert len(lines) == 7  # 1 short + 5 continuation (2, 2.1, 2.2, 2.3, 2.4) + 1 short
-        assert lines[0] == "  1  short line"
-        assert lines[1].startswith("  2  ")
+        assert lines[0] == "  1 | short line"
+        assert lines[1].startswith("  2 | ")
         assert lines[1].count("a") == 5000
-        assert lines[2].startswith("2.1  ")
+        assert lines[2].startswith("2.1 | ")
         assert lines[2].count("a") == 5000
-        assert lines[3].startswith("2.2  ")
+        assert lines[3].startswith("2.2 | ")
         assert lines[3].count("a") == 5000
-        assert lines[4].startswith("2.3  ")
+        assert lines[4].startswith("2.3 | ")
         assert lines[4].count("a") == 5000
-        assert lines[5].startswith("2.4  ")
+        assert lines[5].startswith("2.4 | ")
         assert lines[5].count("a") == 5000
-        assert lines[6] == "  3  another short line"
+        assert lines[6] == "  3 | another short line"
 
     def test_format_content_with_line_numbers_multiple_long_lines(self):
         """Test multiple long lines in sequence with proper line numbering."""
@@ -1467,18 +1469,18 @@ class TestFilesystemMiddleware:
         result = format_content_with_line_numbers(content, start_line=5)
         lines = result.split("\n")
         assert len(lines) == 7  # 3 (line 5, 5.1, 5.2) + 1 middle + 3 (line 7, 7.1, 7.2)
-        assert lines[0].startswith("  5  ")
+        assert lines[0].startswith("  5 | ")
         assert lines[0].count("x") == 5000
-        assert lines[1].startswith("5.1  ")
+        assert lines[1].startswith("5.1 | ")
         assert lines[1].count("x") == 5000
-        assert lines[2].startswith("5.2  ")
+        assert lines[2].startswith("5.2 | ")
         assert lines[2].count("x") == 5000
-        assert lines[3] == "  6  middle"
-        assert lines[4].startswith("  7  ")
+        assert lines[3] == "  6 | middle"
+        assert lines[4].startswith("  7 | ")
         assert lines[4].count("y") == 5000
-        assert lines[5].startswith("7.1  ")
+        assert lines[5].startswith("7.1 | ")
         assert lines[5].count("y") == 5000
-        assert lines[6].startswith("7.2  ")
+        assert lines[6].startswith("7.2 | ")
         assert lines[6].count("y") == 5000
 
     def test_format_content_with_line_numbers_exact_limit(self):
@@ -1489,7 +1491,7 @@ class TestFilesystemMiddleware:
 
         lines = result.split("\n")
         assert len(lines) == 1
-        assert lines[0].startswith("1  b")
+        assert lines[0].startswith("1 | b")
         assert lines[0].count("b") == 5000
 
     def test_read_file_with_long_lines_shows_continuation_markers(self):
@@ -1502,14 +1504,14 @@ class TestFilesystemMiddleware:
         result = format_content_with_line_numbers(sliced.file_data["content"], start_line=1)
         lines = result.split("\n")
         assert len(lines) == 5  # 1 first + 3 continuation (2, 2.1, 2.2) + 1 third
-        assert lines[0] == "  1  first line"
-        assert lines[1].startswith("  2  ")
+        assert lines[0] == "  1 | first line"
+        assert lines[1].startswith("  2 | ")
         assert lines[1].count("z") == 5000
-        assert lines[2].startswith("2.1  ")
+        assert lines[2].startswith("2.1 | ")
         assert lines[2].count("z") == 5000
-        assert lines[3].startswith("2.2  ")
+        assert lines[3].startswith("2.2 | ")
         assert lines[3].count("z") == 5000
-        assert lines[4] == "  3  third line"
+        assert lines[4] == "  3 | third line"
 
     def test_read_file_with_offset_and_long_lines(self):
         """Test that read_file with offset handles long lines correctly."""
@@ -1521,13 +1523,13 @@ class TestFilesystemMiddleware:
         result = format_content_with_line_numbers(sliced.file_data["content"], start_line=3)
         lines = result.split("\n")
         assert len(lines) == 4  # 3 continuation (3, 3.1, 3.2) + 1 line4
-        assert lines[0].startswith("  3  ")
+        assert lines[0].startswith("  3 | ")
         assert lines[0].count("m") == 5000
-        assert lines[1].startswith("3.1  ")
+        assert lines[1].startswith("3.1 | ")
         assert lines[1].count("m") == 5000
-        assert lines[2].startswith("3.2  ")
+        assert lines[2].startswith("3.2 | ")
         assert lines[2].count("m") == 2000
-        assert lines[3] == "  4  line4"
+        assert lines[3] == "  4 | line4"
 
     def test_read_file_partial_window_includes_remaining_lines_notice(self):
         files = {
@@ -1543,7 +1545,7 @@ class TestFilesystemMiddleware:
         result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 2})
 
         assert isinstance(result, ToolMessage)
-        assert result.content == ("1  one\n2  two\n\n[Read 2 lines (lines 1-2 of 5 total). 3 lines remaining from offset 2.]")
+        assert result.content == ("1 | one\n2 | two\n\n[Read 2 lines (lines 1-2 of 5 total). 3 lines remaining from offset 2.]")
 
     def test_read_file_full_window_omits_remaining_lines_notice(self):
         files = {
@@ -1559,7 +1561,7 @@ class TestFilesystemMiddleware:
         result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 10})
 
         assert isinstance(result, ToolMessage)
-        assert result.content == "1  one\n2  two\n3  three"
+        assert result.content == "1 | one\n2 | two\n3 | three"
         assert "remaining from offset" not in result.content
 
     def test_read_file_offset_window_reports_source_line_range(self):
@@ -1576,7 +1578,7 @@ class TestFilesystemMiddleware:
         result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 2, "limit": 2})
 
         assert isinstance(result, ToolMessage)
-        assert result.content == ("3  three\n4  four\n\n[Read 2 lines (lines 3-4 of 5 total). 1 line remaining from offset 4.]")
+        assert result.content == ("3 | three\n4 | four\n\n[Read 2 lines (lines 3-4 of 5 total). 1 line remaining from offset 4.]")
 
     def test_read_file_single_line_window_uses_singular_read_unit(self):
         files = {
@@ -1592,7 +1594,7 @@ class TestFilesystemMiddleware:
         result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 1})
 
         assert isinstance(result, ToolMessage)
-        assert result.content == ("1  one\n\n[Read 1 line (lines 1-1 of 5 total). 4 lines remaining from offset 1.]")
+        assert result.content == ("1 | one\n\n[Read 1 line (lines 1-1 of 5 total). 4 lines remaining from offset 1.]")
 
     def _read_notes(self, *, offset: int, limit: int) -> ToolMessage:
         """Invoke `read_file` against a fixed 3-line file with the given window."""
@@ -1683,13 +1685,13 @@ class TestFilesystemMiddleware:
         result = self._read_notes(offset=-1, limit=100)
 
         assert result.status == "success"
-        assert result.content == ("1  one\n2  two\n3  three\n\n[Requested offset -1 is before the start of the file; read from line 1 instead.]")
+        assert result.content == ("1 | one\n2 | two\n3 | three\n\n[Requested offset -1 is before the start of the file; read from line 1 instead.]")
 
     def test_read_file_non_negative_offset_has_no_clamp_notice(self):
         """The clamp notice must not appear on ordinary reads."""
         result = self._read_notes(offset=0, limit=100)
 
-        assert result.content == "1  one\n2  two\n3  three"
+        assert result.content == "1 | one\n2 | two\n3 | three"
 
     def test_read_file_unknown_total_reports_next_offset(self):
         backend, _ = _make_backend()
@@ -1706,7 +1708,7 @@ class TestFilesystemMiddleware:
             result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 1})
 
         assert isinstance(result, ToolMessage)
-        assert result.content == "1  one\n\n[Read 1 line (lines 1-1). More lines remain from offset 1.]"
+        assert result.content == "1 | one\n\n[Read 1 line (lines 1-1). More lines remain from offset 1.]"
 
     def test_read_file_truncation_omits_notice_when_no_complete_line_fits(self):
         backend, _ = _make_backend()
@@ -1746,8 +1748,8 @@ class TestFilesystemMiddleware:
             result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 100})
 
         assert isinstance(result, ToolMessage)
-        numbered_lines = [line for line in result.content.splitlines() if line.lstrip().partition("  ")[0].isdigit()]
-        last_displayed_line = int(numbered_lines[-1].lstrip().partition("  ")[0])
+        numbered_lines = [line for line in result.content.splitlines() if line.lstrip().partition(" | ")[0].isdigit()]
+        last_displayed_line = int(numbered_lines[-1].lstrip().partition(" | ")[0])
         assert last_displayed_line < 100
         assert f"remaining from offset {last_displayed_line}.]" in result.content
 
@@ -1770,8 +1772,8 @@ class TestFilesystemMiddleware:
             result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 100})
 
         assert isinstance(result, ToolMessage)
-        numbered_lines = [line for line in result.content.splitlines() if line.lstrip().partition("  ")[0].isdigit()]
-        last_displayed_line = int(numbered_lines[-1].lstrip().partition("  ")[0])
+        numbered_lines = [line for line in result.content.splitlines() if line.lstrip().partition(" | ")[0].isdigit()]
+        last_displayed_line = int(numbered_lines[-1].lstrip().partition(" | ")[0])
         assert last_displayed_line < 100
         assert numbered_lines[-1].endswith("x" * 80)
         assert f"remaining from offset {last_displayed_line}.]" in result.content

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -675,7 +675,7 @@ class TestFilesystemMiddlewareAsync:
 
         negative_offset = await read_file_tool.ainvoke({"file_path": "/test.txt", "offset": -1, "limit": 100, "runtime": _runtime()})
         assert negative_offset.status == "success"
-        assert negative_offset.content.startswith("1  Line 1")
+        assert negative_offset.content.startswith("1 | Line 1")
         assert "before the start of the file" in negative_offset.content
 
     async def test_aread_file_with_offset(self):

--- a/libs/deepagents/tests/unit_tests/test_nemotron_ultra_profile.py
+++ b/libs/deepagents/tests/unit_tests/test_nemotron_ultra_profile.py
@@ -156,23 +156,25 @@ def test_read_file_continuation_notice_ignores_wrapped_rows() -> None:
 def test_is_numbered_read_file_row_contract() -> None:
     """Pin which rows count as source lines for the continuation heuristic.
 
-    Primary markers with the current two-space separator or the legacy `cat -n`
-    tab count; padded markers count; continuation (`N.M`) rows and plain text do
-    not. Kept in sync with `format_content_with_line_numbers`' separator.
+    Primary markers with the current ` | ` separator, or a legacy separator
+    (the two-space gutter, or the original `cat -n` tab), count; padded markers
+    count; continuation (`N.M`) rows and plain text do not. Kept in sync with
+    `format_content_with_line_numbers`' separator.
     """
     is_row = ReadFileContinuationNoticeMiddleware._is_numbered_read_file_row
 
-    # Source rows: current two-space, right-justify padding, and legacy tab.
+    # Source rows: current pipe, right-justify padding, and both legacy forms.
+    assert is_row("1 | source")
+    assert is_row(" 10 | source")
     assert is_row("1  source")
-    assert is_row(" 10  source")
     assert is_row("1\tsource")
     # A single space is not the separator: guards against the regex loosening
     # back to `\s+`/`\s{2,}`, which would count malformed rows.
     assert not is_row("1 source")
     # Continuation rows (unpadded and padded) and non-gutter text are not source
     # lines.
-    assert not is_row("1.1  wrapped")
-    assert not is_row(" 5.1  wrapped")
+    assert not is_row("1.1 | wrapped")
+    assert not is_row(" 5.1 | wrapped")
     assert not is_row("plain text with no gutter")
     assert not is_row("")
 


### PR DESCRIPTION
Closes #5343

`read_file`'s line-number gutter now separates the marker from source content with ` | ` instead of two spaces, so the gutter can never be confused with space-indented source. Weaker models were folding the old two-space separator into leading indentation when constructing `edit_file`'s `old_string`, producing a systematic mismatch (deeper indentation made the gap larger and easier to misread) that silently no-op'd or failed the edit.

---

The two-space separator was chosen specifically to disambiguate from tab-indented source (`#4561`), but that left the mirror-image problem: no lexical boundary exists between "two gutter spaces" and "the first two columns of 2/4/8-space-indented source," which is the default indentation style for JS/TS/Python/Go formatters. A single non-whitespace separator removes the ambiguity for both tab- and space-indented source, matching the convention tools like `bat`/`less -N` already use.

This is a producer/consumer contract spanning two packages, so both sides moved together:

- `format_content_with_line_numbers` (the producer, in `deepagents`) now emits ` | `.
- `_truncate_paginated_read` (same package) parses the new separator when computing truncation boundaries.
- `ReadFileContinuationNoticeMiddleware._is_numbered_read_file_row` (the nemotron harness profile) and `ToolCallMessage._compact_line_gutter` (the `deepagents-code` TUI) both now match the current ` | ` separator, while continuing to tolerate the two legacy forms (the two-space gutter, and the original `cat -n` tab) so cached or persisted transcripts written by an older `deepagents` version still parse and display correctly. Only newly-produced output uses the new separator.

Since this changes a wire format shared across packages with independent release cadences, the SDK and CLI changes are bundled in one branch here for review, but may need to land as two separate PRs (SDK first, then `deepagents-code` once its `deepagents` pin is bumped) to satisfy this repo's one-release-PR-per-package convention — happy to split however maintainers prefer.

<details>
<summary>Test plan</summary>

- Existing `format_content_with_line_numbers`, `_is_numbered_read_file_row`, and `_compact_line_gutter` unit tests updated to the new separator.
- New coverage: a space-indented source round-trip demonstrating the gutter is now unambiguous, and legacy-format tolerance tests (two-space and `cat -n` tab) for both consumers.
- `make lint` and `make test` clean in `libs/deepagents` (2453 passed) and targeted runs in `libs/code` (436 passed in the touched TUI module, plus the one other file referencing the format).

</details>
