### PR TITLE
hotfix(code): skip checkout `pyproject.toml` test when running from a built wheel

### DIFF
--- a/libs/code/tests/unit_tests/test_dep_floor_check.py
+++ b/libs/code/tests/unit_tests/test_dep_floor_check.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import builtins
 import json
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
-    from pathlib import Path
     from types import ModuleType
 
 import pytest
@@ -222,6 +222,16 @@ class TestBestEffort:
 
     def test_checkout_pyproject_reads(self) -> None:
         """The live checkout's pyproject parses into requirement strings."""
+        # `_load_cli_requirements` reads the `pyproject.toml` two directories
+        # above the installed module. Wheel installs (e.g. the release
+        # pipeline's built-wheel test run) have no checkout `pyproject.toml`
+        # there, so the function takes its designed `None` fallback and this
+        # test has nothing to assert against.
+        pyproject = (
+            Path(dep_floor_check.__file__).resolve().parent.parent / "pyproject.toml"
+        )
+        if not pyproject.is_file():
+            pytest.skip("no checkout pyproject.toml adjacent to the installed package")
         entries = _load_cli_requirements()
         assert entries is not None
         assert entries


### PR DESCRIPTION
Related: #5386

A unit test that assumed a source checkout now skips when running from an installed wheel, unblocking the `deepagents-code` release pipeline.

---

The test asserts a checkout-only file can be read, but the release pipeline runs tests against the built wheel, where that file doesn't exist. It now checks for the file first and `pytest.skip`s when it's absent; checkout behavior is unchanged.