### PR TITLE
fix(infra): allow transferred issues

### DIFF
--- a/.github/workflows/close_unchecked_issues.yml
+++ b/.github/workflows/close_unchecked_issues.yml
@@ -120,24 +120,33 @@ jobs:
             // write/triage permissions), so a missing type reliably indicates
             // programmatic submission.
             if (!context.payload.issue.type) {
-              let membership;
-              try {
-                membership = await isOrgMember();
-              } catch (e) {
-                // Org membership check failed — skip Rule 0 and let
-                // Rules 1-4 handle validation via checkboxes.
-                core.warning(`Rule 0: org membership check failed, skipping: ${e.message}`);
-              }
-              if (membership?.internal) {
-                console.log(`No issue type, but ${membership.author} is internal — OK`);
-              } else if (membership) {
-                console.log(`No issue type and ${membership.author} is external — closing`);
-                await closeWithComment([
-                  'This issue was automatically closed because it appears to have been submitted programmatically — issue types are automatically set when using the GitHub web interface, and this issue has none.',
-                  '',
-                  'We do not allow automated issue submission at this time.',
-                ]);
-                return;
+              // Transferred issues keep their original created_at but arrive
+              // here as "opened" events with no type in the new repo. Treat
+              // anything older than 5 minutes as transferred and skip Rule 0.
+              const createdAt = new Date(context.payload.issue.created_at).getTime();
+              const ageMs = Date.now() - createdAt;
+              if (ageMs > 5 * 60 * 1000) {
+                console.log(`No issue type, but issue was created ${Math.round(ageMs / 60000)}m ago — likely transferred, skipping Rule 0`);
+              } else {
+                let membership;
+                try {
+                  membership = await isOrgMember();
+                } catch (e) {
+                  // Org membership check failed — skip Rule 0 and let
+                  // Rules 1-4 handle validation via checkboxes.
+                  core.warning(`Rule 0: org membership check failed, skipping: ${e.message}`);
+                }
+                if (membership?.internal) {
+                  console.log(`No issue type, but ${membership.author} is internal — OK`);
+                } else if (membership) {
+                  console.log(`No issue type and ${membership.author} is external — closing`);
+                  await closeWithComment([
+                    'This issue was automatically closed because it appears to have been submitted programmatically — issue types are automatically set when using the GitHub web interface, and this issue has none.',
+                    '',
+                    'We do not allow automated issue submission at this time.',
+                  ]);
+                  return;
+                }
               }
             }
 

--- a/.github/workflows/close_unchecked_issues.yml
+++ b/.github/workflows/close_unchecked_issues.yml
@@ -120,13 +120,22 @@ jobs:
             // write/triage permissions), so a missing type reliably indicates
             // programmatic submission.
             if (!context.payload.issue.type) {
-              // Transferred issues keep their original created_at but arrive
-              // here as "opened" events with no type in the new repo. Treat
-              // anything older than 5 minutes as transferred and skip Rule 0.
-              const createdAt = new Date(context.payload.issue.created_at).getTime();
-              const ageMs = Date.now() - createdAt;
-              if (ageMs > 5 * 60 * 1000) {
-                console.log(`No issue type, but issue was created ${Math.round(ageMs / 60000)}m ago — likely transferred, skipping Rule 0`);
+              // Transferred issues fire an "opened" event in this repo but
+              // carry no issue type here, so check the timeline for a
+              // `transferred` event instead of assuming programmatic
+              // submission.
+              let transferred = false;
+              try {
+                const events = await github.paginate(
+                  github.rest.issues.listEventsForTimeline,
+                  { owner, repo, issue_number, per_page: 100 },
+                );
+                transferred = events.some((e) => e.event === 'transferred');
+              } catch (e) {
+                core.warning(`Rule 0: timeline lookup failed, treating as not transferred: ${e.message}`);
+              }
+              if (transferred) {
+                console.log('No issue type, but issue has a `transferred` timeline event — skipping Rule 0');
               } else {
                 let membership;
                 try {


### PR DESCRIPTION
Related https://github.com/langchain-ai/deepagents/issues/5428#issuecomment-5258093627

Transferred issues no longer get auto-closed as "submitted programmatically" by the unchecked-issues workflow.

---

When an issue is transferred from another repo, GitHub fires an `opened` event in the destination repo, but the issue keeps its original `created_at` timestamp and has no issue type in the new repo. Rule 0 in `close_unchecked_issues.yml` treats a missing issue type as proof of programmatic submission, so transferred issues were being closed with the "submitted programmatically" comment (see the linked issue above).

The fix adds an age-based heuristic before Rule 0: if the issue was created more than 5 minutes ago, it's treated as a transfer and Rule 0 is skipped. Rules 1–4 (checkbox/template validation) still apply, so a transferred issue that genuinely ignored the template can still be closed — just not for the wrong reason.

Fresh issues (age < 5 min) are unaffected: a bot or script that just opened an issue via the API still trips Rule 0 as before.
