### PR TITLE
fix(sdk): patch invalid partial tool calls

### DIFF
--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -42,7 +42,6 @@ class PatchToolCallsMiddleware(AgentMiddleware):
 
         answered_ids = {msg.tool_call_id for msg in messages if msg.type == "tool"}
         patched_messages = []
-        patched_any = False
         for msg in messages:
             patched_messages.append(msg)
             if not isinstance(msg, AIMessage):
@@ -51,9 +50,8 @@ class PatchToolCallsMiddleware(AgentMiddleware):
                 error_message = self._error_tool_message(tool_call)
                 if error_message is not None and error_message.tool_call_id not in answered_ids:
                     patched_messages.append(error_message)
-                    patched_any = True
 
-        if not patched_any:
+        if len(patched_messages) == len(messages):
             return None
         return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *patched_messages]}
 

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -1,49 +1,86 @@
 """Middleware to patch dangling tool calls in the messages history."""
 
+from collections.abc import Mapping
 from typing import Any
 
-from langchain.agents.middleware import AgentMiddleware, AgentState, TracePolicy, omit_payload
-from langchain_core.messages import AIMessage, AnyMessage, RemoveMessage, ToolMessage
+from langchain.agents.middleware import (
+    AgentMiddleware,
+    AgentState,
+    TracePolicy,
+    hook_config,
+    omit_payload,
+)
+from langchain_core.messages import AIMessage, RemoveMessage, ToolMessage
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime
 
 
 class PatchToolCallsMiddleware(AgentMiddleware):
-    """Middleware to patch dangling tool calls in the messages history."""
+    """Middleware to repair incomplete tool calls in the messages history."""
+
+    @staticmethod
+    def _error_tool_message(tool_call: Mapping[str, Any]) -> ToolMessage | None:
+        """Create an error result for an identified tool call."""
+        tool_call_id = tool_call["id"]
+        if tool_call_id is None:
+            return None
+        name = tool_call["name"] or "unknown"
+        if tool_call.get("type") == "invalid_tool_call":
+            content = f"Tool call {name} with id {tool_call_id} could not be executed - arguments were malformed or truncated."
+        else:
+            content = f"Tool call {name} with id {tool_call_id} was cancelled - another message came in before it could be completed."
+        return ToolMessage(content=content, name=name, tool_call_id=tool_call_id, status="error")
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
     """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def before_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
-        """Before the agent runs, handle dangling tool calls from any AIMessage."""
+        """Before the agent runs, repair dangling tool calls from prior turns."""
         messages = state["messages"]
         if not messages:
             return None
 
         answered_ids = {msg.tool_call_id for msg in messages if msg.type == "tool"}
-
-        if not any(
-            tool_call["id"] is not None and tool_call["id"] not in answered_ids
-            for msg in messages
-            if isinstance(msg, AIMessage)
-            for tool_call in (*msg.tool_calls, *msg.invalid_tool_calls)
-        ):
-            return None
-
-        patched_messages: list[AnyMessage] = []
+        patched_messages = []
+        patched_any = False
         for msg in messages:
             patched_messages.append(msg)
             if not isinstance(msg, AIMessage):
                 continue
             for tool_call in (*msg.tool_calls, *msg.invalid_tool_calls):
-                tool_call_id = tool_call["id"]
-                if tool_call_id is None or tool_call_id in answered_ids:
-                    continue
-                name = tool_call["name"] or "unknown"
-                if tool_call.get("type") == "invalid_tool_call":
-                    content = f"Tool call {name} with id {tool_call_id} could not be executed - arguments were malformed or truncated."
-                else:
-                    content = f"Tool call {name} with id {tool_call_id} was cancelled - another message came in before it could be completed."
-                patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id))
+                error_message = self._error_tool_message(tool_call)
+                if error_message is not None and error_message.tool_call_id not in answered_ids:
+                    patched_messages.append(error_message)
+                    patched_any = True
 
+        if not patched_any:
+            return None
         return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *patched_messages]}
+
+    def _recover_invalid_tool_calls(self, state: AgentState) -> dict[str, Any] | None:
+        """Give the model error feedback for malformed calls and retry this turn."""
+        messages = state["messages"]
+        if not messages or not isinstance(messages[-1], AIMessage):
+            return None
+        last_message = messages[-1]
+        error_messages = []
+        for tool_call in last_message.invalid_tool_calls:
+            error_message = self._error_tool_message(tool_call)
+            if error_message is not None:
+                error_messages.append(error_message)
+
+        if not error_messages:
+            return None
+        if last_message.tool_calls:
+            return {"messages": error_messages}
+        return {"messages": error_messages, "jump_to": "model"}
+
+    @hook_config(can_jump_to=["model"])
+    def after_model(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
+        """Retry the current turn when the model emits malformed tool arguments."""
+        return self._recover_invalid_tool_calls(state)
+
+    @hook_config(can_jump_to=["model"])
+    async def aafter_model(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
+        """Async variant of `after_model`."""
+        return self._recover_invalid_tool_calls(state)

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -1,84 +1,49 @@
 """Middleware to patch dangling tool calls in the messages history."""
 
-from collections.abc import Mapping
 from typing import Any
 
-from langchain.agents.middleware import (
-    AgentMiddleware,
-    AgentState,
-    TracePolicy,
-    hook_config,
-    omit_payload,
-)
-from langchain_core.messages import AIMessage, RemoveMessage, ToolMessage
+from langchain.agents.middleware import AgentMiddleware, AgentState, TracePolicy, omit_payload
+from langchain_core.messages import AIMessage, AnyMessage, RemoveMessage, ToolMessage
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime
 
 
 class PatchToolCallsMiddleware(AgentMiddleware):
-    """Middleware to repair incomplete tool calls in the messages history."""
-
-    @staticmethod
-    def _error_tool_message(tool_call: Mapping[str, Any]) -> ToolMessage | None:
-        """Create an error result for an identified tool call."""
-        tool_call_id = tool_call["id"]
-        if tool_call_id is None:
-            return None
-        name = tool_call["name"] or "unknown"
-        if tool_call.get("type") == "invalid_tool_call":
-            content = f"Tool call {name} with id {tool_call_id} could not be executed - arguments were malformed or truncated."
-        else:
-            content = f"Tool call {name} with id {tool_call_id} was cancelled - another message came in before it could be completed."
-        return ToolMessage(content=content, name=name, tool_call_id=tool_call_id, status="error")
+    """Middleware to patch dangling tool calls in the messages history."""
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
     """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def before_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
