### PR TITLE
feat(code): prune expired sessions automatically

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -66,6 +66,10 @@ Like `AUTO_CLASSIFIER_MODEL`, a committed *project* `.env` cannot set it (see
 `config._PROJECT_DOTENV_DENIED_ENV_KEYS`).
 """
 
+AUTO_PRUNE = "DEEPAGENTS_CODE_AUTO_PRUNE"
+"""Toggle automatic session pruning. Enabled by default; set to a falsy value
+(`0`, `false`, `no`, `off`, or empty) to opt out."""
+
 AUTO_UPDATE = "DEEPAGENTS_CODE_AUTO_UPDATE"
 """Toggle automatic app updates. Enabled by default; set to a falsy value
 ('0', 'false', 'no', 'off', or empty) to opt out."""
@@ -408,6 +412,9 @@ reused under either setting. Unrecognized values fall back to `managed`. See
 
 SERVER_ENV_PREFIX = "DEEPAGENTS_CODE_SERVER_"
 """Environment variable prefix used to pass CLI config to the server subprocess."""
+
+SESSION_RETENTION_DAYS = "DEEPAGENTS_CODE_SESSION_RETENTION_DAYS"
+"""Days to retain inactive local sessions before pruning them automatically."""
 
 SHELL_ALLOW_LIST = "DEEPAGENTS_CODE_SHELL_ALLOW_LIST"
 """Comma-separated shell commands to allow (or 'recommended'/'all')."""

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5329,6 +5329,10 @@ class DeepAgentsApp(App):
         if self._resume_thread_intent:
             await self._resolve_resume_thread()
 
+        from deepagents_code.sessions import start_auto_prune
+
+        start_auto_prune(self._lc_thread_id)
+
         # Run deferred model creation. settings.model_name / model_provider
         # are already set eagerly for the status bar display; this call
         # does the heavy langchain import + SDK init and may refine them

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -77,7 +77,7 @@ from deepagents_code.hooks import (
     drain_pending_hooks,
 )
 from deepagents_code.model_config import ModelConfigError
-from deepagents_code.sessions import generate_thread_id
+from deepagents_code.sessions import generate_thread_id, start_auto_prune
 from deepagents_code.tool_display import format_tool_message_content
 from deepagents_code.unicode_security import (
     check_url_safety,
@@ -2057,6 +2057,7 @@ async def run_non_interactive(
     result.apply_to_settings()
 
     thread_id = generate_thread_id()
+    start_auto_prune(thread_id)
 
     thread_url_lookup: ThreadUrlLookupState | None = None
     if not quiet:

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -114,6 +114,12 @@ COMPACT_ON_RESUME_THRESHOLD_DEFAULT = 400_000
 Zero or negative disables the suggestion.
 """
 
