### PR TITLE
fix(code): shorten Auto classifier selection message

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -19817,8 +19817,7 @@ class DeepAgentsApp(App):
                 else:
                     message = (
                         f"Auto classifier model set to {display}{revalidated}; it "
-                        "reviews gated actions from the next turn and is already "
-                        "the default for future sessions."
+                        "reviews gated actions from the next turn."
                     )
             else:
                 message = (

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -13634,7 +13634,8 @@ class TestAutoClassifierModelCommand:
             await pilot.pause()
 
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
-            assert "already the default for future sessions" in rendered
+            assert "reviews gated actions from the next turn." in rendered
+            assert "already the default for future sessions" not in rendered
             assert "Press Ctrl+S" not in rendered
             assert "config.toml" not in rendered
 


### PR DESCRIPTION
Auto classifier selection confirmations no longer state that the saved choice is already the default for future sessions.

---

The persisted-selection path now keeps only the immediate effect of the model change, with a focused test covering the copy.

Made by [Open SWE](https://openswe.vercel.app/agents/ad619540-b1ce-616c-c432-4ffda310a0c0)