-        """Before the agent runs, repair dangling tool calls from prior turns."""
+        """Before the agent runs, handle dangling tool calls from any AIMessage."""
         messages = state["messages"]
         if not messages:
             return None
 
         answered_ids = {msg.tool_call_id for msg in messages if msg.type == "tool"}
-        patched_messages = []
+
+        if not any(
+            tool_call["id"] is not None and tool_call["id"] not in answered_ids
+            for msg in messages
+            if isinstance(msg, AIMessage)
+            for tool_call in (*msg.tool_calls, *msg.invalid_tool_calls)
+        ):
+            return None
+
+        patched_messages: list[AnyMessage] = []
         for msg in messages:
             patched_messages.append(msg)
             if not isinstance(msg, AIMessage):
                 continue
             for tool_call in (*msg.tool_calls, *msg.invalid_tool_calls):
-                error_message = self._error_tool_message(tool_call)
-                if error_message is not None and error_message.tool_call_id not in answered_ids:
-                    patched_messages.append(error_message)
+                tool_call_id = tool_call["id"]
+                if tool_call_id is None or tool_call_id in answered_ids:
+                    continue
+                name = tool_call["name"] or "unknown"
+                if tool_call.get("type") == "invalid_tool_call":
+                    content = f"Tool call {name} with id {tool_call_id} could not be executed - arguments were malformed or truncated."
+                else:
+                    content = f"Tool call {name} with id {tool_call_id} was cancelled - another message came in before it could be completed."
+                patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id, status="error"))
 
-        if len(patched_messages) == len(messages):
-            return None
         return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *patched_messages]}