+SESSION_RETENTION_DAYS_DEFAULT = 14
+"""Days inactive local sessions are retained before automatic pruning."""
+
+SESSION_AUTO_PRUNE_DEFAULT = True
+"""Whether old local sessions are pruned automatically at app startup."""
+
 LANGSMITH_PROJECT_DEFAULT = "deepagents-code"
 """Project agent traces fall back to when no project env var is set.
 
@@ -1477,7 +1483,16 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         toml_keys=("interpreter", "ptc_acknowledge_unsafe"),
         settings_field="interpreter_ptc_acknowledge_unsafe",
     ),
-    # --- Threads (config.toml-only; structured column table excepted) ---
+    # --- Threads -------------------------------------------------------
+    ConfigOption(
+        key="threads.auto_prune",
+        group="Threads",
+        summary="Prune expired local sessions automatically at app startup.",
+        kind=OptionKind.BOOL,
+        default=SESSION_AUTO_PRUNE_DEFAULT,
+        env_var=_env_vars.AUTO_PRUNE,
+        toml_keys=("threads", "auto_prune"),
+    ),
     ConfigOption(
         key="threads.compact_on_resume_threshold",
         group="Threads",
@@ -1487,6 +1502,15 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         kind=OptionKind.INT,
         default=COMPACT_ON_RESUME_THRESHOLD_DEFAULT,
         toml_keys=("threads", "compact_on_resume_threshold"),
+    ),
+    ConfigOption(
+        key="threads.session_retention_days",
+        group="Threads",
+        summary="Days to retain inactive local sessions before pruning.",
+        kind=OptionKind.INT,
+        default=SESSION_RETENTION_DAYS_DEFAULT,
+        env_var=_env_vars.SESSION_RETENTION_DAYS,
+        toml_keys=("threads", "session_retention_days"),
     ),
     ConfigOption(
         key="threads.relative_time",

--- a/libs/code/deepagents_code/hooks/transcript.py
+++ b/libs/code/deepagents_code/hooks/transcript.py
@@ -17,6 +17,7 @@ import hashlib
 import logging
 import os
 import re
+import shutil
 import tempfile
 import threading
 import unicodedata
@@ -598,6 +599,67 @@ def _safe_component(identifier: str) -> str:
     prefix = _SAFE_PREFIX_RE.sub("-", readable).strip("-")[:_SAFE_PREFIX_LENGTH]
     digest = hashlib.sha256(identifier.encode("utf-8")).hexdigest()
     return f"{prefix or 'id'}--{digest}"
+
+
+def delete_thread_transcripts(root: Path, thread_id: str) -> bool:
+    """Remove every materialized transcript artifact owned by a thread.
+
+    Args:
+        root: Transcript store root.
+        thread_id: Conversation thread identifier.
+
+    Returns:
+        `True` if at least one file or directory was removed.
+    """
+    if not thread_id:
+        return False
+
+    component = _safe_component(thread_id)
+    transcript = root / f"{component}.jsonl"
+    files = [transcript, transcript.with_suffix(".jsonl.lock")]
+    try:
+        files.extend(root.glob(f"{transcript.name}.bak-*"))
+    except OSError:
+        logger.warning(
+            "Could not enumerate transcript backups for thread %s",
+            thread_id,
+            exc_info=True,
+        )
+
+    removed = False
+    for path in files:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            logger.warning(
+                "Failed to delete transcript artifact %s for thread %s",
+                path,
+                thread_id,
+                exc_info=True,
+            )
+        else:
+            removed = True
+
+    agent_dir = root / component
+    try:
+        if agent_dir.is_symlink():
+            agent_dir.unlink()
+        else:
+            shutil.rmtree(agent_dir)
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.warning(
+            "Failed to delete subagent transcripts at %s for thread %s",
+            agent_dir,
+            thread_id,
+            exc_info=True,
+        )
+    else:
+        removed = True
+    return removed
 
 
 def _ensure_private_directories(root: Path, target: Path) -> None:

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1847,6 +1847,8 @@ def parse_args() -> argparse.Namespace:
         make_help_action=_make_help_action,
     )
 
+    from deepagents_code.ui import non_negative_int, positive_int
+
     threads_parser = subparsers.add_parser(
         "threads",
         help="Manage conversation threads",
@@ -1918,6 +1920,26 @@ def parse_args() -> argparse.Namespace:
     add_json_output_arg(threads_delete)
     threads_delete.add_argument("thread_id", help="Thread ID to delete")
     threads_delete.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without making changes",
+    )
+
+    threads_prune = threads_sub.add_parser(
+        "prune",
+        help="Delete expired threads",
+        add_help=False,
+        parents=help_parent(_lazy_help("show_threads_prune_help")),
+    )
+    add_json_output_arg(threads_prune)
+    threads_prune.add_argument(
+        "--older-than",
+        type=positive_int,
+        default=None,
+        metavar="DAYS",
+        help="Delete threads older than DAYS (default: from config, or 14)",
+    )
+    threads_prune.add_argument(
         "--dry-run",
         action="store_true",
         help="Show what would happen without making changes",
@@ -2040,8 +2062,6 @@ def parse_args() -> argparse.Namespace:
         '(e.g., \'{"temperature": 0.7, "max_tokens": 4096}\'). '
         "These take priority, overriding config file values.",
     )
-
-    from deepagents_code.ui import non_negative_int, positive_int
 
     parser.add_argument(
         "--max-retries",
@@ -4650,6 +4670,7 @@ def cli_main() -> None:
             from deepagents_code.sessions import (
                 delete_thread_command,
                 list_threads_command,
+                prune_threads_command,
             )
             from deepagents_code.ui import show_threads_help
 
@@ -4690,6 +4711,14 @@ def cli_main() -> None:
                 asyncio.run(
                     delete_thread_command(
                         args.thread_id,
+                        dry_run=args.dry_run,
+                        output_format=output_format,
+                    )
+                )
+            elif args.threads_command == "prune":
+                asyncio.run(
+                    prune_threads_command(
+                        older_than_days=args.older_than,
                         dry_run=args.dry_run,
                         output_format=output_format,
                     )

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -4531,6 +4531,81 @@ def invalidate_thread_config_cache() -> None:
     _thread_config_cache = None
 
 
+def _load_session_config(config_path: Path | None) -> dict[str, Any]:
+    """Load config data for session-retention option resolution.
+
+    Returns:
+        Parsed config data, or an empty mapping when unavailable.
+    """
+    if config_path is None:
+        from deepagents_code.config_manifest import load_config_toml
+
+        return load_config_toml()
+    try:
+        with config_path.open("rb") as file:
+            return tomllib.load(file)
+    except FileNotFoundError:
+        return {}
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.warning(
+            "Could not read session retention config from %s; using defaults",
+            config_path,
+            exc_info=True,
+        )
+        return {}
+
+
+def load_session_retention_days(config_path: Path | None = None) -> int:
+    """Load the number of days inactive sessions are retained.
+
+    Args:
+        config_path: Optional alternate config file.
+
+    Returns:
+        A positive retention window in days.
+    """
+    from deepagents_code.config_manifest import (
+        SESSION_RETENTION_DAYS_DEFAULT,
+        get_option,
+        resolve_scalar,
+    )
+
+    option = get_option("threads.session_retention_days")
+    if option is None:
+        return SESSION_RETENTION_DAYS_DEFAULT
+    value, _ = resolve_scalar(option, toml_data=_load_session_config(config_path))
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    logger.warning(
+        "Ignoring non-positive session retention window %r; using %d days",
+        value,
+        SESSION_RETENTION_DAYS_DEFAULT,
+    )
+    return SESSION_RETENTION_DAYS_DEFAULT
+
+
+def load_session_auto_prune(config_path: Path | None = None) -> bool:
+    """Load whether expired sessions are pruned automatically at startup.
+
+    Args:
+        config_path: Optional alternate config file.
+
+    Returns:
+        Whether automatic pruning is enabled.
+    """
+    from deepagents_code.config_manifest import (
+        SESSION_AUTO_PRUNE_DEFAULT,
+        get_option,
+        resolve_scalar,
+    )
+
+    option = get_option("threads.auto_prune")
+    if option is None:
+        return SESSION_AUTO_PRUNE_DEFAULT
+    value, _ = resolve_scalar(option, toml_data=_load_session_config(config_path))
+    return value if isinstance(value, bool) else SESSION_AUTO_PRUNE_DEFAULT
+
+
 def load_thread_columns(config_path: Path | None = None) -> dict[str, bool]:
     """Load thread column visibility from config file.
 

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -6,8 +6,9 @@ import asyncio
 import contextlib
 import logging
 import sqlite3
