### PR TITLE
fix(code): clarify `/auto model clear` copy

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -19642,7 +19642,10 @@ class DeepAgentsApp(App):
             # entry that reverts to the main agent model. `_auto_usage_text`
             # carries the hint, but it is mounted only for an unrecognized
             # `/auto` subcommand, so no path that opens this modal shows it.
-            tail = " Clear it with `/auto model clear`."
+            tail = (
+                " Run `/auto model clear` to have Auto review with the main agent "
+                "model."
+            )
 
         # Every branch hands the screen a `Content`: the description reaches a
         # `Static`, which parses a plain `str` as markup. The branches naming a

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -13452,7 +13452,7 @@ class TestAutoClassifierModelCommand:
 
         assert self._rendered_description(push) == (
             "Auto currently reviews with anthropic:claude-haiku-4-5."
-            " Clear it with `/auto model clear`."
+            " Run `/auto model clear` to have Auto review with the main agent model."
         )
 
     async def test_selector_description_marks_a_classifier_matching_the_main_model(
@@ -13469,7 +13469,7 @@ class TestAutoClassifierModelCommand:
 
         assert self._rendered_description(push) == (
             "Auto currently reviews with openai:gpt-5.5, the main agent model."
-            " Clear it with `/auto model clear`."
+            " Run `/auto model clear` to have Auto review with the main agent model."
         )
 
     async def test_selector_description_does_not_parse_a_spec_as_markup(self) -> None:
@@ -13484,7 +13484,7 @@ class TestAutoClassifierModelCommand:
 
         assert self._rendered_description(push) == (
             "Auto currently reviews with anthropic:claude-opus-5[dim]."
-            " Clear it with `/auto model clear`."
+            " Run `/auto model clear` to have Auto review with the main agent model."
         )
 
     async def test_selector_description_does_not_crash_on_a_closing_tag_spec(
@@ -13501,7 +13501,7 @@ class TestAutoClassifierModelCommand:
 
         assert self._rendered_description(push) == (
             "Auto currently reviews with anthropic:claude-opus-5[/]."
-            " Clear it with `/auto model clear`."
+            " Run `/auto model clear` to have Auto review with the main agent model."
         )
 
     async def test_selector_description_renders_markup_safely_when_mounted(


### PR DESCRIPTION
The Auto model picker now explains that `/auto model clear` makes Auto review with the main agent model.

---

The previous “Clear it” wording named the command without explaining its effect, leaving users unsure what configuration would change.

Made by [Open SWE](https://openswe.vercel.app/agents/76573f94-69ce-2912-bf18-cb11764930c5)