-
-    def _recover_invalid_tool_calls(self, state: AgentState) -> dict[str, Any] | None:
-        """Give the model error feedback for malformed calls and retry this turn."""
-        messages = state["messages"]
-        if not messages or not isinstance(messages[-1], AIMessage):
-            return None
-        last_message = messages[-1]
-        error_messages = []
-        for tool_call in last_message.invalid_tool_calls:
-            error_message = self._error_tool_message(tool_call)
-            if error_message is not None:
-                error_messages.append(error_message)
-
-        if not error_messages:
-            return None
-        if last_message.tool_calls:
-            return {"messages": error_messages}
-        return {"messages": error_messages, "jump_to": "model"}
-
-    @hook_config(can_jump_to=["model"])
-    def after_model(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
-        """Retry the current turn when the model emits malformed tool arguments."""
-        return self._recover_invalid_tool_calls(state)
-
-    @hook_config(can_jump_to=["model"])
-    async def aafter_model(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
-        """Async variant of `after_model`."""
-        return self._recover_invalid_tool_calls(state)

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -1,25 +1,15 @@
 """Middleware to patch dangling tool calls in the messages history."""
 
-from typing import Annotated, Any, NotRequired
+from typing import Any
 
-from langchain.agents.middleware import AgentMiddleware, AgentState, TracePolicy, hook_config, omit_payload
-from langchain.agents.middleware.types import PrivateStateAttr
+from langchain.agents.middleware import AgentMiddleware, AgentState, TracePolicy, omit_payload
 from langchain_core.messages import AIMessage, AnyMessage, RemoveMessage, ToolMessage
-from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime
 
 
-class PatchToolCallsState(AgentState):
-    """State for bounded invalid tool call retries."""
-
-    invalid_tool_call_retry_count: NotRequired[Annotated[int, UntrackedValue, PrivateStateAttr]]
-
-
-class PatchToolCallsMiddleware(AgentMiddleware[PatchToolCallsState]):
+class PatchToolCallsMiddleware(AgentMiddleware):
     """Middleware to patch dangling tool calls in the messages history."""
-
-    state_schema = PatchToolCallsState
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
     """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
@@ -57,25 +47,3 @@ class PatchToolCallsMiddleware(AgentMiddleware[PatchToolCallsState]):
                 patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id, status="error"))
 
         return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *patched_messages]}
-
-    @hook_config(can_jump_to=["model"])
-    def after_model(self, state: PatchToolCallsState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
-        """Retry once when the model emits an invalid tool call."""
-        messages = state["messages"]
-        if (
-            not messages
-            or not isinstance(messages[-1], AIMessage)
-            or not messages[-1].invalid_tool_calls
-            or state.get("invalid_tool_call_retry_count", 0) > 0
-        ):
-            return None
-        return {
-            "invalid_tool_call_retry_count": 1,
-            "jump_to": "model",
-            "messages": [RemoveMessage(id=messages[-1].id)],
-        }
-
-    @hook_config(can_jump_to=["model"])
-    async def aafter_model(self, state: PatchToolCallsState, runtime: Runtime[Any]) -> dict[str, Any] | None:
-        """Async variant of `after_model`."""
-        return self.after_model(state, runtime)

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -1,15 +1,25 @@
 """Middleware to patch dangling tool calls in the messages history."""
 
-from typing import Any
+from typing import Annotated, Any, NotRequired
 
-from langchain.agents.middleware import AgentMiddleware, AgentState, TracePolicy, omit_payload
+from langchain.agents.middleware import AgentMiddleware, AgentState, TracePolicy, hook_config, omit_payload
+from langchain.agents.middleware.types import PrivateStateAttr
 from langchain_core.messages import AIMessage, AnyMessage, RemoveMessage, ToolMessage
+from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime
 
 
-class PatchToolCallsMiddleware(AgentMiddleware):
+class PatchToolCallsState(AgentState):
+    """State for bounded invalid tool call retries."""
+
+    invalid_tool_call_retry_count: NotRequired[Annotated[int, UntrackedValue, PrivateStateAttr]]
+
+
+class PatchToolCallsMiddleware(AgentMiddleware[PatchToolCallsState]):
     """Middleware to patch dangling tool calls in the messages history."""
+
+    state_schema = PatchToolCallsState
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
     """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
@@ -47,3 +57,25 @@ class PatchToolCallsMiddleware(AgentMiddleware):
                 patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id, status="error"))
 
         return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *patched_messages]}
