### PR TITLE
fix(code): avoid `Path.resolve()` blocking call in `classify_discovered_configs`

### DIFF
--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -1046,12 +1046,18 @@ def classify_discovered_configs(
     Returns:
         Tuple of `(user_configs, project_configs)`.
     """
-    user_dir = Path.home() / ".deepagents"
+    # Use normpath (pure-string) instead of Path.resolve(), which calls
+    # os.path.realpath() -> os.getcwd(), blocked by blockbuster on the
+    # server event loop.  All config paths are already absolute.
+    import os as _os
+
+    user_dir_str = _os.path.normpath(str(Path.home() / ".deepagents"))
     user: list[Path] = []
     project: list[Path] = []
     for path in config_paths:
         try:
-            if path.resolve().is_relative_to(user_dir.resolve()):
+            path_str = _os.path.normpath(str(path))
+            if path_str == user_dir_str or path_str.startswith(user_dir_str + _os.sep):
                 user.append(path)
             else:
                 project.append(path)


### PR DESCRIPTION
`Path.resolve()` calls `os.path.realpath()` which internally calls `os.getcwd()`. On Windows, the blockbuster-guarded server event loop raises `BlockingError`, preventing dcode from starting.

```
blockbuster.blockbuster.BlockingError: Blocking call to os.getcwd
```

at `classify_discovered_configs` → `path.resolve()` → `os.path.realpath()` → `os.getcwd()`.

All config paths from MCP discovery are already absolute, so `Path.resolve()` (which resolves symlinks and relative paths via the filesystem) is unnecessary. This replaces it with `os.path.normpath(str(path))`, a pure-string operation.

---

Tested on Windows 10 with `dcode -M deepseek:deepseek-chat`. Startup proceeds past the readiness check where it previously failed.