### PR TITLE
fix(code): honor plugin `autoUpdate` manifest flag

### DIFF
--- a/libs/code/deepagents_code/plugins/manifest.py
+++ b/libs/code/deepagents_code/plugins/manifest.py
@@ -233,9 +233,6 @@ def load_manifest(
     version_value = raw.get("version")
     version = version_value if isinstance(version_value, str) else None
     display_name_value = raw.get("displayName")
-    auto_update_settings = raw.get("extensions")
-    if isinstance(auto_update_settings, dict):
-        auto_update_settings = auto_update_settings.get("com.langchain.deepagents.code")
     manifest = PluginManifest(
         name=name,
         version=version,
@@ -245,10 +242,7 @@ def load_manifest(
         display_name=(
             display_name_value if isinstance(display_name_value, str) else None
         ),
-        auto_update=(
-            isinstance(auto_update_settings, dict)
-            and auto_update_settings.get("autoUpdate") is True
-        ),
+        auto_update=raw.get("autoUpdate") is True,
     )
     return manifest, manifest_path, tuple(warnings)
 

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -373,9 +373,7 @@ def test_plugin_auto_update_requires_global_and_manifest_enablement(
         "version": "2.0.0",
     }
     if manifest_enabled is not None:
-        manifest["extensions"] = {
-            "com.langchain.deepagents.code": {"autoUpdate": manifest_enabled}
-        }
+        manifest["autoUpdate"] = manifest_enabled
     _write_json(
         marketplace_root / "plugins" / "quality-review-plugin" / "plugin.json",
         manifest,


### PR DESCRIPTION
Plugin auto-updates now honor the existing top-level `autoUpdate` manifest flag instead of requiring a client-specific extension. This keeps plugins portable across supported sources.

---

The existing global auto-update toggle remains unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/019ff2e0-31f5-75db-b8d8-dca23c3def6b)