+
+    @hook_config(can_jump_to=["model"])
+    def after_model(self, state: PatchToolCallsState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
+        """Retry once when the model emits an invalid tool call."""
+        messages = state["messages"]
+        if (
+            not messages
+            or not isinstance(messages[-1], AIMessage)
+            or not messages[-1].invalid_tool_calls
+            or state.get("invalid_tool_call_retry_count", 0) > 0
+        ):
+            return None
+        return {
+            "invalid_tool_call_retry_count": 1,
+            "jump_to": "model",
+            "messages": [RemoveMessage(id=messages[-1].id)],
+        }
+
+    @hook_config(can_jump_to=["model"])
+    async def aafter_model(self, state: PatchToolCallsState, runtime: Runtime[Any]) -> dict[str, Any] | None:
+        """Async variant of `after_model`."""
+        return self.after_model(state, runtime)

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -4198,6 +4198,7 @@ def test_invalid_tool_call_patched_on_next_turn() -> None:
                     ],
                 ),
                 AIMessage(content="Recovered."),
+                AIMessage(content="Still recovered."),
             ]
         )
     )
@@ -4221,6 +4222,111 @@ def test_invalid_tool_call_patched_on_next_turn() -> None:
 
     # Final state must also expose the patched ToolMessage.
     assert any(isinstance(m, ToolMessage) and m.tool_call_id == "call_truncated" for m in result["messages"])
+
+
+def test_invalid_tool_call_recovers_in_same_turn() -> None:
+    fake_model = FakeChatModelWithHistory(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    invalid_tool_calls=[
+                        {
+                            "id": "call_malformed",
+                            "name": "search",
+                            "args": '{"query": "weath',
+                            "error": "Unterminated string at line 1 column 17",
+                            "type": "invalid_tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="Recovered."),
+            ]
+        )
+    )
+    agent = create_deep_agent(model=fake_model)
+
+    result = agent.invoke({"messages": [HumanMessage(content="Search for weather")]})
+
+    assert result["messages"][-1].content == "Recovered."
+    synthetic = next(
+        (m for m in fake_model.call_history[1]["messages"] if isinstance(m, ToolMessage)),
+        None,
+    )
+    assert synthetic is not None
+    assert synthetic.tool_call_id == "call_malformed"
+    assert synthetic.status == "error"
+
+
+def test_mixed_valid_and_invalid_tool_calls_execute_valid_call() -> None:
+    @tool
+    def echo(value: str) -> str:
+        """Echo a value."""
+        return value
+
+    fake_model = FakeChatModelWithHistory(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"id": "call_valid", "name": "echo", "args": {"value": "weather"}}],
+                    invalid_tool_calls=[
+                        {
+                            "id": "call_malformed",
+                            "name": "echo",
+                            "args": '{"value":',
+                            "error": "Unexpected end of JSON input",
+                            "type": "invalid_tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="Recovered."),
+            ]
+        )
+    )
+    agent = create_deep_agent(model=fake_model, tools=[echo])
+
+    result = agent.invoke({"messages": [HumanMessage(content="Call echo")]})
+
+    assert result["messages"][-1].content == "Recovered."
+    tool_messages = [m for m in fake_model.call_history[1]["messages"] if isinstance(m, ToolMessage)]
+    assert {message.tool_call_id for message in tool_messages} == {"call_valid", "call_malformed"}
+    assert next(message for message in tool_messages if message.tool_call_id == "call_valid").content == "weather"
+    assert next(message for message in tool_messages if message.tool_call_id == "call_malformed").status == "error"
+
+
+async def test_invalid_tool_call_recovers_in_same_turn_async() -> None:
+    fake_model = FakeChatModelWithHistory(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    invalid_tool_calls=[
+                        {
+                            "id": "call_malformed",
+                            "name": "search",
+                            "args": '{"query": "weath',
+                            "error": "Unterminated string at line 1 column 17",
+                            "type": "invalid_tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="Recovered."),
+            ]
+        )
+    )
+    agent = create_deep_agent(model=fake_model)
+
+    result = await agent.ainvoke({"messages": [HumanMessage(content="Search for weather")]})
+
+    assert result["messages"][-1].content == "Recovered."
+    synthetic = next(
+        (m for m in fake_model.call_history[1]["messages"] if isinstance(m, ToolMessage)),
+        None,
+    )
+    assert synthetic is not None
+    assert synthetic.tool_call_id == "call_malformed"
+    assert synthetic.status == "error"
 
 
 _OVERFLOW_INPUT_CHAR_THRESHOLD = 50_000

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -4178,8 +4178,10 @@ def test_read_file_video_frames_attached_after_tool_message(monkeypatch: pytest.
     ]
 
 