+import threading
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, NotRequired, TypedDict, cast
 
@@ -34,6 +35,8 @@ _recent_threads_cache: dict[tuple[str | None, int], list[ThreadInfo]] = {}
 _MAX_RECENT_THREADS_CACHE_KEYS = 16
 _DEFAULT_SQLITE_TIMEOUT = 5.0
 """Seconds to wait out a locked database; matches the `sqlite3` default."""
+_auto_prune_lock = threading.Lock()
+_auto_prune_started = False
 
 
 def _patch_aiosqlite() -> None:
@@ -218,6 +221,25 @@ class ThreadInfo(TypedDict):
     """Working directory where the thread was last used."""
 
 
+class PruneResult(TypedDict):
+    """Summary returned by a session-retention prune."""
+
+    thread_ids: list[str]
+    """Threads selected in a dry run or deleted in a real prune."""
+
+    count: int
+    """Number of thread IDs in `thread_ids`."""
+
+    older_than_days: int
+    """Retention window used for the prune."""
+
+    cutoff: str
+    """UTC cutoff computed once when pruning started."""
+
+    dry_run: bool
+    """Whether the prune only reported candidates."""
+
+
 class _CheckpointSummary(NamedTuple):
     """Structured data extracted from a thread's latest checkpoint."""
 
@@ -382,7 +404,7 @@ async def _table_exists(conn: aiosqlite.Connection, table: str) -> bool:
 
 
 _THREADS_LIST_INDEX = "idx_dcode_threads_list"
-"""Covering index that makes the `list_threads` GROUP BY an index-only scan.
+"""Covering index that makes thread-metadata GROUP BY queries index-only scans.
 
 LangGraph's `SqliteSaver` stores each checkpoint's full state blob inline in the
 `checkpoints` row alongside the small `metadata` field. The thread-list query
@@ -394,8 +416,23 @@ the planner satisfies the GROUP BY from the index alone and never touches the
 blob-bearing rows, turning a ~60 s scan into a sub-second lookup.
 
 The column order (leading `thread_id`) also lets the GROUP BY consume the index
