### PR TITLE
style(code): color-code cache hit rate

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -250,8 +250,8 @@ class MetricsLine(Widget):
         ellipsis = get_glyphs().ellipsis
         if width <= len(ellipsis):
             return Content("")
-        first = self._chain(1).plain
-        return Content(first[: width - len(ellipsis)] + ellipsis)
+        first = self._chain(1).truncate(width - len(ellipsis))
+        return first + ellipsis
 
 
 class StatusBar(Vertical):
@@ -868,7 +868,7 @@ class StatusBar(Vertical):
                 f"{percent:.0f}% hit", self._cache_hit_color(percent)
             )
         elif not self.cache_read_tokens and not self.cache_write_tokens:
-            hit_rate = Content.styled("0% hit", self._cache_hit_color(0))
+            hit_rate = Content.styled("0% hit", theme.get_theme_colors(self).muted)
         details = (
             f"{_compact_tokens(self.cache_read_tokens)} read"
             f" / {_compact_tokens(self.cache_write_tokens)} write"

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -815,15 +815,6 @@ class StatusBar(Vertical):
             return colors.warning
         return colors.muted
 
-    def _cache_hit_color(self, percent: float) -> str:
-        """Return the color that encodes cache hit-rate health."""
-        colors = theme.get_theme_colors(self)
-        if percent < 60.0:  # noqa: PLR2004  # cache alert threshold
-            return colors.error
-        if percent < 90.0:  # noqa: PLR2004  # cache warning threshold
-            return colors.warning
-        return colors.muted
-
     def _context_segment(self, count: int, *, approximate: bool = False) -> Content:
         """Build the context percentage and absolute-usage segment.
 
@@ -860,21 +851,26 @@ class StatusBar(Vertical):
         Returns:
             Styled cache usage.
         """
+        colors = theme.get_theme_colors(self)
         hit_rate = Content("")
         if self.cache_input_tokens:
             cached = min(self.cache_read_tokens, self.cache_input_tokens)
             percent = cached / self.cache_input_tokens * 100
-            hit_rate = Content.styled(
-                f"{percent:.0f}% hit", self._cache_hit_color(percent)
-            )
+            if percent < 60.0:  # noqa: PLR2004  # cache alert threshold
+                color = colors.error
+            elif percent < 90.0:  # noqa: PLR2004  # cache warning threshold
+                color = colors.warning
+            else:
+                color = colors.muted
+            hit_rate = Content.styled(f"{percent:.0f}% hit", color)
         elif not self.cache_read_tokens and not self.cache_write_tokens:
-            hit_rate = Content.styled("0% hit", theme.get_theme_colors(self).muted)
+            hit_rate = Content.styled("0% hit", colors.muted)
         details = (
             f"{_compact_tokens(self.cache_read_tokens)} read"
             f" / {_compact_tokens(self.cache_write_tokens)} write"
         )
         return Content.assemble(
-            Content.styled("Cache", theme.get_theme_colors(self).muted),
+            Content.styled("Cache", colors.muted),
             " ",
             hit_rate,
             f" {get_glyphs().bullet} " if hit_rate.plain else "",

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -806,12 +806,6 @@ class StatusBar(Vertical):
     _CONTEXT_CRITICAL_PERCENT = 80.0
     """Context usage at which the percentage turns to alert."""
 
-    _CACHE_WARNING_PERCENT = 90.0
-    """Cache hit rate below which the percentage turns to caution."""
-
-    _CACHE_CRITICAL_PERCENT = 60.0
-    """Cache hit rate below which the percentage turns to alert."""
-
     def _percent_color(self, percent: float) -> str:
         """Return the color that encodes how full the context window is."""
         colors = theme.get_theme_colors(self)
@@ -824,9 +818,9 @@ class StatusBar(Vertical):
     def _cache_hit_color(self, percent: float) -> str:
         """Return the color that encodes cache hit-rate health."""
         colors = theme.get_theme_colors(self)
-        if percent < self._CACHE_CRITICAL_PERCENT:
+        if percent < 60.0:  # noqa: PLR2004  # cache alert threshold
             return colors.error
-        if percent < self._CACHE_WARNING_PERCENT:
+        if percent < 90.0:  # noqa: PLR2004  # cache warning threshold
             return colors.warning
         return colors.muted
 

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -806,12 +806,27 @@ class StatusBar(Vertical):
     _CONTEXT_CRITICAL_PERCENT = 80.0
     """Context usage at which the percentage turns to alert."""
 
+    _CACHE_WARNING_PERCENT = 90.0
+    """Cache hit rate below which the percentage turns to caution."""
+
+    _CACHE_CRITICAL_PERCENT = 60.0
+    """Cache hit rate below which the percentage turns to alert."""
+
     def _percent_color(self, percent: float) -> str:
         """Return the color that encodes how full the context window is."""
         colors = theme.get_theme_colors(self)
         if percent > self._CONTEXT_CRITICAL_PERCENT:
             return colors.error
         if percent > self._CONTEXT_WARNING_PERCENT:
+            return colors.warning
+        return colors.muted
+
+    def _cache_hit_color(self, percent: float) -> str:
+        """Return the color that encodes cache hit-rate health."""
+        colors = theme.get_theme_colors(self)
+        if percent < self._CACHE_CRITICAL_PERCENT:
+            return colors.error
+        if percent < self._CACHE_WARNING_PERCENT:
             return colors.warning
         return colors.muted
 
@@ -851,12 +866,15 @@ class StatusBar(Vertical):
         Returns:
             Styled cache usage.
         """
-        hit_rate = ""
+        hit_rate = Content("")
         if self.cache_input_tokens:
             cached = min(self.cache_read_tokens, self.cache_input_tokens)
-            hit_rate = f"{cached / self.cache_input_tokens * 100:.0f}% hit"
+            percent = cached / self.cache_input_tokens * 100
+            hit_rate = Content.styled(
+                f"{percent:.0f}% hit", self._cache_hit_color(percent)
+            )
         elif not self.cache_read_tokens and not self.cache_write_tokens:
-            hit_rate = "0% hit"
+            hit_rate = Content.styled("0% hit", self._cache_hit_color(0))
         details = (
             f"{_compact_tokens(self.cache_read_tokens)} read"
             f" / {_compact_tokens(self.cache_write_tokens)} write"
@@ -864,7 +882,8 @@ class StatusBar(Vertical):
         return Content.assemble(
             Content.styled("Cache", theme.get_theme_colors(self).muted),
             " ",
-            f"{hit_rate} {get_glyphs().bullet} " if hit_rate else "",
+            hit_rate,
+            f" {get_glyphs().bullet} " if hit_rate.plain else "",
             details,
         )
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -68,36 +68,20 @@ class TestTwoLineMetrics:
             assert bar._percent_color(80.0) == colors.warning
             assert bar._percent_color(80.1) == colors.error
 
-    async def test_cache_hit_color_thresholds(self) -> None:
+    @pytest.mark.parametrize(
+        ("read", "color"),
+        [(0, "muted"), (59, "error"), (60, "warning"), (90, "muted")],
+    )
+    async def test_cache_hit_rate_colors(self, read: int, color: str) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             colors = theme.get_theme_colors(bar)
-
-            assert bar._cache_hit_color(59.9) == colors.error
-            assert bar._cache_hit_color(60.0) == colors.warning
-            assert bar._cache_hit_color(89.9) == colors.warning
-            assert bar._cache_hit_color(90.0) == colors.muted
-
-    async def test_truncated_cache_keeps_hit_rate_color(self) -> None:
-        async with StatusBarApp().run_test() as pilot:
-            bar = pilot.app.query_one("#status-bar", StatusBar)
-            bar.set_cache_tokens(10, 0, input_tokens=100)
+            bar.set_cache_tokens(read, 0, input_tokens=100 if read else 0)
             cache = pilot.app.query_one("#cache-display")
             cache.styles.width = 9
-            await pilot.pause()
-
             rendered = cache.render()
             assert isinstance(rendered, Content)
-            assert rendered.plain == "Cache 10…"
-            assert rendered.spans[-1].style == theme.get_theme_colors(bar).error
-
-    async def test_zero_cache_rate_is_muted(self) -> None:
-        async with StatusBarApp().run_test() as pilot:
-            bar = pilot.app.query_one("#status-bar", StatusBar)
-            rendered = pilot.app.query_one("#cache-display").render()
-
-            assert isinstance(rendered, Content)
-            assert rendered.spans[-1].style == theme.get_theme_colors(bar).muted
+            assert rendered.spans[-1].style == getattr(colors, color)
 
 
 class TestApprovalModeDisplay:

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -67,6 +67,16 @@ class TestTwoLineMetrics:
             assert bar._percent_color(80.0) == colors.warning
             assert bar._percent_color(80.1) == colors.error
 
+    async def test_cache_hit_color_thresholds(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            colors = theme.get_theme_colors(bar)
+
+            assert bar._cache_hit_color(59.9) == colors.error
+            assert bar._cache_hit_color(60.0) == colors.warning
+            assert bar._cache_hit_color(89.9) == colors.warning
+            assert bar._cache_hit_color(90.0) == colors.muted
+
 
 class TestApprovalModeDisplay:
     """Tests for the three-state approval indicator."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 from textual import events
 from textual.app import App, ComposeResult
+from textual.content import Content
 from textual.geometry import Size
 from textual.widgets import Static
 
@@ -76,6 +77,27 @@ class TestTwoLineMetrics:
             assert bar._cache_hit_color(60.0) == colors.warning
             assert bar._cache_hit_color(89.9) == colors.warning
             assert bar._cache_hit_color(90.0) == colors.muted
+
+    async def test_truncated_cache_keeps_hit_rate_color(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cache_tokens(10, 0, input_tokens=100)
+            cache = pilot.app.query_one("#cache-display")
+            cache.styles.width = 9
+            await pilot.pause()
+
+            rendered = cache.render()
+            assert isinstance(rendered, Content)
+            assert rendered.plain == "Cache 10…"
+            assert rendered.spans[-1].style == theme.get_theme_colors(bar).error
+
+    async def test_zero_cache_rate_is_muted(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            rendered = pilot.app.query_one("#cache-display").render()
+
+            assert isinstance(rendered, Content)
+            assert rendered.spans[-1].style == theme.get_theme_colors(bar).muted
 
 
 class TestApprovalModeDisplay:


### PR DESCRIPTION
Related #5408

Cache hit rates in the status footer now use muted, warning, and error colors so low cache reuse is easy to spot.

---

The follow-up styling remained as an uncommitted working-tree diff when the original status-row PR merged. This reapplies that isolated change on current `main`, with boundary coverage for the 60% and 90% thresholds.