-def test_invalid_tool_call_retries_once_and_patches_on_next_turn() -> None:
-    # Each invocation retries once, then the next invocation patches the dangling call.
+def test_invalid_tool_call_patched_on_next_turn() -> None:
+    # Turn 1: model truncates and emits an invalid tool call (no matching ToolMessage
+    # will be produced because agents only route on `tool_calls`).
+    # Turn 2: the middleware must patch the dangling call before the model is re-invoked.
     fake_model = FakeChatModelWithHistory(
         messages=iter(
             [
@@ -4188,30 +4190,6 @@ def test_invalid_tool_call_retries_once_and_patches_on_next_turn() -> None:
                     invalid_tool_calls=[
                         {
                             "id": "call_truncated",
-                            "name": "search",
-                            "args": '{"query": "weath',
-                            "error": "Unterminated string at line 1 column 17",
-                            "type": "invalid_tool_call",
-                        }
-                    ],
-                ),
-                AIMessage(
-                    content="",
-                    invalid_tool_calls=[
-                        {
-                            "id": "call_truncated_again",
-                            "name": "search",
-                            "args": '{"query": "weath',
-                            "error": "Unterminated string at line 1 column 17",
-                            "type": "invalid_tool_call",
-                        }
-                    ],
-                ),
-                AIMessage(
-                    content="",
-                    invalid_tool_calls=[
-                        {
-                            "id": "call_third",
                             "name": "search",
                             "args": '{"query": "weath',
                             "error": "Unterminated string at line 1 column 17",
@@ -4228,20 +4206,15 @@ def test_invalid_tool_call_retries_once_and_patches_on_next_turn() -> None:
     config: dict = {"configurable": {"thread_id": "patch-invalid-tool-calls"}}
 
     first_result = agent.invoke({"messages": [HumanMessage(content="Run a tool")]}, config)
-    assert len(fake_model.call_history) == 2
     assert isinstance(first_result["messages"][-1], AIMessage)
-    assert first_result["messages"][-1].invalid_tool_calls[0]["id"] == "call_truncated_again"
-    assert not any(isinstance(message, ToolMessage) for message in first_result["messages"])
+    assert first_result["messages"][-1].invalid_tool_calls
 
     result = agent.invoke({"messages": [HumanMessage(content="Try again")]}, config)
-    assert len(fake_model.call_history) == 4
-    assert isinstance(result["messages"][-1], AIMessage)
-    assert result["messages"][-1].content == "Recovered."
 
-    # The next invocation must see the dangling invalid_tool_call paired with a ToolMessage.
-    next_invocation_inputs = fake_model.call_history[2]["messages"]
+    # The second model call must see the dangling invalid_tool_call paired with a ToolMessage.
+    second_call_inputs = fake_model.call_history[1]["messages"]
     synthetic = next(
-        (m for m in next_invocation_inputs if isinstance(m, ToolMessage) and m.tool_call_id == "call_truncated_again"),
+        (m for m in second_call_inputs if isinstance(m, ToolMessage) and m.tool_call_id == "call_truncated"),
         None,
     )
     assert synthetic is not None, "PatchToolCallsMiddleware did not inject a ToolMessage for invalid_tool_calls"
@@ -4251,7 +4224,7 @@ def test_invalid_tool_call_retries_once_and_patches_on_next_turn() -> None:
     assert synthetic.status == "error"
 
     # Final state must also expose the patched ToolMessage.
-    assert any(isinstance(m, ToolMessage) and m.tool_call_id == "call_truncated_again" for m in result["messages"])
+    assert any(isinstance(m, ToolMessage) and m.tool_call_id == "call_truncated" for m in result["messages"])
 
 
 _OVERFLOW_INPUT_CHAR_THRESHOLD = 50_000

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -4198,7 +4198,6 @@ def test_invalid_tool_call_patched_on_next_turn() -> None:
                     ],
                 ),
                 AIMessage(content="Recovered."),
-                AIMessage(content="Still recovered."),
             ]
         )
     )
