### PR TITLE
feat(acp): support persistent session loading

### DIFF
--- a/libs/acp/README.md
+++ b/libs/acp/README.md
@@ -110,6 +110,20 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+### Persist and load sessions
+
+`AgentServerACP` can advertise and implement ACP's `session/load` capability when the
+agent uses a durable LangGraph checkpointer:
+
+```python
+server = AgentServerACP(agent, load_sessions=True)
+```
+
+The checkpointer must remain available across agent-process restarts. An in-memory
+checkpointer is suitable for tests but does not provide restart persistence. On load, the
+adapter restores the LangGraph thread, verifies the original working directory, and replays
+the conversation to the client through `session/update` before returning.
+
 ### Launch with Toad
 
 ```sh
@@ -159,6 +173,9 @@ Select a model by passing `--model` (in `provider:model-name` form) to the comma
 ```
 
 `dcode` reads provider API keys from the environment (e.g. `ANTHROPIC_API_KEY`), the same way it does in the terminal. Run `dcode --help` to see the other flags supported in ACP mode, such as `--mcp-config` and `--no-mcp`.
+
+Sessions created through `dcode --acp` are stored in dcode's SQLite session database and can
+be loaded after the ACP server restarts.
 
 ## Model Switching
 

--- a/libs/acp/README.md
+++ b/libs/acp/README.md
@@ -174,9 +174,6 @@ Select a model by passing `--model` (in `provider:model-name` form) to the comma
 
 `dcode` reads provider API keys from the environment (e.g. `ANTHROPIC_API_KEY`), the same way it does in the terminal. Run `dcode --help` to see the other flags supported in ACP mode, such as `--mcp-config` and `--no-mcp`.
 
-Sessions created through `dcode --acp` are stored in dcode's SQLite session database and can
-be loaded after the ACP server restarts.
-
 ## Model Switching
 
 The ACP adapter supports dynamic model switching using Session Config Options. This allows users to switch between different LLM models mid-session without losing conversation history.

--- a/libs/acp/deepagents_acp/server.py
+++ b/libs/acp/deepagents_acp/server.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeGuard
 from uuid import uuid4
 
