### PR TITLE
feat(code): add cache and context status row

### DIFF
--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -144,6 +144,12 @@ class RecordedUsage:
     request_tokens: int
     """Running token total for the request after applying this message."""
 
+    cache_read_tokens: int
+    """Running cache-read total for the request."""
+
+    cache_write_tokens: int
+    """Running cache-write total for the request."""
+
 
 ModelStatsKey = tuple[str, str]
 """Per-model dict key: the `(provider, model_name)` pair.
@@ -172,6 +178,12 @@ class SessionStats:
 
     output_tokens: int = 0
     """Cumulative output tokens across all LLM requests."""
+
+    cache_read_tokens: int = 0
+    """Cumulative prompt tokens served from provider caches."""
+
+    cache_write_tokens: int = 0
+    """Cumulative prompt tokens written to provider caches."""
 
     total_cost_usd: float = 0.0
     """Cumulative estimated USD cost across priceable LLM requests."""
@@ -202,6 +214,8 @@ class SessionStats:
         *,
         cost_usd: float | None = None,
         kind: UsageKind = "assistant",
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
     ) -> None:
         """Accumulate usage for one completed LLM request.
 
@@ -223,10 +237,14 @@ class SessionStats:
 
                 Missing estimates leave monetary totals unchanged.
             kind: Request class used for `/cost` type breakdowns.
+            cache_read_tokens: Input tokens served from provider caches.
+            cache_write_tokens: Input tokens written to provider caches.
         """
         self.request_count += 1
         self.input_tokens += input_toks
         self.output_tokens += output_toks
+        self.cache_read_tokens += cache_read_tokens
+        self.cache_write_tokens += cache_write_tokens
         if cost_usd is not None:
             self.total_cost_usd += cost_usd
             self.priced_request_count += 1
@@ -276,6 +294,8 @@ class SessionStats:
         self.request_count -= 1
         self.input_tokens -= input_toks
         self.output_tokens -= output_toks
+        self.cache_read_tokens -= recorded.cache_read_tokens
+        self.cache_write_tokens -= recorded.cache_write_tokens
         if cost_usd is not None:
             self.total_cost_usd -= cost_usd
             self.priced_request_count -= 1
@@ -318,6 +338,8 @@ class SessionStats:
         self.request_count += other.request_count
         self.input_tokens += other.input_tokens
         self.output_tokens += other.output_tokens
+        self.cache_read_tokens += other.cache_read_tokens
+        self.cache_write_tokens += other.cache_write_tokens
         self.total_cost_usd += other.total_cost_usd
         self.priced_request_count += other.priced_request_count
         self.wall_time_seconds += other.wall_time_seconds
@@ -363,6 +385,12 @@ class RecordedRequest:
 
     output_tokens: int
     """Running output tokens recorded so far for the request."""
+
+    cache_read_tokens: int
+    """Running cache-read tokens recorded so far for the request."""
+
+    cache_write_tokens: int
+    """Running cache-write tokens recorded so far for the request."""
 
     cost_usd: float | None
     """Estimate for the whole request so far, or `None` when unpriceable."""
@@ -654,6 +682,8 @@ def _move_request_to_named_model(
         provider,
         cost_usd=cost_usd,
         kind=previous.kind,
+        cache_read_tokens=previous.cache_read_tokens,
+        cache_write_tokens=previous.cache_write_tokens,
     )
     recorded_requests[request_id] = RecordedRequest(
         model_name=model_name,
@@ -661,6 +691,8 @@ def _move_request_to_named_model(
         kind=previous.kind,
         input_tokens=previous.input_tokens,
         output_tokens=previous.output_tokens,
+        cache_read_tokens=previous.cache_read_tokens,
+        cache_write_tokens=previous.cache_write_tokens,
         cost_usd=cost_usd,
         usage_metadata=previous.usage_metadata,
         finalized=previous.finalized,
@@ -779,10 +811,12 @@ def record_message_usage(
                     output_tokens=0,
                     cost_usd=reprice_delta,
                     request_tokens=previous.input_tokens + previous.output_tokens,
+                    cache_read_tokens=previous.cache_read_tokens,
+                    cache_write_tokens=previous.cache_write_tokens,
                 )
         return None
 
-    from deepagents_code.cost_tracking import estimate_cost
+    from deepagents_code.cost_tracking import cache_token_counts, estimate_cost
 
     model_name, provider = _resolve_usage_model(
         message,
@@ -816,6 +850,8 @@ def record_message_usage(
     # when the fallback is unpriceable, leave a priceable request showing no
     # cost at all.
     cost_usd = estimate_cost(accumulated_usage, model_name, provider)
+    cache_reads, cache_writes = cache_token_counts(accumulated_usage)
+    cache_write_tokens = sum(cache_writes)
 
     stats.record_request(
         model_name,
@@ -824,6 +860,8 @@ def record_message_usage(
         provider,
         cost_usd=cost_usd,
         kind=kind,
+        cache_read_tokens=cache_reads,
+        cache_write_tokens=cache_write_tokens,
     )
     if request_id is not None:
         recorded_requests[request_id] = RecordedRequest(
@@ -832,6 +870,8 @@ def record_message_usage(
             kind=kind,
             input_tokens=input_count,
             output_tokens=output_count,
+            cache_read_tokens=cache_reads,
+            cache_write_tokens=cache_write_tokens,
             cost_usd=cost_usd,
             usage_metadata=accumulated_usage,
             finalized=not is_chunk,
@@ -848,6 +888,8 @@ def record_message_usage(
             previous_model_name=previous.model_name if previous else model_name,
         ),
         request_tokens=input_count + output_count,
+        cache_read_tokens=cache_reads,
+        cache_write_tokens=cache_write_tokens,
     )
 
 

--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -144,12 +144,6 @@ class RecordedUsage:
     request_tokens: int
     """Running token total for the request after applying this message."""
 
-    cache_read_tokens: int
-    """Running cache-read total for the request."""
-
-    cache_write_tokens: int
-    """Running cache-write total for the request."""
-
 
 ModelStatsKey = tuple[str, str]
 """Per-model dict key: the `(provider, model_name)` pair.
@@ -811,8 +805,6 @@ def record_message_usage(
                     output_tokens=0,
                     cost_usd=reprice_delta,
                     request_tokens=previous.input_tokens + previous.output_tokens,
-                    cache_read_tokens=previous.cache_read_tokens,
-                    cache_write_tokens=previous.cache_write_tokens,
                 )
         return None
 
@@ -888,8 +880,6 @@ def record_message_usage(
             previous_model_name=previous.model_name if previous else model_name,
         ),
         request_tokens=input_count + output_count,
-        cache_read_tokens=cache_reads,
-        cache_write_tokens=cache_write_tokens,
     )
 
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4651,6 +4651,7 @@ class DeepAgentsApp(App):
         self._ui_adapter._on_tokens_show = self._show_tokens
         self._ui_adapter._on_session_cost = self._set_session_cost
         self._ui_adapter._on_provisional_cost = self._add_provisional_cost
+        self._ui_adapter._on_usage_update = self._refresh_cache_display
         self._ui_adapter._on_stream_complete = self._mark_thread_turn_completed
 
         if self._server_startup_deferred:
@@ -7642,6 +7643,19 @@ class DeepAgentsApp(App):
         if self._status_bar:
             self._status_bar.show_pending_tokens()
 
+    def _refresh_cache_display(self) -> None:
+        """Show active-thread cache totals, including the in-flight turn."""
+        if self._status_bar is None:
+            return
+        reads = self._thread_stats.cache_read_tokens
+        writes = self._thread_stats.cache_write_tokens
+        if self._inflight_turn_stats is not None and (
+            self._inflight_thread_id == self._lc_thread_id
+        ):
+            reads += self._inflight_turn_stats.cache_read_tokens
+            writes += self._inflight_turn_stats.cache_write_tokens
+        self._status_bar.set_cache_tokens(reads, writes)
+
     def _set_session_cost(
         self,
         cost_usd: float,
@@ -7720,6 +7734,7 @@ class DeepAgentsApp(App):
             has_restored_model_usage: Whether restored history contains model usage.
         """
         self._thread_stats = SessionStats()
+        self._refresh_cache_display()
         self._thread_restored_cost_usd = _coerce_session_cost_usd(cost_usd)
         self._thread_has_restored_model_usage = (
             has_restored_model_usage or self._thread_restored_cost_usd > 0
@@ -15388,6 +15403,7 @@ class DeepAgentsApp(App):
             self._session_stats.merge(offload_stats)
             if offload_thread_id == self._lc_thread_id:
                 self._thread_stats.merge(offload_stats)
+                self._refresh_cache_display()
 
     async def _remove_offload_artifacts(
         self,
@@ -15788,6 +15804,7 @@ class DeepAgentsApp(App):
             logger.debug("Screen stack empty during model sync", exc_info=True)
         if self._status_bar is None:
             return
+        self._status_bar.set_context_limit(settings.model_context_limit)
         if not provider or not model:
             logger.warning(
                 "Settings missing model identity at status sync "
@@ -16340,6 +16357,7 @@ class DeepAgentsApp(App):
                     self._thread_stats.merge(turn_stats)
                 self._inflight_turn_stats = None
                 self._inflight_thread_id = None
+                self._refresh_cache_display()
             # Settle the display on the committed total. Only a completed turn
             # is read back: `durability="exit"` may drop an aborted turn's
             # writes, and the streamed totals already seen are closer to what

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7644,17 +7644,19 @@ class DeepAgentsApp(App):
             self._status_bar.show_pending_tokens()
 
     def _refresh_cache_display(self) -> None:
-        """Show active-thread cache totals, including the in-flight turn."""
+        """Show active-thread cache totals and hit rate, including in-flight use."""
         if self._status_bar is None:
             return
+        inputs = self._thread_stats.input_tokens
         reads = self._thread_stats.cache_read_tokens
         writes = self._thread_stats.cache_write_tokens
         if self._inflight_turn_stats is not None and (
             self._inflight_thread_id == self._lc_thread_id
         ):
+            inputs += self._inflight_turn_stats.input_tokens
             reads += self._inflight_turn_stats.cache_read_tokens
             writes += self._inflight_turn_stats.cache_write_tokens
-        self._status_bar.set_cache_tokens(reads, writes)
+        self._status_bar.set_cache_tokens(reads, writes, input_tokens=inputs)
 
     def _set_session_cost(
         self,

--- a/libs/code/deepagents_code/app.tcss
+++ b/libs/code/deepagents_code/app.tcss
@@ -148,7 +148,7 @@ Screen {
 #status-bar {
     height: 2;
     dock: bottom;
-    padding: 0 1;
+    padding: 0;
 }
 
 /* Tool approval widgets */

--- a/libs/code/deepagents_code/app.tcss
+++ b/libs/code/deepagents_code/app.tcss
@@ -146,7 +146,7 @@ Screen {
 
 /* Status bar */
 #status-bar {
-    height: 1;
+    height: 2;
     dock: bottom;
 }
 

--- a/libs/code/deepagents_code/app.tcss
+++ b/libs/code/deepagents_code/app.tcss
@@ -148,6 +148,7 @@ Screen {
 #status-bar {
     height: 2;
     dock: bottom;
+    padding: 0 1;
 }
 
 /* Tool approval widgets */

--- a/libs/code/deepagents_code/cost_tracking.py
+++ b/libs/code/deepagents_code/cost_tracking.py
@@ -256,6 +256,23 @@ def _clamp_cache_counts(
     )
 
 
+def cache_token_counts(
+    usage_metadata: Mapping[str, Any] | None,
+) -> tuple[int, tuple[int, int, int]]:
+    """Return normalized cache reads and generic, 5m, and 1h writes."""
+    if not usage_metadata:
+        return 0, (0, 0, 0)
+    input_tokens = _token_count(usage_metadata.get("input_tokens"))
+    details = usage_metadata.get("input_token_details")
+    if not isinstance(details, Mapping):
+        return 0, (0, 0, 0)
+    return _clamp_cache_counts(
+        input_tokens,
+        _token_count(details.get("cache_read")),
+        _cache_write_counts(details),
+    )
+
+
 def _clamped_detail(
     value: object,
     total: int,
@@ -1348,9 +1365,7 @@ def estimate_cost(
     # numbers, so say so -- a silent clamp can materially undercount.
     original_cache_read = cache_read_tokens
     original_cache_writes = cache_writes
-    cache_read_tokens, cache_writes = _clamp_cache_counts(
-        input_tokens, cache_read_tokens, cache_writes
-    )
+    cache_read_tokens, cache_writes = cache_token_counts(usage_metadata)
     if (
         cache_read_tokens != original_cache_read
         or cache_writes != original_cache_writes

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -81,6 +81,11 @@ if TYPE_CHECKING:
 
         def __call__(self, cost_usd: float, /) -> None: ...
 
+    class _UsageUpdateCallback(Protocol):
+        """Callback signature for `_on_usage_update`."""
+
+        def __call__(self) -> None: ...
+
 
 from deepagents_code import _session_stats
 from deepagents_code._ask_user_types import (
@@ -775,6 +780,9 @@ class TextualUIAdapter:
         checkpointed yet — a long subagent run, say — without making the client
         a second authority: every server total replaces what this accumulated.
         """
+
+        self._on_usage_update: _UsageUpdateCallback | None = None
+        """Called after streamed request usage changes."""
 
         self._on_stream_complete: Callable[[], None] | None = None
         """Called only after the agent stream reaches a clean end."""
@@ -1834,6 +1842,8 @@ async def execute_task_textual(
                             ),
                             recorded_requests=recorded_usage_requests,
                         )
