### PR TITLE
fix(code): simplify paste expansion toast

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -120,7 +120,7 @@ def _should_collapse_chat_paste(text: str) -> bool:
     return detect_mode_prefix(text) is None and should_collapse_paste(text)
 
 
-_PASTE_COLLAPSED_TOAST = "Large paste collapsed. Paste again to expand it inline."
+_PASTE_COLLAPSED_TOAST = "Large paste collapsed. Paste again to expand."
 """Toast shown when a paste collapses into a `[Pasted text #N]` placeholder.
 
 Emitted only for a new collapse, not when a repeat paste expands an existing

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -5164,7 +5164,7 @@ class TestPasteCollapseIntegration:
             # `[Pasted text #N]` is never interpreted as Textual markup.
             assert calls == [
                 (
-                    chat_input_module._PASTE_COLLAPSED_TOAST,
+                    "Large paste collapsed. Paste again to expand.",
                     {"timeout": 5, "markup": False},
                 )
             ]


### PR DESCRIPTION
The large-paste toast now says “Paste again to expand” for more natural wording.

---

Removes an unnecessary directional qualifier without changing paste behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/4b264370-9295-5b76-d5a7-124361f8c4cd)