### PR TITLE
style(code): link install packages to PyPI

### DIFF
--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -982,6 +982,20 @@ def provider_install_extra(provider: str) -> str | None:
     return dependency[1] if dependency else None
 
 
+def provider_package_name(provider: str) -> str | None:
+    """Return the PyPI package that provides `provider`, if known.
+
+    Args:
+        provider: Provider name (e.g. `"baseten"`, `"google_genai"`).
+
+    Returns:
+        The normalized distribution name, or `None` when the provider has no
+            curated package.
+    """
+    dependency = _PROVIDER_DEPENDENCIES.get(provider)
+    return dependency[0].replace("_", "-") if dependency else None
+
+
 def is_provider_package_installed(provider: str) -> bool:
     """Return whether `provider`'s integration package is importable.
 

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -964,7 +964,13 @@ _PROVIDER_DEPENDENCIES: dict[str, tuple[str, str]] = {
     "together": ("langchain_together", "together"),
     "xai": ("langchain_xai", "xai"),
 }
-"""Provider integration import modules and the extras that install them."""
+"""Provider integration import modules and the extras that install them.
+
+Every import module name here must equal its PyPI distribution name up to
+underscore-for-hyphen substitution -- `provider_package_name` derives the
+distribution from it to build a `pypi.org/project/...` link, and a provider
+whose two names diverge would render a link to a nonexistent project.
+"""
 
 
 def provider_install_extra(provider: str) -> str | None:
@@ -983,14 +989,20 @@ def provider_install_extra(provider: str) -> str | None:
 
 
 def provider_package_name(provider: str) -> str | None:
-    """Return the PyPI package that provides `provider`, if known.
+    """Return the PyPI distribution that provides `provider`, if known.
+
+    Derived from the provider's integration import module by replacing
+    underscores with hyphens (e.g. `langchain_google_genai` ->
+    `langchain-google-genai`), which matches the distribution name for every
+    curated entry -- see the `_PROVIDER_DEPENDENCIES` docstring. This is not
+    PEP 503 normalization, and the result is not validated against PyPI.
 
     Args:
         provider: Provider name (e.g. `"baseten"`, `"google_genai"`).
 
     Returns:
-        The normalized distribution name, or `None` when the provider has no
-            curated package.
+        The distribution name, or `None` when the provider has no curated
+            extra (custom `class_path` providers, ambient-auth providers, etc.).
     """
     dependency = _PROVIDER_DEPENDENCIES.get(provider)
     return dependency[0].replace("_", "-") if dependency else None

--- a/libs/code/deepagents_code/tui/widgets/install_confirm.py
+++ b/libs/code/deepagents_code/tui/widgets/install_confirm.py
@@ -14,10 +14,24 @@ from textual.binding import Binding, BindingType
 from textual.containers import Vertical
 from textual.content import Content
 from textual.screen import ModalScreen
+from textual.style import Style as TStyle
 from textual.widgets import Static
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
+
+
+def _package_link(package: str) -> Content:
+    """Render a package name as a bold PyPI link.
+
+    Args:
+        package: The package name to display and link.
+
+    Returns:
+        Styled content linking to the package's PyPI project page.
+    """
+    url = f"https://pypi.org/project/{package}/"
+    return Content.assemble((package, TStyle(bold=True, underline=True, link=url)))
 
 
 class InstallPackageConfirmScreen(ModalScreen[bool]):
