### PR TITLE
fix(examples): validate async subagent inputs

### DIFF
--- a/examples/async-subagent-server/server.py
+++ b/examples/async-subagent-server/server.py
@@ -244,7 +244,26 @@ async def create_run(thread_id: str, request: Request) -> dict[str, Any]:
     if thread is None:
         raise HTTPException(status_code=404, detail="Thread not found")
 
-    body = await request.json()
+    try:
+        body = await request.json()
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=422, detail="Invalid JSON") from exc
+
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="Request body must be a JSON object")
+
+    input_data = body.get("input")
+    if input_data is None:
+        input_data = {}
+    elif not isinstance(input_data, dict):
+        raise HTTPException(status_code=422, detail="input must be a JSON object")
+
+    messages = input_data.get("messages", [])
+    if messages is None:
+        messages = []
+    elif not isinstance(messages, list):
+        raise HTTPException(status_code=422, detail="messages must be a list")
+
     multitask_strategy = body.get("multitask_strategy")
 
     if multitask_strategy == "interrupt":
@@ -258,7 +277,6 @@ async def create_run(thread_id: str, request: Request) -> dict[str, Any]:
         )
         _conn.commit()
 
-    messages = (body.get("input") or {}).get("messages") or []
     user_message = next((m["content"] for m in messages if m.get("role") == "user"), "")
 
     if user_message:

--- a/examples/async-subagent-server/test_server.py
+++ b/examples/async-subagent-server/test_server.py
@@ -176,7 +176,45 @@ def test_404_for_missing_thread(client):
     assert resp.status_code == 404
 
 
+def test_create_run_for_missing_thread_returns_404(client):
+    resp = client.post(
+        "/threads/nonexistent/runs",
+        json={
+            "assistant_id": "researcher",
+            "input": {"messages": [{"role": "user", "content": "hello"}]},
+        },
+    )
+    assert resp.status_code == 404
+
+
+def test_cancel_run_for_missing_run_returns_404(client):
+    thread = client.post("/threads").json()
+    resp = client.post(f"/threads/{thread['thread_id']}/runs/nonexistent/cancel")
+    assert resp.status_code == 404
+
+
 def test_404_for_missing_run(client):
     thread = client.post("/threads").json()
     resp = client.get(f"/threads/{thread['thread_id']}/runs/nonexistent")
     assert resp.status_code == 404
+
+
+def test_malformed_json_returns_422(client):
+    thread = client.post("/threads").json()
+    resp = client.post(
+        f"/threads/{thread['thread_id']}/runs",
+        data='{"assistant_id":',
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Invalid JSON"
+
+
+def test_create_run_rejects_bad_payload(client):
+    thread = client.post("/threads").json()
+    resp = client.post(
+        f"/threads/{thread['thread_id']}/runs",
+        json={"assistant_id": "researcher", "input": {"messages": "not-a-list"}},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "messages must be a list"


### PR DESCRIPTION
## Summary

- add regression tests for malformed JSON, missing thread/run IDs, and invalid payloads in the async subagent example
- validate create-run request bodies before the server processes them

## Testing

- UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q test_server.py