### PR TITLE
feat(code): warn above configurable session cost threshold

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1390,6 +1390,37 @@ def _load_cursor_style_preference() -> CursorStyle:
     return cast("CursorStyle", value)
 
 
+def _load_session_cost_warning_threshold() -> float:
+    """Resolve the estimated-cost threshold for the one-time session warning.
+
+    Returns:
+        The configured threshold in US dollars. Zero or negative disables the
+            warning.
+    """
+    from deepagents_code.config_manifest import (
+        SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT,
+        get_option,
+        load_config_toml,
+        resolve_scalar,
+    )
+
+    option = get_option("warnings.session_cost_threshold_usd")
+    if option is None:
+        logger.warning(
+            "Unknown config option %r; using the default session cost threshold",
+            "warnings.session_cost_threshold_usd",
+        )
+        return SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT
+    value, _ = resolve_scalar(option, toml_data=load_config_toml())
+    if not isinstance(value, float) or not math.isfinite(value):
+        logger.warning(
+            "Invalid session cost warning threshold %r; using the default",
+            value,
+        )
+        return SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT
+    return value
+
+
 def _load_terminal_progress_preference() -> bool:
     """Load the `OSC 9;4` progress preference from `~/.deepagents/config.toml`.
 
@@ -3936,6 +3967,14 @@ class DeepAgentsApp(App):
         the streamed absolute total during a turn. The client never adds its own
         estimates here.
         """
+
+        self._session_cost_warning_threshold_usd = (
+            _load_session_cost_warning_threshold()
+        )
+        """Configured soft limit for the active thread's estimated cost."""
+
+        self._session_cost_warning_shown = False
+        """Whether the active thread has already crossed its cost soft limit."""
 
         self._provisional_cost_usd: float = 0.0
         """Streamed spend the graph has not reported a total for yet.
@@ -7619,6 +7658,27 @@ class DeepAgentsApp(App):
         self._session_cost_usd = _coerce_session_cost_usd(cost_usd)
         self._provisional_cost_usd = 0.0
         self._refresh_session_cost_display()
+        self._maybe_warn_session_cost()
+
+    def _maybe_warn_session_cost(self) -> None:
+        """Warn once when the active thread crosses its configured cost soft limit."""
+        threshold = self._session_cost_warning_threshold_usd
+        if (
+            self._session_cost_warning_shown
+            or threshold <= 0
+            or self._session_cost_usd <= threshold
+        ):
+            return
+        self._session_cost_warning_shown = True
+        self.notify(
+            f"Estimated session cost is {format_cost(self._session_cost_usd)}, above "
+            f"the configured {format_cost(threshold)} threshold. Consider /compact "
+            "to reduce context usage or /clear to start fresh.",
+            title="Session cost warning",
+            severity="warning",
+            timeout=12,
+            markup=False,
+        )
 
     @property
     def _displayed_cost_usd(self) -> float:
@@ -7648,6 +7708,7 @@ class DeepAgentsApp(App):
             has_restored_model_usage or self._thread_restored_cost_usd > 0
         )
         self._thread_has_completed_turn = False
+        self._session_cost_warning_shown = False
         self._set_session_cost(self._thread_restored_cost_usd)
 
     def _mark_thread_turn_completed(self) -> None:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7672,7 +7672,7 @@ class DeepAgentsApp(App):
         self._session_cost_warning_shown = True
         self.notify(
             f"Estimated session cost is {format_cost(self._session_cost_usd)}, above "
-            f"the configured {format_cost(threshold)} threshold. Consider /compact "
+            f"the configured {format_cost(threshold)} threshold. Consider /offload "
             "to reduce context usage or /clear to start fresh.",
             title="Session cost warning",
             severity="warning",

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1390,37 +1390,6 @@ def _load_cursor_style_preference() -> CursorStyle:
     return cast("CursorStyle", value)
 
 
-def _load_session_cost_warning_threshold() -> float:
-    """Resolve the estimated-cost threshold for the one-time session warning.
-
-    Returns:
-        The configured threshold in US dollars. Zero or negative disables the
-            warning.
-    """
-    from deepagents_code.config_manifest import (
-        SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT,
-        get_option,
-        load_config_toml,
-        resolve_scalar,
-    )
-
-    option = get_option("warnings.session_cost_threshold_usd")
-    if option is None:
-        logger.warning(
-            "Unknown config option %r; using the default session cost threshold",
-            "warnings.session_cost_threshold_usd",
-        )
-        return SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT
-    value, _ = resolve_scalar(option, toml_data=load_config_toml())
-    if not isinstance(value, float) or not math.isfinite(value):
-        logger.warning(
-            "Invalid session cost warning threshold %r; using the default",
-            value,
-        )
-        return SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT
-    return value
-
-
 def _load_terminal_progress_preference() -> bool:
     """Load the `OSC 9;4` progress preference from `~/.deepagents/config.toml`.
 