@@ -4206,7 +4205,10 @@ def test_invalid_tool_call_patched_on_next_turn() -> None:
     agent = create_deep_agent(model=fake_model, checkpointer=checkpointer)
     config: dict = {"configurable": {"thread_id": "patch-invalid-tool-calls"}}
 
-    agent.invoke({"messages": [HumanMessage(content="Run a tool")]}, config)
+    first_result = agent.invoke({"messages": [HumanMessage(content="Run a tool")]}, config)
+    assert isinstance(first_result["messages"][-1], AIMessage)
+    assert first_result["messages"][-1].invalid_tool_calls
+
     result = agent.invoke({"messages": [HumanMessage(content="Try again")]}, config)
 
     # The second model call must see the dangling invalid_tool_call paired with a ToolMessage.
@@ -4219,114 +4221,10 @@ def test_invalid_tool_call_patched_on_next_turn() -> None:
     assert "could not be executed" in synthetic.content
     assert "malformed or truncated" in synthetic.content
     assert synthetic.name == "search"
+    assert synthetic.status == "error"
 
     # Final state must also expose the patched ToolMessage.
     assert any(isinstance(m, ToolMessage) and m.tool_call_id == "call_truncated" for m in result["messages"])
-
-
-def test_invalid_tool_call_recovers_in_same_turn() -> None:
-    fake_model = FakeChatModelWithHistory(
-        messages=iter(
-            [
-                AIMessage(
-                    content="",
-                    invalid_tool_calls=[
-                        {
-                            "id": "call_malformed",
-                            "name": "search",
-                            "args": '{"query": "weath',
-                            "error": "Unterminated string at line 1 column 17",
-                            "type": "invalid_tool_call",
-                        }
-                    ],
-                ),
-                AIMessage(content="Recovered."),
-            ]
-        )
-    )
-    agent = create_deep_agent(model=fake_model)
-
-    result = agent.invoke({"messages": [HumanMessage(content="Search for weather")]})
-
-    assert result["messages"][-1].content == "Recovered."
-    synthetic = next(
-        (m for m in fake_model.call_history[1]["messages"] if isinstance(m, ToolMessage)),
-        None,
-    )
-    assert synthetic is not None
-    assert synthetic.tool_call_id == "call_malformed"
-    assert synthetic.status == "error"
-
-
-def test_mixed_valid_and_invalid_tool_calls_execute_valid_call() -> None:
-    @tool
-    def echo(value: str) -> str:
-        """Echo a value."""
-        return value
-
-    fake_model = FakeChatModelWithHistory(
-        messages=iter(
-            [
-                AIMessage(
-                    content="",
-                    tool_calls=[{"id": "call_valid", "name": "echo", "args": {"value": "weather"}}],
-                    invalid_tool_calls=[
-                        {
-                            "id": "call_malformed",
-                            "name": "echo",
-                            "args": '{"value":',
-                            "error": "Unexpected end of JSON input",
-                            "type": "invalid_tool_call",
-                        }
-                    ],
-                ),
-                AIMessage(content="Recovered."),
-            ]
-        )
-    )
-    agent = create_deep_agent(model=fake_model, tools=[echo])
-
-    result = agent.invoke({"messages": [HumanMessage(content="Call echo")]})
-
-    assert result["messages"][-1].content == "Recovered."
-    tool_messages = [m for m in fake_model.call_history[1]["messages"] if isinstance(m, ToolMessage)]
-    assert {message.tool_call_id for message in tool_messages} == {"call_valid", "call_malformed"}
-    assert next(message for message in tool_messages if message.tool_call_id == "call_valid").content == "weather"
-    assert next(message for message in tool_messages if message.tool_call_id == "call_malformed").status == "error"
-
-
-async def test_invalid_tool_call_recovers_in_same_turn_async() -> None:
-    fake_model = FakeChatModelWithHistory(
-        messages=iter(
-            [
-                AIMessage(
-                    content="",
-                    invalid_tool_calls=[
-                        {
-                            "id": "call_malformed",
-                            "name": "search",
-                            "args": '{"query": "weath',
-                            "error": "Unterminated string at line 1 column 17",
-                            "type": "invalid_tool_call",
-                        }
-                    ],
-                ),
-                AIMessage(content="Recovered."),
-            ]
-        )
-    )
-    agent = create_deep_agent(model=fake_model)
-
-    result = await agent.ainvoke({"messages": [HumanMessage(content="Search for weather")]})
-
-    assert result["messages"][-1].content == "Recovered."
-    synthetic = next(
-        (m for m in fake_model.call_history[1]["messages"] if isinstance(m, ToolMessage)),
-        None,
-    )
-    assert synthetic is not None
-    assert synthetic.tool_call_id == "call_malformed"
-    assert synthetic.status == "error"
 
 
 _OVERFLOW_INPUT_CHAR_THRESHOLD = 50_000

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -4178,10 +4178,8 @@ def test_read_file_video_frames_attached_after_tool_message(monkeypatch: pytest.
     ]
 
 
