### PR TITLE
fix(code): ensure rubric coverage

### DIFF
--- a/libs/code/deepagents_code/reliable_rubric.py
+++ b/libs/code/deepagents_code/reliable_rubric.py
@@ -11,11 +11,8 @@ from deepagents.middleware.rubric import (
     GraderResponse,
     RubricMiddleware,
     RubricState,
-    _strategy_from_result,  # noqa: PLC2701
 )
-from langchain.agents.middleware.types import AgentMiddleware, AgentState, hook_config
-from langchain_core.messages import HumanMessage
-from langgraph.errors import GraphBubbleUp
+from langchain.agents.middleware.types import AgentMiddleware, AgentState
 
 from deepagents_code.goal_state_notice import is_conversation_control_message
 
@@ -26,7 +23,6 @@ if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
     from langchain_core.messages import AnyMessage
     from langchain_core.tools import BaseTool
-    from langgraph.runtime import Runtime
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +109,11 @@ class ReliableRubricMiddleware(RubricMiddleware):
     runtime context without requiring those application-specific capabilities in
     the SDK's `RubricMiddleware`. A transport retry re-invokes only the grader,
     never the task agent, so grader tools must be read-only or idempotent.
+
+    The transport retry wraps `_invoke_grader` (one grader call) rather than
+    `_grade` (the whole grading pass), so the SDK's coverage retry still runs on
+    top of it: a transport fault is retried within a call, and a grader that
+    under-reports its criteria is retried across calls.
     """
 
     def __init__(  # noqa: D107
@@ -135,93 +136,6 @@ class ReliableRubricMiddleware(RubricMiddleware):
         )
         self._grader_middleware = list(grader_middleware or ())
         self._grader_context_schema = grader_context_schema
-
-    @hook_config(can_jump_to=["model"])
-    def after_agent(
-        self,
-        state: RubricState,
-        runtime: Runtime[Any],
-    ) -> dict[str, Any] | None:
-        """Grade synchronously while preserving nested graph interrupts.
-
-        Returns:
-            The rubric state update, or `None` when no rubric is active.
-
-        Raises:
-            GraphBubbleUp: If the nested grader pauses or otherwise bubbles control.
-        """
-        prep = self._prepare_evaluation(state, runtime)
-        if prep is None:
-            return None
-        grading_run_id, iteration = prep
-
-        try:
-            graded = self._grade(
-                state,
-                iteration,
-                context=getattr(runtime, "context", None),
-            )
-        except GraphBubbleUp:
-            raise
-        except Exception as exc:  # noqa: BLE001
-            return self._handle_grader_exception(
-                runtime,
-                state,
-                grading_run_id,
-                iteration,
-                exc,
-            )
-
-        return self._finalize_evaluation(
-            graded,
-            state,
-            runtime,
-            grading_run_id,
-            iteration,
-        )
-
-    async def aafter_agent(
-        self,
-        state: RubricState,
-        runtime: Runtime[Any],
-    ) -> dict[str, Any] | None:
-        """Grade asynchronously while preserving nested graph interrupts.
-
-        Returns:
-            The rubric state update, or `None` when no rubric is active.
-
-        Raises:
-            GraphBubbleUp: If the nested grader pauses or otherwise bubbles control.
-        """
-        prep = self._prepare_evaluation(state, runtime)
-        if prep is None:
-            return None
-        grading_run_id, iteration = prep
-
-        try:
-            graded = await self._agrade(
-                state,
-                iteration,
-                context=getattr(runtime, "context", None),
-            )
-        except GraphBubbleUp:
-            raise
-        except Exception as exc:  # noqa: BLE001
-            return self._handle_grader_exception(
-                runtime,
-                state,
-                grading_run_id,
-                iteration,
-                exc,
-            )
-
-        return self._finalize_evaluation(
-            graded,
-            state,
-            runtime,
-            grading_run_id,
-            iteration,
-        )
 
     def _ensure_grader(self) -> Any:  # noqa: ANN401
         if self._grader is not None:
@@ -250,73 +164,42 @@ class ReliableRubricMiddleware(RubricMiddleware):
         self,
         state: RubricState,
         iteration: int,
+        correction: str | None = None,
     ) -> dict[str, Any]:
         """Build nested-grader input with a stable verification-operation ID.
