### PR TITLE
feat(code): support Agent Plugin layouts

### DIFF
--- a/libs/code/deepagents_code/mcp_config.py
+++ b/libs/code/deepagents_code/mcp_config.py
@@ -1,7 +1,7 @@
 """Validation and environment-variable expansion for MCP server config.
 
 Resolves `${VAR}` and `${VAR:-default}` references in the supported
-configuration fields (`command`, `url`, `args`, `env`, `headers`) and
+configuration fields (`command`, `url`, `cwd`, `args`, `env`, `headers`) and
 validates their types. A `${VAR:-default}` reference falls back to
 `default` when `VAR` is unset *or* empty (POSIX `:-` semantics).
 """
@@ -130,7 +130,7 @@ def resolve_mcp_server_env(
 ) -> dict[str, Any]:
     """Resolve `${VAR}` references in one MCP server's supported fields.
 
-    Interpolates the `command`, `url`, `args`, `env`, and `headers`
+    Interpolates the `command`, `url`, `cwd`, `args`, `env`, and `headers`
     fields (see `_interpolate_env` for the reference syntax); every other
     field is copied through verbatim. The input is not mutated.
 
@@ -150,7 +150,7 @@ def resolve_mcp_server_env(
     resolved: dict[str, Any] = copy.deepcopy(dict(server_config))
     prefix = f"mcpServers.{server_name}"
 
-    for name in ("command", "url"):
+    for name in ("command", "cwd", "url"):
         if name in resolved:
             resolved[name] = _resolve_string(resolved[name], field=f"{prefix}.{name}")
 

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -572,6 +572,10 @@ def _validate_server_config(server_name: str, server_config: dict[str, Any]) -> 
         if "env" in server_config and not isinstance(server_config["env"], dict):
             error_msg = f"Server '{server_name}' 'env' must be a dictionary"
             raise TypeError(error_msg)
+
+        if "cwd" in server_config and not isinstance(server_config["cwd"], str):
+            error_msg = f"Server '{server_name}' 'cwd' must be a string"
+            raise TypeError(error_msg)
     else:
         error_msg = (
             f"Server '{server_name}' has unsupported transport type '{server_type}'. "
@@ -1394,7 +1398,11 @@ def _config_uses_env_interpolation(server_config: dict[str, Any]) -> bool:
     Returns:
         Whether a supported value contains a `${...}` reference.
     """
-    scalar_values = [server_config.get("command"), server_config.get("url")]
+    scalar_values = [
+        server_config.get("command"),
+        server_config.get("cwd"),
+        server_config.get("url"),
+    ]
     sequence_values = server_config.get("args")
     if isinstance(sequence_values, list):
         scalar_values.extend(sequence_values)
