### PR TITLE
fix(evals): override `filelock` to `>=3.30.3` to clear harbor build-lock deadlocks

### DIFF
--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -120,6 +120,14 @@ override-dependencies = [
     "python-multipart>=0.0.32",
     # CVE-2026-0994: JSON recursion depth bypass DoS in <= 6.33.4
     "protobuf>=7.35.1",
+    # tox-dev/filelock#675: in 3.29.7 an `AsyncFileLock` acquire raises a spurious
+    # "Deadlock" whenever another asyncio task on the same loop already holds that
+    # path. Harbor takes exactly that lock around its Docker image builds, so every
+    # trial that starts while a peer is still building dies. Fixed in 3.30.3.
+    # `deepagents-code` caps filelock at `<3.30` and 3.29.7 is the last 3.29, so an
+    # override is the only way to reach the fix; the cap is correct for that package,
+    # which uses only the synchronous `FileLock`.
+    "filelock>=3.30.3",
 ]
 
 [tool.uv.sources]

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -125,8 +125,12 @@ override-dependencies = [
     # path. Harbor takes exactly that lock around its Docker image builds, so every
     # trial that starts while a peer is still building dies. Fixed in 3.30.3.
     # `deepagents-code` caps filelock at `<3.30` and 3.29.7 is the last 3.29, so an
-    # override is the only way to reach the fix; the cap is correct for that package,
-    # which uses only the synchronous `FileLock`.
+    # override is the only way to reach the fix. Leave that cap alone: 3.30+ runs a
+    # blocking temp-dir probe at import time, which trips Blockbuster on the dcode
+    # async server startup path. This override is safe because it is scoped to the
+    # eval harness, where harbor imports filelock eagerly in a plain process with no
+    # Blockbuster active, and it does not reach the sandbox venv, which installs
+    # `deepagents-code` directly and so resolves filelock under that cap.
     "filelock>=3.30.3",
 ]
 

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -19,6 +19,7 @@ required-markers = [
 [manifest]
 overrides = [
     { name = "e2b", specifier = "==2.26.0" },
+    { name = "filelock", specifier = ">=3.30.3" },
     { name = "openai", specifier = ">=2.44.0,<3.0.0" },
     { name = "protobuf", specifier = ">=7.35.1" },
     { name = "python-multipart", specifier = ">=0.0.32" },
@@ -863,11 +864,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.7"
+version = "3.32.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172, upload-time = "2026-07-29T22:46:04.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830, upload-time = "2026-07-29T22:46:03.52Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Unified evals run [31541400926](https://github.com/langchain-ai/deepagents/actions/runs/31541400926) lost **97 of 147 context trials** across all five models. Every shard job still reported ✅, so the failure was only visible in LangSmith and the retained `exception.txt` files.

91 of those trials died during environment setup with:

```
RuntimeError: Deadlock: lock '.../harbor-prebuilt-harbor-docker-egress-control-sidecar-*/.harbor-docker-build.lock'
is already held by a different BaseAsyncFileLock instance in this task.
```

This is [tox-dev/filelock#675](https://github.com/tox-dev/filelock/issues/675): in filelock 3.29.7 the reentrant-deadlock registry is a thread-local, but the check runs on the event-loop thread, so every asyncio task on that loop shares it. An `AsyncFileLock` acquire then raises a spurious "Deadlock" whenever a *different task* already holds the path. Fixed upstream in **3.30.3**.

Harbor takes exactly that lock in `ensure_docker_image_built` around the egress-control sidecar build. Every `cb-cloud-*` context task sets `network_mode = "allowlist"`, so on a cold runner the first trial holds the lock through the image build and every trial starting after it dies immediately. Lite runs 1 task/shard × 3 rollouts, so exactly one rollout per task survived and `avg@k` collapsed to `pass@k / 3`.

## Fix

Add `filelock>=3.30.3` to the existing `[tool.uv] override-dependencies` block in `libs/evals`, and re-lock (3.29.7 → 3.32.2).

An override is required because `deepagents-code` declares `filelock>=3.29.7,<3.30`, and since 3.29.7 is the last 3.29 release that range admits only the broken version. That cap is deliberately left alone: nothing outside harbor uses `AsyncFileLock`, and `deepagents-code` uses only the synchronous `FileLock`, so the bug never affected it.

## Testing

Drove harbor's real `ensure_docker_image_built` from 3 staggered concurrent tasks against a live docker build, clearing the built image and build cache between arms so neither could early-return on a cache hit:

| filelock | result |
|---|---|
| 3.29.7 | 1/3 succeeded, 2 raised `RuntimeError: Deadlock` |
| 3.32.2 | 3/3 succeeded |

The 1-of-3 result reproduces the CI signature exactly. Note that the full `-n 3 --env docker` path cannot run on macOS: `DockerEnvironment` only enables egress control on Linux or when a kernel probe passes, and Docker Desktop's LinuxKit kernel lacks `CONFIG_NFT_FIB_INET`, so allowlist tasks are rejected before the sidecar is ever built. An end-to-end context run on a Linux runner is still worth doing on this branch.