### PR TITLE
fix(code): prevent post-tool hook replay

### DIFF
--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -120,6 +120,16 @@ class _PreToolPassed(TypedDict):
 
 
 _PreToolState: TypeAlias = _PreToolDenied | _PreToolPassed
+
+# Maps a tool-call id to the measured execution duration while the call awaits
+# its post-execution hook. The value is overloaded as a tombstone: a `None`
+# value means "delete this key", not "no duration". This mirrors LangGraph's
+# `RemoveMessage` sentinel -- a LangGraph reducer merges an update into the
+# channel and returns the whole new value, so removal is expressed by writing
+# a `None` sentinel that `_merge_pending_post_tools` pops, rather than by
+# omitting the key (a plain merge can only add/overwrite, never remove).
+# `_pending_post_tools` filters these tombstones out, so consumers only ever
+# see real `int` durations.
 _PendingPostToolState: TypeAlias = dict[str, int | None]
 
 
@@ -127,6 +137,20 @@ def _merge_pending_post_tools(
     current: _PendingPostToolState,
     update: _PendingPostToolState,
 ) -> _PendingPostToolState:
+    """Merge pending entries, treating a `None` value as a deletion sentinel.
+
+    LangGraph reducers return the entire new channel value, so writing
+    `{call_id: None}` removes `call_id` from the merged result instead of
+    storing the `None`. A merge can only add/overwrite keys, so this sentinel
+    is the mechanism for removing a consumed entry.
+
+    Args:
+        current: Current channel value.
+        update: Incoming update; `None` values delete their keys.
+
+    Returns:
+        The merged channel value with tombstoned keys removed.
+    """
     merged = dict(current)
     for call_id, duration_ms in update.items():
         if duration_ms is None:
@@ -425,9 +449,14 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
         pending = _pending_post_tools(state)
         if not pending:
             return None
+        # Construct a new _PendingPostToolState where `duration_ms` is None
+        # for each entry. This causes the pending state to be evicted during
+        # graph state reconciliation in _merge_pending_post_tools
         completed: _PendingPostToolState = dict.fromkeys(pending)
         messages = state.get("messages", ())
         latest_call_message = _latest_tool_call_message(messages)
+        # If there is an extant _PendingPostToolState but no corresponding
+        # tool message, mark the _PendingPostToolState as resolved.
         if latest_call_message is None:
             return {_PENDING_POST_TOOL_STATE_KEY: completed}
         message_index, ai_message = latest_call_message
@@ -448,6 +477,7 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
             duration_ms = pending.get(call.id)
             result = results.get(call.id)
             if duration_ms is None or result is None:
