### PR TITLE
fix(code): clear dynamic subagents on next turn

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -16161,10 +16161,8 @@ class DeepAgentsApp(App):
             self._inflight_turn_start = time.monotonic()
             self._inflight_thread_id = self._lc_thread_id
 
-            # Arm the subagent fan-out panel for this turn, seeding the session
-            # model that labels each row. The panel persists across turns and only
-            # clears when this turn's first subagent actually starts, so a turn that
-            # spawns none leaves the previous workflow's results on screen.
+            # Clear the previous turn's subagent fan-out and seed the session
+            # model that labels rows if this turn starts a new workflow.
             panel = self._get_subagent_panel()
             if panel is not None:
                 spec = self._effective_model_spec()

--- a/libs/code/deepagents_code/tui/widgets/subagent_panel.py
+++ b/libs/code/deepagents_code/tui/widgets/subagent_panel.py
@@ -291,10 +291,6 @@ class SubagentPanel(Vertical):
         self._last_render: dict[str, str] = {}
         self._spinner = Spinner()
         self._timer: Timer | None = None
-        # When True, the next subagent `start` clears the previous workflow's
-        # fan-out before adding the new row (armed by `prepare_turn`). Lets the
-        # panel persist across turns until a new workflow actually begins.
-        self._pending_reset = False
 
     def compose(self) -> ComposeResult:  # noqa: PLR6301 — Textual widget method
         """Yield the header line and the two-pane body (phases | agents)."""
@@ -357,9 +353,6 @@ class SubagentPanel(Vertical):
 
     def _handle_start(self, sub_id: str, eval_key: str, event: dict[str, Any]) -> None:
         """Create/replace a running record and (re-)show the panel."""
-        if self._pending_reset:
-            # A new workflow is starting — drop the previous turn's fan-out now.
-            self._clear()
         phase = self._ensure_phase(eval_key)
         self._active_eval_id = eval_key
 
@@ -449,10 +442,6 @@ class SubagentPanel(Vertical):
         Returns:
             The newly created record, already inserted into its phase.
         """
-        if self._pending_reset:
-            # A dropped-start error is still evidence that a new workflow
-            # started, so clear the previous turn before surfacing it.
-            self._clear()
         phase = self._ensure_phase(eval_key)
         self._active_eval_id = eval_key
         record = _SubagentRecord(
@@ -554,25 +543,11 @@ class SubagentPanel(Vertical):
         self._refresh()
 
     def prepare_turn(self, *, model_label: str | None = None) -> None:
-        """Arm a deferred clear for a new turn without touching the panel yet.
-
-        The visible fan-out persists across turns; it is cleared lazily when the
-        next workflow actually starts a subagent (see `_handle_start`), so a turn
-        that spawns none leaves the previous results on screen. Refreshes the
-        session model used to label rows.
-        """
+        """Clear the previous workflow's fan-out for a new turn."""
         self._model_label = (
             _sanitize(model_label, max_chars=_MODEL_COL) if model_label else None
         )
-        # If the previous turn left rows stuck "running" — e.g. it was cancelled
-        # before the bridge emitted terminal events (CancelledError is a
-        # BaseException, so it bypasses the bridge's `except Exception`) — clear
-        # now instead of persisting a stale, still-spinning fan-out. Otherwise
-        # defer the clear so a completed workflow survives no-subagent turns.
-        if self._any_running():
-            self._clear()
-        else:
-            self._pending_reset = True
+        self._clear()
 
     def reset(self, *, model_label: str | None = None, **_kwargs: Any) -> None:
         """Clear all phases and hide the panel immediately (e.g. on `/clear`)."""
@@ -593,7 +568,6 @@ class SubagentPanel(Vertical):
         self._selected_eval_id = None
         self._applied_height = None
         self._last_render.clear()
-        self._pending_reset = False
         self._stop_timer()
         self.remove_class("-visible")
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_subagent_panel.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_subagent_panel.py
@@ -393,21 +393,20 @@ class TestReset:
             assert panel._phase_order == []
             assert panel._counts() == (0, 0)
 
-    async def test_panel_persists_until_next_workflow(self) -> None:
+    async def test_panel_clears_on_next_turn(self) -> None:
         async with PanelApp().run_test() as pilot:
             panel = pilot.app.query_one("#panel", SubagentPanel)
             panel.on_subagent_event(_start("a", "E1"))
             panel.on_subagent_event(_complete("a", "E1"))
             await pilot.pause()
             assert panel.has_class("-visible")
-            # A new turn begins but spawns no subagents — results persist.
             panel.prepare_turn()
             await pilot.pause()
-            assert panel.has_class("-visible")
-            assert panel._phase_order == ["E1"]
-            # The next workflow's first subagent clears the prior fan-out.
+            assert not panel.has_class("-visible")
+            assert panel._phase_order == []
             panel.on_subagent_event(_start("b", "E2"))
             await pilot.pause()
+            assert panel.has_class("-visible")
             assert panel._phase_order == ["E2"]
             assert panel._find_record("a") is None
 


### PR DESCRIPTION
Dynamic subagent results now close when the next agent turn starts.

---

The panel previously deferred cleanup until another dynamic-subagent workflow appeared, so it could remain docked indefinitely when the next turn spawned none.

Made by [Open SWE](https://openswe.vercel.app/agents/019ff342-b23c-745f-87ba-2d82fb83287c)