### PR TITLE
fix(code): store update logs under the OS cache dir

### DIFF
--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -535,15 +535,19 @@ top-level user-facing config and agent directories so listing/iterating
 def default_cache_dir() -> Path:
     """Return the OS-appropriate cache directory for Deep Agents Code.
 
-    Honors `XDG_CACHE_HOME` on Linux (falling back to `~/.cache`) and uses
-    `~/Library/Caches` on macOS. The install script mirrors the Linux branch
-    for its own `<cache>/deepagents-code/install.log` path.
+    Honors `XDG_CACHE_HOME` on Unix-like platforms (falling back to `~/.cache`)
+    and `LOCALAPPDATA` on Windows (falling back to `~/AppData/Local`). The
+    install script uses the Unix-like branch for its own
+    `<cache>/deepagents-code/install.log` path.
 
     Returns:
         Base cache directory, before the `deepagents-code` subdirectory.
     """
-    if sys.platform == "darwin":
-        return Path.home() / "Library" / "Caches"
+    if sys.platform == "win32":
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        if local_app_data:
+            return Path(local_app_data)
+        return Path.home() / "AppData" / "Local"
     xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
     if xdg_cache_home:
         return Path(xdg_cache_home)

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -539,10 +539,17 @@ def default_cache_dir() -> Path:
     to `~/AppData/Local`), and `XDG_CACHE_HOME` elsewhere when it is an
     absolute path (falling back to `~/.cache`). The XDG spec treats relative
     `XDG_CACHE_HOME` values as invalid, so they are ignored rather than
-    resolved against the launch directory. The install script writes its own
-    `<cache>/deepagents-code/install.log` under `${XDG_CACHE_HOME:-~/.cache}`
-    unconditionally, so on macOS its log and the update logs land under
-    different roots.
+    resolved against the launch directory.
+
+    Platform-native locations are the convention for a long-lived app (this is
+    what `platformdirs` codifies and what `uv` itself does — its own cache is
+    `~/Library/Caches/uv` on macOS). The install script deliberately does not
+    follow this: as a portable one-shot POSIX bootstrap it uses XDG-style
+    `${XDG_CACHE_HOME:-~/.cache}` on every platform (like the rustup and uv
+    installers), so on macOS its `<cache>/deepagents-code/install.log` lands
+    under a different root than the update logs. That divergence is
+    intentional; do not "fix" one side to match the other without a concrete
+    need (e.g., a diagnostic command that collects both logs).
 
     Returns:
         Base cache directory, before the `deepagents-code` subdirectory.

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -12,6 +12,7 @@ import importlib.util
 import json
 import logging
 import os
+import sys
 import tempfile
 import threading
 import tomllib
@@ -529,6 +530,25 @@ sessions database, version-check caches, input history. Kept separate from
 top-level user-facing config and agent directories so listing/iterating
 `~/.deepagents` doesn't conflate state with agents.
 """
+
+
+def default_cache_dir() -> Path:
+    """Return the OS-appropriate cache directory for Deep Agents Code.
+
+    Honors `XDG_CACHE_HOME` on Linux (falling back to `~/.cache`) and uses
+    `~/Library/Caches` on macOS. The install script mirrors the Linux branch
+    for its own `<cache>/deepagents-code/install.log` path.
+
+    Returns:
+        Base cache directory, before the `deepagents-code` subdirectory.
+    """
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches"
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        return Path(xdg_cache_home)
+    return Path.home() / ".cache"
+
 
 RECENT_MODELS_FILENAME = "recent_models.json"
 """Filename under `DEFAULT_STATE_DIR` for the MRU list shown in `/model`."""

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -535,10 +535,14 @@ top-level user-facing config and agent directories so listing/iterating
 def default_cache_dir() -> Path:
     """Return the OS-appropriate cache directory for Deep Agents Code.
 
