### PR TITLE
fix(quickjs): keep async worker lifecycle off event loop

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -492,6 +492,10 @@ class _ThreadREPL:
         """
         self._worker.run_sync(self._ainstall_tools(tools))
 
+    async def ainstall_tools(self, tools: Sequence[BaseTool]) -> None:
+        """Async variant of ``install_tools``."""
+        await self._worker.run_async(self._ainstall_tools(tools))
+
     async def _ainstall_tools(self, tools: Sequence[BaseTool]) -> None:
         ctx = self._require_ctx()
         name_to_tool: dict[str, BaseTool] = {}
@@ -963,6 +967,25 @@ class _Registry:
                 self._slots[thread_id] = slot
             return slot.repl
 
+    async def aget(self, thread_id: str) -> _ThreadREPL:
+        """Return a REPL without blocking the caller's event loop on a miss."""
+        with self._lock:
+            slot = self._slots.get(thread_id)
+        if slot is not None:
+            return slot.repl
+
+        slot = await asyncio.to_thread(self._build_slot, thread_id)
+        with self._lock:
+            current = self._slots.get(thread_id)
+            if current is None:
+                self._slots[thread_id] = slot
+                return slot.repl
+
+        # Another caller won the race to install the slot. Dispose of the
+        # duplicate off the event loop before returning the canonical REPL.
+        await asyncio.to_thread(self._close_slot, slot)
+        return current.repl
+
     def get_if_exists(self, thread_id: str) -> _ThreadREPL | None:
         """Return existing REPL for `thread_id` without creating a new slot."""
         with self._lock:
@@ -1011,7 +1034,14 @@ class _Registry:
         with contextlib.suppress(Exception):
             new_repl.close()
 
+    async def areset_repl(self, thread_id: str) -> None:
+        """Async variant of ``reset_repl``."""
+        await asyncio.to_thread(self.reset_repl, thread_id)
+
     def _build_slot_locked(self, thread_id: str) -> _Slot:
+        return self._build_slot(thread_id)
+
+    def _build_slot(self, thread_id: str) -> _Slot:
         name = f"quickjs-worker-{thread_id[:8]}"
         worker = ThreadWorker(name=name)
         runtime = worker.run_sync(self._acreate_runtime())
@@ -1042,7 +1072,7 @@ class _Registry:
             await slot.repl.aclose()
         with contextlib.suppress(Exception):
             await slot.worker.run_async(_aclose_runtime(slot.runtime))
-        slot.worker.close()
+        await asyncio.to_thread(slot.worker.close)
 
     async def _acreate_runtime(self) -> Runtime:
         return Runtime(

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -301,7 +301,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
             code: Annotated[str, code_doc],
         ) -> ToolMessage:
             thread_id = _resolve_thread_id(fallback_id)
-            repl = middleware._repl_for_eval(thread_id)
+            repl = await middleware._arepl_for_eval(thread_id)
             try:
                 outcome = await repl.eval_async(
                     code,
@@ -310,7 +310,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
                 )
             finally:
                 if middleware._mode == "call":
-                    middleware._registry.reset_repl(thread_id)
+                    await middleware._registry.areset_repl(thread_id)
             return _make_tool_message(outcome, runtime.tool_call_id)
 
         return StructuredTool.from_function(
@@ -338,6 +338,15 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         repl = self._registry.get(thread_id)
         if self._mode == "call" and self._ptc is not None:
             repl.install_tools(list(self._ptc_tools_by_thread.get(thread_id, ())))
+        return repl
+
+    async def _arepl_for_eval(self, thread_id: str) -> Any:
+        """Async variant of ``_repl_for_eval``."""
+        repl = await self._registry.aget(thread_id)
+        if self._mode == "call" and self._ptc is not None:
+            await repl.ainstall_tools(
+                list(self._ptc_tools_by_thread.get(thread_id, ()))
+            )
         return repl
 
     def before_agent(
@@ -376,7 +385,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         if not payload:
             return None
         thread_id = _resolve_thread_id(self._fallback_thread_id)
-        repl = self._registry.get(thread_id)
+        repl = await self._registry.aget(thread_id)
         try:
             await repl.arestore_snapshot(payload, inject_globals=True)
         except Exception:  # noqa: BLE001  # best-effort restore path
@@ -409,7 +418,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         ],
     ) -> ModelResponse[ResponseT]:
         """(async) Inject the REPL's system-prompt snippet on every model call."""