@@ -31,7 +30,6 @@ from acp import (
 )
 from acp.exceptions import RequestError
 from acp.schema import (
-    AcpMcpServer,
     AgentCapabilities,
     AgentMessageChunk,
     AgentPlanUpdate,
@@ -89,13 +87,13 @@ if TYPE_CHECKING:
 SessionConfigOption: Any = getattr(_acp_schema, "SessionConfigOption", None)
 """Compatibility alias for the optional ACP `SessionConfigOption` wrapper."""
 
-McpServer: TypeAlias = HttpMcpServer | SseMcpServer | AcpMcpServer | McpServerStdio
+McpServer: TypeAlias = HttpMcpServer | SseMcpServer | McpServerStdio
 """Type alias for ACP MCP server configuration variants."""
 
 ReplayContentBlock: TypeAlias = TextContentBlock | ImageContentBlock | AudioContentBlock
 """ACP content blocks that can be reconstructed from LangChain messages."""
 
-_MCP_SERVER_TYPES = (HttpMcpServer, SseMcpServer, AcpMcpServer, McpServerStdio)
+_MCP_SERVER_TYPES = (HttpMcpServer, SseMcpServer, McpServerStdio)
 """Runtime MCP server classes used to detect legacy positional `new_session` calls."""
 
 _ACP_MODE_METADATA_KEY = "acp_mode"
@@ -138,58 +136,22 @@ def _is_mcp_servers(
     return all(isinstance(server, _MCP_SERVER_TYPES) for server in mcp_servers)
 
 
-def _langchain_content_blocks(message: Any) -> list[dict[str, Any]]:
-    """Return normalized LangChain content blocks for a persisted message."""
-    try:
-        blocks = message.content_blocks
-    except (AttributeError, TypeError, ValueError):
-        content = getattr(message, "content", "")
-        if isinstance(content, str):
-            return [{"type": "text", "text": content}]
-        if not isinstance(content, list):
-            return []
-        blocks = [
-            {"type": "text", "text": block} if isinstance(block, str) else block
-            for block in content
-        ]
-    return [block for block in blocks if isinstance(block, dict)]
-
-
 def _replay_content_blocks(message: Any) -> list[ReplayContentBlock]:
     """Convert persisted LangChain content into replayable ACP blocks."""
     replay_blocks: list[ReplayContentBlock] = []
-    for block in _langchain_content_blocks(message):
+    for block in message.content_blocks:
         block_type = block.get("type")
-        if block_type == "text" and isinstance(block.get("text"), str):
+        data = block.get("base64")
+        mime_type = block.get("mime_type")
+        if block_type == "text":
             replay_blocks.append(text_block(block["text"]))
+        elif not (isinstance(data, str) and isinstance(mime_type, str)):
             continue
-        if block_type == "image":
-            data = block.get("base64")
-            mime_type = block.get("mime_type")
-            if isinstance(data, str) and isinstance(mime_type, str):
-                replay_blocks.append(image_block(data, mime_type, uri=block.get("url")))
-            elif isinstance(block.get("url"), str):
-                replay_blocks.append(text_block(f"[Image: {block['url']}]"))
-            continue
-        if block_type == "audio":
-            data = block.get("base64")
-            mime_type = block.get("mime_type")
-            if isinstance(data, str) and isinstance(mime_type, str):
-                replay_blocks.append(audio_block(data, mime_type))
+        elif block_type == "image":
+            replay_blocks.append(image_block(data, mime_type, uri=block.get("url")))
+        elif block_type == "audio":
+            replay_blocks.append(audio_block(data, mime_type))
     return replay_blocks
-
-
-def _replay_message_text(message: Any) -> str:
-    """Flatten the textual portion of a persisted message."""
-    text = "".join(
-        block["text"]
-        for block in _langchain_content_blocks(message)
-        if block.get("type") == "text" and isinstance(block.get("text"), str)
-    )
-    if text:
-        return text
-    content = getattr(message, "content", "")
-    return content if isinstance(content, str) else str(content)
 
 
 @dataclass(frozen=True, slots=True)
@@ -386,30 +348,21 @@ class AgentServerACP(ACPAgent):
         if not self._load_sessions:
             method = "session/load"
             raise RequestError.method_not_found(method)
-        if not Path(cwd).is_absolute():
-            raise RequestError.invalid_params({"cwd": "must be an absolute path"})
 
         self._session_cwds[session_id] = cwd
-        self._session_mcp_servers[session_id] = list(mcp_servers or [])
-        self._initialize_session_options(session_id)
         agent = self._checkpointed_agent(session_id)
-
-        snapshot = await agent.aget_state(self._session_config(session_id))
-        if snapshot.created_at is None:
-            self._forget_session(session_id)
-            raise RequestError.resource_not_found(session_id)
-
-        metadata = snapshot.metadata or {}
+        metadata = (await agent.aget_state(self._session_config(session_id))).metadata or {}
         if metadata.get(_ACP_SESSION_METADATA_KEY) is not True:
-            self._forget_session(session_id)
+            del self._session_cwds[session_id]
             raise RequestError.resource_not_found(session_id)
-        saved_cwd = metadata.get("cwd")
-        if saved_cwd != cwd:
-            self._forget_session(session_id)
+        if metadata.get("cwd") != cwd:
+            del self._session_cwds[session_id]
             raise RequestError.invalid_params(
                 {"cwd": "must match the working directory used to create the session"}
             )
 
+        self._session_mcp_servers[session_id] = list(mcp_servers or [])
+        self._initialize_session_options(session_id)
         if self._restore_session_options(session_id, metadata):
             self._reset_agent(session_id)
 
@@ -809,19 +762,6 @@ class AgentServerACP(ACPAgent):
         agent = self._checkpointed_agent(session_id)
         await agent.aupdate_state(self._session_config(session_id), {}, as_node="__start__")
 
-    def _forget_session(self, session_id: str) -> None:
-        """Remove transient state created while attempting to load a session."""
-        self._session_cwds.pop(session_id, None)
-        self._session_mcp_servers.pop(session_id, None)
-        self._session_modes.pop(session_id, None)
-        self._session_mode_states.pop(session_id, None)
-        self._session_models.pop(session_id, None)
-        self._session_plans.pop(session_id, None)
-        self._allowed_command_types.pop(session_id, None)
-        if self._agent_session_id == session_id:
-            self._agent = None
-            self._agent_session_id = None
-
     async def _replay_session(
         self,
         session_id: str,
@@ -829,20 +769,12 @@ class AgentServerACP(ACPAgent):
     ) -> None:
         """Replay persisted conversation entries before `session/load` returns."""
         active_tool_calls: dict[str, dict[str, Any]] = {}
-        messages = await self._persisted_messages(session_id, agent)
-        for index, message in enumerate(messages):
-            message_type = getattr(message, "type", None)
-            message_id = getattr(message, "id", None) or f"{session_id}:message:{index}"
-            if message_type == "human":
-                await self._replay_human_message(session_id, message_id, message)
-            elif message_type == "ai":
-                await self._replay_ai_message(
-                    session_id,
-                    message_id,
-                    message,
-                    active_tool_calls,
-                )
-            elif message_type == "tool":
+        for message in await self._persisted_messages(session_id, agent):
+            if message.type == "human":
+                await self._replay_human_message(session_id, message.id, message)
+            elif message.type == "ai":
+                await self._replay_ai_message(session_id, message.id, message, active_tool_calls)
+            elif message.type == "tool":
                 await self._replay_tool_message(session_id, message, active_tool_calls)
 
     async def _persisted_messages(
@@ -855,36 +787,12 @@ class AgentServerACP(ACPAgent):
             snapshot
             async for snapshot in agent.aget_state_history(self._session_config(session_id))
         ]
-        messages_by_key: dict[tuple[str, int], Any] = {}
-        message_order: list[tuple[str, int]] = []
+        # Reassignment keeps a message's original position while taking its newest revision.
+        messages: dict[str, Any] = {}
         for snapshot in reversed(snapshots):
-            messages = snapshot.values.get("messages", [])
-            if not isinstance(messages, list):
-                continue
-            occurrences: dict[str, int] = {}
-            for message in messages:
-                message_id = getattr(message, "id", None)
-                key = (
-                    message_id
-                    if isinstance(message_id, str)
-                    else json.dumps(
-                        {
-                            "type": getattr(message, "type", None),
-                            "content": getattr(message, "content", None),
-                            "tool_calls": getattr(message, "tool_calls", None),
-                            "tool_call_id": getattr(message, "tool_call_id", None),
-                        },
-                        default=str,
-                        sort_keys=True,
-                    )
-                )
-                occurrence = occurrences.get(key, 0)
-                occurrences[key] = occurrence + 1
-                identity = (key, occurrence)
-                if identity not in messages_by_key:
-                    message_order.append(identity)
-                messages_by_key[identity] = message
-        return [messages_by_key[key] for key in message_order]
+            for message in snapshot.values.get("messages", []):
+                messages[message.id] = message
+        return list(messages.values())
 
     async def _replay_human_message(
         self,
@@ -894,14 +802,13 @@ class AgentServerACP(ACPAgent):
     ) -> None:
         """Replay one persisted user message."""
         for block in _replay_content_blocks(message):
-            update = UserMessageChunk(
-                session_update="user_message_chunk",
-                content=block,
-                message_id=message_id,
-            )
             await self._conn.session_update(
                 session_id=session_id,
-                update=update,
+                update=UserMessageChunk(
+                    session_update="user_message_chunk",
+                    content=block,
+                    message_id=message_id,
+                ),
                 source="DeepAgent",
             )
 
@@ -914,28 +821,21 @@ class AgentServerACP(ACPAgent):
     ) -> None:
         """Replay one persisted assistant message and its tool calls."""
         for block in _replay_content_blocks(message):
-            update = AgentMessageChunk(
-                session_update="agent_message_chunk",
-                content=block,
-                message_id=message_id,
-            )
             await self._conn.session_update(
                 session_id=session_id,
-                update=update,
+                update=AgentMessageChunk(
+                    session_update="agent_message_chunk",
+                    content=block,
+                    message_id=message_id,
+                ),
                 source="DeepAgent",
             )
-        for tool_call in getattr(message, "tool_calls", []):
-            if not isinstance(tool_call, dict):
-                continue
+        for tool_call in message.tool_calls:
             tool_id = tool_call.get("id")
-            tool_name = tool_call.get("name")
-            tool_args = tool_call.get("args")
-            if not (
-                isinstance(tool_id, str)
-                and isinstance(tool_name, str)
-                and isinstance(tool_args, dict)
-            ):
+            if tool_id is None:
                 continue
+            tool_name = tool_call["name"]
+            tool_args = tool_call["args"]
             active_tool_calls[tool_id] = {"name": tool_name, "args": tool_args}
             await self._conn.session_update(
                 session_id=session_id,
@@ -956,13 +856,12 @@ class AgentServerACP(ACPAgent):
         active_tool_calls: dict[str, dict[str, Any]],
     ) -> None:
         """Replay one persisted tool result."""
-        tool_call_id = getattr(message, "tool_call_id", None)
-        tool_info = active_tool_calls.get(tool_call_id)
-        if not isinstance(tool_call_id, str) or tool_info is None:
+        tool_info = active_tool_calls.get(message.tool_call_id)
+        if tool_info is None or tool_info["name"] == "edit_file":
             return
-        if tool_info["name"] == "edit_file":
-            return
-        content = _replay_message_text(message)
+        content = "".join(
+            block["text"] for block in message.content_blocks if block.get("type") == "text"
+        )
         if tool_info["name"] == "execute":
             content = format_execute_result(
                 command=str(tool_info["args"].get("command", "")),
@@ -971,8 +870,8 @@ class AgentServerACP(ACPAgent):
         await self._conn.session_update(
             session_id=session_id,
             update=update_tool_call(
-                tool_call_id=tool_call_id,
-                status=("failed" if getattr(message, "status", None) == "error" else "completed"),
+                tool_call_id=message.tool_call_id,
+                status="failed" if message.status == "error" else "completed",
                 content=[tool_content(text_block(content))],
             ),
             source="DeepAgent",

--- a/libs/acp/deepagents_acp/server.py
+++ b/libs/acp/deepagents_acp/server.py
@@ -340,8 +340,8 @@ class AgentServerACP(ACPAgent):
         self,
         cwd: str,
         session_id: str,
-        mcp_servers: list[McpServer] | None = None,
         additional_directories: list[str] | None = None,  # noqa: ARG002  # capability is not advertised
+        mcp_servers: list[McpServer] | None = None,
         **kwargs: Any,  # noqa: ARG002  # ACP protocol interface parameter
     ) -> LoadSessionResponse:
         """Restore and replay a persisted ACP session."""
@@ -353,10 +353,10 @@ class AgentServerACP(ACPAgent):
         agent = self._checkpointed_agent(session_id)
         metadata = (await agent.aget_state(self._session_config(session_id))).metadata or {}
         if metadata.get(_ACP_SESSION_METADATA_KEY) is not True:
-            del self._session_cwds[session_id]
+            self._forget_session(session_id)
             raise RequestError.resource_not_found(session_id)
         if metadata.get("cwd") != cwd:
-            del self._session_cwds[session_id]
+            self._forget_session(session_id)
             raise RequestError.invalid_params(
                 {"cwd": "must match the working directory used to create the session"}
             )
@@ -876,6 +876,13 @@ class AgentServerACP(ACPAgent):
             ),
             source="DeepAgent",
         )
+
+    def _forget_session(self, session_id: str) -> None:
+        """Discard state created while validating a session."""
+        self._session_cwds.pop(session_id, None)
+        if self._agent_session_id == session_id:
+            self._agent = None
+            self._agent_session_id = None
 
     def _reset_agent(self, session_id: str) -> None:
         """Reset the agent instance, re-creating it from the factory if applicable."""