-in order. Keep the indexed expressions in sync with the `list_threads` query.
+in order. Keep the indexed expressions in sync with thread-list and prune queries.
 """
+
+_PRUNE_CANDIDATES_QUERY = """
+    SELECT thread_id
+    FROM (
+        SELECT
+            thread_id,
+            MAX(json_extract(metadata, '$.updated_at')) AS latest_updated_at
+        FROM checkpoints INDEXED BY idx_dcode_threads_list
+        GROUP BY thread_id
+    )
+    WHERE latest_updated_at IS NOT NULL
+      AND datetime(latest_updated_at) IS NOT NULL
+      AND latest_updated_at < ?
+"""
+"""Select expired thread IDs without reading checkpoint blob columns."""
 
 
 async def _ensure_threads_list_index(conn: aiosqlite.Connection) -> None:
@@ -1526,7 +1563,165 @@ async def delete_thread(thread_id: str) -> bool:
     from deepagents_code.offload import delete_offloaded_history
 
     delete_offloaded_history(thread_id)
+    try:
+        from deepagents_code.hooks.transcript import delete_thread_transcripts
+        from deepagents_code.model_config import DEFAULT_CONFIG_DIR
+
+        delete_thread_transcripts(DEFAULT_CONFIG_DIR / "transcripts", thread_id)
+    except Exception:
+        logger.warning(
+            "Failed to clean transcript artifacts for thread %s",
+            thread_id,
+            exc_info=True,
+        )
     return deleted
+
+
+def _utc_now() -> datetime:
+    """Return the current UTC time for retention cutoff calculation."""
+    return datetime.now(UTC)
+
+
+async def _prune_threads(
+    older_than_days: int,
+    *,
+    dry_run: bool = False,
+    exclude_thread_ids: frozenset[str] | None = None,
+) -> PruneResult:
+    """Prune expired threads while preserving explicitly excluded IDs.
+
+    Args:
+        older_than_days: Delete threads older than this many days.
+        dry_run: Return candidates without deleting anything.
+        exclude_thread_ids: Thread IDs that must be retained.
+
+    Returns:
+        IDs and count selected or deleted, plus the cutoff used.
+
+    Raises:
+        ValueError: If `older_than_days` is not a positive integer.
+    """
+    if (
+        not isinstance(older_than_days, int)
+        or isinstance(older_than_days, bool)
+        or older_than_days <= 0
+    ):
+        msg = "older_than_days must be a positive integer"
+        raise ValueError(msg)
+
+    excluded = exclude_thread_ids or frozenset()
+    cutoff = _utc_now() - timedelta(days=older_than_days)
+    cutoff_text = cutoff.isoformat()
+    candidates: list[str] = []
+    async with _connect() as conn:
+        if await _table_exists(conn, "checkpoints"):
+            await _ensure_threads_list_index(conn)
+            async with conn.execute(_PRUNE_CANDIDATES_QUERY, (cutoff_text,)) as cursor:
+                rows = await cursor.fetchall()
+            candidates = sorted(row[0] for row in rows if row[0] not in excluded)
+
+    if dry_run:
+        return PruneResult(
+            thread_ids=candidates,
+            count=len(candidates),
+            older_than_days=older_than_days,
+            cutoff=cutoff_text,
+            dry_run=True,
+        )
+
+    deleted_ids = [
+        thread_id for thread_id in candidates if await delete_thread(thread_id)
+    ]
+    return PruneResult(
+        thread_ids=deleted_ids,
+        count=len(deleted_ids),
+        older_than_days=older_than_days,
+        cutoff=cutoff_text,
+        dry_run=False,
+    )
+
+
+async def prune_threads(
+    older_than_days: int,
+    *,
+    dry_run: bool = False,
+) -> PruneResult:
+    """Delete threads whose latest known update predates a retention window.
+
+    Threads without any valid `updated_at` metadata are retained because their
+    age is unknown. Each deletion uses `delete_thread`, keeping transactions
+    bounded and cleaning all per-thread local artifacts.
+
+    Args:
+        older_than_days: Delete threads older than this many days.
+        dry_run: Return candidates without deleting anything.
+
+    Returns:
+        IDs and count selected or deleted, plus the cutoff used.
+    """
+    return await _prune_threads(older_than_days, dry_run=dry_run)
+
+
+async def _auto_prune_threads(active_thread_id: str | None) -> PruneResult | None:
+    """Run one failure-tolerant automatic prune around the active thread.
+
+    Returns:
+        The prune result, or `None` when disabled or unsuccessful.
+    """
+    try:
+        from deepagents_code.model_config import (
+            load_session_auto_prune,
+            load_session_retention_days,
+        )
+
+        if not load_session_auto_prune():
+            logger.debug("Automatic session pruning is disabled")
+            return None
+        excluded = frozenset({active_thread_id}) if active_thread_id else frozenset()
+        result = await _prune_threads(
+            load_session_retention_days(),
+            exclude_thread_ids=excluded,
+        )
+    except Exception:
+        logger.warning("Automatic session pruning failed", exc_info=True)
+        return None
+    if result["count"]:
+        logger.info("Automatically pruned %d expired sessions", result["count"])
+    return result
+
+
+def start_auto_prune(active_thread_id: str | None) -> threading.Thread | None:
+    """Start automatic session pruning on a best-effort daemon thread.
+
+    Args:
+        active_thread_id: Thread being started or resumed, which must be retained.
+
+    Returns:
+        The started worker, or `None` if pruning already started or scheduling
+            failed.
+    """
+    global _auto_prune_started  # noqa: PLW0603  # Process-wide one-shot guard
+
+    with _auto_prune_lock:
+        if _auto_prune_started:
+            return None
+        _auto_prune_started = True
+
+    def run() -> None:
+        try:
+            asyncio.run(_auto_prune_threads(active_thread_id))
+        except Exception:
+            logger.warning("Automatic session prune worker failed", exc_info=True)
+
+    worker = threading.Thread(target=run, name="dcode-session-prune", daemon=True)
+    try:
+        worker.start()
+    except RuntimeError:
+        with _auto_prune_lock:
+            _auto_prune_started = False
+        logger.warning("Could not start automatic session pruning", exc_info=True)
+        return None
+    return worker
 
 
 @asynccontextmanager
@@ -1749,6 +1944,59 @@ async def list_threads_command(
             "Override with -n/--limit or DA_CLI_RECENT_THREADS.[/dim]"
         )
     console.print()
+
+
+async def prune_threads_command(
+    older_than_days: int | None = None,
+    *,
+    dry_run: bool = False,
+    output_format: OutputFormat = "text",
+) -> None:
+    """CLI handler for `deepagents threads prune`.
+
+    Args:
+        older_than_days: Retention window override, or the configured default.
+        dry_run: Report candidates without deleting anything.
+        output_format: Output format — `'text'` (Rich) or `'json'`.
+    """
+    if older_than_days is None:
+        from deepagents_code.model_config import load_session_retention_days
+
+        older_than_days = load_session_retention_days()
+    result = await prune_threads(older_than_days, dry_run=dry_run)
+
+    if output_format == "json":
+        from deepagents_code.output import write_json
+
+        write_json("threads prune", dict(result))
+        return
+
+    from rich.markup import escape as escape_markup
+
+    from deepagents_code.config import console
+
+    count = result["count"]
+    noun = "thread" if count == 1 else "threads"
+    if dry_run:
+        if count:
+            console.print(
+                f"Would prune {count} {noun} older than {older_than_days} days:"
+            )
+            for thread_id in result["thread_ids"]:
+                console.print(f"  {escape_markup(thread_id)}")
+        else:
+            console.print(f"No threads older than {older_than_days} days found.")
+        console.print("No changes made.", style="dim")
+        return
+
+    if count:
+        console.print(
+            f"[green]Pruned {count} {noun} older than {older_than_days} days.[/green]"
+        )
+        for thread_id in result["thread_ids"]:
+            console.print(f"  {escape_markup(thread_id)}")
+    else:
+        console.print(f"No threads older than {older_than_days} days found.")
 
 
 async def delete_thread_command(

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -19,6 +19,7 @@ _TIP_SHIFT_TAB_WITHOUT_YOLO = "Press Shift+Tab to toggle Manual and Auto modes"
 _TIPS: dict[str, int] = {
     "Use @ to reference files and / for commands": 3,
     "Try /threads to resume a previous conversation": 2,
+    "Use dcode threads prune --dry-run to preview session cleanup": 1,
     "Use /offload to summarize older messages and free up the context window": 2,
     "Use /copy to copy the latest message": 3,
     "Use /cost to see a breakdown of estimated spend": 1,

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -910,6 +910,7 @@ def show_threads_help() -> None:
     console.print("[bold]Commands:[/bold]", style=theme.PRIMARY)
     console.print("  list|ls           List all threads")
     console.print("  delete <ID>       Delete a thread")
+    console.print("  prune             Delete expired threads")
     console.print()
     _print_option_section()
     console.print()
@@ -918,6 +919,7 @@ def show_threads_help() -> None:
     console.print("  dcode threads list -n 10")
     console.print("  dcode threads list --agent mybot")
     console.print("  dcode threads delete abc123")
+    console.print("  dcode threads prune --dry-run")
     console.print()
 
 
@@ -934,6 +936,26 @@ def show_threads_delete_help() -> None:
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  dcode threads delete abc123")
     console.print("  dcode threads delete abc123 --dry-run")
+    console.print()
+
+
+def show_threads_prune_help() -> None:
+    """Show help information for the `threads prune` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode threads prune [options]")
+    console.print()
+    _print_option_section(
+        (
+            "  --older-than DAYS        Delete threads older than DAYS "
+            "(default: config or 14)"
+        ),
+        "  --dry-run                Show what would happen without making changes",
+    )
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode threads prune")
+    console.print("  dcode threads prune --older-than 30 --dry-run")
     console.print()
 
 