+                    if recorded_usage is not None and adapter._on_usage_update:
+                        adapter._on_usage_update()
                     if recorded_usage is not None and (
                         recorded_usage.cost_usd is not None
                         and adapter._on_provisional_cost

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -81,11 +81,6 @@ if TYPE_CHECKING:
 
         def __call__(self, cost_usd: float, /) -> None: ...
 
-    class _UsageUpdateCallback(Protocol):
-        """Callback signature for `_on_usage_update`."""
-
-        def __call__(self) -> None: ...
-
 
 from deepagents_code import _session_stats
 from deepagents_code._ask_user_types import (
@@ -781,7 +776,7 @@ class TextualUIAdapter:
         a second authority: every server total replaces what this accumulated.
         """
 
-        self._on_usage_update: _UsageUpdateCallback | None = None
+        self._on_usage_update: Callable[[], None] | None = None
         """Called after streamed request usage changes."""
 
         self._on_stream_complete: Callable[[], None] | None = None

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -51,15 +51,8 @@ StatusMessageSource = Literal["agent", "hooks"]
 def _compact_tokens(count: int) -> str:
     """Format a token count without a trailing `.0`.
 
-    The metrics line packs several counts into one row, where `1M` and `660K`
-    read faster than the `1.0M` / `660.0K` that `format_token_count` produces
-    for the wider `/context` and `/cost` tables.
-
-    Args:
-        count: Number of tokens.
-
     Returns:
-        A short token count such as `'660K'`, `'44.3K'`, or `'512'`.
+        Compact token count.
     """
     text = format_token_count(count)
     return text.replace(".0", "", 1) if ".0" in text else text
@@ -110,16 +103,7 @@ class ModelLabel(Widget):
                 the provider default) when one is present, else
                 `text` unchanged.
         """
-        return f"{text}{self._effort_suffix()}"
-
-    def _effort_suffix(self) -> str:
-        """Return the separator-and-effort suffix appended to the model name.
-
-        Returns:
-            The space-prefixed effort label, or an empty string when no effort
-                applies.
-        """
-        return f" {self.effort}" if self.effort else ""
+        return f"{text} {self.effort}" if self.effort else text
 
     def get_content_width(self, container: Size, viewport: Size) -> int:  # noqa: ARG002
         """Return the intrinsic width so `width: auto` works.
@@ -154,7 +138,7 @@ class ModelLabel(Widget):
             return Content(full_with_effort)
         if len(model_with_effort) <= width:
             return Content(model_with_effort)
-        suffix = self._effort_suffix()
+        suffix = f" {self.effort}" if self.effort else ""
         if suffix and width > len(suffix) + 1:
             model_width = width - len(suffix)
             return Content(f"\u2026{model[-(model_width - 1) :]}{suffix}")
@@ -224,26 +208,17 @@ class MetricsLine(Widget):
 
     segments: reactive[tuple[Content, ...]] = reactive((), layout=True)
 
-    leads_with_separator: reactive[bool] = reactive(False, layout=True)
-    """Whether to open with a separator, continuing the slot to the left."""
-
     def _separator(self) -> Content:  # noqa: PLR6301 — reads the active glyph set
         """Return the styled separator drawn between two segments."""
         return Content(f" {get_glyphs().bullet} ")
 
     def _chain(self, count: int) -> Content:
-        """Join the first `count` segments into one bullet-separated run.
-
-        Args:
-            count: How many leading segments to include.
+        """Join the first `count` segments with bullet separators.
 
         Returns:
-            The joined run, opened by a separator when this line continues from
-                the slot to its left.
+            Joined metric segments.
         """
-        separator = self._separator()
-        chain = separator.join(self.segments[:count])
-        return separator + chain if self.leads_with_separator else chain
+        return self._separator().join(self.segments[:count])
 
     def get_content_width(self, container: Size, viewport: Size) -> int:  # noqa: ARG002
         """Return the intrinsic width of the full chain so `width: auto` works.
@@ -280,12 +255,7 @@ class MetricsLine(Widget):
 
 
 class StatusBar(Vertical):
-    """Two-line status bar for session identity and runtime metrics.
-
-    The top line carries the model, workspace, and approval mode. The bottom
-    line keeps cache activity on the left and context usage and cost on the
-    right, with transient connection state flowing ahead of the cache.
-    """
+    """Two-line status bar for session identity and runtime metrics."""
 
     DEFAULT_CSS = """
     StatusBar {
@@ -326,10 +296,6 @@ class StatusBar(Vertical):
         text-style: bold;
     }
 
-    /* Colored text, not a filled pill: the mode is a persistent property of the
-       session rather than an alert, so it earns color but not a block of
-       background that competes with the input box for attention. No right pad
-       keeps it flush with the terminal edge, like the input box border above. */
     StatusBar .status-auto-approve {
         width: auto;
         padding: 0 0 0 2;
@@ -407,7 +373,6 @@ class StatusBar(Vertical):
     }
 
     StatusBar ModelLabel {
-        /* Keep enough of the top line available for cwd, branch, and run mode. */
         width: auto;
         max-width: 40%;
         min-width: 0;
@@ -430,11 +395,7 @@ class StatusBar(Vertical):
     cwd: reactive[str] = reactive("", init=False)
     branch: reactive[str] = reactive("", init=False)
     tokens: reactive[int] = reactive(0, init=False)
-    context_limit: reactive[int | None] = reactive(None, init=False)
     cost_usd: reactive[float] = reactive(0.0, init=False)
-    cache_input_tokens: reactive[int] = reactive(0, init=False)
-    cache_read_tokens: reactive[int] = reactive(0, init=False)
-    cache_write_tokens: reactive[int] = reactive(0, init=False)
     rubric_label: reactive[str] = reactive("", init=False)
 
     def __init__(self, cwd: str | Path | None = None, **kwargs: Any) -> None:
@@ -452,6 +413,10 @@ class StatusBar(Vertical):
         self._spinner = Spinner()
         self._spinner_timer: Timer | None = None
         self._busy_message = ""
+        self.context_limit: int | None = None
+        self.cache_input_tokens = 0
+        self.cache_read_tokens = 0
+        self.cache_write_tokens = 0
         self._status_by_source: dict[StatusMessageSource, str] = {
             "agent": "",
             "hooks": "",
@@ -494,12 +459,7 @@ class StatusBar(Vertical):
         self._set_cwd_visible(not self._hide_cwd and width >= self._CWD_WIDTH_THRESHOLD)
 
     def _set_cwd_visible(self, visible: bool) -> None:
-        """Show or hide the cwd.
-
-        No adjacent spacing has to be adjusted: the model owns the gap before
-        the cwd, and the branch simply takes over after the model when cwd is
-        hidden.
-        """
+        """Show or hide the cwd."""
         with suppress(NoMatches):
             self.query_one("#cwd-display", Static).display = visible
 
@@ -669,8 +629,6 @@ class StatusBar(Vertical):
             parts.append(f"{self.queued_count} {label} queued")
         separator = f" {get_glyphs().bullet} "
         text = separator.join(parts)
-        # Hide the widget entirely when empty so its trailing pad doesn't leave a
-        # blank column before the cwd.
         widget.display = bool(text)
         widget.update(text)
 
@@ -821,25 +779,9 @@ class StatusBar(Vertical):
         """Update the combined token and cost display when tokens change."""
         self._render_tokens(new_value, approximate=self._approximate)
 
-    def watch_context_limit(self, _new_value: int | None) -> None:
-        """Update context percentage when the model limit changes."""
-        self._render_tokens(self.tokens, approximate=self._approximate)
-
     def watch_cost_usd(self, _new_value: float) -> None:
         """Update the combined token and cost display when cost changes."""
         self._render_tokens(self.tokens, approximate=self._approximate)
-
-    def watch_cache_read_tokens(self, _new_value: int) -> None:
-        """Update the metrics line when cache read tokens change."""
-        self._refresh_metrics()
-
-    def watch_cache_input_tokens(self, _new_value: int) -> None:
-        """Update the cache hit rate when cumulative input tokens change."""
-        self._refresh_metrics()
-
-    def watch_cache_write_tokens(self, _new_value: int) -> None:
-        """Update the metrics line when cache write tokens change."""
-        self._refresh_metrics()
 
     def _refresh_metrics(self) -> None:
         """Re-render the metrics line from the current reactive values."""
@@ -861,14 +803,7 @@ class StatusBar(Vertical):
     """Context usage at which the percentage turns to alert."""
 
     def _percent_color(self, percent: float) -> str:
-        """Return the color that encodes how full the context window is.
-
-        Args:
-            percent: Used portion of the context window, from `0` to `100`.
-
-        Returns:
-            A theme color escalating from muted through warning to error.
-        """
+        """Return the color that encodes how full the context window is."""
         colors = theme.get_theme_colors(self)
         if percent >= self._CONTEXT_CRITICAL_PERCENT:
             return colors.error
@@ -877,25 +812,16 @@ class StatusBar(Vertical):
         return colors.muted
 
     def _context_segment(self, count: int, *, approximate: bool = False) -> Content:
-        """Build the context segment: percentage used, then absolute usage.
-
-        The percentage carries the color, so a context window filling up reads
-        at a glance without spending width on a gauge.
-
-        Args:
-            count: Total context token count.
-            approximate: Whether the count is stale (shown with a `+` suffix).
+        """Build the context percentage and absolute-usage segment.
 
         Returns:
-            The context segment, or an empty `Content` when there is nothing to
-                report (no count and no known limit).
+            Styled context usage.
         """
         pending = self._tokens_pending
         suffix = "+" if approximate else ""
         if pending:
             return Content("... tokens")
         if self.context_limit is None:
-            # No limit to scale against, so report the raw count only.
             return Content(f"{_compact_tokens(count)}{suffix} tokens")
         percent = min(100.0, max(0.0, count / self.context_limit * 100))
         return Content.assemble(
@@ -904,11 +830,10 @@ class StatusBar(Vertical):
         )
 
     def _cache_segment(self) -> Content:
-        """Build the cache segment for the active thread.
+        """Build the active thread's cache segment.
 
         Returns:
-            Cumulative cache reads and writes, or an empty `Content` when the
-                thread has used no prompt cache.
+            Styled cache usage.
         """
         hit_rate = ""
         if self.cache_input_tokens:
@@ -931,18 +856,12 @@ class StatusBar(Vertical):
         """Format cumulative cost, including the initial zero state.
 
         Returns:
-            Formatted cost with a display floor for positive sub-cent values.
+            Formatted cost.
         """
         return format_cost(self.cost_usd)
 
     def _render_tokens(self, count: int, *, approximate: bool = False) -> None:
-        """Render cache left and context/cost right on the metrics line.
-
-        Args:
-            count: Total context token count.
-            approximate: Append "+" suffix to indicate the count is stale
-                (e.g. after an interrupted generation).
-        """
+        """Render cache left and context/cost right on the metrics line."""
         try:
             cache_display = self.query_one("#cache-display", MetricsLine)
             context_display = self.query_one("#tokens-display", MetricsLine)
@@ -996,11 +915,8 @@ class StatusBar(Vertical):
 
     def set_context_limit(self, limit: int | None) -> None:
         """Set the active model's context limit."""
-        normalized = limit if isinstance(limit, int) and limit > 0 else None
-        if self.context_limit == normalized:
-            self._refresh_metrics()
-        else:
-            self.context_limit = normalized
+        self.context_limit = limit if isinstance(limit, int) and limit > 0 else None
+        self._refresh_metrics()
 
     def set_cache_tokens(
         self,
@@ -1020,18 +936,10 @@ class StatusBar(Vertical):
         reads = max(read_tokens, 0)
         writes = max(write_tokens, 0)
         inputs = max(input_tokens, 0)
-        changed = False
-        if self.cache_input_tokens != inputs:
-            self.cache_input_tokens = inputs
-            changed = True
-        if self.cache_read_tokens != reads:
-            self.cache_read_tokens = reads
-            changed = True
-        if self.cache_write_tokens != writes:
-            self.cache_write_tokens = writes
-            changed = True
-        if not changed:
-            self._refresh_metrics()
+        self.cache_input_tokens = inputs
+        self.cache_read_tokens = reads
+        self.cache_write_tokens = writes
+        self._refresh_metrics()
 
     def set_cost(self, cost_usd: float) -> None:
         """Set the cumulative thread cost shown beside context tokens.

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -14,6 +14,7 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
 
+from deepagents_code import theme
 from deepagents_code._constants import FIREWORKS_MODEL_ID_PREFIXES
 from deepagents_code._env_vars import HIDE_CWD, HIDE_GIT_BRANCH, is_env_truthy
 from deepagents_code._session_stats import format_cost, format_token_count
@@ -47,8 +48,25 @@ StatusMessageSource = Literal["agent", "hooks"]
 """Owners that may write the shared status-message slot."""
 
 
+def _compact_tokens(count: int) -> str:
+    """Format a token count without a trailing `.0`.
+
+    The metrics line packs several counts into one row, where `1M` and `660K`
+    read faster than the `1.0M` / `660.0K` that `format_token_count` produces
+    for the wider `/context` and `/cost` tables.
+
+    Args:
+        count: Number of tokens.
+
+    Returns:
+        A short token count such as `'660K'`, `'44.3K'`, or `'512'`.
+    """
+    text = format_token_count(count)
+    return text.replace(".0", "", 1) if ".0" in text else text
+
+
 class ModelLabel(Widget):
-    """A label that displays a model name, right-aligned with smart truncation.
+    """A label that displays a model name with smart truncation.
 
     When the full `provider:model` text doesn't fit, the provider is dropped
     first. If the bare model name still doesn't fit, it is left-truncated
@@ -92,7 +110,16 @@ class ModelLabel(Widget):
                 the provider default) when one is present, else
                 `text` unchanged.
         """
-        return f"{text} {self.effort}" if self.effort else text
+        return f"{text}{self._effort_suffix()}"
+
+    def _effort_suffix(self) -> str:
+        """Return the separator-and-effort suffix appended to the model name.
+
+        Returns:
+            The space-prefixed effort label, or an empty string when no effort
+                applies.
+        """
+        return f" {self.effort}" if self.effort else ""
 
     def get_content_width(self, container: Size, viewport: Size) -> int:  # noqa: ARG002
         """Return the intrinsic width so `width: auto` works.
@@ -127,9 +154,10 @@ class ModelLabel(Widget):
             return Content(full_with_effort)
         if len(model_with_effort) <= width:
             return Content(model_with_effort)
-        if self.effort and width > len(self.effort) + 2:
-            model_width = width - len(self.effort) - 1
-            return Content(f"\u2026{model[-(model_width - 1) :]} {self.effort}")
+        suffix = self._effort_suffix()
+        if suffix and width > len(suffix) + 1:
+            model_width = width - len(suffix)
+            return Content(f"\u2026{model[-(model_width - 1) :]}{suffix}")
         if len(model) <= width:
             return Content(model)
         if width > 1:
@@ -185,8 +213,79 @@ class BranchLabel(Widget):
         return full[: width - len(ellipsis)] + ellipsis
 
 
+class MetricsLine(Widget):
+    """A bullet-separated chain of session metrics.
+
+    Segments are supplied pre-styled and in priority order. When the chain is
+    wider than the bar, trailing segments are dropped one at a time (so the
+    least important metric goes first and the surviving segments never shift
+    position), and a lone segment that still overflows is ellipsized.
+    """
+
+    segments: reactive[tuple[Content, ...]] = reactive((), layout=True)
+
+    leads_with_separator: reactive[bool] = reactive(False, layout=True)
+    """Whether to open with a separator, continuing the slot to the left."""
+
+    def _separator(self) -> Content:  # noqa: PLR6301 — reads the active glyph set
+        """Return the styled separator drawn between two segments."""
+        return Content(f" {get_glyphs().bullet} ")
+
+    def _chain(self, count: int) -> Content:
+        """Join the first `count` segments into one bullet-separated run.
+
+        Args:
+            count: How many leading segments to include.
+
+        Returns:
+            The joined run, opened by a separator when this line continues from
+                the slot to its left.
+        """
+        separator = self._separator()
+        chain = separator.join(self.segments[:count])
+        return separator + chain if self.leads_with_separator else chain
+
+    def get_content_width(self, container: Size, viewport: Size) -> int:  # noqa: ARG002
+        """Return the intrinsic width of the full chain so `width: auto` works.
+
+        Args:
+            container: Size of the container.
+            viewport: Size of the viewport.
+
+        Returns:
+            Cell width of every segment joined by the separator.
+        """
+        if not self.segments:
+            return 0
+        return self._chain(len(self.segments)).cell_length
+
+    def render(self) -> RenderResult:
+        """Render as many leading segments as the available width allows.
+
+        Returns:
+            The joined chain, shortened from the tail until it fits.
+        """
+        width = self.content_size.width
+        if not self.segments or width <= 0:
+            return Content("")
+        for count in range(len(self.segments), 0, -1):
+            chain = self._chain(count)
+            if chain.cell_length <= width:
+                return chain
+        ellipsis = get_glyphs().ellipsis
+        if width <= len(ellipsis):
+            return Content("")
+        first = self._chain(1).plain
+        return Content(first[: width - len(ellipsis)] + ellipsis)
+
+
 class StatusBar(Vertical):
-    """Two-line status bar showing workspace, cache, context, cost, and model."""
+    """Two-line status bar for session identity and runtime metrics.
+
+    The top line carries the model, workspace, and approval mode. The bottom
+    line keeps cache activity on the left and context usage and cost on the
+    right, with transient connection state flowing ahead of the cache.
+    """
 
     DEFAULT_CSS = """
     StatusBar {
@@ -195,7 +294,7 @@ class StatusBar(Vertical):
         background: $background;
     }
 
-    StatusBar .status-top,
+    StatusBar .status-session,
     StatusBar .status-metrics {
         width: 1fr;
         height: 1;
@@ -227,37 +326,39 @@ class StatusBar(Vertical):
         text-style: bold;
     }
 
+    /* Colored text, not a filled pill: the mode is a persistent property of the
+       session rather than an alert, so it earns color but not a block of
+       background that competes with the input box for attention. No right pad
+       keeps it flush with the terminal edge, like the input box border above. */
     StatusBar .status-auto-approve {
         width: auto;
-        padding: 0 1;
+        padding: 0 0 0 2;
+        text-align: right;
     }
 
     StatusBar .status-auto-approve.yolo {
-        background: $error;
-        color: white;
+        color: $error;
         text-style: bold;
     }
 
     StatusBar .status-auto-approve.auto {
-        background: $success;
-        color: $background;
+        color: $success;
     }
 
     StatusBar .status-auto-approve.manual {
-        background: $warning;
-        color: $background;
+        color: $warning;
     }
 
     StatusBar .status-connection {
         width: auto;
-        padding: 0 1;
+        padding: 0 1 0 0;
         color: $warning;
         text-style: bold;
     }
 
     StatusBar .status-message {
         width: auto;
-        padding: 0 1;
+        padding: 0 1 0 0;
         color: $text-muted;
     }
 
@@ -267,12 +368,12 @@ class StatusBar(Vertical):
 
     StatusBar .status-cwd {
         width: auto;
-        text-align: right;
+        max-width: 45%;
+        padding: 0 1 0 0;
         color: $text-muted;
-        /* Own both adjacent gaps so they disappear with the cwd: the left gap
-           separates it from the auto-approve pill when transient status slots
-           are hidden, and the right gap separates it from the branch. */
-        padding: 0 1 0 1;
+        overflow-x: hidden;
+        text-overflow: ellipsis;
+        text-wrap: nowrap;
     }
 
     StatusBar .status-branch {
@@ -282,66 +383,44 @@ class StatusBar(Vertical):
         text-wrap: nowrap;
     }
 
-    StatusBar .status-left-collapsible {
+    StatusBar .status-cache-line {
         width: 1fr;
         min-width: 0;
-        height: 1;
-        overflow-x: hidden;
-    }
-
-    StatusBar .status-cache {
-        width: 1fr;
-        padding: 0 1;
+        padding: 0;
         color: $text-muted;
     }
 
-    StatusBar .status-tokens {
+    StatusBar .status-context-line {
         width: auto;
-        padding: 0 1;
+        max-width: 55%;
+        min-width: 0;
+        padding: 0 0 0 2;
         color: $text-muted;
         text-align: right;
     }
 
     StatusBar .status-rubric {
         width: auto;
-        padding: 0 1;
+        padding: 0 0 0 2;
         color: $success;
         text-style: bold;
     }
 
     StatusBar ModelLabel {
+        /* Keep enough of the top line available for cwd, branch, and run mode. */
         width: auto;
-        /* No right pad: this is the last slot in the bar, so any right padding
-           would hold the model text short of the terminal edge while every
-           other full-width element (the input box border, the mode pill's
-           background) sits flush against it. The left pad is the separator
-           from the token counter. */
-        padding: 0 0 0 2;
+        max-width: 40%;
+        min-width: 0;
+        padding: 0 2 0 0;
         color: $text-muted;
-        text-align: right;
     }
 
     StatusBar BranchLabel {
         color: $text-muted;
-        /* No left pad while cwd is visible: the cwd owns that gap. */
-        padding: 0 1 0 0;
-    }
-
-    StatusBar .status-cwd.after-status {
-        padding: 0 1 0 0;
-    }
-
-    StatusBar BranchLabel.cwd-hidden {
-        /* When cwd is hidden, the branch needs the same left separator that
-           cwd normally provides after the auto-approve pill. */
-        padding: 0 1 0 1;
-    }
-
-    StatusBar BranchLabel.cwd-hidden.after-status {
-        padding: 0 1 0 0;
+        padding: 0;
     }
     """
-    """Mode badges and auto-approve pills use distinct colors for at-a-glance status."""
+    """Mode badges color the input mode; the approval mode is colored text."""
 
     mode: reactive[str] = reactive("normal", init=False)
     status_message: reactive[str] = reactive("", init=False)
@@ -353,6 +432,7 @@ class StatusBar(Vertical):
     tokens: reactive[int] = reactive(0, init=False)
     context_limit: reactive[int | None] = reactive(None, init=False)
     cost_usd: reactive[float] = reactive(0.0, init=False)
+    cache_input_tokens: reactive[int] = reactive(0, init=False)
     cache_read_tokens: reactive[int] = reactive(0, init=False)
     cache_write_tokens: reactive[int] = reactive(0, init=False)
     rubric_label: reactive[str] = reactive("", init=False)
@@ -381,26 +461,24 @@ class StatusBar(Vertical):
         """Compose the status bar layout.
 
         Yields:
-            Widgets for mode, auto-approve, message, cwd, branch, tokens, and
-                model display.
+            The model/workspace line followed by cache and context metrics.
         """
-        with Horizontal(classes="status-top"):
+        with Horizontal(classes="status-session"):
             yield Static("", classes="status-mode normal", id="mode-indicator")
+            yield ModelLabel(id="model-display")
+            yield Static("", classes="status-cwd", id="cwd-display")
+            yield BranchLabel(classes="status-branch", id="branch-display")
+            yield Static("", classes="status-rubric", id="rubric-display")
             yield Static(
                 "manual",
                 classes="status-auto-approve manual",
                 id="auto-approve-indicator",
             )
-            with Horizontal(classes="status-left-collapsible"):
-                yield Static("", classes="status-connection", id="connection-indicator")
-                yield Static("", classes="status-message", id="status-message")
-                yield Static("", classes="status-cwd", id="cwd-display")
-                yield BranchLabel(classes="status-branch", id="branch-display")
-            yield Static("", classes="status-rubric", id="rubric-display")
-            yield ModelLabel(id="model-display")
         with Horizontal(classes="status-metrics"):
-            yield Static("", classes="status-cache", id="cache-display")
-            yield Static("", classes="status-tokens", id="tokens-display")
+            yield Static("", classes="status-connection", id="connection-indicator")
+            yield Static("", classes="status-message", id="status-message")
+            yield MetricsLine(classes="status-cache-line", id="cache-display")
+            yield MetricsLine(classes="status-context-line", id="tokens-display")
 
     _CWD_WIDTH_THRESHOLD = 70
     """Hide cwd display below this terminal width."""
@@ -416,35 +494,14 @@ class StatusBar(Vertical):
         self._set_cwd_visible(not self._hide_cwd and width >= self._CWD_WIDTH_THRESHOLD)
 
     def _set_cwd_visible(self, visible: bool) -> None:
-        """Show or hide cwd and keep adjacent branch spacing in sync."""
+        """Show or hide the cwd.
+
+        No adjacent spacing has to be adjusted: the model owns the gap before
+        the cwd, and the branch simply takes over after the model when cwd is
+        hidden.
+        """
         with suppress(NoMatches):
             self.query_one("#cwd-display", Static).display = visible
-        with suppress(NoMatches):
-            branch = self.query_one("#branch-display", BranchLabel)
-            if visible:
-                branch.remove_class("cwd-hidden")
-            else:
-                branch.add_class("cwd-hidden")
-        self._sync_left_separator()
-
-    def _sync_left_separator(self) -> None:
-        """Use one separator between the last transient status item and cwd/branch."""
-        preceded_by_status = False
-        with suppress(NoMatches):
-            preceded_by_status = bool(
-                self.query_one("#connection-indicator", Static).display
-                or self.query_one("#status-message", Static).display
-            )
-        for selector, widget_type in (
-            ("#cwd-display", Static),
-            ("#branch-display", BranchLabel),
-        ):
-            with suppress(NoMatches):
-                widget = self.query_one(selector, widget_type)
-                if preceded_by_status:
-                    widget.add_class("after-status")
-                else:
-                    widget.remove_class("after-status")
 
     def on_unmount(self) -> None:
         """Stop the spinner timer so it can't tick on a detached widget."""
@@ -465,14 +522,13 @@ class StatusBar(Vertical):
         label.provider = settings.model_provider or ""
         label.model = settings.model_name or ""
         self.set_context_limit(settings.model_context_limit)
-        self._render_cache_metrics()
         with suppress(NoMatches):
             self.query_one("#rubric-display", Static).display = False
         # Reactives are `init=False`, so the connection watcher never fires on
         # mount; render once to hide the empty indicator (and its padding).
         self._render_connection()
         self.watch_status_message(self.status_message)
-        self._render_tokens(self.tokens, approximate=self._approximate)
+        self._refresh_metrics()
 
     def watch_mode(self, mode: str) -> None:
         """Update mode indicator when mode changes."""
@@ -544,7 +600,6 @@ class StatusBar(Vertical):
                 msg_widget.add_class("thinking")
         else:
             msg_widget.update("")
-        self._sync_left_separator()
 
     def watch_connection_state(self, _new_value: ConnectionState) -> None:
         """Start or stop the spinner and re-render when connection state changes."""
@@ -614,11 +669,10 @@ class StatusBar(Vertical):
             parts.append(f"{self.queued_count} {label} queued")
         separator = f" {get_glyphs().bullet} "
         text = separator.join(parts)
-        # Hide the widget entirely when empty so its `padding: 0 1` doesn't
-        # leave a 2-column gap between the auto-approve pill and the cwd.
+        # Hide the widget entirely when empty so its trailing pad doesn't leave a
+        # blank column before the cwd.
         widget.display = bool(text)
         widget.update(text)
-        self._sync_left_separator()
 
     def _render_busy(self) -> None:
         """Render the animated busy indicator into the status-message slot."""
@@ -632,7 +686,6 @@ class StatusBar(Vertical):
         widget.display = True
         frame = self._spinner.current_frame()
         widget.update(Content.assemble(frame, " ", Content(self._busy_message)))
-        self._sync_left_separator()
 
     def set_busy(self, message: str) -> None:
         """Show or clear an animated busy indicator in the status-message slot.
@@ -777,12 +830,20 @@ class StatusBar(Vertical):
         self._render_tokens(self.tokens, approximate=self._approximate)
 
     def watch_cache_read_tokens(self, _new_value: int) -> None:
-        """Update cache metrics when read tokens change."""
-        self._render_cache_metrics()
+        """Update the metrics line when cache read tokens change."""
+        self._refresh_metrics()
+
+    def watch_cache_input_tokens(self, _new_value: int) -> None:
+        """Update the cache hit rate when cumulative input tokens change."""
+        self._refresh_metrics()
 
     def watch_cache_write_tokens(self, _new_value: int) -> None:
-        """Update cache metrics when write tokens change."""
-        self._render_cache_metrics()
+        """Update the metrics line when cache write tokens change."""
+        self._refresh_metrics()
+
+    def _refresh_metrics(self) -> None:
+        """Re-render the metrics line from the current reactive values."""
+        self._render_tokens(self.tokens, approximate=self._approximate)
 
     def watch_rubric_label(self, new_value: str) -> None:
         """Update rubric display when active rubric state changes."""
@@ -793,41 +854,89 @@ class StatusBar(Vertical):
         display.display = bool(new_value)
         display.update(new_value)
 
-    def _token_text(self, count: int, *, approximate: bool = False) -> str:
-        """Format context percentage and token count for the metrics row.
+    _CONTEXT_WARNING_PERCENT = 60.0
+    """Context usage at which the percentage turns from calm to caution."""
+
+    _CONTEXT_CRITICAL_PERCENT = 85.0
+    """Context usage at which the percentage turns to alert."""
+
+    def _percent_color(self, percent: float) -> str:
+        """Return the color that encodes how full the context window is.
+
+        Args:
+            percent: Used portion of the context window, from `0` to `100`.
 
         Returns:
-            Compact context usage text.
+            A theme color escalating from muted through warning to error.
         """
-        if count <= 0:
-            return ""
-        suffix = "+" if approximate else ""
-        tokens = f"{format_token_count(count)}{suffix} tokens"
-        if self.context_limit is None:
-            return f"Context: {tokens}"
-        return f"Context: {count / self.context_limit * 100:.0f}% / {tokens}"
+        colors = theme.get_theme_colors(self)
+        if percent >= self._CONTEXT_CRITICAL_PERCENT:
+            return colors.error
+        if percent >= self._CONTEXT_WARNING_PERCENT:
+            return colors.warning
+        return colors.muted
 
-    def _render_cache_metrics(self) -> None:
-        """Render cumulative cache reads and writes for the active thread."""
-        try:
-            display = self.query_one("#cache-display", Static)
-        except NoMatches:
-            return
-        display.update(
-            f"Cache: {format_token_count(self.cache_read_tokens)} read / "
-            f"{format_token_count(self.cache_write_tokens)} write"
+    def _context_segment(self, count: int, *, approximate: bool = False) -> Content:
+        """Build the context segment: percentage used, then absolute usage.
+
+        The percentage carries the color, so a context window filling up reads
+        at a glance without spending width on a gauge.
+
+        Args:
+            count: Total context token count.
+            approximate: Whether the count is stale (shown with a `+` suffix).
+
+        Returns:
+            The context segment, or an empty `Content` when there is nothing to
+                report (no count and no known limit).
+        """
+        pending = self._tokens_pending
+        suffix = "+" if approximate else ""
+        if pending:
+            return Content("... tokens")
+        if self.context_limit is None:
+            # No limit to scale against, so report the raw count only.
+            return Content(f"{_compact_tokens(count)}{suffix} tokens")
+        percent = min(100.0, max(0.0, count / self.context_limit * 100))
+        return Content.assemble(
+            (f"{percent:.0f}%", self._percent_color(percent)),
+            f"  {_compact_tokens(count)}{suffix}/{_compact_tokens(self.context_limit)}",
+        )
+
+    def _cache_segment(self) -> Content:
+        """Build the cache segment for the active thread.
+
+        Returns:
+            Cumulative cache reads and writes, or an empty `Content` when the
+                thread has used no prompt cache.
+        """
+        hit_rate = ""
+        if self.cache_input_tokens:
+            cached = min(self.cache_read_tokens, self.cache_input_tokens)
+            hit_rate = f"{cached / self.cache_input_tokens * 100:.0f}% hit"
+        elif not self.cache_read_tokens and not self.cache_write_tokens:
+            hit_rate = "0% hit"
+        details = (
+            f"{_compact_tokens(self.cache_read_tokens)} read"
+            f" / {_compact_tokens(self.cache_write_tokens)} write"
+        )
+        return Content.assemble(
+            Content.styled("Cache", theme.get_theme_colors(self).muted),
+            " ",
+            f"{hit_rate} {get_glyphs().bullet} " if hit_rate else "",
+            details,
         )
 
     def _cost_text(self) -> str:
-        """Format positive cost, hiding zero and unknown estimates.
+        """Format cumulative cost, including the initial zero state.
 
         Returns:
-            Formatted cost, or an empty string when no positive estimate exists.
+            Formatted cost with a display floor for positive sub-cent values.
         """
-        return format_cost(self.cost_usd) if self.cost_usd > 0 else ""
+        return format_cost(self.cost_usd)
 
     def _render_tokens(self, count: int, *, approximate: bool = False) -> None:
-        """Render context tokens and cumulative cost in one compact slot.
+        """Render cache left and context/cost right on the metrics line.
 
         Args:
             count: Total context token count.
@@ -835,19 +944,23 @@ class StatusBar(Vertical):
                 (e.g. after an interrupted generation).
         """
         try:
-            display = self.query_one("#tokens-display", Static)
+            cache_display = self.query_one("#cache-display", MetricsLine)
+            context_display = self.query_one("#tokens-display", MetricsLine)
         except NoMatches:
             return
 
-        token_text = (
-            "... tokens"
-            if self._tokens_pending
-            else self._token_text(count, approximate=approximate)
+        cost = self._cost_text()
+        context_segments = tuple(
+            segment
+            for segment in (
+                self._context_segment(count, approximate=approximate),
+                Content(cost) if cost else Content(""),
+            )
+            if segment.plain
         )
-        parts = [part for part in (token_text, self._cost_text()) if part]
-        display.display = bool(parts)
-        separator = f" {get_glyphs().bullet} "
-        display.update(separator.join(parts))
+        cache = self._cache_segment()
+        cache_display.segments = (cache,) if cache.plain else ()
+        context_display.segments = context_segments
 
     def set_rubric_label(self, label: str) -> None:
         """Set the rubric status label.
@@ -885,14 +998,32 @@ class StatusBar(Vertical):
         """Set the active model's context limit."""
         normalized = limit if isinstance(limit, int) and limit > 0 else None
         if self.context_limit == normalized:
-            self._render_tokens(self.tokens, approximate=self._approximate)
+            self._refresh_metrics()
         else:
             self.context_limit = normalized
 
-    def set_cache_tokens(self, read_tokens: int, write_tokens: int) -> None:
-        """Set cumulative cache read and write counts for the active thread."""
-        reads, writes = max(read_tokens, 0), max(write_tokens, 0)
+    def set_cache_tokens(
+        self,
+        read_tokens: int,
+        write_tokens: int,
+        *,
+        input_tokens: int = 0,
+    ) -> None:
+        """Set cumulative input and cache token counts for the active thread.
+
+        Args:
+            read_tokens: Input tokens served from the provider cache.
+            write_tokens: Input tokens written to the provider cache.
+            input_tokens: Inclusive input-token total used as the hit-rate
+                denominator.
+        """
+        reads = max(read_tokens, 0)
+        writes = max(write_tokens, 0)
+        inputs = max(input_tokens, 0)
         changed = False
+        if self.cache_input_tokens != inputs:
+            self.cache_input_tokens = inputs
+            changed = True
         if self.cache_read_tokens != reads:
             self.cache_read_tokens = reads
             changed = True
@@ -900,7 +1031,7 @@ class StatusBar(Vertical):
             self.cache_write_tokens = writes
             changed = True
         if not changed:
-            self._render_cache_metrics()
+            self._refresh_metrics()
 
     def set_cost(self, cost_usd: float) -> None:
         """Set the cumulative thread cost shown beside context tokens.
@@ -909,7 +1040,7 @@ class StatusBar(Vertical):
             cost_usd: Cumulative estimated cost in US dollars.
         """
         if self.cost_usd == cost_usd:
-            self._render_tokens(self.tokens, approximate=self._approximate)
+            self._refresh_metrics()
         else:
             self.cost_usd = cost_usd
 
@@ -920,13 +1051,7 @@ class StatusBar(Vertical):
         # Latch the placeholder so a mid-turn cost refresh keeps it instead of
         # re-rendering the previous turn's count.
         self._tokens_pending = True
-        try:
-            display = self.query_one("#tokens-display", Static)
-        except NoMatches:
-            return
-        parts = [part for part in ("... tokens", self._cost_text()) if part]
-        separator = f" {get_glyphs().bullet} "
-        display.update(separator.join(parts))
+        self._refresh_metrics()
 
     def set_model(self, *, provider: str, model: str, effort: str = "") -> None:
         """Update the model display text.

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -298,21 +298,24 @@ class StatusBar(Vertical):
 
     StatusBar .status-auto-approve {
         width: auto;
-        padding: 0 0 0 2;
-        text-align: right;
+        padding: 0 1;
+        margin-right: 1;
     }
 
     StatusBar .status-auto-approve.yolo {
-        color: $error;
+        background: $error;
+        color: white;
         text-style: bold;
     }
 
     StatusBar .status-auto-approve.auto {
-        color: $success;
+        background: $success;
+        color: $background;
     }
 
     StatusBar .status-auto-approve.manual {
-        color: $warning;
+        background: $warning;
+        color: $background;
     }
 
     StatusBar .status-connection {
@@ -376,8 +379,9 @@ class StatusBar(Vertical):
         width: auto;
         max-width: 40%;
         min-width: 0;
-        padding: 0 2 0 0;
+        padding: 0 0 0 2;
         color: $text-muted;
+        text-align: right;
     }
 
     StatusBar BranchLabel {
@@ -430,15 +434,15 @@ class StatusBar(Vertical):
         """
         with Horizontal(classes="status-session"):
             yield Static("", classes="status-mode normal", id="mode-indicator")
-            yield ModelLabel(id="model-display")
-            yield Static("", classes="status-cwd", id="cwd-display")
-            yield BranchLabel(classes="status-branch", id="branch-display")
-            yield Static("", classes="status-rubric", id="rubric-display")
             yield Static(
                 "manual",
                 classes="status-auto-approve manual",
                 id="auto-approve-indicator",
             )
+            yield Static("", classes="status-cwd", id="cwd-display")
+            yield BranchLabel(classes="status-branch", id="branch-display")
+            yield Static("", classes="status-rubric", id="rubric-display")
+            yield ModelLabel(id="model-display")
         with Horizontal(classes="status-metrics"):
             yield Static("", classes="status-connection", id="connection-indicator")
             yield Static("", classes="status-message", id="status-message")

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -7,7 +7,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
-from textual.containers import Horizontal
+from textual.containers import Horizontal, Vertical
 from textual.content import Content
 from textual.css.query import NoMatches
 from textual.reactive import reactive
@@ -16,7 +16,7 @@ from textual.widgets import Static
 
 from deepagents_code._constants import FIREWORKS_MODEL_ID_PREFIXES
 from deepagents_code._env_vars import HIDE_CWD, HIDE_GIT_BRANCH, is_env_truthy
-from deepagents_code._session_stats import format_cost
+from deepagents_code._session_stats import format_cost, format_token_count
 from deepagents_code.config import get_glyphs
 from deepagents_code.tui.widgets.loading import Spinner
 
@@ -185,14 +185,20 @@ class BranchLabel(Widget):
         return full[: width - len(ellipsis)] + ellipsis
 
 
-class StatusBar(Horizontal):
-    """Status bar showing mode, cwd, tokens with cost, and the active model."""
+class StatusBar(Vertical):
+    """Two-line status bar showing workspace, cache, context, cost, and model."""
 
     DEFAULT_CSS = """
     StatusBar {
-        height: 1;
+        height: 2;
         dock: bottom;
         background: $background;
+    }
+
+    StatusBar .status-top,
+    StatusBar .status-metrics {
+        width: 1fr;
+        height: 1;
     }
 
     StatusBar .status-mode {
@@ -283,10 +289,17 @@ class StatusBar(Horizontal):
         overflow-x: hidden;
     }
 
+    StatusBar .status-cache {
+        width: 1fr;
+        padding: 0 1;
+        color: $text-muted;
+    }
+
     StatusBar .status-tokens {
         width: auto;
         padding: 0 1;
         color: $text-muted;
+        text-align: right;
     }
 
     StatusBar .status-rubric {
@@ -338,7 +351,10 @@ class StatusBar(Horizontal):
     cwd: reactive[str] = reactive("", init=False)
     branch: reactive[str] = reactive("", init=False)
     tokens: reactive[int] = reactive(0, init=False)
+    context_limit: reactive[int | None] = reactive(None, init=False)
     cost_usd: reactive[float] = reactive(0.0, init=False)
+    cache_read_tokens: reactive[int] = reactive(0, init=False)
+    cache_write_tokens: reactive[int] = reactive(0, init=False)
     rubric_label: reactive[str] = reactive("", init=False)
 
     def __init__(self, cwd: str | Path | None = None, **kwargs: Any) -> None:
@@ -368,20 +384,23 @@ class StatusBar(Horizontal):
             Widgets for mode, auto-approve, message, cwd, branch, tokens, and
                 model display.
         """
-        yield Static("", classes="status-mode normal", id="mode-indicator")
-        yield Static(
-            "manual",
-            classes="status-auto-approve manual",
-            id="auto-approve-indicator",
-        )
-        with Horizontal(classes="status-left-collapsible"):
-            yield Static("", classes="status-connection", id="connection-indicator")
-            yield Static("", classes="status-message", id="status-message")
-            yield Static("", classes="status-cwd", id="cwd-display")
-            yield BranchLabel(classes="status-branch", id="branch-display")
-        yield Static("", classes="status-rubric", id="rubric-display")
-        yield Static("", classes="status-tokens", id="tokens-display")
-        yield ModelLabel(id="model-display")
+        with Horizontal(classes="status-top"):
+            yield Static("", classes="status-mode normal", id="mode-indicator")
+            yield Static(
+                "manual",
+                classes="status-auto-approve manual",
+                id="auto-approve-indicator",
+            )
+            with Horizontal(classes="status-left-collapsible"):
+                yield Static("", classes="status-connection", id="connection-indicator")
+                yield Static("", classes="status-message", id="status-message")
+                yield Static("", classes="status-cwd", id="cwd-display")
+                yield BranchLabel(classes="status-branch", id="branch-display")
+            yield Static("", classes="status-rubric", id="rubric-display")
+            yield ModelLabel(id="model-display")
+        with Horizontal(classes="status-metrics"):
+            yield Static("", classes="status-cache", id="cache-display")
+            yield Static("", classes="status-tokens", id="tokens-display")
 
     _CWD_WIDTH_THRESHOLD = 70
     """Hide cwd display below this terminal width."""
@@ -445,16 +464,15 @@ class StatusBar(Horizontal):
         label = self.query_one("#model-display", ModelLabel)
         label.provider = settings.model_provider or ""
         label.model = settings.model_name or ""
+        self.set_context_limit(settings.model_context_limit)
+        self._render_cache_metrics()
         with suppress(NoMatches):
             self.query_one("#rubric-display", Static).display = False
         # Reactives are `init=False`, so the connection watcher never fires on
         # mount; render once to hide the empty indicator (and its padding).
         self._render_connection()
-        # Same reasoning for the message and token slots: both start empty, so
-        # hide them on mount so their padding doesn't reserve a blank gap.
         self.watch_status_message(self.status_message)
-        with suppress(NoMatches):
-            self.query_one("#tokens-display", Static).display = False
+        self._render_tokens(self.tokens, approximate=self._approximate)
 
     def watch_mode(self, mode: str) -> None:
         """Update mode indicator when mode changes."""
@@ -750,9 +768,21 @@ class StatusBar(Horizontal):
         """Update the combined token and cost display when tokens change."""
         self._render_tokens(new_value, approximate=self._approximate)
 
+    def watch_context_limit(self, _new_value: int | None) -> None:
+        """Update context percentage when the model limit changes."""
+        self._render_tokens(self.tokens, approximate=self._approximate)
+
     def watch_cost_usd(self, _new_value: float) -> None:
         """Update the combined token and cost display when cost changes."""
         self._render_tokens(self.tokens, approximate=self._approximate)
+
+    def watch_cache_read_tokens(self, _new_value: int) -> None:
+        """Update cache metrics when read tokens change."""
+        self._render_cache_metrics()
+
+    def watch_cache_write_tokens(self, _new_value: int) -> None:
+        """Update cache metrics when write tokens change."""
+        self._render_cache_metrics()
 
     def watch_rubric_label(self, new_value: str) -> None:
         """Update rubric display when active rubric state changes."""
@@ -763,19 +793,30 @@ class StatusBar(Horizontal):
         display.display = bool(new_value)
         display.update(new_value)
 
-    @staticmethod
-    def _token_text(count: int, *, approximate: bool = False) -> str:
-        """Format the token portion of the shared status-bar slot.
+    def _token_text(self, count: int, *, approximate: bool = False) -> str:
+        """Format context percentage and token count for the metrics row.
 
         Returns:
-            Formatted token count, or an empty string when no count is known.
+            Compact context usage text.
         """
         if count <= 0:
             return ""
         suffix = "+" if approximate else ""
-        if count >= 1000:  # noqa: PLR2004  # Count formatting threshold
-            return f"{count / 1000:.1f}K{suffix} tokens"
-        return f"{count}{suffix} tokens"
+        tokens = f"{format_token_count(count)}{suffix} tokens"
+        if self.context_limit is None:
+            return f"Context: {tokens}"
+        return f"Context: {count / self.context_limit * 100:.0f}% / {tokens}"
+
+    def _render_cache_metrics(self) -> None:
+        """Render cumulative cache reads and writes for the active thread."""
+        try:
+            display = self.query_one("#cache-display", Static)
+        except NoMatches:
+            return
+        display.update(
+            f"Cache: {format_token_count(self.cache_read_tokens)} read / "
+            f"{format_token_count(self.cache_write_tokens)} write"
+        )
 
     def _cost_text(self) -> str:
         """Format positive cost, hiding zero and unknown estimates.
@@ -839,6 +880,27 @@ class StatusBar(Horizontal):
             # Reactive assignment triggers watch_tokens, which reads
             # self._approximate for the suffix.
             self.tokens = count
+
+    def set_context_limit(self, limit: int | None) -> None:
+        """Set the active model's context limit."""
+        normalized = limit if isinstance(limit, int) and limit > 0 else None
+        if self.context_limit == normalized:
+            self._render_tokens(self.tokens, approximate=self._approximate)
+        else:
+            self.context_limit = normalized
+
+    def set_cache_tokens(self, read_tokens: int, write_tokens: int) -> None:
+        """Set cumulative cache read and write counts for the active thread."""
+        reads, writes = max(read_tokens, 0), max(write_tokens, 0)
+        changed = False
+        if self.cache_read_tokens != reads:
+            self.cache_read_tokens = reads
+            changed = True
+        if self.cache_write_tokens != writes:
+            self.cache_write_tokens = writes
+            changed = True
+        if not changed:
+            self._render_cache_metrics()
 
     def set_cost(self, cost_usd: float) -> None:
         """Set the cumulative thread cost shown beside context tokens.

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -824,20 +824,25 @@ class StatusBar(Vertical):
         pending = self._tokens_pending
         suffix = "+" if approximate else ""
         if pending:
-            usage = Content("... tokens")
+            percent_content = Content("...")
+            count_text = "..."
         elif self.context_limit is None:
-            usage = Content(f"{_compact_tokens(count)}{suffix} tokens")
+            percent_content = Content("0%" if count <= 0 else "--")
+            count_text = f"{_compact_tokens(count)}{suffix}"
         else:
             percent = min(100.0, max(0.0, count / self.context_limit * 100))
-            usage = Content.assemble(
-                (f"{percent:.0f}%", self._percent_color(percent)),
-                f"  {_compact_tokens(count)}{suffix}/"
-                f"{_compact_tokens(self.context_limit)}",
+            percent_content = Content.styled(
+                f"{percent:.0f}%", self._percent_color(percent)
             )
+            count_text = f"{_compact_tokens(count)}{suffix}"
+        muted = theme.get_theme_colors(self).muted
         return Content.assemble(
-            Content.styled("Context", theme.get_theme_colors(self).muted),
+            Content.styled("Context:", muted),
             " ",
-            usage,
+            percent_content,
+            " / ",
+            Content.styled("Tokens:", muted),
+            f" {count_text}",
         )
 
     def _cache_segment(self) -> Content:

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -820,13 +820,20 @@ class StatusBar(Vertical):
         pending = self._tokens_pending
         suffix = "+" if approximate else ""
         if pending:
-            return Content("... tokens")
-        if self.context_limit is None:
-            return Content(f"{_compact_tokens(count)}{suffix} tokens")
-        percent = min(100.0, max(0.0, count / self.context_limit * 100))
+            usage = Content("... tokens")
+        elif self.context_limit is None:
+            usage = Content(f"{_compact_tokens(count)}{suffix} tokens")
+        else:
+            percent = min(100.0, max(0.0, count / self.context_limit * 100))
+            usage = Content.assemble(
+                (f"{percent:.0f}%", self._percent_color(percent)),
+                f"  {_compact_tokens(count)}{suffix}/"
+                f"{_compact_tokens(self.context_limit)}",
+            )
         return Content.assemble(
-            (f"{percent:.0f}%", self._percent_color(percent)),
-            f"  {_compact_tokens(count)}{suffix}/{_compact_tokens(self.context_limit)}",
+            Content.styled("Context", theme.get_theme_colors(self).muted),
+            " ",
+            usage,
         )
 
     def _cache_segment(self) -> Content:

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -799,15 +799,15 @@ class StatusBar(Vertical):
     _CONTEXT_WARNING_PERCENT = 60.0
     """Context usage at which the percentage turns from calm to caution."""
 
-    _CONTEXT_CRITICAL_PERCENT = 85.0
+    _CONTEXT_CRITICAL_PERCENT = 80.0
     """Context usage at which the percentage turns to alert."""
 
     def _percent_color(self, percent: float) -> str:
         """Return the color that encodes how full the context window is."""
         colors = theme.get_theme_colors(self)
-        if percent >= self._CONTEXT_CRITICAL_PERCENT:
+        if percent > self._CONTEXT_CRITICAL_PERCENT:
             return colors.error
-        if percent >= self._CONTEXT_WARNING_PERCENT:
+        if percent > self._CONTEXT_WARNING_PERCENT:
             return colors.warning
         return colors.muted
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2572,18 +2572,6 @@ class TestAppCSSValidation:
             # If we get here without exception, CSS is valid
             assert app.is_running
 
-    async def test_chat_input_is_wider_than_status_rows(self) -> None:
-        """The input frame should extend one column past each status-bar edge."""
-        app = DeepAgentsApp()
-        async with app.run_test(size=(120, 30)) as pilot:
-            await pilot.pause()
-
-            input_box = app.query_one("#input-box")
-            session = app.query_one(".status-session")
-            metrics = app.query_one(".status-metrics")
-            assert input_box.region.x < session.region.x == metrics.region.x
-            assert input_box.region.right > session.region.right == metrics.region.right
-
 
 class TestCacheStatus:
     """Tests for active-thread cache metrics forwarded to the status bar."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2572,6 +2572,46 @@ class TestAppCSSValidation:
             # If we get here without exception, CSS is valid
             assert app.is_running
 
+    async def test_chat_input_is_wider_than_status_rows(self) -> None:
+        """The input frame should extend one column past each status-bar edge."""
+        app = DeepAgentsApp()
+        async with app.run_test(size=(120, 30)) as pilot:
+            await pilot.pause()
+
+            input_box = app.query_one("#input-box")
+            session = app.query_one(".status-session")
+            metrics = app.query_one(".status-metrics")
+            assert input_box.region.x < session.region.x == metrics.region.x
+            assert input_box.region.right > session.region.right == metrics.region.right
+
+
+class TestCacheStatus:
+    """Tests for active-thread cache metrics forwarded to the status bar."""
+
+    def test_refresh_includes_matching_inflight_input_total(self) -> None:
+        """The hit-rate denominator should cover persisted and in-flight usage."""
+        app = DeepAgentsApp(thread_id="thread-123")
+        app._status_bar = MagicMock()
+        app._thread_stats = SessionStats(
+            input_tokens=1_000,
+            cache_read_tokens=800,
+            cache_write_tokens=100,
+        )
+        app._inflight_turn_stats = SessionStats(
+            input_tokens=500,
+            cache_read_tokens=400,
+            cache_write_tokens=50,
+        )
+        app._inflight_thread_id = app._lc_thread_id
+
+        app._refresh_cache_display()
+
+        app._status_bar.set_cache_tokens.assert_called_once_with(
+            1_200,
+            150,
+            input_tokens=1_500,
+        )
+
 
 class TestThreadCachePrewarm:
     """Tests for startup thread-cache prewarming."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2572,6 +2572,19 @@ class TestAppCSSValidation:
             # If we get here without exception, CSS is valid
             assert app.is_running
 
+    async def test_chat_input_aligns_with_status_rows(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test(size=(120, 30)) as pilot:
+            await pilot.pause()
+
+            input_box = app.query_one("#input-box")
+            session = app.query_one(".status-session")
+            metrics = app.query_one(".status-metrics")
+            assert input_box.region.x == session.region.x == metrics.region.x
+            assert (
+                input_box.region.right == session.region.right == metrics.region.right
+            )
+
 
 class TestCacheStatus:
     """Tests for active-thread cache metrics forwarded to the status bar."""

--- a/libs/code/tests/unit_tests/test_cost_tracking.py
+++ b/libs/code/tests/unit_tests/test_cost_tracking.py
@@ -52,7 +52,6 @@ from deepagents_code.cost_tracking import (
     _ModelCallRecord,
     _SessionCostRecorder,
     _set_configured_provider_metadata,
-    cache_token_counts,
     estimate_cost,
     resolve_message_model,
 )
@@ -357,14 +356,6 @@ class TestEstimateCost:
 
     def test_codex_subscription_usage_is_not_priced_as_openai_api(self) -> None:
         assert estimate_cost(_usage(), "gpt-5.4", "openai_codex") is None
-
-    def test_cache_counts_share_pricing_normalization(self) -> None:
-        usage = _usage(1_000, 100, cache_read=600, cache_write=900)
-
-        reads, writes = cache_token_counts(usage)
-
-        assert reads == 600
-        assert sum(writes) == 400
 
     def test_cache_read_is_priced_separately(self) -> None:
         uncached = estimate_cost(_usage(), KNOWN_MODEL, KNOWN_PROVIDER)

--- a/libs/code/tests/unit_tests/test_cost_tracking.py
+++ b/libs/code/tests/unit_tests/test_cost_tracking.py
@@ -52,6 +52,7 @@ from deepagents_code.cost_tracking import (
     _ModelCallRecord,
     _SessionCostRecorder,
     _set_configured_provider_metadata,
+    cache_token_counts,
     estimate_cost,
     resolve_message_model,
 )
@@ -356,6 +357,14 @@ class TestEstimateCost:
 
     def test_codex_subscription_usage_is_not_priced_as_openai_api(self) -> None:
         assert estimate_cost(_usage(), "gpt-5.4", "openai_codex") is None
+
+    def test_cache_counts_share_pricing_normalization(self) -> None:
+        usage = _usage(1_000, 100, cache_read=600, cache_write=900)
+
+        reads, writes = cache_token_counts(usage)
+
+        assert reads == 600
+        assert sum(writes) == 400
 
     def test_cache_read_is_priced_separately(self) -> None:
         uncached = estimate_cost(_usage(), KNOWN_MODEL, KNOWN_PROVIDER)

--- a/libs/code/tests/unit_tests/test_session_stats.py
+++ b/libs/code/tests/unit_tests/test_session_stats.py
@@ -656,8 +656,10 @@ class TestRecordMessageUsage:
         record_message_usage(uncached, self._chunk(1_000, 100), recorded_requests={})
 
         # Cache reads are cheaper than ordinary input, so losing the detail in
-        # the merge would silently overprice the request.
+        # the merge would silently overprice the request or status metric.
         assert stats.total_cost_usd < uncached.total_cost_usd
+        assert stats.cache_read_tokens == 800
+        assert stats.cache_write_tokens == 0
 
     def test_reports_message_delta_and_running_request_tokens(self) -> None:
         """Pricing needs a delta while context display needs the running total."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -37,22 +37,89 @@ class TestTwoLineMetrics:
     async def test_layout_and_metrics(self) -> None:
         async with StatusBarApp().run_test(size=(120, 24)) as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_model(provider="openai", model="gpt-5.6", effort="high")
+            bar.set_cache_tokens(12_500, 750, input_tokens=15_625)
+            bar.set_context_limit(200_000)
+            bar.set_tokens(12_500)
+            bar.set_cost(0.42)
+            bar.branch = "main"
+            await pilot.pause()
+
+            session = pilot.app.query_one(".status-session")
+            metrics = pilot.app.query_one(".status-metrics")
+            model = pilot.app.query_one("#model-display")
+            cwd = pilot.app.query_one("#cwd-display")
+            cache = pilot.app.query_one("#cache-display")
+            context = pilot.app.query_one("#tokens-display")
+            assert bar.size.height == 2
+            assert metrics.region.y == session.region.y + 1
+            assert model.region.x == session.region.x
+            assert cwd.region.y == session.region.y
+            assert cwd.region.x == model.region.right
+            assert pilot.app.query_one("#branch-display").region.y == session.region.y
+            assert cache.region.x == metrics.region.x
+            assert context.region.right == metrics.region.right
+            assert str(cache.render()) == ("Cache 80% hit • 12.5K read / 750 write")
+            assert str(context.render()) == "6%  12.5K/200K • $0.42"
+
+    async def test_narrow_width_keeps_context_right_aligned(self) -> None:
+        """The context/cost group stays anchored right when cache space shrinks."""
+        async with StatusBarApp().run_test(size=(48, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_cache_tokens(12_500, 750)
             bar.set_context_limit(200_000)
             bar.set_tokens(12_500)
             bar.set_cost(0.42)
             await pilot.pause()
 
-            top = pilot.app.query_one(".status-top")
+            context = pilot.app.query_one("#tokens-display")
             metrics = pilot.app.query_one(".status-metrics")
-            assert bar.size.height == 2
-            assert metrics.region.y == top.region.y + 1
-            assert str(pilot.app.query_one("#cache-display").render()) == (
-                "Cache: 12.5K read / 750 write"
-            )
-            rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert "Context: 6% / 12.5K tokens" in rendered
-            assert "$0.42" in rendered
+            assert str(context.render()) == "6%  12.5K/200K • $0.42"
+            assert context.region.right == metrics.region.right
+
+
+class TestCacheMetrics:
+    """Tests for prompt-cache totals and hit rates."""
+
+    async def test_zero_state_is_visible_on_mount(self) -> None:
+        """The lower-left metric should not be blank before the first request."""
+        async with StatusBarApp().run_test() as pilot:
+            await pilot.pause()
+
+            rendered = str(pilot.app.query_one("#cache-display").render())
+            assert rendered == "Cache 0% hit • 0 read / 0 write"
+
+    async def test_unknown_input_total_omits_hit_rate(self) -> None:
+        """Restored cache totals without a denominator should remain useful."""
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cache_tokens(800, 100)
+            await pilot.pause()
+
+            rendered = str(pilot.app.query_one("#cache-display").render())
+            assert rendered == "Cache 800 read / 100 write"
+
+    async def test_hit_rate_is_clamped_to_one_hundred_percent(self) -> None:
+        """Malformed provider totals must not produce a rate above 100%."""
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cache_tokens(1_200, 0, input_tokens=1_000)
+            await pilot.pause()
+
+            rendered = str(pilot.app.query_one("#cache-display").render())
+            assert rendered == "Cache 100% hit • 1.2K read / 0 write"
+
+    async def test_input_only_update_refreshes_hit_rate(self) -> None:
+        """A denominator correction should update the rate with stable cache totals."""
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cache_tokens(500, 0, input_tokens=1_000)
+            await pilot.pause()
+            assert "50% hit" in str(pilot.app.query_one("#cache-display").render())
+
+            bar.set_cache_tokens(500, 0, input_tokens=2_000)
+            await pilot.pause()
+            assert "25% hit" in str(pilot.app.query_one("#cache-display").render())
 
 
 class TestApprovalModeDisplay:
@@ -71,6 +138,7 @@ class TestApprovalModeDisplay:
             indicator = pilot.app.query_one("#auto-approve-indicator", Static)
             assert str(indicator.render()) == label
             assert indicator.has_class(mode)
+            assert indicator.styles.background.a == 0
 
 
 class TestCwdDisplay:
@@ -101,10 +169,10 @@ class TestCwdDisplay:
             branch = pilot.app.query_one("#branch-display")
             assert cwd.display is False
             assert branch.display is True
-            assert branch.styles.padding.left == 1
+            assert branch.styles.padding.left == 0
 
-    async def test_cwd_owns_left_gap_after_auto_approve_pill(self) -> None:
-        """The cwd keeps visible spacing when transient status slots are hidden."""
+    async def test_cwd_follows_model_without_a_leading_gap(self) -> None:
+        """The cwd owns only its trailing gap on the model/workspace line."""
         async with StatusBarApp().run_test() as pilot:
             cwd = pilot.app.query_one("#cwd-display")
             connection = pilot.app.query_one("#connection-indicator")
@@ -112,7 +180,7 @@ class TestCwdDisplay:
 
             assert connection.display is False
             assert status.display is False
-            assert cwd.styles.padding.left == 1
+            assert cwd.styles.padding.left == 0
             assert cwd.styles.padding.right == 1
 
 
@@ -334,14 +402,14 @@ class TestResizePriority:
             await pilot.pause()
             branch = pilot.app.query_one("#branch-display")
             assert branch.display is True
-            assert branch.styles.padding.left == 1
+            assert branch.styles.padding.left == 0
 
-    async def test_branch_removes_fallback_gap_when_cwd_returns(self) -> None:
-        """Resizing wide again restores branch spacing to the cwd-visible layout."""
+    async def test_branch_keeps_alignment_when_cwd_returns(self) -> None:
+        """Resizing wide again does not introduce a leading branch gap."""
         async with StatusBarApp().run_test(size=(50, 24)) as pilot:
             branch = pilot.app.query_one("#branch-display")
             await pilot.pause()
-            assert branch.styles.padding.left == 1
+            assert branch.styles.padding.left == 0
 
             await pilot.resize_terminal(120, 24)
             await pilot.pause()
@@ -403,29 +471,42 @@ class TestResizePriority:
 class TestEdgeAlignment:
     """Tests that the status bar spans the full terminal width."""
 
-    async def test_model_label_is_flush_with_the_right_edge(self) -> None:
-        """The model name should end on the last column, not short of it."""
+    async def test_model_label_is_flush_with_the_left_edge(self) -> None:
+        """The model should align with the workspace row's left edge."""
         async with StatusBarApp().run_test(size=(80, 24)) as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_model(provider="fireworks", model="kimi-k3")
             await pilot.pause()
             model = pilot.app.query_one("#model-display", ModelLabel)
-            assert model.styles.padding.right == 0
-            assert model.content_region.right == bar.region.right
+            assert model.styles.padding.left == 0
+            assert model.content_region.x == bar.region.x
 
-    async def test_approval_pill_is_flush_with_the_left_edge(self) -> None:
-        """The pill's background starts on column 0; only its text is inset.
-
-        The pill keeps its horizontal padding — that padding is filled with the
-        pill's background color, so it reads as part of the badge rather than as
-        a gap that narrows the bar.
-        """
+    async def test_approval_text_is_flush_with_the_right_edge(self) -> None:
+        """The approval mode should occupy the session row's rightmost columns."""
         async with StatusBarApp().run_test(size=(80, 24)) as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_approval_mode("auto")
             await pilot.pause()
-            pill = pilot.app.query_one("#auto-approve-indicator", Static)
-            assert pill.region.x == bar.region.x
+            indicator = pilot.app.query_one("#auto-approve-indicator", Static)
+            assert indicator.content_region.right == bar.region.right
+
+    async def test_narrow_session_keeps_approval_text_on_the_right(self) -> None:
+        """Long model details must not displace the right-aligned approval mode."""
+        async with StatusBarApp().run_test(size=(40, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_model(
+                provider="anthropic",
+                model="claude-sonnet-4-5-20250929",
+                effort="xhigh",
+            )
+            bar.set_context_limit(200_000)
+            bar.set_tokens(150_000)
+            await pilot.pause()
+
+            model = pilot.app.query_one("#model-display", ModelLabel)
+            indicator = pilot.app.query_one("#auto-approve-indicator", Static)
+            assert indicator.content_region.right == bar.region.right
+            assert model.region.right <= indicator.region.x
 
 
 class TestTokenDisplay:
@@ -437,7 +518,7 @@ class TestTokenDisplay:
             bar.set_tokens(5000)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert "5.0K" in str(display.render())
+            assert "5K" in str(display.render())
 
     async def test_show_pending_tokens_shows_unknown_placeholder(self) -> None:
         async with StatusBarApp().run_test() as pilot:
@@ -447,15 +528,15 @@ class TestTokenDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "... tokens"
+            assert str(display.render()) == "... tokens • $0.00"
 
-    async def test_show_pending_tokens_before_count_leaves_display_empty(self) -> None:
+    async def test_show_pending_tokens_before_count_keeps_zero_state(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == ""
+            assert str(display.render()) == "0 tokens • $0.00"
 
     async def test_set_tokens_after_pending_restores_display(self) -> None:
         """Regression: set_tokens must refresh even when value is unchanged.
@@ -474,7 +555,7 @@ class TestTokenDisplay:
             bar.set_tokens(5000)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert "5.0K" in str(display.render())
+            assert "5K" in str(display.render())
 
     async def test_show_pending_tokens_after_count_change_keeps_placeholder(
         self,
@@ -490,7 +571,7 @@ class TestTokenDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "... tokens"
+            assert str(display.render()) == "... tokens • $0.00"
 
     async def test_cost_update_while_pending_keeps_the_placeholder(self) -> None:
         """A mid-turn cost update must not resurrect the stale token count.
@@ -511,7 +592,7 @@ class TestTokenDisplay:
 
             display = str(pilot.app.query_one("#tokens-display").render())
             assert "... tokens" in display
-            assert "5.0K" not in display
+            assert "5K" not in display
             assert "$1.25" in display
 
     async def test_accurate_count_replaces_the_placeholder_with_cost(self) -> None:
@@ -544,7 +625,7 @@ class TestTokenDisplay:
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
             rendered = str(display.render())
-            assert "5.0K+" in rendered
+            assert "5K+" in rendered
 
     async def test_approximate_after_pending_restores_with_plus(self) -> None:
         """Interrupted restore: same value + approximate should show count with '+'."""
@@ -558,7 +639,7 @@ class TestTokenDisplay:
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
             rendered = str(display.render())
-            assert "5.0K+" in rendered
+            assert "5K+" in rendered
 
     async def test_exact_count_clears_plus(self) -> None:
         """A non-approximate set_tokens after an approximate one should drop '+'."""
@@ -570,17 +651,18 @@ class TestTokenDisplay:
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
             rendered = str(display.render())
-            assert "8.0K" in rendered
+            assert "8K" in rendered
             assert "+" not in rendered
 
-    async def test_empty_tokens_hidden_on_mount(self) -> None:
-        """An empty token slot is hidden so its padding adds no gap."""
+    async def test_zero_context_and_cost_are_visible_on_mount(self) -> None:
+        """The lower-right metrics should not be blank before the first request."""
         async with StatusBarApp().run_test() as pilot:
             display = pilot.app.query_one("#tokens-display")
-            assert display.display is False
+            assert display.display is True
+            assert str(display.render()) == "0 tokens • $0.00"
 
-    async def test_set_tokens_shows_then_zero_hides(self) -> None:
-        """A positive count reveals the token slot; zeroing hides it again."""
+    async def test_set_tokens_then_zero_restores_zero_state(self) -> None:
+        """Zeroing a positive count restores visible placeholders."""
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_tokens(5000)
@@ -589,7 +671,8 @@ class TestTokenDisplay:
             assert display.display is True
             bar.set_tokens(0)
             await pilot.pause()
-            assert display.display is False
+            assert display.display is True
+            assert str(display.render()) == "0 tokens • $0.00"
 
 
 class TestCostDisplay:
@@ -611,25 +694,26 @@ class TestCostDisplay:
             bar.set_cost(1.25)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "$1.25"
+            assert str(display.render()) == "0 tokens • $1.25"
             assert display.display is True
 
-    async def test_zero_cost_is_hidden(self) -> None:
+    async def test_zero_cost_is_visible(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_tokens(5000)
             bar.set_cost(0.0)
             await pilot.pause()
             rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert rendered == "Context: 5.0K tokens"
-            assert "$" not in rendered
+            assert rendered == "5K tokens • $0.00"
 
     async def test_sub_cent_cost_uses_display_floor(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_cost(0.0045)
             await pilot.pause()
-            assert str(pilot.app.query_one("#tokens-display").render()) == "<$0.01"
+            assert str(pilot.app.query_one("#tokens-display").render()) == (
+                "0 tokens • <$0.01"
+            )
 
     async def test_approximate_token_marker_survives_cost_update(self) -> None:
         async with StatusBarApp().run_test() as pilot:
@@ -638,7 +722,7 @@ class TestCostDisplay:
             bar.set_cost(0.42)
             await pilot.pause()
             rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert "5.0K+ tokens" in rendered
+            assert "5K+ tokens" in rendered
             assert "$0.42" in rendered
 
     async def test_pending_tokens_keep_cost_visible(self) -> None:
@@ -805,8 +889,8 @@ class TestModelLabelPrefixStripping:
             label = pilot.app.query_one("#model-display", ModelLabel)
             label.provider = "fireworks"
             label.model = "accounts/fireworks/models/kimi-k2p6"
-            # padding 0 0 0 2 -> content width = 9, fits "kimi-k2p6" but not
-            # the full "fireworks:kimi-k2p6" (19 chars).
+            # This width fits "kimi-k2p6" but not the full
+            # "fireworks:kimi-k2p6" (19 chars).
             label.styles.width = 11
             await pilot.pause()
             assert str(label.render()) == "kimi-k2p6"
@@ -817,7 +901,7 @@ class TestModelLabelPrefixStripping:
             label = pilot.app.query_one("#model-display", ModelLabel)
             label.provider = "fireworks"
             label.model = "accounts/fireworks/models/kimi-k2p6"
-            # padding 0 0 0 2 -> content width = 5, smaller than "kimi-k2p6" (9).
+            # Two columns are padding, leaving five for truncated content.
             label.styles.width = 7
             await pilot.pause()
             rendered = str(label.render())
@@ -912,15 +996,14 @@ class TestModelLabelPrefixStripping:
             label.provider = ""
             label.model = "o1"
             label.effort = "medium"
-            # padding 0 0 0 2 -> content width = 6: too narrow for "o1 medium"
-            # (9) and below len("medium") + 2, but wide enough for bare "o1".
-            label.styles.width = 8
+            # Six columns are too narrow for "o1 medium" but fit bare "o1".
+            label.styles.width = 6
             await pilot.pause()
             assert str(label.render()) == "o1"
 
     async def test_no_provider_no_stripping(self) -> None:
         """Without a provider, the model name is passed through unchanged."""
-        async with StatusBarApp().run_test() as pilot:
+        async with StatusBarApp().run_test(size=(150, 24)) as pilot:
             label = pilot.app.query_one("#model-display", ModelLabel)
             label.provider = ""
             label.model = "accounts/fireworks/models/kimi-k2p6"

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -55,7 +55,7 @@ class TestTwoLineMetrics:
             assert cache.region.x == metrics.region.x
             assert context.region.right == metrics.region.right
             assert str(cache.render()) == ("Cache 80% hit • 12.5K read / 750 write")
-            assert str(context.render()) == "Context 6%  12.5K/200K • $0.42"
+            assert str(context.render()) == "Context: 6% / Tokens: 12.5K • $0.42"
 
     async def test_context_percentage_color_thresholds(self) -> None:
         async with StatusBarApp().run_test() as pilot:
@@ -458,7 +458,7 @@ class TestTokenDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "Context ... tokens • $0.00"
+            assert str(display.render()) == "Context: ... / Tokens: ... • $0.00"
 
     async def test_show_pending_tokens_before_count_keeps_zero_state(self) -> None:
         async with StatusBarApp().run_test() as pilot:
@@ -466,7 +466,7 @@ class TestTokenDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "Context 0 tokens • $0.00"
+            assert str(display.render()) == "Context: 0% / Tokens: 0 • $0.00"
 
     async def test_set_tokens_after_pending_restores_display(self) -> None:
         """Regression: set_tokens must refresh even when value is unchanged.
@@ -501,7 +501,7 @@ class TestTokenDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "Context ... tokens • $0.00"
+            assert str(display.render()) == "Context: ... / Tokens: ... • $0.00"
 
     async def test_cost_update_while_pending_keeps_the_placeholder(self) -> None:
         """A mid-turn cost update must not resurrect the stale token count.
@@ -521,7 +521,7 @@ class TestTokenDisplay:
             await pilot.pause()
 
             display = str(pilot.app.query_one("#tokens-display").render())
-            assert "... tokens" in display
+            assert "Tokens: ..." in display
             assert "5K" not in display
             assert "$1.25" in display
 
@@ -540,7 +540,7 @@ class TestTokenDisplay:
 
             display = str(pilot.app.query_one("#tokens-display").render())
             assert "7.5K" in display
-            assert "... tokens" not in display
+            assert "Tokens: ..." not in display
             assert "$1.25" in display
 
     def test_show_pending_tokens_without_mount_is_noop(self) -> None:
@@ -589,7 +589,7 @@ class TestTokenDisplay:
         async with StatusBarApp().run_test() as pilot:
             display = pilot.app.query_one("#tokens-display")
             assert display.display is True
-            assert str(display.render()) == "Context 0 tokens • $0.00"
+            assert str(display.render()) == "Context: 0% / Tokens: 0 • $0.00"
 
     async def test_set_tokens_then_zero_restores_zero_state(self) -> None:
         """Zeroing a positive count restores visible placeholders."""
@@ -602,7 +602,7 @@ class TestTokenDisplay:
             bar.set_tokens(0)
             await pilot.pause()
             assert display.display is True
-            assert str(display.render()) == "Context 0 tokens • $0.00"
+            assert str(display.render()) == "Context: 0% / Tokens: 0 • $0.00"
 
 
 class TestCostDisplay:
@@ -615,7 +615,7 @@ class TestCostDisplay:
             bar.set_cost(0.42)
             await pilot.pause()
             rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert "12.5K tokens" in rendered
+            assert "Tokens: 12.5K" in rendered
             assert "$0.42" in rendered
 
     async def test_cost_displays_without_tokens(self) -> None:
@@ -624,7 +624,7 @@ class TestCostDisplay:
             bar.set_cost(1.25)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "Context 0 tokens • $1.25"
+            assert str(display.render()) == "Context: 0% / Tokens: 0 • $1.25"
             assert display.display is True
 
     async def test_zero_cost_is_visible(self) -> None:
@@ -634,7 +634,7 @@ class TestCostDisplay:
             bar.set_cost(0.0)
             await pilot.pause()
             rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert rendered == "Context 5K tokens • $0.00"
+            assert rendered == "Context: -- / Tokens: 5K • $0.00"
 
     async def test_sub_cent_cost_uses_display_floor(self) -> None:
         async with StatusBarApp().run_test() as pilot:
@@ -642,7 +642,7 @@ class TestCostDisplay:
             bar.set_cost(0.0045)
             await pilot.pause()
             assert str(pilot.app.query_one("#tokens-display").render()) == (
-                "Context 0 tokens • <$0.01"
+                "Context: 0% / Tokens: 0 • <$0.01"
             )
 
     async def test_approximate_token_marker_survives_cost_update(self) -> None:
@@ -652,7 +652,7 @@ class TestCostDisplay:
             bar.set_cost(0.42)
             await pilot.pause()
             rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert "5K+ tokens" in rendered
+            assert "Tokens: 5K+" in rendered
             assert "$0.42" in rendered
 
     async def test_pending_tokens_keep_cost_visible(self) -> None:
@@ -664,7 +664,7 @@ class TestCostDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert "... tokens" in rendered
+            assert "Tokens: ..." in rendered
             assert "$0.42" in rendered
 
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -47,79 +47,14 @@ class TestTwoLineMetrics:
 
             session = pilot.app.query_one(".status-session")
             metrics = pilot.app.query_one(".status-metrics")
-            model = pilot.app.query_one("#model-display")
-            cwd = pilot.app.query_one("#cwd-display")
             cache = pilot.app.query_one("#cache-display")
             context = pilot.app.query_one("#tokens-display")
             assert bar.size.height == 2
             assert metrics.region.y == session.region.y + 1
-            assert model.region.x == session.region.x
-            assert cwd.region.y == session.region.y
-            assert cwd.region.x == model.region.right
-            assert pilot.app.query_one("#branch-display").region.y == session.region.y
             assert cache.region.x == metrics.region.x
             assert context.region.right == metrics.region.right
             assert str(cache.render()) == ("Cache 80% hit • 12.5K read / 750 write")
             assert str(context.render()) == "6%  12.5K/200K • $0.42"
-
-    async def test_narrow_width_keeps_context_right_aligned(self) -> None:
-        """The context/cost group stays anchored right when cache space shrinks."""
-        async with StatusBarApp().run_test(size=(48, 24)) as pilot:
-            bar = pilot.app.query_one("#status-bar", StatusBar)
-            bar.set_cache_tokens(12_500, 750)
-            bar.set_context_limit(200_000)
-            bar.set_tokens(12_500)
-            bar.set_cost(0.42)
-            await pilot.pause()
-
-            context = pilot.app.query_one("#tokens-display")
-            metrics = pilot.app.query_one(".status-metrics")
-            assert str(context.render()) == "6%  12.5K/200K • $0.42"
-            assert context.region.right == metrics.region.right
-
-
-class TestCacheMetrics:
-    """Tests for prompt-cache totals and hit rates."""
-
-    async def test_zero_state_is_visible_on_mount(self) -> None:
-        """The lower-left metric should not be blank before the first request."""
-        async with StatusBarApp().run_test() as pilot:
-            await pilot.pause()
-
-            rendered = str(pilot.app.query_one("#cache-display").render())
-            assert rendered == "Cache 0% hit • 0 read / 0 write"
-
-    async def test_unknown_input_total_omits_hit_rate(self) -> None:
-        """Restored cache totals without a denominator should remain useful."""
-        async with StatusBarApp().run_test() as pilot:
-            bar = pilot.app.query_one("#status-bar", StatusBar)
-            bar.set_cache_tokens(800, 100)
-            await pilot.pause()
-
-            rendered = str(pilot.app.query_one("#cache-display").render())
-            assert rendered == "Cache 800 read / 100 write"
-
-    async def test_hit_rate_is_clamped_to_one_hundred_percent(self) -> None:
-        """Malformed provider totals must not produce a rate above 100%."""
-        async with StatusBarApp().run_test() as pilot:
-            bar = pilot.app.query_one("#status-bar", StatusBar)
-            bar.set_cache_tokens(1_200, 0, input_tokens=1_000)
-            await pilot.pause()
-
-            rendered = str(pilot.app.query_one("#cache-display").render())
-            assert rendered == "Cache 100% hit • 1.2K read / 0 write"
-
-    async def test_input_only_update_refreshes_hit_rate(self) -> None:
-        """A denominator correction should update the rate with stable cache totals."""
-        async with StatusBarApp().run_test() as pilot:
-            bar = pilot.app.query_one("#status-bar", StatusBar)
-            bar.set_cache_tokens(500, 0, input_tokens=1_000)
-            await pilot.pause()
-            assert "50% hit" in str(pilot.app.query_one("#cache-display").render())
-
-            bar.set_cache_tokens(500, 0, input_tokens=2_000)
-            await pilot.pause()
-            assert "25% hit" in str(pilot.app.query_one("#cache-display").render())
 
 
 class TestApprovalModeDisplay:
@@ -138,7 +73,6 @@ class TestApprovalModeDisplay:
             indicator = pilot.app.query_one("#auto-approve-indicator", Static)
             assert str(indicator.render()) == label
             assert indicator.has_class(mode)
-            assert indicator.styles.background.a == 0
 
 
 class TestCwdDisplay:
@@ -489,24 +423,6 @@ class TestEdgeAlignment:
             await pilot.pause()
             indicator = pilot.app.query_one("#auto-approve-indicator", Static)
             assert indicator.content_region.right == bar.region.right
-
-    async def test_narrow_session_keeps_approval_text_on_the_right(self) -> None:
-        """Long model details must not displace the right-aligned approval mode."""
-        async with StatusBarApp().run_test(size=(40, 24)) as pilot:
-            bar = pilot.app.query_one("#status-bar", StatusBar)
-            bar.set_model(
-                provider="anthropic",
-                model="claude-sonnet-4-5-20250929",
-                effort="xhigh",
-            )
-            bar.set_context_limit(200_000)
-            bar.set_tokens(150_000)
-            await pilot.pause()
-
-            model = pilot.app.query_one("#model-display", ModelLabel)
-            indicator = pilot.app.query_one("#auto-approve-indicator", Static)
-            assert indicator.content_region.right == bar.region.right
-            assert model.region.right <= indicator.region.x
 
 
 class TestTokenDisplay:

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -10,6 +10,7 @@ from textual.app import App, ComposeResult
 from textual.geometry import Size
 from textual.widgets import Static
 
+from deepagents_code import theme
 from deepagents_code._env_vars import HIDE_CWD, HIDE_GIT_BRANCH
 from deepagents_code.config import reset_glyphs_cache
 from deepagents_code.tui.widgets.status import BranchLabel, ModelLabel, StatusBar
@@ -55,6 +56,16 @@ class TestTwoLineMetrics:
             assert context.region.right == metrics.region.right
             assert str(cache.render()) == ("Cache 80% hit • 12.5K read / 750 write")
             assert str(context.render()) == "Context 6%  12.5K/200K • $0.42"
+
+    async def test_context_percentage_color_thresholds(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            colors = theme.get_theme_colors(bar)
+
+            assert bar._percent_color(60.0) == colors.muted
+            assert bar._percent_color(60.1) == colors.warning
+            assert bar._percent_color(80.0) == colors.warning
+            assert bar._percent_color(80.1) == colors.error
 
 
 class TestApprovalModeDisplay:

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -54,7 +54,7 @@ class TestTwoLineMetrics:
             assert cache.region.x == metrics.region.x
             assert context.region.right == metrics.region.right
             assert str(cache.render()) == ("Cache 80% hit • 12.5K read / 750 write")
-            assert str(context.render()) == "6%  12.5K/200K • $0.42"
+            assert str(context.render()) == "Context 6%  12.5K/200K • $0.42"
 
 
 class TestApprovalModeDisplay:
@@ -444,7 +444,7 @@ class TestTokenDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "... tokens • $0.00"
+            assert str(display.render()) == "Context ... tokens • $0.00"
 
     async def test_show_pending_tokens_before_count_keeps_zero_state(self) -> None:
         async with StatusBarApp().run_test() as pilot:
@@ -452,7 +452,7 @@ class TestTokenDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "0 tokens • $0.00"
+            assert str(display.render()) == "Context 0 tokens • $0.00"
 
     async def test_set_tokens_after_pending_restores_display(self) -> None:
         """Regression: set_tokens must refresh even when value is unchanged.
@@ -487,7 +487,7 @@ class TestTokenDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "... tokens • $0.00"
+            assert str(display.render()) == "Context ... tokens • $0.00"
 
     async def test_cost_update_while_pending_keeps_the_placeholder(self) -> None:
         """A mid-turn cost update must not resurrect the stale token count.
@@ -575,7 +575,7 @@ class TestTokenDisplay:
         async with StatusBarApp().run_test() as pilot:
             display = pilot.app.query_one("#tokens-display")
             assert display.display is True
-            assert str(display.render()) == "0 tokens • $0.00"
+            assert str(display.render()) == "Context 0 tokens • $0.00"
 
     async def test_set_tokens_then_zero_restores_zero_state(self) -> None:
         """Zeroing a positive count restores visible placeholders."""
@@ -588,7 +588,7 @@ class TestTokenDisplay:
             bar.set_tokens(0)
             await pilot.pause()
             assert display.display is True
-            assert str(display.render()) == "0 tokens • $0.00"
+            assert str(display.render()) == "Context 0 tokens • $0.00"
 
 
 class TestCostDisplay:
@@ -610,7 +610,7 @@ class TestCostDisplay:
             bar.set_cost(1.25)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "0 tokens • $1.25"
+            assert str(display.render()) == "Context 0 tokens • $1.25"
             assert display.display is True
 
     async def test_zero_cost_is_visible(self) -> None:
@@ -620,7 +620,7 @@ class TestCostDisplay:
             bar.set_cost(0.0)
             await pilot.pause()
             rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert rendered == "5K tokens • $0.00"
+            assert rendered == "Context 5K tokens • $0.00"
 
     async def test_sub_cent_cost_uses_display_floor(self) -> None:
         async with StatusBarApp().run_test() as pilot:
@@ -628,7 +628,7 @@ class TestCostDisplay:
             bar.set_cost(0.0045)
             await pilot.pause()
             assert str(pilot.app.query_one("#tokens-display").render()) == (
-                "0 tokens • <$0.01"
+                "Context 0 tokens • <$0.01"
             )
 
     async def test_approximate_token_marker_survives_cost_update(self) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -84,6 +84,7 @@ class TestApprovalModeDisplay:
             indicator = pilot.app.query_one("#auto-approve-indicator", Static)
             assert str(indicator.render()) == label
             assert indicator.has_class(mode)
+            assert indicator.styles.background.a == 1
 
 
 class TestCwdDisplay:
@@ -416,24 +417,26 @@ class TestResizePriority:
 class TestEdgeAlignment:
     """Tests that the status bar spans the full terminal width."""
 
-    async def test_model_label_is_flush_with_the_left_edge(self) -> None:
-        """The model should align with the workspace row's left edge."""
-        async with StatusBarApp().run_test(size=(80, 24)) as pilot:
-            bar = pilot.app.query_one("#status-bar", StatusBar)
-            bar.set_model(provider="fireworks", model="kimi-k3")
-            await pilot.pause()
-            model = pilot.app.query_one("#model-display", ModelLabel)
-            assert model.styles.padding.left == 0
-            assert model.content_region.x == bar.region.x
-
-    async def test_approval_text_is_flush_with_the_right_edge(self) -> None:
-        """The approval mode should occupy the session row's rightmost columns."""
+    async def test_approval_badge_is_flush_with_the_left_edge(self) -> None:
+        """The approval badge should occupy the session row's left edge."""
         async with StatusBarApp().run_test(size=(80, 24)) as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_approval_mode("auto")
             await pilot.pause()
             indicator = pilot.app.query_one("#auto-approve-indicator", Static)
-            assert indicator.content_region.right == bar.region.right
+            cwd = pilot.app.query_one("#cwd-display", Static)
+            assert indicator.region.x == bar.region.x
+            assert cwd.region.x == indicator.region.right + 1
+
+    async def test_model_label_is_flush_with_the_right_edge(self) -> None:
+        """The model should occupy the session row's rightmost columns."""
+        async with StatusBarApp().run_test(size=(80, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_model(provider="fireworks", model="kimi-k3")
+            await pilot.pause()
+            model = pilot.app.query_one("#model-display", ModelLabel)
+            assert model.styles.padding.right == 0
+            assert model.content_region.right == bar.region.right
 
 
 class TestTokenDisplay:

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -33,6 +33,28 @@ class StatusBarApp(App):
         yield StatusBar(id="status-bar")
 
 
+class TestTwoLineMetrics:
+    async def test_layout_and_metrics(self) -> None:
+        async with StatusBarApp().run_test(size=(120, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cache_tokens(12_500, 750)
+            bar.set_context_limit(200_000)
+            bar.set_tokens(12_500)
+            bar.set_cost(0.42)
+            await pilot.pause()
+
+            top = pilot.app.query_one(".status-top")
+            metrics = pilot.app.query_one(".status-metrics")
+            assert bar.size.height == 2
+            assert metrics.region.y == top.region.y + 1
+            assert str(pilot.app.query_one("#cache-display").render()) == (
+                "Cache: 12.5K read / 750 write"
+            )
+            rendered = str(pilot.app.query_one("#tokens-display").render())
+            assert "Context: 6% / 12.5K tokens" in rendered
+            assert "$0.42" in rendered
+
+
 class TestApprovalModeDisplay:
     """Tests for the three-state approval indicator."""
 
@@ -599,7 +621,7 @@ class TestCostDisplay:
             bar.set_cost(0.0)
             await pilot.pause()
             rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert rendered == "5.0K tokens"
+            assert rendered == "Context: 5.0K tokens"
             assert "$" not in rendered
 
     async def test_sub_cent_cost_uses_display_floor(self) -> None:


### PR DESCRIPTION
Depends on #5407

The status footer now shows cache reads and writes, context usage, and cumulative cost on a second row.

---

Cache metrics reuse pricing normalization and remain scoped to the active thread, including in-flight and offload usage.

Made by [Open SWE](https://openswe.vercel.app/agents/019fee35-60e2-723d-ab02-fd45c20e28ed)

## References
- Plan: https://openswe.vercel.app/agents/019fee35-60e2-723d-ab02-fd45c20e28ed/plan

## Screenshots
<img width="749" height="135" alt="Screenshot 2026-08-11 at 2 49 02 PM" src="https://github.com/user-attachments/assets/849eedc5-c260-4ca1-807f-6dc78513aaff" />