@@ -1903,6 +1911,18 @@ async def _load_tools_from_config(
     # discovery, and the final fold-in loop below.
     transports = {name: _resolve_server_type(cfg) for name, cfg in server_items}
 
+    def _stdio_connection(server_config: dict[str, Any]) -> Connection:
+        connection: Connection = StdioConnection(
+            command=server_config["command"],
+            args=server_config.get("args", []),
+            env=server_config.get("env") or None,
+            transport="stdio",
+        )
+        cwd = server_config.get("cwd")
+        if cwd is not None:
+            connection["cwd"] = cwd
+        return connection
+
     async def _preflight_and_connect(
         server_name: str,
         server_config: dict[str, Any],
@@ -2008,12 +2028,7 @@ async def _load_tools_from_config(
                     )
 
                 return conn
-            return StdioConnection(
-                command=server_config["command"],
-                args=server_config.get("args", []),
-                env=server_config.get("env") or None,
-                transport="stdio",
-            )
+            return _stdio_connection(server_config)
         except (OSError, RuntimeError, TypeError, ValueError) as exc:
             if redact_failure_details:
                 error = (
@@ -2758,6 +2773,14 @@ async def resolve_and_load_mcp_tools(
 
     from deepagents_code.mcp_disabled import get_disabled_servers
 
+    def _reported_transport(server_config: object) -> str:
+        if not isinstance(server_config, dict):
+            return "unknown"
+        try:
+            return _resolve_server_type(cast("dict[str, Any]", server_config))
+        except (TypeError, ValueError):
+            return "unknown"
+
     disabled_names = get_disabled_servers()
     disabled_infos: list[MCPServerInfo] = []
     if disabled_names:
@@ -2767,9 +2790,7 @@ async def resolve_and_load_mcp_tools(
                 disabled_infos.append(
                     MCPServerInfo(
                         name=server_name,
-                        transport=_resolve_server_type(server_config)
-                        if isinstance(server_config, dict)
-                        else "unknown",
+                        transport=_reported_transport(server_config),
                         status="disabled",
                         error="Disabled by user (F2 to re-enable).",
                     ),
@@ -2781,12 +2802,26 @@ async def resolve_and_load_mcp_tools(
     if not merged.get("mcpServers"):
         return [], None, disabled_infos + _bad_config_infos()
 
-    try:
-        for server_name, server_config in merged["mcpServers"].items():
+    invalid_infos: list[MCPServerInfo] = []
+    valid_servers: dict[str, Any] = {}
+    for server_name, server_config in merged["mcpServers"].items():
+        try:
             _validate_server_config(server_name, server_config)
-    except (TypeError, ValueError, RuntimeError) as exc:
-        msg = f"Invalid MCP server configuration: {exc}"
-        raise RuntimeError(msg) from exc
+        except (TypeError, ValueError, RuntimeError) as exc:
+            invalid_infos.append(
+                MCPServerInfo(
+                    name=server_name,
+                    transport=_reported_transport(server_config),
+                    status="error",
+                    error=f"Invalid MCP server configuration: {exc}",
+                )
+            )
+        else:
+            valid_servers[server_name] = server_config
+    merged = {"mcpServers": valid_servers}
+
+    if not valid_servers:
+        return [], None, disabled_infos + invalid_infos + _bad_config_infos()
 
     tools, manager, server_infos = await _load_tools_from_config(
         merged,
@@ -2794,5 +2829,6 @@ async def resolve_and_load_mcp_tools(
         session_manager=session_manager,
     )
     server_infos.extend(disabled_infos)
+    server_infos.extend(invalid_infos)
     server_infos.extend(_bad_config_infos())
     return tools, manager, server_infos

--- a/libs/code/deepagents_code/plugins/adapters/hooks.py
+++ b/libs/code/deepagents_code/plugins/adapters/hooks.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from deepagents_code.hooks.loading import PluginHooksSource, read_hooks_json
 from deepagents_code.hooks.models.domain import HookDiagnostic, HookEvent
-from deepagents_code.plugins.manifest import find_manifest_path
+from deepagents_code.plugins.manifest import select_manifest_path
 from deepagents_code.plugins.substitution import plugin_environment
 
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ def _plugin_documents(
             documents.append((path, document))
     manifest = plugin.manifest
     if manifest and manifest.inline_hooks:
-        manifest_path = find_manifest_path(plugin.root) or plugin.root
+        manifest_path = select_manifest_path(plugin.root) or plugin.root
         documents.append((manifest_path, manifest.inline_hooks))
     return documents, diagnostics
 

--- a/libs/code/deepagents_code/plugins/adapters/mcp.py
+++ b/libs/code/deepagents_code/plugins/adapters/mcp.py
@@ -10,15 +10,36 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from deepagents_code.plugins._json import json_object, json_value
+from deepagents_code.plugins.layouts import accepts_mcp_schema, dialect_by_name
 from deepagents_code.plugins.substitution import plugin_environment, substitute_json
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from deepagents_code.plugins.layouts import PluginDialect
     from deepagents_code.plugins.models import JsonObject, JsonValue, PluginInstance
 
 logger = logging.getLogger(__name__)
 # For example, `tools@example.com` becomes `tools_example_com_<hash>`.
 _MCP_NAME_PART_RE = re.compile(r"[^A-Za-z0-9_-]+")
 _MCP_NAME_PART_LENGTH = 48
+_REMOTE_TRANSPORTS = {"http", "sse", "streamable-http", "streamable_http"}
+
+
+class _PluginMCPConfigError(ValueError):
+    """Raised when a plugin-relative MCP path escapes its permitted root."""
+
+
+def _resolved_within(path: Path, root: Path, field: str) -> Path:
+    try:
+        resolved = path.resolve()
+    except (OSError, RuntimeError, ValueError) as exc:
+        msg = f"Could not resolve plugin MCP {field}: {exc}"
+        raise _PluginMCPConfigError(msg) from exc
+    if not resolved.is_relative_to(root):
+        msg = f"Plugin MCP {field} escapes its permitted root"
+        raise _PluginMCPConfigError(msg)
+    return resolved
 
 
 def _safe_mcp_name_part(value: str) -> str:
@@ -72,13 +93,7 @@ def plugin_mcp_server_entries(
     Returns:
         Deduplicated server entries in declaration order.
     """
-    servers: dict[str, object] = {}
-    for path in plugin.inventory.mcp_files:
-        if path.suffix in {".mcpb", ".dxt"}:
-            continue
-        servers.update(_load_mcp_server_map(path))
-    if plugin.manifest and plugin.manifest.inline_mcp:
-        servers.update(_server_map(plugin.manifest.inline_mcp))
+    servers = _plugin_mcp_server_map(plugin)
     entries: list[tuple[str, str, bool]] = []
     seen: set[str] = set()
     for name, server in servers.items():
@@ -106,25 +121,42 @@ def _server_map(raw: object) -> JsonObject:
     """
     if not isinstance(raw, dict):
         return {}
-    wrapped = raw.get("mcpServers")
-    if isinstance(wrapped, dict):
-        return json_object(wrapped)
-    codex_wrapped = raw.get("mcp_servers")
-    if isinstance(codex_wrapped, dict):
-        return json_object(codex_wrapped)
+    if "mcpServers" in raw:
+        wrapped = raw.get("mcpServers")
+        return json_object(wrapped) if isinstance(wrapped, dict) else {}
+    if "mcp_servers" in raw:
+        wrapped = raw.get("mcp_servers")
+        return json_object(wrapped) if isinstance(wrapped, dict) else {}
     return json_object(raw)
 
 
-def _load_mcp_server_map(path: Path) -> JsonObject:
+def _load_mcp_server_map(
+    path: Path,
+    *,
+    dialect: PluginDialect | None = None,
+) -> JsonObject:
     """Load an MCP config file and extract its server-name to config map.
 
+    Args:
+        path: MCP configuration path.
+        dialect: Dialect policy for a conventional schema-bearing document.
+
     Returns:
-        The extracted server map, or an empty map when the file cannot be read.
+        The extracted server map, or an empty map when the file cannot be read
+        with the selected dialect.
     """
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("Skipping plugin MCP config %s: %s", path, exc)
+        return {}
+    schema = raw.get("$schema") if isinstance(raw, dict) else None
+    if dialect is not None and not accepts_mcp_schema(dialect, schema):
+        logger.warning(
+            "Skipping plugin MCP config %s: unsupported schema %r",
+            path,
+            schema,
+        )
         return {}
     return _server_map(raw)
 
@@ -136,6 +168,16 @@ def _plugin_mcp_server_map(plugin: PluginInstance) -> JsonObject:
         The unscoped server configuration keyed by declared server name.
     """
     servers: JsonObject = {}
+    dialect = (
+        dialect_by_name(plugin.manifest.dialect)
+        if plugin.manifest is not None
+        else None
+    )
+    conventional_mcp = (
+        (plugin.root / "mcp.json").resolve()
+        if dialect is not None and dialect.mcp_schema is not None
+        else None
+    )
     for path in plugin.inventory.mcp_files:
         if path.suffix in {".mcpb", ".dxt"}:
             logger.warning(
@@ -144,7 +186,12 @@ def _plugin_mcp_server_map(plugin: PluginInstance) -> JsonObject:
                 path,
             )
             continue
-        servers.update(_load_mcp_server_map(path))
+        servers.update(
+            _load_mcp_server_map(
+                path,
+                dialect=dialect if path == conventional_mcp else None,
+            )
+        )
     if plugin.manifest and plugin.manifest.inline_mcp:
         servers.update(_server_map(plugin.manifest.inline_mcp))
     return servers
@@ -166,30 +213,84 @@ def plugin_mcp_server_names(plugin: PluginInstance) -> tuple[str, ...]:
     )
 
 
+def _is_stdio_server(server: Mapping[str, object]) -> bool:
+    transport = server.get("type") or server.get("transport")
+    if transport is not None and not isinstance(transport, str):
+        return False
+    return "url" not in server and transport not in _REMOTE_TRANSPORTS
+
+
 def _normalize_server(
     server: object, *, plugin: PluginInstance, project_dir: Path | None
 ) -> JsonValue:
+    plugin_root = plugin.root.resolve()
+    plugin_data = plugin.data_dir.resolve()
+    dialect = (
+        dialect_by_name(plugin.manifest.dialect)
+        if plugin.manifest is not None
+        else None
+    )
+    enforce_containment = dialect is not None and dialect.mcp_schema is not None
     normalized_server = json_value(server)
+    raw_cwd = (
+        normalized_server.get("cwd") if isinstance(normalized_server, dict) else None
+    )
     substituted = substitute_json(
         normalized_server,
-        plugin_root=plugin.root,
-        plugin_data=plugin.data_dir,
+        plugin_root=plugin_root,
+        plugin_data=plugin_data,
         project_dir=project_dir,
     )
-    if isinstance(substituted, dict):
+    if not isinstance(substituted, dict):
+        return json_value(substituted)
+
+    if _is_stdio_server(substituted):
+        command = substituted.get("command")
+        if isinstance(command, str) and command.startswith("./"):
+            command_path = plugin_root / command[2:]
+            resolved_command = (
+                _resolved_within(command_path, plugin_root, "command")
+                if enforce_containment
+                else command_path.resolve()
+            )
+            substituted = {**substituted, "command": str(resolved_command)}
         cwd = substituted.get("cwd")
         if isinstance(cwd, str) and cwd and not Path(cwd).is_absolute():
-            substituted = {**substituted, "cwd": str((plugin.root / cwd).resolve())}
-        env = substituted.get("env")
-        plugin_env = plugin_environment(
-            plugin_root=plugin.root,
-            plugin_data=plugin.data_dir,
-            project_dir=project_dir,
-        )
-        if isinstance(env, dict):
-            substituted = {**substituted, "env": {**plugin_env, **env}}
-        else:
-            substituted = {**substituted, "env": plugin_env}
+            if "${" not in cwd:
+                cwd_path = plugin_root / cwd
+                resolved_cwd = (
+                    _resolved_within(cwd_path, plugin_root, "cwd")
+                    if enforce_containment
+                    else cwd_path.resolve()
+                )
+                substituted = {**substituted, "cwd": str(resolved_cwd)}
+        elif cwd is None:
+            substituted = {**substituted, "cwd": str(plugin_root)}
+        if enforce_containment and isinstance(raw_cwd, str):
+            cwd_root = None
+            if raw_cwd.startswith(("${PLUGIN_ROOT}", "${CLAUDE_PLUGIN_ROOT}")):
+                cwd_root = plugin_root
+            elif raw_cwd.startswith(("${PLUGIN_DATA}", "${CLAUDE_PLUGIN_DATA}")):
+                cwd_root = plugin_data
+            substituted_cwd = substituted.get("cwd")
+            if cwd_root is not None and isinstance(substituted_cwd, str):
+                resolved_cwd = _resolved_within(
+                    Path(substituted_cwd),
+                    cwd_root,
+                    "cwd",
+                )
+                substituted = {**substituted, "cwd": str(resolved_cwd)}
+
+    env = substituted.get("env")
+    plugin_env = plugin_environment(
+        plugin_root=plugin_root,
+        plugin_data=plugin_data,
+        project_dir=project_dir,
+    )
+    if isinstance(env, dict):
+        substituted = {**substituted, "env": {**env, **plugin_env}}
+    else:
+        substituted = {**substituted, "env": plugin_env}
     return json_value(substituted)
 
 
@@ -223,7 +324,7 @@ def plugin_mcp_configs(
 ) -> list[JsonObject]:
     """Build MCP config layers for enabled plugins.
 
-    Default `.mcp.json` files are loaded before manifest `mcpServers`, so manifest
+    Conventional MCP files are loaded before manifest `mcpServers`, so manifest
     entries win on server-name conflicts.
 
     Args:
@@ -252,9 +353,19 @@ def plugin_mcp_configs(
             if not isinstance(name, str):
                 continue
             scoped_name = scoped_mcp_server_name(plugin.plugin_id, name)
-            scoped[scoped_name] = _normalize_server(
-                server, plugin=plugin, project_dir=project_dir
-            )
+            try:
+                scoped[scoped_name] = _normalize_server(
+                    server,
+                    plugin=plugin,
+                    project_dir=project_dir,
+                )
+            except _PluginMCPConfigError as exc:
+                logger.warning(
+                    "Skipping plugin MCP server %s from %s: %s",
+                    name,
+                    plugin.plugin_id,
+                    exc,
+                )
         if scoped:
             configs.append({"mcpServers": scoped})
     return configs

--- a/libs/code/deepagents_code/plugins/discovery.py
+++ b/libs/code/deepagents_code/plugins/discovery.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from deepagents_code.plugins.manifest import (
     PluginManifestError,
-    build_inventory,
+    discover_components,
     load_manifest,
 )
 from deepagents_code.plugins.marketplace import (
@@ -281,7 +281,7 @@ def _validate_plugin_copy(
     except PluginManifestError as exc:
         msg = f"Cannot install {plugin_id}: {exc}"
         raise MarketplaceError(msg) from exc
-    build_inventory(root, manifest, warnings)
+    discover_components(root, manifest, warnings)
 
 
 def _plugin_from_install_path(
@@ -300,7 +300,7 @@ def _plugin_from_install_path(
         return None, (f"Skipping plugin {plugin_id}: {exc}",)
     warnings.extend(manifest_warnings)
     name = manifest.name if manifest and manifest.name else fallback_name
-    inventory = build_inventory(root, manifest, tuple(warnings))
+    inventory = discover_components(root, manifest, tuple(warnings))
     try:
         instance = PluginInstance(
             plugin_id=plugin_id,

--- a/libs/code/deepagents_code/plugins/layouts.py
+++ b/libs/code/deepagents_code/plugins/layouts.py
@@ -1,0 +1,146 @@
+"""Schema-selected layouts for supported plugin dialects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deepagents_code.plugins.models import PluginDialectName
+
+_AGENT_PLUGIN_SCHEMA_PREFIX = "https://agent-plugins.org/schemas/"
+AGENT_PLUGIN_V1_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+AGENT_PLUGIN_V1_MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
+
+
+@dataclass(frozen=True, slots=True)
+class PluginLayout:
+    """Conventional component locations for a plugin dialect."""
+
+    skill_paths: tuple[Path, ...]
+    mcp_paths: tuple[Path, ...]
+    hook_paths: tuple[Path, ...]
+    root_skill_fallback: bool
+
+
+@dataclass(frozen=True, slots=True)
+class PluginDialect:
+    """Manifest interpretation and component layout selected by schema."""
+
+    name: PluginDialectName
+    schema: str | None
+    mcp_schema: str | None
+    layout: PluginLayout
+    supports_auto_update: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentDiscoveryPlan:
+    """Ordered conventional and manifest-declared component candidates."""
+
+    skill_paths: tuple[Path, ...]
+    declared_skill_paths: tuple[Path, ...]
+    mcp_paths: tuple[Path, ...]
+    declared_mcp_paths: tuple[Path, ...]
+    hook_paths: tuple[Path, ...]
+    declared_hook_paths: tuple[Path, ...]
+    root_skill_path: Path | None
+
+
+CLAUDE_PLUGIN_DIALECT = PluginDialect(
+    name="claude",
+    schema=None,
+    mcp_schema=None,
+    layout=PluginLayout(
+        skill_paths=(Path("skills"),),
+        mcp_paths=(Path(".mcp.json"),),
+        hook_paths=(Path("hooks") / "hooks.json",),
+        root_skill_fallback=True,
+    ),
+    supports_auto_update=True,
+)
+
+AGENT_PLUGIN_V1_DIALECT = PluginDialect(
+    name="agent-plugin-v1",
+    schema=AGENT_PLUGIN_V1_SCHEMA,
+    mcp_schema=AGENT_PLUGIN_V1_MCP_SCHEMA,
+    layout=PluginLayout(
+        skill_paths=(Path("skills"),),
+        mcp_paths=(Path("mcp.json"),),
+        hook_paths=(Path("hooks") / "hooks.json",),
+        root_skill_fallback=False,
+    ),
+    supports_auto_update=False,
+)
+
+_DIALECTS_BY_NAME = {
+    CLAUDE_PLUGIN_DIALECT.name: CLAUDE_PLUGIN_DIALECT,
+    AGENT_PLUGIN_V1_DIALECT.name: AGENT_PLUGIN_V1_DIALECT,
+}
+_DIALECTS_BY_SCHEMA = {
+    dialect.schema: dialect
+    for dialect in _DIALECTS_BY_NAME.values()
+    if dialect.schema is not None
+}
+
+
+class UnsupportedPluginSchemaError(ValueError):
+    """Raised when a manifest targets an unsupported Agent Plugins schema."""
+
+
+def dialect_for_schema(schema: object) -> PluginDialect:
+    """Select a plugin dialect from a manifest schema value.
+
+    Args:
+        schema: Raw `$schema` value from the selected manifest.
+
+    Returns:
+        The registered Agent Plugin dialect for a supported schema, otherwise
+        the permissive Claude-style dialect.
+
+    Raises:
+        UnsupportedPluginSchemaError: If an Agent Plugins schema is recognized
+            but its version is unsupported.
+    """
+    if not isinstance(schema, str):
+        return CLAUDE_PLUGIN_DIALECT
+    dialect = _DIALECTS_BY_SCHEMA.get(schema)
+    if dialect is not None:
+        return dialect
+    if schema.startswith(_AGENT_PLUGIN_SCHEMA_PREFIX):
+        msg = f"Unsupported Agent Plugins schema: {schema}"
+        raise UnsupportedPluginSchemaError(msg)
+    return CLAUDE_PLUGIN_DIALECT
+
+
+def accepts_mcp_schema(dialect: PluginDialect, schema: object) -> bool:
+    """Return whether a component schema is compatible with its dialect.
+
+    Missing and non-Agent schemas remain permissive. Explicit Agent Plugins
+    schema versions must match the version selected by the package manifest.
+
+    Args:
+        dialect: Schema-selected plugin dialect.
+        schema: Raw `$schema` value from an MCP document.
+
+    Returns:
+        Whether the MCP document can use the selected loading strategy.
+    """
+    if not isinstance(schema, str) or not schema.startswith(
+        _AGENT_PLUGIN_SCHEMA_PREFIX
+    ):
+        return True
+    return dialect.mcp_schema == schema
+
+
+def dialect_by_name(name: PluginDialectName) -> PluginDialect:
+    """Return the registered dialect for a normalized dialect name.
+
+    Args:
+        name: Normalized plugin dialect name.
+
+    Returns:
+        Registered plugin dialect.
+    """
+    return _DIALECTS_BY_NAME[name]

--- a/libs/code/deepagents_code/plugins/manifest.py
+++ b/libs/code/deepagents_code/plugins/manifest.py
@@ -8,6 +8,12 @@ import re
 from pathlib import Path, PureWindowsPath
 
 from deepagents_code.plugins._json import json_object
+from deepagents_code.plugins.layouts import (
+    ComponentDiscoveryPlan,
+    UnsupportedPluginSchemaError,
+    dialect_by_name,
+    dialect_for_schema,
+)
 from deepagents_code.plugins.models import (
     ComponentInventory,
     JsonObject,
@@ -34,7 +40,7 @@ class PluginManifestError(ValueError):
     """Raised when a plugin manifest is malformed enough to skip the plugin."""
 
 
-def find_manifest_path(root: Path) -> Path | None:
+def select_manifest_path(root: Path) -> Path | None:
     """Return the first supported manifest path under `root`, if present.
 
     Args:
@@ -189,7 +195,7 @@ def _inline_hooks(value: object) -> JsonObject:
 def load_manifest(
     root: Path, *, fallback_name: str | None = None
 ) -> tuple[PluginManifest | None, Path | None, tuple[str, ...]]:
-    """Load an Agent Plugins, Claude, or Codex plugin manifest.
+    """Load an Agent Plugin or Claude-style plugin manifest.
 
     Args:
         root: Plugin root directory.
@@ -201,9 +207,18 @@ def load_manifest(
     Raises:
         PluginManifestError: If the manifest exists but is invalid.
     """
-    manifest_path = find_manifest_path(root)
+    manifest_path = select_manifest_path(root)
     if manifest_path is None:
         return None, None, ()
+    try:
+        resolved_manifest = manifest_path.resolve()
+        resolved_root = root.resolve()
+    except (OSError, RuntimeError, ValueError) as exc:
+        msg = f"Could not resolve plugin manifest {manifest_path}: {exc}"
+        raise PluginManifestError(msg) from exc
+    if not resolved_manifest.is_relative_to(resolved_root):
+        msg = f"Plugin manifest escapes plugin root: {manifest_path}"
+        raise PluginManifestError(msg)
     try:
         decoded = json.loads(manifest_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
@@ -216,6 +231,12 @@ def load_manifest(
         msg = f"Plugin manifest {manifest_path} must be a JSON object"
         raise PluginManifestError(msg)
     raw = json_object(decoded)
+    schema_value = raw.get("$schema")
+    schema = schema_value if isinstance(schema_value, str) else None
+    try:
+        dialect = dialect_for_schema(schema)
+    except UnsupportedPluginSchemaError as exc:
+        raise PluginManifestError(str(exc)) from exc
 
     warnings: list[str] = []
     name = _validate_name(raw.get("name"), fallback=fallback_name)
@@ -234,8 +255,10 @@ def load_manifest(
     version = version_value if isinstance(version_value, str) else None
     display_name_value = raw.get("displayName")
     auto_update_settings = raw.get("extensions")
-    if isinstance(auto_update_settings, dict):
+    if dialect.supports_auto_update and isinstance(auto_update_settings, dict):
         auto_update_settings = auto_update_settings.get("com.langchain.deepagents.code")
+    else:
+        auto_update_settings = None
     manifest = PluginManifest(
         name=name,
         version=version,
@@ -245,6 +268,8 @@ def load_manifest(
         display_name=(
             display_name_value if isinstance(display_name_value, str) else None
         ),
+        dialect=dialect.name,
+        schema=schema,
         auto_update=(
             isinstance(auto_update_settings, dict)
             and auto_update_settings.get("autoUpdate") is True
@@ -297,7 +322,34 @@ def _unsupported_component_dirs(
     return tuple(found)
 
 
-def build_inventory(
+def _component_discovery_plan(
+    plugin_root: Path,
+    manifest: PluginManifest | None,
+) -> ComponentDiscoveryPlan:
+    dialect = (
+        dialect_by_name(manifest.dialect)
+        if manifest is not None
+        else dialect_for_schema(None)
+    )
+    layout = dialect.layout
+    declared = manifest.component_paths if manifest is not None else {}
+    root_skill_path = (
+        plugin_root / "SKILL.md"
+        if layout.root_skill_fallback and "skills" not in declared
+        else None
+    )
+    return ComponentDiscoveryPlan(
+        skill_paths=tuple(plugin_root / path for path in layout.skill_paths),
+        declared_skill_paths=declared.get("skills", ()),
+        mcp_paths=tuple(plugin_root / path for path in layout.mcp_paths),
+        declared_mcp_paths=declared.get("mcpServers", ()),
+        hook_paths=tuple(plugin_root / path for path in layout.hook_paths),
+        declared_hook_paths=declared.get("hooks", ()),
+        root_skill_path=root_skill_path,
+    )
+
+
+def discover_components(
     plugin_root: Path,
     manifest: PluginManifest | None,
     manifest_warnings: tuple[str, ...] = (),
@@ -314,28 +366,33 @@ def build_inventory(
     """
     plugin_root = plugin_root.resolve()
     warnings = list(manifest_warnings)
-    metadata_paths = manifest.component_paths if manifest else {}
+    plan = _component_discovery_plan(plugin_root, manifest)
 
-    default_skills = _existing_component_path(plugin_root / "skills", plugin_root)
+    default_skills = tuple(
+        component
+        for path in plan.skill_paths
+        for component in _existing_component_path(path, plugin_root)
+    )
     root_skill = (
         ()
-        if default_skills or (manifest and "skills" in manifest.component_paths)
-        else _existing_component_path(plugin_root / "SKILL.md", plugin_root)
+        if default_skills or plan.root_skill_path is None
+        else _existing_component_path(plan.root_skill_path, plugin_root)
     )
-    skills = (*default_skills, *metadata_paths.get("skills", ()), *root_skill)
+    skills = (*default_skills, *plan.declared_skill_paths, *root_skill)
 
     mcp_files = (
-        *_existing_component_path(plugin_root / ".mcp.json", plugin_root),
-        *metadata_paths.get("mcpServers", ()),
+        *(
+            component
+            for path in plan.mcp_paths
+            for component in _existing_component_path(path, plugin_root)
+        ),
+        *plan.declared_mcp_paths,
     )
 
-    hook_files = (
-        *_hooks_document_paths(plugin_root / "hooks", plugin_root),
-        *(
-            document
-            for path in metadata_paths.get("hooks", ())
-            for document in _hooks_document_paths(path, plugin_root)
-        ),
+    hook_files = tuple(
+        document
+        for path in (*plan.hook_paths, *plan.declared_hook_paths)
+        for document in _hooks_document_paths(path, plugin_root)
     )
 
     unsupported = _unsupported_component_dirs(plugin_root)
@@ -347,3 +404,7 @@ def build_inventory(
         unsupported=unsupported,
         warnings=tuple(warnings),
     )
+
+
+find_manifest_path = select_manifest_path
+build_inventory = discover_components

--- a/libs/code/deepagents_code/plugins/models.py
+++ b/libs/code/deepagents_code/plugins/models.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 MarketplaceSourceType = Literal["directory", "file", "github", "git", "url"]
 ExternalPluginRepositorySourceType = Literal["github", "git-subdir", "url"]
+PluginDialectName = Literal["claude", "agent-plugin-v1"]
 UnsupportedComponent = Literal["agents", "commands"]
 """Plugin component directory that `deepagents-code` does not load."""
 
@@ -63,6 +64,8 @@ class PluginManifest:
         inline_mcp: Inline MCP servers declared in the manifest.
         inline_hooks: Inline hook configuration declared in the manifest, in
             `hooks.json` document form.
+        dialect: Schema-selected manifest and component layout dialect.
+        schema: Manifest schema URI, if one was declared.
         auto_update: Whether this plugin permits automatic updates.
     """
 
@@ -72,6 +75,8 @@ class PluginManifest:
     inline_mcp: JsonObject
     inline_hooks: JsonObject = field(default_factory=dict)
     display_name: str | None = None
+    dialect: PluginDialectName = "claude"
+    schema: str | None = None
     auto_update: bool = False
 
 

--- a/libs/code/deepagents_code/plugins/substitution.py
+++ b/libs/code/deepagents_code/plugins/substitution.py
@@ -23,8 +23,8 @@ def plugin_environment(
     Returns:
         Environment variables for plugin subprocesses.
     """
-    root = str(plugin_root)
-    data = str(plugin_data)
+    root = str(plugin_root.resolve())
+    data = str(plugin_data.resolve())
     env = {
         "CLAUDE_PLUGIN_ROOT": root,
         "CLAUDE_PLUGIN_DATA": data,

--- a/libs/code/tests/unit_tests/plugins/test_plugin_hooks.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugin_hooks.py
@@ -12,6 +12,7 @@ from deepagents_code.approval_mode import ApprovalMode
 from deepagents_code.hooks.manager import HookSessionIdentity, HooksManager
 from deepagents_code.hooks.models.domain import HookEvent, SessionStartCause
 from deepagents_code.plugins import add_local_marketplace, install_plugin
+from deepagents_code.plugins.layouts import AGENT_PLUGIN_V1_SCHEMA
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -37,6 +38,8 @@ def _stage_plugins(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     documents: Mapping[str, dict[str, object] | bytes],
+    *,
+    agent_plugin: bool = False,
 ) -> tuple[Path, Path]:
     user_dir = tmp_path / "config"
     user_dir.mkdir(parents=True, exist_ok=True)
@@ -57,10 +60,15 @@ def _stage_plugins(
     )
     for name, document in documents.items():
         plugin = root / "plugins" / name
-        _write_json(
-            plugin / ".claude-plugin" / "plugin.json",
-            {"name": name, "version": "1.0.0"},
+        manifest_path = (
+            plugin / "plugin.json"
+            if agent_plugin
+            else plugin / ".claude-plugin" / "plugin.json"
         )
+        manifest: dict[str, object] = {"name": name, "version": "1.0.0"}
+        if agent_plugin:
+            manifest["$schema"] = AGENT_PLUGIN_V1_SCHEMA
+        _write_json(manifest_path, manifest)
         hooks_path = plugin / "hooks" / "hooks.json"
         hooks_path.parent.mkdir(parents=True, exist_ok=True)
         if isinstance(document, bytes):
@@ -78,8 +86,12 @@ def _install_all(root: Path, names: tuple[str, ...]) -> tuple[Path, ...]:
 @pytest.mark.skipif(
     sys.platform == "win32", reason="the hook command needs a POSIX shell"
 )
+@pytest.mark.parametrize("agent_plugin", [False, True])
 async def test_plugin_hook_runs_with_its_exported_variables(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    agent_plugin: bool,
 ) -> None:
     from deepagents_code.plugins.store import plugin_data_dir
 
@@ -93,6 +105,7 @@ async def test_plugin_hook_runs_with_its_exported_variables(
                 '"${CLAUDE_PROJECT_DIR}" > "${CLAUDE_PLUGIN_DATA}/observed.txt"'
             )
         },
+        agent_plugin=agent_plugin,
     )
     (plugin_root,) = _install_all(root, ("quality-review-plugin",))
     workspace = tmp_path / "$(touch${IFS}PWNED)"

--- a/libs/code/tests/unit_tests/plugins/test_plugin_layouts.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugin_layouts.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from deepagents_code.mcp_config import resolve_mcp_server_env
+from deepagents_code.plugins import (
+    add_local_marketplace,
+    discover_plugins,
+    install_plugin,
+)
+from deepagents_code.plugins.adapters.hooks import discover_plugin_hook_sources
+from deepagents_code.plugins.adapters.mcp import (
+    plugin_mcp_configs,
+    scoped_mcp_server_name,
+)
+from deepagents_code.plugins.layouts import (
+    AGENT_PLUGIN_V1_MCP_SCHEMA,
+    AGENT_PLUGIN_V1_SCHEMA,
+)
+from deepagents_code.plugins.manifest import (
+    PluginManifestError,
+    discover_components,
+    load_manifest,
+    select_manifest_path,
+)
+from deepagents_code.plugins.models import PluginInstance
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from deepagents_code.plugins.models import JsonObject, PluginManifest
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _write_skill(path: Path, name: str = "review") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nname: {name}\ndescription: Review code.\n---\n\nReview code.",
+        encoding="utf-8",
+    )
+
+
+def _agent_manifest(name: str = "quality") -> dict[str, object]:
+    return {
+        "$schema": AGENT_PLUGIN_V1_SCHEMA,
+        "name": name,
+        "version": "1.0.0",
+    }
+
+
+def _plugin_instance(
+    root: Path,
+    manifest: PluginManifest,
+    *,
+    plugin_id: str = "quality@tools",
+) -> PluginInstance:
+    return PluginInstance(
+        plugin_id=plugin_id,
+        name=plugin_id.rsplit("@", 1)[0],
+        marketplace=plugin_id.rsplit("@", 1)[1],
+        version=manifest.version,
+        root=root,
+        data_dir=root.parent / "data" / plugin_id,
+        manifest=manifest,
+        inventory=discover_components(root, manifest),
+    )
+
+
+@pytest.mark.parametrize(
+    ("schema", "expected"),
+    [
+        (AGENT_PLUGIN_V1_SCHEMA, "agent-plugin-v1"),
+        (None, "claude"),
+        ("https://example.com/plugin.schema.json", "claude"),
+    ],
+)
+def test_root_manifest_schema_selects_dialect(
+    tmp_path: Path,
+    schema: str | None,
+    expected: str,
+) -> None:
+    document: dict[str, object] = {"name": "quality", "futureField": True}
+    if schema is not None:
+        document["$schema"] = schema
+    _write_json(tmp_path / "plugin.json", document)
+
+    manifest, path, warnings = load_manifest(tmp_path)
+
+    assert manifest is not None
+    assert manifest.dialect == expected
+    assert manifest.schema == schema
+    assert path == tmp_path / "plugin.json"
+    assert warnings == ()
+
+
+def test_future_agent_plugin_schema_is_not_misread_as_claude(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "plugin.json",
+        {
+            "$schema": "https://agent-plugins.org/schemas/2.0.0/plugin.schema.json",
+            "name": "quality",
+        },
+    )
+
+    with pytest.raises(PluginManifestError, match="Unsupported Agent Plugins schema"):
+        load_manifest(tmp_path)
+
+
+def test_root_manifest_is_authoritative(tmp_path: Path) -> None:
+    _write_json(tmp_path / "plugin.json", _agent_manifest())
+    nested = tmp_path / ".claude-plugin" / "plugin.json"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("{invalid", encoding="utf-8")
+
+    manifest, path, _warnings = load_manifest(tmp_path)
+
+    assert manifest is not None
+    assert manifest.dialect == "agent-plugin-v1"
+    assert path == tmp_path / "plugin.json"
+    assert select_manifest_path(tmp_path) == tmp_path / "plugin.json"
+
+
+def test_invalid_root_manifest_does_not_fall_through(tmp_path: Path) -> None:
+    (tmp_path / "plugin.json").write_text("{invalid", encoding="utf-8")
+    _write_json(
+        tmp_path / ".claude-plugin" / "plugin.json",
+        {"name": "quality"},
+    )
+
+    with pytest.raises(PluginManifestError, match="Invalid JSON syntax"):
+        load_manifest(tmp_path)
+
+
+def test_manifest_symlink_cannot_escape_plugin_root(tmp_path: Path) -> None:
+    root = tmp_path / "plugin"
+    root.mkdir()
+    outside = tmp_path / "outside.json"
+    _write_json(outside, _agent_manifest())
+    try:
+        (root / "plugin.json").symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(PluginManifestError, match="escapes plugin root"):
+        load_manifest(root)
+
+
+def test_agent_layout_composes_standard_paths_hooks_and_declarations(
+    tmp_path: Path,
+) -> None:
+    manifest_document = {
+        **_agent_manifest(),
+        "skills": "./extra-skills",
+        "mcpServers": "./extra-mcp.json",
+        "hooks": "./extra-hooks.json",
+    }
+    _write_json(tmp_path / "plugin.json", manifest_document)
+    _write_skill(tmp_path / "skills" / "review" / "SKILL.md")
+    _write_skill(tmp_path / "extra-skills" / "audit" / "SKILL.md", "audit")
+    _write_skill(tmp_path / "SKILL.md", "root")
+    _write_json(tmp_path / "mcp.json", {"mcpServers": {}})
+    _write_json(tmp_path / ".mcp.json", {"mcpServers": {"ignored": {}}})
+    _write_json(tmp_path / "extra-mcp.json", {"mcpServers": {}})
+    _write_json(tmp_path / "hooks" / "hooks.json", {"hooks": {}})
+    _write_json(tmp_path / "extra-hooks.json", {"hooks": {}})
+
+    manifest, _path, warnings = load_manifest(tmp_path)
+    assert manifest is not None
+    inventory = discover_components(tmp_path, manifest, warnings)
+
+    assert inventory.skills == (
+        (tmp_path / "skills").resolve(),
+        (tmp_path / "extra-skills").resolve(),
+    )
+    assert inventory.mcp_files == (
+        (tmp_path / "mcp.json").resolve(),
+        (tmp_path / "extra-mcp.json").resolve(),
+    )
+    assert inventory.hook_files == (
+        (tmp_path / "hooks" / "hooks.json").resolve(),
+        (tmp_path / "extra-hooks.json").resolve(),
+    )
+
+
+def test_claude_layout_preserves_existing_conventions(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / ".claude-plugin" / "plugin.json",
+        {"name": "quality"},
+    )
+    _write_skill(tmp_path / "SKILL.md")
+    _write_json(tmp_path / ".mcp.json", {"mcpServers": {}})
+    _write_json(tmp_path / "mcp.json", {"mcpServers": {"ignored": {}}})
+    _write_json(tmp_path / "hooks" / "hooks.json", {"hooks": {}})
+
+    manifest, _path, warnings = load_manifest(tmp_path)
+    assert manifest is not None
+    inventory = discover_components(tmp_path, manifest, warnings)
+
+    assert manifest.dialect == "claude"
+    assert inventory.skills == ((tmp_path / "SKILL.md").resolve(),)
+    assert inventory.mcp_files == ((tmp_path / ".mcp.json").resolve(),)
+    assert inventory.hook_files == ((tmp_path / "hooks" / "hooks.json").resolve(),)
+
+
+@pytest.mark.parametrize("dialect", ["agent-plugin-v1", "claude"])
+def test_plugin_stdio_defaults_are_shared_across_dialects(
+    tmp_path: Path,
+    dialect: str,
+) -> None:
+    root = tmp_path / dialect
+    if dialect == "agent-plugin-v1":
+        _write_json(root / "plugin.json", _agent_manifest())
+        mcp_path = root / "mcp.json"
+    else:
+        _write_json(
+            root / ".claude-plugin" / "plugin.json",
+            {"name": "quality"},
+        )
+        mcp_path = root / ".mcp.json"
+    _write_json(
+        mcp_path,
+        {"mcpServers": {"stdio": {"command": "./bin/server"}}},
+    )
+    manifest, _path, _warnings = load_manifest(root)
+    assert manifest is not None
+    plugin = _plugin_instance(root, manifest)
+
+    configs = plugin_mcp_configs((plugin,))
+    servers = cast("dict[str, JsonObject]", configs[0]["mcpServers"])
+    server = servers[scoped_mcp_server_name(plugin.plugin_id, "stdio")]
+
+    assert server["command"] == str((root / "bin" / "server").resolve())
+    assert server["cwd"] == str(root.resolve())
+
+
+def test_agent_and_claude_auto_update_semantics_are_independent(
+    tmp_path: Path,
+) -> None:
+    setting = {"com.langchain.deepagents.code": {"autoUpdate": True}}
+    agent_root = tmp_path / "agent"
+    claude_root = tmp_path / "claude"
+    _write_json(
+        agent_root / "plugin.json",
+        {**_agent_manifest(), "extensions": setting},
+    )
+    _write_json(
+        claude_root / ".claude-plugin" / "plugin.json",
+        {"name": "quality", "extensions": setting},
+    )
+
+    agent, _path, _warnings = load_manifest(agent_root)
+    claude, _path, _warnings = load_manifest(claude_root)
+
+    assert agent is not None
+    assert claude is not None
+    assert agent.auto_update is False
+    assert claude.auto_update is True
+
+
+def test_unsupported_agent_mcp_schema_disables_only_mcp(tmp_path: Path) -> None:
+    root = tmp_path / "plugin"
+    _write_json(root / "plugin.json", _agent_manifest())
+    _write_skill(root / "skills" / "review" / "SKILL.md")
+    _write_json(
+        root / "mcp.json",
+        {
+            "$schema": "https://agent-plugins.org/schemas/2.0.0/mcp.schema.json",
+            "mcpServers": {"server": {"command": "python"}},
+        },
+    )
+    manifest, _path, _warnings = load_manifest(root)
+    assert manifest is not None
+    plugin = _plugin_instance(root, manifest)
+
+    assert plugin.inventory.skills == ((root / "skills").resolve(),)
+    assert plugin_mcp_configs((plugin,)) == []
+
+
+def test_agent_mcp_path_escapes_are_isolated(tmp_path: Path) -> None:
+    root = tmp_path / "plugin"
+    _write_json(root / "plugin.json", _agent_manifest())
+    outside = tmp_path / "outside"
+    outside.write_text("server", encoding="utf-8")
+    (root / "bin").mkdir(parents=True)
+    try:
+        (root / "bin" / "linked").symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+    _write_json(
+        root / "mcp.json",
+        {
+            "mcpServers": {
+                "valid": {"command": "python"},
+                "command-traversal": {"command": "./../outside"},
+                "cwd-traversal": {"command": "python", "cwd": "../outside"},
+                "symlink-escape": {"command": "./bin/linked"},
+            }
+        },
+    )
+    manifest, _path, _warnings = load_manifest(root)
+    assert manifest is not None
+    plugin = _plugin_instance(root, manifest)
+
+    configs = plugin_mcp_configs((plugin,))
+    servers = cast("dict[str, JsonObject]", configs[0]["mcpServers"])
+
+    assert set(servers) == {scoped_mcp_server_name(plugin.plugin_id, "valid")}
+
+
+def test_agent_mcp_uses_shared_substitution_and_environment_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "plugin"
+    _write_json(root / "plugin.json", _agent_manifest())
+    _write_json(
+        root / "mcp.json",
+        {
+            "$schema": AGENT_PLUGIN_V1_MCP_SCHEMA,
+            "mcpServers": {
+                "stdio": {
+                    "type": "stdio",
+                    "command": "./bin/server",
+                    "args": ["${PLUGIN_ROOT}", "${PLUGIN_TOKEN}"],
+                    "cwd": "work",
+                    "env": {
+                        "TOKEN": "${PLUGIN_TOKEN}",
+                        "PLUGIN_ROOT": "/configured/root",
+                        "PLUGIN_DATA": "/configured/data",
+                    },
+                },
+                "remote": {
+                    "type": "streamable-http",
+                    "url": "https://example.com/${PLUGIN_PATH}",
+                    "headers": {"Authorization": "Bearer ${PLUGIN_TOKEN}"},
+                },
+                "ambient-cwd": {
+                    "command": "python",
+                    "cwd": "${PLUGIN_WORK_DIR}",
+                },
+                "invalid": {"type": []},
+            },
+        },
+    )
+    manifest, _path, _warnings = load_manifest(root)
+    assert manifest is not None
+    plugin = _plugin_instance(root, manifest)
+
+    configs = plugin_mcp_configs((plugin,), project_dir=tmp_path / "project")
+    servers = cast("dict[str, JsonObject]", configs[0]["mcpServers"])
+    stdio_name = scoped_mcp_server_name(plugin.plugin_id, "stdio")
+    remote_name = scoped_mcp_server_name(plugin.plugin_id, "remote")
+    ambient_cwd_name = scoped_mcp_server_name(plugin.plugin_id, "ambient-cwd")
+    invalid_name = scoped_mcp_server_name(plugin.plugin_id, "invalid")
+    assert invalid_name in servers
+    stdio = servers[stdio_name]
+    remote = servers[remote_name]
+    ambient_cwd = servers[ambient_cwd_name]
+    stdio_env = cast("dict[str, str]", stdio["env"])
+    remote_env = cast("dict[str, str]", remote["env"])
+
+    assert stdio["command"] == str((root / "bin" / "server").resolve())
+    assert stdio["cwd"] == str((root / "work").resolve())
+    assert stdio_env["PLUGIN_ROOT"] == str(root.resolve())
+    assert stdio_env["PLUGIN_DATA"] == str(plugin.data_dir.resolve())
+    assert stdio_env["TOKEN"] == "${PLUGIN_TOKEN}"
+    assert remote_env["PLUGIN_ROOT"] == str(root.resolve())
+    assert ambient_cwd["cwd"] == "${PLUGIN_WORK_DIR}"
+
+    monkeypatch.setenv("PLUGIN_TOKEN", "token-value")
+    monkeypatch.setenv("PLUGIN_PATH", "mcp")
+    monkeypatch.setenv("PLUGIN_WORK_DIR", "/tmp/plugin-work")
+    resolved_stdio = resolve_mcp_server_env(stdio_name, stdio)
+    resolved_remote = resolve_mcp_server_env(remote_name, remote)
+    resolved_ambient_cwd = resolve_mcp_server_env(
+        ambient_cwd_name,
+        ambient_cwd,
+    )
+
+    assert resolved_stdio["args"] == [str(root.resolve()), "token-value"]
+    assert resolved_stdio["env"]["TOKEN"] == "token-value"
+    assert resolved_remote["url"] == "https://example.com/mcp"
+    assert resolved_remote["headers"]["Authorization"] == "Bearer token-value"
+    assert resolved_ambient_cwd["cwd"] == "/tmp/plugin-work"
+
+
+def test_agent_hooks_use_the_shared_hook_adapter(tmp_path: Path) -> None:
+    root = tmp_path / "plugin"
+    _write_json(
+        root / "plugin.json",
+        {
+            **_agent_manifest(),
+            "hooks": {"Stop": [{"hooks": [{"type": "command", "command": "inline"}]}]},
+        },
+    )
+    _write_json(
+        root / "hooks" / "hooks.json",
+        {
+            "hooks": {
+                "SessionStart": [{"hooks": [{"type": "command", "command": "file"}]}]
+            }
+        },
+    )
+    manifest, _path, _warnings = load_manifest(root)
+    assert manifest is not None
+    plugin = _plugin_instance(root, manifest)
+
+    documents, diagnostics = discover_plugin_hook_sources(
+        project_dir=tmp_path / "project",
+        plugins=(plugin,),
+    )
+
+    assert diagnostics == ()
+    assert len(documents) == 2
+    assert documents[0][0].location == str((root / "hooks" / "hooks.json").resolve())
+    assert documents[0][0].env["PLUGIN_ROOT"] == str(root.resolve())
+    assert documents[1][0].location == str(root / "plugin.json")
+
+
+def test_marketplace_installs_and_discovers_agent_plugin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR",
+        tmp_path / "state",
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR",
+        tmp_path / "config",
+    )
+    marketplace = tmp_path / "marketplace"
+    _write_json(
+        marketplace / ".claude-plugin" / "marketplace.json",
+        {
+            "name": "tools",
+            "plugins": [{"name": "quality", "source": "./plugins/quality"}],
+        },
+    )
+    source = marketplace / "plugins" / "quality"
+    _write_json(source / "plugin.json", _agent_manifest())
+    _write_skill(source / "skills" / "review" / "SKILL.md")
+    _write_json(source / "mcp.json", {"mcpServers": {}})
+    _write_json(source / "hooks" / "hooks.json", {"hooks": {}})
+
+    add_local_marketplace(marketplace)
+    installed = install_plugin("quality@tools")
+    discovered = discover_plugins().plugins
+
+    assert installed.manifest is not None
+    assert installed.manifest.dialect == "agent-plugin-v1"
+    assert installed.root != source
+    assert installed.inventory.skills == ((installed.root / "skills").resolve(),)
+    assert installed.inventory.mcp_files == ((installed.root / "mcp.json").resolve(),)
+    assert installed.inventory.hook_files == (
+        (installed.root / "hooks" / "hooks.json").resolve(),
+    )
+    assert discovered == (installed,)

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -495,6 +495,13 @@ class TestLoadMCPConfig:
         with pytest.raises(TypeError, match="env"):
             load_mcp_config(path)
 
+    def test_stdio_cwd_wrong_type(self, write_config: Callable[..., str]) -> None:
+        path = write_config(
+            {"mcpServers": {"fs": {"command": "x", "cwd": ["invalid"]}}}
+        )
+        with pytest.raises(TypeError, match="cwd"):
+            load_mcp_config(path)
+
     def test_remote_missing_url(self, write_config: Callable[..., str]) -> None:
         """Remote servers must declare a `url`."""
         path = write_config({"mcpServers": {"api": {"transport": "http"}}})
@@ -1429,6 +1436,7 @@ class TestGetMCPTools:
                 "srv": {
                     "command": "${DA_MCP_HOME}/server",
                     "args": ["--root", "${DA_MCP_HOME}"],
+                    "cwd": "${DA_MCP_HOME}/work",
                     "env": {"TOKEN": "${DA_MCP_TOKEN}"},
                 }
             }
@@ -1442,9 +1450,11 @@ class TestGetMCPTools:
 
         assert checked[0]["command"] == "/opt/mcp/server"
         assert checked[0]["args"] == ["--root", "/opt/mcp"]
+        assert checked[0]["cwd"] == "/opt/mcp/work"
         assert recorded[0] == {
             "command": "/opt/mcp/server",
             "args": ["--root", "/opt/mcp"],
+            "cwd": "/opt/mcp/work",
             "env": {"TOKEN": "token"},
             "transport": "stdio",
         }
@@ -5312,6 +5322,39 @@ class TestSelectiveProjectMcpTrust:
 
         assert merged is not None
         assert set(merged["mcpServers"]) == {"plugin", "other"}
+
+    async def test_invalid_plugin_server_does_not_hide_valid_sibling(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        home = tmp_path / "home"
+        (home / ".deepagents").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        user_config = tmp_path / "config.toml"
+        user_config.write_text("[mcp]\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "deepagents_code.model_config.DEFAULT_CONFIG_PATH", user_config
+        )
+        loader = AsyncMock(return_value=([], None, []))
+        monkeypatch.setattr("deepagents_code.mcp_tools._load_tools_from_config", loader)
+        ctx = ProjectContext(user_cwd=project, project_root=project)
+
+        _tools, _manager, infos = await resolve_and_load_mcp_tools(
+            project_context=ctx,
+            trust_project_mcp=False,
+            additional_configs=(
+                {
+                    "mcpServers": {
+                        "valid": self._stdio(),
+                        "invalid": {"type": []},
+                    }
+                },
+            ),
+        )
+
+        assert set(loader.call_args.args[0]["mcpServers"]) == {"valid"}
+        assert any(info.name == "invalid" and info.status == "error" for info in infos)
 
     async def test_disabled_plugin_server_stays_disabled(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Supersedes #5378

Deep Agents Code can now load Agent Plugins v1 package layouts alongside Claude-style plugins while retaining hooks and environment-aware MCP behavior.

---

Agent Plugins defines a useful portable core, but treating its schema as a capability allowlist would prevent dcode plugins from composing additional supported components. This change instead uses the selected manifest schema to choose a package dialect and conventional layout, then converges both dialects on the existing skills, hooks, and MCP adapters.

The root manifest remains authoritative over nested Claude-compatible locations. Agent Plugin packages discover `skills/` and `mcp.json`; Claude-style packages retain their existing conventions. Both can declare additional dcode components, load hooks, and use the same MCP environment interpolation and connection path. Explicit unsupported Agent schema versions are rejected, plugin-relative Agent MCP paths remain contained, and malformed MCP servers are isolated from valid siblings.

The layout and discovery-plan models leave component discovery composable without introducing a runtime extensions system.

<details>
<summary>Test plan</summary>

- Full Deep Agents Code unit suite: 12,376 passed, 3 skipped
- Focused plugin layout, plugin hook, and MCP tests
- Ruff formatting and lint checks on all changed files
- `ty` type checking
- Command catalog drift check

</details>