+
+        Drops dcode control turns before delegating to the SDK, which applies
+        the delimiter sanitization for the untrusted transcript.
+
+        Args:
+            state: Agent state, read for the rubric and transcript.
+            iteration: Zero-based grading iteration.
+            correction: Feedback about a previous unusable response, if any.
 
         Returns:
             The nested grader's input state.
         """
         grading_run_id = state.get("_current_grading_run_id") or "untracked"
         grader_state = _without_internal_control_messages(state)
-        payload = self._build_grader_payload(grader_state, iteration)
-        return {
-            "messages": [HumanMessage(content=payload)],
-            "rubric_grading_operation_id": f"{grading_run_id}:{iteration}",
-        }
+        grader_input = super()._grader_input(grader_state, iteration, correction)
+        grader_input["rubric_grading_operation_id"] = f"{grading_run_id}:{iteration}"
+        return grader_input
 
-    def _grade_once(
+    def _invoke_grader(
         self,
         state: RubricState,
         iteration: int,
-        *,
-        context: object | None,
-    ) -> GraderResponse:
-        grader = self._ensure_grader()
-        metadata = self._grader_trace_metadata()
-        self._record_grader_trace_metadata(metadata)
-        result = grader.invoke(
-            self._grader_input(state, iteration),
-            config=self._grader_invocation_config(metadata),
-            context=context,
-        )
-        self._record_grader_trace_metadata(
-            self._grader_trace_metadata(
-                effective_strategy=_strategy_from_result(result),
-            )
-        )
-        return self._extract_graded(result)
-
-    async def _agrade_once(
-        self,
-        state: RubricState,
-        iteration: int,
-        *,
-        context: object | None,
-    ) -> GraderResponse:
-        grader = self._ensure_grader()
-        metadata = self._grader_trace_metadata()
-        self._record_grader_trace_metadata(metadata)
-        result = await grader.ainvoke(
-            self._grader_input(state, iteration),
-            config=self._grader_invocation_config(metadata),
-            context=context,
-        )
-        self._record_grader_trace_metadata(
-            self._grader_trace_metadata(
-                effective_strategy=_strategy_from_result(result),
-            )
-        )
-        return self._extract_graded(result)
-
-    def _grade(
-        self,
-        state: RubricState,
-        iteration: int,
+        correction: str | None = None,
         *,
         context: object | None = None,
     ) -> GraderResponse:
+        """Run one grader call, retrying once on a transient transport failure.
+
+        Returns:
+            The grader's structured verdict.
+        """
         try:
-            return self._grade_once(state, iteration, context=context)
+            return super()._invoke_grader(state, iteration, correction, context=context)
         except Exception as exc:
             if not _is_transient_grader_transport_error(exc):
                 raise
@@ -324,17 +207,25 @@ class ReliableRubricMiddleware(RubricMiddleware):
                 "Rubric grader transport failed; retrying grading once",
                 exc_info=True,
             )
-        return self._grade_once(state, iteration, context=context)
+        return super()._invoke_grader(state, iteration, correction, context=context)
 
-    async def _agrade(
+    async def _ainvoke_grader(
         self,
         state: RubricState,
         iteration: int,
+        correction: str | None = None,
         *,
         context: object | None = None,
     ) -> GraderResponse:
+        """Async variant of `_invoke_grader`. See that method for details.
+
+        Returns:
+            The grader's structured verdict.
+        """
         try:
-            return await self._agrade_once(state, iteration, context=context)
+            return await super()._ainvoke_grader(
+                state, iteration, correction, context=context
+            )
         except Exception as exc:
             if not _is_transient_grader_transport_error(exc):
                 raise
@@ -342,4 +233,6 @@ class ReliableRubricMiddleware(RubricMiddleware):
                 "Rubric grader transport failed; retrying grading once",
                 exc_info=True,
             )
-        return await self._agrade_once(state, iteration, context=context)
+        return await super()._ainvoke_grader(
+            state, iteration, correction, context=context
+        )

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -566,13 +566,20 @@ def _format_rubric_event(data: dict[str, Any]) -> str | None:
         return None
     if result == "satisfied":
         return f"{glyphs.checkmark} Acceptance criteria satisfied"
+    # `unverified` marks a grader that could not account for every criterion, so
+    # the verdict is a verification gap rather than a list of confirmed defects.
+    unverified = data.get("unverified") is True
     if result == "needs_revision":
+        if unverified:
+            return f"{glyphs.retry} Acceptance criteria could not be verified"
         return f"{glyphs.retry} Acceptance criteria not yet satisfied"
     if result == "max_iterations_reached":
-        return (
-            f"{glyphs.warning} Acceptance criteria not yet satisfied "
-            "(iteration limit reached)"
+        summary = (
+            "Acceptance criteria could not be verified"
+            if unverified
+            else "Acceptance criteria not yet satisfied"
         )
+        return f"{glyphs.warning} {summary} (iteration limit reached)"
     if result == "failed":
         return f"{glyphs.warning} Rubric is invalid or cannot be evaluated"
     if result == "grader_error":
@@ -616,10 +623,19 @@ def _format_rubric_details(data: dict[str, Any], *, goal_active: bool = False) -
             lines.append(f"- {name}" + (f"\n  {gap}" if gap else ""))
         sections.append("\n".join(lines))
 
+    unverified = data.get("unverified") is True
+
     if result == "max_iterations_reached" and goal_active:
         next_step = (
             "The goal remains active. Continue with another prompt to resume or "
             "retry, use `/goal <objective>` to amend it, or `/goal clear` to clear it."
+        )
+    elif result in {"needs_revision", "max_iterations_reached"} and unverified:
+        # No criterion was confirmed to have failed, so telling the user to
+        # address unmet criteria would point at an empty list.
+        next_step = (
+            "The grader could not account for every criterion, so nothing was "
+            "confirmed. Retry the check to re-verify the work."
         )
     elif result in {"needs_revision", "max_iterations_reached"}:
         next_step = "Address every unmet criterion, then retry the check."

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -611,17 +611,33 @@ def _format_rubric_details(data: dict[str, Any], *, goal_active: bool = False) -
 
     criteria = data.get("criteria")
     failing: list[tuple[str, str]] = []
+    passing: list[str] = []
     if isinstance(criteria, list):
         for criterion in criteria:
-            if isinstance(criterion, dict) and criterion.get("passed") is False:
+            if not isinstance(criterion, dict):
+                continue
+            verdict = criterion.get("passed")
+            # Strict identity keeps a missing or non-boolean verdict out of both
+            # lists rather than guessing which way it should count.
+            if verdict is False:
                 name = str(criterion.get("name") or "Unnamed criterion").strip()
                 gap = str(criterion.get("gap") or "").strip()
                 failing.append((name, gap))
+            elif verdict is True:
+                passing.append(
+                    str(criterion.get("name") or "Unnamed criterion").strip()
+                )
     if failing:
         lines = ["Unmet criteria"]
         for name, gap in failing:
             lines.append(f"- {name}" + (f"\n  {gap}" if gap else ""))
         sections.append("\n".join(lines))
+    if passing:
+        # Shown so the panel reports the grader's full accounting; without it a
+        # partial evaluation is indistinguishable from a complete one.
+        sections.append(
+            "\n".join(["Satisfied criteria", *(f"- {name}" for name in passing)])
+        )
 
     unverified = data.get("unverified") is True
 

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -647,11 +647,11 @@ def _format_rubric_details(data: dict[str, Any], *, goal_active: bool = False) -
             "retry, use `/goal <objective>` to amend it, or `/goal clear` to clear it."
         )
     elif result in {"needs_revision", "max_iterations_reached"} and unverified:
-        # No criterion was confirmed to have failed, so telling the user to
-        # address unmet criteria would point at an empty list.
+        # The gap is in coverage, not in the criteria the grader did report, so
+        # the next step is to re-verify rather than to fix a listed failure.
         next_step = (
-            "The grader could not account for every criterion, so nothing was "
-            "confirmed. Retry the check to re-verify the work."
+            "The grader could not account for every criterion, so the full "
+            "rubric was not verified. Retry the check to re-verify the work."
         )
     elif result in {"needs_revision", "max_iterations_reached"}:
         next_step = "Address every unmet criterion, then retry the check."

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -627,17 +627,17 @@ def _format_rubric_details(data: dict[str, Any], *, goal_active: bool = False) -
                 passing.append(
                     str(criterion.get("name") or "Unnamed criterion").strip()
                 )
-    if failing:
-        lines = ["Unmet criteria"]
-        for name, gap in failing:
-            lines.append(f"- {name}" + (f"\n  {gap}" if gap else ""))
-        sections.append("\n".join(lines))
     if passing:
         # Shown so the panel reports the grader's full accounting; without it a
         # partial evaluation is indistinguishable from a complete one.
         sections.append(
             "\n".join(["Satisfied criteria", *(f"- {name}" for name in passing)])
         )
+    if failing:
+        lines = ["Unmet criteria"]
+        for name, gap in failing:
+            lines.append(f"- {name}" + (f"\n  {gap}" if gap else ""))
+        sections.append("\n".join(lines))
 
     unverified = data.get("unverified") is True
 

--- a/libs/code/tests/unit_tests/test_reliable_rubric.py
+++ b/libs/code/tests/unit_tests/test_reliable_rubric.py
@@ -100,13 +100,50 @@ def _state() -> RubricState:
 
 
 def _satisfied_result() -> dict[str, Any]:
+    """A usable verdict: at least one per-criterion result, so no coverage retry."""
     return {
         "structured_response": GraderResponse(
             result="satisfied",
             explanation="all checks pass",
-            criteria=[],
+            criteria=[{"name": "tests pass", "passed": True}],
         )
     }
+
+
+def _frozen_criteria_state() -> RubricState:
+    """State whose frozen criteria list the grader is expected to cover exactly."""
+    state = _state()
+    state["_rubric_criteria"] = ["compiles", "tests pass"]
+    return state
+
+
+def _under_reported_result() -> dict[str, Any]:
+    """A `satisfied` verdict backed by fewer criteria than the rubric froze."""
+    return {
+        "structured_response": GraderResponse(
+            result="satisfied",
+            explanation="looks fine",
+            criteria=[{"name": "compiles", "passed": True}],
+        )
+    }
+
+
+def _fully_reported_result() -> dict[str, Any]:
+    return {
+        "structured_response": GraderResponse(
+            result="satisfied",
+            explanation="all checks pass",
+            criteria=[
+                {"name": "compiles", "passed": True},
+                {"name": "tests pass", "passed": True},
+            ],
+        )
+    }
+
+
+def _grader_payload(call: Any) -> str:  # noqa: ANN401
+    """Return the prompt text of the grader input passed to a recorded call."""
+    return str(call.args[0]["messages"][0].content)
 
 
 def _tool_satisfied_result() -> dict[str, Any]:
@@ -288,7 +325,7 @@ class TestReliableRubricMiddleware:
         )
         context = {"approval_mode": "manual"}
 
-        result = middleware._grade_once(_state(), 0, context=context)
+        result = middleware._invoke_grader(_state(), 0, context=context)
 
         assert result.result == "satisfied"
         assert grader.invoke.call_args.kwargs == {
@@ -332,7 +369,7 @@ class TestReliableRubricMiddleware:
         )
         context = {"approval_mode": "manual"}
 
-        result = await middleware._agrade_once(_state(), 0, context=context)
+        result = await middleware._ainvoke_grader(_state(), 0, context=context)
 
         assert result.result == "satisfied"
         assert grader.ainvoke.await_args.kwargs == {
@@ -371,6 +408,55 @@ class TestReliableRubricMiddleware:
             middleware._grade(_state(), 0)
 
         assert grader.invoke.call_count == 2
+
+    def test_inherits_sdk_coverage_retry_sync(self) -> None:
+        # The transport retry wraps a single grader call, so the SDK's coverage
+        # retry must still fire when the grader under-reports its criteria.
+        middleware = ReliableRubricMiddleware(model="fake-model")
+        grader = MagicMock()
+        grader.invoke.side_effect = [
+            _under_reported_result(),
+            _fully_reported_result(),
+        ]
+        middleware._grader = grader
+
+        result = middleware._grade(_frozen_criteria_state(), 0)
+
+        assert result.result == "satisfied"
+        assert grader.invoke.call_count == 2
+        assert "1 criteria" in _grader_payload(grader.invoke.call_args_list[1])
+
+    async def test_inherits_sdk_coverage_retry_async(self) -> None:
+        middleware = ReliableRubricMiddleware(model="fake-model")
+        grader = AsyncMock()
+        grader.ainvoke.side_effect = [
+            _under_reported_result(),
+            _fully_reported_result(),
+        ]
+        middleware._grader = grader
+
+        result = await middleware._agrade(_frozen_criteria_state(), 0)
+
+        assert result.result == "satisfied"
+        assert grader.ainvoke.await_count == 2
+        assert "1 criteria" in _grader_payload(grader.ainvoke.await_args_list[1])
+
+    def test_transport_retry_nests_inside_coverage_retry(self) -> None:
+        # A transport fault is retried within a call; an under-report is retried
+        # across calls. Both must be available in the same grading pass.
+        middleware = ReliableRubricMiddleware(model="fake-model")
+        grader = MagicMock()
+        grader.invoke.side_effect = [
+            _read_error(),
+            _under_reported_result(),
+            _fully_reported_result(),
+        ]
+        middleware._grader = grader
+
+        result = middleware._grade(_frozen_criteria_state(), 0)
+
+        assert result.result == "satisfied"
+        assert grader.invoke.call_count == 3
 
     def test_builds_context_aware_nested_grader(
         self,

--- a/libs/code/tests/unit_tests/test_reliable_rubric.py
+++ b/libs/code/tests/unit_tests/test_reliable_rubric.py
@@ -424,7 +424,7 @@ class TestReliableRubricMiddleware:
 
         assert result.result == "satisfied"
         assert grader.invoke.call_count == 2
-        assert "1 criteria" in _grader_payload(grader.invoke.call_args_list[1])
+        assert "1 of the 2 criteria" in _grader_payload(grader.invoke.call_args_list[1])
 
     async def test_inherits_sdk_coverage_retry_async(self) -> None:
         middleware = ReliableRubricMiddleware(model="fake-model")
@@ -439,7 +439,9 @@ class TestReliableRubricMiddleware:
 
         assert result.result == "satisfied"
         assert grader.ainvoke.await_count == 2
-        assert "1 criteria" in _grader_payload(grader.ainvoke.await_args_list[1])
+        assert "1 of the 2 criteria" in _grader_payload(
+            grader.ainvoke.await_args_list[1]
+        )
 
     def test_transport_retry_nests_inside_coverage_retry(self) -> None:
         # A transport fault is retried within a call; an under-report is retried

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -2474,6 +2474,48 @@ class TestFormatRubricEvent:
         assert "The goal remains active" in details
         assert "`/goal clear`" in details
 
+    def test_unverified_verdict_reads_as_a_verification_gap(self) -> None:
+        """A downgraded `satisfied` has no failing criteria to address."""
+        event = {
+            "type": "rubric_evaluation_end",
+            "result": "needs_revision",
+            "unverified": True,
+            "explanation": "Grading was incomplete.",
+            "criteria": [{"name": "compiles", "passed": True}],
+        }
+
+        assert _format_rubric_event(event) == (
+            "↻ Acceptance criteria could not be verified"
+        )
+        details = _format_rubric_details(event)
+        assert "Unmet criteria" not in details
+        assert "Address every unmet criterion" not in details
+        assert "could not account for every criterion" in details
+
+    def test_unverified_max_iterations_marks_the_limit_and_the_gap(self) -> None:
+        """The iteration-limit verdict keeps its suffix when nothing was verified."""
+        event = {
+            "type": "rubric_evaluation_end",
+            "result": "max_iterations_reached",
+            "unverified": True,
+        }
+
+        assert _format_rubric_event(event) == (
+            "⚠ Acceptance criteria could not be verified (iteration limit reached)"
+        )
+
+    def test_verified_revision_keeps_the_unmet_criteria_wording(self) -> None:
+        """Without `unverified`, confirmed defects still drive the next step."""
+        event = {
+            "type": "rubric_evaluation_end",
+            "result": "needs_revision",
+            "unverified": False,
+            "criteria": [{"name": "tests pass", "passed": False}],
+        }
+
+        assert _format_rubric_event(event) == "↻ Acceptance criteria not yet satisfied"
+        assert "Address every unmet criterion" in _format_rubric_details(event)
+
     def test_end_event_without_result_returns_none(self) -> None:
         """Partial end events should not render a spurious warning."""
         assert _format_rubric_event({"type": "rubric_evaluation_end"}) is None

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -2408,7 +2408,7 @@ class TestFormatRubricEvent:
         assert explanation.strip() in details
         assert "Exact copy remains intact" in details
         assert "Expected 'Not ready'; found 'Pending'." in details
-        assert "Passing criterion" not in details
+        assert "Satisfied criteria\n- Passing criterion" in details
         assert "Address every unmet criterion, then retry the check." in details
         assert "{'name':" not in details
         assert "truncated" not in details
@@ -2473,6 +2473,59 @@ class TestFormatRubricEvent:
 
         assert "The goal remains active" in details
         assert "`/goal clear`" in details
+
+    def test_details_report_the_full_pass_fail_accounting(self) -> None:
+        """Both verdicts render so a partial evaluation is visible as partial."""
+        details = _format_rubric_details(
+            {
+                "result": "needs_revision",
+                "criteria": [
+                    {"name": "Reports infeasibility", "passed": True},
+                    {"name": "Lists 15 shops", "passed": False, "gap": "Only 5."},
+                    {"name": "Two sources each", "passed": False},
+                ],
+            }
+        )
+
+        assert (
+            "Unmet criteria\n- Lists 15 shops\n  Only 5.\n- Two sources each" in details
+        )
+        assert "Satisfied criteria\n- Reports infeasibility" in details
+        # Unmet criteria stay above the satisfied list; the panel leads with
+        # what the user has to act on.
+        assert details.index("Unmet criteria") < details.index("Satisfied criteria")
+
+    def test_criterion_without_a_boolean_verdict_is_listed_in_neither_section(
+        self,
+    ) -> None:
+        """A missing or non-boolean `passed` must not be guessed either way."""
+        details = _format_rubric_details(
+            {
+                "result": "needs_revision",
+                "criteria": [
+                    {"name": "No verdict"},
+                    {"name": "Null verdict", "passed": None},
+                    {"name": "Truthy non-bool", "passed": 1},
+                ],
+            }
+        )
+
+        assert "Unmet criteria" not in details
+        assert "Satisfied criteria" not in details
+
+    def test_all_criteria_passing_still_renders_on_a_failure_verdict(self) -> None:
+        """A downgraded verdict has passing criteria but no failing ones."""
+        details = _format_rubric_details(
+            {
+                "result": "needs_revision",
+                "unverified": True,
+                "criteria": [{"name": "compiles", "passed": True}],
+            }
+        )
+
+        assert "Unmet criteria" not in details
+        assert "Satisfied criteria\n- compiles" in details
+        assert "could not account for every criterion" in details
 
     def test_unverified_verdict_reads_as_a_verification_gap(self) -> None:
         """A downgraded `satisfied` has no failing criteria to address."""

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -2526,6 +2526,9 @@ class TestFormatRubricEvent:
         assert "Unmet criteria" not in details
         assert "Satisfied criteria\n- compiles" in details
         assert "could not account for every criterion" in details
+        # The next step must not deny the criteria the same panel just listed.
+        assert "nothing was confirmed" not in details
+        assert "the full rubric was not verified" in details
 
     def test_unverified_verdict_reads_as_a_verification_gap(self) -> None:
         """A downgraded `satisfied` has no failing criteria to address."""

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -2491,9 +2491,9 @@ class TestFormatRubricEvent:
             "Unmet criteria\n- Lists 15 shops\n  Only 5.\n- Two sources each" in details
         )
         assert "Satisfied criteria\n- Reports infeasibility" in details
-        # Unmet criteria stay above the satisfied list; the panel leads with
-        # what the user has to act on.
-        assert details.index("Unmet criteria") < details.index("Satisfied criteria")
+        # The satisfied list comes first so the panel reads as an accounting of
+        # the whole rubric rather than a list of defects.
+        assert details.index("Satisfied criteria") < details.index("Unmet criteria")
 
     def test_criterion_without_a_boolean_verdict_is_listed_in_neither_section(
         self,


### PR DESCRIPTION
Stacked on #5234. Review that one first; this PR's diff is only the `libs/code` half.

## The bug

`ReliableRubricMiddleware` overrides `_grade`/`_agrade` to retry a transient grader transport failure. Those are the same methods that hold the SDK's coverage retry, and the override never calls `super()`, so dcode replaced the coverage retry rather than composing with it.

The consequence is asymmetric, because the *downgrade* that the coverage retry protects is in `_finalize_evaluation`, which dcode does inherit:

| | grader calls before downgrade |
|---|---|
| SDK `RubricMiddleware` | 2 (under-report, re-ask, still short) |
| dcode `ReliableRubricMiddleware` | 1 (under-report) |

So a grader that miscounts its criteria once turns a `satisfied` into `needs_revision` in dcode with no second chance. At `max_iterations=3` a slip on the final iteration becomes `max_iterations_reached`, and `_resolve_pending_goal_completion` then refuses to complete a `/goal` whose work was actually satisfied.

Second, smaller bug: on that downgrade path no criterion is marked failed, so the transcript rendered "Acceptance criteria not yet satisfied" plus "Address every unmet criterion, then retry the check." above an empty list.

## The fix

- The transport retry moves down to `_invoke_grader`/`_ainvoke_grader`, which wrap exactly one grader call and delegate to `super()`. The two retries now nest correctly: a transport fault is retried within a call, an under-report across calls.
- `_grader_input` takes the SDK's `correction` argument and builds its payload through `super()`, so the retry's corrective feedback reaches the grader and the delimiter sanitization is no longer re-implemented here.
- The `after_agent`/`aafter_agent` overrides are deleted. They existed only to re-raise `GraphBubbleUp` and to thread `runtime.context`; the SDK does both now. This also drops the private `_strategy_from_result` import.
- `_format_rubric_event`/`_format_rubric_details` read the new `unverified` flag and describe the verdict as a verification gap ("could not be verified", "the grader could not account for every criterion") instead of pointing at criteria that do not exist.

## Tests

`libs/code`: 11680 passed, 3 skipped. `make lint` and `make type` clean.

New coverage:
- the coverage retry fires for an under-reporting grader, sync and async, and the second call carries the correction
- a transport fault and an under-report in the same pass produce three grader calls
- `unverified` rendering for `needs_revision` and `max_iterations_reached`, plus a guard that the ordinary revision wording is unchanged