--- a/libs/acp/deepagents_acp/server.py
+++ b/libs/acp/deepagents_acp/server.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeGuard
 from uuid import uuid4
 
@@ -90,9 +89,6 @@ SessionConfigOption: Any = getattr(_acp_schema, "SessionConfigOption", None)
 McpServer: TypeAlias = HttpMcpServer | SseMcpServer | McpServerStdio
 """Type alias for ACP MCP server configuration variants."""
 
-ReplayContentBlock: TypeAlias = TextContentBlock | ImageContentBlock | AudioContentBlock
-"""ACP content blocks that can be reconstructed from LangChain messages."""
-
 _MCP_SERVER_TYPES = (HttpMcpServer, SseMcpServer, McpServerStdio)
 """Runtime MCP server classes used to detect legacy positional `new_session` calls."""
 
@@ -136,9 +132,11 @@ def _is_mcp_servers(
     return all(isinstance(server, _MCP_SERVER_TYPES) for server in mcp_servers)
 
 
-def _replay_content_blocks(message: Any) -> list[ReplayContentBlock]:
+def _replay_content_blocks(
+    message: Any,
+) -> list[TextContentBlock | ImageContentBlock | AudioContentBlock]:
     """Convert persisted LangChain content into replayable ACP blocks."""
-    replay_blocks: list[ReplayContentBlock] = []
+    replay_blocks: list[TextContentBlock | ImageContentBlock | AudioContentBlock] = []
     for block in message.content_blocks:
         block_type = block.get("type")
         data = block.get("base64")
@@ -175,7 +173,6 @@ class AgentServerACP(ACPAgent):
         modes: SessionModeState | None = None,
         models: list[dict[str, str]] | None = None,
         load_sessions: bool = False,
-        checkpoint_metadata: Mapping[str, Any] | None = None,
     ) -> None:
         """Initialize the ACP agent server with the given agent factory or compiled graph.
 
@@ -186,7 +183,6 @@ class AgentServerACP(ACPAgent):
               'description'
             load_sessions: Advertise and implement durable `session/load`. The agent graph
               must use a checkpointer that survives server restarts.
-            checkpoint_metadata: Metadata to add to every ACP session checkpoint.
         """
         super().__init__()
         self._cwd = ""
@@ -194,7 +190,6 @@ class AgentServerACP(ACPAgent):
         self._agent: CompiledStateGraph | None = None
         self._agent_session_id: str | None = None
         self._load_sessions = load_sessions
-        self._checkpoint_metadata = dict(checkpoint_metadata or {})
 
         if isinstance(agent, CompiledStateGraph):
             if modes is not None:
@@ -737,10 +732,8 @@ class AgentServerACP(ACPAgent):
     def _session_config(self, session_id: str) -> RunnableConfig:
         """Build the LangGraph config and durable metadata for an ACP session."""
         metadata = {
-            **self._checkpoint_metadata,
             _ACP_SESSION_METADATA_KEY: True,
             "cwd": self._session_cwds[session_id],
-            "updated_at": datetime.now(UTC).isoformat(),
         }
         if session_id in self._session_modes:
             metadata[_ACP_MODE_METADATA_KEY] = self._session_modes[session_id]
@@ -768,31 +761,23 @@ class AgentServerACP(ACPAgent):
         agent: CompiledStateGraph,
     ) -> None:
         """Replay persisted conversation entries before `session/load` returns."""
+        snapshots = [
+            snapshot
+            async for snapshot in agent.aget_state_history(self._session_config(session_id))
+        ]
+        messages: dict[str, Any] = {}
+        for snapshot in reversed(snapshots):
+            for message in snapshot.values.get("messages", []):
+                messages[message.id] = message
+
         active_tool_calls: dict[str, dict[str, Any]] = {}
-        for message in await self._persisted_messages(session_id, agent):
+        for message in messages.values():
             if message.type == "human":
                 await self._replay_human_message(session_id, message.id, message)
             elif message.type == "ai":
                 await self._replay_ai_message(session_id, message.id, message, active_tool_calls)
             elif message.type == "tool":
                 await self._replay_tool_message(session_id, message, active_tool_calls)