-    Honors `XDG_CACHE_HOME` on Unix-like platforms (falling back to `~/.cache`)
-    and `LOCALAPPDATA` on Windows (falling back to `~/AppData/Local`). The
-    install script uses the Unix-like branch for its own
-    `<cache>/deepagents-code/install.log` path.
+    Uses `~/Library/Caches` on macOS, `LOCALAPPDATA` on Windows (falling back
+    to `~/AppData/Local`), and `XDG_CACHE_HOME` elsewhere when it is an
+    absolute path (falling back to `~/.cache`). The XDG spec treats relative
+    `XDG_CACHE_HOME` values as invalid, so they are ignored rather than
+    resolved against the launch directory. The install script writes its own
+    `<cache>/deepagents-code/install.log` under `${XDG_CACHE_HOME:-~/.cache}`
+    unconditionally, so on macOS its log and the update logs land under
+    different roots.
 
     Returns:
         Base cache directory, before the `deepagents-code` subdirectory.
@@ -548,8 +552,10 @@ def default_cache_dir() -> Path:
         if local_app_data:
             return Path(local_app_data)
         return Path.home() / "AppData" / "Local"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches"
     xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
-    if xdg_cache_home:
+    if xdg_cache_home and Path(xdg_cache_home).is_absolute():
         return Path(xdg_cache_home)
     return Path.home() / ".cache"
 

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -38,7 +38,11 @@ from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 from deepagents_code._version import PYPI_URL, SDK_PYPI_URL, USER_AGENT, __version__
-from deepagents_code.model_config import DEFAULT_CONFIG_PATH, DEFAULT_STATE_DIR
+from deepagents_code.model_config import (
+    DEFAULT_CONFIG_PATH,
+    DEFAULT_STATE_DIR,
+    default_cache_dir,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -182,8 +186,15 @@ _TERMINATE_WAIT_TIMEOUT = 5  # seconds
 INSTALL_SCRIPT_COMMAND = "curl -LsSf https://langch.in/dcode | bash"
 """Promoted public install command for Deep Agents Code."""
 
-UPDATE_LOG_DIR: Path = DEFAULT_STATE_DIR / "update_logs"
-"""Directory for persisted update command logs."""
+UPDATE_LOG_DIR: Path = default_cache_dir() / "deepagents-code" / "update_logs"
+"""Directory for persisted update command logs.
+
+Lives under the OS cache directory (`default_cache_dir()`) alongside the
+install script's `<cache>/deepagents-code/install.log`, since these are
+ephemeral `uv`/`pip` diagnostics rather than app state. Logs previously
+written under `~/.deepagents/.state/update_logs/` are left in place — they
+age out on their own under the retention policy below.
+"""
 
 UPDATE_LOG_RETENTION_DAYS = 14
 """Delete update logs older than this many days."""

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -191,9 +191,7 @@ UPDATE_LOG_DIR: Path = default_cache_dir() / "deepagents-code" / "update_logs"
 
 Lives under the OS cache directory (`default_cache_dir()`) alongside the
 install script's `<cache>/deepagents-code/install.log`, since these are
-ephemeral `uv`/`pip` diagnostics rather than app state. Logs previously
-written under `~/.deepagents/.state/update_logs/` are left in place — they
-age out on their own under the retention policy below.
+ephemeral `uv`/`pip` diagnostics rather than app state.
 """
 
 UPDATE_LOG_RETENTION_DAYS = 14

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -189,9 +189,11 @@ INSTALL_SCRIPT_COMMAND = "curl -LsSf https://langch.in/dcode | bash"
 UPDATE_LOG_DIR: Path = default_cache_dir() / "deepagents-code" / "update_logs"
 """Directory for persisted update command logs.
 
-Lives under the OS cache directory (`default_cache_dir()`) alongside the
-install script's `<cache>/deepagents-code/install.log`, since these are
-ephemeral `uv`/`pip` diagnostics rather than app state.
+Lives under the OS cache directory (`default_cache_dir()`), since these are
+ephemeral `uv`/`pip` diagnostics rather than app state. Note the install
+script's `<cache>/deepagents-code/install.log` follows
+`${XDG_CACHE_HOME:-~/.cache}` unconditionally, so on macOS the two logs land
+under different roots.
 """
 
 UPDATE_LOG_RETENTION_DAYS = 14

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1753,10 +1753,16 @@ UV_REPORTED_PACKAGE_CHANGES=false
 # Mirror uv's raw output to a persistent log under the XDG cache dir. A
 # same-version dependency bump prints only a one-line summary and a failed
 # install scrolls past, so the log preserves the full diff/errors for later.
-# Prefer $XDG_CACHE_HOME, falling back to ~/.cache. INSTALL_LOG is the real
-# path used for writes; INSTALL_LOG_DISPLAY is the tilde-collapsed form shown
-# to the user. Both stay empty when the dir can't be created, which every
-# consumer treats as "feature disabled" so messages degrade cleanly.
+# Prefer $XDG_CACHE_HOME, falling back to ~/.cache — XDG-style on every
+# platform (like the rustup and uv installers), since this is a portable
+# one-shot POSIX bootstrap. The installed app instead uses platform-native
+# cache dirs (e.g. ~/Library/Caches on macOS) for its update logs, so the two
+# intentionally land under different roots on macOS; see default_cache_dir()
+# in deepagents_code/model_config.py.
+# INSTALL_LOG is the real path used for writes; INSTALL_LOG_DISPLAY is the
+# tilde-collapsed form shown to the user. Both stay empty when the dir can't
+# be created, which every consumer treats as "feature disabled" so messages
+# degrade cleanly.
 INSTALL_LOG=""
 INSTALL_LOG_DISPLAY=""
 cache_root="${XDG_CACHE_HOME:-}"

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -109,14 +109,40 @@ class TestDefaultCacheDir:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         assert default_cache_dir() == tmp_path / ".cache"
 
-    def test_macos_uses_library_caches(
+    def test_macos_honors_xdg_cache_home(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """MacOS resolves to `~/Library/Caches`, ignoring `XDG_CACHE_HOME`."""
+        """The macOS resolver uses the same XDG cache location as the installer."""
         monkeypatch.setattr(sys, "platform", "darwin")
         monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        assert default_cache_dir() == tmp_path / "Library" / "Caches"
+        assert default_cache_dir() == tmp_path / "xdg-cache"
+
+    def test_macos_without_xdg_cache_home_falls_back_to_dot_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The macOS resolver uses `~/.cache` when `XDG_CACHE_HOME` is unset."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert default_cache_dir() == tmp_path / ".cache"
+
+    def test_windows_uses_local_app_data(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows uses its native local application-data directory."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local-app-data"))
+        assert default_cache_dir() == tmp_path / "local-app-data"
+
+    def test_windows_without_local_app_data_uses_home_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows retains a predictable fallback when `LOCALAPPDATA` is unavailable."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert default_cache_dir() == tmp_path / "AppData" / "Local"
 
 
 def _create_git_repository(root: Path) -> Path:

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -109,21 +109,30 @@ class TestDefaultCacheDir:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         assert default_cache_dir() == tmp_path / ".cache"
 
-    def test_macos_honors_xdg_cache_home(
+    def test_macos_uses_library_caches(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The macOS resolver uses the same XDG cache location as the installer."""
+        """MacOS resolves to `~/Library/Caches`, ignoring `XDG_CACHE_HOME`."""
         monkeypatch.setattr(sys, "platform", "darwin")
         monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        assert default_cache_dir() == tmp_path / "xdg-cache"
+        assert default_cache_dir() == tmp_path / "Library" / "Caches"
 
-    def test_macos_without_xdg_cache_home_falls_back_to_dot_cache(
+    def test_macos_without_xdg_cache_home_uses_library_caches(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The macOS resolver uses `~/.cache` when `XDG_CACHE_HOME` is unset."""
+        """MacOS resolves to `~/Library/Caches` when `XDG_CACHE_HOME` is unset."""
         monkeypatch.setattr(sys, "platform", "darwin")
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert default_cache_dir() == tmp_path / "Library" / "Caches"
+
+    def test_xdg_cache_home_relative_falls_back_to_dot_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A relative `XDG_CACHE_HOME` is invalid per the XDG spec and ignored."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setenv("XDG_CACHE_HOME", "cache")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         assert default_cache_dir() == tmp_path / ".cache"
 

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -2,6 +2,7 @@
 
 import io
 import logging
+import sys
 import threading
 import tomllib
 from collections.abc import Iterator
@@ -43,6 +44,7 @@ from deepagents_code.model_config import (
     clear_default_agent,
     clear_default_model,
     clear_effort_for_model,
+    default_cache_dir,
     fingerprint_mcp_server_config,
     get_available_models,
     get_model_profiles,
@@ -76,6 +78,45 @@ def _create_git_common_dir(common_dir: Path) -> Path:
     (common_dir / "HEAD").write_text("ref: refs/heads/main\n")
     (common_dir / "config").write_text("[core]\n\tbare = false\n")
     return common_dir
+
+
+class TestDefaultCacheDir:
+    """`default_cache_dir` resolves the OS-appropriate cache root."""
+
+    def test_xdg_cache_home_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A set `XDG_CACHE_HOME` wins on Linux."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+        assert default_cache_dir() == tmp_path / "xdg-cache"
+
+    def test_xdg_cache_home_unset_falls_back_to_dot_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without `XDG_CACHE_HOME`, Linux falls back to `~/.cache`."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert default_cache_dir() == tmp_path / ".cache"
+
+    def test_xdg_cache_home_empty_falls_back_to_dot_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty `XDG_CACHE_HOME` is treated as unset."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setenv("XDG_CACHE_HOME", "")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert default_cache_dir() == tmp_path / ".cache"
+
+    def test_macos_uses_library_caches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """MacOS resolves to `~/Library/Caches`, ignoring `XDG_CACHE_HOME`."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert default_cache_dir() == tmp_path / "Library" / "Caches"
 
 
 def _create_git_repository(root: Path) -> Path:


### PR DESCRIPTION
Update logs from self-updates (`uv tool install` / `pip install` output) are ephemeral diagnostics, not application state. This moves `UPDATE_LOG_DIR` from `~/.deepagents/.state/update_logs/` to `<cache>/deepagents-code/update_logs/`, where `<cache>` is the platform-native cache directory (`~/Library/Caches` on macOS, `%LOCALAPPDATA%` on Windows, `$XDG_CACHE_HOME` or `~/.cache` elsewhere).

---

Before this change, every self-update wrote a timestamped log under `~/.deepagents/.state/update_logs/`. That directory also holds OAuth tokens, the sessions database, and input history — things users expect to persist — while the update logs are transient `uv`/`pip` output that the retention policy (`UPDATE_LOG_RETENTION_DAYS = 14`, `UPDATE_LOG_MAX_FILES = 10`) already treats as disposable. A cache directory is the more correct home.

- New `default_cache_dir()` resolver lives next to `DEFAULT_STATE_DIR` in `model_config.py`: `~/Library/Caches` on macOS, `LOCALAPPDATA` on Windows (falling back to `~/AppData/Local`), and `XDG_CACHE_HOME` elsewhere when it is an absolute path (falling back to `~/.cache`). Relative `XDG_CACHE_HOME` values are invalid per the XDG spec and are ignored rather than resolved against the launch directory.
- Resulting `UPDATE_LOG_DIR` values:
    - macOS: `~/Library/Caches/deepagents-code/update_logs/`
    - Windows: `%LOCALAPPDATA%/deepagents-code/update_logs/`
    - Linux with `XDG_CACHE_HOME` set: `$XDG_CACHE_HOME/deepagents-code/update_logs/`
    - Linux without it: `~/.cache/deepagents-code/update_logs/`
- The install script writes its own `install.log` under `${XDG_CACHE_HOME:-~/.cache}` on every platform, so on macOS the two logs intentionally land under different roots. Each side follows the convention appropriate to it — a portable one-shot POSIX bootstrap (like the rustup and uv installers) versus a long-lived app (like `platformdirs`, and `uv`'s own cache at `~/Library/Caches/uv`). Both docstrings now state this explicitly so the divergence isn't later "fixed" by mistake.
- `create_update_log_path` / `cleanup_update_logs` signatures and the `OSError`-tolerant debug-log-and-continue behavior in `perform_upgrade` are unchanged — a non-writable cache dir must not break updates. The timestamped `<stamp>-update.log` naming and retention policy are untouched. Existing logs under the old `~/.deepagents/.state/update_logs/` path are simply orphaned; nothing reads them back.
- Nothing in the codebase reads update logs back (verified: write-only across the package), so no reader migration is needed. No docs/help text referenced the old path.

<details>
<summary>Test plan</summary>

- New `TestDefaultCacheDir` in `test_model_config.py`: XDG set/unset/empty/relative, macOS with and without `XDG_CACHE_HOME`, Windows with and without `LOCALAPPDATA`.
- `test_update_check.py` (388 tests, including the existing `UPDATE_LOG_DIR` patch-based fixture) passes unchanged.
- `make -C libs/code lint` (ruff + ty + format) passes.

</details>
