### PR TITLE
fix(code): queue `/copy` during active generation

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -14185,7 +14185,7 @@ class DeepAgentsApp(App):
             success, error = copy_text_to_clipboard(self, content)
             if success:
                 await self._mount_message(
-                    AppMessage("Copied latest assistant message to clipboard."),
+                    AppMessage("Copied latest response to clipboard."),
                 )
             else:
                 fail_msg = (

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -122,7 +122,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         name="/copy",
         description="Copy the latest assistant message to clipboard",
-        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+        bypass_tier=BypassTier.QUEUED,
     ),
     SlashCommand(
         name="/context",

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -7428,7 +7428,7 @@ class TestCopyCommand:
             copy_mock.assert_called_once_with(app, markdown)
             assert any(w._content == "/copy" for w in app.query(UserMessage))
             assert any(
-                str(w._content) == "Copied latest assistant message to clipboard."
+                str(w._content) == "Copied latest response to clipboard."
                 for w in app.query(AppMessage)
             )
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -23481,7 +23481,7 @@ class TestDeferredActions:
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
-            for cmd in ("/changelog", "/copy", "/docs", "/feedback", "/mcp"):
+            for cmd in ("/changelog", "/docs", "/feedback", "/mcp"):
                 assert app._can_bypass_queue(cmd) is True
 
     async def test_queued_commands_do_not_bypass(self) -> None:
@@ -23489,8 +23489,21 @@ class TestDeferredActions:
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
-            for cmd in ("/help", "/clear", "/tokens"):
+            for cmd in ("/help", "/clear", "/copy", "/tokens"):
                 assert app._can_bypass_queue(cmd) is False
+
+    async def test_copy_queues_while_agent_is_running(self) -> None:
+        """`/copy` waits for the active assistant response to complete."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            app.post_message(ChatInput.Submitted("/copy", "command"))
+            await pilot.pause()
+
+            assert len(app._pending_messages) == 1
+            assert app._pending_messages[0].text == "/copy"
 
     async def test_can_bypass_queue_empty_string(self) -> None:
         """Empty string should not bypass the queue."""

--- a/libs/code/tests/unit_tests/test_command_registry.py
+++ b/libs/code/tests/unit_tests/test_command_registry.py
@@ -300,8 +300,8 @@ class TestCopyCommand:
         # assert the entry is registered with a non-empty description.
         assert copy_entry.description
 
-    def test_copy_classified_as_side_effect_free(self) -> None:
-        assert "/copy" in SIDE_EFFECT_FREE
+    def test_copy_classified_as_queue_bound(self) -> None:
+        assert "/copy" in QUEUE_BOUND
 
 
 class TestCommandsCatalogDrift:


### PR DESCRIPTION
`/copy` now waits for active generation to finish before copying the latest assistant message, and its success message now reads `Copied latest response to clipboard.`

---

Classifying the command as queue-bound prevents it from racing an in-progress response and copying the prior completed response (which can be confusing if you were expecting it to copy the in-progress generation).

Made by [Open SWE](https://openswe.vercel.app/agents/d6cdd47e-3cb7-51d8-983c-4501047ec603)