-
-    async def _persisted_messages(
-        self,
-        session_id: str,
-        agent: CompiledStateGraph,
-    ) -> list[Any]:
-        """Reconstruct messages removed from the latest state by compaction."""
-        snapshots = [
-            snapshot
-            async for snapshot in agent.aget_state_history(self._session_config(session_id))
-        ]
-        # Reassignment keeps a message's original position while taking its newest revision.
-        messages: dict[str, Any] = {}
-        for snapshot in reversed(snapshots):
-            for message in snapshot.values.get("messages", []):
-                messages[message.id] = message
-        return list(messages.values())
 
     async def _replay_human_message(
         self,

--- a/libs/acp/deepagents_acp/server.py
+++ b/libs/acp/deepagents_acp/server.py
@@ -4,16 +4,21 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeGuard
 from uuid import uuid4
 
 from acp import (
     Agent as ACPAgent,
     InitializeResponse,
+    LoadSessionResponse,
     NewSessionResponse,
     PromptResponse,
     SetSessionConfigOptionResponse,
     SetSessionModeResponse,
+    audio_block,
+    image_block,
     run_agent as run_acp_agent,
     schema as _acp_schema,
     start_edit_tool_call,
@@ -26,7 +31,9 @@ from acp import (
 )
 from acp.exceptions import RequestError
 from acp.schema import (
+    AcpMcpServer,
     AgentCapabilities,
+    AgentMessageChunk,
     AgentPlanUpdate,
     AudioContentBlock,
     ClientCapabilities,
@@ -48,6 +55,7 @@ from acp.schema import (
     ToolCallStart,
     ToolCallUpdate,
     ToolKind,
+    UserMessageChunk,
 )
 from deepagents import create_deep_agent
 from deepagents.backends import CompositeBackend, FilesystemBackend, StateBackend
@@ -68,7 +76,7 @@ from deepagents_acp.utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Mapping, Sequence
 
     from acp.interfaces import Client
     from deepagents.graph import Checkpointer
@@ -81,11 +89,18 @@ if TYPE_CHECKING:
 SessionConfigOption: Any = getattr(_acp_schema, "SessionConfigOption", None)
 """Compatibility alias for the optional ACP `SessionConfigOption` wrapper."""
 
-McpServer: TypeAlias = HttpMcpServer | SseMcpServer | McpServerStdio
+McpServer: TypeAlias = HttpMcpServer | SseMcpServer | AcpMcpServer | McpServerStdio
 """Type alias for ACP MCP server configuration variants."""
 
-_MCP_SERVER_TYPES = (HttpMcpServer, SseMcpServer, McpServerStdio)
+ReplayContentBlock: TypeAlias = TextContentBlock | ImageContentBlock | AudioContentBlock
+"""ACP content blocks that can be reconstructed from LangChain messages."""
+
+_MCP_SERVER_TYPES = (HttpMcpServer, SseMcpServer, AcpMcpServer, McpServerStdio)
 """Runtime MCP server classes used to detect legacy positional `new_session` calls."""
+
+_ACP_MODE_METADATA_KEY = "acp_mode"
+_ACP_MODEL_METADATA_KEY = "acp_model"
+_ACP_SESSION_METADATA_KEY = "acp_session"
 
 
 def _normalize_new_session_args(
@@ -123,6 +138,60 @@ def _is_mcp_servers(
     return all(isinstance(server, _MCP_SERVER_TYPES) for server in mcp_servers)
 
 
+def _langchain_content_blocks(message: Any) -> list[dict[str, Any]]:
+    """Return normalized LangChain content blocks for a persisted message."""
+    try:
+        blocks = message.content_blocks
+    except (AttributeError, TypeError, ValueError):
+        content = getattr(message, "content", "")
+        if isinstance(content, str):
+            return [{"type": "text", "text": content}]
+        if not isinstance(content, list):
+            return []
+        blocks = [
+            {"type": "text", "text": block} if isinstance(block, str) else block
+            for block in content
+        ]
+    return [block for block in blocks if isinstance(block, dict)]
+
+
+def _replay_content_blocks(message: Any) -> list[ReplayContentBlock]:
+    """Convert persisted LangChain content into replayable ACP blocks."""
+    replay_blocks: list[ReplayContentBlock] = []
+    for block in _langchain_content_blocks(message):
+        block_type = block.get("type")
+        if block_type == "text" and isinstance(block.get("text"), str):
+            replay_blocks.append(text_block(block["text"]))
+            continue
+        if block_type == "image":
+            data = block.get("base64")
+            mime_type = block.get("mime_type")
+            if isinstance(data, str) and isinstance(mime_type, str):
+                replay_blocks.append(image_block(data, mime_type, uri=block.get("url")))
+            elif isinstance(block.get("url"), str):
+                replay_blocks.append(text_block(f"[Image: {block['url']}]"))
+            continue
+        if block_type == "audio":
+            data = block.get("base64")
+            mime_type = block.get("mime_type")
+            if isinstance(data, str) and isinstance(mime_type, str):
+                replay_blocks.append(audio_block(data, mime_type))
+    return replay_blocks
+
+
+def _replay_message_text(message: Any) -> str:
+    """Flatten the textual portion of a persisted message."""
+    text = "".join(
+        block["text"]
+        for block in _langchain_content_blocks(message)
+        if block.get("type") == "text" and isinstance(block.get("text"), str)
+    )
+    if text:
+        return text
+    content = getattr(message, "content", "")
+    return content if isinstance(content, str) else str(content)
+
+
 @dataclass(frozen=True, slots=True)
 class AgentSessionContext:
     """Context for an agent session, including working directory, mode, and model."""
@@ -143,6 +212,8 @@ class AgentServerACP(ACPAgent):
         *,
         modes: SessionModeState | None = None,
         models: list[dict[str, str]] | None = None,
+        load_sessions: bool = False,
+        checkpoint_metadata: Mapping[str, Any] | None = None,
     ) -> None:
         """Initialize the ACP agent server with the given agent factory or compiled graph.
 
@@ -151,11 +222,17 @@ class AgentServerACP(ACPAgent):
             modes: Optional mode configuration (deprecated, use config_options instead)
             models: Optional list of available models with 'value', 'name', and optionally
               'description'
+            load_sessions: Advertise and implement durable `session/load`. The agent graph
+              must use a checkpointer that survives server restarts.
+            checkpoint_metadata: Metadata to add to every ACP session checkpoint.
         """
         super().__init__()
         self._cwd = ""
         self._agent_factory = agent
         self._agent: CompiledStateGraph | None = None
+        self._agent_session_id: str | None = None
+        self._load_sessions = load_sessions
+        self._checkpoint_metadata = dict(checkpoint_metadata or {})
 
         if isinstance(agent, CompiledStateGraph):
             if modes is not None:
@@ -260,9 +337,10 @@ class AgentServerACP(ACPAgent):
         return InitializeResponse(
             protocol_version=protocol_version,
             agent_capabilities=AgentCapabilities(
+                load_session=self._load_sessions,
                 prompt_capabilities=PromptCapabilities(
                     image=True,
-                )
+                ),
             ),
         )
 
@@ -279,13 +357,10 @@ class AgentServerACP(ACPAgent):
         self._session_cwds[session_id] = cwd
         self._session_mcp_servers[session_id] = mcp_servers
 
-        # Initialize session state
-        if self._modes is not None:
-            self._session_modes[session_id] = self._modes.current_mode_id
-            self._session_mode_states[session_id] = self._modes
+        self._initialize_session_options(session_id)
 
-        if self._models is not None and len(self._models) > 0:
-            self._session_models[session_id] = self._models[0]["value"]
+        if self._load_sessions:
+            await self._persist_session(session_id)
 
         # Build config options if we have modes or models
         config_options = None
@@ -297,6 +372,51 @@ class AgentServerACP(ACPAgent):
             session_id=session_id,
             modes=self._modes if self._modes is not None else None,
             config_options=config_options,
+        )
+
+    async def load_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[McpServer] | None = None,
+        additional_directories: list[str] | None = None,  # noqa: ARG002  # capability is not advertised
+        **kwargs: Any,  # noqa: ARG002  # ACP protocol interface parameter
+    ) -> LoadSessionResponse:
+        """Restore and replay a persisted ACP session."""
+        if not self._load_sessions:
+            method = "session/load"
+            raise RequestError.method_not_found(method)
+        if not Path(cwd).is_absolute():
+            raise RequestError.invalid_params({"cwd": "must be an absolute path"})
+
+        self._session_cwds[session_id] = cwd
+        self._session_mcp_servers[session_id] = list(mcp_servers or [])
+        self._initialize_session_options(session_id)
+        agent = self._checkpointed_agent(session_id)
+
+        snapshot = await agent.aget_state(self._session_config(session_id))
+        if snapshot.created_at is None:
+            self._forget_session(session_id)
+            raise RequestError.resource_not_found(session_id)
+
+        metadata = snapshot.metadata or {}
+        if metadata.get(_ACP_SESSION_METADATA_KEY) is not True:
+            self._forget_session(session_id)
+            raise RequestError.resource_not_found(session_id)
+        saved_cwd = metadata.get("cwd")
+        if saved_cwd != cwd:
+            self._forget_session(session_id)
+            raise RequestError.invalid_params(
+                {"cwd": "must match the working directory used to create the session"}
+            )
+
+        if self._restore_session_options(session_id, metadata):
+            self._reset_agent(session_id)
+
+        await self._replay_session(session_id, agent)
+        return LoadSessionResponse(
+            modes=self._session_mode_states.get(session_id),
+            config_options=self._build_config_options(session_id) or None,
         )
 
     async def set_session_mode(
@@ -314,6 +434,8 @@ class AgentServerACP(ACPAgent):
                 current_mode_id=mode_id,
             )
             self._reset_agent(session_id)
+            if self._load_sessions:
+                await self._persist_session(session_id)
         return SetSessionModeResponse()
 
     async def set_config_option(
@@ -349,6 +471,8 @@ class AgentServerACP(ACPAgent):
                     current_mode_id=value,
                 )
                 self._reset_agent(session_id)
+                if self._load_sessions:
+                    await self._persist_session(session_id)
 
         elif config_id == "model":
             # Handle model switching
@@ -363,6 +487,8 @@ class AgentServerACP(ACPAgent):
                 self._session_models[session_id] = value
                 # Reset the agent to use the new model
                 self._reset_agent(session_id)
+                if self._load_sessions:
+                    await self._persist_session(session_id)
         else:
             msg = f"Unknown config option: {config_id}"
             raise RequestError(-32602, msg)
@@ -616,6 +742,242 @@ class AgentServerACP(ACPAgent):
             raw_input=tool_args,
         )
 