@@ -3968,9 +3937,28 @@ class DeepAgentsApp(App):
         estimates here.
         """
 
-        self._session_cost_warning_threshold_usd = (
-            _load_session_cost_warning_threshold()
+        from deepagents_code.config_manifest import (
+            SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT,
+            get_option,
+            load_config_toml,
+            resolve_scalar,
         )
+
+        cost_warning_option = get_option("warnings.session_cost_threshold_usd")
+        cost_warning_threshold: object = SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT
+        if cost_warning_option is not None:
+            cost_warning_threshold, _ = resolve_scalar(
+                cost_warning_option, toml_data=load_config_toml()
+            )
+        if not isinstance(cost_warning_threshold, float) or not math.isfinite(
+            cost_warning_threshold
+        ):
+            logger.warning(
+                "Invalid session cost warning threshold %r; using the default",
+                cost_warning_threshold,
+            )
+            cost_warning_threshold = SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT
+        self._session_cost_warning_threshold_usd = cost_warning_threshold
         """Configured soft limit for the active thread's estimated cost."""
 
         self._session_cost_warning_shown = False
@@ -7658,27 +7646,21 @@ class DeepAgentsApp(App):
         self._session_cost_usd = _coerce_session_cost_usd(cost_usd)
         self._provisional_cost_usd = 0.0
         self._refresh_session_cost_display()
-        self._maybe_warn_session_cost()
-
-    def _maybe_warn_session_cost(self) -> None:
-        """Warn once when the active thread crosses its configured cost soft limit."""
         threshold = self._session_cost_warning_threshold_usd
         if (
-            self._session_cost_warning_shown
-            or threshold <= 0
-            or self._session_cost_usd <= threshold
+            not self._session_cost_warning_shown
+            and 0 < threshold < self._session_cost_usd
         ):
-            return
-        self._session_cost_warning_shown = True
-        self.notify(
-            f"Estimated session cost is {format_cost(self._session_cost_usd)}, above "
-            f"the configured {format_cost(threshold)} threshold. Consider /offload "
-            "to reduce context usage or /clear to start fresh.",
-            title="Session cost warning",
-            severity="warning",
-            timeout=12,
-            markup=False,
-        )
+            self._session_cost_warning_shown = True
+            self.notify(
+                f"Estimated session cost is {format_cost(self._session_cost_usd)}, "
+                f"above the configured {format_cost(threshold)} threshold. Consider "
+                "/offload to reduce context usage or /clear to start fresh.",
+                title="Session cost warning",
+                severity="warning",
+                timeout=12,
+                markup=False,
+            )
 
     @property
     def _displayed_cost_usd(self) -> float:

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -114,6 +114,12 @@ COMPACT_ON_RESUME_THRESHOLD_DEFAULT = 400_000
 Zero or negative disables the suggestion.
 """
 
+SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT = 50.0
+"""Estimated thread cost above which the user is warned once per session.
+
+Zero or negative disables the warning.
+"""
+
 LANGSMITH_PROJECT_DEFAULT = "deepagents-code"
 """Project agent traces fall back to when no project env var is set.
 
@@ -1540,6 +1546,16 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         toml_keys=("threads", "columns"),
     ),
     # --- Warnings ------------------------------------------------------
