### PR TITLE
chore(infra): clarify `dangerous-nonmain-release` input description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ on:
         default: false
         description:
           "Release from a non-main branch (danger!) - Only use for backports
-          and hotfixes"
+          or hotfixes not on main"
       dangerous-skip-sdk-pin-check:
         required: false
         type: boolean


### PR DESCRIPTION
The old wording was ambiguous: "backports and hotfixes" could read as if the input applied to hotfixes generally, but hotfix commits are normally layered on top of the release-please squash-merge commit on `main` and released via the standard `release_commit` path. The non-main toggle is only for the cases where the release genuinely cannot come from `main` — a backport release cut from a version branch, or a hotfix that for some reason lives off `main`.