+    def _initialize_session_options(self, session_id: str) -> None:
+        """Initialize mode and model state for a new or loaded session."""
+        if self._modes is not None:
+            self._session_modes[session_id] = self._modes.current_mode_id
+            self._session_mode_states[session_id] = self._modes
+        if self._models:
+            self._session_models[session_id] = self._models[0]["value"]
+
+    def _restore_session_options(self, session_id: str, metadata: Mapping[str, Any]) -> bool:
+        """Restore persisted mode and model selections.
+
+        Returns:
+            Whether restoring the selections requires rebuilding a factory agent.
+        """
+        changed = False
+        saved_mode = metadata.get(_ACP_MODE_METADATA_KEY)
+        if (
+            self._modes is not None
+            and isinstance(saved_mode, str)
+            and any(mode.id == saved_mode for mode in self._modes.available_modes)
+        ):
+            state = self._session_mode_states[session_id]
+            self._session_modes[session_id] = saved_mode
+            self._session_mode_states[session_id] = SessionModeState(
+                available_modes=state.available_modes,
+                current_mode_id=saved_mode,
+            )
+            changed = saved_mode != self._modes.current_mode_id
+
+        saved_model = metadata.get(_ACP_MODEL_METADATA_KEY)
+        if (
+            self._models
+            and isinstance(saved_model, str)
+            and any(model["value"] == saved_model for model in self._models)
+        ):
+            self._session_models[session_id] = saved_model
+            changed = changed or saved_model != self._models[0]["value"]
+        return changed
+
+    def _session_config(self, session_id: str) -> RunnableConfig:
+        """Build the LangGraph config and durable metadata for an ACP session."""
+        metadata = {
+            **self._checkpoint_metadata,
+            _ACP_SESSION_METADATA_KEY: True,
+            "cwd": self._session_cwds[session_id],
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+        if session_id in self._session_modes:
+            metadata[_ACP_MODE_METADATA_KEY] = self._session_modes[session_id]
+        if session_id in self._session_models:
+            metadata[_ACP_MODEL_METADATA_KEY] = self._session_models[session_id]
+        return {"configurable": {"thread_id": session_id}, "metadata": metadata}
+
+    def _checkpointed_agent(self, session_id: str) -> CompiledStateGraph:
+        """Return the session agent, requiring a configured checkpointer."""
+        if self._agent is None or self._agent_session_id != session_id:
+            self._reset_agent(session_id)
+        if self._agent is None or getattr(self._agent, "checkpointer", None) is None:
+            msg = "session/load requires an agent compiled with a checkpointer"
+            raise RuntimeError(msg)
+        return self._agent
+
+    async def _persist_session(self, session_id: str) -> None:
+        """Write the current ACP session metadata to its checkpoint thread."""
+        agent = self._checkpointed_agent(session_id)
+        await agent.aupdate_state(self._session_config(session_id), {}, as_node="__start__")
+
+    def _forget_session(self, session_id: str) -> None:
+        """Remove transient state created while attempting to load a session."""
+        self._session_cwds.pop(session_id, None)
+        self._session_mcp_servers.pop(session_id, None)
+        self._session_modes.pop(session_id, None)
+        self._session_mode_states.pop(session_id, None)
+        self._session_models.pop(session_id, None)
+        self._session_plans.pop(session_id, None)
+        self._allowed_command_types.pop(session_id, None)
+        if self._agent_session_id == session_id:
+            self._agent = None
+            self._agent_session_id = None
+
+    async def _replay_session(
+        self,
+        session_id: str,
+        agent: CompiledStateGraph,
+    ) -> None:
+        """Replay persisted conversation entries before `session/load` returns."""
+        active_tool_calls: dict[str, dict[str, Any]] = {}
+        messages = await self._persisted_messages(session_id, agent)
+        for index, message in enumerate(messages):
+            message_type = getattr(message, "type", None)
+            message_id = getattr(message, "id", None) or f"{session_id}:message:{index}"
+            if message_type == "human":
+                await self._replay_human_message(session_id, message_id, message)
+            elif message_type == "ai":
+                await self._replay_ai_message(
+                    session_id,
+                    message_id,
+                    message,
+                    active_tool_calls,
+                )
+            elif message_type == "tool":
+                await self._replay_tool_message(session_id, message, active_tool_calls)
+
+    async def _persisted_messages(
+        self,
+        session_id: str,
+        agent: CompiledStateGraph,
+    ) -> list[Any]:
+        """Reconstruct messages removed from the latest state by compaction."""
+        snapshots = [
+            snapshot
+            async for snapshot in agent.aget_state_history(self._session_config(session_id))
+        ]
+        messages_by_key: dict[tuple[str, int], Any] = {}
+        message_order: list[tuple[str, int]] = []
+        for snapshot in reversed(snapshots):
+            messages = snapshot.values.get("messages", [])
+            if not isinstance(messages, list):
+                continue
+            occurrences: dict[str, int] = {}
+            for message in messages:
+                message_id = getattr(message, "id", None)
+                key = (
+                    message_id
+                    if isinstance(message_id, str)
+                    else json.dumps(
+                        {
+                            "type": getattr(message, "type", None),
+                            "content": getattr(message, "content", None),
+                            "tool_calls": getattr(message, "tool_calls", None),
+                            "tool_call_id": getattr(message, "tool_call_id", None),
+                        },
+                        default=str,
+                        sort_keys=True,
+                    )
+                )
+                occurrence = occurrences.get(key, 0)
+                occurrences[key] = occurrence + 1
+                identity = (key, occurrence)
+                if identity not in messages_by_key:
+                    message_order.append(identity)
+                messages_by_key[identity] = message
+        return [messages_by_key[key] for key in message_order]
+
+    async def _replay_human_message(
+        self,
+        session_id: str,
+        message_id: str,
+        message: Any,
+    ) -> None:
+        """Replay one persisted user message."""
+        for block in _replay_content_blocks(message):
+            update = UserMessageChunk(
+                session_update="user_message_chunk",
+                content=block,
+                message_id=message_id,
+            )
+            await self._conn.session_update(
+                session_id=session_id,
+                update=update,
+                source="DeepAgent",
+            )
+
+    async def _replay_ai_message(
+        self,
+        session_id: str,
+        message_id: str,
+        message: Any,
+        active_tool_calls: dict[str, dict[str, Any]],
+    ) -> None:
+        """Replay one persisted assistant message and its tool calls."""
+        for block in _replay_content_blocks(message):
+            update = AgentMessageChunk(
+                session_update="agent_message_chunk",
+                content=block,
+                message_id=message_id,
+            )
+            await self._conn.session_update(
+                session_id=session_id,
+                update=update,
+                source="DeepAgent",
+            )
+        for tool_call in getattr(message, "tool_calls", []):
+            if not isinstance(tool_call, dict):
+                continue
+            tool_id = tool_call.get("id")
+            tool_name = tool_call.get("name")
+            tool_args = tool_call.get("args")
+            if not (
+                isinstance(tool_id, str)
+                and isinstance(tool_name, str)
+                and isinstance(tool_args, dict)
+            ):
+                continue
+            active_tool_calls[tool_id] = {"name": tool_name, "args": tool_args}
+            await self._conn.session_update(
+                session_id=session_id,
+                update=self._create_tool_call_start(tool_id, tool_name, tool_args),
+                source="DeepAgent",
+            )
+            if tool_name == "write_todos":
+                await self._handle_todo_update(
+                    session_id,
+                    tool_args.get("todos", []),
+                    log_plan=False,
+                )
+
+    async def _replay_tool_message(
+        self,
+        session_id: str,
+        message: Any,
+        active_tool_calls: dict[str, dict[str, Any]],
+    ) -> None:
+        """Replay one persisted tool result."""
+        tool_call_id = getattr(message, "tool_call_id", None)
+        tool_info = active_tool_calls.get(tool_call_id)
+        if not isinstance(tool_call_id, str) or tool_info is None:
+            return
+        if tool_info["name"] == "edit_file":
+            return
+        content = _replay_message_text(message)
+        if tool_info["name"] == "execute":
+            content = format_execute_result(
+                command=str(tool_info["args"].get("command", "")),
+                result=content,
+            )
+        await self._conn.session_update(
+            session_id=session_id,
+            update=update_tool_call(
+                tool_call_id=tool_call_id,
+                status=("failed" if getattr(message, "status", None) == "error" else "completed"),
+                content=[tool_content(text_block(content))],
+            ),
+            source="DeepAgent",
+        )
+
     def _reset_agent(self, session_id: str) -> None:
         """Reset the agent instance, re-creating it from the factory if applicable."""
         cwd = self._session_cwds.get(session_id)
@@ -631,6 +993,7 @@ class AgentServerACP(ACPAgent):
             model = self._session_models.get(session_id) if self._models is not None else None
             context = AgentSessionContext(cwd=self._cwd, mode=mode, model=model)
             self._agent = self._agent_factory(context)
+        self._agent_session_id = session_id
 
     async def prompt(  # noqa: C901, PLR0912, PLR0915  # Complex streaming protocol handler with many branches
         self,
@@ -646,7 +1009,9 @@ class AgentServerACP(ACPAgent):
         **kwargs: Any,  # noqa: ARG002  # ACP protocol interface parameter
     ) -> PromptResponse:
         """Process a user prompt and stream the agent response."""
-        if self._agent is None:
+        if self._agent is None or (
+            self._agent_session_id is not None and self._agent_session_id != session_id
+        ):
             self._reset_agent(session_id)
 
         if self._agent is None:
@@ -677,7 +1042,7 @@ class AgentServerACP(ACPAgent):
             elif isinstance(block, EmbeddedResourceContentBlock):
                 content_blocks.extend(convert_embedded_resource_block_to_content_blocks(block))
         # Stream the deep agent response with multimodal content
-        config: RunnableConfig = {"configurable": {"thread_id": session_id}}
+        config = self._session_config(session_id)
 
         # Track active tool calls and accumulate chunks by index
         active_tool_calls = {}

--- a/libs/acp/tests/test_agent.py
+++ b/libs/acp/tests/test_agent.py
@@ -433,7 +433,15 @@ async def test_acp_agent_load_session_rejects_sessions_it_did_not_create() -> No
 
 
 async def test_acp_agent_load_session_rejects_different_cwd() -> None:
-    server, _ = _persistent_server(_persistent_graph(MemorySaver()))
+    checkpointer = MemorySaver()
+    contexts: list[AgentSessionContext] = []
+
+    def build_agent(context: AgentSessionContext) -> CompiledStateGraph:
+        contexts.append(context)
+        return _persistent_graph(checkpointer)
+
+    server = AgentServerACP(agent=build_agent, load_sessions=True)
+    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
     session = await server.new_session(cwd="/tmp/original", mcp_servers=[])
 
     with pytest.raises(RequestError) as exc_info:
@@ -444,6 +452,8 @@ async def test_acp_agent_load_session_rejects_different_cwd() -> None:
         )
 
     assert exc_info.value.code == -32602