--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -358,6 +358,12 @@ def _clear_update_env(
 
 
 @pytest.fixture(autouse=True)
+def _disable_automatic_session_pruning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent app tests from touching the developer's real session database."""
+    monkeypatch.setenv("DEEPAGENTS_CODE_AUTO_PRUNE", "0")
+
+
+@pytest.fixture(autouse=True)
 def _disable_app_startup_update_checks(
     request: pytest.FixtureRequest,
     monkeypatch: pytest.MonkeyPatch,

--- a/libs/code/tests/unit_tests/test_args.py
+++ b/libs/code/tests/unit_tests/test_args.py
@@ -9,7 +9,11 @@ import pytest
 from rich.console import Console
 
 from deepagents_code.main import parse_args
-from deepagents_code.ui import show_help, show_threads_list_help
+from deepagents_code.ui import (
+    show_help,
+    show_threads_list_help,
+    show_threads_prune_help,
+)
 
 
 class TestInitialPromptArg:
@@ -372,6 +376,27 @@ class TestSubcommandHelpFlags:
             must_contain="delete",
             must_not_contain="--sandbox",
         )
+
+    def test_threads_prune_help(self) -> None:
+        """Running `deepagents threads prune -h` should show prune help."""
+        self._run_help(
+            ["deepagents", "threads", "prune", "-h"],
+            must_contain="--older-than",
+            must_not_contain="--sandbox",
+        )
+
+
+def test_threads_prune_arguments() -> None:
+    """The prune subcommand parses its retention override and dry-run flag."""
+    with patch.object(
+        sys,
+        "argv",
+        ["deepagents", "threads", "prune", "--older-than", "30", "--dry-run"],
+    ):
+        args = parse_args()
+    assert args.threads_command == "prune"
+    assert args.older_than == 30
+    assert args.dry_run is True
 
 
 class TestShortFlags:
@@ -872,6 +897,32 @@ class TestHelpScreenDrift:
             f"Flags in argparse but missing from show_threads_list_help(): {missing}\n"
             "Add them to the Options section in ui.show_threads_list_help()."
         )
