### PR TITLE
feat(code): trust user-declared endpoints for cold-cache policies

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4427,6 +4427,9 @@ class DeepAgentsApp(App):
         self._last_cache_model_params: dict[str, Any] | None = None
         """Model params associated with `_last_model_request_at`."""
 
+        self._last_cache_endpoint: str | None = None
+        """Endpoint identity associated with `_last_model_request_at`."""
+
         self._tokens_approximate: bool = False
         """Whether the cached token count is stale (interrupted generation)."""
 
@@ -8361,6 +8364,7 @@ class DeepAgentsApp(App):
         self._last_model_request_at = None
         self._last_cache_model_spec = ""
         self._last_cache_model_params = None
+        self._last_cache_endpoint = None
         self._session_cost_warning_shown = False
         self._set_session_cost(self._thread_restored_cost_usd)
 
@@ -8657,6 +8661,21 @@ class DeepAgentsApp(App):
             # so it silently pins every later send to "model changed".
             return value.strip() if isinstance(value, str) and value.strip() else None
 
+        def _usable_endpoint_identity(value: object) -> str | None:
+            # Shape-checked, not merely non-empty: `endpoint_cache_identity`
+            # only ever mints `"default"`, `"invalid:<digest>"`, or a value
+            # containing `"://"`. Anything else (a hand-edited row, a future
+            # format) can never equal a freshly computed identity, so accepting
+            # it would report `identity_changed` on the next send while the
+            # discard warning below stayed silent. Discarding is the quieter
+            # wrong answer and it self-heals on the next checkpoint write.
+            usable = _usable_spec(value)
+            if usable is None:
+                return None
+            if usable == "default" or usable.startswith("invalid:") or "://" in usable:
+                return usable
+            return None
+
         raw_spec = _usable_spec(
             state_values.get("_last_cache_model_spec")
         ) or _usable_spec(state_values.get("_model_spec"))
@@ -8674,10 +8693,24 @@ class DeepAgentsApp(App):
                 type(state_values.get("_model_spec")).__name__,
             )
         self._last_cache_model_spec = raw_spec or ""
-        raw_params = state_values.get("_model_params")
+        raw_params = state_values.get("_last_cache_params")
         self._last_cache_model_params = (
             dict(raw_params) if isinstance(raw_params, dict) else None
         )
+        raw_endpoint = state_values.get("_last_cache_endpoint")
+        self._last_cache_endpoint = _usable_endpoint_identity(raw_endpoint)
+        if raw_endpoint is not None and self._last_cache_endpoint is None:
+            # Unlike a bad spec, a discarded endpoint fails *quietly*: `None`
+            # reads back as "never recorded", which suppresses endpoint-change
+            # detection instead of over-warning. It self-heals once any model
+            # call re-checkpoints, but nothing else would surface the gap, so it
+            # is logged here.
+            logger.warning(
+                "Discarding checkpointed _last_cache_endpoint (%s); endpoint "
+                "changes will not be detected until the next successful model "
+                "request records a fresh one",
+                type(raw_endpoint).__name__,
+            )
 
     def _stamp_cache_identity_locally(self) -> None:
         """Record the just-run model as the cache identity, without a checkpoint.
@@ -8692,10 +8725,16 @@ class DeepAgentsApp(App):
         """
         from datetime import UTC, datetime
 
+        from deepagents_code.cold_cache import cache_identity_params
+
         self._last_model_request_at = datetime.now(UTC).isoformat()
         self._last_cache_model_spec = self._effective_model_spec() or ""
+        # Record only the cache-identity projection of the session overrides,
+        # matching what the middleware checkpoints in `_last_cache_params`:
+        # the comparison side filters through `cache_identity_params` too, so
+        # unrelated knobs must not read as a cache change here either.
         self._last_cache_model_params = (
-            dict(self._model_params_override) if self._model_params_override else None
+            cache_identity_params(self._model_params_override) or None
         )
 
     async def _sync_session_cost_from_checkpoint(self) -> None:
@@ -11240,9 +11279,9 @@ class DeepAgentsApp(App):
             )
             return None
 
-        current_params = self._model_params_override or None
         last_spec = self._last_cache_model_spec
         last_params = self._last_cache_model_params
+        last_endpoint = self._last_cache_endpoint
 
         def _evaluate() -> ColdCacheWarning | None:
             from datetime import UTC, datetime
@@ -11253,7 +11292,9 @@ class DeepAgentsApp(App):
                 RewarmEstimate,
                 cache_identity_params,
                 debug_stand_in_policy,
+                endpoint_cache_identity,
                 estimate_rewarm_cost,
+                load_trusted_cache_endpoints,
                 parse_cache_timestamp,
                 resolve_prompt_cache_policy,
             )
@@ -11268,11 +11309,45 @@ class DeepAgentsApp(App):
             # `Anthropic:claude-opus-5` would report no custom endpoint and
             # price a gateway user at official-API rates.
             provider = model_spec.split(":", 1)[0].strip().lower()
-            base_url = ModelConfig.load().get_base_url(provider)
+            config = ModelConfig.load()
+            _, _, model_name = model_spec.partition(":")
+            configured_params = config.get_effective_kwargs(
+                provider,
+                model_name=model_name,
+                overrides=self._model_params_override,
+            )
+            # Test doubles and third-party config implementations created
+            # before `get_effective_kwargs` existed may not implement it.
+            # Retain the old endpoint-only behavior for those objects while
+            # production `ModelConfig` always supplies the complete mapping.
+            current_params = (
+                configured_params if isinstance(configured_params, dict) else {}
+            )
+            if not current_params:
+                current_params = dict(self._model_params_override or {})
+                fallback_base_url = config.get_base_url(provider)
+                if isinstance(fallback_base_url, str):
+                    current_params["base_url"] = fallback_base_url
+            # Endpoint changes have their own normalized identity. Keeping
+            # `base_url` out of this mapping avoids treating the same endpoint
+            # as two independent identity changes.
+            params_for_policy = {
+                key: value for key, value in current_params.items() if key != "base_url"
+            } or None
+            resolved_base_url = current_params.get("base_url")
+            base_url = resolved_base_url if isinstance(resolved_base_url, str) else None
+            endpoint = endpoint_cache_identity(base_url)
             policy = resolve_prompt_cache_policy(
                 model_spec,
-                current_params,
+                params_for_policy,
                 base_url=base_url,
+                # Only consulted for a custom endpoint: with no `base_url`,
+                # `_official_endpoint` short-circuits to `True` and the trust
+                # set is provably unused. Loading it eagerly would re-read and
+                # re-parse `config.toml` from disk on every turn of the common
+                # official-API path, which is the very cost the comment below
+                # is about.
+                trusted_endpoints=load_trusted_cache_endpoints() if base_url else None,
             )
             # Resolved before the suppression lookup so the common
             # no-policy case skips re-reading and re-parsing config.toml.
@@ -11353,17 +11428,26 @@ class DeepAgentsApp(App):
                 )
             else:
                 age_seconds = max(elapsed or 0.0, 0.0)
-                # Only cache-participating params are compared: `/effort` and
-                # friends rewrite `model_params` without touching the prefix.
-                if model_spec != last_spec or cache_identity_params(
-                    current_params
-                ) != cache_identity_params(last_params):
+                if (
+                    model_spec != last_spec
+                    # Only cache-participating params are compared: `/effort`
+                    # and friends rewrite `model_params` without touching the
+                    # prefix, and must not read as a cache identity change.
+                    or cache_identity_params(current_params)
+                    != cache_identity_params(last_params)
+                    # `None` means no endpoint was ever recorded -- e.g. a
+                    # thread checkpointed before this field existed, or one
+                    # whose stored value was unreadable and discarded on load.
+                    # Treating "unrecorded" as "changed" would fire a spurious
+                    # warning on the first turn of each such thread, so only a
+                    # recorded value that actually differs counts.
+                    or (last_endpoint is not None and endpoint != last_endpoint)
+                ):
                     reason = "identity_changed"
                 elif age_seconds > policy.window_seconds:
                     reason = "idle"
                 else:
                     return None
-
             estimate = estimate_rewarm_cost(context_tokens, model_spec, policy)
             if estimate is None:
                 logger.debug(
@@ -13128,6 +13212,8 @@ class DeepAgentsApp(App):
                     "_last_cache_model_spec": state_values.get(
                         "_last_cache_model_spec"
                     ),
+                    "_last_cache_endpoint": state_values.get("_last_cache_endpoint"),
+                    "_last_cache_params": state_values.get("_last_cache_params"),
                     "_model_spec": model_spec,
                     "_model_params": model_params,
                 }

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2729,9 +2729,6 @@ provider key is *not* a LangSmith gateway key. Only the prefix is inspected —
 the secret value is never logged or otherwise introspected.
 """
 
-_LANGSMITH_GATEWAY_HOST = "smith.langchain.com"
-"""Host substring identifying the LangSmith gateway endpoint."""
-
 
 def _langsmith_gateway_key_mismatch(provider: str | None) -> str | None:
     """Detect a non-LangSmith key being routed through the LangSmith gateway.
@@ -2754,15 +2751,18 @@ def _langsmith_gateway_key_mismatch(provider: str | None) -> str | None:
     if not provider:
         return None
     try:
+        from urllib.parse import urlsplit
+
         from deepagents_code.model_config import (
             ModelConfig,
             get_credential_env_var,
+            is_langsmith_gateway_host,
             resolve_env_var,
             resolved_env_var_name,
         )
 
         base_url = ModelConfig.load().get_base_url(provider)
-        if not base_url or _LANGSMITH_GATEWAY_HOST not in base_url:
+        if not base_url or not is_langsmith_gateway_host(urlsplit(base_url).hostname):
             return None
         key_env = get_credential_env_var(provider)
         if not key_env:

--- a/libs/code/deepagents_code/cold_cache.py
+++ b/libs/code/deepagents_code/cold_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import math
 import re
@@ -11,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Literal, assert_never
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Set as AbstractSet
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,6 @@ Named rather than spelled inline at each site: the reader, the writer, and the
 leave the warning firing after the user asked it to stop, with no error
 anywhere to explain why.
 """
-
 CacheConfidence = Literal["expired", "may_be_cold"]
 """How firmly a passed retention window implies the cached prefix is gone.
 
@@ -91,6 +91,7 @@ identity change for a setting the effective requests never differed on.
 """
 
 _OPENAI_MODEL_VERSION = re.compile(r"^gpt-(?P<major>\d+)(?:\.(?P<minor>\d+))?")
+_DEFAULT_ENDPOINT_PORTS = {"http": 80, "https": 443}
 
 _ANTHROPIC_MINIMUM_TOKENS: tuple[tuple[str, int], ...] = (
     ("claude-opus-5", 512),
@@ -284,6 +285,106 @@ def debug_stand_in_policy() -> PromptCachePolicy:
     )
 
 
+def _opaque_digest(value: str) -> str:
+    """Reduce endpoint text to a stable token, keeping secrets out of it.
+
+    Identities are written to the checkpoint store (`_last_cache_endpoint`) and
+    only ever compared for equality, so the two parts of an endpoint most
+    likely to carry a secret -- the query, and any value too malformed to parse
+    -- are recorded as a digest instead of verbatim text. An endpoint that
+    authenticates via `?api-key=`, or a key pasted into the base-URL field,
+    must not have that value durably copied into a session database nobody
+    thinks to inspect.
+
+    This is narrower than `doctor._sanitize_endpoint`, which keeps only
+    `scheme://host[:port]` and so also withholds the path.
+    `endpoint_cache_identity` keeps the path verbatim because proxies route on
+    it, which means a key embedded in a *path* is still recorded in the clear.
+    Digesting the path would make the identity useless for its one job, so the
+    residual is accepted rather than closed.
+
+    Truncation to 16 hex characters bounds what the checkpoint carries; a
+    collision would merely suppress one warning, so the full digest buys
+    nothing here. Note the digest is unsalted, so it confirms a *guessed*
+    low-entropy value -- irrelevant in practice, since the real credential
+    already sits in the local credential store, but it is not a one-way
+    guarantee against a known-plaintext check.
+
+    Returns:
+        A short hex digest of *value*.
+    """
+    return hashlib.sha256(value.encode("utf-8", "surrogatepass")).hexdigest()[:16]
+
+
+def _normalized_endpoint_cache_identity(base_url: str) -> str | None:
+    """Normalize a valid HTTP endpoint, if possible.
+
+    Returns:
+        The normalized endpoint identity, or `None` when `base_url` is not an
+        HTTP URL with a hostname.
+    """
+    parsed = urlparse(base_url)
+    host = parsed.hostname
+    if parsed.scheme not in {"http", "https"} or not host:
+        return None
+    scheme = parsed.scheme.lower()
+    hostname = host.lower().removesuffix(".")
+    port = parsed.port
+    # `parsed.hostname` strips IPv6 brackets; without them a trailing port is
+    # ambiguous, so distinct endpoints like `https://[::1]:8080` and
+    # `https://[::1:8080]` would serialize to the same identity.
+    authority = f"[{hostname}]" if ":" in hostname else hostname
+    if port is not None and port != _DEFAULT_ENDPOINT_PORTS[scheme]:
+        authority = f"{authority}:{port}"
+    path = parsed.path.rstrip("/")
+    # Digested, not dropped: a query can route to a separate backend (so it
+    # must stay part of the identity) but can equally carry an auth token (so
+    # it must not be stored). Equality is all this value is used for, and a
+    # digest preserves that exactly.
+    query = f"?{_opaque_digest(parsed.query)}" if parsed.query else ""
+    return f"{scheme}://{authority}{path}{query}"
+
+
+def endpoint_cache_identity(base_url: str | None) -> str:
+    """Return a stable identity for the endpoint that owns a prompt cache.
+
+    A missing endpoint means the provider's default API. Only scheme, host,
+    port, path and a digest of the query are significant; every other spelling
+    detail is normalized away, including host/scheme case, a trailing slash, a
+    default port, a trailing root dot, fragments, userinfo, and `;params`.
+    Path and query stay significant because proxies can route them to separate
+    backends; the query does so via `_opaque_digest`, which keeps a
+    credential-bearing query out of the checkpoint. Path case is preserved --
+    proxies may route on it -- which also means a credential embedded in a path
+    is recorded verbatim; see `_opaque_digest` for why that residual is
+    accepted.
+
+    The result is opaque: compare it for equality, never parse it.
+
+    Args:
+        base_url: Resolved provider endpoint, or `None` for its default API.
+
+    Returns:
+        A checkpoint-safe endpoint identity.
+    """
+    if base_url is None or not base_url.strip():
+        return "default"
+    stripped = base_url.strip()
+    try:
+        normalized = _normalized_endpoint_cache_identity(stripped)
+    except ValueError:
+        # Malformed values stay distinct identities. This is deliberately
+        # conservative: a bad endpoint must never be considered cache-equivalent
+        # to the provider default or to a valid endpoint. It is digested rather
+        # than echoed because this branch is reached exactly when the field
+        # holds something unexpected -- a pasted API key being the case that
+        # must not reach disk.
+        return f"invalid:{_opaque_digest(stripped)}"
+    if normalized is not None:
+        return normalized
+    return f"invalid:{_opaque_digest(stripped)}"
+
+
 def _official_endpoint(base_url: str | None, hostname: str) -> bool:
     """Return whether an optional endpoint targets the provider's official API."""
     if not base_url:
@@ -302,6 +403,293 @@ def _official_endpoint(base_url: str | None, hostname: str) -> bool:
         )
         return False
     return parsed.scheme in {"http", "https"} and parsed.hostname == hostname
