### PR TITLE
style(code): simplify `ask_user` question presentation

### DIFF
--- a/libs/code/deepagents_code/app.tcss
+++ b/libs/code/deepagents_code/app.tcss
@@ -369,16 +369,11 @@ ToolCallMessage.-ascii:hover {
 .ask-user-menu .ask-user-question {
     height: auto;
     margin-bottom: 1;
-}
-
-.ask-user-menu .ask-user-question-active {
-    border-left: thick $success;
-    padding-left: 1;
+    padding-left: 2;
 }
 
 .ask-user-menu .ask-user-question-inactive {
     opacity: 0.5;
-    padding-left: 2;
 }
 
 .ask-user-menu .ask-user-question-text {

--- a/libs/code/deepagents_code/tui/widgets/ask_user.py
+++ b/libs/code/deepagents_code/tui/widgets/ask_user.py
@@ -169,7 +169,7 @@ class AskUserMenu(Container):
 
         with Vertical(classes="ask-user-questions"):
             for i, q in enumerate(self._questions):
-                qw = _QuestionWidget(q, index=i)
+                qw = _QuestionWidget(q, index=i, show_number=count > 1)
                 self._question_widgets.append(qw)
                 yield qw
 
@@ -387,11 +387,19 @@ class _QuestionWidget(Vertical):
     can_focus = True
     can_focus_children = True
 
-    def __init__(self, question: Question, index: int, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        question: Question,
+        index: int,
+        *,
+        show_number: bool = True,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(classes="ask-user-question", **kwargs)
         question_type = question.get("type", "text")
         self._question: Question = question
         self._index: int = index
+        self._show_number = show_number
         self._q_type: Literal["text", "multiple_choice"] = (
             "multiple_choice" if question_type == "multiple_choice" else "text"
         )
@@ -405,11 +413,11 @@ class _QuestionWidget(Vertical):
 
     def compose(self) -> ComposeResult:
         q_text = _TRAILING_ANNOTATION_RE.sub("", self._question.get("question", ""))
-        num = self._index + 1
+        prefix = f"**{self._index + 1}.** " if self._show_number else ""
         suffix = " *(required)*" if self._required else ""
         # q_text is agent-authored; rendered as markdown intentionally so
         # agents can use inline formatting, links, and code spans in questions.
-        yield Markdown(f"**{num}.** {q_text}{suffix}", classes="ask-user-question-text")
+        yield Markdown(f"{prefix}{q_text}{suffix}", classes="ask-user-question-text")
 
         if self._q_type == "multiple_choice" and self._choices:
             for i, choice in enumerate(self._choices):

--- a/libs/code/tests/unit_tests/tui/widgets/test_ask_user.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_ask_user.py
@@ -1150,6 +1150,32 @@ class TestAskUserMenu:
             help_text = menu.query_one(".ask-user-help").render()
             assert "Ctrl+X" not in str(help_text)
 
+    async def test_single_question_hides_number_label(self) -> None:
+        app = _AskUserTestApp([{"question": "Name?", "type": "text"}])
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu = app.query_one("#ask-user-menu", AskUserMenu)
+            source = menu._question_widgets[0].query_one(Markdown).source
+            assert source == "Name? *(required)*"
+
+    async def test_multiple_questions_show_number_labels(self) -> None:
+        app = _AskUserTestApp(
+            [
+                {"question": "Name?", "type": "text"},
+                {"question": "Color?", "type": "text"},
+            ]
+        )
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu = app.query_one("#ask-user-menu", AskUserMenu)
+            sources = [qw.query_one(Markdown).source for qw in menu._question_widgets]
+            assert sources == [
+                "**1.** Name? *(required)*",
+                "**2.** Color? *(required)*",
+            ]
+
     async def test_required_label_shown_for_required_question(self) -> None:
         """Required questions display a (required) indicator."""
         app = _AskUserTestApp([{"question": "Name?", "type": "text", "required": True}])


### PR DESCRIPTION
Single-question `ask_user` prompts no longer repeat a `1.` label, and active questions no longer show a left-side highlight bar.

---

The prompt title already conveys singular versus plural context, so numbering remains only when it helps distinguish multiple questions. Shared padding keeps active and inactive questions aligned while inactive dimming still communicates navigation state.

Made by [Open SWE](https://openswe.vercel.app/agents/59f5b894-b153-a1c4-7c99-0e8309efcb8b)