+
+    def test_threads_prune_flags_appear_in_help(self) -> None:
+        """Every `threads prune` flag appears in its hand-maintained help."""
+        stdout_buf = io.StringIO()
+        with (
+            patch.object(sys, "argv", ["deepagents", "threads", "prune", "-h"]),
+            patch("sys.stdout", stdout_buf),
+            patch("deepagents_code.ui.console", Console(file=io.StringIO())),
+            pytest.raises(SystemExit),
+        ):
+            parse_args()
+        raw = stdout_buf.getvalue()
+        options_section = raw.split("options:")[-1] if "options:" in raw else raw
+        parser_flags = set(re.findall(r"--[\w][\w-]*", options_section))
+        parser_flags.discard("--help")
+
+        help_buf = io.StringIO()
+        with patch(
+            "deepagents_code.ui.console",
+            Console(file=help_buf, highlight=False, width=200),
+        ):
+            show_threads_prune_help()
+        help_flags = set(re.findall(r"--[\w][\w-]*", help_buf.getvalue()))
+
+        missing = parser_flags - help_flags
+        assert not missing
 
 
 class TestJsonArg:

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -86,6 +86,54 @@ def test_option_keys_unique() -> None:
     assert len(keys) == len(set(keys))
 
 
+def test_session_retention_manifest_defaults() -> None:
+    """Session retention options are documented with safe defaults."""
+    retention = get_option("threads.session_retention_days")
+    auto_prune = get_option("threads.auto_prune")
+    assert retention is not None
+    assert retention.default == 14
+    assert retention.env_var == _env_vars.SESSION_RETENTION_DAYS
+    assert auto_prune is not None
+    assert auto_prune.default is True
+    assert auto_prune.env_var == _env_vars.AUTO_PRUNE
+
+
+def test_session_retention_loaders_resolve_toml_and_env(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Runtime loaders honor TOML and environment precedence."""
+    from deepagents_code.model_config import (
+        load_session_auto_prune,
+        load_session_retention_days,
+    )
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "[threads]\nsession_retention_days = 30\nauto_prune = false\n"
+    )
+    monkeypatch.delenv(_env_vars.SESSION_RETENTION_DAYS, raising=False)
+    monkeypatch.delenv(_env_vars.AUTO_PRUNE, raising=False)
+    assert load_session_retention_days(config_path) == 30
+    assert load_session_auto_prune(config_path) is False
+
+    monkeypatch.setenv(_env_vars.SESSION_RETENTION_DAYS, "7")
+    monkeypatch.setenv(_env_vars.AUTO_PRUNE, "true")
+    assert load_session_retention_days(config_path) == 7
+    assert load_session_auto_prune(config_path) is True
+
+
+def test_non_positive_session_retention_falls_back(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-positive window cannot trigger unsafe immediate deletion."""
+    from deepagents_code.model_config import load_session_retention_days
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("[threads]\nsession_retention_days = 0\n")
+    monkeypatch.delenv(_env_vars.SESSION_RETENTION_DAYS, raising=False)
+    assert load_session_retention_days(config_path) == 14
+
+
 def test_memory_auto_save_defaults_enabled(monkeypatch) -> None:
     """`memory.auto_save` resolves to enabled when nothing overrides it."""
     option = get_option("memory.auto_save")

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1670,6 +1670,45 @@ class TestAgentResolutionScope:
         valid_recent.assert_not_called()
 
 
+class TestThreadsPruneDispatch:
+    """Tests for `threads prune` CLI dispatch."""
+
+    def test_dispatches_retention_and_dry_run(self) -> None:
+        """The parsed prune options reach the async command handler."""
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "deepagents",
+                    "threads",
+                    "prune",
+                    "--older-than",
+                    "30",
+                    "--dry-run",
+                    "--json",
+                ],
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_code.main.check_cli_dependencies"),
+            patch(
+                "deepagents_code.sessions.prune_threads_command",
+                new_callable=AsyncMock,
+            ) as prune,
+        ):
+            cli_main()
+
+        prune.assert_awaited_once_with(
+            older_than_days=30,
+            dry_run=True,
+            output_format="json",
+        )
+
+
 class TestThreadsListCwdFilter:
     """Tests for `deepagents threads list --cwd` path normalization."""
 

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -416,6 +416,256 @@ class TestThreadFunctions:
         assert not archive.exists()
 
 
