### PR TITLE
fix(code): remove optional-provider startup tip

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -23,7 +23,6 @@ _TIPS: dict[str, int] = {
     "Use /copy to copy the latest message": 3,
     "Use /cost to see a breakdown of estimated spend": 1,
     "Use /tools to list the tools available to the agent": 1,
-    "Use dcode install <name> for optional providers": 1,
     "Use /mcp login <server> to authenticate MCP servers": 1,
     "Use /remember to save learnings from this conversation": 1,
     "Use /model to switch models mid-conversation": 2,


### PR DESCRIPTION
Bad to show a CLI tip inside the TUI

Made by [Open SWE](https://openswe.vercel.app/agents/d02b123b-7e6c-391e-fc9a-8b06642d89d9)