+
+
+def _endpoint_hostname(base_url: str) -> str | None:
+    """Extract a lowercase hostname from an endpoint URL.
+
+    A trailing root dot is removed. Both sides of the trust comparison come
+    through this helper -- configured entries via `_trusted_entry_hostname` and
+    the live endpoint via `endpoint_ok` -- so stripping here is what lets the
+    fully-qualified spelling (`gw.example.com.`) match an entry written the bare
+    way, and the reverse. Without it the two spellings name the same server but
+    never compare equal, and trust silently fails to apply.
+
+    Returns:
+        The lowercase hostname, or `None` when the scheme is not `http`/`https`
+        or the host is empty, whitespace-padded, or only a root dot.
+    """
+    try:
+        parsed = urlparse(base_url)
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    host = parsed.hostname
+    if not host or host != host.strip():
+        return None
+    normalized = host.lower().removesuffix(".")
+    return normalized or None
+
+
+_TRUSTED_LABEL = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+"""Shape each dot-separated label of a trusted-endpoint entry must have.
+
+`urlparse` accepts almost any junk as a host -- `smith.langchain,com` and
+`not a url` both survive it -- which would silently populate the trust set
+with an entry that can never match a real endpoint. Validating per label
+instead means a typo is reported rather than stored, including the two most
+likely in a hostname list that a single whole-string pattern lets through: a
+doubled dot (`smith..langchain.com`, an empty label) and a label edged with a
+hyphen (`a.-b.com`). IPv6 literals are not accepted (IPv4 literals are); a
+proxy addressed by raw IPv6 must be trusted by DNS name.
+"""
+
+
+def _trusted_host_shape_ok(host: str) -> bool:
+    """Return whether a reduced hostname is shaped like a hostname.
+
+    Args:
+        host: Lowercase, root-dot-stripped hostname.
+
+    Returns:
+        `True` when every dot-separated label is well formed.
+    """
+    labels = host.split(".")
+    return all(_TRUSTED_LABEL.match(label) for label in labels)
+
+
+def _trusted_entry_hostname(entry: object) -> str | None:
+    """Reduce one configured trust entry to a hostname.
+
+    Entries carrying userinfo are rejected rather than reduced: it would
+    otherwise be silently reinterpreted as something the user did not write, as
+    `api.anthropic.com@evil.example` parses to the host *after* the `@`, so an
+    entry that reads as trusting Anthropic would trust `evil.example` instead.
+    Whitespace inside an entry is rejected for the same reason -- `urlsplit`
+    strips a tab or newline rather than failing, so an entry whose host carries
+    an embedded newline before `evil` would otherwise be stored as the single
+    host `gw.example.comevil`.
+
+    A *default* port is accepted and discarded (`https://gw.example.com:443/v1`
+    names the same endpoint as the portless spelling, and pasting a full URL is
+    the obvious thing to do). Any other port is rejected, because trust is
+    matched on the host alone -- `endpoint_ok` compares against
+    `_endpoint_hostname`, which discards the port -- so a port-scoped entry
+    could not be honored as written and would silently widen to every port on
+    that host. Rejecting keeps the module's stated bargain that a typo is
+    reported rather than stored.
+
+    Args:
+        entry: Raw value from the TOML list; any type, validated here.
+
+    Returns:
+        The lowercase hostname, or `None` when the entry is unusable.
+    """
+    if not isinstance(entry, str) or not entry.strip():
+        return None
+    candidate = entry.strip()
+    # Checked before parsing: `urlsplit` would strip these rather than reject.
+    if any(character.isspace() for character in candidate):
+        return None
+    # Bare hosts are accepted alongside URLs for convenience.
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    try:
+        parsed = urlparse(candidate)
+        authority = parsed.netloc
+        port = parsed.port
+    except ValueError:
+        return None
+    if "@" in authority:
+        return None
+    scheme = parsed.scheme.lower()
+    if port is not None and port != _DEFAULT_ENDPOINT_PORTS.get(scheme):
+        return None
+    host = _endpoint_hostname(candidate)
+    if host is None or not _trusted_host_shape_ok(host):
+        return None
+    return host
+
+
+_LOGGED_DIAGNOSTICS: set[str] = set()
+"""Config-diagnostic messages already emitted, so each fires once per process.
+
+Shared by every record `_log_once` carries, not just the entry rejections:
+the accepted-host confirmation, the endpoint/trust-set mismatch warning, and
+the cross-format suppression notice all key into this one set. A burst of one
+kind can therefore evict the memory of another, which only ever costs a
+duplicate log line.
+
+`load_trusted_cache_endpoints` re-reads `config.toml` on every turn so a live
+edit takes effect without a restart. Without this, one malformed entry would
+warn once per turn, crowding out the other warnings in the bounded debug-log
+buffer (which partitions retention per level, so the damage is confined to
+that level -- see `_debug_buffer.InMemoryLogBuffer`).
+
+Bounded, because the key embeds the rejected entry: a config edited repeatedly
+into new bad states would otherwise accumulate one string per distinct typo
+for the life of the process. On overflow the whole set is dropped rather than
+evicted one by one -- re-warning about a still-broken entry is the harmless
+direction, and it keeps a live-edit session from going permanently quiet.
+
+Mutated from worker threads (`app` and `configurable_model` both reach it via
+`asyncio.to_thread`). The check-then-clear-then-add below is not atomic, so a
+concurrent overflow can drop a key that was just added; a repeated log line is
+the harmless direction, so this is left unlocked deliberately.
+"""
+
+_MAX_LOGGED_DIAGNOSTICS = 64
+"""Cap on `_LOGGED_DIAGNOSTICS` before it is cleared wholesale."""
+
+
+def _log_once(level: int, message: str, *args: object) -> None:
+    """Emit a config-diagnostic record the first time this process produces it.
+
+    Args:
+        level: `logging` level. Kept at `INFO` or above -- these records exist
+            to explain a silently disabled warning, and `DEBUG` does not reach
+            the Debug Console unless debug logging was enabled at startup.
+        message: `%`-style format string, also the deduplication key once
+            formatted.
+        *args: Format arguments.
+    """
+    formatted = message % args
+    if formatted in _LOGGED_DIAGNOSTICS:
+        return
+    if len(_LOGGED_DIAGNOSTICS) >= _MAX_LOGGED_DIAGNOSTICS:
+        _LOGGED_DIAGNOSTICS.clear()
+    _LOGGED_DIAGNOSTICS.add(formatted)
+    logger.log(level, "%s", formatted)
+
+
+def _warn_once(message: str, *args: object) -> None:
+    """Emit a rejection warning the first time this process produces it."""
+    _log_once(logging.WARNING, message, *args)
+
+
+def load_trusted_cache_endpoints(
+    config: dict[str, Any] | None = None,
+) -> frozenset[str]:
+    """Read `[warnings].trusted_cache_endpoints` as a set of hostnames.
+
+    Entries declare that an alternate endpoint forwards cache-affecting request
+    fields (`cache_control`, `prompt_cache_key`, `prompt_cache_retention`) and
+    honors the upstream provider's documented retention.
+
+    Trust is matched on the exact host: trusting `example.com` does not trust
+    `gw.example.com`. Each host a request may actually reach must be listed.
+
+    Malformed *content* never raises: an unusable entry is dropped and a value
+    that is not a list is ignored wholesale. Because a dropped entry silently
+    leaves the warning disabled -- the opposite of what the user edited the
+    file to achieve -- the offending entry is logged by value and a non-list
+    value by type. Each distinct rejection is logged once per process.
+
+    Args:
+        config: Parsed `config.toml` mapping; loaded from disk when omitted.
+            The disk read tolerates an absent, unreadable, or undecodable file
+            by falling back to `{}`.
+
+    Returns:
+        Lowercase hostnames of user-trusted endpoints (possibly empty).
+    """
+    if config is None:
+        from deepagents_code.config_manifest import load_config_toml
+
+        config = load_config_toml()
+    warnings_section = config.get("warnings", {})
+    if not isinstance(warnings_section, dict):
+        # `warnings = "off"` reads like a plausible toggle, and silently
+        # discards every option in the section rather than just this one.
+        _warn_once(
+            "Ignoring [warnings] in config.toml (expected a table, got %s)",
+            type(warnings_section).__name__,
+        )
+        return frozenset()
+    entries = warnings_section.get("trusted_cache_endpoints", [])
+    if entries == []:
+        return frozenset()
+    if not isinstance(entries, list):
+        _warn_once(
+            "Ignoring [warnings].trusted_cache_endpoints in config.toml "
+            "(expected a list of hostnames, got %s)",
+            type(entries).__name__,
+        )
+        return frozenset()
+    hosts: set[str] = set()
+    for entry in entries:
+        host = _trusted_entry_hostname(entry)
+        if host is None:
+            _warn_once(
+                "Ignoring [warnings].trusted_cache_endpoints entry %r in "
+                "config.toml (expected a bare hostname or http(s) URL, with no "
+                "user:password prefix; trust is matched on the host alone, so "
+                "a non-default port cannot be honored -- drop it only if you "
+                "mean to trust that host on every port)",
+                entry,
+            )
+            continue
+        hosts.add(host)
+    if hosts:
+        # Deduplicated and emitted at a level that reaches the Debug Console by
+        # default, so a user who corrects a bad entry gets confirmation on the
+        # surface where they saw the complaint. Once per distinct host set,
+        # not once per turn.
+        _log_once(
+            logging.INFO, "Trusting cache endpoints: %s", ", ".join(sorted(hosts))
+        )
+    return frozenset(hosts)
+
+
+def _effective_model_name(
+    provider: str,
+    model_name: str,
+) -> str | None:
+    """Resolve the model name a policy lookup and pricing should use.
+
+    Gateways and proxies read a `provider/model` prefix in the model field to
+    route a request to a provider other than the one the wire format implies
+    (an OpenAI-format request carrying `anthropic/claude-...`). Such a hop is
+    translated between API formats, and translation rewrites or drops the very
+    fields a policy assumes (`cache_control`, `prompt_cache_*`), so the
+    upstream provider's documented retention no longer describes what happens.
+
+    Any prefix that does not match the wire-format provider is therefore
+    treated as a crossing, including prefixes for providers this module cannot
+    price -- suppressing a warning is safe, whereas pricing a route whose cache
+    semantics were rewritten is not. A matching prefix (`openai/gpt-5.6` in
+    OpenAI format) is a same-provider route, forwarded untranslated; the prefix
+    is stripped so model-family detection and pricing see the bare name they
+    expect.
+
+    The rule is applied wherever the prefix appears, not only on the LangSmith
+    gateway: `provider/model` is the naming convention of proxies generally
+    (LiteLLM-style deployments included), and those are exactly the endpoints
+    this module lets users trust. Scoping it to one known host would leave a
+    prefixed name on every other trusted proxy resolving a policy that could
+    never be priced -- so the warning silently never fires -- while the
+    unstripped name also defeats model-family detection and yields the wrong
+    cache minimum. On a provider's official API no legitimate model name
+    carries a prefix, so the rule is inert there.
+
+    Args:
+        provider: Wire-format provider from the `provider:model` spec. Both
+            sides of the comparison are normalized here, so an unnormalized
+            value cannot read every prefixed route as a crossing.
+        model_name: Model portion of the spec, as sent to the endpoint.
+
+    Returns:
+        The model name to price with, or `None` when the route crosses formats
+        or carries a prefix with an empty remainder (`openai/`). A name with no
+        prefix is returned unchanged.
+    """
+    if "/" not in model_name:
+        return model_name
+    prefix, remainder = model_name.split("/", 1)
+    if prefix.strip().lower() != provider.strip().lower() or not remainder.strip():
+        return None
+    return remainder.strip()
 
 
 def _openai_uses_thirty_minute_cache(model_name: str) -> bool:
@@ -332,8 +720,30 @@ def resolve_prompt_cache_policy(
     model_params: dict[str, Any] | None = None,
     *,
     base_url: str | None = None,
+    trusted_endpoints: AbstractSet[str] | None = None,
 ) -> PromptCachePolicy | None:
     """Resolve a documented cache policy for one effective model invocation.
+
+    Policies apply only when the endpoint is the provider's official API or a
+    user-declared trusted endpoint (see `load_trusted_cache_endpoints`).
+
+    A route that crosses wire formats (e.g. an OpenAI-format request routed to
+    an Anthropic model, spelled `openai:anthropic/claude-...`) resolves nothing,
+    because the translation such a hop requires rewrites or drops the caching
+    fields the policy assumes. See `_effective_model_name`. Cross-format routing
+    that is *not* spelled in the model name cannot be detected -- declaring an
+    endpoint trusted asserts that it does not do this.
+
+    Args:
+        model_spec: `provider:model` identifier for the invocation.
+        model_params: Request params that affect retention, if any.
+        base_url: Resolved endpoint, or `None` for the provider default.
+        trusted_endpoints: Hostnames the user has declared trusted, as returned
+            by `load_trusted_cache_endpoints`. Full http(s) URLs are accepted
+            too and reduced to their host; entries that are not a usable
+            hostname are dropped, exactly as the loader drops them. Matching is
+            per exact host -- a trusted `example.com` does not cover
+            `gw.example.com`.
 
     Returns:
         Matching policy, or `None` when retention cannot be resolved safely.
@@ -347,8 +757,83 @@ def resolve_prompt_cache_policy(
         return None
     params = model_params or {}
 
+    # Reduced through the same validator the config loader uses, so a value is
+    # never trusted here that `load_trusted_cache_endpoints` would reject --
+    # and a URL, which callers reasonably reach for, is not a silent no-op.
+    trusted = {
+        host
+        for entry in trusted_endpoints or ()
+        if (host := _trusted_entry_hostname(entry)) is not None
+    }
+    effective_model = _effective_model_name(provider, model_name)
+    if effective_model is None:
+        # Surfaced for the same reason the host mismatch below is: the only
+        # other symptom is an unexplained absence of warnings, and this branch
+        # returns before `endpoint_ok` runs, so the trust-mismatch warning
+        # cannot stand in for it. A user who edited `config.toml` specifically
+        # to enable these warnings and still gets none is told why. Warned when
+        # trust is configured (that edit is evidence they want the warnings),
+        # informational otherwise; `DEBUG` would not reach the Debug Console.
+        #
+        # The two levels carry different text on purpose: `_log_once` keys on
+        # the *formatted* message, so a shared string would let an earlier
+        # `INFO` swallow the `WARNING` that a user who has since configured
+        # trust is the one who needs.
+        if trusted:
+            _warn_once(
+                "No cold-cache policy: model %r does not stay in the %r wire "
+                "format, so the provider's documented cache retention cannot "
+                "be assumed even on a trusted endpoint",
+                model_name,
+                provider,
+            )
+        else:
+            _log_once(
+                logging.INFO,
+                "No cold-cache policy: model %r does not stay in the %r wire "
+                "format, so the provider's documented cache retention cannot "
+                "be assumed for it",
+                model_name,
+                provider,
+            )
+        return None
+    model_name = effective_model
+
+    def endpoint_ok(official_hostname: str) -> bool:
+        # `official_hostname` gates only the official-API branch. Trust is
+        # declared per endpoint, not per provider, so a trusted host serves
+        # whichever provider is routed through it.
+        if _official_endpoint(base_url, official_hostname):
+            return True
+        actual_host = _endpoint_hostname(base_url) if base_url else None
+        if trusted and actual_host in trusted:
+            return True
+        if trusted:
+            # A configured trust set that never matches is unambiguously a
+            # misconfiguration -- typically trusting `smith.langchain.com`
+            # while requests go to `api.smith.langchain.com`. It is warned
+            # rather than logged at debug because its only other symptom is an
+            # unexplained absence of warnings, and debug records do not reach
+            # the Debug Console at the default log level. Deduplicated, so a
+            # standing mismatch does not repeat every turn. Only the host is
+            # named: the full endpoint may carry credentials.
+            _warn_once(
+                "No cold-cache policy: endpoint host %r is neither %s nor in "
+                "the trusted set %s (see [warnings].trusted_cache_endpoints)",
+                actual_host or "(unparseable)",
+                official_hostname,
+                sorted(trusted),
+            )
+            return False
+        logger.debug(
+            "No cache policy: endpoint host %r is not %s and no endpoints are trusted",
+            actual_host or "(unparseable)",
+            official_hostname,
+        )
+        return False
+
     if provider == "anthropic":
-        if not _official_endpoint(base_url, "api.anthropic.com"):
+        if not endpoint_ok("api.anthropic.com"):
             return None
         # Deliberately ignores `params["cache_control"]`: see
         # `_ANTHROPIC_MIDDLEWARE_TTL_SECONDS` for why a user-set `ttl` never
@@ -361,7 +846,7 @@ def resolve_prompt_cache_policy(
             write_bucket="5m",
         )
 
-    if provider != "openai" or not _official_endpoint(base_url, "api.openai.com"):
+    if provider != "openai" or not endpoint_ok("api.openai.com"):
         return None
 
     # Write pricing follows the model version, independent of retention: only
@@ -439,6 +924,16 @@ def estimate_rewarm_cost(
     cold request -- so the catalog stays the single source of truth. Outputs
     are zeroed on both sides so the delta is input-only.
 
+    A `provider/model` prefix is resolved through `_effective_model_name`, the
+    same helper `resolve_prompt_cache_policy` uses, so a spec that resolved a
+    policy is priced under the name that policy was chosen for. Letting the two
+    disagree is what makes a warning silently never fire.
+
+    Args:
+        context_tokens: Prefix size to price.
+        model_spec: `provider:model` identifier for the invocation.
+        policy: Resolved policy, which selects the cache-write price bucket.
+
     Returns:
         Price estimate, or `None` when the prefix is below the provider's cache
             minimum or the usage cannot be priced defensibly.
@@ -446,8 +941,14 @@ def estimate_rewarm_cost(
     if context_tokens < policy.minimum_tokens or ":" not in model_spec:
         return None
     provider, model_name = model_spec.split(":", 1)
+    provider = provider.strip()
+    model_name = model_name.strip()
     if not provider or not model_name:
         return None
+    effective_model = _effective_model_name(provider, model_name)
+    if effective_model is None:
+        return None
+    model_name = effective_model
 
     warm_usage: dict[str, Any] = {
         "input_tokens": context_tokens,

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -4600,10 +4600,7 @@ def _get_provider_kwargs(
     from deepagents_code.model_config import ModelConfig
 
     config = ModelConfig.load()
-    result: dict[str, Any] = config.get_kwargs(provider, model_name=model_name)
-    base_url = config.get_base_url(provider)
-    if base_url:
-        result["base_url"] = base_url
+    result = config.get_effective_kwargs(provider, model_name=model_name)
     from deepagents_code.model_config import (
         OPTIONAL_AUTH_ENV,
         PROVIDER_API_KEY_ENV,

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -421,7 +421,12 @@ def load_config_toml() -> dict[str, Any]:
             return tomllib.load(f)
     except FileNotFoundError:
         return {}
-    except (OSError, tomllib.TOMLDecodeError):
+    except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError):
+        # `UnicodeDecodeError` is neither of the other two (it subclasses
+        # `ValueError`), but a file saved as UTF-16 or holding a stray byte is
+        # unreadable TOML in exactly the same way -- without it, a config that
+        # is merely mis-encoded raises out of every caller instead of falling
+        # back to defaults.
         # `exc_info=True` preserves the TOML line/column (or permission cause):
         # a corrupt file makes every option fall back to its default, so the
         # log must say *why*, not just that the read failed.
@@ -1564,6 +1569,20 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         kind=OptionKind.FLOAT,
         default=COLD_CACHE_WARNING_THRESHOLD_USD_DEFAULT,
         toml_keys=("warnings", "cold_cache_min_delta_usd"),
+    ),
+    ConfigOption(
+        key="warnings.trusted_cache_endpoints",
+        group="Warnings",
+        summary=(
+            "Alternate endpoint hosts assumed to forward cache settings and "
+            "honor provider cache retention "
+            '(e.g. ["smith.langchain.com"]). Matched per exact host, so list '
+            "each subdomain you actually connect to; trusting a host trusts it "
+            "on every port. Bare hostnames or http(s) URLs; entries carrying a "
+            "user:password prefix or a non-default port are rejected."
+        ),
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("warnings", "trusted_cache_endpoints"),
     ),
     ConfigOption(
         key="warnings.session_cost_threshold_usd",

--- a/libs/code/deepagents_code/configurable_model.py
+++ b/libs/code/deepagents_code/configurable_model.py
@@ -27,6 +27,7 @@ from langchain.agents.middleware.types import (
 from langgraph.types import Command
 
 from deepagents_code._cli_context import CLIContextSchema
+from deepagents_code.cold_cache import cache_identity_params
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -54,6 +55,76 @@ class _ResolvedModelRequest:
 
     model_params_known: bool = False
     """Whether `model_params` is known and should be written to the checkpoint."""
+
+
+def _cache_endpoint_identity(
+    model_spec: str | None, model_params: Mapping[str, Any] | None = None
+) -> str:
+    """Resolve the endpoint identity used by a model request for checkpointing.
+
+    Performs blocking filesystem reads: `ModelConfig.load()` is process-cached,
+    but `get_base_url` falls through to the credential store for any provider
+    with no `config.toml` `base_url` and no base-URL env var *set* -- the
+    default for `anthropic` and `openai`, whose env vars are registered in
+    `PROVIDER_BASE_URL_ENV` but normally unset -- and that store re-reads its
+    file every call. Callers on the blockbuster-guarded server loop must
+    therefore invoke this via `asyncio.to_thread` (see
+    `ConfigurableModelMiddleware.awrap_model_call`).
+
+    A spec with no `provider:` prefix cannot name an endpoint, so it resolves to
+    the same identity as the provider default. That is preferable to returning
+    nothing: `_last_cache_endpoint` is written unconditionally alongside the
+    spec and timestamp it describes, and a skipped write would leave the
+    previous turn's endpoint paired with this turn's spec.
+
+    The provider is normalized exactly as the reader normalizes it
+    (`app._cold_cache_warning_for`). `get_kwargs`/`get_base_url` are
+    exact-key lookups, so a spec the user spelled `Anthropic:claude-opus-5`
+    would resolve `default` here while the reader resolved the real endpoint --
+    a disagreement that never self-heals, because both sides keep recomputing
+    their own answer, and every send would report `identity_changed`.
+
+    Never raises. Both call sites run *after* `handler()` has returned, so the
+    model call is already made and billed; letting a config-shaped surprise
+    (a non-string `base_url` from a `class_path` provider that ignores it, say)
+    propagate would discard a paid response over a diagnostic value. Failing to
+    the provider default is the same degradation an unreadable checkpointed
+    endpoint already gets.
+
+    Returns:
+        The normalized endpoint identity, or the provider-default identity when
+        it cannot be resolved.
+    """
+    from deepagents_code.cold_cache import endpoint_cache_identity
+
+    if not model_spec or ":" not in model_spec:
+        return endpoint_cache_identity(None)
+    from deepagents_code.model_config import ModelConfig
+
+    raw_provider, _, model_name = model_spec.partition(":")
+    provider = raw_provider.strip().lower()
+    try:
+        config = ModelConfig.load()
+        kwargs = config.get_effective_kwargs(
+            provider,
+            model_name=model_name,
+            overrides=model_params,
+        )
+        base_url = (
+            kwargs.get("base_url")
+            if isinstance(kwargs, dict)
+            else config.get_base_url(provider)
+        )
+    except Exception:
+        logger.warning(
+            "Could not resolve the cache endpoint for %r; recording the "
+            "provider default, so an endpoint change may go undetected for "
+            "this turn",
+            provider,
+            exc_info=True,
+        )
+        return endpoint_cache_identity(None)
+    return endpoint_cache_identity(base_url if isinstance(base_url, str) else None)
 
 
 def _get_ls_provider(model: object) -> str | None:
@@ -586,9 +657,73 @@ def _utc_now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _effective_cache_params(
+    model_spec: str | None, runtime_overrides: Mapping[str, Any] | None
+) -> dict[str, Any] | None:
+    """Resolve the cache-identity params a request actually runs with.
+
+    Mirrors the app-side comparison: the cold-cache check reads configured
+    provider/per-model `params` (via `ModelConfig.get_effective_kwargs`) plus
+    runtime overrides. If the checkpoint stores only the runtime overrides, a
+    user with a configured `prompt_cache_retention` and no session override
+    records `None` here while the reader sees `{"prompt_cache_retention": ...}`,
+    so the next turn compares unequal and reports a false `identity_changed`
+    every turn. Persisting the effective params makes both sides match.
+
+    The result is projected through `cache_identity_params` and recorded in the
+    dedicated `_last_cache_params` channel rather than `_model_params`: the
+    latter is read back on resume as per-session runtime overrides, so storing
+    the merged config there would pin every configured knob (temperature,
+    headers, ...) into old threads and silently override newer config.
+
+    Performs blocking config reads; async callers should offload.
+
+    Args:
+        model_spec: `provider:model` spec for the call.
+        runtime_overrides: Per-request params (the middleware's `model_params`).
+
+    Returns:
+        Cache-identity projection of the effective kwargs (without `base_url`),
+        or `None` when no identity keys are present.
+    """
+    if not model_spec or ":" not in model_spec:
+        overrides = dict(runtime_overrides) if runtime_overrides else None
+        return cache_identity_params(overrides) or None
+    from deepagents_code.model_config import ModelConfig
+
+    _, _, model_name = model_spec.partition(":")
+    provider = model_spec.split(":", 1)[0].strip().lower()
+    try:
+        config = ModelConfig.load()
+        kwargs = config.get_effective_kwargs(
+            provider,
+            model_name=model_name,
+            overrides=runtime_overrides,
+        )
+    except Exception:
+        logger.warning(
+            "Could not resolve effective cache params for %r; recording only "
+            "runtime overrides, so a configured cache param may read as a "
+            "spurious identity change until the next turn",
+            model_spec,
+            exc_info=True,
+        )
+        overrides = dict(runtime_overrides) if runtime_overrides else None
+        return cache_identity_params(overrides) or None
+    if not isinstance(kwargs, dict):
+        overrides = dict(runtime_overrides) if runtime_overrides else None
+        return cache_identity_params(overrides) or None
+    # `base_url` is tracked separately as the endpoint identity; keeping it out
+    # of the params avoids a double-counted identity change.
+    result = cache_identity_params({k: v for k, v in kwargs.items() if k != "base_url"})
+    return result or None
+
+
 def _checkpoint_command(
     resolved: _ResolvedModelRequest,
     request_started_at: str,
+    cache_endpoint: str,
+    cache_params: dict[str, Any] | None = None,
 ) -> Command[Any]:
     """Build the private resume-state update for a completed model call.
 
@@ -597,6 +732,15 @@ def _checkpoint_command(
         request_started_at: UTC ISO timestamp captured before the model call.
             It only reaches a checkpoint because this runs after `handler()`
             returned, which is what makes it a successful-call marker.
+        cache_endpoint: Endpoint identity for `resolved.model_spec`, from
+            `_cache_endpoint_identity`. Passed in rather than resolved here so
+            the async caller can keep its blocking config/credential reads off
+            the event loop.
+        cache_params: Cache-identity projection of the effective params for
+            this call, from `_effective_cache_params`. Passed in for the same
+            offloading reason as `cache_endpoint`. When `None` and
+            `resolved.model_params_known` is true, falls back to the identity
+            projection of the runtime overrides.
 
     Returns:
         Command carrying cache timing and effective model metadata.
@@ -606,14 +750,17 @@ def _checkpoint_command(
     # override fails with `ModelConfigError`, `_apply_overrides` falls back to
     # the original model while `ctx.model` still names the rejected override.
     #
-    # The timestamp is written only alongside a known spec. The two are one
-    # fact -- when the cache was warmed, and for which model -- and a
-    # timestamp without an identity would read back as a permanent "model
-    # changed", warning on every send with copy that names a change that never
-    # happened.
+    # The timestamp is written only alongside a known spec. The three are one
+    # fact -- when the cache was warmed, for which model, and against which
+    # endpoint -- and a timestamp without an identity would read back as a
+    # permanent "model changed", warning on every send with copy that names a
+    # change that never happened. For the same reason the endpoint is written
+    # unconditionally here: a skipped write would leave the *previous* turn's
+    # endpoint describing this turn's spec and timestamp.
     if resolved.model_spec:
         update["_last_model_request_at"] = request_started_at
         update["_last_cache_model_spec"] = resolved.model_spec
+        update["_last_cache_endpoint"] = cache_endpoint
         update["_model_spec"] = resolved.model_spec
     else:
         # The previous turn's timestamp stays in place, so the next cold-cache
@@ -623,7 +770,22 @@ def _checkpoint_command(
             type(resolved.request.model).__name__,
         )
     if resolved.model_params_known:
+        # `_model_params` stays the *runtime overrides only*: resume reads it
+        # back as per-session overrides for `_switch_model`, so storing the
+        # merged config there would pin provider defaults (temperature, max
+        # retries, headers, ...) into old threads and silently override newer
+        # config on resume.
         update["_model_params"] = resolved.model_params
+        # The cold-cache identity projection goes to its own channel. It must
+        # include configured provider params -- not just the session override
+        # above -- or the reader's effective-params comparison reports a false
+        # `identity_changed` on every turn for anyone with a configured cache
+        # knob.
+        update["_last_cache_params"] = (
+            cache_params
+            if cache_params is not None
+            else (cache_identity_params(resolved.model_params) or None)
+        )
     return Command(update=update)
 
 
@@ -693,7 +855,20 @@ class ConfigurableModelMiddleware(AgentMiddleware):
         response = handler(resolved.request)
         if not self._persist_model_state:
             return response
-        command = _checkpoint_command(resolved, request_started_at)
+        cache_endpoint = (
+            _cache_endpoint_identity(resolved.model_spec, resolved.model_params)
+            if resolved.model_params is not None
+            else _cache_endpoint_identity(resolved.model_spec)
+        )
+        cache_params = _effective_cache_params(
+            resolved.model_spec, resolved.model_params
+        )
+        command = _checkpoint_command(
+            resolved,
+            request_started_at,
+            cache_endpoint,
+            cache_params,
+        )
         return ExtendedModelResponse(model_response=response, command=command)
 
     async def awrap_model_call(
@@ -714,5 +889,24 @@ class ConfigurableModelMiddleware(AgentMiddleware):
         response = await handler(resolved.request)
         if not self._persist_model_state:
             return response
-        command = _checkpoint_command(resolved, request_started_at)
+        # Offloaded: `_cache_endpoint_identity` and `_effective_cache_params`
+        # read the config and credential store, which `blockbuster` rejects on
+        # the server event loop.
+        cache_endpoint = (
+            await asyncio.to_thread(
+                _cache_endpoint_identity,
+                resolved.model_spec,
+                resolved.model_params,
+            )
+            if resolved.model_params is not None
+            else await asyncio.to_thread(_cache_endpoint_identity, resolved.model_spec)
+        )
+        cache_params = await asyncio.to_thread(
+            _effective_cache_params,
+            resolved.model_spec,
+            resolved.model_params,
+        )
+        command = _checkpoint_command(
+            resolved, request_started_at, cache_endpoint, cache_params
+        )
         return ExtendedModelResponse(model_response=response, command=command)

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -351,20 +351,14 @@ def _sanitize_endpoint(endpoint: str) -> str:
     return f"{parsed.scheme}://{netloc}"
 
 
-_LANGSMITH_GATEWAY_HOST = "smith.langchain.com"
-"""Host identifying LangSmith's managed (SaaS) tracing gateway.
-
-Traces sent to an endpoint whose host is `smith.langchain.com` (or a subdomain
-of it) route through the managed gateway; any other host is a self-hosted or
-dev/staging target. `app.py` keeps the same constant for its model-gateway
-key-mismatch check, but matches a raw-URL substring; this module matches the
-parsed hostname exactly or by subdomain suffix so lookalike hosts such as
-`smith.langchain.com.evil.example` are not treated as the gateway.
-"""
-
-
 def _endpoint_gateway_state(endpoint: str) -> str:
     """Classify a single tracing endpoint as gateway, non-gateway, or unknown.
+
+    Traces sent to the managed gateway host (or a subdomain of it) route
+    through LangSmith SaaS; any other host is a self-hosted or dev/staging
+    target. The exact/subdomain comparison, and the case and root-dot
+    normalization it needs, both live in
+    `model_config.is_langsmith_gateway_host`.
 
     Args:
         endpoint: A configured tracing endpoint URL.
@@ -375,15 +369,19 @@ def _endpoint_gateway_state(endpoint: str) -> str:
             and `"unknown"` when the endpoint cannot be parsed into a host — so
             a typo'd or malformed URL is never silently reported as `"no"`.
     """
+    from deepagents_code.model_config import is_langsmith_gateway_host
+
     try:
         host = urlsplit(endpoint.strip()).hostname or ""
     except ValueError:
         # urlsplit raises on bracket-malformed IPv6 (e.g. `http://[::1`); a
         # diagnostic must degrade to "unknown" rather than crash `dcode doctor`.
         return "unknown"
-    if not host:
+    # A host of only a root dot carries no name, so it stays `"unknown"` rather
+    # than being reported as a definite non-gateway.
+    if not host.removesuffix("."):
         return "unknown"
-    if host == _LANGSMITH_GATEWAY_HOST or host.endswith(f".{_LANGSMITH_GATEWAY_HOST}"):
+    if is_langsmith_gateway_host(host):
         return "yes"
     return "no"
 

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -582,6 +582,42 @@ LANGSMITH_GATEWAY_PROVIDERS: frozenset[str] = frozenset(
 )
 """Providers whose LangChain integrations support LangSmith LLM Gateway env vars."""
 
+LANGSMITH_GATEWAY_HOST = "smith.langchain.com"
+"""Host identifying LangSmith's managed (SaaS) gateway.
+
+The single definition: compare against it through `is_langsmith_gateway_host`
+rather than testing it as a raw-URL substring, which also accepts lookalikes
+such as `smith.langchain.com.evil.example`.
+"""
+
+
+def is_langsmith_gateway_host(host: str | None) -> bool:
+    """Return whether a parsed hostname is the LangSmith managed gateway.
+
+    Matches the host exactly or as a subdomain (org-scoped gateway URLs). The
+    suffix match requires a dot boundary, so `notsmith.langchain.com` does not
+    qualify; a host that merely *contains* the gateway name earlier in the
+    string (`smith.langchain.com.evil.example`) is not a suffix and is
+    likewise rejected.
+
+    Case and a trailing root dot are normalized here rather than left to the
+    caller. Both callers reach this from a different parser, and a precondition
+    enforced only by a comment in each caller is the way the two drift apart.
+
+    Args:
+        host: A hostname, or `None` when the URL could not be parsed.
+
+    Returns:
+        `True` when the host is the gateway or a subdomain of it.
+    """
+    if host is None:
+        return False
+    normalized = host.strip().lower().removesuffix(".")
+    return normalized == LANGSMITH_GATEWAY_HOST or normalized.endswith(
+        f".{LANGSMITH_GATEWAY_HOST}"
+    )
+
+
 LANGSMITH_GATEWAY_ENV = "LANGSMITH_GATEWAY"
 LANGSMITH_GATEWAY_API_KEY_ENV = "LANGSMITH_GATEWAY_API_KEY"
 _LANGSMITH_GATEWAY_FALSE_VALUES = frozenset({"false", "0", "no"})
@@ -3015,6 +3051,37 @@ class ModelConfig:
             overrides = params.get(model_name)
             if isinstance(overrides, dict):
                 result.update(overrides)
+        return result
+
+    def get_effective_kwargs(
+        self,
+        provider_name: str,
+        *,
+        model_name: str | None = None,
+        overrides: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Resolve the effective configured and runtime model kwargs.
+
+        This mirrors the ordering used when constructing a model: provider and
+        per-model `params`, then the resolved `base_url`, then runtime
+        overrides. Consumers that need to reason about an actual request (such
+        as cache policy checks) must use this rather than inspecting one source
+        of settings in isolation.
+
+        Args:
+            provider_name: Provider whose configuration should be resolved.
+            model_name: Optional model name for per-model params.
+            overrides: Per-request params, which take highest precedence.
+
+        Returns:
+            Effective model kwargs.
+        """
+        result = self.get_kwargs(provider_name, model_name=model_name)
+        base_url = self.get_base_url(provider_name)
+        if base_url:
+            result["base_url"] = base_url
+        if overrides:
+            result.update(overrides)
         return result
 
     def get_profile_overrides(

--- a/libs/code/deepagents_code/resume_state.py
+++ b/libs/code/deepagents_code/resume_state.py
@@ -222,6 +222,9 @@ class ResumeState(GoalRubricChannels):
     else `_model_spec` comes to mean.
     """
 
+    _last_cache_endpoint: Annotated[NotRequired[str], PrivateStateAttr]
+    """Normalized endpoint identity associated with `_last_model_request_at`."""
+
     _pending_goal_objective: Annotated[NotRequired[str | None], PrivateStateAttr]
     """Goal objective awaiting acceptance of proposed criteria."""
 

--- a/libs/code/deepagents_code/tui/modals/cold_cache.py
+++ b/libs/code/deepagents_code/tui/modals/cold_cache.py
@@ -211,11 +211,17 @@ class ColdCacheWarningScreen(ModalScreen[ColdCacheChoice | None]):
         # with the status sentence above it.
         match self._warning.reason:
             case "identity_changed":
+                # All three triggers are named because the caller collapses
+                # them into one reason (see `app._cold_cache_warning_for`):
+                # the model, the endpoint, and the cache-affecting params each
+                # invalidate the prefix. Naming only some of them tells a user
+                # who switched endpoints that their model changed, which sends
+                # them debugging the wrong thing.
                 certain = True
                 status = (
-                    "The active model or prompt-cache settings differ from the "
-                    "last successful turn, so the previous cached prefix "
-                    "cannot be reused."
+                    "The active model, endpoint, or prompt-cache settings "
+                    "differ from the last successful turn, so the previous "
+                    "cached prefix cannot be reused."
                 )
             case "age_unknown":
                 certain = False

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -14272,6 +14272,56 @@ class TestLangsmithGatewayKeyMismatch:
         )
         assert _langsmith_gateway_key_mismatch("openai") is None
 
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            # Passes a raw-URL substring test but is not the gateway.
+            "https://smith.langchain.com.evil.example/openai",
+            "https://notsmith.langchain.com/openai",
+            "https://evil.example/?next=smith.langchain.com",
+        ],
+    )
+    def test_lookalike_gateway_hosts_are_not_flagged(
+        self, monkeypatch, base_url: str
+    ) -> None:
+        """Matching must be on the parsed host, not a substring of the URL.
+
+        A substring match would name the user's provider key in a message that
+        blames the LangSmith gateway for an endpoint that is not the gateway.
+        """
+        from deepagents_code.app import _langsmith_gateway_key_mismatch
+
+        self._patch(monkeypatch, base_url=base_url, key="sk-proj-abc")
+        assert _langsmith_gateway_key_mismatch("openai") is None
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://SMITH.LANGCHAIN.COM/openai",
+            "https://smith.langchain.com./openai",
+            "https://org.smith.langchain.com/openai",
+        ],
+    )
+    def test_gateway_host_spellings_are_flagged(
+        self, monkeypatch, base_url: str
+    ) -> None:
+        """Control for the lookalikes: real gateway spellings still match.
+
+        Case and a trailing root dot are normalized by
+        `is_langsmith_gateway_host`, so no caller has to remember to do it.
+        """
+        from deepagents_code.app import _langsmith_gateway_key_mismatch
+
+        self._patch(monkeypatch, base_url=base_url, key="sk-proj-abc")
+        assert _langsmith_gateway_key_mismatch("openai") == "OPENAI_API_KEY"
+
+    def test_malformed_base_url_is_not_flagged(self, monkeypatch) -> None:
+        """`urlsplit` raises on bracket-malformed IPv6; degrade, do not crash."""
+        from deepagents_code.app import _langsmith_gateway_key_mismatch
+
+        self._patch(monkeypatch, base_url="http://[::1", key="sk-proj-abc")
+        assert _langsmith_gateway_key_mismatch("openai") is None
+
     def test_no_provider_is_not_flagged(self) -> None:
         from deepagents_code.app import _langsmith_gateway_key_mismatch
 
