### PR TITLE
feat(infra): post a timeline comment when `@release-bot draft` regenerates notes

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -63,6 +63,8 @@ Keep the release PR in draft while changes are still accumulating. When it is re
 
 Run `@release-bot draft` to regenerate the draft if the automatic run fails or new changes cause release-please to add changelog entries to the release PR. If release-please updates the PR after the notes were applied, the check will fail until you run `draft` and `apply` again.
 
+Re-drafting rewrites the original notes comment in place, which GitHub does not surface in the timeline. So that a regenerated draft is not missed, the bot follows an in-place rewrite with a short comment linking back to the refreshed notes — one per re-draft. A first-time draft posts no such pointer, since a brand-new comment is already visible.
+
 `@release-bot draft` accepts optional one-off editing instructions on the same line, for example `@release-bot draft emphasize the breaking SDK change`. The instruction is passed to the drafting model as guidance subordinate to its fixed editing rules, capped at 500 characters, and echoed in the posted draft comment so the prompt that produced a draft is auditable. Anything after a second `@` on the line is dropped. `@release-bot apply` takes no instructions — it republishes the stored draft verbatim, so text after `apply` is ignored.
 
 During a fanout release each package gets its own release PR, and each needs its own `draft`/`apply`. Commands act only on the PR they are posted to.

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -540,10 +540,24 @@ async function upsertOwnMarkedComment({ github, owner, repo, number, comments, l
 // original comment. After an in-place update, post a small pointer comment so
 // the refresh shows up in the timeline. Best-effort: a failure here must not
 // turn an already-successful draft post into a job failure. The pointer body
-// must never include COMMAND_MENTION, or it would re-trigger the command flow.
+// must never include COMMAND_MENTION; bot-authored comments are already dropped
+// by validateTrigger and by the workflow's author_association gate, and keeping
+// the mention out means neither of those is the only thing standing between an
+// echo and a self-trigger loop.
+//
+// REFRESH_MARKER is only there for humans and `grep` — nothing parses it back,
+// and unlike every other marked comment these notices are deliberately *not*
+// upserted. Editing a prior notice in place would be exactly as silent as the
+// problem being solved, so one notice per re-draft is the point.
 async function announceRefresh({ github, owner, repo, number, core, refreshedComment, component, version }) {
+  // Misuse must fail here rather than inside the catch below, where it would
+  // replace a real API error with a TypeError from an absent `core`.
+  if (typeof core?.warning !== 'function') {
+    throw new TypeError('announceRefresh requires a core with a warning() method');
+  }
+  // `||`, not `??`: an empty-string html_url would otherwise produce a dead link.
   const url = refreshedComment.html_url
-    ?? `https://github.com/${owner}/${repo}/pull/${number}#issuecomment-${refreshedComment.id}`;
+    || `https://github.com/${owner}/${repo}/pull/${number}#issuecomment-${refreshedComment.id}`;
   try {
     await createComment(
       github,
@@ -553,8 +567,12 @@ async function announceRefresh({ github, owner, repo, number, core, refreshedCom
       `${REFRESH_MARKER} for ${component} ${version} -->\nThe curated release-notes comment on this PR was regenerated in place; review the latest draft in [the original comment](${url}).`,
     );
   } catch (error) {
+    // Include the status: a transient 403 rate limit and a permanent 422 body
+    // rejection both land here, but only the latter will recur on every
+    // re-draft and needs a human to notice it in the run log.
+    const status = error?.status ? ` (HTTP ${error.status})` : '';
     core.warning(
-      `Draft comment ${refreshedComment.id} was updated but posting the refreshed notice failed: ${error instanceof Error ? error.message : String(error)}`,
+      `Draft comment ${refreshedComment.id} on ${owner}/${repo}#${number} (${component} ${version}) was updated but posting the refreshed notice failed${status}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 }
@@ -755,7 +773,12 @@ function validateDraftOutput(output) {
   return notes;
 }
 
-async function postDraft({ github, owner, repo, stateFile, outputFile, appSlug, login, id, core = null }) {
+// `core` is required, not optional: an absent one would skip the refresh notice
+// with no throw and no warning, silently restoring the very bug it exists to fix.
+async function postDraft({ github, owner, repo, stateFile, outputFile, appSlug, login, id, core }) {
+  if (typeof core?.warning !== 'function') {
+    throw new TypeError('postDraft requires a core with a warning() method');
+  }
   await authenticatedBot(github, appSlug, login, id);
   const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
   const pr = await getPr(github, owner, repo, state.number);
@@ -791,7 +814,7 @@ async function postDraft({ github, owner, repo, stateFile, outputFile, appSlug, 
       instructions: state.instructions ?? '',
     }),
   });
-  if (!created && core) {
+  if (!created) {
     await announceRefresh({
       github,
       owner,

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -541,18 +541,20 @@ async function upsertOwnMarkedComment({ github, owner, repo, number, comments, l
 // the refresh shows up in the timeline. Best-effort: a failure here must not
 // turn an already-successful draft post into a job failure. The pointer body
 // must never include COMMAND_MENTION, or it would re-trigger the command flow.
-async function announceRefresh({ github, owner, repo, number, core, refreshedCommentId, component, version }) {
+async function announceRefresh({ github, owner, repo, number, core, refreshedComment, component, version }) {
+  const url = refreshedComment.html_url
+    ?? `https://github.com/${owner}/${repo}/pull/${number}#issuecomment-${refreshedComment.id}`;
   try {
     await createComment(
       github,
       owner,
       repo,
       number,
-      `${REFRESH_MARKER} for ${component} ${version} -->\nThe curated release-notes comment on this PR was regenerated in place; review the latest draft in that comment.`,
+      `${REFRESH_MARKER} for ${component} ${version} -->\nThe curated release-notes comment on this PR was regenerated in place; review the latest draft in [that comment](${url}).`,
     );
   } catch (error) {
     core.warning(
-      `Draft comment ${refreshedCommentId} was updated but posting the refreshed notice failed: ${error instanceof Error ? error.message : String(error)}`,
+      `Draft comment ${refreshedComment.id} was updated but posting the refreshed notice failed: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 }
@@ -796,7 +798,7 @@ async function postDraft({ github, owner, repo, stateFile, outputFile, appSlug, 
       repo,
       number: state.number,
       core,
-      refreshedCommentId: comment.id,
+      refreshedComment: comment,
       component: state.component,
       version: state.version,
     });

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -550,7 +550,7 @@ async function announceRefresh({ github, owner, repo, number, core, refreshedCom
       owner,
       repo,
       number,
-      `${REFRESH_MARKER} for ${component} ${version} -->\nThe curated release-notes comment on this PR was regenerated in place; review the latest draft in [that comment](${url}).`,
+      `${REFRESH_MARKER} for ${component} ${version} -->\nThe curated release-notes comment on this PR was regenerated in place; review the latest draft in [the original comment](${url}).`,
     );
   } catch (error) {
     core.warning(

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -23,6 +23,7 @@ const CONTENT_END = '<!-- release-notes-content-end -->';
 const STALE_MARKER = '<!-- release-notes-stale';
 const FAILURE_MARKER = '<!-- release-notes-draft-failure';
 const APPLY_FAILURE_MARKER = '<!-- release-notes-apply-failure';
+const REFRESH_MARKER = '<!-- release-notes-refreshed';
 // Prefix shared by every marker above. validateDraftOutput rejects it wholesale so
 // model output cannot forge any of them.
 const MARKER_PREFIX = '<!-- release-notes-';
@@ -513,6 +514,9 @@ async function createComment(github, owner, repo, number, body) {
   return github.rest.issues.createComment({ owner, repo, issue_number: number, body });
 }
 
+// Upserts the latest bot-owned comment carrying `marker`. Returns
+// { comment, created } so a caller can tell a fresh comment from an in-place
+// edit — an edit is what maintainers would otherwise never notice.
 async function upsertOwnMarkedComment({ github, owner, repo, number, comments, login, id, marker, body }) {
   const existing = [...comments]
     .filter(comment => matchesBot(comment, login, id) && (comment.body ?? '').startsWith(`<!-- ${marker}\n`))
@@ -524,10 +528,33 @@ async function upsertOwnMarkedComment({ github, owner, repo, number, comments, l
       comment_id: existing.id,
       body,
     });
-    return response.data;
+    return { comment: response.data, created: false };
   }
   const response = await createComment(github, owner, repo, number, body);
-  return response.data;
+  return { comment: response.data, created: true };
+}
+
+// Re-drafting replaces the curated-notes comment in place, and GitHub surfaces
+// comment edits quietly (no notification, no timeline entry), so a regenerated
+// draft is easy to miss — the PR looks unchanged unless someone re-opens the
+// original comment. After an in-place update, post a small pointer comment so
+// the refresh shows up in the timeline. Best-effort: a failure here must not
+// turn an already-successful draft post into a job failure. The pointer body
+// must never include COMMAND_MENTION, or it would re-trigger the command flow.
+async function announceRefresh({ github, owner, repo, number, core, refreshedCommentId, component, version }) {
+  try {
+    await createComment(
+      github,
+      owner,
+      repo,
+      number,
+      `${REFRESH_MARKER} for ${component} ${version} -->\nThe curated release-notes comment on this PR was regenerated in place; review the latest draft in that comment.`,
+    );
+  } catch (error) {
+    core.warning(
+      `Draft comment ${refreshedCommentId} was updated but posting the refreshed notice failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 async function getPr(github, owner, repo, number) {
@@ -726,7 +753,7 @@ function validateDraftOutput(output) {
   return notes;
 }
 
-async function postDraft({ github, owner, repo, stateFile, outputFile, appSlug, login, id }) {
+async function postDraft({ github, owner, repo, stateFile, outputFile, appSlug, login, id, core = null }) {
   await authenticatedBot(github, appSlug, login, id);
   const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
   const pr = await getPr(github, owner, repo, state.number);
@@ -743,7 +770,7 @@ async function postDraft({ github, owner, repo, stateFile, outputFile, appSlug, 
   const notes = validateDraftOutput(fs.readFileSync(outputFile, 'utf8'));
   const section = `${state.heading}\n\n${notes.trim()}\n`;
   const comments = await listComments(github, owner, repo, state.number);
-  return upsertOwnMarkedComment({
+  const { comment, created } = await upsertOwnMarkedComment({
     github,
     owner,
     repo,
@@ -762,6 +789,19 @@ async function postDraft({ github, owner, repo, stateFile, outputFile, appSlug, 
       instructions: state.instructions ?? '',
     }),
   });
+  if (!created && core) {
+    await announceRefresh({
+      github,
+      owner,
+      repo,
+      number: state.number,
+      core,
+      refreshedCommentId: comment.id,
+      component: state.component,
+      version: state.version,
+    });
+  }
+  return comment;
 }
 
 // Post a bot-authored failure notice once per PR head (deduped by the head-scoped
@@ -948,7 +988,7 @@ async function publishAppliedState({ github, owner, repo, stateFile, appliedHead
   });
   await validateReleaseBranchHead({ github, owner, repo, releaseBranch: target.releaseBranch, expectedHead: appliedHead });
   await github.rest.pulls.update({ owner, repo, pull_number: state.number, body: state.body });
-  return upsertOwnMarkedComment({
+  const { comment } = await upsertOwnMarkedComment({
     github,
     owner,
     repo,
@@ -968,6 +1008,7 @@ async function publishAppliedState({ github, owner, repo, stateFile, appliedHead
       contentHash: state.contentHash,
     }),
   });
+  return comment;
 }
 
 async function fetchChangelog(github, owner, repo, ref, changelogPath) {
@@ -1242,6 +1283,7 @@ module.exports = {
   CONTENT_END,
   CONTENT_START,
   RELEASE_BRANCH_PREFIX,
+  announceRefresh,
   canonical,
   changelogFingerprint,
   checkCuratedState,

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -1649,6 +1649,68 @@ test('re-drafting updates the existing override comment instead of creating a ne
   assert.equal(run.calls.createComment.length, 0);
 });
 
+test('re-drafting posts a refreshed notice after editing the override comment in place', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-notes-refresh-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const state = path.join(dir, 'state.json');
+  const output = path.join(dir, 'output.md');
+  fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
+  fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
+  const run = makeGithub({ comments: [overrideComment({ id: 55 })] });
+  const core = makeCore();
+  await releaseNotes.postDraft({ github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core, ...BOT_AUTH });
+  assert.equal(run.calls.updateComment.length, 1);
+  // The in-place edit is followed by exactly one timeline comment that points at
+  // the regenerated draft, so maintainers learn the notes changed without
+  // watching the original comment.
+  assert.equal(run.calls.createComment.length, 1);
+  const notice = run.calls.createComment[0].body;
+  assert.match(notice, /regenerated in place/);
+  assert.match(notice, /release-notes-refreshed/);
+  // The pointer must never re-trigger the command flow.
+  assert.ok(!notice.includes('@release-bot'));
+  assert.equal(core.warnings.length, 0);
+});
+
+test('a first-time draft creates the override comment without a refreshed notice', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-notes-first-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const state = path.join(dir, 'state.json');
+  const output = path.join(dir, 'output.md');
+  fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
+  fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
+  const run = makeGithub();
+  await releaseNotes.postDraft({ github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH });
+  assert.equal(run.calls.updateComment.length, 0);
+  // Only the draft comment itself; no "regenerated" pointer, because nothing
+  // pre-existing was silently edited.
+  assert.equal(run.calls.createComment.length, 1);
+  assert.match(run.calls.createComment[0].body, /release-notes-override/);
+});
+
+test('a failed refreshed notice only warns and never fails the draft post', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-notes-refresh-fail-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const state = path.join(dir, 'state.json');
+  const output = path.join(dir, 'output.md');
+  fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
+  fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
+  let created = 0;
+  const run = makeGithub({
+    comments: [overrideComment({ id: 55 })],
+    onCreateComment: () => {
+      created += 1;
+      throw new Error('secondary rate limit');
+    },
+  });
+  const core = makeCore();
+  await releaseNotes.postDraft({ github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core, ...BOT_AUTH });
+  assert.equal(created, 1);
+  assert.equal(run.calls.updateComment.length, 1);
+  assert.equal(core.warnings.length, 1);
+  assert.match(core.warnings[0], /posting the refreshed notice failed/);
+});
+
 test('prepareApply fails when no valid override is present', async t => {
   const workspace = tempWorkspace();
   t.after(() => fs.rmSync(workspace.root, { recursive: true, force: true }));

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -45,11 +45,14 @@ function releasePr(overrides = {}) {
   };
 }
 
-function overrideComment({ id = 10, section = CURATED_SECTION, fingerprint = releaseNotes.changelogFingerprint(GENERATED_SECTION), head = HEAD, updatedAt = OVERRIDE_UPDATED_AT } = {}) {
+function overrideComment({ id = 10, section = CURATED_SECTION, fingerprint = releaseNotes.changelogFingerprint(GENERATED_SECTION), head = HEAD, updatedAt = OVERRIDE_UPDATED_AT, htmlUrl = null } = {}) {
   return {
     id,
     updated_at: updatedAt,
     user: BOT,
+    // Real GitHub always returns html_url; opt in per-test so both the
+    // API-provided link and the hand-built fallback stay covered.
+    ...(htmlUrl === null ? {} : { html_url: htmlUrl }),
     body: [
       '<!-- release-notes-override',
       'package: deepagents-code',
@@ -532,7 +535,7 @@ test('posts a bot-authored draft and refuses stale agent output', async t => {
   fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
   fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
   const { github, calls } = makeGithub();
-  await releaseNotes.postDraft({ github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, ...BOT_AUTH });
+  await releaseNotes.postDraft({ github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH });
   assert.deepEqual(calls.getByUsername, [{ username: BOT.login }]);
   assert.equal(calls.createComment.length, 1);
   assert.match(calls.createComment[0].body, /changelog-fingerprint:/);
@@ -549,7 +552,7 @@ test('posts a bot-authored draft and refuses stale agent output', async t => {
 
   const stale = makeGithub({ pr: releasePr({ head: { ...releasePr().head, sha: 'c'.repeat(40) } }) });
   await assert.rejects(
-    releaseNotes.postDraft({ github: stale.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, ...BOT_AUTH }),
+    releaseNotes.postDraft({ github: stale.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH }),
     /changed while notes were being drafted/,
   );
 });
@@ -562,7 +565,7 @@ test('posts a draft that echoes the maintainer instructions it used', async t =>
   fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING, instructions: 'emphasize the breaking SDK change' }));
   fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
   const { github, calls } = makeGithub();
-  await releaseNotes.postDraft({ github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, ...BOT_AUTH });
+  await releaseNotes.postDraft({ github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH });
   assert.equal(calls.createComment.length, 1);
   assert.match(calls.createComment[0].body, /Drafted with maintainer instructions: emphasize the breaking SDK change/);
   // The echo sits outside the marked metadata block and the editable content
@@ -893,14 +896,14 @@ test('postDraft fails when the installation App is not the configured bot', asyn
 
   const wrongSlug = makeGithub();
   await assert.rejects(
-    releaseNotes.postDraft({ github: wrongSlug.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, ...BOT_AUTH, appSlug: 'someone-else' }),
+    releaseNotes.postDraft({ github: wrongSlug.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH, appSlug: 'someone-else' }),
     /token was minted for someone-else\[bot\]/,
   );
   assert.equal(wrongSlug.calls.getByUsername.length, 0);
 
   const wrongUser = makeGithub({ appUser: { login: BOT.login, id: 7 } });
   await assert.rejects(
-    releaseNotes.postDraft({ github: wrongUser.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, ...BOT_AUTH }),
+    releaseNotes.postDraft({ github: wrongUser.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH }),
     /GitHub App bot is release-notes-bot\[bot\] \(7\)/,
   );
   assert.equal(wrongUser.calls.createComment.length, 0);
@@ -1188,7 +1191,7 @@ test('postDraft output round-trips through parseOverrideComment', async t => {
   fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
   fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
   const { github, calls } = makeGithub();
-  await releaseNotes.postDraft({ github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, ...BOT_AUTH });
+  await releaseNotes.postDraft({ github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH });
   const parsed = releaseNotes.parseOverrideComment({ user: BOT, body: calls.createComment[0].body });
   assert.ok(parsed, 'override comment should parse');
   assert.equal(parsed.metadata.version, VERSION);
@@ -1643,10 +1646,12 @@ test('re-drafting updates the existing override comment instead of creating a ne
   fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
   fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
   const run = makeGithub({ comments: [overrideComment({ id: 55 })] });
-  await releaseNotes.postDraft({ github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, ...BOT_AUTH });
+  await releaseNotes.postDraft({ github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH });
   assert.equal(run.calls.updateComment.length, 1);
   assert.equal(run.calls.updateComment[0].comment_id, 55);
-  assert.equal(run.calls.createComment.length, 0);
+  // The draft itself is an edit, so no *second* override comment is created.
+  // The one comment posted here is the refresh notice, which the test below owns.
+  assert.equal(run.calls.createComment.filter(call => call.body.includes('release-notes-override')).length, 0);
 });
 
 test('re-drafting posts a refreshed notice after editing the override comment in place', async t => {
@@ -1666,13 +1671,65 @@ test('re-drafting posts a refreshed notice after editing the override comment in
   assert.equal(run.calls.createComment.length, 1);
   const notice = run.calls.createComment[0].body;
   assert.match(notice, /regenerated in place/);
-  assert.match(notice, /release-notes-refreshed/);
-  // The pointer links directly to the edited comment so one click jumps to the
-  // new draft (the mocked comment has no html_url, so the fallback is used).
+  // Assert the whole marker line: a component/version that stopped flowing
+  // through would otherwise render as "for undefined undefined" unnoticed.
+  assert.ok(notice.startsWith(`<!-- release-notes-refreshed for ${COMPONENT} ${VERSION} -->\n`));
+  // This mocked comment carries no html_url, so the hand-built fallback is used.
   assert.ok(notice.includes('[the original comment](https://github.com/langchain-ai/deepagents/pull/123#issuecomment-55)'));
-  // The pointer must never re-trigger the command flow.
+  // Belt and braces: the pointer never echoes the command mention, so it cannot
+  // look like a command even if the bot-author filters are ever loosened.
   assert.ok(!notice.includes('@release-bot'));
   assert.equal(core.warnings.length, 0);
+});
+
+test('the refreshed notice prefers the html_url GitHub returns over the built fallback', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-notes-refresh-url-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const state = path.join(dir, 'state.json');
+  const output = path.join(dir, 'output.md');
+  fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
+  fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
+  // The path production always takes: real GitHub returns a permalink, and the
+  // notice must link to that rather than reconstructing one by hand.
+  const permalink = 'https://github.com/langchain-ai/deepagents/pull/123#issuecomment-987654';
+  const run = makeGithub({ comments: [overrideComment({ id: 55, htmlUrl: permalink })] });
+  await releaseNotes.postDraft({ github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH });
+  assert.equal(run.calls.createComment.length, 1);
+  assert.ok(run.calls.createComment[0].body.includes(`[the original comment](${permalink})`));
+});
+
+test('every re-draft posts its own notice rather than upserting one', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-notes-refresh-twice-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const state = path.join(dir, 'state.json');
+  const output = path.join(dir, 'output.md');
+  fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
+  fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
+  const run = makeGithub({ comments: [overrideComment({ id: 55 })] });
+  const draft = () => releaseNotes.postDraft({ github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH });
+  await draft();
+  await draft();
+  // Deliberately not deduped: editing a prior notice in place would be exactly
+  // as invisible as the silent comment edit this whole feature exists to expose.
+  assert.equal(run.calls.updateComment.length, 2);
+  assert.equal(run.calls.createComment.length, 2);
+});
+
+test('postDraft refuses to run without a core to warn through', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-notes-nocore-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const state = path.join(dir, 'state.json');
+  const output = path.join(dir, 'output.md');
+  fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
+  fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
+  const run = makeGithub({ comments: [overrideComment({ id: 55 })] });
+  // A missing core used to skip the notice silently, which is the same
+  // invisible-refresh bug this feature fixes. It must fail loudly instead.
+  await assert.rejects(
+    releaseNotes.postDraft({ github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, ...BOT_AUTH }),
+    /requires a core/,
+  );
+  assert.equal(run.calls.updateComment.length, 0);
 });
 
 test('a first-time draft creates the override comment without a refreshed notice', async t => {

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -1669,7 +1669,7 @@ test('re-drafting posts a refreshed notice after editing the override comment in
   assert.match(notice, /release-notes-refreshed/);
   // The pointer links directly to the edited comment so one click jumps to the
   // new draft (the mocked comment has no html_url, so the fallback is used).
-  assert.ok(notice.includes('[that comment](https://github.com/langchain-ai/deepagents/pull/123#issuecomment-55)'));
+  assert.ok(notice.includes('[the original comment](https://github.com/langchain-ai/deepagents/pull/123#issuecomment-55)'));
   // The pointer must never re-trigger the command flow.
   assert.ok(!notice.includes('@release-bot'));
   assert.equal(core.warnings.length, 0);

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -1667,6 +1667,9 @@ test('re-drafting posts a refreshed notice after editing the override comment in
   const notice = run.calls.createComment[0].body;
   assert.match(notice, /regenerated in place/);
   assert.match(notice, /release-notes-refreshed/);
+  // The pointer links directly to the edited comment so one click jumps to the
+  // new draft (the mocked comment has no html_url, so the fallback is used).
+  assert.ok(notice.includes('[that comment](https://github.com/langchain-ai/deepagents/pull/123#issuecomment-55)'));
   // The pointer must never re-trigger the command flow.
   assert.ok(!notice.includes('@release-bot'));
   assert.equal(core.warnings.length, 0);

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -237,6 +237,7 @@ jobs:
                 appSlug: process.env.APP_SLUG,
                 login: process.env.BOT_LOGIN,
                 id: process.env.BOT_ID,
+                core,
               });
             } catch (error) {
               core.setOutput('error', error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
Re-running `@release-bot draft` on a release PR now posts a short timeline comment linking to the regenerated notes, so the refresh is visible without re-opening the original comment.

---

Re-drafting edits the bot's curated-notes comment in place, and GitHub surfaces comment edits quietly: no notification, no timeline entry. From the timeline the PR looked unchanged, so a maintainer who re-ran `draft` with steering instructions had no signal that the notes actually regenerated.

The upsert helper now reports whether it created or edited the draft comment, and the draft job posts the pointer only after an in-place edit. First-time drafts (including the automatic `ready_for_review` draft) post nothing extra — a brand-new comment already shows up in the timeline. The notice is best-effort: if posting it fails, the draft still succeeds and the failure lands as a workflow warning. The notice body never mentions `@release-bot`, so it cannot re-trigger the command flow.

Example — maintainer re-runs `draft` with steering instructions:

1. Bot edits its existing curated-notes comment in place (no timeline entry).
2. Bot posts a new timeline comment:

   > The curated release-notes comment on this PR was regenerated in place; review the latest draft in [the original comment](#issuecomment-…).
