### PR TITLE
feat(code): add OpenRouter `meta/muse-spark-1.2` to model switcher

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -101,6 +101,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "openrouter:deepseek/deepseek-v4-flash:free": "DeepSeek V4 Flash (free)",
     "openrouter:deepseek/deepseek-v4-pro": "DeepSeek V4 Pro",
     "openrouter:google/gemini-3.6-flash": "Gemini 3.6 Flash",
+    "openrouter:meta/muse-spark-1.2": "Muse Spark 1.2",
     "openrouter:moonshotai/kimi-k3": "Kimi K3",
     "openrouter:nvidia/nemotron-3-ultra-550b-a55b": "Nemotron 3 Ultra 550B A55B",
     "openrouter:openrouter/fusion": "OpenRouter Fusion",

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -2669,6 +2669,7 @@ class TestGetModelDisplayName:
             ("openai_codex:gpt-5.6-luna", "GPT-5.6 Luna"),
             ("openai_codex:gpt-5.6-sol", "GPT-5.6 Sol"),
             ("openai_codex:gpt-5.6-terra", "GPT-5.6 Terra"),
+            ("openrouter:meta/muse-spark-1.2", "Muse Spark 1.2"),
             ("xai:grok-4.5", "Grok 4.5"),
         ],
     )


### PR DESCRIPTION
Muse Spark 1.2 now appears in the `/model` picker, onboarding picker, and "Recommended only" toggle as an OpenRouter-served entry (`openrouter:meta/muse-spark-1.2`).

---

Meta released Muse Spark 1.2 on August 5, 2026 — a coding-focused update to Muse Spark 1.1 with a 1M-token context window — and OpenRouter began serving it the same day at $1.25/M input and $4.25/M output under the model ID `meta/muse-spark-1.2` ([OpenRouter model page](https://openrouter.ai/meta/muse-spark-1.2), [OpenRouter announcement](https://x.com/OpenRouter/status/2085093509519090030)).

The `openrouter` provider is already fully wired into dcode (`PROVIDER_API_KEY_ENV`, extra, auth flow), so only the curated entry in `_RECOMMENDED_MODELS` and its test pin were needed.