+    await server.load_session(cwd="/tmp/original", session_id=session.session_id, mcp_servers=[])
+    assert contexts[-1].cwd == "/tmp/original"
 
 
 async def test_acp_agent_load_session_is_unavailable_when_disabled() -> None:

--- a/libs/acp/tests/test_agent.py
+++ b/libs/acp/tests/test_agent.py
@@ -222,14 +222,25 @@ async def test_acp_agent_initialize_and_modes() -> None:
     assert session.modes is None
 
 
-async def test_acp_agent_load_session_replays_persisted_history() -> None:
-    checkpointer = MemorySaver()
-    first_graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([AIMessage(content="Pong")])),
+def _persistent_graph(checkpointer: MemorySaver, *replies: str) -> CompiledStateGraph:
+    """Compile a deep agent over `checkpointer` that answers with `replies`."""
+    return create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([AIMessage(content=reply) for reply in replies])),
         checkpointer=checkpointer,
     )
-    first_server = AgentServerACP(agent=first_graph, load_sessions=True)
-    first_server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+
+
+def _persistent_server(graph: CompiledStateGraph) -> tuple[AgentServerACP, FakeACPClient]:
+    """Build a `load_sessions` server for `graph` with a connected fake client."""
+    server = AgentServerACP(agent=graph, load_sessions=True)
+    client = FakeACPClient()
+    server.on_connect(client)  # type: ignore[arg-type]
+    return server, client
+
+
+async def test_acp_agent_load_session_replays_persisted_history() -> None:
+    checkpointer = MemorySaver()
+    first_server, _ = _persistent_server(_persistent_graph(checkpointer, "Pong"))
 
     session = await first_server.new_session(cwd="/tmp", mcp_servers=[])
     await first_server.prompt(
@@ -237,14 +248,7 @@ async def test_acp_agent_load_session_replays_persisted_history() -> None:
         session_id=session.session_id,
     )
 
-    restarted_graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=checkpointer,
-    )
-    restarted_server = AgentServerACP(agent=restarted_graph, load_sessions=True)
-    client = FakeACPClient()
-    restarted_server.on_connect(client)  # type: ignore[arg-type]
-
+    restarted_server, client = _persistent_server(_persistent_graph(checkpointer))
     init = await restarted_server.initialize(protocol_version=1)
     assert init.agent_capabilities.load_session is True
     response = await restarted_server.load_session(
@@ -264,12 +268,8 @@ async def test_acp_agent_load_session_replays_persisted_history() -> None:
 
 async def test_acp_agent_load_session_replays_tool_calls() -> None:
     checkpointer = MemorySaver()
-    graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=checkpointer,
-    )
-    server = AgentServerACP(agent=graph, load_sessions=True)
-    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    graph = _persistent_graph(checkpointer)
+    server, _ = _persistent_server(graph)
     session = await server.new_session(cwd="/tmp", mcp_servers=[])
     await graph.aupdate_state(
         server._session_config(session.session_id),
@@ -277,6 +277,7 @@ async def test_acp_agent_load_session_replays_tool_calls() -> None:
             "messages": [
                 AIMessage(
                     content="",
+                    id="agent-message",
                     tool_calls=[
                         {
                             "name": "execute",
@@ -286,20 +287,13 @@ async def test_acp_agent_load_session_replays_tool_calls() -> None:
                         }
                     ],
                 ),
-                ToolMessage(content="hi", tool_call_id="call_1"),
+                ToolMessage(content="hi", id="tool-message", tool_call_id="call_1"),
             ]
         },
         as_node="__start__",
     )
 
-    restarted_graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=checkpointer,
-    )
-    restarted_server = AgentServerACP(agent=restarted_graph, load_sessions=True)
-    client = FakeACPClient()
-    restarted_server.on_connect(client)  # type: ignore[arg-type]
-
+    restarted_server, client = _persistent_server(_persistent_graph(checkpointer))
     await restarted_server.load_session(
         cwd="/tmp",
         session_id=session.session_id,
@@ -320,12 +314,8 @@ async def test_acp_agent_load_session_replays_tool_calls() -> None:
 
 async def test_acp_agent_load_session_replays_compacted_messages() -> None:
     checkpointer = MemorySaver()
-    graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=checkpointer,
-    )
-    server = AgentServerACP(agent=graph, load_sessions=True)
-    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    graph = _persistent_graph(checkpointer)
+    server, _ = _persistent_server(graph)
     session = await server.new_session(cwd="/tmp", mcp_servers=[])
     config = server._session_config(session.session_id)
     await graph.aupdate_state(
@@ -350,13 +340,7 @@ async def test_acp_agent_load_session_replays_compacted_messages() -> None:
         as_node="model",
     )
 
-    restarted_graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=checkpointer,
-    )
-    restarted_server = AgentServerACP(agent=restarted_graph, load_sessions=True)
-    client = FakeACPClient()
-    restarted_server.on_connect(client)  # type: ignore[arg-type]
+    restarted_server, client = _persistent_server(_persistent_graph(checkpointer))
     await restarted_server.load_session(
         cwd="/tmp",
         session_id=session.session_id,
@@ -433,74 +417,23 @@ async def test_acp_agent_load_session_restores_config_options() -> None:
     assert contexts[-1] == AgentSessionContext(cwd="/tmp", mode="manual", model="model-b")
 
 
-async def test_acp_agent_load_session_restores_empty_session() -> None:
-    checkpointer = MemorySaver()
-    graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=checkpointer,
-    )
-    server = AgentServerACP(agent=graph, load_sessions=True)
-    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
-    session = await server.new_session(cwd="/tmp", mcp_servers=[])
-
-    restarted_graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=checkpointer,
-    )
-    restarted_server = AgentServerACP(agent=restarted_graph, load_sessions=True)
-    client = FakeACPClient()
-    restarted_server.on_connect(client)  # type: ignore[arg-type]
-
-    await restarted_server.load_session(
-        cwd="/tmp",
-        session_id=session.session_id,
-        mcp_servers=[],
-    )
-    assert client.events == []
-
-
-async def test_acp_agent_load_session_rejects_unknown_session() -> None:
-    graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=MemorySaver(),
-    )
-    server = AgentServerACP(agent=graph, load_sessions=True)
-    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
-
-    with pytest.raises(RequestError) as exc_info:
-        await server.load_session(cwd="/tmp", session_id="missing", mcp_servers=[])
-
-    assert exc_info.value.code == -32002
-
-
-async def test_acp_agent_load_session_rejects_non_acp_checkpoint() -> None:
-    checkpointer = MemorySaver()
-    graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=checkpointer,
-    )
+async def test_acp_agent_load_session_rejects_sessions_it_did_not_create() -> None:
+    graph = _persistent_graph(MemorySaver())
     await graph.aupdate_state(
         {"configurable": {"thread_id": "other"}, "metadata": {"cwd": "/tmp"}},
         {},
         as_node="__start__",
     )