+                # This pending entry has already been consumed, continue
                 continue
             updated = self._maybe_post_tool_use(
                 call,
@@ -723,9 +753,7 @@ def _post_tool_boundary_enabled(
     )
 
 
-def _pending_post_tools(state: object) -> dict[str, int]:
-    if not isinstance(state, Mapping):
-        return {}
+def _pending_post_tools(state: ServerHooksState) -> dict[str, int]:
     raw = state.get(_PENDING_POST_TOOL_STATE_KEY)
     if not isinstance(raw, Mapping):
         return {}

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -95,6 +95,7 @@ if TYPE_CHECKING:
 _DEFAULT_DEADLINE = timedelta(seconds=600)
 _STOP_STATE_KEY = "_hooks_stop_continuation_count"
 _PRE_TOOL_STATE_KEY = "_hooks_pre_tool_outcomes"
+_PENDING_POST_TOOL_STATE_KEY = "_hooks_pending_post_tools"
 _TASK_TOOL_NAME = "task"
 _COMPACT_TOOL_NAME = "compact_conversation"
 _INVOCATION_NAMESPACE = UUID("f2896d18-cf2a-4e7d-b11a-d5b10fc0e335")
@@ -119,27 +120,37 @@ class _PreToolPassed(TypedDict):
 
 
 _PreToolState: TypeAlias = _PreToolDenied | _PreToolPassed
+_PendingPostToolState: TypeAlias = dict[str, int | None]
+
+
+def _merge_pending_post_tools(
+    current: _PendingPostToolState,
+    update: _PendingPostToolState,
+) -> _PendingPostToolState:
+    merged = dict(current)
+    for call_id, duration_ms in update.items():
+        if duration_ms is None:
+            merged.pop(call_id, None)
+        else:
+            merged[call_id] = duration_ms
+    return merged
 
 
 class ServerHooksState(AgentState[Any]):
     """Agent state extensions for server-owned hook middleware.
 
-    Both fields are per-turn bookkeeping owned by `ServerHooksMiddleware` and
+    All fields are per-turn bookkeeping owned by `ServerHooksMiddleware` and
     marked `PrivateStateAttr`: they are omitted from the public graph I/O schema,
-    and `SubAgentMiddleware` strips them from subagent result merges so parallel
-    `task` calls cannot produce two concurrent writes to these `LastValue`
-    channels.
+    and `SubAgentMiddleware` strips them from subagent result merges.
 
     `PrivateStateAttr` only omits the fields from the input and output schemas;
-    the channels stay ordinary checkpointed `LastValue` channels visible to every
-    node, so values still flow from `after_model` to `wrap_tool_call` and survive
-    interrupt/resume.
+    the channels remain checkpointed and visible to graph nodes, so values flow
+    across lifecycle boundaries and survive interrupt/resume.
 
     Note:
-        If either field ever needs a reducer, the reducer must be placed *after*
-        `PrivateStateAttr` in the `Annotated` metadata. LangGraph only inspects
-        the last metadata entry when detecting reducers, so a reducer added
-        before the marker is silently ignored.
+        Reducers must be placed *after* `PrivateStateAttr` in the `Annotated`
+        metadata. LangGraph only inspects the last metadata entry when detecting
+        reducers, so a reducer added before the marker is silently ignored.
     """
 
     _hooks_stop_continuation_count: NotRequired[Annotated[int, PrivateStateAttr]]
@@ -154,6 +165,15 @@ class ServerHooksState(AgentState[Any]):
     `_after_model` replaces the whole dict (including with `{}`) so stale ids
     cannot survive into a later turn.
     """
+
+    _hooks_pending_post_tools: NotRequired[
+        Annotated[
+            _PendingPostToolState,
+            PrivateStateAttr,
+            _merge_pending_post_tools,
+        ]
+    ]
+    """Executed calls awaiting post-tool hooks at a checkpointed boundary."""
 
 
 class _SessionHookGate(TypedDict):
@@ -231,6 +251,30 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
             and (server := _mcp_server_from_tool(tool)) is not None
         }
 
+    def before_model(
+        self,
+        state: ServerHooksState,
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Run post-execution hooks after tool results are checkpointed.
+
+        Returns:
+            State updates for rewritten results and completed hook bookkeeping.
+        """
+        return self._before_model(state, runtime)
+
+    async def abefore_model(
+        self,
+        state: ServerHooksState,
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Run async post-execution hooks at the same safe boundary.
+
+        Returns:
+            State updates for rewritten results and completed hook bookkeeping.
+        """
+        return self._before_model(state, runtime)
+
     def after_model(
         self,
         state: ServerHooksState,
@@ -260,10 +304,10 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
     ) -> ToolMessage | Command[Any]:
-        """Run Pre/Post tool hooks around a synchronous tool call.
+        """Run pre-tool hooks and record synchronous results for post hooks.
 
         Returns:
-            Tool result, possibly rewritten by hook decisions.
+            Tool result with checkpointed post-hook bookkeeping when needed.
         """
         gate = _session_gate(request.runtime.context)
         call = _tool_call_data(request)
@@ -282,22 +326,19 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
             result = handler(request)
         duration_ms = int((time.perf_counter() - started) * 1000)
         result = _append_message_text(result, pre.context, call.id)
-        result = self._maybe_post_tool_use(
-            call, context, gate, request.runtime.config, result, duration_ms
-        )
-        return self._maybe_subagent_stop(
-            call, context, gate, request.runtime.config, result
-        )
+        if _post_tool_boundary_enabled(gate, call):
+            return _record_pending_post_tool(result, call.id, duration_ms)
+        return result
 
     async def awrap_tool_call(
         self,
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
     ) -> ToolMessage | Command[Any]:
-        """Run Pre/Post tool hooks around an asynchronous tool call.
+        """Run pre-tool hooks and record asynchronous results for post hooks.
 
         Returns:
-            Tool result, possibly rewritten by hook decisions.
+            Tool result with checkpointed post-hook bookkeeping when needed.
         """
         gate = _session_gate(request.runtime.context)
         call = _tool_call_data(request)
@@ -316,12 +357,9 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
             result = await handler(request)
         duration_ms = int((time.perf_counter() - started) * 1000)
         result = _append_message_text(result, pre.context, call.id)
-        result = self._maybe_post_tool_use(
-            call, context, gate, request.runtime.config, result, duration_ms
-        )
-        return self._maybe_subagent_stop(
-            call, context, gate, request.runtime.config, result
-        )
+        if _post_tool_boundary_enabled(gate, call):
+            return _record_pending_post_tool(result, call.id, duration_ms)
+        return result
 
     @hook_config(can_jump_to=["model"])
     def after_agent(
@@ -378,6 +416,64 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
                 ),
             )
         return _inject_subagent_start_context(request, decision)
+
+    def _before_model(
+        self,
+        state: ServerHooksState,
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        pending = _pending_post_tools(state)
+        if not pending:
+            return None
+        completed: _PendingPostToolState = dict.fromkeys(pending)
+        messages = state.get("messages", ())
+        latest_call_message = _latest_tool_call_message(messages)
+        if latest_call_message is None:
+            return {_PENDING_POST_TOOL_STATE_KEY: completed}
+        message_index, ai_message = latest_call_message
+        results = {
+            message.tool_call_id: message
+            for message in messages[message_index + 1 :]
+            if isinstance(message, ToolMessage)
+        }
+        gate = _session_gate(runtime.context)
+        config = _runtime_hook_config(runtime)
+        context = _hook_context(runtime.context, config, self._cwd)
+        updates: list[ToolMessage] = []
+        for tool_call in ai_message.tool_calls:
+            call = _tool_call_data_from_call(
+                tool_call,
+                mcp_server=self._mcp_servers.get(str(tool_call.get("name") or "")),
+            )
+            duration_ms = pending.get(call.id)
+            result = results.get(call.id)
+            if duration_ms is None or result is None:
+                continue
+            updated = self._maybe_post_tool_use(
+                call,
+                context,
+                gate,
+                config,
+                result,
+                duration_ms,
+            )
+            updated = self._maybe_subagent_stop(
+                call,
+                context,
+                gate,
+                config,
+                updated,
+            )
+            if not isinstance(updated, ToolMessage):
+                msg = "Post-tool hooks must preserve committed ToolMessage results"
+                raise TypeError(msg)
+            updates.append(updated)
+        state_update: dict[str, Any] = {
+            _PENDING_POST_TOOL_STATE_KEY: completed,
+        }
+        if updates:
+            state_update["messages"] = updates
+        return state_update
 
     def _after_model(
         self,
@@ -613,6 +709,33 @@ def _event_enabled(gate: _SessionHookGate | None, event: HookEvent) -> bool:
     return gate is not None and event.value in gate["events"]
 
 
+def _post_tool_boundary_enabled(
+    gate: _SessionHookGate | None,
+    call: ToolCallData,
+) -> bool:
+    return (
+        _event_enabled(gate, HookEvent.POST_TOOL_USE)
+        or _event_enabled(gate, HookEvent.POST_TOOL_USE_FAILURE)
+        or (
+            call.name == _TASK_TOOL_NAME
+            and _event_enabled(gate, HookEvent.SUBAGENT_STOP)
+        )
+    )
+
+
+def _pending_post_tools(state: object) -> dict[str, int]:
+    if not isinstance(state, Mapping):
+        return {}
+    raw = state.get(_PENDING_POST_TOOL_STATE_KEY)
+    if not isinstance(raw, Mapping):
+        return {}
+    return {
+        str(call_id): duration_ms
+        for call_id, duration_ms in raw.items()
+        if isinstance(duration_ms, int) and not isinstance(duration_ms, bool)
+    }
+
+
 def hook_decided_permission(state: object, tool_call_id: str) -> bool:
     """Report whether a pre-execution hook already settled permission for a call.
 
@@ -768,6 +891,21 @@ def _context_mapping(runtime_context: object) -> dict[str, Any]:
         if value is not None:
             result[key] = value
     return result
+
+
+def _runtime_hook_config(runtime: Runtime[Any]) -> dict[str, Any] | None:
+    info = runtime.execution_info
+    if info is None:
+        return None
+    configurable = {
+        key: value
+        for key, value in (
+            ("run_id", info.run_id),
+            ("thread_id", info.thread_id),
+        )
+        if value
+    }
+    return {"configurable": configurable} if configurable else None
 
 
 def _run_id(config: Mapping[str, Any] | None, thread_id: str) -> str:
@@ -967,6 +1105,20 @@ def _ask_permission_via_hitl(
     return None
 
 
+def _record_pending_post_tool(
+    result: ToolMessage | Command[Any],
+    call_id: str,
+    duration_ms: int,
+) -> Command[Any]:
+    pending = {_PENDING_POST_TOOL_STATE_KEY: {call_id: duration_ms}}
+    if isinstance(result, ToolMessage):
+        return Command(update={"messages": [result], **pending})
+    update = result.update
+    if not isinstance(update, Mapping):
+        return result
+    return replace(result, update={**update, **pending})
+
+
 def _append_message_text(
     result: ToolMessage | Command[Any],
     parts: Sequence[str],
@@ -1144,6 +1296,19 @@ def _tool_result_text(result: ToolMessage | Command[Any], call_id: str) -> str:
         str(message.content)
         for message in _command_messages(result)
         if _is_call_result(message, call_id)
+    )
+
+
+def _latest_tool_call_message(
+    messages: Sequence[Any],
+) -> tuple[int, AIMessage] | None:
+    return next(
+        (
+            (index, message)
+            for index, message in reversed(list(enumerate(messages)))
+            if isinstance(message, AIMessage) and message.tool_calls
+        ),
+        None,
     )
 
 

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -49,6 +49,7 @@ from deepagents_code.hooks.models.domain import (
     HookInvocation,
     PermissionEffect,
     PostToolUseDecision,
+    PostToolUseEvent,
     PostToolUseFailureDecision,
     PostToolUseFailureEvent,
     PreCompactDecision,
@@ -120,6 +121,7 @@ class _PublicHookState(AgentState[Any]):
 
     _hooks_stop_continuation_count: NotRequired[int]
     _hooks_pre_tool_outcomes: NotRequired[dict[str, Any]]
+    _hooks_pending_post_tools: NotRequired[dict[str, int | None]]
 
 
 def _hook_state_keys() -> frozenset[str]:
@@ -135,7 +137,7 @@ def _hook_state_keys() -> frozenset[str]:
 
 
 def _hook_state_subagent(*, name: str, content: str) -> CompiledSubAgent:
-    """Subagent that writes both hook keys directly, as a bare compiled runnable.
+    """Subagent that writes every hook key directly as a compiled runnable.
 
     `CompiledSubAgent` is the weaker of the two outbound layers: a raw `SubAgent`
     also gets filtered by its own graph's output schema, so only this shape
@@ -146,6 +148,7 @@ def _hook_state_subagent(*, name: str, content: str) -> CompiledSubAgent:
         return {
             "_hooks_stop_continuation_count": 1,
             "_hooks_pre_tool_outcomes": {name: {"behavior": "none", "context": []}},
+            "_hooks_pending_post_tools": {name: 1},
             "messages": [AIMessage(content=content)],
         }
 
@@ -183,11 +186,13 @@ def test_server_hook_state_fields_are_private() -> None:
 
     assert "_hooks_pre_tool_outcomes" in private_fields
     assert "_hooks_stop_continuation_count" in private_fields
+    assert "_hooks_pending_post_tools" in private_fields
     # `private_state_field_names` skips schemas whose annotations cannot be
     # resolved, which would silently return an empty set and revert the fix.
     assert _hook_state_keys() == {
         "_hooks_pre_tool_outcomes",
         "_hooks_stop_continuation_count",
+        "_hooks_pending_post_tools",
     }
 
 
@@ -317,6 +322,8 @@ def test_parallel_tasks_do_not_merge_subagent_server_hook_state(
     state = agent.get_state(config).values
     assert "first" not in state.get("_hooks_pre_tool_outcomes", {})
     assert "second" not in state.get("_hooks_pre_tool_outcomes", {})
+    assert "first" not in state.get("_hooks_pending_post_tools", {})
+    assert "second" not in state.get("_hooks_pending_post_tools", {})
     assert "_hooks_stop_continuation_count" not in state
 
 
@@ -407,6 +414,99 @@ def test_pretool_deny_blocks_tool_through_real_graph(
     assert len(denied) == 1
     assert denied[0].status == "error"
     assert "blocked by policy" in str(denied[0].content)
+
+
+async def test_post_tool_resumes_do_not_reexecute_parallel_tools(
+    tmp_path: Path,
+) -> None:
+    executed: list[str] = []
+
+    @tool
+    def side_effect(value: str) -> str:
+        """Record one visible side effect."""
+        executed.append(value)
+        return f"recorded {value}"
+
+    tool_calls = [
+        {
+            "name": "side_effect",
+            "args": {"value": value},
+            "id": f"call-{value}",
+            "type": "tool_call",
+        }
+        for value in ("first", "second")
+    ]
+    model = _ToolCallingFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(content="", tool_calls=tool_calls),
+                AIMessage(content="done"),
+            ]
+        )
+    )
+    agent = create_agent(
+        model=model,
+        tools=[side_effect],
+        middleware=[ServerHooksMiddleware(cwd=tmp_path)],
+        context_schema=CLIContextSchema,
+        checkpointer=InMemorySaver(),
+    )
+    context = CLIContextSchema(
+        hooks_snapshot_id="snap",
+        hooks_server_events=[HookEvent.POST_TOOL_USE.value],
+        thread_id="thread-post-tool",
+        approval_mode=ApprovalMode.MANUAL.value,
+    )
+    config: RunnableConfig = {"configurable": {"thread_id": "thread-post-tool"}}
+
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage(content="run both")]},
+        config=config,
+        context=context,
+    )
+
+    assert sorted(executed) == ["first", "second"]
+    assert "_hooks_pending_post_tools" not in result
+    checkpoint = agent.get_state(config).values
+    assert checkpoint["_hooks_pending_post_tools"].keys() == {
+        "call-first",
+        "call-second",
+    }
+    invoked: set[str] = set()
+    while result.get("__interrupt__"):
+        pending = result["__interrupt__"][0]
+        request = parse_hook_interrupt_payload(pending.value)
+        assert request is not None
+        event = request.invocation.event
+        assert isinstance(event, PostToolUseEvent)
+        assert event.duration_ms is not None
+        invoked.add(event.call.id)
+        response = HookInvocationResponse(
+            protocol_version=1,
+            invocation_id=request.invocation_id,
+            snapshot_id=request.snapshot_id,
+            decision=PostToolUseDecision(
+                event=HookEvent.POST_TOOL_USE,
+                feedback=[f"reviewed {event.call.id}"],
+            ),
+        )
+        result = await agent.ainvoke(
+            Command(resume=build_hook_resume_value(response)),
+            config=config,
+            context=context,
+        )
+        assert sorted(executed) == ["first", "second"]
+
+    assert invoked == {"call-first", "call-second"}
+    tool_results = {
+        message.tool_call_id: str(message.content)
+        for message in result["messages"]
+        if isinstance(message, ToolMessage)
+    }
+    for value in ("first", "second"):
+        assert f"recorded {value}" in tool_results[f"call-{value}"]
+        assert f"reviewed call-{value}" in tool_results[f"call-{value}"]
+    assert agent.get_state(config).values.get("_hooks_pending_post_tools") == {}
 
 
 def _request(event: PreToolUseEvent | None = None) -> HookInvocationRequest:


### PR DESCRIPTION
Post-execution hooks no longer replay tools when resumed, preventing duplicate side effects in all Hooks v2 sessions.

---

`PostToolUse`, `PostToolUseFailure`, and `SubagentStop` previously interrupted inside the tools node after execution but before its result committed. This moves those interrupts to a checkpoint-safe post-tools boundary while preserving duration reporting and result feedback/context rewriting through private state. Hooks v2 has loaded by default since #5307, so the fix applies regardless of `DEEPAGENTS_CODE_EXPERIMENTAL`.

<details>
<summary>Test plan</summary>

- `make lint`
- `uv run --group test pytest -q tests/unit_tests/hooks` (220 passed)

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/d820d546-4257-bc9f-82ee-3a038ddc0005)