@@ -38081,8 +38131,106 @@ async def _run_cold_cache_gate(
         )
 
 
+_COLD_CACHE_EVAL_FAILURE_LOG = "Could not evaluate the cold prompt-cache warning"
+"""The evaluator's fail-open log message, asserted from both directions.
+
+Shared by the malformed-endpoint test (which requires its absence) and
+`test_evaluation_failure_is_logged` (which requires its presence), so rewording
+the production string breaks a test instead of quietly making the absence
+assertion vacuous.
+"""
+
+
 class TestColdCacheWarningFlow:
     """Tests for advisory cold prompt-cache dispatch gating."""
+
+    async def test_provider_params_enable_older_openai_cache_policy(self) -> None:
+        """Configured retention is considered even without a session override."""
+        app = DeepAgentsApp()
+        app._model_override = "openai:gpt-5.5"
+        app._model_params_override = None
+        app._last_cache_model_spec = "openai:gpt-5.5"
+        app._last_cache_model_params = None
+        app._last_model_request_at = (
+            datetime.now(UTC) - timedelta(hours=2)
+        ).isoformat()
+        app._context_tokens = 50_000
+        app._cold_cache_warning_threshold_usd = 0.10
+        config = MagicMock()
+        config.get_effective_kwargs.return_value = {
+            "base_url": "https://api.openai.com/v1",
+            "prompt_cache_retention": "24h",
+        }
+
+        def estimate(usage: dict[str, Any], _model: str, _provider: str) -> float:
+            details = usage.get("input_token_details", {})
+            return 0.10 if "cache_read" in details else 0.35
+
+        with (
+            patch(
+                "deepagents_code.model_config.ModelConfig.load",
+                return_value=config,
+            ),
+            patch(
+                "deepagents_code.model_config.is_warning_suppressed",
+                return_value=False,
+            ),
+            patch("deepagents_code.cost_tracking.estimate_cost", estimate),
+        ):
+            warning = await app._cold_cache_warning_for(
+                QueuedMessage("continue", "normal")
+            )
+
+        assert warning is not None
+        assert warning.policy.window_seconds == 86_400
+
+    async def test_configured_params_warm_turn_stays_quiet(self) -> None:
+        """A configured retention with no session override is not a change.
+
+        Regression: the checkpoint must persist the *effective* cache params,
+        not just runtime overrides. With `prompt_cache_retention = "24h"` in
+        config and no session override, a warm turn within the window must not
+        report `identity_changed` -- otherwise the modal fires every turn.
+        """
+        app = DeepAgentsApp()
+        app._model_override = "openai:gpt-5.5"
+        app._model_params_override = None
+        app._last_cache_model_spec = "openai:gpt-5.5"
+        # What the checkpoint now stores after a real turn: the effective
+        # cache-affecting params (config merged with overrides), base_url aside.
+        app._last_cache_model_params = {"prompt_cache_retention": "24h"}
+        # Two minutes old -- well within the 24-hour window.
+        app._last_model_request_at = (
+            datetime.now(UTC) - timedelta(minutes=2)
+        ).isoformat()
+        app._context_tokens = 50_000
+        app._cold_cache_warning_threshold_usd = 0.10
+        config = MagicMock()
+        config.get_effective_kwargs.return_value = {
+            "base_url": "https://api.openai.com/v1",
+            "prompt_cache_retention": "24h",
+        }
+
+        def estimate(usage: dict[str, Any], _model: str, _provider: str) -> float:
+            details = usage.get("input_token_details", {})
+            return 0.10 if "cache_read" in details else 0.35
+
+        with (
+            patch(
+                "deepagents_code.model_config.ModelConfig.load",
+                return_value=config,
+            ),
+            patch(
+                "deepagents_code.model_config.is_warning_suppressed",
+                return_value=False,
+            ),
+            patch("deepagents_code.cost_tracking.estimate_cost", estimate),
+        ):
+            warning = await app._cold_cache_warning_for(
+                QueuedMessage("continue", "normal")
+            )
+
+        assert warning is None
 
     async def test_builds_warning_for_stale_material_openai_cache(self) -> None:
         app = DeepAgentsApp()
@@ -38127,6 +38275,515 @@ class TestColdCacheWarningFlow:
         assert warning.policy.provider_name == "OpenAI"
         assert warning.estimate.incremental_cost_usd == pytest.approx(0.25)
         assert warning.reason == "idle"
