### PR TITLE
feat(code): add Meta `muse-spark-1.2` to model switcher

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -84,6 +84,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "fireworks:accounts/fireworks/models/qwen3p7-plus": "Qwen 3.7 Plus",
     "google_genai:gemini-3.6-flash": "Gemini 3.6 Flash",
     "meta:muse-spark-1.1": "Muse Spark 1.1",
+    "meta:muse-spark-1.2": "Muse Spark 1.2",
     "ollama:deepseek-v4-flash:cloud": "DeepSeek V4 Flash",
     "ollama:deepseek-v4-pro:cloud": "DeepSeek V4 Pro",
     "ollama:glm-5.2:cloud": "GLM 5.2",

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -2662,6 +2662,7 @@ class TestGetModelDisplayName:
         [
             ("fireworks:accounts/fireworks/models/kimi-k3", "Kimi K3"),
             ("meta:muse-spark-1.1", "Muse Spark 1.1"),
+            ("meta:muse-spark-1.2", "Muse Spark 1.2"),
             ("openai:gpt-5.6-luna", "GPT-5.6 Luna"),
             ("openai:gpt-5.6-sol", "GPT-5.6 Sol"),
             ("openai:gpt-5.6-terra", "GPT-5.6 Terra"),


### PR DESCRIPTION
Muse Spark 1.2 now appears as a recommended model in the `/model` picker, under the Meta provider as `meta:muse-spark-1.2`.

---

The Meta provider (`langchain-meta`, `MODEL_API_KEY`) is already wired through the switcher, credential manager, and model discovery — the only change needed is the curated entry in `_RECOMMENDED_MODELS` (with its display-name fallback), which also feeds the onboarding picker and the "Recommended only" toggle. A parametrized display-name test entry pins the fallback.

Muse Spark 1.1 stays listed; users on the older revision can keep selecting it.