+class TestPruneThreads:
+    """Tests for retention-based thread pruning."""
+
+    @pytest.fixture
+    def prune_db(self, tmp_path: Path) -> Path:
+        """Create threads around a fixed 14-day cutoff."""
+        db_path = tmp_path / "prune.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("""
+            CREATE TABLE checkpoints (
+                thread_id TEXT NOT NULL,
+                checkpoint_ns TEXT NOT NULL DEFAULT '',
+                checkpoint_id TEXT NOT NULL,
+                metadata BLOB,
+                PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE writes (
+                thread_id TEXT NOT NULL,
+                checkpoint_ns TEXT NOT NULL DEFAULT '',
+                checkpoint_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                idx INTEGER NOT NULL,
+                channel TEXT NOT NULL,
+                type TEXT,
+                value BLOB,
+                PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
+            )
+        """)
+        timestamps: dict[str, list[str | None]] = {
+            "old": ["2026-07-17T12:00:00+00:00"],
+            "boundary": ["2026-07-18T12:00:00+00:00"],
+            "new": ["2026-07-19T12:00:00+00:00"],
+            "unknown": [None],
+            "invalid": ["2026-13-01T12:00:00+00:00"],
+            "mixed-old": [None, "2026-07-17T12:00:00+00:00"],
+            "mixed-new": ["2026-07-17T12:00:00+00:00", "2026-07-20T12:00:00+00:00"],
+        }
+        for thread_id, updates in timestamps.items():
+            for index, updated_at in enumerate(updates):
+                metadata = {} if updated_at is None else {"updated_at": updated_at}
+                conn.execute(
+                    "INSERT INTO checkpoints "
+                    "(thread_id, checkpoint_ns, checkpoint_id, metadata) "
+                    "VALUES (?, '', ?, ?)",
+                    (thread_id, f"cp-{index}", json.dumps(metadata)),
+                )
+            conn.execute(
+                "INSERT INTO writes "
+                "(thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel) "
+                "VALUES (?, '', 'cp-0', 'task', 0, 'messages')",
+                (thread_id,),
+            )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    @staticmethod
+    def _fixed_now() -> datetime:
+        return datetime(2026, 8, 1, 12, tzinfo=UTC)
+
+    def test_cutoff_boundary_and_missing_timestamp_skip(
+        self, prune_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Only strictly older threads with a known latest update are pruned."""
+        monkeypatch.setattr(sessions, "_utc_now", self._fixed_now)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        with patch.object(sessions, "get_db_path", return_value=prune_db):
+            result = asyncio.run(sessions.prune_threads(14))
+
+        assert result["thread_ids"] == ["mixed-old", "old"]
+        assert result["count"] == 2
+        conn = sqlite3.connect(prune_db)
+        try:
+            remaining = {
+                row[0]
+                for row in conn.execute("SELECT DISTINCT thread_id FROM checkpoints")
+            }
+            remaining_writes = {
+                row[0] for row in conn.execute("SELECT DISTINCT thread_id FROM writes")
+            }
+        finally:
+            conn.close()
+        assert remaining == {
+            "boundary",
+            "new",
+            "unknown",
+            "invalid",
+            "mixed-new",
+        }
+        assert remaining_writes == remaining
+
+    def test_candidate_query_requires_covering_index(
+        self, prune_db: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The prune lookup is pinned to the metadata-only covering index."""
+        monkeypatch.setattr(sessions, "_utc_now", self._fixed_now)
+        with patch.object(sessions, "get_db_path", return_value=prune_db):
+            asyncio.run(sessions.prune_threads(14, dry_run=True))
+
+        conn = sqlite3.connect(prune_db)
+        try:
+            plan = " ".join(
+                str(row[3])
+                for row in conn.execute(
+                    "EXPLAIN QUERY PLAN " + sessions._PRUNE_CANDIDATES_QUERY,
+                    ("2026-07-18T12:00:00+00:00",),
+                )
+            )
+        finally:
+            conn.close()
+        assert "idx_dcode_threads_list" in plan
+        assert "sqlite_autoindex_checkpoints_1" not in plan
+
+    def test_dry_run_returns_candidates_without_changes(
+        self, prune_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Dry-run reports IDs while preserving database and filesystem state."""
+        monkeypatch.setattr(sessions, "_utc_now", self._fixed_now)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        config_dir = tmp_path / ".deepagents"
+        archive = config_dir / "conversation_history" / "old.md"
+        archive.parent.mkdir(parents=True)
+        archive.write_text("history")
+
+        from deepagents_code import model_config
+        from deepagents_code.hooks.transcript import TranscriptStore
+
+        monkeypatch.setattr(model_config, "DEFAULT_CONFIG_DIR", config_dir)
+        store = TranscriptStore(config_dir / "transcripts")
+        transcript = store.thread_path("old")
+        transcript.write_text("transcript")
+
+        with patch.object(sessions, "get_db_path", return_value=prune_db):
+            result = asyncio.run(sessions.prune_threads(14, dry_run=True))
+
+        assert result["thread_ids"] == ["mixed-old", "old"]
+        assert result["count"] == 2
+        assert result["dry_run"] is True
+        assert archive.exists()
+        assert transcript.exists()
+        conn = sqlite3.connect(prune_db)
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM checkpoints").fetchone()[0] == 9
+            assert conn.execute("SELECT COUNT(*) FROM writes").fetchone()[0] == 7
+        finally:
+            conn.close()
+
+    def test_prune_cleans_all_thread_artifacts(
+        self, prune_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Pruning removes offloaded, root, backup, lock, and subagent artifacts."""
+        monkeypatch.setattr(sessions, "_utc_now", self._fixed_now)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        config_dir = tmp_path / ".deepagents"
+        archive = config_dir / "conversation_history" / "old.md"
+        archive.parent.mkdir(parents=True)
+        archive.write_text("history")
+
+        from deepagents_code import model_config
+        from deepagents_code.hooks.transcript import TranscriptStore
+
+        monkeypatch.setattr(model_config, "DEFAULT_CONFIG_DIR", config_dir)
+        store = TranscriptStore(config_dir / "transcripts")
+        transcript = store.thread_path("old")
+        backup = transcript.with_suffix(".jsonl.bak-revision")
+        lock = transcript.with_suffix(".jsonl.lock")
+        agent = store.agent_path("old", "agent")
+        agent.parent.mkdir(parents=True)
+        for path in (transcript, backup, lock, agent):
+            path.write_text("artifact")
+
+        with patch.object(sessions, "get_db_path", return_value=prune_db):
+            result = asyncio.run(sessions.prune_threads(14))
+
+        assert "old" in result["thread_ids"]
+        assert not archive.exists()
+        assert not transcript.exists()
+        assert not backup.exists()
+        assert not lock.exists()
+        assert not agent.parent.parent.exists()
+
+    def test_cleanup_failure_does_not_fail_prune(
+        self, prune_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A transcript cleanup error is logged and does not block deletion."""
+        monkeypatch.setattr(sessions, "_utc_now", self._fixed_now)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        from deepagents_code.hooks import transcript
+
+        cleanup = MagicMock(side_effect=OSError("read-only"))
+        monkeypatch.setattr(transcript, "delete_thread_transcripts", cleanup)
+        with patch.object(sessions, "get_db_path", return_value=prune_db):
+            result = asyncio.run(sessions.prune_threads(14))
+
+        assert result["count"] == 2
+        assert cleanup.call_count == 2
+
+    def test_auto_prune_excludes_active_thread(
+        self, prune_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Automatic pruning never deletes the thread being resumed."""
+        monkeypatch.setattr(sessions, "_utc_now", self._fixed_now)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        with patch.object(sessions, "get_db_path", return_value=prune_db):
+            result = asyncio.run(
+                sessions._prune_threads(
+                    14,
+                    exclude_thread_ids=frozenset({"old"}),
+                )
+            )
+            assert asyncio.run(sessions.thread_exists("old")) is True
+
+        assert result["thread_ids"] == ["mixed-old"]
+
+    def test_auto_prune_scheduler_is_one_shot(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only one background prune worker is scheduled per process."""
+        monkeypatch.setattr(sessions, "_auto_prune_started", False)
+        worker = MagicMock()
+        with patch.object(sessions.threading, "Thread", return_value=worker) as thread:
+            assert sessions.start_auto_prune("active") is worker
+            assert sessions.start_auto_prune("other") is None
+
+        worker.start.assert_called_once_with()
+        thread.assert_called_once_with(
+            target=thread.call_args.kwargs["target"],
+            name="dcode-session-prune",
+            daemon=True,
+        )
+
+    def test_auto_prune_swallows_database_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Automatic pruning logs database failures and lets startup continue."""
+        from deepagents_code import model_config
+
+        monkeypatch.setattr(model_config, "load_session_auto_prune", lambda: True)
+        monkeypatch.setattr(model_config, "load_session_retention_days", lambda: 14)
+        monkeypatch.setattr(
+            sessions,
+            "_prune_threads",
+            AsyncMock(side_effect=sqlite3.DatabaseError("corrupt")),
+        )
+
+        assert asyncio.run(sessions._auto_prune_threads("active")) is None
+
+
 class TestGetCheckpointer:
     """Tests for get_checkpointer async context manager."""
 
@@ -2365,6 +2615,42 @@ class TestDeleteThreadCommandJson:
 
         result = json.loads(buf.getvalue())
         assert result["data"]["deleted"] is False
+
+
+class TestPruneThreadsCommand:
+    """Tests for `prune_threads_command` output and config defaults."""
+
+    _RESULT: ClassVar[sessions.PruneResult] = {
+        "thread_ids": ["old-thread"],
+        "count": 1,
+        "older_than_days": 30,
+        "cutoff": "2026-07-02T12:00:00+00:00",
+        "dry_run": True,
+    }
+
+    def test_json_uses_configured_retention_default(self) -> None:
+        """JSON mode loads configured days when the flag is omitted."""
+        import io
+
+        buf = io.StringIO()
+        prune = AsyncMock(return_value=self._RESULT)
+        with (
+            patch(
+                "deepagents_code.model_config.load_session_retention_days",
+                return_value=30,
+            ),
+            patch.object(sessions, "prune_threads", prune),
+            patch("sys.stdout", buf),
+        ):
+            asyncio.run(
+                sessions.prune_threads_command(dry_run=True, output_format="json")
+            )
+
+        result = json.loads(buf.getvalue())
+        assert result["command"] == "threads prune"
+        assert result["data"]["thread_ids"] == ["old-thread"]
+        assert result["data"]["count"] == 1
+        prune.assert_awaited_once_with(30, dry_run=True)
 
 
 class TestBatchCheckpointSummaries:


### PR DESCRIPTION
Deep Agents Code now prunes expired local sessions in the background with a configurable retention window and manual dry-run/JSON controls.

---

The metadata-only indexed lookup keeps startup responsive, preserves active and unknown-age threads, and reuses full thread deletion so checkpoint, write, history, and transcript artifacts stay consistent. Automatic failures are logged without blocking launch.

Verified with 816 focused unit tests and `make lint` in `libs/code`.

Made by [Open SWE](https://openswe.vercel.app/agents/e08b7ed8-1ede-3b54-97d7-cabc7ad0ad1f)

## References
- Plan: https://openswe.vercel.app/agents/e08b7ed8-1ede-3b54-97d7-cabc7ad0ad1f/plan