### PR TITLE
fix(sdk): return tool-execution exceptions to the model instead of ending the run

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -45,6 +45,7 @@ from deepagents.backends.protocol import BackendProtocol
 from deepagents.middleware._fs_interrupt import _build_interrupt_on_from_permissions
 from deepagents.middleware._prompt_caching import append_prompt_caching_middleware
 from deepagents.middleware._state import private_state_field_names
+from deepagents.middleware._tool_errors import _create_tool_error_middleware
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
@@ -298,6 +299,28 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     [`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol].
     For non-sandbox backends, the `execute` tool will return an error message.
 
+    !!! note "Tool errors"
+
+        A tool that raises costs the model one step, not the whole run. Every
+        stack assembled here leads with a
+        [`ToolErrorMiddleware`][langchain.agents.middleware.ToolErrorMiddleware]
+        that turns tool-execution exceptions into an error `ToolMessage` and
+        lets the loop continue -- for built-in, caller-supplied, and MCP tools
+        alike, in subagents as well as the main agent. `ToolException` (what
+        `langchain-mcp-adapters` raises for an `isError` result) reaches the
+        model verbatim, since its message is written for the model; any other
+        exception is reported by type only, with the detail logged rather than
+        handed to the model.
+
+        Not converted, so they still end the run: LangGraph control-flow
+        signals (`interrupt()`, parent commands), recursion/cancellation/timeout
+        errors, and failures escaping the `task` tool -- a subagent whose *own*
+        tools fail already recovers inside its own loop, so anything still
+        surfacing there is that nested run breaking, not a tool misbehaving.
+
+        Pass your own `ToolErrorMiddleware` in `middleware` to replace the
+        default; an `on_error` returning `None` restores strict propagation.
+
     Args:
         model: The model to use.
 
@@ -363,6 +386,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             Base stack:
 
+            - [`ToolErrorMiddleware`][langchain.agents.middleware.ToolErrorMiddleware]
+                (unconditional; first, so it is the outermost `wrap_tool_call`)
             - [`SkillsMiddleware`][deepagents.middleware.skills.SkillsMiddleware] (if `skills` is provided)
             - [`FilesystemMiddleware`][deepagents.middleware.filesystem.FilesystemMiddleware]
             - [`SubAgentMiddleware`][deepagents.middleware.subagents.SubAgentMiddleware]
@@ -665,6 +690,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             # Build middleware: base stack + skills (if specified) + user's middleware
             subagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [
+                # First entry, so it is the outermost `wrap_tool_call` and a
+                # raising tool costs the subagent one step instead of taking
+                # the parent run down with it.
+                _create_tool_error_middleware(),
                 FilesystemMiddleware(
                     backend=backend,
                     custom_tool_descriptions=_subagent_profile.tool_description_overrides,
@@ -750,6 +779,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     gp_profile = _profile.general_purpose_subagent or GeneralPurposeSubagentProfile()
     if gp_profile.enabled is not False and not any(spec["name"] == GENERAL_PURPOSE_SUBAGENT["name"] for spec in inline_subagents):
         gp_middleware: list[AgentMiddleware[Any, Any, Any]] = [
+            _create_tool_error_middleware(),
             FilesystemMiddleware(
                 backend=backend,
                 custom_tool_descriptions=_profile.tool_description_overrides,
@@ -813,8 +843,9 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
         inline_subagents.insert(0, general_purpose_spec)
 
-    # Build main agent middleware stack
-    deepagent_middleware: list[AgentMiddleware[Any, Any, Any]] = []
+    # Build main agent middleware stack. Tool-error handling goes first so it
+    # wraps every other `wrap_tool_call` in the stack.
+    deepagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [_create_tool_error_middleware()]
     if skills is not None:
         deepagent_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
     deepagent_middleware.append(

--- a/libs/deepagents/deepagents/middleware/_tool_errors.py
+++ b/libs/deepagents/deepagents/middleware/_tool_errors.py
@@ -1,0 +1,100 @@
+"""Default tool-error handling for deep agents.
+
+A tool that raises should cost the model one step, not the whole run. Without
+this, only argument-binding failures come back as an error `ToolMessage`
+(`ToolNode` converts those before the tool runs); anything the tool *body*
+raises escapes the graph and ends `.invoke()`.
+
+The handler here backs the `ToolErrorMiddleware` that `create_deep_agent`
+places at the head of every stack it assembles, so the conversion applies to
+built-in tools, caller-supplied tools, MCP tools, and tools running inside a
+subagent alike.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware import ToolErrorMiddleware
+from langchain_core.tools import ToolException
+from langgraph.errors import GraphRecursionError, NodeCancelledError, NodeTimeoutError
+
+from deepagents.middleware.subagents import TASK_TOOL_NAME
+
+if TYPE_CHECKING:
+    from langchain.agents.middleware.types import AgentMiddleware
+    from langchain.tools.tool_node import ToolCallRequest
+
+logger = logging.getLogger(__name__)
+
+
+_NEVER_HANDLED: tuple[type[Exception], ...] = (
+    # Recursion is a structural failure, not a tool failure. Reporting it to
+    # the model invites the same runaway delegation that tripped the limit.
+    GraphRecursionError,
+    # Cancellation and node timeouts are the runtime deciding this work stops.
+    # Answering the model as if the tool merely failed would undo that.
+    NodeCancelledError,
+    NodeTimeoutError,
+)
+"""Exceptions that keep propagating even though they reach `on_error`.
+
+`GraphBubbleUp` (interrupts, parent commands) never reaches the handler at all
+-- `ToolErrorMiddleware` re-raises it before calling us -- so human-in-the-loop
+is unaffected. `KeyboardInterrupt`, `SystemExit`, and `asyncio.CancelledError`
+derive from `BaseException` and are likewise out of reach.
+"""
+
+
+def _default_on_tool_error(exc: Exception, request: ToolCallRequest) -> str | None:
+    """Convert a tool-execution exception into content for an error `ToolMessage`.
+
+    Args:
+        exc: Exception raised while executing the tool.
+        request: The tool call that failed (name, args, call id).
+
+    Returns:
+        Content for an error `ToolMessage`, or `None` to let `exc` propagate.
+    """
+    if isinstance(exc, _NEVER_HANDLED):
+        return None
+
+    tool_name = request.tool.name if request.tool else request.tool_call["name"]
+
+    if tool_name == TASK_TOOL_NAME:
+        # `task` nests a whole agent run rather than doing leaf work. Tool
+        # failures *inside* the subagent are already converted by that
+        # subagent's own copy of this middleware, so anything still escaping
+        # here is structural -- its model erroring out, a `CompiledSubAgent`
+        # violating the state contract. Reporting those as a recoverable tool
+        # error would hide a broken subagent behind a retry loop and strip the
+        # `failed` status off the streamed subagent handle.
+        return None
+
+    if isinstance(exc, ToolException):
+        # The one exception type whose message is written *for* the model:
+        # "allows tools to signal errors without stopping the agent". This is
+        # what `langchain_mcp_adapters` raises for an `isError` tool result, so
+        # the text is the upstream server's own error report. Matches what
+        # `handle_tool_error=True` produces in `langchain-core`.
+        logger.debug("Tool %r raised ToolException; returning it to the model.", tool_name, exc_info=exc)
+        return str(exc.args[0]) if exc.args else "Tool execution error"
+
+    # Everything else is an unplanned failure whose message may carry internal
+    # detail (paths, hosts, credentials in a URL). Name the type so the model
+    # can react, and leave the detail in the logs for whoever owns the tool.
+    logger.exception("Tool %r raised %s; returning an error to the model.", tool_name, type(exc).__name__, exc_info=exc)
+    return f"Error: tool `{tool_name}` failed with {type(exc).__name__}. Check the arguments, or use a different approach if it keeps failing."
+
+
+def _create_tool_error_middleware() -> AgentMiddleware[Any, Any, Any]:
+    """Build the `ToolErrorMiddleware` that `create_deep_agent` installs by default.
+
+    Placed first in each assembled stack, so it is the outermost
+    `wrap_tool_call` and also catches failures raised by inner middleware.
+
+    Returns:
+        A `ToolErrorMiddleware` wired to [`_default_on_tool_error`][deepagents.middleware._tool_errors._default_on_tool_error].
+    """
+    return ToolErrorMiddleware(_default_on_tool_error)

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -282,6 +282,15 @@ class TaskToolSchema(BaseModel):
     subagent_type: str = Field(description=("The type of subagent to use. Must be one of the available agent types listed in the tool description."))
 
 
+TASK_TOOL_NAME = "task"
+"""Name of the delegation tool that runs a subagent in-process.
+
+Unlike a leaf tool, `task` nests an entire agent run, so failures reaching its
+boundary are the nested run's failures, not a tool's. Default tool-error
+handling skips it for that reason -- see
+[`deepagents.middleware._tool_errors`][deepagents.middleware._tool_errors].
+"""
+
 TASK_TOOL_DESCRIPTION = """Launch an ephemeral subagent to handle a complex, multi-step task in an isolated context window.
 
 Available agent types and the tools they have access to:
@@ -596,7 +605,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
     return StructuredTool.from_function(
-        name="task",
+        name=TASK_TOOL_NAME,
         func=task,
         coroutine=atask,
         description=description,

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_errors.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_errors.py
@@ -1,0 +1,311 @@
+"""Unit tests for default tool-error handling in `create_deep_agent`."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain.agents.middleware import ToolErrorMiddleware
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.tools import ToolException, tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.errors import GraphRecursionError, NodeCancelledError, NodeTimeoutError
+from langgraph.types import interrupt
+
+from deepagents import create_deep_agent
+from deepagents.middleware.subagents import SubAgent, SubAgentMiddleware
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks import CallbackManagerForLLMRun
+    from langchain_core.outputs import ChatResult
+
+
+@tool
+def raises_tool_exception(q: str) -> str:
+    """Raise the exception `langchain_mcp_adapters` raises for an `isError` result."""
+    msg = f"upstream server returned an error for {q!r}"
+    raise ToolException(msg)
+
+
+@tool
+def raises_value_error(q: str) -> str:
+    """Raise an unplanned exception carrying detail the model shouldn't see."""
+    msg = f"connection to postgres://user:hunter2@internal-db/{q} refused"
+    raise ValueError(msg)
+
+
+@tool
+def interrupts(q: str) -> str:
+    """Raise a `GraphBubbleUp` from inside the tool body."""
+    return str(interrupt(f"approve {q}?"))
+
+
+@tool
+def ok(q: str) -> str:
+    """Succeed."""
+    return f"ok: {q}"
+
+
+_GRAPH_ERRORS: dict[str, Exception] = {
+    "recursion": GraphRecursionError("limit reached"),
+    "cancelled": NodeCancelledError("tools", "cancelled"),
+    "timeout": NodeTimeoutError("tools", 1.0, kind="run", run_timeout=1.0),
+}
+
+
+@tool
+def raises_graph_error(q: str) -> str:
+    """Raise the graph-level error named by `q`."""
+    raise _GRAPH_ERRORS[q]
+
+
+def _propagate(_exc: Exception, _request: object) -> None:
+    """`on_error` handler that hands every exception back to the caller."""
+
+
+def _tool_call(name: str, call_id: str = "call-1", **args: Any) -> AIMessage:
+    return AIMessage(content="", tool_calls=[{"name": name, "args": args or {"q": "x"}, "id": call_id}])
+
+
+def _scripted(*messages: AIMessage) -> GenericFakeChatModel:
+    """Fake model that plays `messages` in order."""
+    return GenericFakeChatModel(messages=iter(messages))
+
+
+def _calls_then_answers(tool_name: str) -> GenericFakeChatModel:
+    """Fake model that calls `tool_name` once, then answers."""
+    return _scripted(_tool_call(tool_name), AIMessage(content="done"))
+
+
+def _tool_messages(result: dict[str, Any]) -> list[ToolMessage]:
+    return [m for m in result["messages"] if isinstance(m, ToolMessage)]
+
+
+class TestToolExceptionsReachTheModel:
+    """A raising tool costs one step, not the whole run (deepagents#5356)."""
+
+    def test_tool_exception_becomes_error_tool_message(self) -> None:
+        agent = create_deep_agent(model=_calls_then_answers("raises_tool_exception"), tools=[raises_tool_exception])
+
+        result = agent.invoke({"messages": [HumanMessage(content="go")]})
+
+        (tool_msg,) = _tool_messages(result)
+        assert tool_msg.status == "error"
+        # ToolException is written *for* the model, so its message is passed through.
+        assert tool_msg.content == "upstream server returned an error for 'x'"
+        assert result["messages"][-1].content == "done", "loop did not continue past the failure"
+
+    def test_arbitrary_exception_becomes_error_tool_message(self) -> None:
+        agent = create_deep_agent(model=_calls_then_answers("raises_value_error"), tools=[raises_value_error])
+
+        result = agent.invoke({"messages": [HumanMessage(content="go")]})
+
+        (tool_msg,) = _tool_messages(result)
+        assert tool_msg.status == "error"
+        assert "ValueError" in tool_msg.content
+        assert "raises_value_error" in tool_msg.content
+        assert result["messages"][-1].content == "done"
+
+    def test_arbitrary_exception_message_is_not_leaked_to_the_model(self) -> None:
+        """Only the exception *type* is surfaced; the message may hold secrets."""
+        agent = create_deep_agent(model=_calls_then_answers("raises_value_error"), tools=[raises_value_error])
+
+        result = agent.invoke({"messages": [HumanMessage(content="go")]})
+
+        (tool_msg,) = _tool_messages(result)
+        assert "hunter2" not in tool_msg.content
+        assert "internal-db" not in tool_msg.content
+
+    def test_arbitrary_exception_detail_is_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Detail withheld from the model still reaches whoever owns the tool."""
+        agent = create_deep_agent(model=_calls_then_answers("raises_value_error"), tools=[raises_value_error])
+
+        with caplog.at_level(logging.ERROR, logger="deepagents.middleware._tool_errors"):
+            agent.invoke({"messages": [HumanMessage(content="go")]})
+
+        (record,) = caplog.records
+        assert record.exc_info is not None
+        assert "hunter2" in caplog.text
+
+    async def test_tool_exception_is_handled_on_the_async_path(self) -> None:
+        agent = create_deep_agent(model=_calls_then_answers("raises_tool_exception"), tools=[raises_tool_exception])
+
+        result = await agent.ainvoke({"messages": [HumanMessage(content="go")]})
+
+        (tool_msg,) = _tool_messages(result)
+        assert tool_msg.status == "error"
+        assert tool_msg.content == "upstream server returned an error for 'x'"
+
+    def test_successful_tool_calls_are_untouched(self) -> None:
+        agent = create_deep_agent(model=_calls_then_answers("ok"), tools=[ok])
+
+        result = agent.invoke({"messages": [HumanMessage(content="go")]})
+
+        (tool_msg,) = _tool_messages(result)
+        assert tool_msg.status == "success"
+        assert tool_msg.content == "ok: x"
+
+
+class TestSubagentContainment:
+    """A tool failure inside a subagent no longer takes the parent down."""
+
+    def test_subagent_tool_failure_does_not_kill_the_parent(self) -> None:
+        subagent: SubAgent = {
+            "name": "searcher",
+            "description": "searches",
+            "system_prompt": "search",
+            "tools": [raises_tool_exception],
+            "model": _calls_then_answers("raises_tool_exception"),
+        }
+        agent = create_deep_agent(
+            model=_scripted(
+                _tool_call("task", description="search", subagent_type="searcher"),
+                AIMessage(content="parent done"),
+            ),
+            subagents=[subagent],
+        )
+
+        result = agent.invoke({"messages": [HumanMessage(content="go")]})
+
+        assert result["messages"][-1].content == "parent done"
+
+    def test_subagent_run_failures_still_propagate(self) -> None:
+        """`task` nests a run; a structural failure there must surface, not become a `ToolMessage`."""
+
+        class _FailingModel(GenericFakeChatModel):
+            def _generate(
+                self,
+                messages: list[BaseMessage],
+                stop: list[str] | None = None,
+                run_manager: CallbackManagerForLLMRun | None = None,
+                **kwargs: Any,
+            ) -> ChatResult:
+                msg = "research failed"
+                raise RuntimeError(msg)
+
+        subagent: SubAgent = {
+            "name": "searcher",
+            "description": "searches",
+            "system_prompt": "search",
+            "tools": [ok],
+            "model": _FailingModel(messages=iter([])),
+        }
+        agent = create_deep_agent(
+            model=_scripted(
+                _tool_call("task", description="search", subagent_type="searcher"),
+                AIMessage(content="parent done"),
+            ),
+            subagents=[subagent],
+        )
+
+        with pytest.raises(RuntimeError, match="research failed"):
+            agent.invoke({"messages": [HumanMessage(content="go")]})
+
+
+class TestExceptionsThatMustPropagate:
+    """Control-flow and structural signals are not tool failures."""
+
+    def test_interrupt_from_a_tool_body_still_interrupts(self) -> None:
+        """`GraphBubbleUp` must not become an error `ToolMessage`, or HITL breaks."""
+        agent = create_deep_agent(
+            model=_scripted(_tool_call("interrupts"), AIMessage(content="done")),
+            tools=[interrupts],
+            checkpointer=InMemorySaver(),
+        )
+
+        result = agent.invoke(
+            {"messages": [HumanMessage(content="go")]},
+            config={"configurable": {"thread_id": "t1"}},
+        )
+
+        assert result.get("__interrupt__"), "interrupt was swallowed by tool-error handling"
+        assert not _tool_messages(result)
+
+    @pytest.mark.parametrize("kind", list(_GRAPH_ERRORS))
+    def test_graph_level_errors_propagate(self, kind: str) -> None:
+        agent = create_deep_agent(
+            model=_scripted(_tool_call("raises_graph_error", q=kind), AIMessage(content="done")),
+            tools=[raises_graph_error],
+        )
+
+        with pytest.raises(type(_GRAPH_ERRORS[kind])):
+            agent.invoke({"messages": [HumanMessage(content="go")]})
+
+
+class TestOptOut:
+    """Callers keep control via the usual name-based middleware override."""
+
+    def test_caller_middleware_replaces_the_default(self) -> None:
+        agent = create_deep_agent(
+            model=_calls_then_answers("raises_tool_exception"),
+            tools=[raises_tool_exception],
+            middleware=[ToolErrorMiddleware(lambda _exc, _request: "handled by the caller")],
+        )
+
+        result = agent.invoke({"messages": [HumanMessage(content="go")]})
+
+        (tool_msg,) = _tool_messages(result)
+        assert tool_msg.content == "handled by the caller"
+
+    def test_caller_can_restore_strict_propagation(self) -> None:
+        agent = create_deep_agent(
+            model=_calls_then_answers("raises_tool_exception"),
+            tools=[raises_tool_exception],
+            middleware=[ToolErrorMiddleware(_propagate)],
+        )
+
+        with pytest.raises(ToolException, match="upstream server returned an error"):
+            agent.invoke({"messages": [HumanMessage(content="go")]})
+
+    def test_override_does_not_stack_two_instances(self) -> None:
+        override = ToolErrorMiddleware(_propagate)
+        fake_agent = MagicMock()
+        fake_agent.with_config.return_value = "compiled-agent"
+
+        with patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create:
+            create_deep_agent(model=_scripted(AIMessage(content="ok")), middleware=[override])
+
+        stack = mock_create.call_args.kwargs["middleware"]
+        instances = [m for m in stack if isinstance(m, ToolErrorMiddleware)]
+        assert instances == [override]
+
+
+class TestStackPlacement:
+    """The middleware is outermost in every stack `create_deep_agent` assembles."""
+
+    def _main_stack(self, **kwargs: Any) -> list[Any]:
+        fake_agent = MagicMock()
+        fake_agent.with_config.return_value = "compiled-agent"
+        with patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create:
+            create_deep_agent(model=_scripted(AIMessage(content="ok")), **kwargs)
+        return list(mock_create.call_args.kwargs["middleware"])
+
+    def test_first_in_the_main_stack(self) -> None:
+        stack = self._main_stack()
+        assert isinstance(stack[0], ToolErrorMiddleware), [m.name for m in stack]
+
+    def test_first_in_the_main_stack_with_skills(self) -> None:
+        """Skills middleware normally leads the stack; error handling still precedes it."""
+        stack = self._main_stack(skills=[])
+        assert isinstance(stack[0], ToolErrorMiddleware), [m.name for m in stack]
+
+    def test_first_in_the_general_purpose_subagent_stack(self) -> None:
+        stack = self._main_stack()
+        sub_mw = next(m for m in stack if isinstance(m, SubAgentMiddleware))
+        gp_spec = next(s for s in sub_mw._subagents if s["name"] == "general-purpose")
+        assert isinstance(gp_spec["middleware"][0], ToolErrorMiddleware)
+
+    def test_first_in_an_inline_subagent_stack(self) -> None:
+        subagent: SubAgent = {
+            "name": "worker",
+            "description": "a worker",
+            "system_prompt": "work",
+            "model": _scripted(AIMessage(content="ok")),
+        }
+        stack = self._main_stack(subagents=[subagent])
+        sub_mw = next(m for m in stack if isinstance(m, SubAgentMiddleware))
+        worker_spec = next(s for s in sub_mw._subagents if s.get("name") == "worker")
+        assert isinstance(worker_spec["middleware"][0], ToolErrorMiddleware)


### PR DESCRIPTION
Fixes #5356

A tool that raises now returns an error `ToolMessage` and the agent keeps going, instead of the exception escaping `.invoke()` and ending the run.

---

`create_agent` builds its `ToolNode` without `handle_tool_errors`, so the LangGraph default applies: argument-binding failures come back as an error `ToolMessage`, but anything a tool *body* raises propagates out of the graph. The model never sees the failure, so one bad tool call costs the whole session rather than one step.

It bites hardest with MCP — `langchain-mcp-adapters` raises `ToolException` for every `isError` result, so any agent with MCP tools attached inherits "a remote server having a bad minute ends the run".

Every stack `create_deep_agent` assembles — main agent, general-purpose subagent, inline subagents — now leads with a `ToolErrorMiddleware`. First position makes it the outermost `wrap_tool_call`, so it also covers failures raised by inner middleware. `ToolException` reaches the model verbatim, since its message is written for the model (same as `handle_tool_error=True` in langchain-core); every other exception is reported by type alone, with the detail logged rather than handed to the model — following the advice in the `ToolErrorMiddleware` docstring, so a stack trace can't leak paths or credentials into the transcript.

Deliberately still fatal:

- **LangGraph control-flow signals.** `ToolErrorMiddleware` re-raises `GraphBubbleUp` before the handler runs, so `interrupt()` and human-in-the-loop are untouched.
- **`GraphRecursionError`, `NodeCancelledError`, `NodeTimeoutError`.** The runtime deciding this work stops, not a tool failing.
- **Anything escaping the `task` tool.** This one is worth calling out: `task` nests a whole agent run rather than doing leaf work, and the subagent's own copy of this middleware already recovers from *its* tool failures. What still surfaces at the `task` boundary is the nested run breaking — its model erroring out, a `CompiledSubAgent` violating the state contract — and that has to stay visible, including as `status="failed"` on the streamed subagent handle. Two existing tests pin this down (`test_subagent_error_surfaces_failed_status`, `test_compiled_subagent_without_messages_raises_error`); an earlier draft that handled `task` too broke both, which is what pointed at the distinction.

So the issue's subagent case is fixed by containment one level down, not by swallowing at the `task` boundary — a subagent's tool failure now costs the subagent a step and the parent is never involved.

No new parameter on `create_deep_agent`: the existing name-based middleware merge already does the job. Passing a `ToolErrorMiddleware` in `middleware` replaces the default in place, and an `on_error` returning `None` restores strict propagation. A `HarnessProfile` can drop it via `excluded_middleware`. Happy to add an explicit kwarg instead if you'd prefer it discoverable from the signature.

`TASK_TOOL_NAME` is factored out of `subagents.py` so the exclusion can't drift from the tool it names.

**Verification.** All four cases from the issue (`ToolException`, `ZeroDivisionError`, subagent, async) reproduce on `main` and pass after the change. 19 new tests in `tests/unit_tests/middleware/test_tool_errors.py` cover the conversion, the no-leak guarantee, the async path, subagent containment, each propagation carve-out, the override/opt-out, and stack placement in all three stacks. Full suite: 2472 passed, `make lint` and `make type` clean.

No dependency or `uv.lock` changes.
