### PR TITLE
feat(sdk): add `harness_profile` argument to `create_deep_agent`

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -60,6 +60,7 @@ from deepagents.middleware.subagents import (
 from deepagents.middleware.summarization import create_summarization_middleware
 from deepagents.profiles.harness.harness_profiles import (
     GeneralPurposeSubagentProfile,
+    HarnessProfile,
     _apply_profile_prompt,
     _harness_profile_for_model,
 )
@@ -285,6 +286,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache | None = None,
+    harness_profile: HarnessProfile | None = None,
 ) -> CompiledStateGraph[AgentState[ResponseT], ContextT, InputAgentState, OutputAgentState[ResponseT]]:  # ty: ignore[invalid-type-arguments]  # ty can't verify generic TypedDicts satisfy StateLike bound
     r"""Create a deep agent.
 
@@ -561,6 +563,14 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             Passed through to [`create_agent`][langchain.agents.create_agent].
 
+        harness_profile: Explicit
+            [`HarnessProfile`][deepagents.HarnessProfile] to apply, bypassing
+            registry lookup by model identity. Use this to select a profile
+            independently of the model — e.g. to route between several personas
+            that share one pre-built model instance, without aliasing the
+            model's identifier. When `None` (the default) the profile is resolved
+            from the model as before.
+
     Returns:
         A configured deep agent.
 
@@ -602,7 +612,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         model = _build_default_model()
     else:
         model = resolve_model(model)
-    _profile = _harness_profile_for_model(model, _model_spec)
+    _profile = harness_profile if harness_profile is not None else _harness_profile_for_model(model, _model_spec)
     # Validate profile-level invariants (required scaffolding, private names)
     _validate_excluded_middleware_config(
         _profile,

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -15,10 +15,11 @@ import pytest
 from langchain.agents.middleware import TodoListMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.tools import BaseTool, StructuredTool
 
 from deepagents._api.deprecation import LangChainDeprecationWarning
+from deepagents._models import get_model_provider
 from deepagents._tools import _apply_tool_description_overrides, _tool_name
 from deepagents._version import __version__, _lc_version, _with_editable_local_version
 from deepagents.backends import StateBackend
@@ -182,6 +183,76 @@ class TestProfileForModel:
         model._get_ls_params = MagicMock(return_value={})
         result = _harness_profile_for_model(model, None)
         assert result == HarnessProfile()
+
+
+def _system_prompt_text(messages: list[Any]) -> str:
+    return "\n".join(str(m.content) for m in messages if isinstance(m, SystemMessage))
+
+
+class TestExplicitHarnessProfile:
+    """Tests for the `harness_profile` argument of `create_deep_agent`."""
+
+    def test_explicit_profile_is_applied(self) -> None:
+        """An explicit `harness_profile` drives the agent's system prompt."""
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        model.call_history.clear()
+
+        agent = create_deep_agent(
+            model=model,
+            harness_profile=HarnessProfile(base_system_prompt="EXPLICIT-PERSONA-MARKER"),
+        )
+        agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+        system_prompt = _system_prompt_text(model.call_history[-1]["messages"])
+        assert "EXPLICIT-PERSONA-MARKER" in system_prompt
+
+    def test_explicit_profile_overrides_registry_lookup(self) -> None:
+        """An explicit profile wins over the one registered for the model."""
+        original = dict(_HARNESS_PROFILES)
+        try:
+            model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+            provider = get_model_provider(model)
+            assert provider is not None
+            register_harness_profile(
+                provider,
+                HarnessProfile(base_system_prompt="REGISTERED-MARKER"),
+            )
+            model.call_history.clear()
+
+            agent = create_deep_agent(
+                model=model,
+                harness_profile=HarnessProfile(base_system_prompt="EXPLICIT-MARKER"),
+            )
+            agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+            system_prompt = _system_prompt_text(model.call_history[-1]["messages"])
+            assert "EXPLICIT-MARKER" in system_prompt
+            assert "REGISTERED-MARKER" not in system_prompt
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+    def test_none_falls_back_to_registry_lookup(self) -> None:
+        """Without an explicit profile, the model-registered profile is used."""
+        original = dict(_HARNESS_PROFILES)
+        try:
+            model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+            provider = get_model_provider(model)
+            assert provider is not None
+            register_harness_profile(
+                provider,
+                HarnessProfile(base_system_prompt="REGISTERED-MARKER"),
+            )
+            model.call_history.clear()
+
+            agent = create_deep_agent(model=model)
+            agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+            system_prompt = _system_prompt_text(model.call_history[-1]["messages"])
+            assert "REGISTERED-MARKER" in system_prompt
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
 
 
 class TestToolName:


### PR DESCRIPTION
`create_deep_agent` now accepts an optional `harness_profile` to apply a `HarnessProfile` explicitly, instead of always resolving it from the model's identity.

---

Today the harness profile is resolved from the model via `_harness_profile_for_model(model, _model_spec)`, keyed by `provider:model_name`, and there's no way to pass one in. That welds profile selection to model identity: to serve two profiles from **one pre-built model instance** (e.g. two personas that share a single gateway-authed chat model), you have to give the model a distinct `model_name` alias — which then leaks a synthetic model name into LangSmith/MLflow traces and cost attribution.

This adds a keyword-only `harness_profile: HarnessProfile | None = None`. When provided, it is used verbatim and registry lookup is skipped; when `None` (default) behavior is unchanged, so it's backward compatible. The change is one expression at the existing resolution site:

```python
_profile = (
    harness_profile
    if harness_profile is not None
    else _harness_profile_for_model(model, _model_spec)
)
```

This makes "several profiles behind a router, one shared model" expressible without aliasing the model — the model instance keeps its real identity.

<details>
<summary>Test plan</summary>

Added `TestExplicitHarnessProfile` in `tests/unit_tests/test_graph.py`:
- an explicit profile drives the agent's system prompt,
- an explicit profile overrides the profile registered for the model,
- `None` still falls back to registry lookup.

`make format`, `make lint` (ruff + ty) clean; `test_graph.py` 133 passed.

</details>