+    ConfigOption(
+        key="warnings.session_cost_threshold_usd",
+        group="Warnings",
+        summary=(
+            "Warn once when estimated thread cost exceeds this USD amount (0 disables)."
+        ),
+        kind=OptionKind.FLOAT,
+        default=SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT,
+        toml_keys=("warnings", "session_cost_threshold_usd"),
+    ),
     ConfigOption(
         key="warnings.suppress",
         group="Warnings",

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1546,7 +1546,9 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
     ConfigOption(
         key="warnings.session_cost_threshold_usd",
         group="Warnings",
-        summary="Warn above this estimated thread cost in USD (0 disables).",
+        summary=(
+            "Warn once when estimated thread cost exceeds this USD amount (0 disables)."
+        ),
         kind=OptionKind.FLOAT,
         default=SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT,
         toml_keys=("warnings", "session_cost_threshold_usd"),

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -115,10 +115,7 @@ Zero or negative disables the suggestion.
 """
 
 SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT = 50.0
-"""Estimated thread cost above which the user is warned once per session.
-
-Zero or negative disables the warning.
-"""
+"""Default warning threshold in USD; zero or negative disables the warning."""
 
 LANGSMITH_PROJECT_DEFAULT = "deepagents-code"
 """Project agent traces fall back to when no project env var is set.
@@ -1549,9 +1546,7 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
     ConfigOption(
         key="warnings.session_cost_threshold_usd",
         group="Warnings",
-        summary=(
-            "Warn once when estimated thread cost exceeds this USD amount (0 disables)."
-        ),
+        summary="Warn above this estimated thread cost in USD (0 disables).",
         kind=OptionKind.FLOAT,
         default=SESSION_COST_WARNING_THRESHOLD_USD_DEFAULT,
         toml_keys=("warnings", "session_cost_threshold_usd"),

--- a/libs/code/tests/unit_tests/test_resume_state.py
+++ b/libs/code/tests/unit_tests/test_resume_state.py
@@ -340,6 +340,43 @@ class TestCostDisplayCallbacks:
         assert app._session_cost_usd == pytest.approx(1.25)
         assert app._displayed_cost_usd == pytest.approx(1.25)
 
+    def test_cost_threshold_warns_once_per_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_code import config_manifest
+
+        monkeypatch.setattr(
+            config_manifest,
+            "load_config_toml",
+            lambda: {"warnings": {"session_cost_threshold_usd": 1.0}},
+        )
+        app = DeepAgentsApp()
+        notifications: list[tuple[str, dict[str, Any]]] = []
+        monkeypatch.setattr(
+            app,
+            "notify",
+            lambda message, **kwargs: notifications.append((message, kwargs)),
+        )
+
+        app._set_session_cost(1.0)
+        app._set_session_cost(1.01)
+        app._set_session_cost(2.0)
+
+        assert len(notifications) == 1
+        message, kwargs = notifications[0]
+        assert "$1.01" in message
+        assert "/compact" in message
+        assert "/clear" in message
+        assert kwargs == {
+            "title": "Session cost warning",
+            "severity": "warning",
+            "timeout": 12,
+            "markup": False,
+        }
+
+        app._reset_thread_usage(1.5)
+        assert len(notifications) == 2
+
     def test_streamed_estimate_shows_ahead_of_the_server_total(self) -> None:
         """Spend the graph has not reported yet still moves the display."""
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_resume_state.py
+++ b/libs/code/tests/unit_tests/test_resume_state.py
@@ -343,19 +343,16 @@ class TestCostDisplayCallbacks:
     def test_cost_threshold_warns_once_per_thread(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from deepagents_code import config_manifest
-
         monkeypatch.setattr(
-            config_manifest,
-            "load_config_toml",
+            "deepagents_code.config_manifest.load_config_toml",
             lambda: {"warnings": {"session_cost_threshold_usd": 1.0}},
         )
         app = DeepAgentsApp()
-        notifications: list[tuple[str, dict[str, Any]]] = []
+        notifications: list[str] = []
         monkeypatch.setattr(
             app,
             "notify",
-            lambda message, **kwargs: notifications.append((message, kwargs)),
+            lambda message, **_: notifications.append(message),
         )
 
         app._set_session_cost(1.0)
@@ -363,16 +360,9 @@ class TestCostDisplayCallbacks:
         app._set_session_cost(2.0)
 
         assert len(notifications) == 1
-        message, kwargs = notifications[0]
-        assert "$1.01" in message
-        assert "/offload" in message
-        assert "/clear" in message
-        assert kwargs == {
-            "title": "Session cost warning",
-            "severity": "warning",
-            "timeout": 12,
-            "markup": False,
-        }
+        assert "$1.01" in notifications[0]
+        assert "/offload" in notifications[0]
+        assert "/clear" in notifications[0]
 
         app._reset_thread_usage(1.5)
         assert len(notifications) == 2

--- a/libs/code/tests/unit_tests/test_resume_state.py
+++ b/libs/code/tests/unit_tests/test_resume_state.py
@@ -365,7 +365,7 @@ class TestCostDisplayCallbacks:
         assert len(notifications) == 1
         message, kwargs = notifications[0]
         assert "$1.01" in message
-        assert "/compact" in message
+        assert "/offload" in message
         assert "/clear" in message
         assert kwargs == {
             "title": "Session cost warning",


### PR DESCRIPTION
Deep Agents Code now warns once when a thread's estimated cost exceeds a configurable soft limit, defaulting to $50, and suggests `/offload` or `/clear`.

---

Cost warnings use the graph's authoritative cumulative total rather than provisional estimates, avoiding alerts on spend that may later be corrected downward. Configure `[warnings].session_cost_threshold_usd`; non-positive values disable the warning.

## Screenshots
<img width="445" height="284" alt="Screenshot 2026-08-10 at 12 03 15 PM" src="https://github.com/user-attachments/assets/2d1b1763-dfe4-4101-af2c-f3828a40a0f0" />