-    server = AgentServerACP(agent=graph, load_sessions=True)
-    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    server, _ = _persistent_server(graph)
 
-    with pytest.raises(RequestError) as exc_info:
-        await server.load_session(cwd="/tmp", session_id="other", mcp_servers=[])
-
-    assert exc_info.value.code == -32002
+    for session_id in ("missing", "other"):
+        with pytest.raises(RequestError) as exc_info:
+            await server.load_session(cwd="/tmp", session_id=session_id, mcp_servers=[])
+        assert exc_info.value.code == -32002
 
 
 async def test_acp_agent_load_session_rejects_different_cwd() -> None:
-    checkpointer = MemorySaver()
-    graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=checkpointer,
-    )
-    server = AgentServerACP(agent=graph, load_sessions=True)
-    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    server, _ = _persistent_server(_persistent_graph(MemorySaver()))
     session = await server.new_session(cwd="/tmp/original", mcp_servers=[])
 
     with pytest.raises(RequestError) as exc_info:
@@ -513,25 +446,8 @@ async def test_acp_agent_load_session_rejects_different_cwd() -> None:
     assert exc_info.value.code == -32602
 
 
-async def test_acp_agent_load_session_rejects_relative_cwd() -> None:
-    graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=MemorySaver(),
-    )
-    server = AgentServerACP(agent=graph, load_sessions=True)
-
-    with pytest.raises(RequestError) as load_exc:
-        await server.load_session(cwd="relative", session_id="missing", mcp_servers=[])
-
-    assert load_exc.value.code == -32602
-
-
 async def test_acp_agent_load_session_is_unavailable_when_disabled() -> None:
-    graph = create_deep_agent(
-        model=GenericFakeChatModel(messages=iter([])),
-        checkpointer=MemorySaver(),
-    )
-    server = AgentServerACP(agent=graph)
+    server = AgentServerACP(agent=_persistent_graph(MemorySaver()))
 
     with pytest.raises(RequestError) as exc_info:
         await server.load_session(cwd="/tmp", session_id="session", mcp_servers=[])

--- a/libs/acp/tests/test_agent.py
+++ b/libs/acp/tests/test_agent.py
@@ -251,19 +251,17 @@ async def test_acp_agent_load_session_replays_persisted_history() -> None:
     restarted_server, client = _persistent_server(_persistent_graph(checkpointer))
     init = await restarted_server.initialize(protocol_version=1)
     assert init.agent_capabilities.load_session is True
