### PR TITLE
feat(code): add Meta `muse-spark-1.2` to model switcher

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -84,6 +84,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "fireworks:accounts/fireworks/models/qwen3p7-plus": "Qwen 3.7 Plus",
     "google_genai:gemini-3.6-flash": "Gemini 3.6 Flash",
     "meta:muse-spark-1.1": "Muse Spark 1.1",
+    "meta:muse-spark-1.2": "Muse Spark 1.2",
     "ollama:deepseek-v4-flash:cloud": "DeepSeek V4 Flash",
     "ollama:deepseek-v4-pro:cloud": "DeepSeek V4 Pro",
     "ollama:glm-5.2:cloud": "GLM 5.2",

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -2662,6 +2662,7 @@ class TestGetModelDisplayName:
         [
             ("fireworks:accounts/fireworks/models/kimi-k3", "Kimi K3"),
             ("meta:muse-spark-1.1", "Muse Spark 1.1"),
+            ("meta:muse-spark-1.2", "Muse Spark 1.2"),
             ("openai:gpt-5.6-luna", "GPT-5.6 Luna"),
             ("openai:gpt-5.6-sol", "GPT-5.6 Sol"),
             ("openai:gpt-5.6-terra", "GPT-5.6 Terra"),


### PR DESCRIPTION
Muse Spark 1.2 now appears in the `/model` picker, onboarding picker, and "Recommended only" toggle as Meta's recommended entry alongside Muse Spark 1.1.

---

Meta released Muse Spark 1.2 on August 5, 2026 — a coding-focused update to Muse Spark 1.1 with a 1M-token context window, available on Meta's first-party Model API as `muse-spark-1.2` ([Meta announcement](https://research.meta.ai/blog/introducing-muse-code-and-muse-spark-1-2), [OpenRouter listing](https://openrouter.ai/meta/muse-spark-1.2)).

The `meta` provider is already fully wired into dcode (`PROVIDER_API_KEY_ENV`, extra, auth flow), so only the curated entry in `_RECOMMENDED_MODELS` and its test pin were needed. The 1.1 entry stays listed so users on the older revision can still select it.
