### PR TITLE
feat(code): persist and reconfigure ACP sessions

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast
 
 if TYPE_CHECKING:
     from deepagents import FsToolName
+    from deepagents_acp.server import AgentSessionContext
+    from langgraph.pregel import Pregel
     from rich.console import Console
 
     from deepagents_code._dep_floor_check import _FloorViolation
@@ -2957,15 +2959,13 @@ async def _run_acp_cli_async(
         async with get_checkpointer() as checkpointer:
             await checkpointer.setup()
 
-            def build_agent(context: Any) -> Any:  # noqa: ANN401  # ACP factory protocol
-                session_project_context = ProjectContext.from_user_cwd(
-                    Path(context.cwd)
-                )
+            def build_agent(
+                context: "AgentSessionContext",
+            ) -> "Pregel[Any, Any, Any, Any]":
                 agent_graph, _backend = create_cli_agent(
                     model=model_result.model,
                     assistant_id=assistant_id,
                     tools=tools,
-                    mcp_tools=mcp_tools,
                     mcp_server_info=mcp_server_info,
                     checkpointer=checkpointer,
                     async_subagents=async_subagents,
@@ -2973,7 +2973,7 @@ async def _run_acp_cli_async(
                     recursion_limit=recursion_limit,
                     memory_auto_save=is_memory_auto_save_enabled(),
                     cwd=context.cwd,
-                    project_context=session_project_context,
+                    project_context=ProjectContext.from_user_cwd(Path(context.cwd)),
                 )
                 return agent_graph
 
@@ -2982,19 +2982,13 @@ async def _run_acp_cli_async(
                 load_sessions=True,
                 checkpoint_metadata={"agent_name": assistant_id},
             )
-            try:
-                await run_acp_agent(server)
-            except KeyboardInterrupt:
-                pass
-            except Exception as exc:
-                sys.stderr.write(f"Error: ACP server failed: {exc}\n")
-                sys.stderr.flush()
-                logger.exception("ACP server crashed")
-                exit_code = 1
+            await run_acp_agent(server)
+    except KeyboardInterrupt:
+        pass
     except Exception as exc:
-        sys.stderr.write(f"Error: failed to create agent: {exc}\n")
+        sys.stderr.write(f"Error: ACP server failed: {exc}\n")
         sys.stderr.flush()
-        logger.debug("ACP agent creation failed", exc_info=True)
+        logger.exception("ACP server crashed")
         exit_code = 1
     finally:
         if mcp_session_manager is not None:

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2950,37 +2950,51 @@ async def _run_acp_cli_async(
         return 1
 
     async_subagents = load_async_subagents() or None
-
+    exit_code = 0
     try:
-        from langgraph.checkpoint.memory import InMemorySaver
+        from deepagents_code.sessions import get_checkpointer
 
-        agent_graph, _backend = create_cli_agent(
-            model=model_result.model,
-            assistant_id=assistant_id,
-            tools=tools,
-            mcp_server_info=mcp_server_info,
-            checkpointer=InMemorySaver(),
-            async_subagents=async_subagents,
-            fs_tools=allow_fs_tools,
-            recursion_limit=recursion_limit,
-            memory_auto_save=is_memory_auto_save_enabled(),
-        )
+        async with get_checkpointer() as checkpointer:
+            await checkpointer.setup()
+
+            def build_agent(context: Any) -> Any:  # noqa: ANN401  # ACP factory protocol
+                session_project_context = ProjectContext.from_user_cwd(
+                    Path(context.cwd)
+                )
+                agent_graph, _backend = create_cli_agent(
+                    model=model_result.model,
+                    assistant_id=assistant_id,
+                    tools=tools,
+                    mcp_tools=mcp_tools,
+                    mcp_server_info=mcp_server_info,
+                    checkpointer=checkpointer,
+                    async_subagents=async_subagents,
+                    fs_tools=allow_fs_tools,
+                    recursion_limit=recursion_limit,
+                    memory_auto_save=is_memory_auto_save_enabled(),
+                    cwd=context.cwd,
+                    project_context=session_project_context,
+                )
+                return agent_graph
+
+            server = agent_server_cls(
+                build_agent,
+                load_sessions=True,
+                checkpoint_metadata={"agent_name": assistant_id},
+            )
+            try:
+                await run_acp_agent(server)
+            except KeyboardInterrupt:
+                pass
+            except Exception as exc:
+                sys.stderr.write(f"Error: ACP server failed: {exc}\n")
+                sys.stderr.flush()
+                logger.exception("ACP server crashed")
+                exit_code = 1
     except Exception as exc:
         sys.stderr.write(f"Error: failed to create agent: {exc}\n")
         sys.stderr.flush()
         logger.debug("ACP agent creation failed", exc_info=True)
-        return 1
-
-    server = agent_server_cls(agent_graph)  # Pregel is a CompiledStateGraph at runtime
-    exit_code = 0
-    try:
-        await run_acp_agent(server)
-    except KeyboardInterrupt:
-        pass
-    except Exception as exc:
-        sys.stderr.write(f"Error: ACP server failed: {exc}\n")
-        sys.stderr.flush()
-        logger.exception("ACP server crashed")
         exit_code = 1
     finally:
         if mcp_session_manager is not None:

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2880,6 +2880,7 @@ async def _run_acp_cli_async(
     )
     from deepagents_code.model_config import (
         ModelConfigError,
+        get_available_models,
         save_recent_model,
         touch_recent_model,
     )
@@ -2914,6 +2915,19 @@ async def _run_acp_cli_async(
     resolved_spec = f"{model_result.provider}:{model_result.model_name}"
     save_recent_model(resolved_spec)
     touch_recent_model(resolved_spec)
+    models = [
+        {"value": spec, "name": spec}
+        for spec in dict.fromkeys(
+            [
+                resolved_spec,
+                *(
+                    f"{provider}:{model}"
+                    for provider, available in get_available_models().items()
+                    for model in available
+                ),
+            ]
+        )
+    ]
 
     tools: list[Any] = [fetch_url, get_current_thread_id]
     if settings.has_tavily:
@@ -2962,8 +2976,20 @@ async def _run_acp_cli_async(
             def build_agent(
                 context: "AgentSessionContext",
             ) -> "Pregel[Any, Any, Any, Any]":
+                selected_model = context.model or resolved_spec
+                session_model = (
+                    model_result
+                    if selected_model == resolved_spec
+                    else create_model(
+                        selected_model,
+                        extra_kwargs=model_params,
+                        profile_overrides=profile_override,
+                    )
+                )
+                if session_model is not model_result:
+                    session_model.apply_to_settings()
                 agent_graph, _backend = create_cli_agent(
-                    model=model_result.model,
+                    model=session_model.model,
                     assistant_id=assistant_id,
                     tools=tools,
                     mcp_server_info=mcp_server_info,
@@ -2979,6 +3005,7 @@ async def _run_acp_cli_async(
 
             server = agent_server_cls(
                 build_agent,
+                models=models,
                 load_sessions=True,
                 checkpoint_metadata={"agent_name": assistant_id},
             )

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2986,8 +2986,7 @@ async def _run_acp_cli_async(
                         profile_overrides=profile_override,
                     )
                 )
-                if session_model is not model_result:
-                    session_model.apply_to_settings()
+                session_model.apply_to_settings()
                 agent_graph, _backend = create_cli_agent(
                     model=session_model.model,
                     assistant_id=assistant_id,

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -97,7 +97,7 @@ dependencies = [
     "anyio>=4.14.2,<5.0.0",
 
     # ACP
-    "deepagents-acp>=0.0.9,<1.0.0",
+    "deepagents-acp>=0.0.10,<1.0.0",
     "mcp>=1.28.1,<2.0.0",
 ]
 
@@ -208,6 +208,7 @@ include = [
 
 [tool.uv.sources]
 deepagents = { path = "../deepagents", editable = true }
+deepagents-acp = { path = "../acp", editable = true }
 langchain-daytona = { path = "../partners/daytona", editable = true }
 langchain-modal = { path = "../partners/modal", editable = true }
 langchain-quickjs = { path = "../partners/quickjs", editable = true }

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -5,12 +5,41 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from deepagents_code.main import _preload_session_mcp_server_info, cli_main
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+
+@pytest.fixture(autouse=True)
+def test_acp_checkpointer() -> AsyncIterator[SimpleNamespace]:
+    checkpointer = SimpleNamespace(setup=AsyncMock(return_value=None))
+
+    @asynccontextmanager
+    async def get_checkpointer() -> AsyncIterator[SimpleNamespace]:
+        yield checkpointer
+
+    with patch("deepagents_code.sessions.get_checkpointer", get_checkpointer):
+        yield checkpointer
+
+
+def _build_agent_server(server: object) -> Callable[..., object]:
+    def build(agent_factory: Callable[..., object], **kwargs: object) -> object:
+        assert kwargs == {
+            "load_sessions": True,
+            "checkpoint_metadata": {"agent_name": "agent"},
+        }
+        agent_factory(SimpleNamespace(cwd="/tmp"))
+        return server
+
+    return build
 
 
 def _make_acp_args(**overrides: object) -> argparse.Namespace:
@@ -53,7 +82,9 @@ def test_acp_mode_rejects_auto_classifier_model(
     resolve_agent.assert_not_called()
 
 
-def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
+def test_acp_mode_loads_tools_and_mcp_and_runs_server(
+    test_acp_checkpointer: SimpleNamespace,
+) -> None:
     """`--acp` should build the ACP agent with web tools and MCP tools."""
     args = _make_acp_args(
         model_params='{"temperature": 0.2}',
@@ -139,7 +170,8 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
             "deepagents_code.agent.create_cli_agent", return_value=("graph", object())
         ) as mock_create_agent,
         patch(
-            "deepagents_acp.server.AgentServerACP", return_value=server
+            "deepagents_acp.server.AgentServerACP",
+            side_effect=_build_agent_server(server),
         ) as mock_server_cls,
         patch("acp.run_agent", run_agent),
         pytest.raises(SystemExit) as exc_info,
@@ -166,11 +198,16 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
     assert call_kwargs["model"] is model_obj
     assert call_kwargs["assistant_id"] == "agent"
     assert call_kwargs["tools"] == [fetch_tool, thread_tool, search_tool, mcp_tool]
+    assert call_kwargs["mcp_tools"] == [mcp_tool]
     assert call_kwargs["mcp_server_info"] is mcp_server_info
     assert call_kwargs["checkpointer"] is not None
+    assert call_kwargs["checkpointer"] is test_acp_checkpointer
+    assert call_kwargs["cwd"] == "/tmp"
+    assert call_kwargs["project_context"] is acp_project_context
     assert call_kwargs["memory_auto_save"] is False
     mock_memory_auto_save.assert_called_once_with()
-    mock_server_cls.assert_called_once_with("graph")
+    test_acp_checkpointer.setup.assert_awaited_once_with()
+    mock_server_cls.assert_called_once()
     run_agent.assert_awaited_once_with(server)
     mcp_manager.cleanup.assert_awaited_once_with()
 
@@ -211,7 +248,10 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
         patch(
             "deepagents_code.agent.create_cli_agent", return_value=("graph", object())
         ) as mock_create_agent,
-        patch("deepagents_acp.server.AgentServerACP", return_value=server),
+        patch(
+            "deepagents_acp.server.AgentServerACP",
+            side_effect=_build_agent_server(server),
+        ),
         patch("acp.run_agent", run_agent),
         pytest.raises(SystemExit) as exc_info,
     ):
@@ -260,7 +300,10 @@ def test_acp_mode_forwards_allow_fs_tools() -> None:
         patch(
             "deepagents_code.agent.create_cli_agent", return_value=("graph", object())
         ) as mock_create_agent,
-        patch("deepagents_acp.server.AgentServerACP", return_value=server),
+        patch(
+            "deepagents_acp.server.AgentServerACP",
+            side_effect=_build_agent_server(server),
+        ),
         patch("acp.run_agent", run_agent),
         pytest.raises(SystemExit) as exc_info,
     ):
@@ -302,7 +345,10 @@ def test_acp_mode_forwards_none_allow_fs_tools_by_default() -> None:
         patch(
             "deepagents_code.agent.create_cli_agent", return_value=("graph", object())
         ) as mock_create_agent,
-        patch("deepagents_acp.server.AgentServerACP", return_value=object()),
+        patch(
+            "deepagents_acp.server.AgentServerACP",
+            side_effect=_build_agent_server(object()),
+        ),
         patch("acp.run_agent", run_agent),
         pytest.raises(SystemExit) as exc_info,
     ):
@@ -345,7 +391,10 @@ def test_acp_mode_forwards_recursion_limit() -> None:
         patch(
             "deepagents_code.agent.create_cli_agent", return_value=("graph", object())
         ) as mock_create_agent,
-        patch("deepagents_acp.server.AgentServerACP", return_value=object()),
+        patch(
+            "deepagents_acp.server.AgentServerACP",
+            side_effect=_build_agent_server(object()),
+        ),
         patch("acp.run_agent", run_agent),
         pytest.raises(SystemExit) as exc_info,
     ):

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -190,7 +190,7 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server(
         additional_configs=plugin_configs,
     )
     discover_plugin_mcp.assert_called_once_with(project_dir=acp_project_root)
-    model_result.apply_to_settings.assert_called_once_with()
+    assert model_result.apply_to_settings.call_count == 2
     mock_create_agent.assert_called_once()
     call_kwargs = mock_create_agent.call_args.kwargs
     assert call_kwargs["model"] is model_obj

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -34,7 +34,7 @@ def _build_agent_server(server: object) -> Callable[..., object]:
     """Stand in for `AgentServerACP`, exercising the agent factory it is handed."""
 
     def build(agent_factory: Callable[..., object], **_kwargs: object) -> object:
-        agent_factory(SimpleNamespace(cwd="/tmp"))
+        agent_factory(SimpleNamespace(cwd="/tmp", model=None))
         return server
 
     return build
@@ -203,9 +203,13 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server(
     assert call_kwargs["memory_auto_save"] is False
     mock_memory_auto_save.assert_called_once_with()
     test_acp_checkpointer.setup.assert_awaited_once_with()
-    assert mock_server_cls.call_args.kwargs == {
-        "load_sessions": True,
-        "checkpoint_metadata": {"agent_name": "agent"},
+    assert mock_server_cls.call_args.kwargs["models"][0] == {
+        "value": "anthropic:claude-sonnet-4-6",
+        "name": "anthropic:claude-sonnet-4-6",
+    }
+    assert mock_server_cls.call_args.kwargs["load_sessions"] is True
+    assert mock_server_cls.call_args.kwargs["checkpoint_metadata"] == {
+        "agent_name": "agent"
     }
     run_agent.assert_awaited_once_with(server)
     mcp_manager.cleanup.assert_awaited_once_with()

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -15,11 +15,11 @@ import pytest
 from deepagents_code.main import _preload_session_mcp_server_info, cli_main
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable
+    from collections.abc import AsyncIterator, Callable, Generator
 
 
 @pytest.fixture(autouse=True)
-def test_acp_checkpointer() -> AsyncIterator[SimpleNamespace]:
+def test_acp_checkpointer() -> Generator[SimpleNamespace]:
     checkpointer = SimpleNamespace(setup=AsyncMock(return_value=None))
 
     @asynccontextmanager

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -31,11 +31,9 @@ def test_acp_checkpointer() -> AsyncIterator[SimpleNamespace]:
 
 
 def _build_agent_server(server: object) -> Callable[..., object]:
-    def build(agent_factory: Callable[..., object], **kwargs: object) -> object:
-        assert kwargs == {
-            "load_sessions": True,
-            "checkpoint_metadata": {"agent_name": "agent"},
-        }
+    """Stand in for `AgentServerACP`, exercising the agent factory it is handed."""
+
+    def build(agent_factory: Callable[..., object], **_kwargs: object) -> object:
         agent_factory(SimpleNamespace(cwd="/tmp"))
         return server
 
@@ -198,16 +196,17 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server(
     assert call_kwargs["model"] is model_obj
     assert call_kwargs["assistant_id"] == "agent"
     assert call_kwargs["tools"] == [fetch_tool, thread_tool, search_tool, mcp_tool]
-    assert call_kwargs["mcp_tools"] == [mcp_tool]
     assert call_kwargs["mcp_server_info"] is mcp_server_info
-    assert call_kwargs["checkpointer"] is not None
     assert call_kwargs["checkpointer"] is test_acp_checkpointer
     assert call_kwargs["cwd"] == "/tmp"
     assert call_kwargs["project_context"] is acp_project_context
     assert call_kwargs["memory_auto_save"] is False
     mock_memory_auto_save.assert_called_once_with()
     test_acp_checkpointer.setup.assert_awaited_once_with()
-    mock_server_cls.assert_called_once()
+    assert mock_server_cls.call_args.kwargs == {
+        "load_sessions": True,
+        "checkpoint_metadata": {"agent_name": "agent"},
+    }
     run_agent.assert_awaited_once_with(server)
     mcp_manager.cleanup.assert_awaited_once_with()
 

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1101,15 +1101,35 @@ test = [
 [[package]]
 name = "deepagents-acp"
 version = "0.0.9"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../acp" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "deepagents" },
     { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/b4/dd22ccee75bb532028bcb35cd8a9ba72fbcd01cb75a3e8f3cd8a663de09c/deepagents_acp-0.0.9.tar.gz", hash = "sha256:692e671f1862e8665a9539a4a028e72ae23beb000a57bab76f543f8d54855b96", size = 13011722, upload-time = "2026-07-07T19:30:00.182Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/30/0e9ce37f54b9f45116a8c6aa0d6945a662edaf34e9dd5e30d6b986ab325d/deepagents_acp-0.0.9-py3-none-any.whl", hash = "sha256:f6c4693e5b49bb01bef4217beb1aed044e0e548ffeaf4affa94599218450e999", size = 18363, upload-time = "2026-07-07T19:29:59.042Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-client-protocol", specifier = ">=0.10.1" },
+    { name = "deepagents", editable = "../deepagents" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+]
+
+[package.metadata.requires-dev]
+examples = [
+    { name = "langchain-baseten", specifier = ">=0.2.1" },
+    { name = "langchain-openai", specifier = ">=1.3.4" },
+]
+test = [
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-socket", specifier = ">=0.8.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0,<3.0.0" },
+    { name = "pytest-watcher", specifier = ">=0.6.3,<1.0.0" },
+    { name = "ruff", specifier = ">=0.15.20,<0.16.0" },
+    { name = "ty", specifier = ">=0.0.54,<1.0.0" },
 ]
 
 [[package]]
@@ -1299,7 +1319,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.14.2,<5.0.0" },
     { name = "av", marker = "extra == 'media'", specifier = ">=18.0.0,<19.0.0" },
     { name = "deepagents", editable = "../deepagents" },
-    { name = "deepagents-acp", specifier = ">=0.0.10,<1.0.0" },
+    { name = "deepagents-acp", editable = "../acp" },
     { name = "deepagents-code", extras = ["agentcore", "daytona", "modal", "runloop", "vercel"], marker = "extra == 'all-sandboxes'" },
     { name = "deepagents-code", extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "meta", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "together", "vertex", "xai"], marker = "extra == 'all-providers'" },
     { name = "filelock", specifier = ">=3.29.7,<3.30" },
@@ -2381,8 +2401,8 @@ dependencies = [
     { name = "ibm-cos-sdk" },
     { name = "lomond" },
     { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.14.*'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.14.*'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "requests" },
     { name = "tabulate" },
     { name = "urllib3" },
@@ -4466,11 +4486,11 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
+    { name = "pytz", marker = "python_full_version < '3.14'" },
+    { name = "tzdata", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4525,9 +4545,9 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.14'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.14' and sys_platform == 'emscripten') or (python_full_version >= '3.14' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -5790,8 +5810,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -6560,11 +6580,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "vercel" },
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "vercel", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1299,7 +1299,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.14.2,<5.0.0" },
     { name = "av", marker = "extra == 'media'", specifier = ">=18.0.0,<19.0.0" },
     { name = "deepagents", editable = "../deepagents" },
-    { name = "deepagents-acp", specifier = ">=0.0.9,<1.0.0" },
+    { name = "deepagents-acp", specifier = ">=0.0.10,<1.0.0" },
     { name = "deepagents-code", extras = ["agentcore", "daytona", "modal", "runloop", "vercel"], marker = "extra == 'all-sandboxes'" },
     { name = "deepagents-code", extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "meta", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "together", "vertex", "xai"], marker = "extra == 'all-providers'" },
     { name = "filelock", specifier = ">=3.29.7,<3.30" },


### PR DESCRIPTION
Depends on #5365

`dcode --acp` sessions now survive process restarts and can switch among discovered models without losing checkpointed context.

---

ACP mode now keeps dcode’s SQLite checkpointer open, builds each session for its cwd and selected model, and advertises the installed model catalog through `session/set_config_option`.

<details>
<summary>Test plan</summary>

- `PYTHONPATH=../acp:../deepagents:. .venv/bin/python -m pytest -q tests/unit_tests/test_main_acp_mode.py`
- Ruff and `ty` checks for the changed files

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/019fdd2c-6961-769a-95e8-e808b66d23d4)