### PR TITLE
fix(code): count distinct targets in grouped tool summaries

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -3935,6 +3935,17 @@ _TOOL_SUMMARY_TARGET_ARGS: dict[str, tuple[str, ...]] = {
     "fetch": ("url",),
 }
 
+_PATH_TARGET_CATEGORIES = frozenset({"read", "write", "edit", "delete"})
+"""Categories from `_TOOL_SUMMARY_TARGET_ARGS` whose target is a filesystem path.
+
+Only these may be compared with `normpath`. Path rules are wrong for a URL: they
+rewrite `//` after the scheme, drop a trailing slash, and resolve `..` — so
+`/a//b`, `/a/`, and `/a/../b` would each be judged the same target as a
+different URL the server can answer differently. That would undercount, which
+this code must never do. Any category added here needs a genuine path, and any
+other target is compared exactly.
+"""
+
 
 def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
     """Identify the object a call acts on, for repeat-call collapsing.
@@ -3944,11 +3955,11 @@ def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
         args: The call's parsed arguments.
 
     Returns:
-        A normalized identity for the target, or None when the category counts
-        attempts rather than objects, or the naming argument is missing or not a
-        non-empty string. None means "cannot be judged a repeat", so the call is
-        always counted — an unparsed or partially streamed argument list
-        undercounts nothing.
+        An identity for the target, or None when the category counts attempts
+        rather than objects, or the naming argument is missing or not a non-empty
+        string. None means "cannot be judged a repeat", so the call is always
+        counted — an unparsed or partially streamed argument list undercounts
+        nothing.
     """
     category = _TOOL_SUMMARY_CATEGORY.get(tool_name, tool_name)
     arg_names = _TOOL_SUMMARY_TARGET_ARGS.get(category)
@@ -3957,6 +3968,10 @@ def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
     for arg_name in arg_names:
         value = args.get(arg_name)
         if isinstance(value, str) and value:
+            if category not in _PATH_TARGET_CATEGORIES:
+                # Not a path, so compare it exactly — see the type's docstring
+                # for why path rules would undercount a URL.
+                return f"{category}:{value}"
             # Purely lexical normalization: `normpath` collapses "a//b" and
             # "./a" without touching the filesystem. A relative and an absolute
             # spelling of one path stay distinct — the TUI's cwd is not

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import json
 import logging
+import os
 import re
 import textwrap
 from dataclasses import dataclass