-    response = await restarted_server.load_session(
+    await restarted_server.load_session(
         cwd="/tmp",
         session_id=session.session_id,
         mcp_servers=[],
     )
 
-    assert response.config_options is None
     updates = [event["update"] for event in client.events]
     user_updates = [update for update in updates if isinstance(update, UserMessageChunk)]
     agent_updates = [update for update in updates if isinstance(update, AgentMessageChunk)]
     assert [update.content.text for update in user_updates] == ["Ping"]
     assert [update.content.text for update in agent_updates] == ["Pong"]
-    assert all(update.message_id for update in [*user_updates, *agent_updates])
 
 
 async def test_acp_agent_load_session_replays_tool_calls() -> None:
@@ -454,15 +452,6 @@ async def test_acp_agent_load_session_rejects_different_cwd() -> None:
     assert exc_info.value.code == -32602
     await server.load_session(cwd="/tmp/original", session_id=session.session_id, mcp_servers=[])
     assert contexts[-1].cwd == "/tmp/original"
-
-
-async def test_acp_agent_load_session_is_unavailable_when_disabled() -> None:
-    server = AgentServerACP(agent=_persistent_graph(MemorySaver()))
-
-    with pytest.raises(RequestError) as exc_info:
-        await server.load_session(cwd="/tmp", session_id="session", mcp_servers=[])
-
-    assert exc_info.value.code == -32601
 
 
 async def test_new_session_preserves_positional_mcp_servers_slot() -> None:

--- a/libs/acp/tests/test_agent.py
+++ b/libs/acp/tests/test_agent.py
@@ -9,6 +9,7 @@ from acp import text_block, update_agent_message
 from acp.exceptions import RequestError
 from acp.interfaces import Client
 from acp.schema import (
+    AgentMessageChunk,
     AllowedOutcome,
     EmbeddedResourceContentBlock,
     ImageContentBlock,
@@ -22,12 +23,19 @@ from acp.schema import (
     TextContentBlock,
     TextResourceContents,
     ToolCallUpdate,
+    UserMessageChunk,
 )
 from deepagents import create_deep_agent
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware
 from langchain.tools import ToolRuntime
-from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    HumanMessage,
+    RemoveMessage,
+    ToolMessage,
+)
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langgraph.checkpoint.base import (
@@ -208,10 +216,327 @@ async def test_acp_agent_initialize_and_modes() -> None:
 
     init = await agent.initialize(protocol_version=1)
     assert init.agent_capabilities.prompt_capabilities.image is True
-
+    assert init.agent_capabilities.load_session is False
     session = await agent.new_session(cwd="/tmp", mcp_servers=[])
     assert session.session_id
     assert session.modes is None
+
+
+async def test_acp_agent_load_session_replays_persisted_history() -> None:
+    checkpointer = MemorySaver()
+    first_graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([AIMessage(content="Pong")])),
+        checkpointer=checkpointer,
+    )
+    first_server = AgentServerACP(agent=first_graph, load_sessions=True)
+    first_server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+
+    session = await first_server.new_session(cwd="/tmp", mcp_servers=[])
+    await first_server.prompt(
+        [TextContentBlock(type="text", text="Ping")],
+        session_id=session.session_id,
+    )
+
+    restarted_graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=checkpointer,
+    )
+    restarted_server = AgentServerACP(agent=restarted_graph, load_sessions=True)
+    client = FakeACPClient()
+    restarted_server.on_connect(client)  # type: ignore[arg-type]
+
+    init = await restarted_server.initialize(protocol_version=1)
+    assert init.agent_capabilities.load_session is True
+    response = await restarted_server.load_session(
+        cwd="/tmp",
+        session_id=session.session_id,
+        mcp_servers=[],
+    )
+
+    assert response.config_options is None
+    updates = [event["update"] for event in client.events]
+    user_updates = [update for update in updates if isinstance(update, UserMessageChunk)]
+    agent_updates = [update for update in updates if isinstance(update, AgentMessageChunk)]
+    assert [update.content.text for update in user_updates] == ["Ping"]
+    assert [update.content.text for update in agent_updates] == ["Pong"]
+    assert all(update.message_id for update in [*user_updates, *agent_updates])
+
+
+async def test_acp_agent_load_session_replays_tool_calls() -> None:
+    checkpointer = MemorySaver()
+    graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=checkpointer,
+    )
+    server = AgentServerACP(agent=graph, load_sessions=True)
+    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    session = await server.new_session(cwd="/tmp", mcp_servers=[])
+    await graph.aupdate_state(
+        server._session_config(session.session_id),
+        {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "execute",
+                            "args": {"command": "echo hi"},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                ToolMessage(content="hi", tool_call_id="call_1"),
+            ]
+        },
+        as_node="__start__",
+    )
+
+    restarted_graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=checkpointer,
+    )
+    restarted_server = AgentServerACP(agent=restarted_graph, load_sessions=True)
+    client = FakeACPClient()
+    restarted_server.on_connect(client)  # type: ignore[arg-type]
+
+    await restarted_server.load_session(
+        cwd="/tmp",
+        session_id=session.session_id,
+        mcp_servers=[],
+    )
+
+    updates = [event["update"] for event in client.events]
+    tool_updates = [
+        update for update in updates if getattr(update, "tool_call_id", None) == "call_1"
+    ]
+    assert [update.session_update for update in tool_updates] == [
+        "tool_call",
+        "tool_call_update",
+    ]
+    assert tool_updates[0].raw_input == {"command": "echo hi"}
+    assert tool_updates[1].status == "completed"
+
+
+async def test_acp_agent_load_session_replays_compacted_messages() -> None:
+    checkpointer = MemorySaver()
+    graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=checkpointer,
+    )
+    server = AgentServerACP(agent=graph, load_sessions=True)
+    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    session = await server.new_session(cwd="/tmp", mcp_servers=[])
+    config = server._session_config(session.session_id)
+    await graph.aupdate_state(
+        config,
+        {
+            "messages": [
+                HumanMessage(content="old", id="old-user"),
+                AIMessage(content="old reply", id="old-agent"),
+            ]
+        },
+        as_node="__start__",
+    )
+    await graph.aupdate_state(
+        config,
+        {
+            "messages": [
+                RemoveMessage(id="old-user"),
+                RemoveMessage(id="old-agent"),
+                HumanMessage(content="new", id="new-user"),
+            ]
+        },
+        as_node="model",
+    )
+
+    restarted_graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=checkpointer,
+    )
+    restarted_server = AgentServerACP(agent=restarted_graph, load_sessions=True)
+    client = FakeACPClient()
+    restarted_server.on_connect(client)  # type: ignore[arg-type]
+    await restarted_server.load_session(
+        cwd="/tmp",
+        session_id=session.session_id,
+        mcp_servers=[],
+    )
+
+    updates = [event["update"] for event in client.events]
+    assert [
+        update.content.text
+        for update in updates
+        if isinstance(update, (UserMessageChunk, AgentMessageChunk))
+    ] == ["old", "old reply", "new"]
+
+
+async def test_acp_agent_load_session_restores_config_options() -> None:
+    checkpointer = MemorySaver()
+    contexts: list[AgentSessionContext] = []
+    modes = SessionModeState(
+        current_mode_id="auto",
+        available_modes=[
+            SessionMode(id="auto", name="Auto"),
+            SessionMode(id="manual", name="Manual"),
+        ],
+    )
+    models = [
+        {"value": "model-a", "name": "Model A"},
+        {"value": "model-b", "name": "Model B"},
+    ]
+
+    def build_agent(context: AgentSessionContext) -> CompiledStateGraph:
+        contexts.append(context)
+        return create_deep_agent(
+            model=GenericFakeChatModel(messages=iter([])),
+            checkpointer=checkpointer,
+        )
+
+    server = AgentServerACP(
+        agent=build_agent,
+        modes=modes,
+        models=models,
+        load_sessions=True,
+    )
+    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    session = await server.new_session(cwd="/tmp", mcp_servers=[])
+    await server.set_config_option(
+        config_id="mode",
+        session_id=session.session_id,
+        value="manual",
+    )
+    await server.set_config_option(
+        config_id="model",
+        session_id=session.session_id,
+        value="model-b",
+    )
+
+    restarted_server = AgentServerACP(
+        agent=build_agent,
+        modes=modes,
+        models=models,
+        load_sessions=True,
+    )
+    restarted_server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    response = await restarted_server.load_session(
+        cwd="/tmp",
+        session_id=session.session_id,
+        mcp_servers=[],
+    )
+
+    assert response.modes is not None
+    assert response.modes.current_mode_id == "manual"
+    options = [getattr(option, "root", option) for option in response.config_options or []]
+    model_option = next(option for option in options if option.id == "model")
+    assert model_option.current_value == "model-b"
+    assert contexts[-1] == AgentSessionContext(cwd="/tmp", mode="manual", model="model-b")
+
+
+async def test_acp_agent_load_session_restores_empty_session() -> None:
+    checkpointer = MemorySaver()
+    graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=checkpointer,
+    )
+    server = AgentServerACP(agent=graph, load_sessions=True)
+    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    session = await server.new_session(cwd="/tmp", mcp_servers=[])
+
+    restarted_graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=checkpointer,
+    )
+    restarted_server = AgentServerACP(agent=restarted_graph, load_sessions=True)
+    client = FakeACPClient()
+    restarted_server.on_connect(client)  # type: ignore[arg-type]
+
+    await restarted_server.load_session(
+        cwd="/tmp",
+        session_id=session.session_id,
+        mcp_servers=[],
+    )
+    assert client.events == []
+
+
+async def test_acp_agent_load_session_rejects_unknown_session() -> None:
+    graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=MemorySaver(),
+    )
+    server = AgentServerACP(agent=graph, load_sessions=True)
+    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+
+    with pytest.raises(RequestError) as exc_info:
+        await server.load_session(cwd="/tmp", session_id="missing", mcp_servers=[])
+
+    assert exc_info.value.code == -32002
+
+
+async def test_acp_agent_load_session_rejects_non_acp_checkpoint() -> None:
+    checkpointer = MemorySaver()
+    graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=checkpointer,
+    )
+    await graph.aupdate_state(
+        {"configurable": {"thread_id": "other"}, "metadata": {"cwd": "/tmp"}},
+        {},
+        as_node="__start__",
+    )
+    server = AgentServerACP(agent=graph, load_sessions=True)
+    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+
+    with pytest.raises(RequestError) as exc_info:
+        await server.load_session(cwd="/tmp", session_id="other", mcp_servers=[])
+
+    assert exc_info.value.code == -32002
+
+
+async def test_acp_agent_load_session_rejects_different_cwd() -> None:
+    checkpointer = MemorySaver()
+    graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=checkpointer,
+    )
+    server = AgentServerACP(agent=graph, load_sessions=True)
+    server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    session = await server.new_session(cwd="/tmp/original", mcp_servers=[])
+
+    with pytest.raises(RequestError) as exc_info:
+        await server.load_session(
+            cwd="/tmp/different",
+            session_id=session.session_id,
+            mcp_servers=[],
+        )
+
+    assert exc_info.value.code == -32602
+
+
+async def test_acp_agent_load_session_rejects_relative_cwd() -> None:
+    graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=MemorySaver(),
+    )
+    server = AgentServerACP(agent=graph, load_sessions=True)
+
+    with pytest.raises(RequestError) as load_exc:
+        await server.load_session(cwd="relative", session_id="missing", mcp_servers=[])
+
+    assert load_exc.value.code == -32602
+
+
+async def test_acp_agent_load_session_is_unavailable_when_disabled() -> None:
+    graph = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([])),
+        checkpointer=MemorySaver(),
+    )
+    server = AgentServerACP(agent=graph)
+
+    with pytest.raises(RequestError) as exc_info:
+        await server.load_session(cwd="/tmp", session_id="session", mcp_servers=[])
+
+    assert exc_info.value.code == -32601
 
 
 async def test_new_session_preserves_positional_mcp_servers_slot() -> None:


### PR DESCRIPTION
ACP agents can now opt into durable `session/load`, restoring session configuration and replaying complete conversation history after process restarts.

---

`AgentServerACP` previously exposed only in-process threads. This adds an explicit `load_sessions` capability backed by the graph checkpointer, persists ACP ownership, cwd, mode, and model metadata, and returns protocol errors for unknown sessions or mismatched working directories.

Replay is reconstructed across checkpoint history so messages removed from the latest state by compaction are still included, as required by ACP v1. Tool calls and multimodal message content are converted back into their ACP session-update forms. The feature remains opt-in so existing adapters retain their current behavior.

The follow-up dcode integration is stacked separately because `deepagents-acp` and `deepagents-code` are independently released.

<details>
<summary>Test plan</summary>

- `PYTHONPATH=libs/acp:libs/deepagents libs/code/.venv/bin/python -m pytest -q libs/acp/tests`
- ACP Ruff format and lint checks
- SQLite close/reopen exercise, including messages removed from current state by compaction

</details>


Made by [Open SWE](https://openswe.vercel.app/agents/019fd88f-b03e-7476-86ba-2ef3c4634a72)
