### PR TITLE
fix(code): clarify project hooks trust prompt and stop prompting for user hooks

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3869,7 +3869,7 @@ def _check_mcp_project_trust(
     return True
 
 
-_PROJECT_HOOKS_REMEMBER_LABEL = "Always allow hooks in this repo"
+_PROJECT_HOOKS_REMEMBER_LABEL = "Always allow hooks in this project"
 
 
 def _check_project_hooks_trust(
@@ -3931,8 +3931,7 @@ def _check_project_hooks_trust(
     prompt_console.print(f"Hooks file: {escape(str(config_path))}", highlight=False)
     prompt_console.print(
         f'Trusting "{escape(str(project_root))}" means its hooks run without '
-        "asking, including any future edits. Only trust repositories you "
-        "control.",
+        "asking, including any future edits. Only trust projects you control.",
         style="yellow",
         highlight=False,
     )

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3935,9 +3935,9 @@ def _check_project_hooks_trust(
     )
     prompt_console.print(f"Hooks file: {escape(str(config_path))}", highlight=False)
     prompt_console.print(
-        f'Trusting "{escape(str(project_root))}" lets the hooks it defines now '
-        "and any future edits to them run without asking. Only trust "
-        "repositories you control.",
+        f'Trusting "{escape(str(project_root))}" means its hooks run without '
+        "asking, including any future edits. Only trust repositories you "
+        "control.",
         style="yellow",
         highlight=False,
     )

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3924,6 +3924,8 @@ def _check_project_hooks_trust(
     if trust_flag or is_project_hooks_trusted(project_root):
         return granted
 
+    from rich.markup import escape
+
     prompt_console = Console(stderr=True)
     prompt_console.print()
     prompt_console.print(
@@ -3931,11 +3933,11 @@ def _check_project_hooks_trust(
         "machine.[/bold yellow]",
         highlight=False,
     )
-    prompt_console.print(f"Hooks file: {config_path}", highlight=False)
+    prompt_console.print(f"Hooks file: {escape(str(config_path))}", highlight=False)
     prompt_console.print(
-        f'Trusting "{project_root}" lets the hooks it defines now and any '
-        "future edits to them run without asking. Only trust repositories you "
-        "control.",
+        f'Trusting "{escape(str(project_root))}" lets the hooks it defines now '
+        "and any future edits to them run without asking. Only trust "
+        "repositories you control.",
         style="yellow",
         highlight=False,
     )
@@ -3962,8 +3964,8 @@ def _check_project_hooks_trust(
             )
         else:
             prompt_console.print(
-                f'[dim]Hooks for "{project_root}" will run without asking from '
-                "now on.[/dim]",
+                f'[dim]Hooks for "{escape(str(project_root))}" will run without '
+                "asking from now on.[/dim]",
                 highlight=False,
             )
         return granted

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3869,7 +3869,7 @@ def _check_mcp_project_trust(
     return True
 
 
-_PROJECT_HOOKS_REMEMBER_LABEL = "Always allow hooks in this workspace"
+_PROJECT_HOOKS_REMEMBER_LABEL = "Always allow hooks in this repo"
 
 
 def _check_project_hooks_trust(
@@ -3891,7 +3891,6 @@ def _check_project_hooks_trust(
         abort startup.
     """
     from rich.console import Console
-    from rich.text import Text
 
     from deepagents_code.hooks.loading import project_hooks_path
     from deepagents_code.hooks.trust import (
@@ -3903,7 +3902,17 @@ def _check_project_hooks_trust(
 
     try:
         context = ProjectContext.from_user_cwd(Path.cwd())
-        project_root = context.project_root or context.user_cwd
+        if context.project_root is None:
+            # No git root: hooks are only ever loaded from the user config
+            # (~/.deepagents/hooks.json), which needs no trust decision. Skipping
+            # here also keeps a home directory that happens to be a git repo from
+            # turning `~` into a trusted "workspace" — the user hooks path would
+            # otherwise double as the project hooks path (`~/` is the project
+            # root, so the project path resolves to `~/.deepagents/hooks.json`),
+            # and allowing once would execute user hooks thinking they were
+            # project-scoped.
+            return WorkspaceTrust.none()
+        project_root = context.project_root
         config_path = project_hooks_path(project_root)
         if not config_path.is_file():
             return WorkspaceTrust.none()
@@ -3917,12 +3926,16 @@ def _check_project_hooks_trust(
 
     prompt_console = Console(stderr=True)
     prompt_console.print()
-    title = Text("Project hooks can execute commands from ", style="bold yellow")
-    title.append(str(config_path))
-    prompt_console.print(title, highlight=False)
     prompt_console.print(
-        "Only allow hooks for projects you trust. Future edits to this file "
-        "will run without asking again if you always allow.",
+        "[bold yellow]Project hooks can run arbitrary shell commands on your "
+        "machine.[/bold yellow]",
+        highlight=False,
+    )
+    prompt_console.print(f"Hooks file: {config_path}", highlight=False)
+    prompt_console.print(
+        f'Trusting "{project_root}" lets the hooks it defines now and any '
+        "future edits to them run without asking. Only trust repositories you "
+        "control.",
         style="yellow",
         highlight=False,
     )
@@ -3949,7 +3962,8 @@ def _check_project_hooks_trust(
             )
         else:
             prompt_console.print(
-                "[dim]Project hooks trusted for this workspace.[/dim]",
+                f'[dim]Hooks for "{project_root}" will run without asking from '
+                "now on.[/dim]",
                 highlight=False,
             )
         return granted

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3892,7 +3892,7 @@ def _check_project_hooks_trust(
     """
     from rich.console import Console
 
-    from deepagents_code.hooks.loading import project_hooks_path
+    from deepagents_code.hooks.loading import project_hooks_path, user_hooks_path
     from deepagents_code.hooks.trust import (
         WorkspaceTrust,
         is_project_hooks_trusted,
@@ -3902,18 +3902,13 @@ def _check_project_hooks_trust(
 
     try:
         context = ProjectContext.from_user_cwd(Path.cwd())
-        if context.project_root is None:
-            # No git root: hooks are only ever loaded from the user config
-            # (~/.deepagents/hooks.json), which needs no trust decision. Skipping
-            # here also keeps a home directory that happens to be a git repo from
-            # turning `~` into a trusted "workspace" — the user hooks path would
-            # otherwise double as the project hooks path (`~/` is the project
-            # root, so the project path resolves to `~/.deepagents/hooks.json`),
-            # and allowing once would execute user hooks thinking they were
-            # project-scoped.
-            return WorkspaceTrust.none()
-        project_root = context.project_root
+        project_root = context.project_root or context.user_cwd
         config_path = project_hooks_path(project_root)
+        if config_path.resolve(strict=False) == user_hooks_path().resolve(strict=False):
+            # Running from the user config's parent makes the user hooks path
+            # look project-scoped. It needs no trust decision and must not be
+            # granted project trust under the wrong provenance.
+            return WorkspaceTrust.none()
         if not config_path.is_file():
             return WorkspaceTrust.none()
     except OSError:

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3930,8 +3930,9 @@ def _check_project_hooks_trust(
     )
     prompt_console.print(f"Hooks file: {escape(str(config_path))}", highlight=False)
     prompt_console.print(
-        f'Trusting "{escape(str(project_root))}" means its hooks run without '
-        "asking, including any future edits. Only trust projects you control.",
+        "Only trust projects you control. Allow once runs this file as it is "
+        f'now; always allow trusts "{escape(str(project_root))}" for future '
+        "sessions and future edits.",
         style="yellow",
         highlight=False,
     )

--- a/libs/code/deepagents_code/tui/widgets/cwd_switch.py
+++ b/libs/code/deepagents_code/tui/widgets/cwd_switch.py
@@ -281,15 +281,16 @@ class HookTrustScreen(ModalScreen[HookTrustChoice]):
         """
         with Vertical():
             yield Static(
-                "Project hooks can execute commands",
+                "Project hooks can run arbitrary shell commands on your machine",
                 classes="cwd-switch-title",
                 markup=False,
             )
             yield Static(
                 Content.from_markup(
-                    "The workspace [bold]$root[/bold] contains project hooks at "
-                    "[bold]$path[/bold]. Only allow hooks for projects you trust. "
-                    "Always allow also trusts future edits to this file.",
+                    "[bold]$root[/bold] contains project hooks at "
+                    "[bold]$path[/bold]. Trusting it means its hooks run without "
+                    "asking, including any future edits. Only trust projects you "
+                    "control.",
                     root=self._project_root,
                     path=self._config_path,
                 ),

--- a/libs/code/deepagents_code/tui/widgets/cwd_switch.py
+++ b/libs/code/deepagents_code/tui/widgets/cwd_switch.py
@@ -288,9 +288,10 @@ class HookTrustScreen(ModalScreen[HookTrustChoice]):
             yield Static(
                 Content.from_markup(
                     "[bold]$root[/bold] contains project hooks at "
-                    "[bold]$path[/bold]. Only trust projects you control. Allow "
-                    "once runs the file as it is now; always allow trusts "
-                    "[bold]$root[/bold] for future sessions and future edits.",
+                    "[bold]$path[/bold]. Only trust projects you control. "
+                    '"Allow once" runs the file as it is now; "always allow" '
+                    "trusts [bold]$root[/bold] for future sessions and future "
+                    "edits.",
                     root=self._project_root,
                     path=self._config_path,
                 ),

--- a/libs/code/deepagents_code/tui/widgets/cwd_switch.py
+++ b/libs/code/deepagents_code/tui/widgets/cwd_switch.py
@@ -288,9 +288,9 @@ class HookTrustScreen(ModalScreen[HookTrustChoice]):
             yield Static(
                 Content.from_markup(
                     "[bold]$root[/bold] contains project hooks at "
-                    "[bold]$path[/bold]. Trusting it means its hooks run without "
-                    "asking, including any future edits. Only trust projects you "
-                    "control.",
+                    "[bold]$path[/bold]. Only trust projects you control. Allow "
+                    "once runs the file as it is now; always allow trusts "
+                    "[bold]$root[/bold] for future sessions and future edits.",
                     root=self._project_root,
                     path=self._config_path,
                 ),

--- a/libs/code/tests/unit_tests/hooks/test_trust.py
+++ b/libs/code/tests/unit_tests/hooks/test_trust.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from deepagents_code.approval_mode import ApprovalMode
+from deepagents_code.hooks.loading import project_hooks_path
 from deepagents_code.hooks.manager import HookSessionIdentity, HooksManager
 from deepagents_code.hooks.models.domain import (
     HookContext,
@@ -234,13 +235,17 @@ def test_non_git_workspace_without_hooks_skips_prompt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from deepagents_code.hooks import trust
     from deepagents_code.main import _check_project_hooks_trust
 
     # No .git or project hooks exist anywhere under tmp_path.
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
+        trust, "_default_store_path", lambda: tmp_path / "state" / "hooks_trust.json"
+    )
+    monkeypatch.setattr(
         "deepagents_code.main._select_trust_action",
-        lambda *_args, **_kwargs: pytest.fail("prompt ran without a project root"),
+        lambda *_args, **_kwargs: pytest.fail("prompt ran without project hooks"),
     )
 
     decision = _check_project_hooks_trust()
@@ -270,12 +275,15 @@ def test_user_hooks_path_collision_skips_prompt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from deepagents_code.hooks import loading
+    from deepagents_code.hooks import loading, trust
     from deepagents_code.main import _check_project_hooks_trust
 
     home = _write_project_hooks(tmp_path / "home", git=False)
     monkeypatch.chdir(home)
     monkeypatch.setattr(loading, "DEFAULT_CONFIG_DIR", home / ".deepagents")
+    monkeypatch.setattr(
+        trust, "_default_store_path", lambda: tmp_path / "state" / "hooks_trust.json"
+    )
     monkeypatch.setattr(
         "deepagents_code.main._select_trust_action",
         lambda *_args, **_kwargs: pytest.fail("prompt ran for user hooks"),
@@ -284,6 +292,34 @@ def test_user_hooks_path_collision_skips_prompt(
     decision = _check_project_hooks_trust(trust_flag=True)
     assert isinstance(decision, WorkspaceTrust)
     assert not decision.allows(home)
+
+
+def test_prompt_renders_paths_containing_markup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from deepagents_code.hooks import trust
+    from deepagents_code.main import _check_project_hooks_trust, _TrustAction
+
+    # Rich consumes `[bold]` as a style tag, so an unescaped path would render
+    # as "projx" — silently wrong in the prompt the trust decision rests on.
+    root = _write_project_hooks(tmp_path / "proj[bold]x")
+    monkeypatch.chdir(root)
+    monkeypatch.setenv("COLUMNS", "400")
+    monkeypatch.setattr(
+        trust, "_default_store_path", lambda: tmp_path / "state" / "hooks_trust.json"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.main._select_trust_action",
+        lambda *_args, **_kwargs: _TrustAction.REMEMBER,
+    )
+
+    _check_project_hooks_trust()
+
+    err = capsys.readouterr().err
+    assert "proj[bold]x" in err
+    assert str(project_hooks_path(root)) in err
 
 
 @pytest.mark.parametrize(

--- a/libs/code/tests/unit_tests/hooks/test_trust.py
+++ b/libs/code/tests/unit_tests/hooks/test_trust.py
@@ -222,6 +222,26 @@ async def test_runtime_refuses_loaded_project_hooks_without_trust(
         await runtime.invoke(invocation)
 
 
+def test_no_project_root_skips_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.main import _check_project_hooks_trust
+
+    # No .git anywhere under tmp_path, so the launch directory has no project
+    # root. There is no project hooks file to trust; prompting here would
+    # mislabel the user hooks file as project-scoped.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "deepagents_code.main._select_trust_action",
+        lambda *_args, **_kwargs: pytest.fail("prompt ran without a project root"),
+    )
+
+    decision = _check_project_hooks_trust()
+    assert isinstance(decision, WorkspaceTrust)
+    assert not decision.allows(tmp_path)
+
+
 @pytest.mark.parametrize(
     ("action", "allowed", "persisted"),
     [("REMEMBER", True, True), ("ALLOW_ONCE", True, False), ("DENY", False, False)],

--- a/libs/code/tests/unit_tests/hooks/test_trust.py
+++ b/libs/code/tests/unit_tests/hooks/test_trust.py
@@ -32,8 +32,16 @@ if TYPE_CHECKING:
     from deepagents_code.app import DeepAgentsApp
 
 
-def _write_project_hooks(root: Path, *, event: str = "Stop") -> Path:
-    (root / ".git").mkdir(parents=True, exist_ok=True)
+def _write_project_hooks(
+    root: Path,
+    *,
+    event: str = "Stop",
+    git: bool = True,
+) -> Path:
+    if git:
+        (root / ".git").mkdir(parents=True, exist_ok=True)
+    else:
+        root.mkdir(parents=True, exist_ok=True)
     hooks_dir = root / ".deepagents"
     hooks_dir.mkdir(exist_ok=True)
     (hooks_dir / "hooks.json").write_text(
@@ -222,15 +230,13 @@ async def test_runtime_refuses_loaded_project_hooks_without_trust(
         await runtime.invoke(invocation)
 
 
-def test_no_project_root_skips_prompt(
+def test_non_git_workspace_without_hooks_skips_prompt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from deepagents_code.main import _check_project_hooks_trust
 
-    # No .git anywhere under tmp_path, so the launch directory has no project
-    # root. There is no project hooks file to trust; prompting here would
-    # mislabel the user hooks file as project-scoped.
+    # No .git or project hooks exist anywhere under tmp_path.
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         "deepagents_code.main._select_trust_action",
@@ -240,6 +246,44 @@ def test_no_project_root_skips_prompt(
     decision = _check_project_hooks_trust()
     assert isinstance(decision, WorkspaceTrust)
     assert not decision.allows(tmp_path)
+
+
+def test_explicit_trust_allows_non_git_project_hooks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.main import _check_project_hooks_trust
+
+    root = _write_project_hooks(tmp_path / "project", git=False)
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(
+        "deepagents_code.main._select_trust_action",
+        lambda *_args, **_kwargs: pytest.fail("prompt ran despite explicit trust"),
+    )
+
+    decision = _check_project_hooks_trust(trust_flag=True)
+    assert isinstance(decision, WorkspaceTrust)
+    assert decision.allows(root)
+
+
+def test_user_hooks_path_collision_skips_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.hooks import loading
+    from deepagents_code.main import _check_project_hooks_trust
+
+    home = _write_project_hooks(tmp_path / "home", git=False)
+    monkeypatch.chdir(home)
+    monkeypatch.setattr(loading, "DEFAULT_CONFIG_DIR", home / ".deepagents")
+    monkeypatch.setattr(
+        "deepagents_code.main._select_trust_action",
+        lambda *_args, **_kwargs: pytest.fail("prompt ran for user hooks"),
+    )
+
+    decision = _check_project_hooks_trust(trust_flag=True)
+    assert isinstance(decision, WorkspaceTrust)
+    assert not decision.allows(home)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The project hooks trust prompt now states what is actually being trusted, and no longer offers the user's own hooks file as if a project had shipped it.

## Prompt copy

```
Project hooks can run arbitrary shell commands on your machine.
Hooks file: /path/to/project/.deepagents/hooks.json
Only trust projects you control. Allow once runs this file as it is now;
always allow trusts "/path/to/project" for future sessions and future edits.
```

The old copy said hooks "can execute commands from <path>" and named neither the scope nor the directory the grant attaches to. The distinction matters: allow once fingerprints `hooks.json` (edits invalidate the grant); only always allow survives edits and later sessions. `HookTrustScreen` (shown on cwd switch) carries the same wording.

## User hooks are no longer promptable as project hooks

Launching from `~` with no enclosing Git repo made the project hooks path identical to the user hooks path (`~/.deepagents/hooks.json`), so the prompt asked the user to grant project trust to their own config — and granting it subjected that file to the project-hook gate. The trust check now returns an ungranted policy when the two paths coincide.

Non-Git workspaces otherwise keep working: the hooks loader resolves a non-repo directory as its own project root, so gating on a Git root would have silently stopped loading hooks that still get read.

## Path escaping

Prompt paths are interpolated into Rich markup; a directory named `proj[bold]x` would render as `projx`. Paths are now escaped.