@@ -75,7 +76,7 @@ from deepagents_code.tui.widgets.diff import (
 from deepagents_code.unicode_security import render_with_unicode_markers
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping, Sequence
 
     from rich.console import (
         Console as RichConsole,
@@ -3915,6 +3916,84 @@ _TOOL_SUMMARY_PHRASES: dict[str, tuple[str, str, str, str]] = {
     "task": ("Running", "Ran", "agent", "agents"),
 }
 
+# category -> tool-arg names naming the thing the call acts on, in fallback
+# order. Only categories whose summary noun is a durable object belong here:
+# their counts claim "N distinct things", so repeat calls on one target must
+# collapse (see `dedupe_repeat_targets`).
+#
+# Deliberately absent: "shell", "js", "task", and "search" count attempts, not
+# objects — running one command or grepping one pattern twice is genuinely two
+# pieces of work. "web_search" phrases its own repeats ("Searched the web 2
+# times"). "ls" is excluded because a bare `ls()` means "the backend's working
+# directory", which `execute` can change mid-step, so two bare calls cannot be
+# assumed to name the same directory.
+_TOOL_SUMMARY_TARGET_ARGS: dict[str, tuple[str, ...]] = {
+    "read": ("file_path", "path"),
+    "write": ("file_path", "path"),
+    "edit": ("file_path", "path"),
+    "delete": ("file_path", "path"),
+    "fetch": ("url",),
+}
+
+
+def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
+    """Identify the object a call acts on, for repeat-call collapsing.
+
+    Args:
+        tool_name: Raw tool name for the call.
+        args: The call's parsed arguments.
+
+    Returns:
+        A normalized identity for the target, or None when the category counts
+        attempts rather than objects, or the naming argument is missing or not a
+        non-empty string. None means "cannot be judged a repeat", so the call is
+        always counted — an unparsed or partially streamed argument list
+        undercounts nothing.
+    """
+    category = _TOOL_SUMMARY_CATEGORY.get(tool_name, tool_name)
+    arg_names = _TOOL_SUMMARY_TARGET_ARGS.get(category)
+    if arg_names is None:
+        return None
+    for arg_name in arg_names:
+        value = args.get(arg_name)
+        if isinstance(value, str) and value:
+            # Purely lexical normalization: `normpath` collapses "a//b" and
+            # "./a" without touching the filesystem. A relative and an absolute
+            # spelling of one path stay distinct — the TUI's cwd is not
+            # necessarily the backend's, so resolving them here would be a
+            # guess. Missing a collapse only restores the old count.
+            return f"{category}:{os.path.normpath(value)}"
+    return None
+
+
+def dedupe_repeat_targets(calls: Sequence[tuple[str, Mapping[str, Any]]]) -> list[str]:
+    """Drop repeat calls naming a target an earlier call in `calls` already named.
+
+    The summary counts nouns ("Read 2 files"), so a file read twice must count
+    once or the line overstates how much of the tree the step touched. Applied
+    per tense bucket by the caller, so a file whose second read is still in
+    flight is still reported as being read.
+
+    Args:
+        calls: `(raw tool name, parsed args)` for each call, in call order.
+
+    Returns:
+        Raw tool names to summarize, in first-appearance order, with repeat
+        calls on an already-named target removed. Calls whose target cannot be
+        identified are always kept.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    for tool_name, args in calls:
+        target = _summary_target(tool_name, args)
+        if target is not None:
+            if target in seen:
+                continue
+            seen.add(target)
+        names.append(tool_name)
+    return names
+
+
 _DIFF_HEADER_CATEGORIES = frozenset({"write", "edit", "delete"})
 """Summary categories whose past verb heads a `DiffMessage`.
 
@@ -3952,11 +4031,10 @@ _Tense = Literal["present", "past"]
 
 
 def _summary_segment(category: str, count: int, tool_name: str, tense: _Tense) -> str:
-    """Phrase a single count segment for one category.
+    """Phrase a single count segment, e.g. "Read 2 files" / "Reading 2 files".
 
-    Most categories are phrased from `_TOOL_SUMMARY_PHRASES` as
-    "<verb> <count> <noun>", but several deviate per tense, e.g. reads render
-    as "2 file reads" in the past and "Reading 2 files" in the present.
+    The count must already have had repeat calls on one target collapsed (see
+    `dedupe_repeat_targets`); this phrasing claims N distinct nouns.
 
     Args:
         category: The summary category the tools were bucketed into.
@@ -3973,15 +4051,6 @@ def _summary_segment(category: str, count: int, tool_name: str, tense: _Tense) -
         return base if count == 1 else f"{base} {count} times"
     if category == "todos":
         return "Updating todos" if tense == "present" else "Updated todos"
-    if category == "read" and tense == "past":
-        # Reads dominate most steps, so counting operations rather than files
-        # keeps a repeatedly-read file from reading as several distinct ones.
-        # Deliberately past-only: in-flight lines keep the verb ("Reading 2
-        # files") to signal an active state. The cost is a joined line that
-        # mixes grammars ("Ran 1 shell command, 1 file read") — intended, not a
-        # bug, so don't "fix" it by deleting this branch.
-        noun = "read" if count == 1 else "reads"
-        return f"{count} file {noun}"
     phrase = _TOOL_SUMMARY_PHRASES.get(category)
     if phrase is None:
         present, past = "Running", "Ran"
@@ -3998,7 +4067,11 @@ def summarize_tool_group(tool_names: list[str], *, tense: _Tense = "past") -> st
 
     Aggregates by category in first-appearance order and lowercases the lead
     word of every segment after the first, e.g.
-    `["read_file", "read_file", "execute"]` -> "2 file reads, ran 1 shell command".
+    `["read_file", "read_file", "execute"]` -> "Read 2 files, ran 1 shell command".
+
+    Counts calls, not distinct targets: pass `tool_names` through
+    `dedupe_repeat_targets` first, or two reads of one file are summarized as
+    "Read 2 files".
 
     Args:
         tool_names: Raw tool names for the run, in call order.
@@ -4033,10 +4106,8 @@ def _join_segments(segments: list[str]) -> str:
         segments: Pre-phrased segments in display order.
 
     Returns:
-        The segments joined with ", ", e.g. `["Ran 1 shell command", "1 file read"]`
-        -> "Ran 1 shell command, 1 file read". Segments leading with a digit (the
-        file-read phrasing) are unaffected by the lowercasing, so they read
-        identically in any position.
+        The segments joined with ", ", e.g. `["Read 2 files", "Running 1 agent"]`
+        -> "Read 2 files, running 1 agent".
     """
     first, *rest = segments
     lowered = [f"{seg[0].lower()}{seg[1:]}" if seg else seg for seg in rest]
@@ -4052,6 +4123,11 @@ def summarize_live_tool_group(
     the step stays visible, and the still-running calls are phrased in the
     present tense, e.g. `["execute", "execute"]` completed plus `["task"]`
     pending -> "Ran 2 shell commands, running 1 agent".
+
+    Each list must be deduped separately by the caller (see
+    `dedupe_repeat_targets`) — never as one list, or a file whose second read is
+    still running would drop out of the present-tense half and the line would
+    stop reporting the step as reading anything.
 
     Args:
         completed_names: Raw tool names that have finished successfully, in
@@ -4093,11 +4169,11 @@ class ToolGroupSummary(Static):
     """Collapsed one-line stand-in for an assistant step's tool calls.
 
     Tools are hidden from the moment they start; this single line shows live
-    progress ("Running 1 shell command…") and flips to the settled line ("Ran 1
-    shell command", or "1 file read" for reads) once every tool finishes. While
-    the step is live, finished calls stay visible in the past tense next to the
-    ones still running in the present tense (e.g. "Ran 2 shell commands, running
-    1 agent…") so the work already done doesn't disappear. Failed, rejected,
+    progress ("Running 1 shell command…") and flips to the fully past-tense
+    line ("Ran 1 shell command") once every tool finishes. While the step is
+    live, finished calls stay visible in the past tense next to the ones still
+    running in the present tense (e.g. "Ran 2 shell commands, running 1 agent…")
+    so the work already done in the step doesn't disappear. Failed, rejected,
     and skipped tools are evicted to standalone rows (see `_evict_unfoldable`) so
     errors stay visible. Clicking the line or pressing Ctrl+O expands the
     underlying tool rows (and their diffs).
@@ -4174,10 +4250,10 @@ class ToolGroupSummary(Static):
         # every spinner tick). None means "recompute on next render".
         self._present_text: str | None = None
         self._past_text: str | None = None
-        # The (completed, pending) tool-name tuples the cached live line was
-        # built from. The line mixes finished (past tense) and running (present
-        # tense) members, so it must be rebuilt whenever a member finishes, not
-        # just when membership grows.
+        # The (completed, pending) post-dedup tool-name tuples the cached live
+        # line was built from. The line mixes finished (past tense) and running
+        # (present tense) members, so it must be rebuilt whenever a member
+        # finishes, not just when membership grows.
         self._present_key: tuple[tuple[str, ...], tuple[str, ...]] | None = None
 
     def on_mount(self) -> None:
@@ -4471,8 +4547,16 @@ class ToolGroupSummary(Static):
         if in_progress is None:
             in_progress = self._in_progress()
         if not self._finalized and in_progress:
-            pending = [tool.tool_name for tool in self._tools if tool.is_pending]
-            completed = [tool.tool_name for tool in self._tools if not tool.is_pending]
+            # Deduped per bucket, not across both: a file whose second read is
+            # still in flight must stay visible as being read.
+            pending = dedupe_repeat_targets(
+                [(t.tool_name, t.args) for t in self._tools if t.is_pending]
+            )
+            completed = dedupe_repeat_targets(
+                [(t.tool_name, t.args) for t in self._tools if not t.is_pending]
+            )
+            # Safe as a cache key even though it is post-dedup: the rendered
+            # line is a pure function of these name lists.
             key = (tuple(completed), tuple(pending))
             summary_changed = self._present_text is None or key != self._present_key
             if summary_changed:
@@ -4492,7 +4576,10 @@ class ToolGroupSummary(Static):
             )
             if self._past_text is None:
                 self._past_text = summarize_tool_group(
-                    [tool.tool_name for tool in self._tools], tense="past"
+                    dedupe_repeat_targets(
+                        [(tool.tool_name, tool.args) for tool in self._tools]
+                    ),
+                    tense="past",
                 )
             self.update(Content(f"{mark} {self._past_text}"), layout=layout)
 

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ast
 import json
 import logging
-import posixpath
+import os
 import re
 import textwrap
 from dataclasses import dataclass
@@ -4000,31 +4000,23 @@ def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
 
 
 def _normalize_path_target(value: str) -> str:
-    r"""Normalize a backend path for equality, collapsing only what is safe.
+    r"""Normalize a path using the filesystem middleware's canonical form.
 
-    Purely lexical and filesystem-free: it collapses "a//b" and "./a" so two
-    spellings of one path tally once. Deliberately conservative in three ways,
-    because a missed collapse only restores the old count while a wrong collapse
-    undercounts:
-
-    - POSIX rules always, even on a Windows client. These are the *backend's*
-      paths, and `os.path` would apply Windows rules locally, merging `a\b`
-      (a legal POSIX filename) with `a/b`.
-    - A `..` segment disables normalization entirely. Resolving it is lexical,
-      so `d/../a` would merge with `a` even when `d` is a symlink elsewhere.
-    - A relative and an absolute spelling stay distinct — the TUI's cwd is not
-      necessarily the backend's, so joining them here would be a guess.
+    This mirrors `validate_path` for paths that pass its validation: normalize
+    with the host's path rules, convert backslashes to forward slashes, and add
+    the virtual filesystem's leading slash. Rejected traversal paths remain
+    unchanged so failed calls are never folded into valid ones.
 
     Args:
         value: The raw path string as the tool was called with it.
 
     Returns:
-        The normalized path, or `value` unchanged when it contains a `..`
-        segment.
+        The normalized virtual path, or `value` for a rejected traversal path.
     """
-    if ".." in value.split("/"):
+    if ".." in value.replace("\\", "/").split("/"):
         return value
-    return posixpath.normpath(value)
+    normalized = os.path.normpath(value).replace("\\", "/")
+    return normalized if normalized.startswith("/") else f"/{normalized}"
 
 
 # category -> plural noun for the operation, used to report repeat work on one

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -3952,7 +3952,7 @@ _Tense = Literal["present", "past"]
 
 
 def _summary_segment(category: str, count: int, tool_name: str, tense: _Tense) -> str:
-    """Phrase a single count segment, e.g. "Read 2 files" / "Reading 2 files".
+    """Phrase a single count segment, e.g. "2 file reads" / "Reading 2 files".
 
     Args:
         category: The summary category the tools were bucketed into.
@@ -3969,6 +3969,9 @@ def _summary_segment(category: str, count: int, tool_name: str, tense: _Tense) -
         return base if count == 1 else f"{base} {count} times"
     if category == "todos":
         return "Updating todos" if tense == "present" else "Updated todos"
+    if category == "read" and tense == "past":
+        noun = "read" if count == 1 else "reads"
+        return f"{count} file {noun}"
     phrase = _TOOL_SUMMARY_PHRASES.get(category)
     if phrase is None:
         present, past = "Running", "Ran"
@@ -3985,7 +3988,7 @@ def summarize_tool_group(tool_names: list[str], *, tense: _Tense = "past") -> st
 
     Aggregates by category in first-appearance order and lowercases the lead
     word of every segment after the first, e.g.
-    `["read_file", "read_file", "execute"]` -> "Read 2 files, ran 1 shell command".
+    `["read_file", "read_file", "execute"]` -> "2 file reads, ran 1 shell command".
 
     Args:
         tool_names: Raw tool names for the run, in call order.
@@ -4020,8 +4023,8 @@ def _join_segments(segments: list[str]) -> str:
         segments: Pre-phrased segments in display order.
 
     Returns:
-        The segments joined with ", ", e.g. `["Ran 2 files", "Running 1 agent"]`
-        -> "Ran 2 files, running 1 agent".
+        The segments joined with ", ", e.g. `["2 file reads", "Running 1 agent"]`
+        -> "2 file reads, running 1 agent".
     """
     first, *rest = segments
     lowered = [f"{seg[0].lower()}{seg[1:]}" if seg else seg for seg in rest]

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -3903,8 +3903,6 @@ _TOOL_SUMMARY_CATEGORY: dict[str, str] = {
 
 # category -> (present verb, past verb, singular noun, plural noun).
 _TOOL_SUMMARY_PHRASES: dict[str, tuple[str, str, str, str]] = {
-    # The past verb is dead: `_summary_segment` phrases settled reads as a noun
-    # phrase, and `read` is not diff-eligible. Editing it changes no output.
     "read": ("Reading", "Read", "file", "files"),
     "write": ("Writing", "Wrote", "file", "files"),
     "edit": ("Editing", "Edited", "file", "files"),

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -3609,10 +3609,11 @@ class ToolCallMessage(Vertical):
         """This row as `(tool name, args)` for the group summary line.
 
         Unlike `args` this does not copy: the group rebuilds its cache key from
-        every member on each spinner tick, and a copy per member per tick is pure
-        waste on a path that otherwise avoids all per-tick work. Safe because the
-        `Mapping` return type is read-only and `_args` never changes after
-        construction — do not widen this to a caller that mutates.
+        every member on each spinner tick, so a copy per member per tick buys
+        nothing the caller uses. Safe because the `Mapping` return type is
+        read-only and this widget never mutates `_args` after construction — the
+        dict is the caller's, though, so do not widen this to a caller that
+        mutates.
         """
         return (self._tool_name, self._args)
 
@@ -3943,12 +3944,13 @@ _TOOL_SUMMARY_PHRASES: dict[str, tuple[str, str, str, str]] = {
 # their counts claim "N distinct things", so repeat calls on one target must
 # collapse (see `_tally_categories`).
 #
-# Deliberately absent: "shell", "js", "task", and "search" count attempts, not
-# objects — running one command or grepping one pattern twice is genuinely two
-# pieces of work. "web_search" phrases its own repeats ("Searched the web 2
-# times"). "ls" is excluded because a listing is a snapshot, not a durable
-# object: a group spans a whole step, so an intervening write can make the
-# second listing of one directory show different contents.
+# Every other category is absent on purpose. "shell", "js", "task", and "search"
+# count attempts, not objects — running one command or grepping one pattern twice
+# is genuinely two pieces of work. "web_search" phrases its own repeats
+# ("Searched the web 2 times") and "todos" carries no count at all. "ls" is
+# excluded because a listing is a snapshot, not a durable object: a group spans a
+# whole step, so an intervening write can make the second listing of one
+# directory show different contents.
 _TOOL_SUMMARY_TARGET_ARGS: dict[str, tuple[str, ...]] = {
     "read": ("file_path", "path"),
     "write": ("file_path", "path"),
@@ -3989,8 +3991,8 @@ def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
         value = args.get(arg_name)
         if isinstance(value, str) and value:
             if category not in _PATH_TARGET_CATEGORIES:
-                # Not a path, so compare it exactly — see the type's docstring
-                # for why path rules would undercount a URL.
+                # Not a path, so compare it exactly — see
+                # `_PATH_TARGET_CATEGORIES` for why path rules undercount a URL.
                 return f"{category}:{value}"
             # The category prefix is load-bearing: `_tally_categories` shares one
             # `seen` set across categories, so identities must be namespaced or
@@ -4028,8 +4030,9 @@ def _normalize_path_target(value: str) -> str:
 # genuinely be mutated twice — `delete a.py`, `write_file a.py`, `delete a.py`
 # is two real deletions. "fetch" qualifies too: a repeated fetch of one URL is a
 # deliberate re-request, not pagination, and "Fetched 1 URL" for two requests
-# reads like the second one vanished. Only "read" is absent — a repeat read is
-# usually pagination, where the count is noise, so reads collapse silently.
+# reads like the second one vanished. Of the categories that name a target, only
+# "read" is absent — a repeat read is usually pagination, where the count is
+# noise, so reads collapse silently.
 #
 # A category here has no effect unless it is also in `_TOOL_SUMMARY_TARGET_ARGS`:
 # without a target, `calls` can never exceed `targets`.
@@ -4138,9 +4141,9 @@ _Tense = Literal["present", "past"]
 def _summary_segment(tally: _CategoryTally, tense: _Tense) -> str:
     """Phrase one category's segment, e.g. "Read 2 files" / "Reading 2 files".
 
-    The lead noun counts distinct targets. When a mutating category repeated
-    work on one of them, the operation count trails in parentheses ("Edited 1
-    file (3 edits)") so neither number is lost.
+    The lead noun counts distinct targets. When a category in
+    `_REPEAT_COUNT_NOUNS` repeated work on one of them, the operation count
+    trails in parentheses ("Edited 1 file (3 edits)") so neither number is lost.
 
     Args:
         tally: The category's distinct-target and total-call counts.
@@ -4255,12 +4258,12 @@ def _summary_cache_key(
     """Build a cache key capturing everything a summary line depends on.
 
     The line is a function of each call's `(name, target)`, so the key is too.
-    A names-only key would in fact be sufficient today — membership is
-    append-only and every mutation clears the cache outright, so two successive
-    states cannot share a name list while differing in targets. Deriving the key
-    from the summarizer's real inputs instead of relying on that argument keeps
-    it correct if grouping ever changes. Over-invalidation is the only cost:
-    reordering calls within a category rebuilds identical text.
+    A names-only key would in fact be sufficient today — every membership
+    mutation, append and eviction alike, clears the cache outright, so two
+    cached states cannot share a name list while differing in targets. Deriving
+    the key from the summarizer's real inputs instead of relying on that
+    argument keeps it correct if grouping ever changes. Over-invalidation is the
+    only cost: reordering calls within a category rebuilds identical text.
 
     Args:
         calls: `(raw tool name, parsed args)` for each call, in call order.

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -3984,15 +3984,18 @@ def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
 # category -> plural noun for the operation, used to report repeat work on one
 # target alongside the target count, e.g. "Edited 1 file (3 edits)".
 #
-# Only mutations qualify. Each one is an event that changed the tree and owns a
+# Mutations qualify: each one is an event that changed the tree and owns a
 # diff, so collapsing three edits of a file to a bare "Edited 1 file" hides work
-# the reader wants. A repeat read is usually pagination, where the count is
-# noise, so reads collapse silently. "delete" is absent because a second
-# successful delete of one path cannot happen — a failed retry is evicted from
-# the group before it is summarized.
+# the reader wants. "fetch" qualifies too — a repeated fetch of one URL is a
+# deliberate re-request, not pagination, and "Fetched 1 URL" for two requests
+# reads like the second one vanished. A repeat read is usually pagination,
+# where the count is noise, so reads collapse silently. "delete" is absent
+# because a second successful delete of one path cannot happen — a failed retry
+# is evicted from the group before it is summarized.
 _REPEAT_COUNT_NOUNS: dict[str, str] = {
     "edit": "edits",
     "write": "writes",
+    "fetch": "calls",
 }
 
 

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 import json
 import logging
-import os
 import re
 import textwrap
 from dataclasses import dataclass
@@ -4004,21 +4003,25 @@ def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
 def _normalize_path_target(value: str) -> str:
     r"""Normalize a path using the filesystem middleware's canonical form.
 
-    This mirrors `validate_path` for paths that pass its validation: normalize
-    with the host's path rules, convert backslashes to forward slashes, and add
-    the virtual filesystem's leading slash. Rejected traversal paths remain
-    unchanged so failed calls are never folded into valid ones.
+    Defers to `validate_path` rather than reimplementing it, so the identity is
+    exactly the string the file tools act on and cannot drift from it. Every
+    path the middleware rejects — `..` traversal, a leading `~`, a drive prefix
+    like `C:/` — is returned verbatim: a call that could not have run has no
+    canonical form, and canonicalizing one would fold it into a valid target's
+    tally. `~` and `/~` are different reads and must count as two.
 
     Args:
         value: The raw path string as the tool was called with it.
 
     Returns:
-        The normalized virtual path, or `value` for a rejected traversal path.
+        The normalized virtual path, or `value` when the middleware rejects it.
     """
-    if ".." in value.replace("\\", "/").split("/"):
+    from deepagents.backends.utils import validate_path
+
+    try:
+        return validate_path(value)
+    except ValueError:
         return value
-    normalized = os.path.normpath(value).replace("\\", "/")
-    return normalized if normalized.startswith("/") else f"/{normalized}"
 
 
 # category -> plural noun for the operation, used to report repeat work on one

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import ast
 import json
 import logging
-import os
+import posixpath
 import re
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 from time import time
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple, TypeAlias
 
 from textual import on
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -92,6 +92,15 @@ if TYPE_CHECKING:
 
     from deepagents_code.input import MediaTracker
     from deepagents_code.theme import ThemeColors
+
+    _SummaryCall: TypeAlias = tuple[str, Mapping[str, Any]]
+    """One tool call as the summary code sees it: `(raw tool name, parsed args)`."""
+
+    _SummaryCacheKey: TypeAlias = tuple[tuple[str, str | None], ...]
+    """Opaque identity of a summary line's inputs — compare only for equality."""
+
+    _LiveSummaryKey: TypeAlias = tuple[_SummaryCacheKey, _SummaryCacheKey]
+    """The `(completed, pending)` key pair behind a cached live summary line."""
 
 logger = logging.getLogger(__name__)
 
@@ -3596,6 +3605,18 @@ class ToolCallMessage(Vertical):
         return dict(self._args)
 
     @property
+    def summary_call(self) -> _SummaryCall:
+        """This row as `(tool name, args)` for the group summary line.
+
+        Unlike `args` this does not copy: the group rebuilds its cache key from
+        every member on each spinner tick, and a copy per member per tick is pure
+        waste on a path that otherwise avoids all per-tick work. Safe because the
+        `Mapping` return type is read-only and `_args` never changes after
+        construction — do not widen this to a caller that mutates.
+        """
+        return (self._tool_name, self._args)
+
+    @property
     def is_success(self) -> bool:
         """Whether the tool completed successfully."""
         return self._status == "success"
@@ -3618,9 +3639,10 @@ class ToolCallMessage(Vertical):
         A caveat is the user's only account of a change the transcript cannot
         render, and it is carried inside this row's output. A groupable tool
         (`write_file`, `delete`) is folded at mount, and the collapsed summary
-        line is built from tool names alone — so without this the caveat is
-        folded away and destroying a 5,000-line file whose contents could not be
-        read renders as `▸ Deleted 1 file`, exactly like destroying an empty one.
+        line is built from tool names and arguments, never from tool output — so
+        without this the caveat is folded away and destroying a 5,000-line file
+        whose contents could not be read renders as `▸ Deleted 1 file`, exactly
+        like destroying an empty one.
 
         Read by the group code alongside `is_failed`: a caveated row is not a
         failure, but it has the same claim on staying on screen.
@@ -3924,9 +3946,9 @@ _TOOL_SUMMARY_PHRASES: dict[str, tuple[str, str, str, str]] = {
 # Deliberately absent: "shell", "js", "task", and "search" count attempts, not
 # objects — running one command or grepping one pattern twice is genuinely two
 # pieces of work. "web_search" phrases its own repeats ("Searched the web 2
-# times"). "ls" is excluded because a bare `ls()` means "the backend's working
-# directory", which `execute` can change mid-step, so two bare calls cannot be
-# assumed to name the same directory.
+# times"). "ls" is excluded because a listing is a snapshot, not a durable
+# object: a group spans a whole step, so an intervening write can make the
+# second listing of one directory show different contents.
 _TOOL_SUMMARY_TARGET_ARGS: dict[str, tuple[str, ...]] = {
     "read": ("file_path", "path"),
     "write": ("file_path", "path"),
@@ -3938,12 +3960,11 @@ _TOOL_SUMMARY_TARGET_ARGS: dict[str, tuple[str, ...]] = {
 _PATH_TARGET_CATEGORIES = frozenset({"read", "write", "edit", "delete"})
 """Categories from `_TOOL_SUMMARY_TARGET_ARGS` whose target is a filesystem path.
 
-Only these may be compared with `normpath`. Path rules are wrong for a URL: they
-rewrite `//` after the scheme, drop a trailing slash, and resolve `..` — so
-`/a//b`, `/a/`, and `/a/../b` would each be judged the same target as a
-different URL the server can answer differently. That would undercount, which
-this code must never do. Any category added here needs a genuine path, and any
-other target is compared exactly.
+Only these are normalized before comparison. Path rules are wrong for a URL:
+`http://x/a//b`, `http://x/a/` and `http://x/a` would each be judged the same
+target as a URL the server can answer differently. That undercounts, which this
+code must never do. Any category added here needs a genuine path, and any other
+target is compared exactly.
 """
 
 
@@ -3958,8 +3979,7 @@ def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
         An identity for the target, or None when the category counts attempts
         rather than objects, or the naming argument is missing or not a non-empty
         string. None means "cannot be judged a repeat", so the call is always
-        counted — an unparsed or partially streamed argument list undercounts
-        nothing.
+        counted — an argument list this code cannot read undercounts nothing.
     """
     category = _TOOL_SUMMARY_CATEGORY.get(tool_name, tool_name)
     arg_names = _TOOL_SUMMARY_TARGET_ARGS.get(category)
@@ -3972,29 +3992,59 @@ def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
                 # Not a path, so compare it exactly — see the type's docstring
                 # for why path rules would undercount a URL.
                 return f"{category}:{value}"
-            # Purely lexical normalization: `normpath` collapses "a//b" and
-            # "./a" without touching the filesystem. A relative and an absolute
-            # spelling of one path stay distinct — the TUI's cwd is not
-            # necessarily the backend's, so resolving them here would be a
-            # guess. Missing a collapse only restores the old count.
-            return f"{category}:{os.path.normpath(value)}"
+            # The category prefix is load-bearing: `_tally_categories` shares one
+            # `seen` set across categories, so identities must be namespaced or
+            # reading and then editing one file would read as a repeat.
+            return f"{category}:{_normalize_path_target(value)}"
     return None
+
+
+def _normalize_path_target(value: str) -> str:
+    r"""Normalize a backend path for equality, collapsing only what is safe.
+
+    Purely lexical and filesystem-free: it collapses "a//b" and "./a" so two
+    spellings of one path tally once. Deliberately conservative in three ways,
+    because a missed collapse only restores the old count while a wrong collapse
+    undercounts:
+
+    - POSIX rules always, even on a Windows client. These are the *backend's*
+      paths, and `os.path` would apply Windows rules locally, merging `a\b`
+      (a legal POSIX filename) with `a/b`.
+    - A `..` segment disables normalization entirely. Resolving it is lexical,
+      so `d/../a` would merge with `a` even when `d` is a symlink elsewhere.
+    - A relative and an absolute spelling stay distinct — the TUI's cwd is not
+      necessarily the backend's, so joining them here would be a guess.
+
+    Args:
+        value: The raw path string as the tool was called with it.
+
+    Returns:
+        The normalized path, or `value` unchanged when it contains a `..`
+        segment.
+    """
+    if ".." in value.split("/"):
+        return value
+    return posixpath.normpath(value)
 
 
 # category -> plural noun for the operation, used to report repeat work on one
 # target alongside the target count, e.g. "Edited 1 file (3 edits)".
 #
-# Mutations qualify: each one is an event that changed the tree and owns a
-# diff, so collapsing three edits of a file to a bare "Edited 1 file" hides work
-# the reader wants. "fetch" qualifies too — a repeated fetch of one URL is a
+# Every mutating category qualifies: each call is an event that changed the tree
+# and owns a diff, so collapsing three edits of one file to a bare "Edited 1
+# file" hides work the reader wants. A group spans a whole step, so one path can
+# genuinely be mutated twice — `delete a.py`, `write_file a.py`, `delete a.py`
+# is two real deletions. "fetch" qualifies too: a repeated fetch of one URL is a
 # deliberate re-request, not pagination, and "Fetched 1 URL" for two requests
-# reads like the second one vanished. A repeat read is usually pagination,
-# where the count is noise, so reads collapse silently. "delete" is absent
-# because a second successful delete of one path cannot happen — a failed retry
-# is evicted from the group before it is summarized.
+# reads like the second one vanished. Only "read" is absent — a repeat read is
+# usually pagination, where the count is noise, so reads collapse silently.
+#
+# A category here has no effect unless it is also in `_TOOL_SUMMARY_TARGET_ARGS`:
+# without a target, `calls` can never exceed `targets`.
 _REPEAT_COUNT_NOUNS: dict[str, str] = {
     "edit": "edits",
     "write": "writes",
+    "delete": "deletions",
     "fetch": "calls",
 }
 
@@ -4018,7 +4068,7 @@ class _CategoryTally(NamedTuple):
 
 
 def _tally_categories(
-    calls: Sequence[tuple[str, Mapping[str, Any]]],
+    calls: Sequence[_SummaryCall],
 ) -> list[_CategoryTally]:
     """Aggregate calls by category, counting distinct targets and total calls.
 
@@ -4033,6 +4083,10 @@ def _tally_categories(
         One tally per category, in first-appearance order.
     """
     tallies: dict[str, _CategoryTally] = {}
+    # One set across all categories is safe because `_summary_target` namespaces
+    # every identity by category. That is also why the first-call branch below
+    # may ignore `repeat`: a repeat implies an earlier call in the same category,
+    # which must already have created that category's tally.
     seen: set[str] = set()
     for tool_name, args in calls:
         category = _TOOL_SUMMARY_CATEGORY.get(tool_name, tool_name)
@@ -4042,7 +4096,9 @@ def _tally_categories(
             seen.add(target)
         current = tallies.get(category)
         if current is None:
-            tallies[category] = _CategoryTally(category, tool_name, 1, 1)
+            tallies[category] = _CategoryTally(
+                category=category, rep_name=tool_name, targets=1, calls=1
+            )
             continue
         tallies[category] = current._replace(
             targets=current.targets + (0 if repeat else 1),
@@ -4125,7 +4181,7 @@ def _summary_segment(tally: _CategoryTally, tense: _Tense) -> str:
 
 
 def summarize_tool_group(
-    calls: Sequence[tuple[str, Mapping[str, Any]]], *, tense: _Tense = "past"
+    calls: Sequence[_SummaryCall], *, tense: _Tense = "past"
 ) -> str:
     """Build a one-line summary of a run of tool calls.
 
@@ -4166,8 +4222,8 @@ def _join_segments(segments: list[str]) -> str:
 
 
 def summarize_live_tool_group(
-    completed_calls: Sequence[tuple[str, Mapping[str, Any]]],
-    pending_calls: Sequence[tuple[str, Mapping[str, Any]]],
+    completed_calls: Sequence[_SummaryCall],
+    pending_calls: Sequence[_SummaryCall],
 ) -> str:
     """Summarize an in-flight run, mixing past and present tense.
 
@@ -4202,15 +4258,17 @@ def summarize_live_tool_group(
 
 
 def _summary_cache_key(
-    calls: Sequence[tuple[str, Mapping[str, Any]]],
-) -> tuple[tuple[str, str | None], ...]:
+    calls: Sequence[_SummaryCall],
+) -> _SummaryCacheKey:
     """Build a cache key capturing everything a summary line depends on.
 
-    Names alone are not enough: the line reports distinct targets, so a second
-    read of a *new* file changes the text while leaving the name list looking
-    identical in shape. Pairing each name with its target keeps repeats and
-    fresh targets distinguishable, and unidentifiable targets stay distinct by
-    position.
+    The line is a function of each call's `(name, target)`, so the key is too.
+    A names-only key would in fact be sufficient today — membership is
+    append-only and every mutation clears the cache outright, so two successive
+    states cannot share a name list while differing in targets. Deriving the key
+    from the summarizer's real inputs instead of relying on that argument keeps
+    it correct if grouping ever changes. Over-invalidation is the only cost:
+    reordering calls within a category rebuilds identical text.
 
     Args:
         calls: `(raw tool name, parsed args)` for each call, in call order.
@@ -4328,12 +4386,7 @@ class ToolGroupSummary(Static):
         # was built from. The line mixes finished (past tense) and running
         # (present tense) members, so it must be rebuilt whenever a member
         # finishes, not just when membership grows.
-        self._present_key: (
-            tuple[
-                tuple[tuple[str, str | None], ...], tuple[tuple[str, str | None], ...]
-            ]
-            | None
-        ) = None
+        self._present_key: _LiveSummaryKey | None = None
 
     def on_mount(self) -> None:
         """Apply initial visibility, render, and arm the spinner if live."""
@@ -4516,8 +4569,9 @@ class ToolGroupSummary(Static):
         Two reasons qualify. A non-success (errored, rejected, skipped) must stay
         visible so a failure is not summarized away. So must a success whose
         output opens with a display caveat: the summary is built from tool names
-        alone, so folding one hides the only statement that the change could not
-        be shown — see `ToolCallMessage.has_display_caveat`.
+        and arguments, never from tool output, so folding one hides the only
+        statement that the change could not be shown — see
+        `ToolCallMessage.has_display_caveat`.
         """
         failed = [t for t in self._tools if t.is_failed or t.has_display_caveat]
         if not failed:
@@ -4628,8 +4682,8 @@ class ToolGroupSummary(Static):
         if not self._finalized and in_progress:
             # Tallied per bucket, not across both: a file whose second read is
             # still in flight must stay visible as being read.
-            pending = [(t.tool_name, t.args) for t in self._tools if t.is_pending]
-            completed = [(t.tool_name, t.args) for t in self._tools if not t.is_pending]
+            pending = [t.summary_call for t in self._tools if t.is_pending]
+            completed = [t.summary_call for t in self._tools if not t.is_pending]
             key = (_summary_cache_key(completed), _summary_cache_key(pending))
             summary_changed = self._present_text is None or key != self._present_key
             if summary_changed:
@@ -4649,8 +4703,7 @@ class ToolGroupSummary(Static):
             )
             if self._past_text is None:
                 self._past_text = summarize_tool_group(
-                    [(tool.tool_name, tool.args) for tool in self._tools],
-                    tense="past",
+                    [tool.summary_call for tool in self._tools], tense="past"
                 )
             self.update(Content(f"{mark} {self._past_text}"), layout=layout)
 

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -3903,6 +3903,8 @@ _TOOL_SUMMARY_CATEGORY: dict[str, str] = {
 
 # category -> (present verb, past verb, singular noun, plural noun).
 _TOOL_SUMMARY_PHRASES: dict[str, tuple[str, str, str, str]] = {
+    # The past verb is dead: `_summary_segment` phrases settled reads as a noun
+    # phrase, and `read` is not diff-eligible. Editing it changes no output.
     "read": ("Reading", "Read", "file", "files"),
     "write": ("Writing", "Wrote", "file", "files"),
     "edit": ("Editing", "Edited", "file", "files"),
@@ -3952,7 +3954,11 @@ _Tense = Literal["present", "past"]
 
 
 def _summary_segment(category: str, count: int, tool_name: str, tense: _Tense) -> str:
-    """Phrase a single count segment, e.g. "2 file reads" / "Reading 2 files".
+    """Phrase a single count segment for one category.
+
+    Most categories are phrased from `_TOOL_SUMMARY_PHRASES` as
+    "<verb> <count> <noun>", but several deviate per tense, e.g. reads render
+    as "2 file reads" in the past and "Reading 2 files" in the present.
 
     Args:
         category: The summary category the tools were bucketed into.
@@ -3970,6 +3976,12 @@ def _summary_segment(category: str, count: int, tool_name: str, tense: _Tense) -
     if category == "todos":
         return "Updating todos" if tense == "present" else "Updated todos"
     if category == "read" and tense == "past":
+        # Reads dominate most steps, so counting operations rather than files
+        # keeps a repeatedly-read file from reading as several distinct ones.
+        # Deliberately past-only: in-flight lines keep the verb ("Reading 2
+        # files") to signal an active state. The cost is a joined line that
+        # mixes grammars ("Ran 1 shell command, 1 file read") — intended, not a
+        # bug, so don't "fix" it by deleting this branch.
         noun = "read" if count == 1 else "reads"
         return f"{count} file {noun}"
     phrase = _TOOL_SUMMARY_PHRASES.get(category)
@@ -4023,8 +4035,10 @@ def _join_segments(segments: list[str]) -> str:
         segments: Pre-phrased segments in display order.
 
     Returns:
-        The segments joined with ", ", e.g. `["2 file reads", "Running 1 agent"]`
-        -> "2 file reads, running 1 agent".
+        The segments joined with ", ", e.g. `["Ran 1 shell command", "1 file read"]`
+        -> "Ran 1 shell command, 1 file read". Segments leading with a digit (the
+        file-read phrasing) are unaffected by the lowercasing, so they read
+        identically in any position.
     """
     first, *rest = segments
     lowered = [f"{seg[0].lower()}{seg[1:]}" if seg else seg for seg in rest]
@@ -4081,11 +4095,11 @@ class ToolGroupSummary(Static):
     """Collapsed one-line stand-in for an assistant step's tool calls.
 
     Tools are hidden from the moment they start; this single line shows live
-    progress ("Running 1 shell command…") and flips to the fully past-tense
-    line ("Ran 1 shell command") once every tool finishes. While the step is
-    live, finished calls stay visible in the past tense next to the ones still
-    running in the present tense (e.g. "Ran 2 shell commands, running 1 agent…")
-    so the work already done in the step doesn't disappear. Failed, rejected,
+    progress ("Running 1 shell command…") and flips to the settled line ("Ran 1
+    shell command", or "1 file read" for reads) once every tool finishes. While
+    the step is live, finished calls stay visible in the past tense next to the
+    ones still running in the present tense (e.g. "Ran 2 shell commands, running
+    1 agent…") so the work already done doesn't disappear. Failed, rejected,
     and skipped tools are evicted to standalone rows (see `_evict_unfoldable`) so
     errors stay visible. Clicking the line or pressing Ctrl+O expands the
     underlying tool rows (and their diffs).

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -11,7 +11,7 @@ import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 from time import time
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple
 
 from textual import on
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -3919,7 +3919,7 @@ _TOOL_SUMMARY_PHRASES: dict[str, tuple[str, str, str, str]] = {
 # category -> tool-arg names naming the thing the call acts on, in fallback
 # order. Only categories whose summary noun is a durable object belong here:
 # their counts claim "N distinct things", so repeat calls on one target must
-# collapse (see `dedupe_repeat_targets`).
+# collapse (see `_tally_categories`).
 #
 # Deliberately absent: "shell", "js", "task", and "search" count attempts, not
 # objects — running one command or grepping one pattern twice is genuinely two
@@ -3966,32 +3966,71 @@ def _summary_target(tool_name: str, args: Mapping[str, Any]) -> str | None:
     return None
 
 
-def dedupe_repeat_targets(calls: Sequence[tuple[str, Mapping[str, Any]]]) -> list[str]:
-    """Drop repeat calls naming a target an earlier call in `calls` already named.
+# category -> plural noun for the operation, used to report repeat work on one
+# target alongside the target count, e.g. "Edited 1 file (3 edits)".
+#
+# Only mutations qualify. Each one is an event that changed the tree and owns a
+# diff, so collapsing three edits of a file to a bare "Edited 1 file" hides work
+# the reader wants. A repeat read is usually pagination, where the count is
+# noise, so reads collapse silently. "delete" is absent because a second
+# successful delete of one path cannot happen — a failed retry is evicted from
+# the group before it is summarized.
+_REPEAT_COUNT_NOUNS: dict[str, str] = {
+    "edit": "edits",
+    "write": "writes",
+}
 
-    The summary counts nouns ("Read 2 files"), so a file read twice must count
-    once or the line overstates how much of the tree the step touched. Applied
-    per tense bucket by the caller, so a file whose second read is still in
-    flight is still reported as being read.
+
+class _CategoryTally(NamedTuple):
+    """One category's contribution to a summary line."""
+
+    category: str
+    """The summary category being counted."""
+
+    rep_name: str
+    """First raw tool name seen for the category, for fallback phrasing."""
+
+    targets: int
+    """Distinct targets touched. Calls with no identifiable target each count
+    for themselves, so this never drops below the honest minimum."""
+
+    calls: int
+    """Total calls, including repeats on one target. Equals `targets` unless
+    something was touched more than once."""
+
+
+def _tally_categories(
+    calls: Sequence[tuple[str, Mapping[str, Any]]],
+) -> list[_CategoryTally]:
+    """Aggregate calls by category, counting distinct targets and total calls.
+
+    Both numbers are needed because the phrasing claims nouns ("Read 2 files")
+    while the work is calls: a file read twice is one file, and an edit made
+    twice is one file but two edits.
 
     Args:
         calls: `(raw tool name, parsed args)` for each call, in call order.
 
     Returns:
-        Raw tool names to summarize, in first-appearance order, with repeat
-        calls on an already-named target removed. Calls whose target cannot be
-        identified are always kept.
+        One tally per category, in first-appearance order.
     """
-    names: list[str] = []
+    tallies: dict[str, _CategoryTally] = {}
     seen: set[str] = set()
     for tool_name, args in calls:
+        category = _TOOL_SUMMARY_CATEGORY.get(tool_name, tool_name)
         target = _summary_target(tool_name, args)
+        repeat = target is not None and target in seen
         if target is not None:
-            if target in seen:
-                continue
             seen.add(target)
-        names.append(tool_name)
-    return names
+        current = tallies.get(category)
+        if current is None:
+            tallies[category] = _CategoryTally(category, tool_name, 1, 1)
+            continue
+        tallies[category] = current._replace(
+            targets=current.targets + (0 if repeat else 1),
+            calls=current.calls + 1,
+        )
+    return list(tallies.values())
 
 
 _DIFF_HEADER_CATEGORIES = frozenset({"write", "edit", "delete"})
@@ -4030,22 +4069,21 @@ def _diff_header_verb(tool_name: str | None) -> str:
 _Tense = Literal["present", "past"]
 
 
-def _summary_segment(category: str, count: int, tool_name: str, tense: _Tense) -> str:
-    """Phrase a single count segment, e.g. "Read 2 files" / "Reading 2 files".
+def _summary_segment(tally: _CategoryTally, tense: _Tense) -> str:
+    """Phrase one category's segment, e.g. "Read 2 files" / "Reading 2 files".
 
-    The count must already have had repeat calls on one target collapsed (see
-    `dedupe_repeat_targets`); this phrasing claims N distinct nouns.
+    The lead noun counts distinct targets. When a mutating category repeated
+    work on one of them, the operation count trails in parentheses ("Edited 1
+    file (3 edits)") so neither number is lost.
 
     Args:
-        category: The summary category the tools were bucketed into.
-        count: How many tools fell into this category.
-        tool_name: A representative raw tool name, used to phrase categories
-            that have no dedicated entry in `_TOOL_SUMMARY_PHRASES`.
+        tally: The category's distinct-target and total-call counts.
         tense: Whether to phrase the segment in the present or past tense.
 
     Returns:
-        The phrased segment for this category, count, and tense.
+        The phrased segment for this category and tense.
     """
+    category, tool_name, count = tally.category, tally.rep_name, tally.targets
     if category == "web_search":
         base = "Searching the web" if tense == "present" else "Searched the web"
         return base if count == 1 else f"{base} {count} times"
@@ -4059,44 +4097,39 @@ def _summary_segment(category: str, count: int, tool_name: str, tense: _Tense) -
         present, past, singular, plural = phrase
     verb = present if tense == "present" else past
     noun = singular if count == 1 else plural
-    return f"{verb} {count} {noun}"
+    segment = f"{verb} {count} {noun}"
+    repeat_noun = _REPEAT_COUNT_NOUNS.get(category)
+    if repeat_noun is not None and tally.calls > count:
+        # `calls > count` implies at least two calls, so the noun is always
+        # plural.
+        segment += f" ({tally.calls} {repeat_noun})"
+    return segment
 
 
-def summarize_tool_group(tool_names: list[str], *, tense: _Tense = "past") -> str:
+def summarize_tool_group(
+    calls: Sequence[tuple[str, Mapping[str, Any]]], *, tense: _Tense = "past"
+) -> str:
     """Build a one-line summary of a run of tool calls.
 
     Aggregates by category in first-appearance order and lowercases the lead
-    word of every segment after the first, e.g.
-    `["read_file", "read_file", "execute"]` -> "Read 2 files, ran 1 shell command".
+    word of every segment after the first, e.g. two `read_file` calls on
+    different paths plus an `execute` -> "Read 2 files, ran 1 shell command".
 
-    Counts calls, not distinct targets: pass `tool_names` through
-    `dedupe_repeat_targets` first, or two reads of one file are summarized as
-    "Read 2 files".
+    Takes args, not just names, because the counts claim distinct nouns: without
+    the argument naming each call's target, one file read twice is
+    indistinguishable from two files read once.
 
     Args:
-        tool_names: Raw tool names for the run, in call order.
+        calls: `(raw tool name, parsed args)` for each call, in call order.
         tense: Whether to phrase the summary in the present or past tense.
 
     Returns:
         The aggregated one-line summary string in the requested tense.
     """
-    counts: dict[str, int] = {}
-    order: list[str] = []
-    rep_name: dict[str, str] = {}
-    for name in tool_names:
-        category = _TOOL_SUMMARY_CATEGORY.get(name, name)
-        if category not in counts:
-            counts[category] = 0
-            order.append(category)
-            rep_name[category] = name
-        counts[category] += 1
-
-    segments = [
-        _summary_segment(cat, counts[cat], rep_name[cat], tense) for cat in order
-    ]
-    if not segments:
+    tallies = _tally_categories(calls)
+    if not tallies:
         return "Running tools" if tense == "present" else "Ran tools"
-    return _join_segments(segments)
+    return _join_segments([_summary_segment(tally, tense) for tally in tallies])
 
 
 def _join_segments(segments: list[str]) -> str:
@@ -4115,36 +4148,59 @@ def _join_segments(segments: list[str]) -> str:
 
 
 def summarize_live_tool_group(
-    completed_names: list[str], pending_names: list[str]
+    completed_calls: Sequence[tuple[str, Mapping[str, Any]]],
+    pending_calls: Sequence[tuple[str, Mapping[str, Any]]],
 ) -> str:
     """Summarize an in-flight run, mixing past and present tense.
 
     Completed calls are phrased in the past tense so the work already done in
     the step stays visible, and the still-running calls are phrased in the
-    present tense, e.g. `["execute", "execute"]` completed plus `["task"]`
-    pending -> "Ran 2 shell commands, running 1 agent".
+    present tense, e.g. two completed `execute` calls plus a pending `task` ->
+    "Ran 2 shell commands, running 1 agent".
 
-    Each list must be deduped separately by the caller (see
-    `dedupe_repeat_targets`) — never as one list, or a file whose second read is
-    still running would drop out of the present-tense half and the line would
-    stop reporting the step as reading anything.
+    Each half is tallied independently, so a file whose second read is still
+    running is counted in both — collapsing across the split would drop it from
+    the present-tense half and the line would stop reporting the step as
+    reading.
 
     Args:
-        completed_names: Raw tool names that have finished successfully, in
-            call order. Failed/rejected calls are evicted before this runs.
-        pending_names: Raw tool names still pending or running, in call order.
+        completed_calls: `(raw tool name, parsed args)` for calls that finished
+            successfully, in call order. Failed/rejected calls are evicted
+            before this runs.
+        pending_calls: `(raw tool name, parsed args)` for calls still pending or
+            running, in call order.
 
     Returns:
-        The combined one-line summary. Empty when neither list has members.
+        The combined one-line summary. Empty when neither half has members.
     """
     segments: list[str] = []
-    if completed_names:
-        segments.append(summarize_tool_group(completed_names, tense="past"))
-    if pending_names:
-        segments.append(summarize_tool_group(pending_names, tense="present"))
+    if completed_calls:
+        segments.append(summarize_tool_group(completed_calls, tense="past"))
+    if pending_calls:
+        segments.append(summarize_tool_group(pending_calls, tense="present"))
     if not segments:
         return ""
     return _join_segments(segments)
+
+
+def _summary_cache_key(
+    calls: Sequence[tuple[str, Mapping[str, Any]]],
+) -> tuple[tuple[str, str | None], ...]:
+    """Build a cache key capturing everything a summary line depends on.
+
+    Names alone are not enough: the line reports distinct targets, so a second
+    read of a *new* file changes the text while leaving the name list looking
+    identical in shape. Pairing each name with its target keeps repeats and
+    fresh targets distinguishable, and unidentifiable targets stay distinct by
+    position.
+
+    Args:
+        calls: `(raw tool name, parsed args)` for each call, in call order.
+
+    Returns:
+        A hashable key, order-sensitive to match segment ordering.
+    """
+    return tuple((name, _summary_target(name, args)) for name, args in calls)
 
 
 _TOOL_GROUP_COLLAPSED_ACCESSORY_CLASS = "-tool-group-collapsed-accessory"
@@ -4250,11 +4306,16 @@ class ToolGroupSummary(Static):
         # every spinner tick). None means "recompute on next render".
         self._present_text: str | None = None
         self._past_text: str | None = None
-        # The (completed, pending) post-dedup tool-name tuples the cached live
-        # line was built from. The line mixes finished (past tense) and running
+        # The (completed, pending) `_summary_cache_key` pair the cached live line
+        # was built from. The line mixes finished (past tense) and running
         # (present tense) members, so it must be rebuilt whenever a member
         # finishes, not just when membership grows.
-        self._present_key: tuple[tuple[str, ...], tuple[str, ...]] | None = None
+        self._present_key: (
+            tuple[
+                tuple[tuple[str, str | None], ...], tuple[tuple[str, str | None], ...]
+            ]
+            | None
+        ) = None
 
     def on_mount(self) -> None:
         """Apply initial visibility, render, and arm the spinner if live."""
@@ -4547,17 +4608,11 @@ class ToolGroupSummary(Static):
         if in_progress is None:
             in_progress = self._in_progress()
         if not self._finalized and in_progress:
-            # Deduped per bucket, not across both: a file whose second read is
+            # Tallied per bucket, not across both: a file whose second read is
             # still in flight must stay visible as being read.
-            pending = dedupe_repeat_targets(
-                [(t.tool_name, t.args) for t in self._tools if t.is_pending]
-            )
-            completed = dedupe_repeat_targets(
-                [(t.tool_name, t.args) for t in self._tools if not t.is_pending]
-            )
-            # Safe as a cache key even though it is post-dedup: the rendered
-            # line is a pure function of these name lists.
-            key = (tuple(completed), tuple(pending))
+            pending = [(t.tool_name, t.args) for t in self._tools if t.is_pending]
+            completed = [(t.tool_name, t.args) for t in self._tools if not t.is_pending]
+            key = (_summary_cache_key(completed), _summary_cache_key(pending))
             summary_changed = self._present_text is None or key != self._present_key
             if summary_changed:
                 self._present_text = summarize_live_tool_group(completed, pending)
@@ -4576,9 +4631,7 @@ class ToolGroupSummary(Static):
             )
             if self._past_text is None:
                 self._past_text = summarize_tool_group(
-                    dedupe_repeat_targets(
-                        [(tool.tool_name, tool.args) for tool in self._tools]
-                    ),
+                    [(tool.tool_name, tool.args) for tool in self._tools],
                     tense="past",
                 )
             self.update(Content(f"{mark} {self._past_text}"), layout=layout)

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -35825,7 +35825,7 @@ class TestToolGroupCollapse:
             assert all(tool.display is False for tool in tools)
             rendered = summaries[0].render()
             assert isinstance(rendered, Content)
-            assert "1 file read, ran 1 shell command" in rendered.plain
+            assert "Read 1 file, ran 1 shell command" in rendered.plain
 
     @pytest.mark.parametrize("tool_name", ["ask_user", "edit_file", "write_todos"])
     async def test_regroup_leaves_excluded_tools_expanded(self, tool_name: str) -> None:
@@ -36024,7 +36024,7 @@ class TestToolGroupCollapse:
             assert t2.display is False
             rendered = summaries[0].render()
             assert isinstance(rendered, Content)
-            assert "2 file reads" in rendered.plain
+            assert "Read 2 files" in rendered.plain
 
             summaries[0].toggle()
             await pilot.pause()
@@ -36165,7 +36165,7 @@ class TestToolGroupCollapse:
             assert app._active_tool_group is None
             rendered = summaries[0].render()
             assert isinstance(rendered, Content)
-            assert "1 file read" in rendered.plain
+            assert "Read 1 file" in rendered.plain
             assert tool.display is False
             assert footer.display is False
 
@@ -36285,7 +36285,7 @@ class TestToolGroupCollapse:
             assert summaries[0].is_attached
             rendered = summaries[0].render()
             assert isinstance(rendered, Content)
-            assert "Ran 1 shell command, 1 file read" in rendered.plain
+            assert "Ran 1 shell command, read 1 file" in rendered.plain
 
 
 class TestForcedGoalCriteriaSync:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -35825,7 +35825,7 @@ class TestToolGroupCollapse:
             assert all(tool.display is False for tool in tools)
             rendered = summaries[0].render()
             assert isinstance(rendered, Content)
-            assert "Read 1 file, ran 1 shell command" in rendered.plain
+            assert "1 file read, ran 1 shell command" in rendered.plain
 
     @pytest.mark.parametrize("tool_name", ["ask_user", "edit_file", "write_todos"])
     async def test_regroup_leaves_excluded_tools_expanded(self, tool_name: str) -> None:
@@ -36024,7 +36024,7 @@ class TestToolGroupCollapse:
             assert t2.display is False
             rendered = summaries[0].render()
             assert isinstance(rendered, Content)
-            assert "Read 2 files" in rendered.plain
+            assert "2 file reads" in rendered.plain
 
             summaries[0].toggle()
             await pilot.pause()
@@ -36165,7 +36165,7 @@ class TestToolGroupCollapse:
             assert app._active_tool_group is None
             rendered = summaries[0].render()
             assert isinstance(rendered, Content)
-            assert "Read 1 file" in rendered.plain
+            assert "1 file read" in rendered.plain
             assert tool.display is False
             assert footer.display is False
 
@@ -36285,7 +36285,7 @@ class TestToolGroupCollapse:
             assert summaries[0].is_attached
             rendered = summaries[0].render()
             assert isinstance(rendered, Content)
-            assert "Ran 1 shell command, read 1 file" in rendered.plain
+            assert "Ran 1 shell command, 1 file read" in rendered.plain
 
 
 class TestForcedGoalCriteriaSync:

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5178,18 +5178,18 @@ class TestSummarizeToolGroup:
             (["execute"], "Ran 1 shell command"),
             (
                 ["read_file", "read_file", "execute", "execute", "execute"],
-                "Read 2 files, ran 3 shell commands",
+                "2 file reads, ran 3 shell commands",
             ),
             (["grep"], "Searched for 1 pattern"),
             (["grep", "glob", "glob"], "Searched for 3 patterns"),
-            (["read_file"], "Read 1 file"),
+            (["read_file"], "1 file read"),
             (["web_search", "web_search"], "Searched the web 2 times"),
             (["web_search"], "Searched the web"),
             (["write_todos"], "Updated todos"),
             (["task", "task"], "Ran 2 agents"),
             (
                 ["edit_file", "write_file", "read_file"],
-                "Edited 1 file, wrote 1 file, read 1 file",
+                "Edited 1 file, wrote 1 file, 1 file read",
             ),
             (["mystery", "mystery"], "Ran 2 mystery calls"),
         ],
@@ -5241,7 +5241,7 @@ class TestToolGroupSummary:
             assert t2.display is False
             rendered = summary.render()
             assert isinstance(rendered, Content)
-            assert "Read 1 file, ran 1 shell command" in rendered.plain
+            assert "1 file read, ran 1 shell command" in rendered.plain
 
     async def test_toggle_expands_and_recollapses_members(self) -> None:
         """Toggling flips member visibility and the disclosure glyph."""
@@ -5531,7 +5531,7 @@ class TestLiveToolGroupSummary:
             assert t2.display is False
             rendered = summary.render()
             assert isinstance(rendered, Content)
-            assert "Read 1 file" in rendered.plain
+            assert "1 file read" in rendered.plain
 
     async def test_close_waits_for_pending_member_terminal_status(self) -> None:
         """A stream boundary must not report a still-pending tool as having run."""
@@ -5562,7 +5562,7 @@ class TestLiveToolGroupSummary:
             assert read.display is False
             rendered = summary.render()
             assert isinstance(rendered, Content)
-            assert "Read 1 file" in rendered.plain
+            assert "1 file read" in rendered.plain
             assert "shell command" not in rendered.plain
 
     async def test_open_group_accepts_member_after_current_members_settle(self) -> None:
@@ -5654,7 +5654,7 @@ class TestLiveToolGroupSummary:
             assert t2.display is False
             rendered = summary.render()
             assert isinstance(rendered, Content)
-            assert "Read 1 file" in rendered.plain
+            assert "1 file read" in rendered.plain
 
     async def test_skipped_member_is_evicted_and_uncounted_on_close(self) -> None:
         """A skipped tool stays visible and is left out of the summary count.
@@ -5683,7 +5683,7 @@ class TestLiveToolGroupSummary:
             assert t2.display is False
             rendered = summary.render()
             assert isinstance(rendered, Content)
-            assert "Read 1 file" in rendered.plain
+            assert "1 file read" in rendered.plain
             # The skipped execute must not be summarized as if it had run.
             assert "shell command" not in rendered.plain
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5178,18 +5178,18 @@ class TestSummarizeToolGroup:
             (["execute"], "Ran 1 shell command"),
             (
                 ["read_file", "read_file", "execute", "execute", "execute"],
-                "2 file reads, ran 3 shell commands",
+                "Read 2 files, ran 3 shell commands",
             ),
             (["grep"], "Searched for 1 pattern"),
             (["grep", "glob", "glob"], "Searched for 3 patterns"),
-            (["read_file"], "1 file read"),
+            (["read_file"], "Read 1 file"),
             (["web_search", "web_search"], "Searched the web 2 times"),
             (["web_search"], "Searched the web"),
             (["write_todos"], "Updated todos"),
             (["task", "task"], "Ran 2 agents"),
             (
                 ["edit_file", "write_file", "read_file"],
-                "Edited 1 file, wrote 1 file, 1 file read",
+                "Edited 1 file, wrote 1 file, read 1 file",
             ),
             (["mystery", "mystery"], "Ran 2 mystery calls"),
         ],
@@ -5205,6 +5205,134 @@ class TestSummarizeToolGroup:
         from deepagents_code.tui.widgets.messages import summarize_tool_group
 
         assert summarize_tool_group([]) == "Ran tools"
+
+
+class TestDedupeRepeatTargets:
+    """Repeat calls on one target collapse before the summary counts nouns."""
+
+    @pytest.mark.parametrize(
+        ("calls", "expected"),
+        [
+            # The bug this guards: one file read twice is one file.
+            (
+                [
+                    ("read_file", {"file_path": "a.py"}),
+                    ("read_file", {"file_path": "a.py"}),
+                ],
+                ["read_file"],
+            ),
+            # Distinct paths are distinct work.
+            (
+                [
+                    ("read_file", {"file_path": "a.py"}),
+                    ("read_file", {"file_path": "b.py"}),
+                ],
+                ["read_file", "read_file"],
+            ),
+            # Lexically equal paths collapse; `normpath` needs no filesystem.
+            (
+                [
+                    ("read_file", {"file_path": "./a.py"}),
+                    ("read_file", {"file_path": "a.py"}),
+                ],
+                ["read_file"],
+            ),
+            (
+                [
+                    ("read_file", {"file_path": "d//a.py"}),
+                    ("read_file", {"file_path": "d/a.py"}),
+                ],
+                ["read_file"],
+            ),
+            # Same path, different category: reading then editing is two acts.
+            (
+                [
+                    ("read_file", {"file_path": "a.py"}),
+                    ("edit_file", {"file_path": "a.py"}),
+                ],
+                ["read_file", "edit_file"],
+            ),
+            # The `path` fallback is honored for tools that use it.
+            (
+                [("read_file", {"path": "a.py"}), ("read_file", {"file_path": "a.py"})],
+                ["read_file"],
+            ),
+            # URLs collapse on exact match.
+            (
+                [
+                    ("fetch_url", {"url": "http://x/y"}),
+                    ("fetch_url", {"url": "http://x/y"}),
+                ],
+                ["fetch_url"],
+            ),
+            # Attempt-counting categories never collapse: two runs of one
+            # command are genuinely two runs.
+            (
+                [("execute", {"command": "ls"}), ("execute", {"command": "ls"})],
+                ["execute", "execute"],
+            ),
+            (
+                [("grep", {"pattern": "x"}), ("grep", {"pattern": "x"})],
+                ["grep", "grep"],
+            ),
+            # A bare `ls()` means "the working directory", which `execute` can
+            # change mid-step, so identical calls are not assumed identical.
+            ([("ls", {}), ("ls", {})], ["ls", "ls"]),
+            # Unidentifiable targets fail open — counting twice merely restores
+            # the pre-dedup count, while collapsing would invent a repeat.
+            (
+                [("read_file", {}), ("read_file", {})],
+                ["read_file", "read_file"],
+            ),
+            (
+                [("read_file", {"file_path": ""}), ("read_file", {"file_path": None})],
+                ["read_file", "read_file"],
+            ),
+            (
+                [("read_file", {"file_path": 42}), ("read_file", {"file_path": 42})],
+                ["read_file", "read_file"],
+            ),
+            ([], []),
+        ],
+    )
+    def test_dedupe(self, calls: list[tuple[str, dict]], expected: list[str]) -> None:
+        """Repeat targets collapse; distinct and unidentifiable ones do not."""
+        from deepagents_code.tui.widgets.messages import dedupe_repeat_targets
+
+        assert dedupe_repeat_targets(calls) == expected
+
+    def test_first_appearance_order_is_preserved(self) -> None:
+        """The kept call is the first one, so category ordering is unchanged."""
+        from deepagents_code.tui.widgets.messages import (
+            dedupe_repeat_targets,
+            summarize_tool_group,
+        )
+
+        calls = [
+            ("execute", {"command": "ls"}),
+            ("read_file", {"file_path": "a.py"}),
+            ("read_file", {"file_path": "a.py"}),
+        ]
+        assert dedupe_repeat_targets(calls) == ["execute", "read_file"]
+        assert (
+            summarize_tool_group(dedupe_repeat_targets(calls))
+            == "Ran 1 shell command, read 1 file"
+        )
+
+    def test_repeated_read_reports_one_file_in_both_tenses(self) -> None:
+        """The user-visible payoff: neither tense claims two files."""
+        from deepagents_code.tui.widgets.messages import (
+            dedupe_repeat_targets,
+            summarize_tool_group,
+        )
+
+        calls = [
+            ("read_file", {"file_path": "a.py"}),
+            ("read_file", {"file_path": "a.py"}),
+        ]
+        names = dedupe_repeat_targets(calls)
+        assert summarize_tool_group(names, tense="past") == "Read 1 file"
+        assert summarize_tool_group(names, tense="present") == "Reading 1 file"
 
 
 class _ToolGroupApp(App[None]):
@@ -5241,7 +5369,7 @@ class TestToolGroupSummary:
             assert t2.display is False
             rendered = summary.render()
             assert isinstance(rendered, Content)
-            assert "1 file read, ran 1 shell command" in rendered.plain
+            assert "Read 1 file, ran 1 shell command" in rendered.plain
 
     async def test_toggle_expands_and_recollapses_members(self) -> None:
         """Toggling flips member visibility and the disclosure glyph."""
@@ -5263,6 +5391,29 @@ class TestToolGroupSummary:
             assert summary._collapsed is True
             assert t1.display is False
             assert t2.display is False
+
+    async def test_repeated_read_of_one_file_counts_once(self) -> None:
+        """A file read twice renders as one file, not two."""
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        class _RepeatReadApp(App[None]):
+            def compose(self) -> ComposeResult:
+                t1 = ToolCallMessage("read_file", {"file_path": "a.py"})
+                t1.id = "t1"
+                t2 = ToolCallMessage("read_file", {"file_path": "a.py"})
+                t2.id = "t2"
+                summary = ToolGroupSummary(tools=[t1, t2], collapsible=[t1, t2])
+                summary.id = "summary"
+                yield summary
+                yield t1
+                yield t2
+
+        async with _RepeatReadApp().run_test() as pilot:
+            summary = pilot.app.query_one("#summary", ToolGroupSummary)
+            rendered = summary.render()
+            assert isinstance(rendered, Content)
+            assert "Read 1 file" in rendered.plain
+            assert "2 files" not in rendered.plain
 
     async def test_has_attached_members_tracks_removal(self) -> None:
         """`has_attached_members` flips to False once members are removed."""
@@ -5531,7 +5682,7 @@ class TestLiveToolGroupSummary:
             assert t2.display is False
             rendered = summary.render()
             assert isinstance(rendered, Content)
-            assert "1 file read" in rendered.plain
+            assert "Read 1 file" in rendered.plain
 
     async def test_close_waits_for_pending_member_terminal_status(self) -> None:
         """A stream boundary must not report a still-pending tool as having run."""
@@ -5562,7 +5713,7 @@ class TestLiveToolGroupSummary:
             assert read.display is False
             rendered = summary.render()
             assert isinstance(rendered, Content)
-            assert "1 file read" in rendered.plain
+            assert "Read 1 file" in rendered.plain
             assert "shell command" not in rendered.plain
 
     async def test_open_group_accepts_member_after_current_members_settle(self) -> None:
@@ -5654,7 +5805,7 @@ class TestLiveToolGroupSummary:
             assert t2.display is False
             rendered = summary.render()
             assert isinstance(rendered, Content)
-            assert "1 file read" in rendered.plain
+            assert "Read 1 file" in rendered.plain
 
     async def test_skipped_member_is_evicted_and_uncounted_on_close(self) -> None:
         """A skipped tool stays visible and is left out of the summary count.
@@ -5683,7 +5834,7 @@ class TestLiveToolGroupSummary:
             assert t2.display is False
             rendered = summary.render()
             assert isinstance(rendered, Content)
-            assert "1 file read" in rendered.plain
+            assert "Read 1 file" in rendered.plain
             # The skipped execute must not be summarized as if it had run.
             assert "shell command" not in rendered.plain
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5169,6 +5169,16 @@ class TestUserMessageCancelled:
             assert msg.has_class("-cancelled")
 
 
+def _calls(*names: str) -> list[tuple[str, dict]]:
+    """Build argument-less calls, where every call counts for itself.
+
+    With no argument naming a target, nothing can be judged a repeat, so these
+    exercise phrasing and category aggregation without target collapsing. See
+    `TestSummaryTargetCounting` for the target-aware behavior.
+    """
+    return [(name, {}) for name in names]
+
+
 class TestSummarizeToolGroup:
     """Tests for the tool-group summary phrasing."""
 
@@ -5198,7 +5208,7 @@ class TestSummarizeToolGroup:
         """The summary aggregates by category and lowercases trailing verbs."""
         from deepagents_code.tui.widgets.messages import summarize_tool_group
 
-        assert summarize_tool_group(names) == expected
+        assert summarize_tool_group(_calls(*names)) == expected
 
     def test_empty_group_has_fallback(self) -> None:
         """An empty tool list yields a generic fallback rather than crashing."""
@@ -5207,8 +5217,8 @@ class TestSummarizeToolGroup:
         assert summarize_tool_group([]) == "Ran tools"
 
 
-class TestDedupeRepeatTargets:
-    """Repeat calls on one target collapse before the summary counts nouns."""
+class TestSummaryTargetCounting:
+    """The lead noun counts distinct targets, not calls."""
 
     @pytest.mark.parametrize(
         ("calls", "expected"),
@@ -5219,7 +5229,7 @@ class TestDedupeRepeatTargets:
                     ("read_file", {"file_path": "a.py"}),
                     ("read_file", {"file_path": "a.py"}),
                 ],
-                ["read_file"],
+                "Read 1 file",
             ),
             # Distinct paths are distinct work.
             (
@@ -5227,7 +5237,7 @@ class TestDedupeRepeatTargets:
                     ("read_file", {"file_path": "a.py"}),
                     ("read_file", {"file_path": "b.py"}),
                 ],
-                ["read_file", "read_file"],
+                "Read 2 files",
             ),
             # Lexically equal paths collapse; `normpath` needs no filesystem.
             (
@@ -5235,14 +5245,23 @@ class TestDedupeRepeatTargets:
                     ("read_file", {"file_path": "./a.py"}),
                     ("read_file", {"file_path": "a.py"}),
                 ],
-                ["read_file"],
+                "Read 1 file",
             ),
             (
                 [
                     ("read_file", {"file_path": "d//a.py"}),
                     ("read_file", {"file_path": "d/a.py"}),
                 ],
-                ["read_file"],
+                "Read 1 file",
+            ),
+            # A relative and an absolute spelling stay distinct: the TUI's cwd
+            # is not necessarily the backend's, so equating them would guess.
+            (
+                [
+                    ("read_file", {"file_path": "a.py"}),
+                    ("read_file", {"file_path": "/repo/a.py"}),
+                ],
+                "Read 2 files",
             ),
             # Same path, different category: reading then editing is two acts.
             (
@@ -5250,12 +5269,12 @@ class TestDedupeRepeatTargets:
                     ("read_file", {"file_path": "a.py"}),
                     ("edit_file", {"file_path": "a.py"}),
                 ],
-                ["read_file", "edit_file"],
+                "Read 1 file, edited 1 file",
             ),
             # The `path` fallback is honored for tools that use it.
             (
                 [("read_file", {"path": "a.py"}), ("read_file", {"file_path": "a.py"})],
-                ["read_file"],
+                "Read 1 file",
             ),
             # URLs collapse on exact match.
             (
@@ -5263,76 +5282,133 @@ class TestDedupeRepeatTargets:
                     ("fetch_url", {"url": "http://x/y"}),
                     ("fetch_url", {"url": "http://x/y"}),
                 ],
-                ["fetch_url"],
+                "Fetched 1 URL",
             ),
             # Attempt-counting categories never collapse: two runs of one
             # command are genuinely two runs.
             (
                 [("execute", {"command": "ls"}), ("execute", {"command": "ls"})],
-                ["execute", "execute"],
+                "Ran 2 shell commands",
             ),
             (
                 [("grep", {"pattern": "x"}), ("grep", {"pattern": "x"})],
-                ["grep", "grep"],
+                "Searched for 2 patterns",
             ),
             # A bare `ls()` means "the working directory", which `execute` can
             # change mid-step, so identical calls are not assumed identical.
-            ([("ls", {}), ("ls", {})], ["ls", "ls"]),
-            # Unidentifiable targets fail open — counting twice merely restores
-            # the pre-dedup count, while collapsing would invent a repeat.
-            (
-                [("read_file", {}), ("read_file", {})],
-                ["read_file", "read_file"],
-            ),
+            ([("ls", {}), ("ls", {})], "Listed 2 directories"),
+            # Unidentifiable targets fail open: counting each merely restores the
+            # old count, while collapsing would invent a repeat.
+            ([("read_file", {}), ("read_file", {})], "Read 2 files"),
             (
                 [("read_file", {"file_path": ""}), ("read_file", {"file_path": None})],
-                ["read_file", "read_file"],
+                "Read 2 files",
             ),
             (
                 [("read_file", {"file_path": 42}), ("read_file", {"file_path": 42})],
-                ["read_file", "read_file"],
+                "Read 2 files",
             ),
-            ([], []),
         ],
     )
-    def test_dedupe(self, calls: list[tuple[str, dict]], expected: list[str]) -> None:
+    def test_distinct_target_counting(
+        self, calls: list[tuple[str, dict]], expected: str
+    ) -> None:
         """Repeat targets collapse; distinct and unidentifiable ones do not."""
-        from deepagents_code.tui.widgets.messages import dedupe_repeat_targets
+        from deepagents_code.tui.widgets.messages import summarize_tool_group
 
-        assert dedupe_repeat_targets(calls) == expected
+        assert summarize_tool_group(calls) == expected
 
-    def test_first_appearance_order_is_preserved(self) -> None:
-        """The kept call is the first one, so category ordering is unchanged."""
-        from deepagents_code.tui.widgets.messages import (
-            dedupe_repeat_targets,
-            summarize_tool_group,
-        )
+    def test_category_order_follows_first_call(self) -> None:
+        """Collapsing a repeat does not disturb first-appearance ordering."""
+        from deepagents_code.tui.widgets.messages import summarize_tool_group
 
         calls = [
             ("execute", {"command": "ls"}),
             ("read_file", {"file_path": "a.py"}),
             ("read_file", {"file_path": "a.py"}),
         ]
-        assert dedupe_repeat_targets(calls) == ["execute", "read_file"]
-        assert (
-            summarize_tool_group(dedupe_repeat_targets(calls))
-            == "Ran 1 shell command, read 1 file"
-        )
+        assert summarize_tool_group(calls) == "Ran 1 shell command, read 1 file"
 
     def test_repeated_read_reports_one_file_in_both_tenses(self) -> None:
         """The user-visible payoff: neither tense claims two files."""
-        from deepagents_code.tui.widgets.messages import (
-            dedupe_repeat_targets,
-            summarize_tool_group,
-        )
+        from deepagents_code.tui.widgets.messages import summarize_tool_group
 
         calls = [
             ("read_file", {"file_path": "a.py"}),
             ("read_file", {"file_path": "a.py"}),
         ]
-        names = dedupe_repeat_targets(calls)
-        assert summarize_tool_group(names, tense="past") == "Read 1 file"
-        assert summarize_tool_group(names, tense="present") == "Reading 1 file"
+        assert summarize_tool_group(calls, tense="past") == "Read 1 file"
+        assert summarize_tool_group(calls, tense="present") == "Reading 1 file"
+
+
+class TestRepeatOperationCounts:
+    """Mutations report repeat work on a target; reads collapse silently."""
+
+    @pytest.mark.parametrize(
+        ("calls", "expected"),
+        [
+            # A mutation is an event with its own diff, so three edits of one
+            # file must not read as a single edit.
+            (
+                [("edit_file", {"file_path": "a.py"})] * 3,
+                "Edited 1 file (3 edits)",
+            ),
+            # Both numbers survive when files and edits disagree.
+            (
+                [
+                    ("edit_file", {"file_path": "a.py"}),
+                    ("edit_file", {"file_path": "a.py"}),
+                    ("edit_file", {"file_path": "b.py"}),
+                ],
+                "Edited 2 files (3 edits)",
+            ),
+            # No repeats, no parenthetical.
+            (
+                [
+                    ("edit_file", {"file_path": "a.py"}),
+                    ("edit_file", {"file_path": "b.py"}),
+                ],
+                "Edited 2 files",
+            ),
+            ([("edit_file", {"file_path": "a.py"})], "Edited 1 file"),
+            (
+                [("write_file", {"file_path": "a.py"})] * 2,
+                "Wrote 1 file (2 writes)",
+            ),
+            # Reads repeat for pagination, where the count is noise.
+            ([("read_file", {"file_path": "a.py"})] * 3, "Read 1 file"),
+            # A repeated fetch of one URL is not a mutation either.
+            ([("fetch_url", {"url": "http://x"})] * 2, "Fetched 1 URL"),
+        ],
+    )
+    def test_repeat_counts(self, calls: list[tuple[str, dict]], expected: str) -> None:
+        """Only mutating categories append the operation count."""
+        from deepagents_code.tui.widgets.messages import summarize_tool_group
+
+        assert summarize_tool_group(calls) == expected
+
+    def test_present_tense_keeps_the_parenthetical(self) -> None:
+        """An in-flight burst of edits reports both numbers too."""
+        from deepagents_code.tui.widgets.messages import summarize_tool_group
+
+        calls = [("edit_file", {"file_path": "a.py"})] * 2
+        assert (
+            summarize_tool_group(calls, tense="present") == "Editing 1 file (2 edits)"
+        )
+
+    def test_parenthetical_lowercases_in_trailing_position(self) -> None:
+        """The segment still joins correctly when it is not the lead."""
+        from deepagents_code.tui.widgets.messages import summarize_tool_group
+
+        calls = [
+            ("execute", {"command": "ls"}),
+            ("edit_file", {"file_path": "a.py"}),
+            ("edit_file", {"file_path": "a.py"}),
+        ]
+        assert (
+            summarize_tool_group(calls)
+            == "Ran 1 shell command, edited 1 file (2 edits)"
+        )
 
 
 class _ToolGroupApp(App[None]):
@@ -5436,11 +5512,13 @@ class TestSummarizeToolGroupPresentTense:
         from deepagents_code.tui.widgets.messages import summarize_tool_group
 
         assert (
-            summarize_tool_group(["execute"], tense="present")
+            summarize_tool_group(_calls("execute"), tense="present")
             == "Running 1 shell command"
         )
         assert (
-            summarize_tool_group(["read_file", "read_file", "grep"], tense="present")
+            summarize_tool_group(
+                _calls("read_file", "read_file", "grep"), tense="present"
+            )
             == "Reading 2 files, searching for 1 pattern"
         )
 
@@ -5453,7 +5531,7 @@ class TestSummarizeLiveToolGroup:
         from deepagents_code.tui.widgets.messages import summarize_live_tool_group
 
         assert (
-            summarize_live_tool_group(["execute", "execute"], ["task"])
+            summarize_live_tool_group(_calls("execute", "execute"), _calls("task"))
             == "Ran 2 shell commands, running 1 agent"
         )
 
@@ -5462,7 +5540,7 @@ class TestSummarizeLiveToolGroup:
         from deepagents_code.tui.widgets.messages import summarize_live_tool_group
 
         assert (
-            summarize_live_tool_group([], ["read_file", "read_file"])
+            summarize_live_tool_group([], _calls("read_file", "read_file"))
             == "Reading 2 files"
         )
 
@@ -5470,7 +5548,7 @@ class TestSummarizeLiveToolGroup:
         """With nothing left running the line is purely past tense."""
         from deepagents_code.tui.widgets.messages import summarize_live_tool_group
 
-        assert summarize_live_tool_group(["execute"], []) == "Ran 1 shell command"
+        assert summarize_live_tool_group(_calls("execute"), []) == "Ran 1 shell command"
 
     def test_empty_returns_blank(self) -> None:
         """No members at all yields an empty string, not a fallback phrase."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5484,20 +5484,46 @@ class TestSummaryTargetCounting:
 
         assert _normalize_path_target(path) == validate_path(path)
 
-    def test_traversal_paths_the_middleware_rejects_are_left_alone(self) -> None:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "d/../a.py",
+            "~",
+            "~/a.py",
+            "C:/a.py",
+            r"C:\a.py",
+        ],
+    )
+    def test_paths_the_middleware_rejects_are_left_alone(self, path: str) -> None:
         """A path the middleware refuses is never canonicalized.
 
         Normalizing one would fold a call that could not have run into a valid
-        target's tally. The `..` is returned verbatim precisely because there is
-        no canonical form to agree with.
+        target's tally. Each is returned verbatim precisely because there is no
+        canonical form to agree with. The middleware rejects more than traversal
+        — `~` and drive prefixes too — so every rejected form is covered here,
+        not just the `..` case.
         """
         from deepagents.backends.utils import validate_path
 
         from deepagents_code.tui.widgets.messages import _normalize_path_target
 
-        with pytest.raises(ValueError, match="traversal"):
-            validate_path("d/../a.py")
-        assert _normalize_path_target("d/../a.py") == "d/../a.py"
+        with pytest.raises(ValueError):  # noqa: PT011
+            validate_path(path)
+        assert _normalize_path_target(path) == path
+
+    def test_rejected_path_does_not_collapse_into_its_valid_twin(self) -> None:
+        """`~` and `/~` are two different reads, so the group must say two.
+
+        Canonicalizing the rejected spelling would make both identities `/~` and
+        undercount the group — the one error this summary must never make.
+        """
+        from deepagents_code.tui.widgets.messages import summarize_tool_group
+
+        calls = [
+            ("read_file", {"file_path": "~"}),
+            ("read_file", {"file_path": "/~"}),
+        ]
+        assert summarize_tool_group(calls) == "Read 2 files"
 
     def test_repeat_nouns_require_a_target_arg(self) -> None:
         """A repeat noun is dead unless its category also names a target.

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5292,6 +5292,39 @@ class TestSummaryTargetCounting:
                 ],
                 "Read 1 file",
             ),
+            # The fallback keeps scanning past a `file_path` that is present but
+            # unusable, which is the backend shape the fallback list exists for.
+            # Stopping at the first key that appears would silently disable it.
+            (
+                [
+                    ("read_file", {"file_path": "", "path": "a.py"}),
+                    ("read_file", {"file_path": "a.py"}),
+                ],
+                "Read 1 file",
+            ),
+            (
+                [
+                    ("read_file", {"file_path": None, "path": "a.py"}),
+                    ("read_file", {"file_path": "a.py"}),
+                ],
+                "Read 1 file",
+            ),
+            # A trailing slash is not a distinct file. This is a collapse, the
+            # direction that must never be wrong, so it is pinned explicitly.
+            (
+                [
+                    ("read_file", {"file_path": "d/a.py/"}),
+                    ("read_file", {"file_path": "d/a.py"}),
+                ],
+                "Read 1 file",
+            ),
+            (
+                [
+                    ("read_file", {"file_path": "d/./a.py"}),
+                    ("read_file", {"file_path": "d/a.py"}),
+                ],
+                "Read 1 file",
+            ),
             # URLs collapse on exact match.
             (
                 [
@@ -5420,12 +5453,51 @@ class TestSummaryTargetCounting:
         ]
         assert summarize_tool_group(calls) == "Read 2 files, edited 2 files"
 
-    def test_path_normalization_matches_filesystem_middleware(self) -> None:
-        r"""Summary identities use the canonical paths executed by file tools."""
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "a.py",
+            "/a.py",
+            r"a\b",
+            "a/b",
+            "d//a.py",
+            "./a.py",
+            "d/a.py/",
+            "d/./a.py",
+            "/repo/a.py",
+            "//a/b",
+            ".",
+        ],
+    )
+    def test_path_normalization_matches_filesystem_middleware(self, path: str) -> None:
+        r"""Summary identities use the canonical paths executed by file tools.
+
+        Compared against `validate_path` itself rather than against hand-written
+        expectations: the identity only has to be *the middleware's* canonical
+        form, so pinning the two together is what catches drift. Two spellings
+        the middleware resolves to one file must tally as one file, and only the
+        middleware decides which spellings those are.
+        """
+        from deepagents.backends.utils import validate_path
+
         from deepagents_code.tui.widgets.messages import _normalize_path_target
 
-        assert _normalize_path_target("a.py") == _normalize_path_target("/a.py")
-        assert _normalize_path_target("a\\b") == _normalize_path_target("a/b")
+        assert _normalize_path_target(path) == validate_path(path)
+
+    def test_traversal_paths_the_middleware_rejects_are_left_alone(self) -> None:
+        """A path the middleware refuses is never canonicalized.
+
+        Normalizing one would fold a call that could not have run into a valid
+        target's tally. The `..` is returned verbatim precisely because there is
+        no canonical form to agree with.
+        """
+        from deepagents.backends.utils import validate_path
+
+        from deepagents_code.tui.widgets.messages import _normalize_path_target
+
+        with pytest.raises(ValueError, match="traversal"):
+            validate_path("d/../a.py")
+        assert _normalize_path_target("d/../a.py") == "d/../a.py"
 
     def test_repeat_nouns_require_a_target_arg(self) -> None:
         """A repeat noun is dead unless its category also names a target.
@@ -5765,6 +5837,23 @@ class _LiveToolGroupOnePathApp(App[None]):
         yield t2
 
 
+class _LiveToolGroupTwoEditsApp(App[None]):
+    """Live group whose two edits name the same file."""
+
+    def compose(self) -> ComposeResult:
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        summary = ToolGroupSummary(live=True)
+        summary.id = "summary"
+        t1 = ToolCallMessage("edit_file", {"file_path": "a.py"})
+        t1.id = "t1"
+        t2 = ToolCallMessage("edit_file", {"file_path": "a.py"})
+        t2.id = "t2"
+        yield summary
+        yield t1
+        yield t2
+
+
 class TestLiveToolGroupSummary:
     """Eager/live group: collapsed from the start, running -> ran transition."""
 
@@ -5963,6 +6052,44 @@ class TestLiveToolGroupSummary:
             rendered = summary.render()
             assert isinstance(rendered, Content)
             assert "Read 1 file" in rendered.plain
+
+    async def test_evicting_a_failed_edit_shrinks_the_repeat_count(self) -> None:
+        """An edit that errored is not counted among the edits that landed.
+
+        The repeat parenthetical asserts work reached the tree, so it has to
+        shrink with the group: two edits of one file where one fails must close
+        as "Edited 1 file", never "Edited 1 file (2 edits)".
+
+        Both edits are settled and rendered first so the past-tense line is
+        cached as "(2 edits)" before the failure arrives — a late terminal
+        result is exactly the case `close` exists for. That ordering is what
+        makes the cache reset in `_evict_unfoldable` load-bearing rather than
+        defensive, so the assertion fails if the reset is dropped.
+        """
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        async with _LiveToolGroupTwoEditsApp().run_test() as pilot:
+            summary = pilot.app.query_one("#summary", ToolGroupSummary)
+            t1 = pilot.app.query_one("#t1", ToolCallMessage)
+            t2 = pilot.app.query_one("#t2", ToolCallMessage)
+
+            summary.add_member(t1)
+            summary.add_member(t2)
+            t1.set_success("ok")
+            t2.set_success("ok")
+            summary._render_line()
+            cached = summary.render()
+            assert isinstance(cached, Content)
+            assert "(2 edits)" in cached.plain
+
+            t1.set_error("boom")
+            summary.close()
+            await pilot.pause()
+
+            rendered = summary.render()
+            assert isinstance(rendered, Content)
+            assert "Edited 1 file" in rendered.plain
+            assert "2 edits" not in rendered.plain
 
     async def test_close_waits_for_pending_member_terminal_status(self) -> None:
         """A stream boundary must not report a still-pending tool as having run."""
@@ -6592,9 +6719,9 @@ class TestCaveatedRowsLeaveTheGroup:
     """A caveat is carried in the row, so folding the row hides the caveat.
 
     `write_file` and `delete` are groupable, and the collapsed summary is built
-    from tool names alone. Without eviction, deleting a 5,000-line file whose
-    contents could not be read renders as `▸ Wrote 1 file` — indistinguishable
-    from the successful case, which is the exact failure this PR set out to fix.
+    from tool names and arguments, never from tool output. Without eviction,
+    deleting a 5,000-line file whose contents could not be read renders as
+    `▸ Wrote 1 file` — indistinguishable from the successful case.
     """
 
     async def test_a_caveated_row_is_evicted_and_revealed(self) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5284,6 +5284,29 @@ class TestSummaryTargetCounting:
                 ],
                 "Fetched 1 URL",
             ),
+            # A URL is compared exactly, never with path rules: a server can
+            # answer each of these differently, so collapsing would undercount.
+            (
+                [
+                    ("fetch_url", {"url": "http://x/a//b"}),
+                    ("fetch_url", {"url": "http://x/a/b"}),
+                ],
+                "Fetched 2 URLs",
+            ),
+            (
+                [
+                    ("fetch_url", {"url": "http://x/a/"}),
+                    ("fetch_url", {"url": "http://x/a"}),
+                ],
+                "Fetched 2 URLs",
+            ),
+            (
+                [
+                    ("fetch_url", {"url": "http://x/a/../b"}),
+                    ("fetch_url", {"url": "http://x/b"}),
+                ],
+                "Fetched 2 URLs",
+            ),
             # Attempt-counting categories never collapse: two runs of one
             # command are genuinely two runs.
             (

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5254,8 +5254,15 @@ class TestSummaryTargetCounting:
                 ],
                 "Read 1 file",
             ),
-            # A relative and an absolute spelling stay distinct: the TUI's cwd
-            # is not necessarily the backend's, so equating them would guess.
+            # The middleware anchors relative paths at the virtual root.
+            (
+                [
+                    ("read_file", {"file_path": "a.py"}),
+                    ("read_file", {"file_path": "/a.py"}),
+                ],
+                "Read 1 file",
+            ),
+            # Different canonical paths remain distinct.
             (
                 [
                     ("read_file", {"file_path": "a.py"}),
@@ -5374,14 +5381,13 @@ class TestSummaryTargetCounting:
                 [("read_file", {"file_path": ""}), ("read_file", {"file_path": "."})],
                 "Read 2 files",
             ),
-            # Backend paths are compared with POSIX rules wherever the TUI runs:
-            # `a\b` is a legal POSIX filename, not a spelling of `a/b`.
+            # The middleware accepts backslashes as path separators.
             (
                 [
                     ("read_file", {"file_path": "a\\b"}),
                     ("read_file", {"file_path": "a/b"}),
                 ],
-                "Read 2 files",
+                "Read 1 file",
             ),
             (
                 [("read_file", {"file_path": 42}), ("read_file", {"file_path": 42})],
@@ -5414,20 +5420,12 @@ class TestSummaryTargetCounting:
         ]
         assert summarize_tool_group(calls) == "Read 2 files, edited 2 files"
 
-    def test_backend_paths_use_posix_rules_on_every_platform(self) -> None:
-        r"""Backend paths never pick up the client's path rules.
-
-        The first assertion is the hazard, not a behavior under test: Windows
-        rules treat a backslash as a separator, so `os.path` on a Windows client
-        would merge `a\\b` — a legal POSIX filename — with `a/b`. This can only
-        fail on a Windows runner, where it is exactly the regression that matters.
-        """
-        import ntpath
-
+    def test_path_normalization_matches_filesystem_middleware(self) -> None:
+        r"""Summary identities use the canonical paths executed by file tools."""
         from deepagents_code.tui.widgets.messages import _normalize_path_target
 
-        assert ntpath.normpath("a\\b") == ntpath.normpath("a/b")
-        assert _normalize_path_target("a\\b") != _normalize_path_target("a/b")
+        assert _normalize_path_target("a.py") == _normalize_path_target("/a.py")
+        assert _normalize_path_target("a\\b") == _normalize_path_target("a/b")
 
     def test_repeat_nouns_require_a_target_arg(self) -> None:
         """A repeat noun is dead unless its category also names a target.

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5282,7 +5282,7 @@ class TestSummaryTargetCounting:
                     ("fetch_url", {"url": "http://x/y"}),
                     ("fetch_url", {"url": "http://x/y"}),
                 ],
-                "Fetched 1 URL",
+                "Fetched 1 URL (2 calls)",
             ),
             # A URL is compared exactly, never with path rules: a server can
             # answer each of these differently, so collapsing would undercount.
@@ -5400,8 +5400,9 @@ class TestRepeatOperationCounts:
             ),
             # Reads repeat for pagination, where the count is noise.
             ([("read_file", {"file_path": "a.py"})] * 3, "Read 1 file"),
-            # A repeated fetch of one URL is not a mutation either.
-            ([("fetch_url", {"url": "http://x"})] * 2, "Fetched 1 URL"),
+            # A repeated fetch of one URL is a deliberate re-request, so the
+            # call count stays visible.
+            ([("fetch_url", {"url": "http://x"})] * 2, "Fetched 1 URL (2 calls)"),
         ],
     )
     def test_repeat_counts(self, calls: list[tuple[str, dict]], expected: str) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5271,9 +5271,18 @@ class TestSummaryTargetCounting:
                 ],
                 "Read 1 file, edited 1 file",
             ),
-            # The `path` fallback is honored for tools that use it.
+            # `path` is accepted as a fallback spelling, mirroring the tolerance
+            # `_filtered_args` already shows for either key.
             (
                 [("read_file", {"path": "a.py"}), ("read_file", {"file_path": "a.py"})],
+                "Read 1 file",
+            ),
+            # `file_path` wins when a call carries both spellings.
+            (
+                [
+                    ("read_file", {"file_path": "a.py", "path": "b.py"}),
+                    ("read_file", {"file_path": "a.py"}),
+                ],
                 "Read 1 file",
             ),
             # URLs collapse on exact match.
@@ -5317,14 +5326,61 @@ class TestSummaryTargetCounting:
                 [("grep", {"pattern": "x"}), ("grep", {"pattern": "x"})],
                 "Searched for 2 patterns",
             ),
-            # A bare `ls()` means "the working directory", which `execute` can
-            # change mid-step, so identical calls are not assumed identical.
-            ([("ls", {}), ("ls", {})], "Listed 2 directories"),
+            # A listing is a snapshot, not a durable object: a group spans a
+            # whole step, so an intervening write can make the second listing of
+            # one directory show something different.
+            (
+                [("ls", {"path": "/repo"}), ("ls", {"path": "/repo"})],
+                "Listed 2 directories",
+            ),
+            # `web_search` phrases its own repeats, so it never collapses either.
+            (
+                [("web_search", {"query": "x"}), ("web_search", {"query": "x"})],
+                "Searched the web 2 times",
+            ),
+            # A `..` segment disables normalization: resolving it lexically would
+            # merge `d/../a.py` with `a.py`, which differ when `d` is a symlink.
+            (
+                [
+                    ("read_file", {"file_path": "d/../a.py"}),
+                    ("read_file", {"file_path": "a.py"}),
+                ],
+                "Read 2 files",
+            ),
+            # Every mutating category reports repeats, deletes included: a group
+            # spans a step, so delete/write/delete is two real deletions.
+            (
+                [
+                    ("delete", {"file_path": "a.py"}),
+                    ("write_file", {"file_path": "a.py"}),
+                    ("delete", {"file_path": "a.py"}),
+                ],
+                "Deleted 1 file (2 deletions), wrote 1 file",
+            ),
             # Unidentifiable targets fail open: counting each merely restores the
             # old count, while collapsing would invent a repeat.
             ([("read_file", {}), ("read_file", {})], "Read 2 files"),
             (
                 [("read_file", {"file_path": ""}), ("read_file", {"file_path": None})],
+                "Read 2 files",
+            ),
+            # Empty is rejected before normalizing, which would turn it into "."
+            # and collapse two unknown paths into one.
+            (
+                [("read_file", {"file_path": ""}), ("read_file", {"file_path": ""})],
+                "Read 2 files",
+            ),
+            (
+                [("read_file", {"file_path": ""}), ("read_file", {"file_path": "."})],
+                "Read 2 files",
+            ),
+            # Backend paths are compared with POSIX rules wherever the TUI runs:
+            # `a\b` is a legal POSIX filename, not a spelling of `a/b`.
+            (
+                [
+                    ("read_file", {"file_path": "a\\b"}),
+                    ("read_file", {"file_path": "a/b"}),
+                ],
                 "Read 2 files",
             ),
             (
@@ -5340,6 +5396,60 @@ class TestSummaryTargetCounting:
         from deepagents_code.tui.widgets.messages import summarize_tool_group
 
         assert summarize_tool_group(calls) == expected
+
+    def test_repeat_detection_is_scoped_per_category(self) -> None:
+        """One category's targets never mask another's.
+
+        The tally shares a single `seen` set, so identities must be namespaced by
+        category. Without that, `b.py` is already seen from the read when the
+        second edit arrives, and the edits collapse to "edited 1 file".
+        """
+        from deepagents_code.tui.widgets.messages import summarize_tool_group
+
+        calls = [
+            ("read_file", {"file_path": "a.py"}),
+            ("read_file", {"file_path": "b.py"}),
+            ("edit_file", {"file_path": "b.py"}),
+            ("edit_file", {"file_path": "a.py"}),
+        ]
+        assert summarize_tool_group(calls) == "Read 2 files, edited 2 files"
+
+    def test_backend_paths_use_posix_rules_on_every_platform(self) -> None:
+        r"""Backend paths never pick up the client's path rules.
+
+        The first assertion is the hazard, not a behavior under test: Windows
+        rules treat a backslash as a separator, so `os.path` on a Windows client
+        would merge `a\\b` — a legal POSIX filename — with `a/b`. This can only
+        fail on a Windows runner, where it is exactly the regression that matters.
+        """
+        import ntpath
+
+        from deepagents_code.tui.widgets.messages import _normalize_path_target
+
+        assert ntpath.normpath("a\\b") == ntpath.normpath("a/b")
+        assert _normalize_path_target("a\\b") != _normalize_path_target("a/b")
+
+    def test_repeat_nouns_require_a_target_arg(self) -> None:
+        """A repeat noun is dead unless its category also names a target.
+
+        `calls` can only exceed `targets` for a category that has a target, so a
+        noun added without one would silently never render.
+        """
+        from deepagents_code.tui.widgets.messages import (
+            _REPEAT_COUNT_NOUNS,
+            _TOOL_SUMMARY_TARGET_ARGS,
+        )
+
+        assert _REPEAT_COUNT_NOUNS.keys() <= _TOOL_SUMMARY_TARGET_ARGS.keys()
+
+    def test_path_compared_categories_all_name_a_target(self) -> None:
+        """Path normalization is unreachable for a category with no target arg."""
+        from deepagents_code.tui.widgets.messages import (
+            _PATH_TARGET_CATEGORIES,
+            _TOOL_SUMMARY_TARGET_ARGS,
+        )
+
+        assert _TOOL_SUMMARY_TARGET_ARGS.keys() >= _PATH_TARGET_CATEGORIES
 
     def test_category_order_follows_first_call(self) -> None:
         """Collapsing a repeat does not disturb first-appearance ordering."""
@@ -5580,6 +5690,31 @@ class TestSummarizeLiveToolGroup:
 
         assert summarize_live_tool_group([], []) == ""
 
+    def test_one_target_across_the_split_counts_in_both_halves(self) -> None:
+        """A file whose second read is still running stays visible as reading.
+
+        The two halves are tallied independently on purpose: collapsing across
+        the split would drop the file from the present-tense half and the line
+        would stop reporting the step as reading at all.
+        """
+        from deepagents_code.tui.widgets.messages import summarize_live_tool_group
+
+        one_read = [("read_file", {"file_path": "a.py"})]
+        assert (
+            summarize_live_tool_group(one_read, one_read)
+            == "Read 1 file, reading 1 file"
+        )
+
+    def test_repeats_within_a_half_still_collapse(self) -> None:
+        """Independent tallies do not disable collapsing inside either half."""
+        from deepagents_code.tui.widgets.messages import summarize_live_tool_group
+
+        two_edits = [("edit_file", {"file_path": "a.py"})] * 2
+        assert (
+            summarize_live_tool_group(two_edits, two_edits)
+            == "Edited 1 file (2 edits), editing 1 file (2 edits)"
+        )
+
 
 class _LiveToolGroupApp(App[None]):
     """Minimal app with an empty live group and two tools to add to it."""
@@ -5615,8 +5750,53 @@ class _LiveToolGroupSameCategoryApp(App[None]):
         yield t2
 
 
+class _LiveToolGroupOnePathApp(App[None]):
+    """Live group whose two reads name the same file."""
+
+    def compose(self) -> ComposeResult:
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        summary = ToolGroupSummary(live=True)
+        summary.id = "summary"
+        t1 = ToolCallMessage("read_file", {"file_path": "a.py"})
+        t1.id = "t1"
+        t2 = ToolCallMessage("read_file", {"file_path": "a.py"})
+        t2.id = "t2"
+        yield summary
+        yield t1
+        yield t2
+
+
 class TestLiveToolGroupSummary:
     """Eager/live group: collapsed from the start, running -> ran transition."""
+
+    async def test_live_line_reads_targets_not_just_names(self) -> None:
+        """The live path collapses repeats, and re-renders when one finishes.
+
+        Without args reaching the live render path both reads would count as two
+        files; without the target in the cache key the line would keep the stale
+        text once the first read finished.
+        """
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        async with _LiveToolGroupOnePathApp().run_test() as pilot:
+            summary = pilot.app.query_one("#summary", ToolGroupSummary)
+            first = pilot.app.query_one("#t1", ToolCallMessage)
+
+            summary.add_member(first)
+            summary.add_member(pilot.app.query_one("#t2", ToolCallMessage))
+            rendered = summary.render()
+            assert isinstance(rendered, Content)
+            assert "Reading 1 file" in rendered.plain
+            assert "2 files" not in rendered.plain
+
+            # One read finishes: the line must rebuild, counting the file in both
+            # halves so the step still reads as reading.
+            first.set_success("done")
+            summary._render_line()
+            rendered = summary.render()
+            assert isinstance(rendered, Content)
+            assert "Read 1 file, reading 1 file" in rendered.plain
 
     async def test_present_tense_while_running_then_past_on_close(self) -> None:
         from deepagents_code.tui.widgets.messages import ToolGroupSummary


### PR DESCRIPTION
The summary line for a step counts the tool calls, but it shows the count with a noun. If the agent reads one file two times, the line shows `Read 2 files`. Only one file is correct.

| Tool calls | Before | After |
| --- | --- | --- |
| read `a.py` two times | `Read 2 files` | `Read 1 file` |
| read `a.py`, read `b.py` | `Read 2 files` | `Read 2 files` |
| edit `a.py` three times | `Edited 3 files` | `Edited 1 file (3 edits)` |
| edit `a.py` two times, edit `b.py` | `Edited 3 files` | `Edited 2 files (3 edits)` |
| fetch one URL two times | `Fetched 2 URLs` | `Fetched 1 URL (2 calls)` |

The line now counts the different targets. A target is the file or the URL of a call, from the `file_path`, `path` or `url` argument. The present-tense line uses the same counts, for example `Reading 1 file`.

Every mutating category (`edit`, `write`, `delete`) and `fetch` also show the number of operations in parentheses. Each mutation writes to the file and has a diff, so the number of files alone is not sufficient: a group spans a whole step, so `delete a.py`, `write_file a.py`, `delete a.py` is two real deletions of one path. A repeated fetch of one URL is a deliberate new request, so `Fetched 1 URL` alone would hide the second call. A repeated read keeps one number, because the agent usually reads a large file in parts.

## Limits

- `shell`, `js`, `task` and `search` count attempts, not objects. Two runs of one command are two operations.
- `web_search` shows repeated calls with a different phrase, for example `Searched the web 2 times`.
- `ls` counts every listing. A listing is a snapshot, not a durable object, so an intervening write can make the second listing of one directory show different contents.
- A call whose target argument is missing or is not a string counts for itself. Failing to identify a target only restores the old count, while a wrong match would hide work.

Paths are compared in the canonical form the filesystem middleware itself produces. `_normalize_path_target` mirrors `validate_path`, so two spellings that the middleware resolves to one file count as one file. The normalization is purely lexical and never touches the filesystem.

- A relative and an absolute spelling match, because the middleware anchors a relative path at the virtual root: `a.py` and `/a.py` are one file.
- A backslash is a separator, because the middleware accepts one: `a\b` and `a/b` are one file.
- Redundant segments collapse: `d//a.py`, `d/./a.py` and `d/a.py/` are all `d/a.py`.
- A `..` segment turns the normalization off. The middleware rejects those paths, so there is no canonical form to agree with, and folding one would count a call that could not have run.
