### PR TITLE
fix(sdk): surface patched tool-call errors and HITL path-validation failures

### DIFF
--- a/libs/deepagents/deepagents/middleware/_fs_interrupt.py
+++ b/libs/deepagents/deepagents/middleware/_fs_interrupt.py
@@ -8,6 +8,7 @@ filesystem permissions into an `interrupt_on` mapping for
 whether the access intersects an interrupt-mode rule.
 """
 
+import logging
 from collections.abc import Callable
 from pathlib import PurePosixPath
 from typing import Literal
@@ -17,6 +18,8 @@ from langchain.tools.tool_node import ToolCallRequest
 
 from deepagents.backends.utils import _glob_anchor, _paths_overlap, to_posix_path, validate_path
 from deepagents.middleware.filesystem import FilesystemOperation, FilesystemPermission, _check_fs_permission
+
+logger = logging.getLogger(__name__)
 
 # Scope of a filesystem tool's path argument:
 #   - "exact": the call operates on exactly the named path (read_file,
@@ -85,6 +88,11 @@ def _make_exact_when_predicate(
         try:
             normalized = validate_path(raw_path)
         except ValueError:
+            logger.debug(
+                "validate_path rejected %r for tool %r; fail-open (no interrupt fires)",
+                raw_path,
+                req.tool_call.get("name"),
+            )
             return False
         return _check_fs_permission(rules, operation, normalized) == "interrupt"
 
@@ -115,6 +123,11 @@ def _make_bulk_when_predicate(
         try:
             normalized = validate_path(raw_path)
         except ValueError:
+            logger.debug(
+                "validate_path rejected %r for tool %r; fail-open (no interrupt fires)",
+                raw_path,
+                req.tool_call.get("name"),
+            )
             return False
         # `validate_path` returns `/.` for current-directory aliases like
         # `"."`, `""`, and `"./"`. Those refer to the whole accessible tree

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -41,6 +41,13 @@ class PatchToolCallsMiddleware(AgentMiddleware):
                     content = f"Tool call {name} with id {tool_call_id} could not be executed - arguments were malformed or truncated."
                 else:
                     content = f"Tool call {name} with id {tool_call_id} was cancelled - another message came in before it could be completed."
-                patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id))
+                patched_messages.append(
+                    ToolMessage(
+                        content=content,
+                        name=name,
+                        tool_call_id=tool_call_id,
+                        status="error",
+                    )
+                )
 
         return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *patched_messages]}

--- a/libs/deepagents/tests/unit_tests/middleware/test_fs_interrupt_logging.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_fs_interrupt_logging.py
@@ -1,0 +1,61 @@
+"""Regression tests for `_fs_interrupt` predicate visibility on path-validation failure.
+
+The silent ``except ValueError: return False`` in the exact and bulk
+interrupt predicates is intentional (fail-open by design), but a
+breadcrumb for operators is required when an LLM-emitted path trips
+``validate_path`` (e.g. contains ``..`` or a Windows-style absolute path).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from langchain.tools import ToolRuntime
+from langchain.tools.tool_node import ToolCallRequest
+
+from deepagents.middleware._fs_interrupt import (
+    _make_bulk_when_predicate,
+    _make_exact_when_predicate,
+)
+from deepagents.middleware.filesystem import FilesystemPermission
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _runtime() -> ToolRuntime:
+    return ToolRuntime(state={}, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={})
+
+
+def _request(path_arg: str, path_value: str) -> ToolCallRequest:
+    return ToolCallRequest(
+        runtime=_runtime(),
+        tool_call={"id": "call-1", "name": "read_file", "args": {path_arg: path_value}},
+        state={},
+        tool=None,
+    )
+
+
+class TestFsInterruptLogging:
+    def test_exact_predicate_logs_on_invalid_path(self, caplog: pytest.LogCaptureFixture) -> None:
+        rules = [FilesystemPermission(operations=["read"], paths=["/secrets/**"], mode="interrupt")]
+        predicate = _make_exact_when_predicate(rules, "read", "file_path")
+
+        with caplog.at_level(logging.DEBUG, logger="deepagents.middleware._fs_interrupt"):
+            assert predicate(_request("file_path", "../etc/passwd")) is False
+
+        assert any("../etc/passwd" in rec.message and "read_file" in rec.message for rec in caplog.records), (
+            f"expected a DEBUG log with raw_path and tool name; got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_bulk_predicate_logs_on_invalid_path(self, caplog: pytest.LogCaptureFixture) -> None:
+        rules = [FilesystemPermission(operations=["read"], paths=["/secrets/**"], mode="interrupt")]
+        predicate = _make_bulk_when_predicate(rules, "read", "path", None)
+
+        with caplog.at_level(logging.DEBUG, logger="deepagents.middleware._fs_interrupt"):
+            assert predicate(_request("path", "../secrets")) is False
+
+        assert any("../secrets" in rec.message and "read_file" in rec.message for rec in caplog.records), (
+            f"expected a DEBUG log with raw_path and tool name; got: {[r.message for r in caplog.records]}"
+        )

--- a/libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls_status.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls_status.py
@@ -1,0 +1,86 @@
+"""Regression tests for `PatchToolCallsMiddleware` synthetic-tool-message visibility.
+
+The synthetic `ToolMessage` injected for cancelled or invalid tool calls
+previously carried no `status` field, while the rest of the SDK
+(``FilesystemMiddleware._tool_error``) sets `status="error"` on tool
+results that did not execute as intended. These tests pin the contract.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, RemoveMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from langgraph.runtime import Runtime
+
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
+
+
+def _runtime() -> Runtime:
+    return Runtime()
+
+
+def _patched_tool_messages(call: AIMessage) -> list:
+    # `AgentState` is a TypedDict; the middleware only reads `state["messages"]`.
+    state = {"messages": [call]}
+    update = PatchToolCallsMiddleware().before_agent(state, _runtime())  # type: ignore[arg-type]
+    assert update is not None
+    msgs = update["messages"]
+    assert isinstance(msgs[0], RemoveMessage)
+    assert msgs[0].id == REMOVE_ALL_MESSAGES
+    return [m for m in msgs[1:] if m.type == "tool"]
+
+
+class TestPatchedToolMessageStatus:
+    def test_synthetic_tool_message_for_invalid_call_has_error_status(self) -> None:
+        ai = AIMessage(
+            content="",
+            id="ai-1",
+            invalid_tool_calls=[
+                {
+                    "id": "call-1",
+                    "name": "read_file",
+                    "args": "{not json",
+                    "type": "invalid_tool_call",
+                }
+            ],
+        )
+        patched = _patched_tool_messages(ai)
+        assert len(patched) == 1
+        assert patched[0].tool_call_id == "call-1"
+        assert patched[0].status == "error"
+
+    def test_synthetic_tool_message_for_cancelled_call_has_error_status(self) -> None:
+        ai = AIMessage(
+            content="",
+            id="ai-2",
+            tool_calls=[{"id": "call-2", "name": "write_file", "args": {"file_path": "/x"}}],
+        )
+        patched = _patched_tool_messages(ai)
+        assert len(patched) == 1
+        assert patched[0].tool_call_id == "call-2"
+        assert patched[0].status == "error"
+
+    def test_synthetic_content_preserved(self) -> None:
+        ai_invalid = AIMessage(
+            content="",
+            id="ai-3",
+            invalid_tool_calls=[
+                {
+                    "id": "call-3",
+                    "name": "read_file",
+                    "args": "{not json",
+                    "type": "invalid_tool_call",
+                }
+            ],
+        )
+        ai_cancelled = AIMessage(
+            content="",
+            id="ai-4",
+            tool_calls=[{"id": "call-4", "name": "write_file", "args": {}}],
+        )
+
+        invalid_msg = _patched_tool_messages(ai_invalid)[0]
+        cancelled_msg = _patched_tool_messages(ai_cancelled)[0]
+
+        assert "could not be executed" in invalid_msg.text
+        assert "was cancelled" in cancelled_msg.text


### PR DESCRIPTION
## What

Two related SDK middleware fixes that hide error state from the model and from operators.

1. **PatchToolCallsMiddleware** injects synthetic ToolMessages for cancelled or invalid tool calls but never set `status="error"`. The rest of the SDK (`FilesystemMiddleware._tool_error`) marks tool results that did not execute as intended with `status="error"`; the patched messages silently deviated, so downstream consumers (LangGraph ToolNode, LangSmith observability) saw them as ordinary successful tool results.

2. **_make_exact_when_predicate** and **_make_bulk_when_predicate** in `_fs_interrupt.py` silently swallow `ValueError` from `validate_path` and fail open. The fail-open contract is intentional and stays; the gap was invisibility — a malformed LLM-emitted path (e.g. one containing `..`) caused the HITL gate to skip with no breadcrumb for operators investigating "why didn't HITL fire on this call?".

## Files

- `libs/deepagents/deepagents/middleware/patch_tool_calls.py` — set `status="error"` on the synthetic ToolMessage.
- `libs/deepagents/deepagents/middleware/_fs_interrupt.py` — add `logging.getLogger(__name__)` + `logger.debug(...)` on both `validate_path` ValueError swallow sites.
- `libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls_status.py` (new) — 3 cases: status for invalid call, status for cancelled call, content preserved.
- `libs/deepagents/tests/unit_tests/middleware/test_fs_interrupt_logging.py` (new) — 2 cases: exact predicate logs, bulk predicate logs.

## Risk

Low. No public API changes. No behavior change for valid inputs. The new `status="error"` is consistent with the existing `FilesystemMiddleware._tool_error` convention. The `logger.debug` line is operator-side only and is silent at default log levels.

## Validation

- `ruff format`: clean
- `ruff check`: clean
- `pytest tests/unit_tests/`: 2458 passed, 0 failed (was 2453 before; +5 new, 0 regressions)
