### PR TITLE
fix(sdk): pass parent state to async subagent invoke

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -870,6 +870,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         )
     )
     sub_agent_middleware: SubAgentMiddleware | None = None
+    async_subagent_middleware: AsyncSubAgentMiddleware | None = None
     if inline_subagents:
         sub_agent_middleware = SubAgentMiddleware(
             backend=backend,
@@ -893,7 +894,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     if async_subagents:
         # Async here means that we run these subagents in a non-blocking manner.
         # Currently this supports agents deployed via LangSmith deployments.
-        deepagent_middleware.append(AsyncSubAgentMiddleware(async_subagents=async_subagents))
+        async_subagent_middleware = AsyncSubAgentMiddleware(async_subagents=async_subagents)
+        deepagent_middleware.append(async_subagent_middleware)
 
     # Names of the core stack, captured before the tail is appended so new user
     # middleware can splice in ahead of the profile/prompt-caching/memory tail.
@@ -941,6 +943,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     private_state_keys = private_state_field_names(*state_schemas)
     if sub_agent_middleware is not None:
         sub_agent_middleware.private_state_keys = private_state_keys
+    if async_subagent_middleware is not None:
+        async_subagent_middleware.private_state_keys = private_state_keys
     # Verify every main-profile exclusion matched at least one middleware in
     # either the main agent stack or the GP subagent stack. An entry that
     # matched nothing across both is almost certainly a typo or a stale

--- a/libs/deepagents/deepagents/middleware/_state.py
+++ b/libs/deepagents/deepagents/middleware/_state.py
@@ -12,11 +12,16 @@ if TYPE_CHECKING:
     from typing import Any
 
 
+_FORKED_CONTEXT_KEY = "_deepagents_forked_context"
+"""State flag that prevents a forked subagent from delegating again."""
+
+
 _EXCLUDED_STATE_KEYS = {
     "messages",
     "todos",
     "structured_response",
     "async_tasks",
+    _FORKED_CONTEXT_KEY,
 }
 """State keys that are excluded when passing state to subagents and when
 returning updates from subagents.

--- a/libs/deepagents/deepagents/middleware/_state.py
+++ b/libs/deepagents/deepagents/middleware/_state.py
@@ -37,7 +37,6 @@ def prepare_subagent_state(
     state: Mapping[str, Any],
     *,
     private_state_keys: frozenset[str] = frozenset(),
-    excluded_keys: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
     """Copy the public portion of parent state for a child subagent.
 
@@ -45,7 +44,7 @@ def prepare_subagent_state(
     returns. This allows synchronous and remote subagents to use their native
     message representations while sharing the same visibility policy.
     """
-    excluded = _EXCLUDED_STATE_KEYS | private_state_keys | excluded_keys
+    excluded = _EXCLUDED_STATE_KEYS | private_state_keys
     return {key: value for key, value in state.items() if key not in excluded}
 
 

--- a/libs/deepagents/deepagents/middleware/_state.py
+++ b/libs/deepagents/deepagents/middleware/_state.py
@@ -37,6 +37,7 @@ def prepare_subagent_state(
     state: Mapping[str, Any],
     *,
     private_state_keys: frozenset[str] = frozenset(),
+    excluded_keys: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
     """Copy the public portion of parent state for a child subagent.
 
@@ -44,8 +45,8 @@ def prepare_subagent_state(
     returns. This allows synchronous and remote subagents to use their native
     message representations while sharing the same visibility policy.
     """
-    excluded_keys = _EXCLUDED_STATE_KEYS | private_state_keys
-    return {key: value for key, value in state.items() if key not in excluded_keys}
+    excluded = _EXCLUDED_STATE_KEYS | private_state_keys | excluded_keys
+    return {key: value for key, value in state.items() if key not in excluded}
 
 
 logger = logging.getLogger(__name__)

--- a/libs/deepagents/deepagents/middleware/_state.py
+++ b/libs/deepagents/deepagents/middleware/_state.py
@@ -45,7 +45,7 @@ def prepare_subagent_state(
     returns. This allows synchronous and remote subagents to use their native
     message representations while sharing the same visibility policy.
     """
-    excluded_keys = _SUBAGENT_EXCLUDED_STATE_KEYS | private_state_keys
+    excluded_keys = _EXCLUDED_STATE_KEYS | private_state_keys
     return {key: value for key, value in state.items() if key not in excluded_keys}
 
 logger = logging.getLogger(__name__)

--- a/libs/deepagents/deepagents/middleware/_state.py
+++ b/libs/deepagents/deepagents/middleware/_state.py
@@ -33,7 +33,6 @@ When returning updates:
 """
 
 
-
 def prepare_subagent_state(
     state: Mapping[str, Any],
     *,
@@ -47,6 +46,7 @@ def prepare_subagent_state(
     """
     excluded_keys = _EXCLUDED_STATE_KEYS | private_state_keys
     return {key: value for key, value in state.items() if key not in excluded_keys}
+
 
 logger = logging.getLogger(__name__)
 

--- a/libs/deepagents/deepagents/middleware/_state.py
+++ b/libs/deepagents/deepagents/middleware/_state.py
@@ -3,9 +3,50 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated, get_args, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Annotated, get_args, get_origin, get_type_hints
 
 from langchain.agents.middleware.types import PrivateStateAttr
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+
+_EXCLUDED_STATE_KEYS = {
+    "messages",
+    "todos",
+    "structured_response",
+    "async_tasks",
+}
+"""State keys that are excluded when passing state to subagents and when
+returning updates from subagents.
+
+When returning updates:
+
+1. The messages key is handled explicitly to ensure only the final message
+    is included
+2. The todos and `structured_response` keys are excluded as they do not have
+    a defined reducer and no clear meaning for returning them from a subagent
+    to the main agent.
+3. Agent-private fields on middleware state schemas are excluded from both
+    subagent output and subagent inputs.
+"""
+
+
+
+def prepare_subagent_state(
+    state: Mapping[str, Any],
+    *,
+    private_state_keys: frozenset[str] = frozenset(),
+) -> dict[str, Any]:
+    """Copy the public portion of parent state for a child subagent.
+
+    Callers must supply the child-specific `messages` value after this helper
+    returns. This allows synchronous and remote subagents to use their native
+    message representations while sharing the same visibility policy.
+    """
+    excluded_keys = _SUBAGENT_EXCLUDED_STATE_KEYS | private_state_keys
+    return {key: value for key, value in state.items() if key not in excluded_keys}
 
 logger = logging.getLogger(__name__)
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -18,7 +18,7 @@ from typing import Annotated, Any, Literal, NotRequired, TypedDict
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ModelRequest, ModelResponse, ResponseT, TracePolicy, omit_payload
 from langchain.tools import ToolRuntime
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
 from langgraph_sdk import get_client, get_sync_client
@@ -26,6 +26,7 @@ from langgraph_sdk.client import LangGraphClient, SyncLangGraphClient
 from langgraph_sdk.schema import Run
 from pydantic import BaseModel, Field
 
+from deepagents.middleware._state import prepare_subagent_state
 from deepagents.middleware._utils import append_to_system_message
 
 logger = logging.getLogger(__name__)
@@ -246,6 +247,8 @@ def _build_start_tool(
     agent_map: dict[str, AsyncSubAgent],
     clients: _ClientCache,
     tool_description: str,
+    *,
+    private_state_keys: frozenset[str] = frozenset(),
 ) -> StructuredTool:
     """Build the `start_async_task` tool."""
 
@@ -261,10 +264,12 @@ def _build_start_tool(
         try:
             client = clients.get_sync(subagent_type)
             thread = client.threads.create()
+            subagent_state = prepare_subagent_state(runtime.state, private_state_keys=private_state_keys)
+            subagent_state["messages"] = [HumanMessage(content=description)]
             run = client.runs.create(
                 thread_id=thread["thread_id"],
                 assistant_id=spec["graph_id"],
-                input={"messages": [{"role": "user", "content": description}]},
+                input=subagent_state,
             )
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             logger.warning("Failed to launch async subagent '%s': %s", subagent_type, e)
@@ -301,10 +306,12 @@ def _build_start_tool(
         try:
             client = clients.get_async(subagent_type)
             thread = await client.threads.create()
+            subagent_state = prepare_subagent_state(runtime.state, private_state_keys=private_state_keys)
+            subagent_state["messages"] = [HumanMessage(content=description)]
             run = await client.runs.create(
                 thread_id=thread["thread_id"],
                 assistant_id=spec["graph_id"],
-                input={"messages": [{"role": "user", "content": description}]},
+                input=subagent_state,
             )
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             logger.warning("Failed to launch async subagent '%s': %s", subagent_type, e)
@@ -814,11 +821,14 @@ def _build_list_tasks_tool(clients: _ClientCache) -> StructuredTool:
 
 def _build_async_subagent_tools(
     agents: list[AsyncSubAgent],
+    *,
+    private_state_keys: frozenset[str] = frozenset(),
 ) -> list[StructuredTool]:
     """Build the async subagent tools from agent specs.
 
     Args:
         agents: List of async subagent specifications.
+        private_state_keys: Parent-state keys that must not be sent to remote subagents.
 
     Returns:
         List of `StructuredTools` for launch, check, update, cancel, and list operations.
@@ -829,7 +839,7 @@ def _build_async_subagent_tools(
     launch_desc = ASYNC_TASK_TOOL_DESCRIPTION.format(available_agents=agents_desc)
 
     return [
-        _build_start_tool(agent_map, clients, launch_desc),
+        _build_start_tool(agent_map, clients, launch_desc, private_state_keys=private_state_keys),
         _build_check_tool(clients),
         _build_update_tool(agent_map, clients),
         _build_cancel_tool(clients),
@@ -859,6 +869,8 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             optional — omit it to use ASGI transport for local servers.
         system_prompt: Instructions appended to the main agent's system prompt
             about how to use the async subagent tools.
+        private_state_keys: State keys marked with `PrivateStateAttr` that
+            must not be forwarded to remote subagents.
 
     Example:
         ```python
@@ -887,6 +899,7 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         *,
         async_subagents: list[AsyncSubAgent],
         system_prompt: str | None = None,
+        private_state_keys: frozenset[str] | None = None,
     ) -> None:
         """Initialize the `AsyncSubAgentMiddleware`."""
         super().__init__()
@@ -900,13 +913,25 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             msg = f"Duplicate async subagent names: {dupes}"
             raise ValueError(msg)
 
-        self.tools = _build_async_subagent_tools(async_subagents)
+        self._specs = async_subagents
+        self._private_state_keys = private_state_keys or frozenset()
+        self.tools = _build_async_subagent_tools(async_subagents, private_state_keys=self._private_state_keys)
 
         if system_prompt:
             agents_desc = "\n".join(f"- {a['name']}: {a['description']}" for a in async_subagents)
             self.system_prompt: str | None = system_prompt + "\n\nAvailable async subagent types:\n\n" + agents_desc
         else:
             self.system_prompt = system_prompt
+
+    @property
+    def private_state_keys(self) -> frozenset[str]:
+        """State keys stripped from parent state before launching remote subagents."""
+        return self._private_state_keys
+
+    @private_state_keys.setter
+    def private_state_keys(self, value: frozenset[str]) -> None:
+        self._private_state_keys = value
+        self.tools = _build_async_subagent_tools(self._specs, private_state_keys=value)
 
     def wrap_model_call(
         self,

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -18,7 +18,7 @@ from typing import Annotated, Any, Literal, NotRequired, TypedDict
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ModelRequest, ModelResponse, ResponseT, TracePolicy, omit_payload
 from langchain.tools import ToolRuntime
-from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
 from langgraph_sdk import get_client, get_sync_client
@@ -265,7 +265,7 @@ def _build_start_tool(
             client = clients.get_sync(subagent_type)
             thread = client.threads.create()
             subagent_state = prepare_subagent_state(runtime.state, private_state_keys=private_state_keys)
-            subagent_state["messages"] = [HumanMessage(content=description)]
+            subagent_state["messages"] = [{"role": "user", "content": description}]
             run = client.runs.create(
                 thread_id=thread["thread_id"],
                 assistant_id=spec["graph_id"],
@@ -307,7 +307,7 @@ def _build_start_tool(
             client = clients.get_async(subagent_type)
             thread = await client.threads.create()
             subagent_state = prepare_subagent_state(runtime.state, private_state_keys=private_state_keys)
-            subagent_state["messages"] = [HumanMessage(content=description)]
+            subagent_state["messages"] = [{"role": "user", "content": description}]
             run = await client.runs.create(
                 thread_id=thread["thread_id"],
                 assistant_id=spec["graph_id"],

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import TypeIs
 
 from deepagents.backends.protocol import BackendProtocol
+from deepagents.middleware._state import prepare_subagent_state
 from deepagents.middleware._utils import append_to_system_message
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
 from deepagents.middleware.summarization import (
@@ -396,7 +397,6 @@ _EXCLUDED_STATE_KEYS = {
     _FORKED_CONTEXT_KEY,
 }
 """State keys excluded when passing state to isolated subagents."""
-
 
 
 class TaskToolSchema(BaseModel):

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -390,14 +390,6 @@ DEFAULT_SUBAGENT_PROMPT = """In order to complete the objective that the user as
 The calling agent only sees your final assistant message, not your intermediate work, tool results, or status tracking. Ensure your final
 response contains the complete answer."""
 
-_EXCLUDED_STATE_KEYS = {
-    "messages",
-    "todos",
-    "structured_response",
-    _FORKED_CONTEXT_KEY,
-}
-"""State keys excluded when passing state to isolated subagents."""
-
 
 class TaskToolSchema(BaseModel):
     """Input schema for the `task` tool."""
@@ -738,7 +730,11 @@ def _build_task_tool(  # noqa: C901, PLR0915
             else:
                 # A compiled runnable is opaque -- it may not declare these
                 # channels, and internal state isn't ours to hand it.
-                inherited = {key: value for key, value in runtime.state.items() if key not in _EXCLUDED_STATE_KEYS | private_state_keys}
+                inherited = prepare_subagent_state(
+                    runtime.state,
+                    private_state_keys=private_state_keys,
+                    excluded_keys=frozenset({_FORKED_CONTEXT_KEY}),
+                )
             subagent_state = {
                 **inherited,
                 "messages": _fork_messages(
@@ -748,7 +744,11 @@ def _build_task_tool(  # noqa: C901, PLR0915
                 ),
             }
         else:
-            subagent_state = {key: value for key, value in runtime.state.items() if key not in _EXCLUDED_STATE_KEYS | private_state_keys}
+            subagent_state = prepare_subagent_state(
+                runtime.state,
+                private_state_keys=private_state_keys,
+                excluded_keys=frozenset({_FORKED_CONTEXT_KEY}),
+            )
             subagent_state["messages"] = [HumanMessage(content=description)]
         return subagent_runnable, subagent_state
 

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -395,19 +395,8 @@ _EXCLUDED_STATE_KEYS = {
     "structured_response",
     _FORKED_CONTEXT_KEY,
 }
-"""State keys that are excluded when passing state to subagents and when
-returning updates from subagents.
+"""State keys excluded when passing state to isolated subagents."""
 
-When returning updates:
-
-1. The messages key is handled explicitly to ensure only the final message
-    is included
-2. The todos and `structured_response` keys are excluded as they do not have
-    a defined reducer and no clear meaning for returning them from a subagent
-    to the main agent.
-3. Agent-private fields on middleware state schemas are excluded from both
-    subagent output and subagent inputs.
-"""
 
 
 class TaskToolSchema(BaseModel):
@@ -684,7 +673,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
             )
             raise ValueError(error_msg)
 
-        state_update = {k: v for k, v in result.items() if k not in _EXCLUDED_STATE_KEYS and k not in private_state_keys}
+        state_update = prepare_subagent_state(result, private_state_keys=private_state_keys)
 
         structured = result.get("structured_response")
         if structured is not None:

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -732,8 +732,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
                 # channels, and internal state isn't ours to hand it.
                 inherited = prepare_subagent_state(
                     runtime.state,
-                    private_state_keys=private_state_keys,
-                    excluded_keys=frozenset({_FORKED_CONTEXT_KEY}),
+                    private_state_keys=private_state_keys | {_FORKED_CONTEXT_KEY},
                 )
             subagent_state = {
                 **inherited,
@@ -746,8 +745,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
         else:
             subagent_state = prepare_subagent_state(
                 runtime.state,
-                private_state_keys=private_state_keys,
-                excluded_keys=frozenset({_FORKED_CONTEXT_KEY}),
+                private_state_keys=private_state_keys | {_FORKED_CONTEXT_KEY},
             )
             subagent_state["messages"] = [HumanMessage(content=description)]
         return subagent_runnable, subagent_state

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -31,7 +31,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import TypeIs
 
 from deepagents.backends.protocol import BackendProtocol
-from deepagents.middleware._state import prepare_subagent_state
+from deepagents.middleware._state import _FORKED_CONTEXT_KEY, prepare_subagent_state
 from deepagents.middleware._utils import append_to_system_message
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
 from deepagents.middleware.summarization import (
@@ -50,13 +50,6 @@ _FORK_EXCLUDED_STATE_KEYS = frozenset({"structured_response", SUMMARIZATION_EVEN
 The summarization event is folded into the fork's messages instead. Dropping the
 session ID lets the subagent generate its own, and dropping a prior structured response
 ensures it cannot be mistaken for the fork's result.
-"""
-
-_FORKED_CONTEXT_KEY = "_deepagents_forked_context"
-"""Set on a forked subagent's own initial state; never on the parent's.
-
-Lets `task`/`atask` refuse recursive delegation at call time instead of
-omitting the tool -- see `_ForkTaskToolMiddleware` for why.
 """
 
 _FORK_RECURSION_REFUSAL = (
@@ -730,10 +723,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
             else:
                 # A compiled runnable is opaque -- it may not declare these
                 # channels, and internal state isn't ours to hand it.
-                inherited = prepare_subagent_state(
-                    runtime.state,
-                    private_state_keys=private_state_keys | {_FORKED_CONTEXT_KEY},
-                )
+                inherited = prepare_subagent_state(runtime.state, private_state_keys=private_state_keys)
             subagent_state = {
                 **inherited,
                 "messages": _fork_messages(
@@ -743,10 +733,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
                 ),
             }
         else:
-            subagent_state = prepare_subagent_state(
-                runtime.state,
-                private_state_keys=private_state_keys | {_FORKED_CONTEXT_KEY},
-            )
+            subagent_state = prepare_subagent_state(runtime.state, private_state_keys=private_state_keys)
             subagent_state["messages"] = [HumanMessage(content=description)]
         return subagent_runnable, subagent_state
 

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -30,9 +30,12 @@ def _make_spec(name: str = "test-agent", **overrides: Any) -> AsyncSubAgent:
     return AsyncSubAgent(**base)  # type: ignore[typeddict-item]
 
 
-def _make_runtime(tool_call_id: str = "tc_test") -> ToolRuntime:
+def _make_runtime(
+    tool_call_id: str = "tc_test",
+    state: dict[str, Any] | None = None,
+) -> ToolRuntime:
     return ToolRuntime(
-        state={},
+        state=state or {},
         context=None,
         tool_call_id=tool_call_id,
         store=None,
@@ -263,6 +266,37 @@ class TestLaunchTool:
             thread_id="thread_abc",
             assistant_id="my_graph",
             input={"messages": [{"role": "user", "content": "analyze data"}]},
+        )
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_launch_forwards_public_state_and_excludes_private_and_internal_keys(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.threads.create.return_value = {"thread_id": "thread_abc"}
+        mock_client.runs.create.return_value = {"run_id": "run_xyz"}
+        mock_get_client.return_value = mock_client
+
+        middleware = AsyncSubAgentMiddleware(async_subagents=[_make_spec("alpha")])
+        middleware.private_state_keys = frozenset({"access_token"})
+        launch = _get_tool(middleware.tools, "start_async_task")
+        runtime = _make_runtime(
+            state={
+                "access_token": "secret",
+                "public_context": "available to the child",
+                "todos": [{"content": "parent-only"}],
+                "structured_response": {"result": "parent-only"},
+                "async_tasks": {"other-task": {}},
+            }
+        )
+
+        launch.func(description="analyze data", subagent_type="alpha", runtime=runtime)
+
+        mock_client.runs.create.assert_called_once_with(
+            thread_id="thread_abc",
+            assistant_id="my_graph",
+            input={
+                "public_context": "available to the child",
+                "messages": [{"role": "user", "content": "analyze data"}],
+            },
         )
 
 

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -8,12 +8,12 @@ import subprocess
 import sys
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import MagicMock, patch
+from typing import TYPE_CHECKING, Annotated, Any, cast
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from langchain.agents.middleware import TodoListMiddleware
-from langchain.agents.middleware.types import AgentMiddleware
+from langchain.agents.middleware.types import AgentMiddleware, PrivateStateAttr
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, SystemMessage
 from langchain_core.tools import BaseTool, StructuredTool
@@ -2935,3 +2935,23 @@ class TestSubagentMiddlewareIsolation:
         )
         helper_spec = next(s for s in sub_mw._subagents if s.get("name") == "helper")
         assert not any(isinstance(m, _DeepAgentsSummarizationMiddleware) for m in helper_spec["middleware"])
+
+
+class TestAsyncSubagentPrivateState:
+    def test_resolves_private_state_keys_for_async_subagents(self) -> None:
+        class State(DeepAgentState):
+            access_token: Annotated[str, PrivateStateAttr]
+
+        model = GenericFakeChatModel(messages=iter([]))
+        async_subagent = {
+            "name": "remote-worker",
+            "description": "A remote worker.",
+            "graph_id": "remote_worker",
+            "url": "http://localhost:8123",
+        }
+
+        with patch.object(AsyncSubAgentMiddleware, "private_state_keys", new_callable=PropertyMock) as private_keys:
+            create_deep_agent(model=model, state_schema=State, subagents=[async_subagent])
+
+        private_keys.assert_called_once()
+        assert "access_token" in private_keys.call_args.args[0]


### PR DESCRIPTION
fixes #2440

* refactors the state propagation logic for sync subagents to a shared utility
* makes it so async subagents pass that state + the additional message as input to the graph run through langgraph sdk

This is technically a behavior change, but we're patching this over as a correctness issue since this is how sync subagents are also propagating state.