-def test_invalid_tool_call_patched_on_next_turn() -> None:
-    # Turn 1: model truncates and emits an invalid tool call (no matching ToolMessage
-    # will be produced because agents only route on `tool_calls`).
-    # Turn 2: the middleware must patch the dangling call before the model is re-invoked.
+def test_invalid_tool_call_retries_once_and_patches_on_next_turn() -> None:
+    # Each invocation retries once, then the next invocation patches the dangling call.
     fake_model = FakeChatModelWithHistory(
         messages=iter(
             [
@@ -4190,6 +4188,30 @@ def test_invalid_tool_call_patched_on_next_turn() -> None:
                     invalid_tool_calls=[
                         {
                             "id": "call_truncated",
+                            "name": "search",
+                            "args": '{"query": "weath',
+                            "error": "Unterminated string at line 1 column 17",
+                            "type": "invalid_tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(
+                    content="",
+                    invalid_tool_calls=[
+                        {
+                            "id": "call_truncated_again",
+                            "name": "search",
+                            "args": '{"query": "weath',
+                            "error": "Unterminated string at line 1 column 17",
+                            "type": "invalid_tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(
+                    content="",
+                    invalid_tool_calls=[
+                        {
+                            "id": "call_third",
                             "name": "search",
                             "args": '{"query": "weath',
                             "error": "Unterminated string at line 1 column 17",
@@ -4206,15 +4228,20 @@ def test_invalid_tool_call_patched_on_next_turn() -> None:
     config: dict = {"configurable": {"thread_id": "patch-invalid-tool-calls"}}
 
     first_result = agent.invoke({"messages": [HumanMessage(content="Run a tool")]}, config)
+    assert len(fake_model.call_history) == 2
     assert isinstance(first_result["messages"][-1], AIMessage)
-    assert first_result["messages"][-1].invalid_tool_calls
+    assert first_result["messages"][-1].invalid_tool_calls[0]["id"] == "call_truncated_again"
+    assert not any(isinstance(message, ToolMessage) for message in first_result["messages"])
 
     result = agent.invoke({"messages": [HumanMessage(content="Try again")]}, config)
+    assert len(fake_model.call_history) == 4
+    assert isinstance(result["messages"][-1], AIMessage)
+    assert result["messages"][-1].content == "Recovered."
 
-    # The second model call must see the dangling invalid_tool_call paired with a ToolMessage.
-    second_call_inputs = fake_model.call_history[1]["messages"]
+    # The next invocation must see the dangling invalid_tool_call paired with a ToolMessage.
+    next_invocation_inputs = fake_model.call_history[2]["messages"]
     synthetic = next(
-        (m for m in second_call_inputs if isinstance(m, ToolMessage) and m.tool_call_id == "call_truncated"),
+        (m for m in next_invocation_inputs if isinstance(m, ToolMessage) and m.tool_call_id == "call_truncated_again"),
         None,
     )
     assert synthetic is not None, "PatchToolCallsMiddleware did not inject a ToolMessage for invalid_tool_calls"
@@ -4224,7 +4251,7 @@ def test_invalid_tool_call_patched_on_next_turn() -> None:
     assert synthetic.status == "error"
 
     # Final state must also expose the patched ToolMessage.
-    assert any(isinstance(m, ToolMessage) and m.tool_call_id == "call_truncated" for m in result["messages"])
+    assert any(isinstance(m, ToolMessage) and m.tool_call_id == "call_truncated_again" for m in result["messages"])
 
 
 _OVERFLOW_INPUT_CHAR_THRESHOLD = 50_000

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -3429,6 +3429,21 @@ class TestPatchToolCallsMiddleware:
         assert patched_messages[4].type == "human"
         assert patched_messages[4].content == "What is the weather in Tokyo?"
 
+    def test_missing_tool_call_reports_error_status(self) -> None:
+        input_messages = [
+            AIMessage(
+                content="",
+                tool_calls=[ToolCall(id="123", name="get_events_for_days", args={})],
+                id="1",
+            )
+        ]
+        middleware = PatchToolCallsMiddleware()
+        state_update = middleware.before_agent({"messages": input_messages}, None)
+
+        assert state_update is not None
+        patched_messages = state_update["messages"]
+        assert patched_messages[-1].status == "error"
+
     def test_no_missing_tool_calls(self) -> None:
         input_messages = [
             SystemMessage(content="You are a helpful assistant.", id="1"),
@@ -3496,8 +3511,6 @@ class TestPatchToolCallsMiddleware:
         assert patched_messages[7].type == "human"
         assert patched_messages[7].content == "What is the weather in Tokyo?"
 
-
-class TestTruncation:
     def test_truncate_list_result_no_truncation(self):
         items = ["/file1.py", "/file2.py", "/file3.py"]
         result = truncate_if_too_long(items)

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -3429,21 +3429,6 @@ class TestPatchToolCallsMiddleware:
         assert patched_messages[4].type == "human"
         assert patched_messages[4].content == "What is the weather in Tokyo?"
 
-    def test_missing_tool_call_reports_error_status(self) -> None:
-        input_messages = [
-            AIMessage(
-                content="",
-                tool_calls=[ToolCall(id="123", name="get_events_for_days", args={})],
-                id="1",
-            )
-        ]
-        middleware = PatchToolCallsMiddleware()
-        state_update = middleware.before_agent({"messages": input_messages}, None)
-
-        assert state_update is not None
-        patched_messages = state_update["messages"]
-        assert patched_messages[-1].status == "error"
-
     def test_no_missing_tool_calls(self) -> None:
         input_messages = [
             SystemMessage(content="You are a helpful assistant.", id="1"),
@@ -3511,6 +3496,8 @@ class TestPatchToolCallsMiddleware:
         assert patched_messages[7].type == "human"
         assert patched_messages[7].content == "What is the weather in Tokyo?"
 
+
+class TestTruncation:
     def test_truncate_list_result_no_truncation(self):
         items = ["/file1.py", "/file2.py", "/file3.py"]
         result = truncate_if_too_long(items)


### PR DESCRIPTION
Fixes #4662

Marks deferred synthetic tool-call repairs as errors without retrying malformed calls in the same invocation. The original `AIMessage` remains the final message for that invocation.

Made by [Open SWE](https://openswe.vercel.app/agents/b1e599d9-4ad2-5932-a0ed-c6da6d0fd5c6) · openai:gpt-5.6-sol (high)