@@ -90,10 +104,10 @@ class InstallPackageConfirmScreen(ModalScreen[bool]):
                 markup=False,
             )
             yield Static(
-                Content.from_markup(
-                    "Installing [bold]$name[/bold] runs third-party code in "
-                    "the dcode environment.",
-                    name=self._package,
+                Content.assemble(
+                    "Installing ",
+                    _package_link(self._package),
+                    " runs third-party code in the dcode environment.",
                 ),
                 classes="install-confirm-body",
                 markup=False,
@@ -196,26 +210,31 @@ class InstallProviderConfirmScreen(ModalScreen[bool]):
         # Gemini") so the title reads naturally, falling back to a title-cased
         # provider key. Avoids the event-loop config read in
         # `provider_display_name`, which is overkill for a static title.
+        from deepagents_code.config_manifest import provider_package_name
         from deepagents_code.tui.widgets.auth import PROVIDER_DISPLAY_NAMES
 
         provider = PROVIDER_DISPLAY_NAMES.get(
             self._provider, self._provider.replace("_", " ").title()
         )
+        package = provider_package_name(self._provider) or self._extra
+        package_link = _package_link(package)
         if self._model_spec is not None:
-            body = Content.from_markup(
-                "To use [bold]$model[/bold], dcode needs to "
-                "install the [bold]$extra[/bold] integration. This will add "
-                "the provider package to your dcode environment.",
-                model=self._model_spec,
-                extra=self._extra,
+            body = Content.assemble(
+                "To use ",
+                (self._model_spec, "bold"),
+                ", dcode needs to install the ",
+                package_link,
+                " integration. This will add the provider package to your "
+                "dcode environment.",
             )
         else:
-            body = Content.from_markup(
-                "To add a key for [bold]$provider[/bold], dcode "
-                "needs to install the [bold]$extra[/bold] integration. This "
-                "will add the provider package to your dcode environment.",
-                provider=provider,
-                extra=self._extra,
+            body = Content.assemble(
+                "To add a key for ",
+                (provider, "bold"),
+                ", dcode needs to install the ",
+                package_link,
+                " integration. This will add the provider package to your "
+                "dcode environment.",
             )
         with Vertical():
             yield Static(

--- a/libs/code/deepagents_code/tui/widgets/install_confirm.py
+++ b/libs/code/deepagents_code/tui/widgets/install_confirm.py
@@ -13,28 +13,85 @@ from typing import TYPE_CHECKING, ClassVar
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical
 from textual.content import Content
+from textual.events import (
+    Click,  # noqa: TC002 - needed at runtime for Textual event dispatch
+    MouseMove,  # noqa: TC002 - needed at runtime for Textual event dispatch
+)
 from textual.screen import ModalScreen
 from textual.style import Style as TStyle
 from textual.widgets import Static
+
+from deepagents_code.tui.widgets._links import event_targets_link, open_style_link
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
 
 
-def _package_link(package: str) -> Content:
+def _package_link(package: str, *, hovered: bool = False) -> Content:
     """Render a package name as a bold PyPI link.
 
     Args:
         package: The package name to display and link.
+        hovered: Whether to add a reverse-video highlight, matching the
+            pointer cursor shown while the mouse is over the link.
 
     Returns:
         Styled content linking to the package's PyPI project page.
     """
     url = f"https://pypi.org/project/{package}/"
-    return Content.assemble((package, TStyle(bold=True, underline=True, link=url)))
+    style = TStyle(bold=True, underline=True, reverse=hovered, link=url)
+    return Content.assemble((package, style))
 
 
-class InstallPackageConfirmScreen(ModalScreen[bool]):
+class _LinkHoverMixin(ModalScreen[bool]):
+    """Pointer-cursor, hover-highlight, and click-to-open for styled links.
+
+    Subclasses define `_body_content(hovered: bool) -> Content` to rebuild
+    their body text with the package link's highlight toggled, and the mixin's
+    `_refresh_body(hovered: bool)` writes it into the `.install-confirm-body`
+    widget. The one widget lookup is cached after first use. Inheriting
+    `ModalScreen[bool]` here (rather than a bare mixin) lets the type checker
+    see `styles`/`query_one`, and gives subclasses a single linear MRO.
+    """
+
+    _hovered: bool = False
+    _body_widget: Static | None = None
+
+    def _body_content(self, *, hovered: bool) -> Content:
+        """Return the body `Content` with the link hover state applied."""
+        raise NotImplementedError
+
+    def _refresh_body(self, *, hovered: bool) -> None:
+        """Rewrite the body widget with the link's hover highlight toggled.
+
+        Args:
+            hovered: Whether the link should render highlighted.
+        """
+        if self._body_widget is None:
+            self._body_widget = self.query_one(".install-confirm-body", Static)
+        self._body_widget.update(self._body_content(hovered=hovered))
+
+    def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler convention
+        """Open style-embedded hyperlinks on single click."""
+        open_style_link(event)
+
+    def on_mouse_move(self, event: MouseMove) -> None:
+        """Show a pointer cursor over the link and highlight it on hover."""
+        over_link = event_targets_link(event)
+        self.styles.pointer = "pointer" if over_link else "default"
+        if over_link != self._hovered:
+            self._hovered = over_link
+            self._refresh_body(hovered=over_link)
+
+    def on_leave(self) -> None:
+        """Reset the cursor and clear any hover highlight."""
+        self.styles.pointer = "default"
+        if self._hovered:
+            self._hovered = False
+            self._refresh_body(hovered=False)
+
+
+class InstallPackageConfirmScreen(_LinkHoverMixin):
     """Confirmation overlay for installing an arbitrary `--package`.
 
     Dismisses with `True` when the user confirms and `False` when the user
@@ -91,6 +148,21 @@ class InstallPackageConfirmScreen(ModalScreen[bool]):
         super().__init__()
         self._package = package
 
+    def _body_content(self, *, hovered: bool = False) -> Content:
+        """Build the body text, toggling the link's hover highlight.
+
+        Args:
+            hovered: Whether the PyPI link should render highlighted.
+
+        Returns:
+            The body `Content` with the package link styled for `hovered`.
+        """
+        return Content.assemble(
+            "Installing ",
+            _package_link(self._package, hovered=hovered),
+            " runs third-party code in the dcode environment.",
+        )
+
     def compose(self) -> ComposeResult:
         """Compose the install confirmation dialog.
 
@@ -104,11 +176,7 @@ class InstallPackageConfirmScreen(ModalScreen[bool]):
                 markup=False,
             )
             yield Static(
-                Content.assemble(
-                    "Installing ",
-                    _package_link(self._package),
-                    " runs third-party code in the dcode environment.",
-                ),
+                self._body_content(),
                 classes="install-confirm-body",
                 markup=False,
             )
@@ -134,7 +202,7 @@ class InstallPackageConfirmScreen(ModalScreen[bool]):
         self.dismiss(False)
 
 
-class InstallProviderConfirmScreen(ModalScreen[bool]):
+class InstallProviderConfirmScreen(_LinkHoverMixin):
     """Confirmation overlay for installing a model provider's extra.
 
     Shown from the model selector when the user picks a model whose provider
@@ -200,11 +268,14 @@ class InstallProviderConfirmScreen(ModalScreen[bool]):
         self._extra = extra
         self._model_spec = model_spec
 
-    def compose(self) -> ComposeResult:
-        """Compose the provider-install confirmation dialog.
+    def _body_content(self, *, hovered: bool = False) -> Content:
+        """Build the body text, toggling the link's hover highlight.
 
-        Yields:
-            Title, body, and help-row widgets parented inside a `Vertical`.
+        Args:
+            hovered: Whether the PyPI link should render highlighted.
+
+        Returns:
+            The body `Content` with the package link styled for `hovered`.
         """
         # Reuse the auth UI's curated labels (e.g. `google_genai` -> "Google
         # Gemini") so the title reads naturally, falling back to a title-cased
@@ -217,9 +288,9 @@ class InstallProviderConfirmScreen(ModalScreen[bool]):
             self._provider, self._provider.replace("_", " ").title()
         )
         package = provider_package_name(self._provider) or self._extra
-        package_link = _package_link(package)
+        package_link = _package_link(package, hovered=hovered)
         if self._model_spec is not None:
-            body = Content.assemble(
+            return Content.assemble(
                 "To use ",
                 (self._model_spec, "bold"),
                 ", dcode needs to install the ",
@@ -227,15 +298,26 @@ class InstallProviderConfirmScreen(ModalScreen[bool]):
                 " integration. This will add the provider package to your "
                 "dcode environment.",
             )
-        else:
-            body = Content.assemble(
-                "To add a key for ",
-                (provider, "bold"),
-                ", dcode needs to install the ",
-                package_link,
-                " integration. This will add the provider package to your "
-                "dcode environment.",
-            )
+        return Content.assemble(
+            "To add a key for ",
+            (provider, "bold"),
+            ", dcode needs to install the ",
+            package_link,
+            " integration. This will add the provider package to your "
+            "dcode environment.",
+        )
+
+    def compose(self) -> ComposeResult:
+        """Compose the provider-install confirmation dialog.
+
+        Yields:
+            Title, body, and help-row widgets parented inside a `Vertical`.
+        """
+        from deepagents_code.tui.widgets.auth import PROVIDER_DISPLAY_NAMES
+
+        provider = PROVIDER_DISPLAY_NAMES.get(
+            self._provider, self._provider.replace("_", " ").title()
+        )
         with Vertical():
             yield Static(
                 f"Install {provider} support?",
@@ -243,7 +325,7 @@ class InstallProviderConfirmScreen(ModalScreen[bool]):
                 markup=False,
             )
             yield Static(
-                body,
+                self._body_content(),
                 classes="install-confirm-body",
                 markup=False,
             )

--- a/libs/code/deepagents_code/tui/widgets/install_confirm.py
+++ b/libs/code/deepagents_code/tui/widgets/install_confirm.py
@@ -8,15 +8,12 @@ install runs. `--force` (or `--yes`) still bypasses the prompt.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, ClassVar
 
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical
 from textual.content import Content
-from textual.events import (
-    Click,  # noqa: TC002 - needed at runtime for Textual event dispatch
-    MouseMove,  # noqa: TC002 - needed at runtime for Textual event dispatch
-)
 from textual.screen import ModalScreen
 from textual.style import Style as TStyle
 from textual.widgets import Static
@@ -25,13 +22,18 @@ from deepagents_code.tui.widgets._links import event_targets_link, open_style_li
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
+    from textual.events import Click, MouseMove
+
+logger = logging.getLogger(__name__)
 
 
 def _package_link(package: str, *, hovered: bool = False) -> Content:
-    """Render a package name as a bold PyPI link.
+    """Render a package name as a bold, underlined PyPI link.
 
     Args:
-        package: The package name to display and link.
+        package: The distribution name to display and link. Callers must only
+            pass names known to exist on PyPI -- the URL is built by
+            interpolation and is never validated against the index.
         hovered: Whether to add a reverse-video highlight, matching the
             pointer cursor shown while the mouse is over the link.
 
@@ -43,37 +45,46 @@ def _package_link(package: str, *, hovered: bool = False) -> Content:
     return Content.assemble((package, style))
 
 
-class _LinkHoverMixin(ModalScreen[bool]):
-    """Pointer-cursor, hover-highlight, and click-to-open for styled links.
+class _InstallConfirmScreen(ModalScreen[bool]):
+    """Base screen adding link hover/click affordances to install prompts.
 
-    Subclasses define `_body_content(hovered: bool) -> Content` to rebuild
-    their body text with the package link's highlight toggled, and the mixin's
-    `_refresh_body(hovered: bool)` writes it into the `.install-confirm-body`
-    widget. The one widget lookup is cached after first use. Inheriting
-    `ModalScreen[bool]` here (rather than a bare mixin) lets the type checker
-    see `styles`/`query_one`, and gives subclasses a single linear MRO.
+    Subclasses define `_body_content(*, hovered: bool) -> Content` to rebuild
+    their body text with the package link's highlight toggled, and must compose
+    exactly one `Static.install-confirm-body` initialized from it;
+    `_refresh_body(hovered=...)` rewrites that widget in place as the pointer
+    enters and leaves the link.
+
+    Subclassing `ModalScreen[bool]` directly, rather than composing a plain
+    mixin, keeps `styles`/`query_one` visible to the type checker without a
+    `Protocol` or multiple inheritance. The trade-off is that this is not
+    reusable by modals with a different dismiss type.
     """
 
     _hovered: bool = False
-    _body_widget: Static | None = None
 
-    def _body_content(self, *, hovered: bool) -> Content:
+    def _body_content(self, *, hovered: bool = False) -> Content:
         """Return the body `Content` with the link hover state applied."""
-        raise NotImplementedError
+        msg = f"{type(self).__name__} must override _body_content"
+        raise NotImplementedError(msg)
 
     def _refresh_body(self, *, hovered: bool) -> None:
         """Rewrite the body widget with the link's hover highlight toggled.
 
+        The widget is looked up on every call rather than cached: a screen
+        instance that is popped and re-pushed re-composes, and a cached
+        `Static` would leave `update` silently writing to a detached widget.
+
         Args:
             hovered: Whether the link should render highlighted.
         """
-        if self._body_widget is None:
-            self._body_widget = self.query_one(".install-confirm-body", Static)
-        self._body_widget.update(self._body_content(hovered=hovered))
+        body = self.query_one(".install-confirm-body", Static)
+        body.update(self._body_content(hovered=hovered))
 
-    def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler convention
+    def on_click(self, event: Click) -> None:
         """Open style-embedded hyperlinks on single click."""
-        open_style_link(event)
+        # Pass `app` explicitly: `open_style_link` otherwise reflects it off the
+        # event, and silently drops its failure toasts when that lookup misses.
+        open_style_link(event, app=self.app)
 
     def on_mouse_move(self, event: MouseMove) -> None:
         """Show a pointer cursor over the link and highlight it on hover."""
@@ -91,7 +102,7 @@ class _LinkHoverMixin(ModalScreen[bool]):
             self._refresh_body(hovered=False)
 
 
-class InstallPackageConfirmScreen(_LinkHoverMixin):
+class InstallPackageConfirmScreen(_InstallConfirmScreen):
     """Confirmation overlay for installing an arbitrary `--package`.
 
     Dismisses with `True` when the user confirms and `False` when the user
@@ -202,7 +213,7 @@ class InstallPackageConfirmScreen(_LinkHoverMixin):
         self.dismiss(False)
 
 
-class InstallProviderConfirmScreen(_LinkHoverMixin):
+class InstallProviderConfirmScreen(_InstallConfirmScreen):
     """Confirmation overlay for installing a model provider's extra.
 
     Shown from the model selector when the user picks a model whose provider
@@ -268,6 +279,50 @@ class InstallProviderConfirmScreen(_LinkHoverMixin):
         self._extra = extra
         self._model_spec = model_spec
 
+    def _provider_label(self) -> str:
+        """Return a human-readable label for the provider.
+
+        Reuses the auth UI's curated labels (e.g. `google_genai` -> "Google
+        Gemini") so the prompt reads naturally, falling back to a title-cased
+        provider key. Avoids the event-loop config read in
+        `provider_display_name`, which is overkill for static prompt text.
+
+        Returns:
+            The curated display name, or the title-cased provider key.
+        """
+        from deepagents_code.tui.widgets.auth import PROVIDER_DISPLAY_NAMES
+
+        return PROVIDER_DISPLAY_NAMES.get(
+            self._provider, self._provider.replace("_", " ").title()
+        )
+
+    def _package_content(self, *, hovered: bool) -> Content:
+        """Render the package name, linked to PyPI when the name is known.
+
+        Extras are `deepagents-code` extra names, not distribution names, and
+        several of them (`vertex`, `bedrock`, ...) collide with unrelated real
+        PyPI projects. So an uncurated provider falls back to plain bold text
+        rather than a confident link to the wrong package.
+
+        Args:
+            hovered: Whether the link should render highlighted.
+
+        Returns:
+            The package name as a PyPI link, or as unlinked bold text.
+        """
+        from deepagents_code.config_manifest import provider_package_name
+
+        package = provider_package_name(self._provider)
+        if package is None:
+            logger.warning(
+                "No curated PyPI package for provider %r; rendering extra %r "
+                "without a link",
+                self._provider,
+                self._extra,
+            )
+            return Content.assemble((self._extra, "bold"))
+        return _package_link(package, hovered=hovered)
+
     def _body_content(self, *, hovered: bool = False) -> Content:
         """Build the body text, toggling the link's hover highlight.
 
@@ -277,32 +332,21 @@ class InstallProviderConfirmScreen(_LinkHoverMixin):
         Returns:
             The body `Content` with the package link styled for `hovered`.
         """
-        # Reuse the auth UI's curated labels (e.g. `google_genai` -> "Google
-        # Gemini") so the title reads naturally, falling back to a title-cased
-        # provider key. Avoids the event-loop config read in
-        # `provider_display_name`, which is overkill for a static title.
-        from deepagents_code.config_manifest import provider_package_name
-        from deepagents_code.tui.widgets.auth import PROVIDER_DISPLAY_NAMES
-
-        provider = PROVIDER_DISPLAY_NAMES.get(
-            self._provider, self._provider.replace("_", " ").title()
-        )
-        package = provider_package_name(self._provider) or self._extra
-        package_link = _package_link(package, hovered=hovered)
+        package = self._package_content(hovered=hovered)
         if self._model_spec is not None:
             return Content.assemble(
                 "To use ",
                 (self._model_spec, "bold"),
                 ", dcode needs to install the ",
-                package_link,
+                package,
                 " integration. This will add the provider package to your "
                 "dcode environment.",
             )
         return Content.assemble(
             "To add a key for ",
-            (provider, "bold"),
+            (self._provider_label(), "bold"),
             ", dcode needs to install the ",
-            package_link,
+            package,
             " integration. This will add the provider package to your "
             "dcode environment.",
         )
@@ -313,14 +357,9 @@ class InstallProviderConfirmScreen(_LinkHoverMixin):
         Yields:
             Title, body, and help-row widgets parented inside a `Vertical`.
         """
-        from deepagents_code.tui.widgets.auth import PROVIDER_DISPLAY_NAMES
-
-        provider = PROVIDER_DISPLAY_NAMES.get(
-            self._provider, self._provider.replace("_", " ").title()
-        )
         with Vertical():
             yield Static(
-                f"Install {provider} support?",
+                f"Install {self._provider_label()} support?",
                 classes="install-confirm-title",
                 markup=False,
             )

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -34,6 +34,7 @@ from deepagents_code.config_manifest import (
     option_keys,
     options_with_key_prefix,
     provider_install_extra,
+    provider_package_name,
     resolve_interpreter_kwargs,
     resolve_scalar,
 )
@@ -470,6 +471,36 @@ def test_provider_install_extra_extra_only_provider() -> None:
 def test_provider_install_extra_unknown_provider() -> None:
     """Providers without a curated extra resolve to `None`."""
     assert provider_install_extra("not-a-real-provider") is None
+
+
+def test_provider_package_name_known_provider() -> None:
+    """Known providers resolve to their PyPI distribution name."""
+    assert provider_package_name("baseten") == "langchain-baseten"
+    # Every underscore in the import module becomes a hyphen, not just the
+    # first -- `nvidia` is the entry with the most.
+    assert provider_package_name("nvidia") == "langchain-nvidia-ai-endpoints"
+    assert provider_package_name("google_genai") == "langchain-google-genai"
+
+
+def test_provider_package_name_differs_from_extra() -> None:
+    """The distribution name is not the extra name.
+
+    `provider_package_name` feeds a `pypi.org/project/...` link, so confusing
+    it with `provider_install_extra` would link an unrelated real project.
+    """
+    assert provider_install_extra("google_vertexai") == "vertex"
+    assert provider_package_name("google_vertexai") == "langchain-google-vertexai"
+
+
+def test_provider_package_name_aliased_providers() -> None:
+    """Providers sharing an integration resolve to the same distribution."""
+    assert provider_package_name("azure_openai") == "langchain-openai"
+    assert provider_package_name("openai") == "langchain-openai"
+
+
+def test_provider_package_name_unknown_provider() -> None:
+    """Providers without a curated extra resolve to `None`."""
+    assert provider_package_name("not-a-real-provider") is None
 
 
 def test_is_provider_package_installed_unknown_provider() -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_install_confirm.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_install_confirm.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 from textual.app import App, ComposeResult
 from textual.content import Content
@@ -15,10 +15,40 @@ from deepagents_code.tui.widgets.install_confirm import (
     InstallProviderConfirmScreen,
 )
 
+if TYPE_CHECKING:
+    from textual.screen import Screen
+
 
 class _InstallConfirmTestApp(App[None]):
     def compose(self) -> ComposeResult:
         yield Static("base")
+
+
+def _body_of(screen: Screen[bool]) -> Static:
+    """Return the body widget of an install confirmation screen."""
+    return screen.query_one(".install-confirm-body", Static)
+
+
+def _rendered(widget: Static) -> Content:
+    """Return a widget's rendered `Content`."""
+    content = widget.render()
+    assert isinstance(content, Content)
+    return content
+
+
+def _link_cells(widget: Static) -> list[tuple[int, int]]:
+    """Return every widget-relative cell whose rendered style carries a link.
+
+    Driving hover and click from real cell offsets (rather than synthetic
+    events carrying a URL of the test's own choosing) means these tests fail
+    if the link is dropped, mis-spanned, or never reaches the rendered output.
+    """
+    return [
+        (x, y)
+        for y in range(widget.region.height)
+        for x in range(widget.region.width)
+        if getattr(widget.get_style_at(x, y), "link", None)
+    ]
 
 
 def _assert_pypi_link(content: Content, package: str) -> None:
@@ -29,16 +59,6 @@ def _assert_pypi_link(content: Content, package: str) -> None:
         if isinstance(span.style, TStyle) and span.style.link
     ]
     assert links == [(package, f"https://pypi.org/project/{package}/")]
-
-
-def _link_span_reverses(content: Content) -> list[bool]:
-    """Return the `reverse` flag of every link-styled span in `content`."""
-    reverses: list[bool] = []
-    for span in content.spans:
-        style = span.style
-        if isinstance(style, TStyle) and style.link:
-            reverses.append(bool(style.reverse))
-    return reverses
 
 
 def _link_span_reverses(content: Content) -> list[bool]:
@@ -212,56 +232,44 @@ class TestInstallProviderConfirmScreen:
 class TestLinkHoverAndClick:
     """Link affordance tests shared by both install confirmation screens."""
 
-    def _move_event(self, url: str | None) -> SimpleNamespace:
-        """Build a minimal mouse-move event over a link (or plain text)."""
-        return SimpleNamespace(style=SimpleNamespace(link=url, meta={}))
-
-    def _click_event(self, url: str | None) -> SimpleNamespace:
-        """Build a minimal click event over a link (or plain text)."""
-        return SimpleNamespace(
-            style=SimpleNamespace(link=url),
-            app=SimpleNamespace(notify=MagicMock()),
-            stop=MagicMock(),
-        )
-
-    async def test_hover_shows_pointer_and_highlights_link(self) -> None:
+    async def test_hover_over_link_shows_pointer_and_highlight(self) -> None:
         """Hovering the link sets a pointer cursor and highlights the text."""
         app = _InstallConfirmTestApp()
         async with app.run_test() as pilot:
             screen = InstallPackageConfirmScreen("langchain-custom")
             app.push_screen(screen)
             await pilot.pause()
+            body = _body_of(screen)
 
-            screen.on_mouse_move(
-                self._move_event("https://pypi.org/project/langchain-custom/")  # ty: ignore
-            )
-            await pilot.pause()
+            await pilot.hover(body, offset=_link_cells(body)[0])
 
             assert screen.styles.pointer == "pointer"
-            content = screen.query_one(".install-confirm-body", Static).render()
-            assert isinstance(content, Content)
-            reverses = _link_span_reverses(content)
+            reverses = _link_span_reverses(_rendered(body))
             assert reverses
             assert all(reverses)
 
-    async def test_leaving_link_clears_pointer_and_highlight(self) -> None:
-        """Moving off the link restores the default cursor and plain style."""
+    async def test_hover_off_link_clears_pointer_and_highlight(self) -> None:
+        """Moving onto plain body text restores the cursor and plain style."""
         app = _InstallConfirmTestApp()
         async with app.run_test() as pilot:
             screen = InstallPackageConfirmScreen("langchain-custom")
             app.push_screen(screen)
             await pilot.pause()
+            body = _body_of(screen)
+            cells = _link_cells(body)
+            linked = set(cells)
 
-            screen.on_mouse_move(
-                self._move_event("https://pypi.org/project/langchain-custom/")  # ty: ignore
+            await pilot.hover(body, offset=cells[0])
+            plain = next(
+                (x, y)
+                for y in range(body.region.height)
+                for x in range(body.region.width)
+                if (x, y) not in linked
             )
-            screen.on_mouse_move(self._move_event(None))  # ty: ignore
-            await pilot.pause()
+            await pilot.hover(body, offset=plain)
 
             assert screen.styles.pointer == "default"
-            content = screen.query_one(".install-confirm-body", Static).render()
-            assert isinstance(content, Content)
-            reverses = _link_span_reverses(content)
+            reverses = _link_span_reverses(_rendered(body))
             assert reverses
             assert not any(reverses)
 
@@ -272,38 +280,116 @@ class TestLinkHoverAndClick:
             screen = InstallPackageConfirmScreen("langchain-custom")
             app.push_screen(screen)
             await pilot.pause()
+            body = _body_of(screen)
 
-            screen.on_mouse_move(
-                self._move_event("https://pypi.org/project/langchain-custom/")  # ty: ignore
-            )
+            await pilot.hover(body, offset=_link_cells(body)[0])
             screen.on_leave()
             await pilot.pause()
 
             assert screen.styles.pointer == "default"
-            content = screen.query_one(".install-confirm-body", Static).render()
-            assert isinstance(content, Content)
-            reverses = _link_span_reverses(content)
+            reverses = _link_span_reverses(_rendered(body))
             assert reverses
             assert not any(reverses)
 
-    def test_click_on_link_opens_url(self) -> None:
-        """A click on the package link routes through `open_style_link`."""
-        screen = InstallPackageConfirmScreen("langchain-custom")
-        event = self._click_event("https://pypi.org/project/langchain-custom/")
-        with patch(
-            "deepagents_code.tui.widgets.install_confirm.open_style_link"
-        ) as mock_open:
-            screen.on_click(event)  # ty: ignore
+    async def test_link_covers_exactly_the_package_name(self) -> None:
+        """The clickable region spans the package name and nothing else."""
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            screen = InstallPackageConfirmScreen("langchain-custom")
+            app.push_screen(screen)
+            await pilot.pause()
 
-        mock_open.assert_called_once_with(event)
+            assert len(_link_cells(_body_of(screen))) == len("langchain-custom")
 
-    def test_provider_screen_click_on_link_opens_url(self) -> None:
-        """The provider screen shares the same click-through behavior."""
-        screen = InstallProviderConfirmScreen("baseten", "baseten")
-        event = self._click_event("https://pypi.org/project/langchain-baseten/")
-        with patch(
-            "deepagents_code.tui.widgets.install_confirm.open_style_link"
-        ) as mock_open:
-            screen.on_click(event)  # ty: ignore
+    async def test_click_on_link_opens_pypi_url(self) -> None:
+        """Clicking the package name opens its PyPI page in a browser."""
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            screen = InstallPackageConfirmScreen("langchain-custom")
+            app.push_screen(screen)
+            await pilot.pause()
+            body = _body_of(screen)
 
-        mock_open.assert_called_once_with(event)
+            with patch(
+                "deepagents_code.tui.widgets._links.webbrowser.open",
+                return_value=True,
+            ) as mock_open:
+                await pilot.click(body, offset=_link_cells(body)[0])
+
+            mock_open.assert_called_once_with(
+                "https://pypi.org/project/langchain-custom/"
+            )
+
+    async def test_provider_click_opens_resolved_package_url(self) -> None:
+        """The provider screen links the resolved distribution, not the extra.
+
+        `nvidia`'s extra is `nvidia`, but its distribution is
+        `langchain-nvidia-ai-endpoints` -- so this also pins the
+        multi-underscore normalization in `provider_package_name`.
+        """
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            screen = InstallProviderConfirmScreen("nvidia", "nvidia")
+            app.push_screen(screen)
+            await pilot.pause()
+            body = _body_of(screen)
+
+            with patch(
+                "deepagents_code.tui.widgets._links.webbrowser.open",
+                return_value=True,
+            ) as mock_open:
+                await pilot.click(body, offset=_link_cells(body)[0])
+
+            mock_open.assert_called_once_with(
+                "https://pypi.org/project/langchain-nvidia-ai-endpoints/"
+            )
+
+    async def test_provider_hover_highlights_link_beside_model_spec(self) -> None:
+        """With a model spec, hover highlights the link and not the bold model."""
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            screen = InstallProviderConfirmScreen(
+                "baseten", "baseten", "baseten:moonshotai/Kimi-K2.7-Code"
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+            body = _body_of(screen)
+
+            await pilot.hover(body, offset=_link_cells(body)[0])
+
+            assert screen.styles.pointer == "pointer"
+            content = _rendered(body)
+            assert all(_link_span_reverses(content))
+            model_spans = [
+                span
+                for span in content.spans
+                if content.plain[span.start : span.end]
+                == "baseten:moonshotai/Kimi-K2.7-Code"
+            ]
+            assert model_spans
+            assert not any(
+                isinstance(span.style, TStyle) and span.style.reverse
+                for span in model_spans
+            )
+
+    async def test_uncurated_provider_renders_package_unlinked(self) -> None:
+        """An unknown provider shows the extra as plain text, not a bad link.
+
+        Extras are not distribution names, so linking one would point at an
+        unrelated PyPI project rather than the integration being installed.
+        """
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            screen = InstallProviderConfirmScreen("not-a-provider", "some-extra")
+            app.push_screen(screen)
+            await pilot.pause()
+            body = _body_of(screen)
+
+            content = _rendered(body)
+            assert "some-extra" in content.plain
+            assert not _link_cells(body)
+            assert not [
+                span
+                for span in content.spans
+                if isinstance(span.style, TStyle) and span.style.link
+            ]

--- a/libs/code/tests/unit_tests/tui/widgets/test_install_confirm.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_install_confirm.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 from textual.app import App, ComposeResult
 from textual.content import Content
 from textual.style import Style as TStyle
@@ -26,6 +29,26 @@ def _assert_pypi_link(content: Content, package: str) -> None:
         if isinstance(span.style, TStyle) and span.style.link
     ]
     assert links == [(package, f"https://pypi.org/project/{package}/")]
+
+
+def _link_span_reverses(content: Content) -> list[bool]:
+    """Return the `reverse` flag of every link-styled span in `content`."""
+    reverses: list[bool] = []
+    for span in content.spans:
+        style = span.style
+        if isinstance(style, TStyle) and style.link:
+            reverses.append(bool(style.reverse))
+    return reverses
+
+
+def _link_span_reverses(content: Content) -> list[bool]:
+    """Return the `reverse` flag of every link-styled span in `content`."""
+    reverses: list[bool] = []
+    for span in content.spans:
+        style = span.style
+        if isinstance(style, TStyle) and style.link:
+            reverses.append(bool(style.reverse))
+    return reverses
 
 
 class TestInstallPackageConfirmScreen:
@@ -184,3 +207,103 @@ class TestInstallProviderConfirmScreen:
             assert "langchain-litellm" in content.plain
             assert "To use" not in content.plain
             _assert_pypi_link(content, "langchain-litellm")
+
+
+class TestLinkHoverAndClick:
+    """Link affordance tests shared by both install confirmation screens."""
+
+    def _move_event(self, url: str | None) -> SimpleNamespace:
+        """Build a minimal mouse-move event over a link (or plain text)."""
+        return SimpleNamespace(style=SimpleNamespace(link=url, meta={}))
+
+    def _click_event(self, url: str | None) -> SimpleNamespace:
+        """Build a minimal click event over a link (or plain text)."""
+        return SimpleNamespace(
+            style=SimpleNamespace(link=url),
+            app=SimpleNamespace(notify=MagicMock()),
+            stop=MagicMock(),
+        )
+
+    async def test_hover_shows_pointer_and_highlights_link(self) -> None:
+        """Hovering the link sets a pointer cursor and highlights the text."""
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            screen = InstallPackageConfirmScreen("langchain-custom")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            screen.on_mouse_move(
+                self._move_event("https://pypi.org/project/langchain-custom/")  # ty: ignore
+            )
+            await pilot.pause()
+
+            assert screen.styles.pointer == "pointer"
+            content = screen.query_one(".install-confirm-body", Static).render()
+            assert isinstance(content, Content)
+            reverses = _link_span_reverses(content)
+            assert reverses
+            assert all(reverses)
+
+    async def test_leaving_link_clears_pointer_and_highlight(self) -> None:
+        """Moving off the link restores the default cursor and plain style."""
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            screen = InstallPackageConfirmScreen("langchain-custom")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            screen.on_mouse_move(
+                self._move_event("https://pypi.org/project/langchain-custom/")  # ty: ignore
+            )
+            screen.on_mouse_move(self._move_event(None))  # ty: ignore
+            await pilot.pause()
+
+            assert screen.styles.pointer == "default"
+            content = screen.query_one(".install-confirm-body", Static).render()
+            assert isinstance(content, Content)
+            reverses = _link_span_reverses(content)
+            assert reverses
+            assert not any(reverses)
+
+    async def test_on_leave_clears_hover_state(self) -> None:
+        """`on_leave` resets cursor and highlight when the mouse exits."""
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            screen = InstallPackageConfirmScreen("langchain-custom")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            screen.on_mouse_move(
+                self._move_event("https://pypi.org/project/langchain-custom/")  # ty: ignore
+            )
+            screen.on_leave()
+            await pilot.pause()
+
+            assert screen.styles.pointer == "default"
+            content = screen.query_one(".install-confirm-body", Static).render()
+            assert isinstance(content, Content)
+            reverses = _link_span_reverses(content)
+            assert reverses
+            assert not any(reverses)
+
+    def test_click_on_link_opens_url(self) -> None:
+        """A click on the package link routes through `open_style_link`."""
+        screen = InstallPackageConfirmScreen("langchain-custom")
+        event = self._click_event("https://pypi.org/project/langchain-custom/")
+        with patch(
+            "deepagents_code.tui.widgets.install_confirm.open_style_link"
+        ) as mock_open:
+            screen.on_click(event)  # ty: ignore
+
+        mock_open.assert_called_once_with(event)
+
+    def test_provider_screen_click_on_link_opens_url(self) -> None:
+        """The provider screen shares the same click-through behavior."""
+        screen = InstallProviderConfirmScreen("baseten", "baseten")
+        event = self._click_event("https://pypi.org/project/langchain-baseten/")
+        with patch(
+            "deepagents_code.tui.widgets.install_confirm.open_style_link"
+        ) as mock_open:
+            screen.on_click(event)  # ty: ignore
+
+        mock_open.assert_called_once_with(event)

--- a/libs/code/tests/unit_tests/tui/widgets/test_install_confirm.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_install_confirm.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from textual.app import App, ComposeResult
+from textual.content import Content
+from textual.style import Style as TStyle
 from textual.widgets import Static
 
 from deepagents_code.tui.widgets.install_confirm import (
@@ -14,6 +16,16 @@ from deepagents_code.tui.widgets.install_confirm import (
 class _InstallConfirmTestApp(App[None]):
     def compose(self) -> ComposeResult:
         yield Static("base")
+
+
+def _assert_pypi_link(content: Content, package: str) -> None:
+    """Assert that only `package` links to its PyPI project page."""
+    links = [
+        (content.plain[span.start : span.end], span.style.link)
+        for span in content.spans
+        if isinstance(span.style, TStyle) and span.style.link
+    ]
+    assert links == [(package, f"https://pypi.org/project/{package}/")]
 
 
 class TestInstallPackageConfirmScreen:
@@ -88,7 +100,10 @@ class TestInstallPackageConfirmScreen:
 
             bodies = app.screen.query(".install-confirm-body")
             assert len(bodies) == 1
-            assert "langchain-custom" in str(bodies.first().render())
+            content = bodies.first().render()
+            assert isinstance(content, Content)
+            assert "langchain-custom" in content.plain
+            _assert_pypi_link(content, "langchain-custom")
 
 
 class TestInstallProviderConfirmScreen:
@@ -143,9 +158,11 @@ class TestInstallProviderConfirmScreen:
 
             bodies = app.screen.query(".install-confirm-body")
             assert len(bodies) == 1
-            rendered = str(bodies.first().render())
-            assert "baseten:moonshotai/Kimi-K2.7-Code" in rendered
-            assert "baseten" in rendered
+            content = bodies.first().render()
+            assert isinstance(content, Content)
+            assert "baseten:moonshotai/Kimi-K2.7-Code" in content.plain
+            assert "langchain-baseten" in content.plain
+            _assert_pypi_link(content, "langchain-baseten")
 
     async def test_renders_add_key_body_without_model_spec(self) -> None:
         """The `/auth` path (no model spec) frames the install around a key.
@@ -156,12 +173,14 @@ class TestInstallProviderConfirmScreen:
         """
         app = _InstallConfirmTestApp()
         async with app.run_test() as pilot:
-            app.push_screen(InstallProviderConfirmScreen("baseten", "baseten"))
+            app.push_screen(InstallProviderConfirmScreen("litellm", "litellm"))
             await pilot.pause()
 
             bodies = app.screen.query(".install-confirm-body")
             assert len(bodies) == 1
-            rendered = str(bodies.first().render())
-            assert "add a key" in rendered
-            assert "baseten" in rendered
-            assert "To use" not in rendered
+            content = bodies.first().render()
+            assert isinstance(content, Content)
+            assert "add a key" in content.plain
+            assert "langchain-litellm" in content.plain
+            assert "To use" not in content.plain
+            _assert_pypi_link(content, "langchain-litellm")


### PR DESCRIPTION
Package names in install confirmation dialogs now link directly to their PyPI project pages.

---

Provider prompts display the underlying LangChain integration distribution, while arbitrary package prompts link the validated package name.

Made by [Open SWE](https://openswe.vercel.app/agents/fe724f24-84d2-3e7b-940b-a71d688a891c)