### PR TITLE
test(code): restore leaked model settings in `apply_to_settings` test

### DIFF
--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -1192,13 +1192,21 @@ class TestModelResultApplyToSettings:
             context_limit=64000,
             unsupported_modalities=frozenset({"image", "audio"}),
         )
-        original = settings.model_unsupported_modalities
+        # `apply_to_settings` writes four fields to the process-global settings;
+        # restore all of them or the values leak into every later test.
+        original_name = settings.model_name
+        original_provider = settings.model_provider
+        original_limit = settings.model_context_limit
+        original_modalities = settings.model_unsupported_modalities
         try:
             model_result.apply_to_settings()
             expected = frozenset({"image", "audio"})
             assert settings.model_unsupported_modalities == expected
         finally:
-            settings.model_unsupported_modalities = original
+            settings.model_name = original_name
+            settings.model_provider = original_provider
+            settings.model_context_limit = original_limit
+            settings.model_unsupported_modalities = original_modalities
 
 
 class TestRetriesConfig:

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -463,6 +463,9 @@ class TestTokenDisplay:
     async def test_show_pending_tokens_before_count_keeps_zero_state(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
+            # `on_mount` reads `settings.model_context_limit` (process-global),
+            # so pin the widget's limit instead of trusting the ambient value.
+            bar.set_context_limit(None)
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
@@ -587,6 +590,11 @@ class TestTokenDisplay:
     async def test_zero_context_and_cost_are_visible_on_mount(self) -> None:
         """The lower-right metrics should not be blank before the first request."""
         async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            # `on_mount` reads `settings.model_context_limit` (process-global),
+            # so pin the widget's limit instead of trusting the ambient value.
+            bar.set_context_limit(None)
+            await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
             assert display.display is True
             assert str(display.render()) == "Context: 0% / Tokens: 0 • $0.00"
@@ -595,6 +603,9 @@ class TestTokenDisplay:
         """Zeroing a positive count restores visible placeholders."""
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
+            # `on_mount` reads `settings.model_context_limit` (process-global),
+            # so pin the widget's limit instead of trusting the ambient value.
+            bar.set_context_limit(None)
             bar.set_tokens(5000)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
@@ -621,6 +632,9 @@ class TestCostDisplay:
     async def test_cost_displays_without_tokens(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
+            # `on_mount` reads `settings.model_context_limit` (process-global),
+            # so pin the widget's limit instead of trusting the ambient value.
+            bar.set_context_limit(None)
             bar.set_cost(1.25)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
@@ -630,6 +644,9 @@ class TestCostDisplay:
     async def test_zero_cost_is_visible(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
+            # `on_mount` reads `settings.model_context_limit` (process-global);
+            # `--` only renders when the limit is `None`, so pin it explicitly.
+            bar.set_context_limit(None)
             bar.set_tokens(5000)
             bar.set_cost(0.0)
             await pilot.pause()
@@ -639,6 +656,9 @@ class TestCostDisplay:
     async def test_sub_cent_cost_uses_display_floor(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
+            # `on_mount` reads `settings.model_context_limit` (process-global),
+            # so pin the widget's limit instead of trusting the ambient value.
+            bar.set_context_limit(None)
             bar.set_cost(0.0045)
             await pilot.pause()
             assert str(pilot.app.query_one("#tokens-display").render()) == (

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -463,9 +463,6 @@ class TestTokenDisplay:
     async def test_show_pending_tokens_before_count_keeps_zero_state(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
-            # `on_mount` reads `settings.model_context_limit` (process-global),
-            # so pin the widget's limit instead of trusting the ambient value.
-            bar.set_context_limit(None)
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
@@ -590,11 +587,6 @@ class TestTokenDisplay:
     async def test_zero_context_and_cost_are_visible_on_mount(self) -> None:
         """The lower-right metrics should not be blank before the first request."""
         async with StatusBarApp().run_test() as pilot:
-            bar = pilot.app.query_one("#status-bar", StatusBar)
-            # `on_mount` reads `settings.model_context_limit` (process-global),
-            # so pin the widget's limit instead of trusting the ambient value.
-            bar.set_context_limit(None)
-            await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
             assert display.display is True
             assert str(display.render()) == "Context: 0% / Tokens: 0 • $0.00"
@@ -603,9 +595,6 @@ class TestTokenDisplay:
         """Zeroing a positive count restores visible placeholders."""
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
-            # `on_mount` reads `settings.model_context_limit` (process-global),
-            # so pin the widget's limit instead of trusting the ambient value.
-            bar.set_context_limit(None)
             bar.set_tokens(5000)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
@@ -614,6 +603,16 @@ class TestTokenDisplay:
             await pilot.pause()
             assert display.display is True
             assert str(display.render()) == "Context: 0% / Tokens: 0 • $0.00"
+
+    async def test_unknown_context_limit_shows_dashes_with_tokens(self) -> None:
+        """With no known limit, a non-zero count renders `--` for the percentage."""
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_context_limit(None)
+            bar.set_tokens(5000)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            assert str(display.render()) == "Context: -- / Tokens: 5K • $0.00"
 
 
 class TestCostDisplay:
@@ -632,9 +631,6 @@ class TestCostDisplay:
     async def test_cost_displays_without_tokens(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
-            # `on_mount` reads `settings.model_context_limit` (process-global),
-            # so pin the widget's limit instead of trusting the ambient value.
-            bar.set_context_limit(None)
             bar.set_cost(1.25)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
@@ -644,8 +640,8 @@ class TestCostDisplay:
     async def test_zero_cost_is_visible(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
-            # `on_mount` reads `settings.model_context_limit` (process-global);
-            # `--` only renders when the limit is `None`, so pin it explicitly.
+            # A `None` limit renders `--` only once tokens are non-zero, so pin
+            # the limit rather than inheriting `settings.model_context_limit`.
             bar.set_context_limit(None)
             bar.set_tokens(5000)
             bar.set_cost(0.0)
@@ -656,9 +652,6 @@ class TestCostDisplay:
     async def test_sub_cent_cost_uses_display_floor(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
-            # `on_mount` reads `settings.model_context_limit` (process-global),
-            # so pin the widget's limit instead of trusting the ambient value.
-            bar.set_context_limit(None)
             bar.set_cost(0.0045)
             await pilot.pause()
             assert str(pilot.app.query_one("#tokens-display").render()) == (


### PR DESCRIPTION
Status bar tests could fail depending on which order tests ran in, because one config test changed the app's model settings and never changed them back. That test now restores the settings it touches, and the status bar's "unknown context limit" display gets its own test instead of being covered only as a side effect of a cost test.