-        prompt = self._prepare_for_call(request)
+        prompt = await self._aprepare_for_call(request)
         return await handler(
             request.override(
                 system_message=self._extend(request.system_message, prompt)
@@ -467,6 +476,35 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         # *identity* — if a tool keeps its name but its schema changes
         # between turns, the cached prompt staleness is on the caller.
         # Same tradeoff the TS package accepts; see the module docstring.
+        exposed_names = frozenset(t.name for t in exposed)
+        if self._ptc_prompt_cache is None or self._ptc_prompt_cache[0] != exposed_names:
+            self._ptc_prompt_cache = (
+                exposed_names,
+                render_ptc_prompt(exposed, tool_name=self._tool_name),
+            )
+        return prompt + self._ptc_prompt_cache[1]
+
+    async def _aprepare_for_call(self, request: ModelRequest[ContextT]) -> str:
+        """Async variant of ``_prepare_for_call``."""
+        request_tools: list[BaseTool] = list(getattr(request, "tools", []) or [])
+
+        subagent_section = ""
+        if self._subagents and find_subagent_task_tool(request_tools) is not None:
+            subagent_section = render_subagent_system_prompt(tool_name=self._tool_name)
+
+        if self._ptc is None:
+            return self._base_prompt(ptc_attached=False) + subagent_section
+
+        exposed = filter_tools_for_ptc(
+            request_tools,
+            self._ptc,
+            self_tool_name=self._tool_name,
+        )
+        prompt = self._base_prompt(ptc_attached=bool(exposed)) + subagent_section
+        thread_id = _resolve_thread_id(self._fallback_thread_id)
+        repl = await self._registry.aget(thread_id)
+        await repl.ainstall_tools(exposed)
+        self._ptc_tools_by_thread[thread_id] = tuple(exposed)
         exposed_names = frozenset(t.name for t in exposed)
         if self._ptc_prompt_cache is None or self._ptc_prompt_cache[0] != exposed_names:
             self._ptc_prompt_cache = (

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -746,6 +747,128 @@ async def test_aevict_closes_and_removes_slot() -> None:
         assert "thread-a" not in reg._slots
     finally:
         reg.close()
+
+
+async def test_async_model_call_build_does_not_block_event_loop() -> None:
+    """Building a QuickJS slot from an async hook leaves the loop responsive."""
+
+    class _Request:
+        def __init__(self) -> None:
+            self.tools: list[BaseTool] = []
+            self.system_message = None
+
+        def override(self, **_: Any) -> _Request:
+            return self
+
+    mw = CodeInterpreterMiddleware(ptc=["eval"])
+    entered = threading.Event()
+    released = threading.Event()
+    pulse = asyncio.Event()
+    pulse_times: list[float] = []
+    release_times: list[float] = []
+    original_run_sync = ThreadWorker.run_sync
+
+    def blocked_run_sync(worker: ThreadWorker, coro: Any) -> Any:
+        entered.set()
+        released.wait(timeout=2.0)
+        return original_run_sync(worker, coro)
+
+    def release() -> None:
+        if not released.is_set():
+            release_times.append(time.monotonic())
+            released.set()
+
+    def record_pulse() -> None:
+        pulse_times.append(time.monotonic())
+        pulse.set()
+
+    async def handler(_: Any) -> str:
+        return "ok"
+
+    release_timer = threading.Timer(0.2, release)
+    try:
+        with patch.object(ThreadWorker, "run_sync", blocked_run_sync):
+            asyncio.get_running_loop().call_later(0.01, record_pulse)
+            task = asyncio.create_task(mw.awrap_model_call(_Request(), handler))
+            release_timer.start()
+            try:
+                await asyncio.wait_for(pulse.wait(), timeout=1.0)
+                release()
+                assert await task == "ok"
+            finally:
+                release()
+                if not task.done():
+                    await task
+    finally:
+        release_timer.cancel()
+        mw._registry.close()
+
+    assert entered.is_set()
+    assert pulse_times
+    assert release_times
+    assert pulse_times[0] < release_times[0]
+
+
+async def test_aevict_worker_close_does_not_block_event_loop() -> None:
+    """Evicting a slot leaves the loop responsive while the worker stops."""
+    reg = _Registry(
+        memory_limit=32 * 1024 * 1024,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
+    reg.get("thread-a")
+    slot = reg._slots["thread-a"]
+    entered = threading.Event()
+    released = threading.Event()
+    pulse = asyncio.Event()
+    pulse_times: list[float] = []
+    release_times: list[float] = []
+    original_close = slot.worker.close
+    loop = asyncio.get_running_loop()
+
+    def blocked_close() -> None:
+        entered.set()
+        released.wait(timeout=2.0)
+        original_close()
+
+    def release() -> None:
+        if not released.is_set():
+            release_times.append(time.monotonic())
+            released.set()
+
+    def record_pulse() -> None:
+        pulse_times.append(time.monotonic())
+        pulse.set()
+
+    def schedule_pulse() -> None:
+        entered.wait(timeout=2.0)
+        loop.call_soon_threadsafe(record_pulse)
+
+    pulse_thread = threading.Thread(target=schedule_pulse)
+    release_timer = threading.Timer(0.2, release)
+    try:
+        with patch.object(slot.worker, "close", blocked_close):
+            pulse_thread.start()
+            release_timer.start()
+            task = asyncio.create_task(reg.aevict("thread-a"))
+            try:
+                await asyncio.wait_for(pulse.wait(), timeout=1.0)
+                release()
+                await task
+            finally:
+                release()
+                if not task.done():
+                    await task
+    finally:
+        pulse_thread.join(timeout=1.0)
+        release_timer.cancel()
+        reg.close()
+
+    assert entered.is_set()
+    assert pulse_times
+    assert release_times
+    assert pulse_times[0] < release_times[0]
 
 
 def test_after_agent_evicts_current_thread_slot() -> None:


### PR DESCRIPTION
Closes #5387

Async QuickJS middleware hooks no longer block the event loop while creating or stopping per-thread workers.

---

`ThreadWorker.run_sync()` remains available for the synchronous API, while async middleware paths now use async registry and REPL helpers. Cache-miss builds and `ThreadWorker.close()` are offloaded with `asyncio.to_thread`, and `run_async()` remains on the worker loop. Async PTC setup and `mode="call"` resets stay on the non-blocking path as well. Concurrent cache misses clean up duplicate slots before returning the canonical slot.

The regression tests hold worker initialization and shutdown long enough to verify that the event loop continues to execute scheduled callbacks.

AI assistance: I used AI assistance to investigate the reported issue, implement the patch, and draft this description. I reviewed the final diff and ran the checks below.

<details>
<summary>Test plan</summary>

- `uv run --group test pytest tests/unit_tests -q` (218 passed)
- `uv run --all-groups ruff check langchain_quickjs tests/unit_tests/test_repl_middleware.py`
- `uv run --all-groups ruff format --check langchain_quickjs tests/unit_tests/test_repl_middleware.py`
- `uv run --all-groups ty check langchain_quickjs`

</details>