+
+    async def test_trusted_gateway_endpoint_allows_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A configured trusted endpoint re-enables warnings behind a proxy."""
+        app = DeepAgentsApp()
+        app._model_override = "openai:gpt-5.6"
+        app._model_params_override = None
+        app._last_cache_model_spec = "openai:gpt-5.6"
+        app._last_cache_model_params = None
+        app._last_model_request_at = (
+            datetime.now(UTC) - timedelta(minutes=31)
+        ).isoformat()
+        app._context_tokens = 50_000
+        app._cold_cache_warning_threshold_usd = 0.10
+        config = MagicMock()
+        config.get_base_url.return_value = "https://smith.langchain.com/gw"
+
+        def estimate(
+            usage: dict[str, Any],
+            _model: str,
+            _provider: str,
+        ) -> float:
+            # The cold side of a `generic` (OpenAI) bucket carries no
+            # cache-write detail at all, so tolerate the key being absent.
+            details = usage.get("input_token_details", {})
+            return 0.10 if "cache_read" in details else 0.35
+
+        def run_with_trusted(
+            trusted: list[str],
+        ) -> Coroutine[Any, Any, ColdCacheWarning | None]:
+            monkeypatch.setattr(
+                "deepagents_code.cold_cache.load_trusted_cache_endpoints",
+                lambda: frozenset(trusted),
+            )
+            return app._cold_cache_warning_for(QueuedMessage("continue", "normal"))
+
+        with (
+            patch(
+                "deepagents_code.model_config.ModelConfig.load",
+                return_value=config,
+            ),
+            patch(
+                "deepagents_code.model_config.is_warning_suppressed",
+                return_value=False,
+            ),
+            patch("deepagents_code.cost_tracking.estimate_cost", estimate),
+        ):
+            # Untrusted gateway: no policy, no warning.
+            assert await run_with_trusted([]) is None
+            warning = await run_with_trusted(["smith.langchain.com"])
+
+        assert warning is not None
+        assert warning.policy.provider_name == "OpenAI"
+        assert warning.estimate.incremental_cost_usd == pytest.approx(0.25)
+
+    async def test_endpoint_change_prevents_warm_cache_reuse(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Switching endpoints warns even while the previous cache is fresh."""
+        monkeypatch.setattr(
+            "deepagents_code.cold_cache.load_trusted_cache_endpoints",
+            lambda: frozenset({"smith.langchain.com"}),
+        )
+        app = DeepAgentsApp()
+        app._model_override = "openai:gpt-5.6"
+        app._last_cache_model_spec = "openai:gpt-5.6"
+        app._last_cache_model_params = None
+        app._last_cache_endpoint = "default"
+        app._last_model_request_at = datetime.now(UTC).isoformat()
+        app._context_tokens = 50_000
+        app._cold_cache_warning_threshold_usd = 0.10
+        config = MagicMock()
+        config.get_base_url.return_value = "https://smith.langchain.com/gw/"
+
+        def estimate(
+            usage: dict[str, Any],
+            _model: str,
+            _provider: str,
+        ) -> float:
+            # The cold side of a `generic` (OpenAI) bucket carries no
+            # cache-write detail at all, so tolerate the key being absent.
+            details = usage.get("input_token_details", {})
+            return 0.10 if "cache_read" in details else 0.35
+
+        with (
+            patch(
+                "deepagents_code.model_config.ModelConfig.load",
+                return_value=config,
+            ),
+            patch(
+                "deepagents_code.model_config.is_warning_suppressed",
+                return_value=False,
+            ),
+            patch("deepagents_code.cost_tracking.estimate_cost", estimate),
+        ):
+            warning = await app._cold_cache_warning_for(
+                QueuedMessage("continue", "normal")
+            )
+
+        assert warning is not None
+        assert warning.reason == "identity_changed"
+
+    async def test_gateway_cross_format_route_suppresses_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A gateway route that translates wire formats never warns.
+
+        `estimate_cost` is stubbed so pricing can never be the reason a warning
+        is absent, and each suppressed spec is paired with one that *does* warn
+        on the same host. Without both, deleting the cross-format guard would
+        leave this test green.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.cold_cache.load_trusted_cache_endpoints",
+            lambda: frozenset({"smith.langchain.com"}),
+        )
+        config = MagicMock()
+        config.get_base_url.return_value = "https://smith.langchain.com/gw"
+
+        def estimate(
+            usage: dict[str, Any],
+            _model: str,
+            _provider: str,
+        ) -> float:
+            # The cold side of a `generic` (OpenAI) bucket carries no
+            # cache-write detail at all, so tolerate the key being absent.
+            details = usage.get("input_token_details", {})
+            return 0.10 if "cache_read" in details else 0.35
+
+        async def warning_for(
+            model_spec: str,
+        ) -> ColdCacheWarning | None:
+            app = DeepAgentsApp()
+            app._model_override = model_spec
+            app._model_params_override = None
+            app._last_cache_model_spec = model_spec
+            app._last_cache_model_params = None
+            app._last_model_request_at = (
+                datetime.now(UTC) - timedelta(minutes=31)
+            ).isoformat()
+            app._context_tokens = 50_000
+            app._cold_cache_warning_threshold_usd = 0.10
+            with (
+                patch(
+                    "deepagents_code.model_config.ModelConfig.load",
+                    return_value=config,
+                ),
+                patch(
+                    "deepagents_code.model_config.is_warning_suppressed",
+                    return_value=False,
+                ),
+                patch("deepagents_code.cost_tracking.estimate_cost", estimate),
+            ):
+                return await app._cold_cache_warning_for(
+                    QueuedMessage("continue", "normal")
+                )
+
+        # Positive control: a same-format route on this host does warn, so a
+        # `None` below can only come from the crossing guard.
+        control = await warning_for("anthropic:claude-sonnet-4-6")
+        assert control is not None
+        assert control.estimate.incremental_cost_usd == pytest.approx(0.25)
+
+        # Anthropic wire format routed to an OpenAI model: the gateway
+        # rewrites caching fields, so the Anthropic policy would be fiction.
+        assert await warning_for("anthropic:openai/gpt-5.6") is None
+
+    async def test_unrecorded_endpoint_is_not_an_identity_change(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A thread checkpointed before endpoint tracking must not warn early.
+
+        `_last_cache_endpoint` is unset for every pre-existing thread. If that
+        counted as a change, the first turn of each would bypass the cache
+        window and warn about a switch that never happened.
+        """
+        # Stubbed so the assertion cannot depend on the developer's own
+        # `config.toml`, which the real loader would otherwise read.
+        monkeypatch.setattr(
+            "deepagents_code.cold_cache.load_trusted_cache_endpoints",
+            frozenset,
+        )
+        app = DeepAgentsApp()
+        app._model_override = "openai:gpt-5.6"
+        app._model_params_override = None
+        app._last_cache_model_spec = "openai:gpt-5.6"
+        app._last_cache_model_params = None
+        app._last_cache_endpoint = None
+        # Well inside the 30m window: only a spurious identity change could
+        # produce a warning here.
+        app._last_model_request_at = (
+            datetime.now(UTC) - timedelta(minutes=2)
+        ).isoformat()
+        app._context_tokens = 50_000
+        app._cold_cache_warning_threshold_usd = 0.10
+        config = MagicMock()
+        config.get_base_url.return_value = None
+
+        with (
+            patch(
+                "deepagents_code.model_config.ModelConfig.load",
+                return_value=config,
+            ),
+            patch(
+                "deepagents_code.model_config.is_warning_suppressed",
+                return_value=False,
+            ),
+        ):
+            assert (
+                await app._cold_cache_warning_for(QueuedMessage("continue", "normal"))
+                is None
+            )
+
+    async def test_recorded_unchanged_endpoint_is_not_an_identity_change(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A warm cache on the *same* endpoint must stay silent.
+
+        The recorded identity is produced by the writer
+        (`configurable_model._cache_endpoint_identity`) against the same
+        `base_url` the reader resolves, so this pins writer/reader agreement
+        rather than a hand-written string. Any drift between them -- an
+        equality check weakened to `is`, normalization changed on one side
+        only -- makes the warning fire on every turn for every user, which no
+        other test in this class would catch.
+
+        The mismatched control below is what keeps that assertion honest: it
+        fails if the endpoint comparison stops running at all.
+        """
+        from deepagents_code.configurable_model import _cache_endpoint_identity
+
+        monkeypatch.setattr(
+            "deepagents_code.cold_cache.load_trusted_cache_endpoints",
+            frozenset,
+        )
+        config = MagicMock()
+        config.get_base_url.return_value = "https://api.openai.com/v1"
+
+        def estimate(
+            usage: dict[str, Any],
+            _model: str,
+            _provider: str,
+        ) -> float:
+            # The cold side of a `generic` (OpenAI) bucket carries no
+            # cache-write detail at all, so tolerate the key being absent.
+            details = usage.get("input_token_details", {})
+            return 0.10 if "cache_read" in details else 0.35
+
+        async def warning_for(recorded_endpoint: str) -> ColdCacheWarning | None:
+            app = DeepAgentsApp()
+            app._model_override = "openai:gpt-5.6"
+            app._model_params_override = None
+            app._last_cache_model_spec = "openai:gpt-5.6"
+            app._last_cache_model_params = None
+            app._last_cache_endpoint = recorded_endpoint
+            # Well inside the 30m window: only an identity change can warn.
+            app._last_model_request_at = (
+                datetime.now(UTC) - timedelta(minutes=2)
+            ).isoformat()
+            app._context_tokens = 50_000
+            app._cold_cache_warning_threshold_usd = 0.10
+            with (
+                patch(
+                    "deepagents_code.model_config.ModelConfig.load",
+                    return_value=config,
+                ),
+                patch(
+                    "deepagents_code.model_config.is_warning_suppressed",
+                    return_value=False,
+                ),
+                patch("deepagents_code.cost_tracking.estimate_cost", estimate),
+            ):
+                return await app._cold_cache_warning_for(
+                    QueuedMessage("continue", "normal")
+                )
+
+        with patch(
+            "deepagents_code.model_config.ModelConfig.load", return_value=config
+        ):
+            recorded = _cache_endpoint_identity("openai:gpt-5.6")
+
+        assert await warning_for(recorded) is None
+        # Control: the same setup with a different endpoint does warn, so the
+        # assertion above cannot pass by the comparison being skipped.
+        warning = await warning_for("https://proxy.example.com/v1")
+        assert warning is not None
+        assert warning.reason == "identity_changed"
+
+    @pytest.mark.parametrize(
+        "model_spec",
+        ["openai:gpt-5.6", "OpenAI:gpt-5.6", " openai:gpt-5.6"],
+    )
+    async def test_writer_and_reader_agree_on_unnormalized_provider(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        model_spec: str,
+    ) -> None:
+        """Both sides must normalize the provider before resolving an endpoint.
+
+        `get_base_url` is an exact-key lookup, so a spec the user spelled
+        `OpenAI:gpt-5.6` resolves a real endpoint only for the reader unless
+        the writer normalizes too. The double below is deliberately strict --
+        it answers for `"openai"` and nothing else -- so a writer that passes
+        the raw casing records `default` and disagrees forever.
+
+        Unlike an unreadable checkpoint value, this disagreement never
+        self-heals: each side keeps recomputing its own answer, so every send
+        reports `identity_changed` with copy naming a change that never
+        happened.
+        """
+        from deepagents_code.configurable_model import _cache_endpoint_identity
+
+        monkeypatch.setattr(
+            "deepagents_code.cold_cache.load_trusted_cache_endpoints",
+            frozenset,
+        )
+        config = MagicMock()
+        # Exact-key, like the real `ModelConfig`: anything but the normalized
+        # provider resolves no endpoint at all.
+        config.get_base_url.side_effect = lambda provider: (
+            "https://api.openai.com/v1" if provider == "openai" else None
+        )
+        # Force both sides down the `get_base_url` fallback path.
+        config.get_effective_kwargs.return_value = None
+
+        def estimate(
+            usage: dict[str, Any],
+            _model: str,
+            _provider: str,
+        ) -> float:
+            details = usage.get("input_token_details", {})
+            return 0.10 if "cache_read" in details else 0.35
+
+        with patch(
+            "deepagents_code.model_config.ModelConfig.load", return_value=config
+        ):
+            recorded = _cache_endpoint_identity(model_spec)
+
+        app = DeepAgentsApp()
+        app._model_override = model_spec
+        app._model_params_override = None
+        app._last_cache_model_spec = model_spec
+        app._last_cache_model_params = None
+        app._last_cache_endpoint = recorded
+        app._last_model_request_at = (
+            datetime.now(UTC) - timedelta(minutes=2)
+        ).isoformat()
+        app._context_tokens = 50_000
+        app._cold_cache_warning_threshold_usd = 0.10
+        with (
+            patch("deepagents_code.model_config.ModelConfig.load", return_value=config),
+            patch(
+                "deepagents_code.model_config.is_warning_suppressed",
+                return_value=False,
+            ),
+            patch("deepagents_code.cost_tracking.estimate_cost", estimate),
+        ):
+            warning = await app._cold_cache_warning_for(
+                QueuedMessage("continue", "normal")
+            )
+
+        # The writer saw the same endpoint the reader resolves, so a warm cache
+        # on an unchanged endpoint stays silent regardless of how the user
+        # spelled the provider.
+        assert warning is None
+        assert recorded == "https://api.openai.com/v1"
+
+    @pytest.mark.parametrize(
+        "base_url",
+        ["http://[::1", "https://proxy.example.com:99999/v1", "not a url"],
+    )
+    async def test_malformed_base_url_does_not_break_evaluation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        base_url: str,
+    ) -> None:
+        """Endpoint parsing must not raise out of the warning evaluation.
+
+        `_cold_cache_warning_for` wraps its worker in a blanket
+        `except Exception`, so a raise here would not crash -- it would
+        silently disable cold-cache warnings for every user, with the same
+        symptom as having nothing to warn about. These inputs reach the
+        `ValueError` guards in `endpoint_cache_identity` and
+        `_endpoint_hostname`.
+
+        The assertion is on that handler's log rather than the returned
+        warning: whether a malformed endpoint resolves a policy varies by how
+        it is malformed (an out-of-range port still parses to a trusted host),
+        and pinning that here would test the wrong thing.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.cold_cache.load_trusted_cache_endpoints",
+            lambda: frozenset({"proxy.example.com"}),
+        )
+        app = DeepAgentsApp()
+        app._model_override = "openai:gpt-5.6"
+        app._model_params_override = None
+        app._last_cache_model_spec = "openai:gpt-5.6"
+        app._last_cache_endpoint = "default"
+        app._last_model_request_at = (
+            datetime.now(UTC) - timedelta(minutes=45)
+        ).isoformat()
+        app._context_tokens = 50_000
+        app._cold_cache_warning_threshold_usd = 0.10
+        config = MagicMock()
+        config.get_base_url.return_value = base_url
+
+        with (
+            caplog.at_level(logging.WARNING, logger="deepagents_code.app"),
+            patch(
+                "deepagents_code.model_config.ModelConfig.load",
+                return_value=config,
+            ),
+            patch(
+                "deepagents_code.model_config.is_warning_suppressed",
+                return_value=False,
+            ),
+        ):
+            await app._cold_cache_warning_for(QueuedMessage("continue", "normal"))
+
+        assert _COLD_CACHE_EVAL_FAILURE_LOG not in caplog.text
+
+    async def test_evaluation_failure_is_logged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Positive control for the absence assertion above.
+
+        That test proves malformed endpoints do *not* log this message. Without a
+        case that makes it fire, rewording the log string would silently turn it
+        into an assertion about a string no code produces -- vacuously true for
+        every input, including the ones it exists to protect.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.cold_cache.resolve_prompt_cache_policy",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        app = DeepAgentsApp()
+        app._model_override = "openai:gpt-5.6"
+        app._model_params_override = None
+        app._last_cache_model_spec = "openai:gpt-5.6"
+        app._last_model_request_at = (
+            datetime.now(UTC) - timedelta(minutes=45)
+        ).isoformat()
+        app._context_tokens = 50_000
+
+        with caplog.at_level(logging.WARNING, logger="deepagents_code.app"):
+            result = await app._cold_cache_warning_for(
+                QueuedMessage("continue", "normal")
+            )
+
+        # Fails open: the send proceeds rather than being blocked by a bug here.
+        assert result is None
+        assert _COLD_CACHE_EVAL_FAILURE_LOG in caplog.text
+
+    async def test_gateway_same_format_prefixed_route_warns(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A `provider/model` name on its own gateway prices end to end.
+
+        The prefix is stripped for model-family detection; this pins that the
+        stripping also reaches pricing, so the route produces a real warning
+        rather than resolving a policy that can never be costed.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.cold_cache.load_trusted_cache_endpoints",
+            lambda: frozenset({"smith.langchain.com"}),
+        )
+        app = DeepAgentsApp()
+        app._model_override = "anthropic:anthropic/claude-opus-4-5"
+        app._model_params_override = None
+        app._last_cache_model_spec = "anthropic:anthropic/claude-opus-4-5"
+        app._last_cache_model_params = None
+        app._last_model_request_at = (
+            datetime.now(UTC) - timedelta(minutes=31)
+        ).isoformat()
+        app._context_tokens = 150_000
+        app._cold_cache_warning_threshold_usd = 0.50
+        config = MagicMock()
+        config.get_base_url.return_value = "https://smith.langchain.com/gw"
+
+        # Unstubbed pricing: the real `estimate_cost` cannot price a prefixed
+        # model name, which is exactly the regression under test.
+        with (
+            patch(
+                "deepagents_code.model_config.ModelConfig.load",
+                return_value=config,
+            ),
+            patch(
+                "deepagents_code.model_config.is_warning_suppressed",
+                return_value=False,
+            ),
+        ):
+            warning = await app._cold_cache_warning_for(
+                QueuedMessage("continue", "normal")
+            )
+
+        assert warning is not None
+        assert warning.policy.provider_name == "Anthropic"
+        assert warning.estimate.incremental_cost_usd > 0.50
 
     async def test_external_message_never_opens_warning(self) -> None:
         app = DeepAgentsApp()
@@ -38555,14 +39212,14 @@ class TestColdCacheWarningFlow:
         assert app._last_cache_model_params is None
 
     def test_non_dict_checkpoint_params_are_discarded(self) -> None:
-        """A malformed `_model_params` must not become cache identity."""
+        """A malformed `_last_cache_params` must not become cache identity."""
         app = DeepAgentsApp()
 
         app._sync_cache_state_from_state(
             {
                 "_last_model_request_at": "2026-08-11T12:30:00+00:00",
                 "_last_cache_model_spec": "openai:gpt-5.6",
-                "_model_params": ["not", "a", "dict"],
+                "_last_cache_params": ["not", "a", "dict"],
             }
         )
 
@@ -38641,7 +39298,11 @@ class TestColdCacheWarningFlow:
                 "_last_model_request_at": "2026-08-11T12:30:00+00:00",
                 "_last_cache_model_spec": "openai:gpt-5.6",
                 "_model_spec": "openai:gpt-5.6",
-                "_model_params": {"prompt_cache_retention": "24h"},
+                "_last_cache_params": {"prompt_cache_retention": "24h"},
+                # Runtime overrides from the same checkpoint; they must not
+                # leak into the cache identity when the dedicated channel is
+                # present.
+                "_model_params": {"reasoning_effort": "high"},
             }
         )
 
@@ -38658,7 +39319,7 @@ class TestColdCacheWarningFlow:
             {
                 "_last_model_request_at": "2026-08-11T12:30:00+00:00",
                 "_last_cache_model_spec": "openai:gpt-5.6",
-                "_model_params": params,
+                "_last_cache_params": params,
             }
         )
         params["prompt_cache_retention"] = "in_memory"
@@ -38986,14 +39647,85 @@ class TestColdCacheWarningFlow:
             {
                 "_last_model_request_at": "2026-08-11T12:30:00+00:00",
                 "_last_cache_model_spec": "anthropic:claude-sonnet-4-6",
+                "_last_cache_endpoint": "https://api.anthropic.com/v1",
                 "_model_spec": "anthropic:claude-sonnet-4-6",
-                "_model_params": {"cache_control": {"ttl": "1h"}},
+                "_last_cache_params": {"cache_control": {"ttl": "1h"}},
             }
         )
 
         assert app._last_model_request_at == "2026-08-11T12:30:00+00:00"
         assert app._last_cache_model_spec == "anthropic:claude-sonnet-4-6"
         assert app._last_cache_model_params == {"cache_control": {"ttl": "1h"}}
+        assert app._last_cache_endpoint == "https://api.anthropic.com/v1"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            123,
+            {"host": "x"},
+            "",
+            # Shaped like nothing `endpoint_cache_identity` mints. A plain
+            # non-empty check accepts these, and they then never equal a fresh
+            # identity -- so the next send reports `identity_changed` with no
+            # log line explaining why.
+            "garbage",
+            "api.anthropic.com",
+            "  ",
+        ],
+    )
+    def test_checkpoint_sync_warns_on_unusable_endpoint(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        raw: object,
+    ) -> None:
+        """A discarded endpoint disables detection quietly, so it must be logged.
+
+        Falling back to `None` reads as "never recorded", which suppresses
+        endpoint-change warnings until the next successful model request rather
+        than over-warning -- an absence nothing else would explain.
+        """
+        app = DeepAgentsApp()
+
+        with caplog.at_level(logging.WARNING, logger="deepagents_code.app"):
+            app._sync_cache_state_from_state(
+                {
+                    "_last_model_request_at": "2026-08-11T12:30:00+00:00",
+                    "_last_cache_model_spec": "anthropic:claude-sonnet-4-6",
+                    "_last_cache_endpoint": raw,
+                }
+            )
+
+        assert app._last_cache_endpoint is None
+        assert "_last_cache_endpoint" in caplog.text
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["default", "invalid:0123456789abcdef", "https://gw.example.com/v1"],
+    )
+    def test_checkpoint_sync_keeps_every_minted_identity_shape(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        raw: str,
+    ) -> None:
+        """The shape check must accept all three namespaces the writer produces.
+
+        Control for the rejection cases above: a validator that discarded any of
+        these would silently disable endpoint-change detection for real threads
+        rather than corrupt ones.
+        """
+        app = DeepAgentsApp()
+
+        with caplog.at_level(logging.WARNING, logger="deepagents_code.app"):
+            app._sync_cache_state_from_state(
+                {
+                    "_last_model_request_at": "2026-08-11T12:30:00+00:00",
+                    "_last_cache_model_spec": "anthropic:claude-sonnet-4-6",
+                    "_last_cache_endpoint": raw,
+                }
+            )
+
+        assert app._last_cache_endpoint == raw
+        assert "_last_cache_endpoint" not in caplog.text
 
     def test_checkpoint_sync_warns_on_malformed_request_time(
         self,
@@ -39006,7 +39738,7 @@ class TestColdCacheWarningFlow:
                 {
                     "_last_model_request_at": "not-a-timestamp",
                     "_last_cache_model_spec": "anthropic:claude-sonnet-4-6",
-                    "_model_params": None,
+                    "_last_cache_params": None,
                 }
             )
 
@@ -39033,7 +39765,7 @@ class TestColdCacheWarningFlow:
                     "_last_model_request_at": "2026-08-11T12:30:00+00:00",
                     "_last_cache_model_spec": 42,
                     "_model_spec": None,
-                    "_model_params": None,
+                    "_last_cache_params": None,
                 }
             )
 
@@ -39318,7 +40050,7 @@ class TestColdCacheStateLifecycle:
                 "_session_cost_usd": 1.25,
                 "_last_model_request_at": stamped,
                 "_last_cache_model_spec": "openai:gpt-5.6",
-                "_model_params": {"prompt_cache_retention": "24h"},
+                "_last_cache_params": {"prompt_cache_retention": "24h"},
             }
         )
 

--- a/libs/code/tests/unit_tests/test_cold_cache.py
+++ b/libs/code/tests/unit_tests/test_cold_cache.py
@@ -2,26 +2,120 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from deepagents_code.cold_cache import (
+    _LOGGED_DIAGNOSTICS,
+    _MAX_LOGGED_DIAGNOSTICS,
     CacheConfidence,
     CacheWriteBucket,
     ColdCacheReason,
     ColdCacheWarning,
     PromptCachePolicy,
     RewarmEstimate,
+    _warn_once,
     cache_identity_params,
     debug_stand_in_policy,
+    endpoint_cache_identity,
     estimate_rewarm_cost,
     format_cache_age,
     format_cache_window,
+    load_trusted_cache_endpoints,
     parse_cache_timestamp,
     resolve_prompt_cache_policy,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _reset_rejection_log() -> None:
+    """Clear the once-per-process rejection log between tests.
+
+    Rejections are deduplicated for the life of the process, so without this a
+    test asserting on `caplog` would pass or fail depending on whether an
+    earlier test happened to log the same message first.
+    """
+    _LOGGED_DIAGNOSTICS.clear()
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        (None, "default"),
+        ("", "default"),
+        ("   ", "default"),
+        (
+            "https://Proxy.EXAMPLE.com:443/v1/#fragment",
+            "https://proxy.example.com/v1",
+        ),
+        ("http://proxy.example.com:8080/v1/", "http://proxy.example.com:8080/v1"),
+    ],
+)
+def test_endpoint_cache_identity_normalizes_endpoint_spelling(
+    base_url: str | None, expected: str
+) -> None:
+    assert endpoint_cache_identity(base_url) == expected
+
+
+def test_endpoint_cache_identity_preserves_query_routing() -> None:
+    """Query changes must not be treated as sharing a prompt cache."""
+    tenant_a = endpoint_cache_identity("https://proxy.example.com/v1?tenant=a")
+    tenant_b = endpoint_cache_identity("https://proxy.example.com/v1?tenant=b")
+
+    assert tenant_a != tenant_b
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://proxy.example.com/v1?api-key=sk-secret-value",
+        "sk-proj-secret-value",
+        "https://user:sk-secret-value@proxy.example.com:99999/v1",
+        "http://[::1/v1?token=sk-secret-value",
+    ],
+)
+def test_endpoint_cache_identity_never_embeds_endpoint_secrets(base_url: str) -> None:
+    """Identities reach the checkpoint store, so they must not carry secrets.
+
+    Covers the valid-URL, unparseable, bad-port, and malformed-IPv6 paths --
+    the last two raise out of `urlparse`/`.port` and land in the `invalid:`
+    branch, which historically echoed its input verbatim.
+    """
+    identity = endpoint_cache_identity(base_url)
+
+    assert "sk-secret-value" not in identity
+    assert "sk-proj-secret-value" not in identity
+
+
+def test_endpoint_cache_identity_keeps_malformed_endpoints_distinct() -> None:
+    """Digesting must not collapse bad endpoints onto each other or a good one.
+
+    A malformed endpoint sharing an identity with the provider default would
+    silently mark a switch between them as "no change".
+    """
+    first = endpoint_cache_identity("not a URL")
+    second = endpoint_cache_identity("also not a URL")
+
+    assert first != second
+    assert first != endpoint_cache_identity(None)
+    assert first != endpoint_cache_identity("https://api.openai.com/v1")
+    # Stable across calls: the identity is compared against a checkpointed one.
+    assert first == endpoint_cache_identity("not a URL")
+
+
+def test_endpoint_cache_identity_distinguishes_ipv6_authorities() -> None:
+    """IPv6 brackets must survive normalization so the port stays unambiguous."""
+    assert endpoint_cache_identity("https://[::1]:8080") == "https://[::1]:8080"
+    assert endpoint_cache_identity("https://[::1:8080]") == "https://[::1:8080]"
+    assert endpoint_cache_identity("https://[::1]:8080") != endpoint_cache_identity(
+        "https://[::1:8080]"
+    )
 
 
 def _policy(
@@ -149,6 +243,472 @@ def test_skips_unresolved_or_custom_provider_policies() -> None:
         )
         is None
     )
+
+
+def test_trusted_endpoints_enable_policies_on_alternate_hosts() -> None:
+    gateway = "https://gateway.example.com/v1"
+    trusted = {"gateway.example.com"}
+
+    assert resolve_prompt_cache_policy(
+        "openai:gpt-5.6", base_url=gateway, trusted_endpoints=trusted
+    ) == _policy("OpenAI", 1800, "may_be_cold", 1024, "generic_write")
+    assert resolve_prompt_cache_policy(
+        "anthropic:claude-sonnet-4-6", base_url=gateway, trusted_endpoints=trusted
+    ) == _policy("Anthropic", 300, "expired", 1024, "5m")
+    # A different, untrusted host on the same spec still resolves nothing.
+    assert (
+        resolve_prompt_cache_policy(
+            "openai:gpt-5.6",
+            base_url="https://other.example.com",
+            trusted_endpoints=trusted,
+        )
+        is None
+    )
+
+
+_ANTHROPIC_5M = _policy("Anthropic", 300, "expired", 1024, "5m")
+"""Policy a same-format Anthropic route resolves, used as the positive control.
+
+The cross-format tests below pair each suppressed spec with a spec that *does*
+resolve on the same host, so a guard that stopped firing would flip a visible
+assertion rather than leave every case at `None`.
+"""
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    ["https://smith.langchain.com", "https://acme.smith.langchain.com"],
+)
+def test_langsmith_gateway_same_format_routes_keep_policies(base_url: str) -> None:
+    trusted = {"smith.langchain.com", "acme.smith.langchain.com"}
+
+    # Bare model names are served by the wire format's own provider.
+    assert resolve_prompt_cache_policy(
+        "openai:gpt-5.6", base_url=base_url, trusted_endpoints=trusted
+    ) == _policy("OpenAI", 1800, "may_be_cold", 1024, "generic_write")
+    # An explicit matching prefix is the same route; the prefix must be
+    # stripped before model-family detection rather than defeating it.
+    assert resolve_prompt_cache_policy(
+        "openai:openai/gpt-5.6", base_url=base_url, trusted_endpoints=trusted
+    ) == _policy("OpenAI", 1800, "may_be_cold", 1024, "generic_write")
+    assert resolve_prompt_cache_policy(
+        "anthropic:anthropic/claude-opus-4-5",
+        base_url=base_url,
+        trusted_endpoints=trusted,
+    ) == _policy("Anthropic", 300, "expired", 4096, "5m")
+
+
+@pytest.mark.parametrize(
+    "model_spec",
+    [
+        # Anthropic wire format routed to an OpenAI model.
+        "anthropic:openai/gpt-5.6",
+        # Prefixes for providers this module cannot price are crossings too:
+        # the gateway still translates, so no policy may be assumed.
+        "anthropic:google_genai/gemini-3",
+        "anthropic:baseten/some-model",
+        "anthropic:myorg/claude-opus-4-5",
+    ],
+)
+def test_langsmith_gateway_cross_format_routes_resolve_no_policy(
+    model_spec: str,
+) -> None:
+    gateway = "https://smith.langchain.com"
+    trusted = {"smith.langchain.com"}
+
+    # The same host and trust set resolve a policy for a same-format route,
+    # so `None` here can only come from the cross-format guard.
+    assert (
+        resolve_prompt_cache_policy(
+            "anthropic:claude-sonnet-4-6", base_url=gateway, trusted_endpoints=trusted
+        )
+        == _ANTHROPIC_5M
+    )
+    assert (
+        resolve_prompt_cache_policy(
+            model_spec, base_url=gateway, trusted_endpoints=trusted
+        )
+        is None
+    )
+    # An untrusted gateway resolves nothing regardless.
+    assert resolve_prompt_cache_policy(model_spec, base_url=gateway) is None
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "smith.langchain.com",
+        "smith.langchain.com.",
+        "notsmith.langchain.com",
+        "smith.langchain.com.evil.example",
+        "gateway.example.com",
+    ],
+)
+def test_cross_format_specs_resolve_nothing_on_any_endpoint(host: str) -> None:
+    """A cross-format `provider/` prefix suppresses wherever it appears.
+
+    `provider/model` is the routing convention of proxies generally, not of one
+    known host, and a translated hop rewrites the caching fields any policy
+    would assume. Scoping the guard to a single host left every other trusted
+    proxy resolving a policy for the wrong provider -- one that could never be
+    priced, so the warning silently never fired.
+    """
+    assert (
+        resolve_prompt_cache_policy(
+            "anthropic:openai/gpt-5.6",
+            base_url=f"https://{host}/gw",
+            trusted_endpoints={host},
+        )
+        is None
+    )
+
+
+def test_same_format_prefix_resolves_off_gateway() -> None:
+    """The control for the suppression above: a matching prefix still works.
+
+    Without this, deleting the prefix handling entirely would leave the
+    cross-format assertions green.
+    """
+    assert resolve_prompt_cache_policy(
+        "anthropic:anthropic/claude-opus-4-5",
+        base_url="https://gateway.example.com/v1",
+        trusted_endpoints={"gateway.example.com"},
+    ) == resolve_prompt_cache_policy(
+        "anthropic:claude-opus-4-5",
+        base_url="https://gateway.example.com/v1",
+        trusted_endpoints={"gateway.example.com"},
+    )
+
+
+def test_cross_format_suppression_warns_when_endpoints_are_trusted(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A user who configured trust and still gets no warning must be told why.
+
+    This branch returns before `endpoint_ok`, so the trust-mismatch warning
+    cannot stand in for it -- without its own record the suppression is
+    invisible at the default log level, and the only symptom is an unexplained
+    absence of cold-cache warnings.
+    """
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.cold_cache"):
+        assert (
+            resolve_prompt_cache_policy(
+                "openai:anthropic/claude-opus-5",
+                base_url="https://gateway.example.com/v1",
+                trusted_endpoints={"gateway.example.com"},
+            )
+            is None
+        )
+    assert "does not stay in the 'openai' wire format" in caplog.text
+    assert "anthropic/claude-opus-5" in caplog.text
+
+
+def test_cross_format_suppression_is_reported_without_trust_configured(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The untrusted case is informational, but still not silent.
+
+    The text differs from the trusted case deliberately: `_log_once` keys on the
+    formatted message, so a shared string would let this `INFO` swallow the
+    `WARNING` a user who later configures trust needs to see.
+    """
+    with caplog.at_level(logging.INFO, logger="deepagents_code.cold_cache"):
+        assert (
+            resolve_prompt_cache_policy(
+                "openai:anthropic/claude-opus-5",
+                base_url="https://gateway.example.com/v1",
+            )
+            is None
+        )
+    assert "does not stay in the 'openai' wire format" in caplog.text
+    assert "even on a trusted endpoint" not in caplog.text
+
+
+def test_cross_format_trusted_warning_survives_an_earlier_untrusted_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dedup must not let the informational record hide the warning.
+
+    Same model, same provider, trust added between the two calls -- which is the
+    real sequence when a user edits `config.toml` mid-session.
+    """
+    spec = "openai:anthropic/claude-opus-5"
+    with caplog.at_level(logging.INFO, logger="deepagents_code.cold_cache"):
+        resolve_prompt_cache_policy(spec, base_url="https://gateway.example.com/v1")
+        caplog.clear()
+        resolve_prompt_cache_policy(
+            spec,
+            base_url="https://gateway.example.com/v1",
+            trusted_endpoints={"gateway.example.com"},
+        )
+    assert "even on a trusted endpoint" in caplog.text
+
+
+def test_trusted_endpoints_accepts_urls_as_well_as_hostnames() -> None:
+    """A URL in the trust set must not silently no-op."""
+    assert resolve_prompt_cache_policy(
+        "openai:gpt-5.6",
+        base_url="https://gateway.example.com/v1",
+        trusted_endpoints={"https://gateway.example.com/v1"},
+    ) == _policy("OpenAI", 1800, "may_be_cold", 1024, "generic_write")
+
+
+def test_load_trusted_cache_endpoints_parses_hosts_and_urls() -> None:
+    config = {
+        "warnings": {
+            "trusted_cache_endpoints": [
+                "https://smith.langchain.com/gw",
+                "gateway.example.com",
+                "  spaced.example.com  ",
+                "UPPER.example.com",
+            ]
+        }
+    }
+
+    assert load_trusted_cache_endpoints(config) == frozenset(
+        {
+            "smith.langchain.com",
+            "gateway.example.com",
+            "spaced.example.com",
+            "upper.example.com",
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "ported.example.com:8443",
+        "https://ported.example.com:8443/v1",
+        "api.anthropic.com@evil.example",
+        "https://api.anthropic.com@evil.example/v1",
+        # `urlsplit` strips these rather than failing, so without an explicit
+        # check they would be stored as `gw.example.comevil` / `hostname`.
+        "gw.example.com\nevil",
+        "host\tname",
+        # A whole-string pattern accepts both of these; neither can ever match
+        # a real endpoint, so both are typos worth reporting.
+        "smith..langchain.com",
+        "a.-b.com",
+        "-gw.example.com",
+    ],
+)
+def test_load_trusted_cache_endpoints_rejects_reinterpretable_entries(
+    entry: str,
+) -> None:
+    """Entries that would be stored as something else must be refused.
+
+    `urlparse` resolves userinfo to the host *after* the `@`, so an entry
+    reading as `api.anthropic.com` would silently trust `evil.example`. A
+    non-default port is refused because trust is matched on the host alone
+    (`endpoint_ok` compares against `_endpoint_hostname`, which discards the
+    port), so honoring `:8443` as written is impossible and accepting it would
+    silently widen trust to every port on that host.
+    """
+    config = {"warnings": {"trusted_cache_endpoints": [entry]}}
+
+    assert load_trusted_cache_endpoints(config) == frozenset()
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "https://gw.example.com:443/v1",
+        "http://gw.example.com:80/v1",
+        "gw.example.com:443",
+    ],
+)
+def test_load_trusted_cache_endpoints_accepts_a_default_port(entry: str) -> None:
+    """A default port names the same endpoint, so pasting a full URL works.
+
+    Rejecting it taught users to delete the port, which is the *broader*
+    action: trust is host-wide, so `gw.example.com` covers every port. The
+    guidance must not push toward the wider grant.
+    """
+    config = {"warnings": {"trusted_cache_endpoints": [entry]}}
+
+    assert load_trusted_cache_endpoints(config) == frozenset({"gw.example.com"})
+
+
+@pytest.mark.parametrize(
+    ("base_url", "entry"),
+    [
+        # Root dot on the endpoint, bare entry.
+        ("https://gw.example.com./v1", "gw.example.com"),
+        # Bare endpoint, root dot on the entry.
+        ("https://gw.example.com/v1", "gw.example.com."),
+        # Both spellings fully qualified.
+        ("https://gw.example.com./v1", "gw.example.com."),
+    ],
+)
+def test_trailing_root_dot_matches_the_bare_spelling(base_url: str, entry: str) -> None:
+    """Both sides are root-dot-stripped, so the two spellings compare equal.
+
+    A same-format spec is used deliberately: a cross-format one resolves `None`
+    with or without the strip, so it could not fail if the normalization were
+    deleted.
+    """
+    assert (
+        resolve_prompt_cache_policy(
+            "openai:gpt-5.6", base_url=base_url, trusted_endpoints={entry}
+        )
+        is not None
+    )
+
+
+def test_trust_is_host_wide_across_ports() -> None:
+    """Document the actual matching semantics the rejection message now states.
+
+    `endpoint_ok` compares `_endpoint_hostname(base_url)`, which discards the
+    port, so a trusted host is trusted on every port it is reached on. This is
+    the property that makes a port-scoped entry unhonorable rather than merely
+    inconvenient.
+    """
+    for base_url in (
+        "https://gw.example.com/v1",
+        "https://gw.example.com:9999/v1",
+        "http://gw.example.com:8080/v1",
+    ):
+        assert (
+            resolve_prompt_cache_policy(
+                "openai:gpt-5.6",
+                base_url=base_url,
+                trusted_endpoints={"gw.example.com"},
+            )
+            is not None
+        )
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "",
+        42,
+        None,
+        True,
+        ["nested"],
+        "not a url at all ::",
+        "not a url at all",
+        # `urlparse` accepts `smith.langchain,com` as a host, so the shape
+        # check is what keeps a comma-for-a-dot typo out of the trust set.
+        "smith.langchain,com",
+        # Wildcards are not supported; storing one would never match.
+        "*.example.com",
+        "ftp://gateway.example.com",
+        "https://",
+    ],
+)
+def test_load_trusted_cache_endpoints_rejects_and_logs_bad_entries(
+    entry: object,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = {"warnings": {"trusted_cache_endpoints": [entry]}}
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.cold_cache"):
+        assert load_trusted_cache_endpoints(config) == frozenset()
+
+    assert "trusted_cache_endpoints" in caplog.text
+
+
+def test_load_trusted_cache_endpoints_tolerates_missing_or_malformed() -> None:
+    assert load_trusted_cache_endpoints({}) == frozenset()
+    assert load_trusted_cache_endpoints({"warnings": []}) == frozenset()
+    assert load_trusted_cache_endpoints({"warnings": {}}) == frozenset()
+
+
+def test_load_trusted_cache_endpoints_logs_a_non_table_section(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`warnings = "off"` discards every option in the section, not just this one."""
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.cold_cache"):
+        assert load_trusted_cache_endpoints({"warnings": "off"}) == frozenset()
+
+    assert "expected a table" in caplog.text
+
+
+def test_load_trusted_cache_endpoints_confirms_a_good_set(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A user who fixes a bad entry needs confirmation on the same surface.
+
+    Rejections warn; without a matching success record at a level the Debug
+    Console shows by default, a corrected config is indistinguishable from one
+    that is still being ignored.
+    """
+    config = {"warnings": {"trusted_cache_endpoints": ["gateway.example.com"]}}
+
+    with caplog.at_level(logging.INFO, logger="deepagents_code.cold_cache"):
+        assert load_trusted_cache_endpoints(config) == frozenset(
+            {"gateway.example.com"}
+        )
+
+    assert "Trusting cache endpoints: gateway.example.com" in caplog.text
+
+
+def test_trusted_set_that_never_matches_is_reported(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Trust configured but never matched is a misconfiguration, not a default.
+
+    Its only other symptom is an absence of warnings, which looks exactly like
+    a healthy cache -- so it must reach the Debug Console at the default level
+    rather than sitting in a debug record nobody sees.
+    """
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.cold_cache"):
+        assert (
+            resolve_prompt_cache_policy(
+                "openai:gpt-5.6",
+                base_url="https://api.gateway.example.com/v1",
+                trusted_endpoints={"gateway.example.com"},
+            )
+            is None
+        )
+
+    assert "api.gateway.example.com" in caplog.text
+    assert "trusted set" in caplog.text
+
+
+def test_untrusted_custom_endpoint_stays_quiet(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The control for the report above: no trust configured is not an error.
+
+    A custom endpoint with no trust list is the ordinary opt-out, so it must
+    not produce a warning on every turn.
+    """
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.cold_cache"):
+        assert (
+            resolve_prompt_cache_policy(
+                "openai:gpt-5.6", base_url="https://proxy.example.com/v1"
+            )
+            is None
+        )
+
+    assert caplog.text == ""
+
+
+def test_log_once_cap_releases_instead_of_growing() -> None:
+    """The dedup set is bounded, and overflow re-warns rather than going quiet.
+
+    Keyed by formatted message, it would otherwise accumulate one entry per
+    distinct typo for the life of the process.
+    """
+    for index in range(_MAX_LOGGED_DIAGNOSTICS * 2):
+        _warn_once("rejected entry %s", index)
+
+    assert len(_LOGGED_DIAGNOSTICS) <= _MAX_LOGGED_DIAGNOSTICS
+
+
+def test_load_trusted_cache_endpoints_logs_a_non_list_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A bare string is the likeliest hand-edit and must not fail silently."""
+    config = {"warnings": {"trusted_cache_endpoints": "smith.langchain.com"}}
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.cold_cache"):
+        assert load_trusted_cache_endpoints(config) == frozenset()
+
+    assert "expected a list" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -310,6 +870,207 @@ def test_cache_time_formatting() -> None:
     assert format_cache_window(1800) == "30m"
     assert format_cache_window(3600) == "1h"
     assert format_cache_window(86400) == "24h"
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    ["https://smith.langchain.com/gw", "https://gateway.example.com/v1"],
+)
+def test_prefixed_same_format_route_can_be_priced(endpoint: str) -> None:
+    """A same-format route must price, not just resolve a policy.
+
+    `resolve_prompt_cache_policy` strips the `provider/` prefix before model
+    family detection; if that stripping does not also reach pricing, the route
+    resolves a policy whose estimate is always `None` and the warning silently
+    never fires -- indistinguishable, to the user, from having nothing to warn
+    about. The bare-name control pins that the two spellings agree, and the
+    non-gateway endpoint pins that this holds for any trusted proxy.
+    """
+    host = endpoint.split("/")[2]
+    trusted = {host}
+
+    for prefixed, bare in (
+        ("openai:openai/gpt-5.6", "openai:gpt-5.6"),
+        ("anthropic:anthropic/claude-opus-4-5", "anthropic:claude-opus-4-5"),
+    ):
+        policy = resolve_prompt_cache_policy(
+            prefixed, base_url=endpoint, trusted_endpoints=trusted
+        )
+        assert policy is not None
+        # The prefix must not defeat family detection either: an unstripped
+        # name falls back to the default minimum rather than the model's own.
+        assert policy == resolve_prompt_cache_policy(
+            bare, base_url=endpoint, trusted_endpoints=trusted
+        )
+        estimate = estimate_rewarm_cost(150_000, prefixed, policy)
+        assert estimate is not None
+        assert estimate.incremental_cost_usd > 0
+        assert estimate == estimate_rewarm_cost(150_000, bare, policy)
+
+
+def test_estimate_rewarm_cost_suppresses_cross_format_routes() -> None:
+    """Pricing applies the same crossing guard as policy resolution."""
+    policy = _policy("Anthropic", 300, "expired", 1024, "5m")
+
+    assert estimate_rewarm_cost(150_000, "anthropic:openai/gpt-5.6", policy) is None
+
+
+def test_trusted_endpoints_reject_what_the_loader_rejects() -> None:
+    """The resolver and the config loader must agree on what is trustable.
+
+    A value the loader drops and logs must not become trusted just because a
+    caller passed it directly -- otherwise the validation regex is a config
+    lint rather than the invariant of the trust set.
+    """
+    for bad in ("my_gw.example.com", "*.example.com", "smith.langchain,com", "::1"):
+        assert (
+            load_trusted_cache_endpoints(
+                {"warnings": {"trusted_cache_endpoints": [bad]}}
+            )
+            == frozenset()
+        )
+        assert (
+            resolve_prompt_cache_policy(
+                "openai:gpt-5.6",
+                base_url=f"https://{bad}",
+                trusted_endpoints={bad},
+            )
+            is None
+        )
+
+
+def test_trusted_endpoints_tolerate_non_string_entries() -> None:
+    """A non-str entry is dropped, not raised on, as the loader drops it.
+
+    The annotation rules this out statically; the check matters because the
+    values ultimately originate in a hand-edited TOML file, and raising here
+    would surface as an unrelated "could not evaluate the warning" error.
+    """
+    mixed = {None, 42, True, "gw.example.com"}
+
+    assert resolve_prompt_cache_policy(
+        "openai:gpt-5.6",
+        base_url="https://gw.example.com",
+        trusted_endpoints=mixed,  # ty: ignore
+    ) == _policy("OpenAI", 1800, "may_be_cold", 1024, "generic_write")
+
+
+def test_trust_does_not_extend_to_subdomains() -> None:
+    """Trust is per exact host, unlike `is_langsmith_gateway_host`.
+
+    Widening this to a suffix match would silently broaden a security boundary,
+    so the non-inheritance is pinned rather than left as an implementation
+    detail.
+    """
+    assert (
+        resolve_prompt_cache_policy(
+            "openai:gpt-5.6",
+            base_url="https://gw.example.com",
+            trusted_endpoints={"example.com"},
+        )
+        is None
+    )
+
+
+def test_gateway_prefix_with_empty_remainder_is_suppressed() -> None:
+    """`openai/` names no model, so nothing can be priced defensibly."""
+    assert (
+        resolve_prompt_cache_policy(
+            "openai:openai/",
+            base_url="https://smith.langchain.com",
+            trusted_endpoints={"smith.langchain.com"},
+        )
+        is None
+    )
+
+
+def test_gateway_prefix_match_is_case_insensitive() -> None:
+    """A capitalized prefix is the same route, not a crossing."""
+    assert resolve_prompt_cache_policy(
+        "openai:OpenAI/gpt-5.6",
+        base_url="https://smith.langchain.com",
+        trusted_endpoints={"smith.langchain.com"},
+    ) == _policy("OpenAI", 1800, "may_be_cold", 1024, "generic_write")
+
+
+def test_load_trusted_cache_endpoints_keeps_good_entries_beside_bad(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One typo must not discard the entries the user got right."""
+    config = {
+        "warnings": {
+            "trusted_cache_endpoints": [
+                "good.example.com",
+                "smith.langchain,com",
+                42,
+                "https://other.example.com/v1",
+            ]
+        }
+    }
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.cold_cache"):
+        assert load_trusted_cache_endpoints(config) == frozenset(
+            {"good.example.com", "other.example.com"}
+        )
+
+    assert "smith.langchain,com" in caplog.text
+    assert "42" in caplog.text
+
+
+def test_load_trusted_cache_endpoints_logs_each_rejection_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The config is re-read every turn; the warning must not repeat forever.
+
+    The debug log buffer is bounded, so a per-turn warning would evict every
+    other record over a long session -- degrading the only surface on which
+    these warnings are visible.
+    """
+    config = {"warnings": {"trusted_cache_endpoints": ["smith.langchain,com"]}}
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.cold_cache"):
+        for _ in range(5):
+            assert load_trusted_cache_endpoints(config) == frozenset()
+
+    assert caplog.text.count("smith.langchain,com") == 1
+
+
+def test_load_trusted_cache_endpoints_reads_config_from_disk(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The no-argument path is the one production uses and must stay wired.
+
+    Every other test supplies `config` explicitly, so a rename or move of
+    `load_config_toml` would ship green and fail only inside the TUI.
+    """
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '[warnings]\ntrusted_cache_endpoints = ["smith.langchain.com"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config_path)
+
+    assert load_trusted_cache_endpoints() == frozenset({"smith.langchain.com"})
+
+
+def test_load_trusted_cache_endpoints_survives_an_undecodable_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A mis-encoded config falls back to defaults instead of raising.
+
+    `UnicodeDecodeError` subclasses `ValueError`, not `OSError` or
+    `TOMLDecodeError`, so it needs its own handling for the documented
+    "malformed content never raises" contract to hold.
+    """
+    config_path = tmp_path / "config.toml"
+    config_path.write_bytes(b"\xff\xfe[warnings]\n")
+    monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config_path)
+
+    assert load_trusted_cache_endpoints() == frozenset()
+
+    assert load_trusted_cache_endpoints() == frozenset()
 
 
 @pytest.mark.parametrize(

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -8,8 +8,9 @@ and that secret-flagged options are never rendered by value.
 from __future__ import annotations
 
 import argparse
+import logging
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -39,6 +40,9 @@ from deepagents_code.config_manifest import (
     resolve_scalar,
 )
 from deepagents_code.model_config import DEFAULT_STARTUP_MODE, PROVIDER_API_KEY_ENV
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # Most unit tests set `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1` to avoid accidental
 # PyPI/DNS work. This module checks whether update settings came from the env,
@@ -3095,3 +3099,26 @@ def test_delegate_static_defaults_are_parseable() -> None:
             continue
         if opt.kind is OptionKind.PTC_DELEGATE:
             assert _parse_interpreter_ptc(opt.default) == opt.default
+
+
+def test_load_config_toml_tolerates_an_undecodable_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A mis-encoded config falls back to defaults instead of raising.
+
+    `UnicodeDecodeError` subclasses `ValueError`, so it is neither `OSError`
+    nor `TOMLDecodeError`. Without explicit handling, a config saved as UTF-16
+    raises out of every caller that reads an option.
+    """
+    from deepagents_code.config_manifest import load_config_toml
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_bytes(b"\xff\xfe[warnings]\n")
+    monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config_path)
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.config_manifest"):
+        assert load_config_toml() == {}
+
+    assert "using defaults" in caplog.text

--- a/libs/code/tests/unit_tests/test_configurable_model.py
+++ b/libs/code/tests/unit_tests/test_configurable_model.py
@@ -20,7 +20,9 @@ from deepagents_code._cli_context import CLIContext, CLIContextSchema
 from deepagents_code.agent import build_model_identity_section
 from deepagents_code.configurable_model import (
     ConfigurableModelMiddleware,
+    _cache_endpoint_identity,
     _checkpoint_command,
+    _effective_cache_params,
     _get_context,
     _is_anthropic_model,
     _is_fireworks_model,
@@ -76,6 +78,8 @@ def _checkpoint_update(
     assert isinstance(timestamp, str)
     cache_model_spec = update.pop("_last_cache_model_spec")
     assert isinstance(cache_model_spec, str)
+    cache_endpoint = update.pop("_last_cache_endpoint")
+    assert isinstance(cache_endpoint, str)
     return update
 
 
@@ -128,6 +132,7 @@ class TestCheckpointPersistence:
         assert isinstance(update, dict)
         assert update["_last_model_request_at"] == "2026-08-11T12:30:00+00:00"
         assert update["_last_cache_model_spec"] == "openai:gpt-5.6"
+        assert update["_last_cache_endpoint"] == "default"
 
     def test_timestamp_is_captured_before_the_model_call(self) -> None:
         """Cache age must be measured from when the prefix was written.
@@ -171,12 +176,13 @@ class TestCheckpointPersistence:
             model_params_known=True,
         )
 
-        command = _checkpoint_command(resolved, "2026-08-11T12:30:00+00:00")
+        command = _checkpoint_command(resolved, "2026-08-11T12:30:00+00:00", "default")
 
         update = command.update
         assert isinstance(update, dict)
         assert "_last_model_request_at" not in update
         assert "_last_cache_model_spec" not in update
+        assert "_last_cache_endpoint" not in update
 
     def test_failed_call_does_not_return_checkpoint_update(self) -> None:
         middleware = ConfigurableModelMiddleware(openai_prompt_cache_key=True)
@@ -220,6 +226,7 @@ class TestNoOverride:
         assert _checkpoint_update(result) == {
             "_model_spec": "openai:claude-sonnet-4-6",
             "_model_params": None,
+            "_last_cache_params": None,
         }
 
     def test_dict_context_reconstructs_approval_fields(self) -> None:
@@ -374,7 +381,128 @@ class TestNoOverride:
         assert _checkpoint_update(result) == {
             "_model_spec": "openai:claude-sonnet-4-6",
             "_model_params": None,
+            "_last_cache_params": None,
         }
+
+
+def test_cache_endpoint_identity_uses_configured_provider_params() -> None:
+    """A `params.base_url` gateway must not be recorded as the default API."""
+    from deepagents_code.model_config import ModelConfig
+
+    config = ModelConfig(
+        providers={"openai": {"params": {"base_url": "https://proxy.example.com/v1"}}}
+    )
+    with patch("deepagents_code.model_config.ModelConfig.load", return_value=config):
+        assert _cache_endpoint_identity("openai:gpt-5.5") == (
+            "https://proxy.example.com/v1"
+        )
+
+
+def test_checkpoint_records_effective_cache_params() -> None:
+    """Configured cache params reach the checkpoint, not just runtime overrides.
+
+    Regression: with `prompt_cache_retention` in config and no session
+    override, storing only the runtime overrides (`None`) makes the next turn's
+    identity check compare `{"prompt_cache_retention": ...}` against `None` and
+    report a false `identity_changed` every turn. The projection lands in the
+    dedicated `_last_cache_params` channel so resume never re-reads it as
+    per-session overrides.
+    """
+    from deepagents_code.model_config import ModelConfig
+
+    config = ModelConfig(
+        providers={"openai": {"params": {"prompt_cache_retention": "24h"}}}
+    )
+    request = _make_request(
+        _make_model("gpt-5.5"),
+        context=CLIContext(),
+    )
+    with patch("deepagents_code.model_config.ModelConfig.load", return_value=config):
+        result = ConfigurableModelMiddleware().wrap_model_call(
+            request, lambda _r: _make_response()
+        )
+
+    update = _checkpoint_update(result)
+    assert update["_last_cache_params"] == {"prompt_cache_retention": "24h"}
+    assert update["_model_params"] is None
+
+
+def test_checkpoint_cache_params_exclude_unrelated_config() -> None:
+    """Only cache-identity keys may be persisted for the cold-cache check.
+
+    Regression: `_model_params` is read back on resume as runtime overrides,
+    so persisting the full effective kwargs there (or anywhere resume reads)
+    pins configured defaults like `temperature` into old threads and silently
+    overrides newer config.
+    """
+    from deepagents_code.model_config import ModelConfig
+
+    config = ModelConfig(
+        providers={
+            "openai": {
+                "params": {
+                    "prompt_cache_retention": "24h",
+                    "temperature": 0.7,
+                    "max_retries": 5,
+                    "default_headers": {"x-trace": "abc"},
+                    "base_url": "https://proxy.example.com/v1",
+                }
+            }
+        }
+    )
+    request = _make_request(
+        _make_model("gpt-5.5"),
+        context=CLIContext(model_params={"reasoning_effort": "high"}),
+    )
+    with patch("deepagents_code.model_config.ModelConfig.load", return_value=config):
+        result = ConfigurableModelMiddleware().wrap_model_call(
+            request, lambda _r: _make_response()
+        )
+
+    update = _checkpoint_update(result)
+    # Only the identity key survives; `base_url` is tracked separately as the
+    # endpoint identity, and the runtime override is not a cache-identity key.
+    assert update["_last_cache_params"] == {"prompt_cache_retention": "24h"}
+    # Resume semantics are untouched: exactly the runtime overrides.
+    assert update["_model_params"] == {"reasoning_effort": "high"}
+
+
+def test_cache_endpoint_identity_normalizes_the_provider() -> None:
+    """The reader lowercases before looking up, so the writer must too.
+
+    `get_kwargs`/`get_base_url` are exact-key lookups, so without this the two
+    sides resolve different endpoints for the same request and disagree on every
+    turn -- a disagreement that never self-heals.
+    """
+    from deepagents_code.model_config import ModelConfig
+
+    config = ModelConfig(
+        providers={"openai": {"params": {"base_url": "https://proxy.example.com/v1"}}}
+    )
+    with patch("deepagents_code.model_config.ModelConfig.load", return_value=config):
+        for spec in ("openai:gpt-5.5", "OpenAI:gpt-5.5", " openai:gpt-5.5"):
+            assert _cache_endpoint_identity(spec) == "https://proxy.example.com/v1"
+
+
+def test_cache_endpoint_identity_degrades_instead_of_raising(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A completed, billed model call must not be lost to a config surprise.
+
+    Both call sites run after `handler()` returns, so propagating here would
+    discard a paid response over a value used only for change detection.
+    """
+    config = MagicMock()
+    config.get_effective_kwargs.side_effect = RuntimeError("config exploded")
+    config.get_base_url.side_effect = RuntimeError("config exploded")
+
+    with (
+        patch("deepagents_code.model_config.ModelConfig.load", return_value=config),
+        caplog.at_level(logging.WARNING, logger="deepagents_code.configurable_model"),
+    ):
+        assert _cache_endpoint_identity("openai:gpt-5.5") == "default"
+
+    assert "Could not resolve the cache endpoint" in caplog.text
 
 
 class TestModelSwap:
@@ -441,10 +569,19 @@ class TestModelSwap:
                 "deepagents_code.configurable_model.asyncio.to_thread", fake_to_thread
             ),
         ):
-            await _mw.awrap_model_call(request, handler)
+            result = await _mw.awrap_model_call(request, handler)
 
         assert captured[0].model is override
-        assert offloaded == [(create, ("openai:gpt-5.5",), {})]
+        # Blocking calls must be offloaded: model construction, the
+        # endpoint-identity lookup, and effective cache-param resolution (both
+        # read the config and credential store). Doing any inline would trip
+        # `blockbuster` on the server event loop.
+        assert offloaded == [
+            (create, ("openai:gpt-5.5",), {}),
+            (_cache_endpoint_identity, ("openai:gpt-5.5",), {}),
+            (_effective_cache_params, ("openai:gpt-5.5", None), {}),
+        ]
+        assert "_last_cache_params" in _checkpoint_update(result)
 
     async def test_async_profile_overrides_forwarded_to_swapped_model(self) -> None:
         original = _make_model("claude-sonnet-4-6")
@@ -552,6 +689,7 @@ class TestModelSwap:
         assert _checkpoint_update(result) == {
             "_model_spec": "openai:gpt-5.5",
             "_model_params": None,
+            "_last_cache_params": None,
         }
 
 
@@ -1435,6 +1573,7 @@ class TestModelParams:
         assert _checkpoint_update(result) == {
             "_model_spec": "openai:claude-sonnet-4-6",
             "_model_params": {"temperature": 0.7},
+            "_last_cache_params": None,
         }
 
     def test_reasoning_effort_reaches_model_settings(self) -> None:
@@ -1460,6 +1599,7 @@ class TestModelParams:
         assert _checkpoint_update(result) == {
             "_model_spec": "openai:claude-opus-4-5",
             "_model_params": {"reasoning_effort": "high"},
+            "_last_cache_params": None,
         }
 
     def test_params_merge_preserves_existing(self) -> None:

--- a/libs/code/tests/unit_tests/test_doctor.py
+++ b/libs/code/tests/unit_tests/test_doctor.py
@@ -425,6 +425,12 @@ class TestEndpointGatewayState:
 
         assert _endpoint_gateway_state("https://smith.langchain.com") == "yes"
 
+    def test_trailing_root_dot_is_gateway(self) -> None:
+        """The fully-qualified spelling classifies as `cold_cache` sees it."""
+        from deepagents_code.doctor import _endpoint_gateway_state
+
+        assert _endpoint_gateway_state("https://smith.langchain.com./") == "yes"
+
     def test_regional_subdomain_is_gateway(self) -> None:
         from deepagents_code.doctor import _endpoint_gateway_state
 

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -4795,6 +4795,38 @@ api_key_env = "CIS_API_KEY"
         assert has_provider_credentials("nonexistent_provider_xyz") is None
 
 
+class TestIsLangsmithGatewayHost:
+    """Tests for the shared LangSmith gateway host predicate.
+
+    Two modules gate behavior on this (`doctor` classifies tracing endpoints,
+    `app` decides whether a provider key mismatches the gateway it is being
+    sent through), so its boundary cases are pinned directly rather than only
+    through callers. `cold_cache` deliberately does *not* use it: its
+    cross-format decision comes from the model-name prefix alone and is
+    host-independent.
+    """
+
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("smith.langchain.com", True),
+            ("eu.api.smith.langchain.com", True),
+            # A dot boundary is required, so a longer name that merely ends in
+            # the gateway's letters is not a subdomain of it.
+            ("notsmith.langchain.com", False),
+            # The gateway name appearing earlier in the string is not a suffix.
+            ("smith.langchain.com.evil.example", False),
+            ("langchain.com", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_host_classification(self, host: str | None, expected: bool) -> None:
+        from deepagents_code.model_config import is_langsmith_gateway_host
+
+        assert is_langsmith_gateway_host(host) is expected
+
+
 class TestIsLocalEndpoint:
     """Tests for _is_local_endpoint URL classification."""
 
@@ -5142,6 +5174,39 @@ temperature = 0.5
         config = ModelConfig.load(config_path)
         kwargs = config.get_kwargs("ollama", model_name="qwen3:4b")
         assert kwargs == {"temperature": 0.5}
+
+
+class TestModelConfigGetEffectiveKwargs:
+    """Tests for effective request kwargs used by model construction and policy."""
+
+    def test_merges_params_endpoint_and_runtime_override(self, tmp_path):
+        """Runtime params win after per-model config and the resolved endpoint."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.openai]
+base_url = "https://configured.example.com/v1"
+
+[models.providers.openai.params]
+temperature = 0
+base_url = "https://params.example.com/v1"
+prompt_cache_retention = "in_memory"
+
+[models.providers.openai.params."gpt-5.5"]
+prompt_cache_retention = "24h"
+""")
+        config = ModelConfig.load(config_path)
+
+        kwargs = config.get_effective_kwargs(
+            "openai",
+            model_name="gpt-5.5",
+            overrides={"temperature": 0.5},
+        )
+
+        assert kwargs == {
+            "temperature": 0.5,
+            "base_url": "https://configured.example.com/v1",
+            "prompt_cache_retention": "24h",
+        }
 
 
 class TestModelConfigGetProfileOverrides:

--- a/libs/code/tests/unit_tests/test_resume_state.py
+++ b/libs/code/tests/unit_tests/test_resume_state.py
@@ -48,6 +48,27 @@ class TestResumeState:
         metadata = getattr(hints["_last_cache_model_spec"], "__metadata__", ())
         assert PrivateStateAttr in metadata
 
+    def test_state_has_last_cache_endpoint_field(self) -> None:
+        """ResumeState declares the `_last_cache_endpoint` channel.
+
+        Without the annotation LangGraph silently drops the
+        `_checkpoint_command` write, so endpoint-change detection never fires
+        again -- and the `configurable_model` tests would stay green, because
+        they assert on the `Command.update` dict rather than on what the schema
+        accepts.
+        """
+        assert "_last_cache_endpoint" in ResumeState.__annotations__
+
+    def test_last_cache_endpoint_is_private(self) -> None:
+        """The endpoint identity must not enter public graph I/O.
+
+        It can embed a proxy hostname and path, so it belongs to the same
+        private set as the spec and timestamp it is checkpointed beside.
+        """
+        hints = get_type_hints(ResumeState, include_extras=True)
+        metadata = getattr(hints["_last_cache_endpoint"], "__metadata__", ())
+        assert PrivateStateAttr in metadata
+
     def test_sticky_rubric_field_is_private(self):
         """Persistent TUI rubrics must not leak through the public schema."""
         # `_sticky_rubric` is inherited from `GoalRubricChannels`, so resolve the

--- a/libs/code/tests/unit_tests/tui/modals/test_cold_cache.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_cold_cache.py
@@ -110,7 +110,12 @@ def test_anthropic_copy_calls_guaranteed_ttl_expired() -> None:
     assert "~$1.2 more" in body
 
 
-def test_identity_change_uses_model_specific_copy() -> None:
+def test_identity_change_uses_identity_specific_copy() -> None:
+    """Identity copy must name every trigger the caller folds into the flag.
+
+    The endpoint is one of them, so copy naming only the model would misdirect
+    a user who switched gateways.
+    """
     screen = ColdCacheWarningScreen(
         _warning(
             _policy("OpenAI", 1800, "may_be_cold", 1024, "generic"),
@@ -123,7 +128,7 @@ def test_identity_change_uses_model_specific_copy() -> None:
 
     body = screen._body()
 
-    assert "active model or prompt-cache settings differ" in body
+    assert "active model, endpoint, or prompt-cache settings differ" in body
     assert "previous cached prefix cannot be reused" in body
     # An identity change guarantees the prefix is unusable, so the cost
     # sentence is unconditional even though the policy is `may_be_cold`.

--- a/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
@@ -4152,6 +4152,35 @@ class TestFetchThreadHistoryData:
 
         assert payload.model_spec == ""
 
+    async def test_extracts_cache_endpoint_identity(self) -> None:
+        """Persisted cache endpoint should propagate to the restore payload."""
+        from deepagents_code.tui.widgets.message_store import MessageData, MessageType
+
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        raw_messages = [object()]
+        state = MagicMock()
+        state.values = {
+            "messages": raw_messages,
+            "_last_model_request_at": "2026-08-11T12:30:00+00:00",
+            "_last_cache_endpoint": "https://api.anthropic.com/v1",
+        }
+        app._agent.aget_state = AsyncMock(return_value=state)
+        converted = [MessageData(type=MessageType.USER, content="hello")]
+
+        with patch(
+            "deepagents_code.app.asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value=converted,
+        ):
+            payload = await app._fetch_thread_history_data("tid-1")
+
+        assert payload.cache_state is not None
+        assert (
+            payload.cache_state["_last_cache_endpoint"]
+            == "https://api.anthropic.com/v1"
+        )
+
     async def test_none_context_tokens_coerced_to_zero(self) -> None:
         """`_context_tokens: None` in checkpoint should coerce to 0."""
         from deepagents_code.tui.widgets.message_store import MessageData, MessageType
@@ -4268,6 +4297,31 @@ class TestLoadThreadHistory:
         assert app._thread_restored_cost_usd == pytest.approx(1.25)
         assert app._displayed_cost_usd == pytest.approx(1.25)
         assert app._thread_stats.request_count == 0
+
+    async def test_resume_restores_cache_endpoint_identity(self) -> None:
+        """Resumed threads retain the endpoint used for their cached prefix."""
+        from deepagents_code.app import _ThreadHistoryPayload
+
+        app = DeepAgentsApp(thread_id="tid-1")
+        preloaded = _ThreadHistoryPayload(
+            messages=[],
+            context_tokens=8500,
+            model_spec="anthropic:claude-sonnet-4-6",
+            cache_state={
+                "_last_model_request_at": "2026-08-11T12:30:00+00:00",
+                "_last_cache_model_spec": "anthropic:claude-sonnet-4-6",
+                "_last_cache_endpoint": "https://api.anthropic.com/v1",
+                "_model_spec": "anthropic:claude-sonnet-4-6",
+                "_model_params": None,
+            },
+        )
+
+        await app._load_thread_history(
+            thread_id="tid-1",
+            preloaded_payload=preloaded,
+        )
+
+        assert app._last_cache_endpoint == "https://api.anthropic.com/v1"
 
     async def test_zero_context_tokens_does_not_overwrite_cache(self) -> None:
         """Loading a payload with 0 tokens should not reset an existing cache."""


### PR DESCRIPTION
Depends on #5439

[Docs](https://github.com/langchain-ai/docs/pull/5524)

Some users don't talk to model providers directly — they go through a gateway or corporate proxy (for example, LangSmith's gateway, or a company-internal relay). The cold-cache warning from #5439 stays silent for all of them, because it only trusts the provider's official API address. This PR adds a setting to say "my endpoint plays by the provider's rules," turning the warnings back on:

```toml
[warnings]
trusted_cache_endpoints = ["smith.langchain.com"]
```

One entry covers every provider routed through that endpoint — no need to repeat it per provider.

---

**Why trust is per-endpoint, not global.** The warning's dollar estimates are only accurate if the thing sitting between you and the provider passes your cache settings through untouched and keeps cached data for as long as the provider documents. A proxy that quietly drops those settings would make the warning's numbers fiction. So instead of one blanket "trust everything" switch, you name the specific endpoints you've verified, and everything else stays silent.

**One case stays silent even on a trusted endpoint.** LangSmith's gateway can translate between API formats — for example, you can send an OpenAI-shaped request and have it answered by an Anthropic model. During that translation, your cache settings get rewritten to a generic 5-minute cache (or dropped entirely), so the provider's documented cache behavior no longer applies and any estimate would be a guess. When dcode can see a request will take one of these translated routes (the model name carries a cross-provider prefix like `openai:anthropic/claude-...`), it skips the warning rather than show numbers built on wrong assumptions. Requests that stay in their own format — the normal case — are forwarded by the gateway byte-for-byte (verified against the gateway source), so their warnings remain exactly as accurate as going direct.

<details><summary>Test plan</summary>

- Unit tests cover trusted-endpoint policy resolution, gateway same-format vs cross-format routes, lookalike-host rejection (`notsmith.langchain.com`, `smith.langchain.com.evil.example`), and malformed config tolerance.
- App-level tests confirm a trusted gateway endpoint allows the warning through, and a cross-format gateway route suppresses it even when trusted.
- Lint, type check, and the cold-cache/manifest suites pass.

</details>
