### PR TITLE
fix(sdk): offload conversation history to distinct session ID when summarizing

### DIFF
--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -41,7 +41,8 @@ agent = create_deep_agent(middleware=[summ, tool_mw])
 
 ## Storage
 
-Offloaded messages are stored as markdown at `/conversation_history/{thread_id}.md`.
+Offloaded messages are stored as markdown at `/conversation_history/{session_id}.md`,
+where `session_id` is an internally generated per-invocation id.
 
 Each summarization event appends a new section to this file, creating a running
 log of all evicted messages. Base64 media in evicted messages is written
@@ -88,7 +89,6 @@ from langchain.tools import (
 from langchain_core.exceptions import ContextOverflowError
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolCall, ToolMessage, get_buffer_string
 from langchain_core.messages.utils import count_tokens_approximately
-from langgraph.config import get_config
 from langgraph.types import Command
 from pydantic import BaseModel
 from typing_extensions import TypedDict
@@ -196,6 +196,12 @@ class SummarizationState(AgentState):
 
     _summarization_event: Annotated[NotRequired[SummarizationEvent | None], PrivateStateAttr]
     """Private field storing the most recent summarization event."""
+
+    _summarization_session_id: Annotated[NotRequired[str | None], PrivateStateAttr]
+    """Private, internally generated id naming the offload history file.
+
+    Scoped per graph invocation so parallel sub-agents do not share one history file.
+    """
 
 
 class SummarizationDefaults(TypedDict):
@@ -647,40 +653,39 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
         """Generate summary for the given messages (async)."""
         return await self._lc_helper._acreate_summary(messages_to_summarize)
 
-    def _get_thread_id(self) -> str:
-        """Extract `thread_id` from langgraph config.
+    def _get_session_id(self, state: Mapping[str, Any]) -> str:
+        """Resolve the session id naming the offload history file.
 
-        Uses `get_config()` to access the `RunnableConfig` from langgraph's
-        `contextvar`. Falls back to a generated session ID if not available.
+        Reuses a previously persisted `_summarization_session_id` so history
+        appends to one file across turns; otherwise generates a fresh id, which
+        the caller persists in the state update so later turns reuse it.
+
+        The id is internal and scoped per graph invocation, so each invocation
+        -- including each sub-agent -- gets its own history file.
+
+        Args:
+            state: The agent state to read the persisted id from.
 
         Returns:
-            Thread ID string from config, or a generated session ID
-                (e.g., `'session_a1b2c3d4'`) if not in a runnable context.
+            A session id (e.g. `'session_a1b2c3d4'`).
         """
-        try:
-            config = get_config()
-            thread_id = config.get("configurable", {}).get("thread_id")
-            if thread_id is not None:
-                return str(thread_id)
-        except RuntimeError:
-            # Not in a runnable context
-            pass
+        existing = state.get("_summarization_session_id")
+        if isinstance(existing, str) and existing:
+            return existing
+        return f"session_{uuid.uuid4().hex[:8]}"
 
-        # Fallback: generate session ID
-        generated_id = f"session_{uuid.uuid4().hex[:8]}"
-        logger.debug("No thread_id found, using generated session ID: %s", generated_id)
-        return generated_id
-
-    def _get_history_path(self) -> str:
+    def _get_history_path(self, session_id: str) -> str:
         """Generate path for storing conversation history.
 
-        Returns a single file per thread that gets appended to over time.
+        Returns a single file per session id that gets appended to over time.
+
+        Args:
+            session_id: An id from `_get_session_id`.
 
         Returns:
-            Path string like `'/conversation_history/{thread_id}.md'`
+            Path string like `'/conversation_history/{session_id}.md'`
         """
-        thread_id = self._get_thread_id()
-        return f"{self._history_path_prefix}/{thread_id}.md"
+        return f"{self._history_path_prefix}/{session_id}.md"
 
     def _is_summary_message(self, msg: AnyMessage) -> bool:
         """Check if a message is a previous summarization message.
@@ -1173,10 +1178,11 @@ A condensed summary follows:
         self,
         backend: BackendProtocol,
         messages: list[AnyMessage],
+        session_id: str,
     ) -> str | None:
         """Persist messages to backend before summarization.
 
-        Appends evicted messages to a single markdown file per thread. Each
+        Appends evicted messages to a single markdown file per session. Each
         summarization event adds a new section with a timestamp header.
 
         Previous summary messages are filtered out to avoid redundant storage during
@@ -1188,11 +1194,12 @@ A condensed summary follows:
         Args:
             backend: Backend to write to.
             messages: Messages being summarized.
+            session_id: Id naming the history file.
 
         Returns:
             The file path where history was offloaded, or `None` on failure.
         """
-        path = self._get_history_path()
+        path = self._get_history_path(session_id)
 
         # Filter out previous summary messages to avoid redundant storage.
         # Base64 images are already converted to path references by the caller.
@@ -1248,10 +1255,11 @@ A condensed summary follows:
         self,
         backend: BackendProtocol,
         messages: list[AnyMessage],
+        session_id: str,
     ) -> str | None:
         """Persist messages to backend before summarization (async).
 
-        Appends evicted messages to a single markdown file per thread. Each
+        Appends evicted messages to a single markdown file per session. Each
         summarization event adds a new section with a timestamp header.
 
         Previous summary messages are filtered out to avoid redundant storage during
@@ -1263,11 +1271,12 @@ A condensed summary follows:
         Args:
             backend: Backend to write to.
             messages: Messages being summarized.
+            session_id: Id naming the history file.
 
         Returns:
             The file path where history was offloaded, or `None` on failure.
         """
-        path = self._get_history_path()
+        path = self._get_history_path(session_id)
 
         # Filter out previous summary messages to avoid redundant storage.
         # Base64 images are already converted to path references by the caller.
@@ -1407,9 +1416,13 @@ A condensed summary follows:
         # Upload inline media once so both offload and summary see path references.
         offloaded_media_messages, failed_media = self._offload_inline_media(backend, messages_to_summarize)
 
+        # Resolve the internal history-file id and persist it below so later turns
+        # append to the same file.
+        session_id = self._get_session_id(request.state)
+
         # Offload to backend first so history is preserved before summarization.
         # If offload fails, summarization still proceeds (with file_path=None).
-        file_path = self._offload_to_backend(backend, offloaded_media_messages)
+        file_path = self._offload_to_backend(backend, offloaded_media_messages, session_id)
         if file_path is None:
             msg = "Offloading conversation history to backend failed during summarization. Older messages will not be recoverable."
             logger.error(msg)
@@ -1445,7 +1458,10 @@ A condensed summary follows:
         modified_messages = [*new_messages, *preserved_messages]
         response = handler(request.override(messages=modified_messages))
 
-        update: dict[str, Any] = {"_summarization_event": new_event}
+        update: dict[str, Any] = {
+            "_summarization_event": new_event,
+            "_summarization_session_id": session_id,
+        }
         if new_state_tail:
             update["messages"] = list(new_state_tail)
 
@@ -1542,10 +1558,14 @@ A condensed summary follows:
         # This must complete before the gather since both methods consume the result.
         offloaded_media_messages, failed_media = await self._aoffload_inline_media(backend, messages_to_summarize)
 
+        # Resolve the internal history-file id and persist it below so later turns
+        # append to the same file.
+        session_id = self._get_session_id(request.state)
+
         # Offload to backend and generate summary concurrently -- they are independent.
         # If offload fails, summarization still proceeds (with file_path=None).
         file_path, summary = await asyncio.gather(
-            self._aoffload_to_backend(backend, offloaded_media_messages),
+            self._aoffload_to_backend(backend, offloaded_media_messages, session_id),
             self._acreate_summary(offloaded_media_messages),
         )
         if file_path is None:
@@ -1580,7 +1600,10 @@ A condensed summary follows:
         modified_messages = [*new_messages, *preserved_messages]
         response = await handler(request.override(messages=modified_messages))
 
-        update: dict[str, Any] = {"_summarization_event": new_event}
+        update: dict[str, Any] = {
+            "_summarization_event": new_event,
+            "_summarization_session_id": session_id,
+        }
         if new_state_tail:
             update["messages"] = list(new_state_tail)
 
@@ -1616,7 +1639,7 @@ def create_summarization_middleware(
     directly if none of the below apply:
 
     - **Backend offload of evicted history.** Evicted messages are appended
-        to `/conversation_history/{thread_id}.md` (default path) on the
+        to `/conversation_history/{session_id}.md` (default path) on the
         configured backend before the summary replaces them, and the
         summary embeds that path so the agent can re-open it via
         `read_file` when `FilesystemMiddleware` is registered. LangChain
@@ -1870,6 +1893,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
         file_path: str | None,
         event: SummarizationEvent | None,
         cutoff: int,
+        session_id: str,
     ) -> Command:
         """Build the `Command` result for a successful compact operation.
 
@@ -1883,6 +1907,8 @@ class SummarizationToolMiddleware(AgentMiddleware):
             file_path: Backend path where history was offloaded, or `None`.
             event: The prior `_summarization_event`, or `None`.
             cutoff: The cutoff index within the effective message list.
+            session_id: Id that named the history file, persisted so later
+                turns reuse it.
 
         Returns:
             A `Command` with `_summarization_event` state update and a
@@ -1901,6 +1927,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
         return Command(
             update={
                 "_summarization_event": new_event,
+                "_summarization_session_id": session_id,
                 "messages": [
                     ToolMessage(
                         content=f"Conversation compacted. Summarized {len(to_summarize)} messages into a concise summary.",
@@ -2033,15 +2060,16 @@ class SummarizationToolMiddleware(AgentMiddleware):
         if cutoff == 0:
             return self._nothing_to_compact(tool_call_id)
 
+        session_id = s._get_session_id(runtime.state)
         try:
             to_summarize, _ = s._partition_messages(effective, cutoff)
             summary = s._create_summary(to_summarize)
-            file_path = s._offload_to_backend(s._backend, to_summarize)
+            file_path = s._offload_to_backend(s._backend, to_summarize, session_id)
         except Exception as exc:  # tool must return a ToolMessage, not raise
             logger.exception("compact_conversation tool failed")
             return self._compact_error(tool_call_id, exc)
 
-        return self._build_compact_result(runtime, to_summarize, summary, file_path, event, cutoff)
+        return self._build_compact_result(runtime, to_summarize, summary, file_path, event, cutoff, session_id)
 
     async def _arun_compact(self, runtime: ToolRuntime) -> Command:
         """Async variant of `_run_compact`. See that method for details.
@@ -2066,15 +2094,16 @@ class SummarizationToolMiddleware(AgentMiddleware):
         if cutoff == 0:
             return self._nothing_to_compact(tool_call_id)
 
+        session_id = s._get_session_id(runtime.state)
         try:
             to_summarize, _ = s._partition_messages(effective, cutoff)
             summary = await s._acreate_summary(to_summarize)
-            file_path = await s._aoffload_to_backend(s._backend, to_summarize)
+            file_path = await s._aoffload_to_backend(s._backend, to_summarize, session_id)
         except Exception as exc:  # tool must return a ToolMessage, not raise
             logger.exception("compact_conversation tool failed")
             return self._compact_error(tool_call_id, exc)
 
-        return self._build_compact_result(runtime, to_summarize, summary, file_path, event, cutoff)
+        return self._build_compact_result(runtime, to_summarize, summary, file_path, event, cutoff, session_id)
 
     def wrap_model_call(
         self,

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -667,12 +667,14 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
             state: The agent state to read the persisted id from.
 
         Returns:
-            A session id (e.g. `'session_a1b2c3d4'`).
+            A session id (e.g. `'session_<uuid4 hex>'`).
         """
         existing = state.get("_summarization_session_id")
         if isinstance(existing, str) and existing:
             return existing
-        return f"session_{uuid.uuid4().hex[:8]}"
+        # Full uuid4 entropy: history filenames must not collide across
+        # independent sessions sharing a backend, or their evicted history mixes.
+        return f"session_{uuid.uuid4().hex}"
 
     def _get_history_path(self, session_id: str) -> str:
         """Generate path for storing conversation history.

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
@@ -1593,6 +1593,26 @@ class TestSessionIdResolution:
         path, _ = backend.write_calls[0]
         assert path == "/conversation_history/session_deadbeef.md"
 
+    def test_independent_invocations_do_not_share_history_file(self) -> None:
+        """Independent invocations over one backend each get their own history file.
+
+        A parent and its sub-agents share a backend but have isolated state, so
+        each mints its own session id rather than overwriting a shared file.
+        """
+        backend = MockBackend()
+
+        # Two invocations, each with its own state and no session id in it --
+        # exactly the parent/sub-agent situation once private state is stripped.
+        for _ in range(2):
+            middleware = self._make_middleware(backend)
+            state = cast("AgentState[Any]", {"messages": make_conversation_messages(num_old=6, num_recent=2)})
+            call_wrap_model_call(middleware, state, make_mock_runtime())
+
+        paths = [p for p, _ in backend.write_calls]
+        assert len(paths) == 2
+        assert len(set(paths)) == 2, f"history files collided: {paths}"
+        assert all(re.fullmatch(r"/conversation_history/session_[0-9a-f]{8}\.md", p) for p in paths)
+
 
 class TestAsyncBehavior:
     """Tests for async version of `before_model`."""

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
@@ -6,10 +6,9 @@ import hashlib
 import inspect
 import re
 import time
-from collections.abc import Callable, Generator
-from contextlib import contextmanager
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from langchain.agents.middleware.types import ExtendedModelResponse, ModelRequest, ModelResponse
@@ -207,12 +206,7 @@ class MockBackend(BackendProtocol):
 
 
 def make_mock_runtime() -> MagicMock:
-    """Create a mock `Runtime`.
-
-    Note: `Runtime` does not have a `config` attribute. Config is accessed
-    via `get_config()` from langgraph's contextvar. Use `mock_get_config()`
-    to control thread_id in tests.
-    """
+    """Create a mock `Runtime`."""
     runtime = MagicMock()
     runtime.context = {}
     runtime.stream_writer = MagicMock()
@@ -220,22 +214,6 @@ def make_mock_runtime() -> MagicMock:
     # Explicitly don't set runtime.config - it doesn't exist on real Runtime
     del runtime.config
     return runtime
-
-
-@contextmanager
-def mock_get_config(thread_id: str | None = "test-thread-123") -> Generator[None, None, None]:
-    """Context manager to mock `get_config()` with a specific `thread_id`.
-
-    Args:
-        thread_id: The `thread_id` to return, or `None` to simulate missing config.
-
-    Yields:
-        `None` - use as a context manager around test code.
-    """
-    config = {"configurable": {"thread_id": thread_id}} if thread_id is not None else {"configurable": {}}
-
-    with patch("deepagents.middleware.summarization.get_config", return_value=config):
-        yield
 
 
 def make_mock_model(summary_response: str = "This is a test summary.") -> MagicMock:
@@ -403,8 +381,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
-            result, _ = call_wrap_model_call(middleware, state, runtime)
+        result, _ = call_wrap_model_call(middleware, state, runtime)
 
         # Should have triggered summarization
         assert isinstance(result, ExtendedModelResponse)
@@ -414,7 +391,7 @@ class TestOffloadingBasic:
         assert len(backend.write_calls) == 1
 
         path, content = backend.write_calls[0]
-        assert path == "/conversation_history/test-thread-123.md"
+        assert re.fullmatch(r"/conversation_history/session_[0-9a-f]{8}\.md", path)
 
         assert "## Summarized at" in content
         assert '<message type="human">' in content or '<message type="ai">' in content
@@ -449,8 +426,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
-            call_wrap_model_call(middleware, state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         assert len(backend.write_calls) == 1
         _, content = backend.write_calls[0]
@@ -493,8 +469,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
-            call_wrap_model_call(middleware, state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         media_uploads = [(p, c) for p, c in backend.write_calls if p.startswith("/conversation_history/media/")]
         assert media_uploads == [(expected_path, "<binary>")]
@@ -554,8 +529,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
-            call_wrap_model_call(middleware, state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         # Identical images are deduped — only one upload despite three messages.
         image_uploads = [(p, c) for p, c in backend.write_calls if p.startswith("/conversation_history/media/")]
@@ -596,15 +570,14 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
-            call_wrap_model_call(middleware, state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         image_uploads = [(p, c) for p, c in mock_backend.write_calls if p.startswith("/custom/conversation_history/media/")]
         assert len(image_uploads) == 1
         assert image_uploads[0][0] == expected_path
 
         archive_write = next((p, c) for p, c in mock_backend.write_calls if p.endswith(".md"))
-        assert archive_write[0] == "/custom/conversation_history/test-thread-123.md"
+        assert re.fullmatch(r"/custom/conversation_history/session_[0-9a-f]{8}\.md", archive_write[0])
         assert expected_path in archive_write[1]
 
     def test_offload_per_block_upload_failure(self) -> None:
@@ -662,7 +635,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config(), pytest.warns(UserWarning, match="could not be offloaded"):
+        with pytest.warns(UserWarning, match="could not be offloaded"):
             call_wrap_model_call(middleware, state, runtime)
 
         # Only image A was uploaded — B's upload raised.
@@ -721,7 +694,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config(), pytest.warns(UserWarning, match="could not be offloaded"):
+        with pytest.warns(UserWarning, match="could not be offloaded"):
             call_wrap_model_call(middleware, state, runtime)
 
         image_uploads = [(p, c) for p, c in backend.write_calls if p.startswith("/conversation_history/media/")]
@@ -763,7 +736,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config(), pytest.warns(UserWarning, match="could not be offloaded"):
+        with pytest.warns(UserWarning, match="could not be offloaded"):
             call_wrap_model_call(middleware, state, runtime)
 
         archive_write = next((p, c) for p, c in backend.write_calls if p.endswith(".md"))
@@ -801,8 +774,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
-            call_wrap_model_call(middleware, state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         image_uploads = [(p, c) for p, c in backend.write_calls if p.startswith("/conversation_history/media/")]
         assert image_uploads == [(expected_path, "<binary>")]
@@ -839,7 +811,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config(), pytest.warns(UserWarning, match="could not be offloaded"):
+        with pytest.warns(UserWarning, match="could not be offloaded"):
             call_wrap_model_call(middleware, state, runtime)
 
         # Nothing was uploaded (decode failed before any upload).
@@ -880,8 +852,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
-            call_wrap_model_call(middleware, state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         media_uploads = [(p, c) for p, c in backend.write_calls if p.startswith("/conversation_history/media/")]
         assert media_uploads == [(expected_path, "<binary>")]
@@ -947,8 +918,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
-            call_wrap_model_call(middleware, state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         media_uploads = [(p, c) for p, c in backend.write_calls if p.startswith("/conversation_history/media/")]
         assert media_uploads == [(expected_path, "<binary>")]
@@ -992,8 +962,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
-            call_wrap_model_call(middleware, state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         # upload_files is called exactly once even though both offload and
         # summary consume the result.
@@ -1198,20 +1167,21 @@ class TestSummaryMessageFormat:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config(thread_id="test-thread"):
-            result, modified_request = call_wrap_model_call(middleware, state, runtime)
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
         assert isinstance(result, ExtendedModelResponse)
         assert result.command is not None
         assert result.command.update is not None
         assert modified_request is not None
 
+        session_id = result.command.update["_summarization_session_id"]
+
         # Get the summary message (first in modified messages list)
         summary_msg = modified_request.messages[0]
 
         # Should include the file path reference
         assert "full conversation history has been saved to" in summary_msg.content
-        assert "/conversation_history/test-thread.md" in summary_msg.content
+        assert f"/conversation_history/{session_id}.md" in summary_msg.content
 
         # Should include the summary in XML tags
         assert "<summary>" in summary_msg.content
@@ -1307,20 +1277,21 @@ class TestSummaryMessageFormat:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config(thread_id="multi-summarize-thread"):
-            result, modified_request = call_wrap_model_call(middleware, state, runtime)
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
         assert isinstance(result, ExtendedModelResponse)
         assert result.command is not None
         assert result.command.update is not None
         assert modified_request is not None
 
+        session_id = result.command.update["_summarization_session_id"]
+
         # The summary message should be the first message
         summary_msg = modified_request.messages[0]
 
         # Should include the file path reference
         assert "full conversation history has been saved to" in summary_msg.content
-        assert "/conversation_history/multi-summarize-thread.md" in summary_msg.content
+        assert f"/conversation_history/{session_id}.md" in summary_msg.content
 
         # Should include the summary in XML tags
         assert "<summary>" in summary_msg.content
@@ -1389,8 +1360,7 @@ def test_system_message_counts_for_trigger_only() -> None:
         captured_request = req
         return AIMessage(content="Mock response")
 
-    with mock_get_config():
-        result = middleware.wrap_model_call(request, handler)
+    result = middleware.wrap_model_call(request, handler)
 
     assert isinstance(result, ExtendedModelResponse)
     assert seen_system["counted"] is True
@@ -1441,8 +1411,7 @@ async def test_async_tools_passed_to_token_counter_for_summarization() -> None:
         captured_request = req
         return AIMessage(content="Mock response")
 
-    with mock_get_config():
-        result = await middleware.awrap_model_call(request, handler)
+    result = await middleware.awrap_model_call(request, handler)
 
     assert isinstance(result, ExtendedModelResponse)
     assert seen["tools"]
@@ -1577,55 +1546,52 @@ class TestBackendFailureHandling:
         assert event["file_path"] is None
 
 
-class TestThreadIdExtraction:
-    """Tests for thread ID extraction via `get_config()`."""
+class TestSessionIdResolution:
+    """Tests for the internal session id that names the offload history file."""
 
-    def test_thread_id_from_config(self) -> None:
-        """Test that `thread_id` is correctly extracted from `get_config()`."""
-        backend = MockBackend()
-        mock_model = make_mock_model()
-
-        middleware = SummarizationMiddleware(
-            model=mock_model,
+    def _make_middleware(self, backend: MockBackend) -> SummarizationMiddleware:
+        return SummarizationMiddleware(
+            model=make_mock_model(),
             backend=backend,
             trigger=("messages", 5),
             keep=("messages", 2),
         )
 
-        messages = make_conversation_messages(num_old=6, num_recent=2)
-        state = cast("AgentState[Any]", {"messages": messages})
-        runtime = make_mock_runtime()
-
-        with mock_get_config(thread_id="custom-thread-456"):
-            call_wrap_model_call(middleware, state, runtime)
-
-        path, _ = backend.write_calls[0]
-        assert path == "/conversation_history/custom-thread-456.md"
-
-    def test_fallback_thread_id_when_missing(self) -> None:
-        """Test that a fallback ID is generated when `thread_id` is not in config."""
+    def test_generates_and_persists_session_id(self) -> None:
+        """With no id in state, a fresh session id is generated and persisted."""
         backend = MockBackend()
-        mock_model = make_mock_model()
-
-        middleware = SummarizationMiddleware(
-            model=mock_model,
-            backend=backend,
-            trigger=("messages", 5),
-            keep=("messages", 2),
-        )
+        middleware = self._make_middleware(backend)
 
         messages = make_conversation_messages(num_old=6, num_recent=2)
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config(thread_id=None):
-            call_wrap_model_call(middleware, state, runtime)
+        result, _ = call_wrap_model_call(middleware, state, runtime)
 
         path, _ = backend.write_calls[0]
+        assert re.fullmatch(r"/conversation_history/session_[0-9a-f]{8}\.md", path)
+        # The id is persisted so later turns append to the same file.
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        persisted = result.command.update["_summarization_session_id"]
+        assert path == f"/conversation_history/{persisted}.md"
 
-        # Should have a generated session ID in the path
-        assert "session_" in path
-        assert path.endswith(".md")
+    def test_reuses_persisted_session_id(self) -> None:
+        """An id already in state is reused so history appends to one file."""
+        backend = MockBackend()
+        middleware = self._make_middleware(backend)
+
+        messages = make_conversation_messages(num_old=6, num_recent=2)
+        state = cast(
+            "AgentState[Any]",
+            {"messages": messages, "_summarization_session_id": "session_deadbeef"},
+        )
+        runtime = make_mock_runtime()
+
+        call_wrap_model_call(middleware, state, runtime)
+
+        path, _ = backend.write_calls[0]
+        assert path == "/conversation_history/session_deadbeef.md"
 
 
 class TestAsyncBehavior:
@@ -2403,8 +2369,7 @@ def test_truncate_before_summarization() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    with mock_get_config(thread_id="test-thread"):
-        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
     assert isinstance(result, ExtendedModelResponse)
     assert result.command is not None
@@ -2759,8 +2724,7 @@ def test_chained_summarization_cutoff_index() -> None:
 
     # --- Round 1: first summarization, no previous event ---
     state = cast("AgentState[Any]", {"messages": make_state_messages(8)})
-    with mock_get_config():
-        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
     assert isinstance(result, ExtendedModelResponse)
     event_1 = result.command.update["_summarization_event"]
@@ -2775,8 +2739,7 @@ def test_chained_summarization_cutoff_index() -> None:
         "AgentState[Any]",
         {"messages": make_state_messages(14), "_summarization_event": event_1},
     )
-    with mock_get_config():
-        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
     assert isinstance(result, ExtendedModelResponse)
     event_2 = result.command.update["_summarization_event"]
@@ -2791,8 +2754,7 @@ def test_chained_summarization_cutoff_index() -> None:
         "AgentState[Any]",
         {"messages": make_state_messages(20), "_summarization_event": event_2},
     )
-    with mock_get_config():
-        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
     assert isinstance(result, ExtendedModelResponse)
     event_3 = result.command.update["_summarization_event"]
@@ -2837,8 +2799,7 @@ def test_context_overflow_triggers_summarization() -> None:
 
     request = make_model_request(state, runtime)
 
-    with mock_get_config():
-        result = middleware.wrap_model_call(request, handler_with_overflow)
+    result = middleware.wrap_model_call(request, handler_with_overflow)
 
     # Should have triggered summarization as fallback
     assert isinstance(result, ExtendedModelResponse)
@@ -2884,8 +2845,7 @@ async def test_async_context_overflow_triggers_summarization() -> None:
 
     request = make_model_request(state, runtime)
 
-    with mock_get_config():
-        result = await middleware.awrap_model_call(request, handler_with_overflow)
+    result = await middleware.awrap_model_call(request, handler_with_overflow)
 
     # Should have triggered summarization as fallback
     assert isinstance(result, ExtendedModelResponse)
@@ -2933,8 +2893,7 @@ def test_profile_inference_triggers_summary() -> None:
     state = cast("AgentState[Any]", {"messages": messages})
     runtime = make_mock_runtime()
 
-    with mock_get_config():
-        result, _ = call_wrap_model_call(middleware, state, runtime)
+    result, _ = call_wrap_model_call(middleware, state, runtime)
 
     # Should not trigger summarization
     assert not isinstance(result, ExtendedModelResponse)
@@ -2952,8 +2911,7 @@ def test_profile_inference_triggers_summary() -> None:
         token_counter=token_counter,
     )
 
-    with mock_get_config():
-        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
     # Should trigger summarization
     assert isinstance(result, ExtendedModelResponse)
@@ -2985,8 +2943,7 @@ def test_profile_inference_triggers_summary() -> None:
         token_counter=token_counter,
     )
 
-    with mock_get_config():
-        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
     assert isinstance(result, ExtendedModelResponse)
     assert modified_request is not None
@@ -3005,8 +2962,7 @@ def test_profile_inference_triggers_summary() -> None:
         token_counter=token_counter,
     )
 
-    with mock_get_config():
-        result, _ = call_wrap_model_call(middleware, state, runtime)
+    result, _ = call_wrap_model_call(middleware, state, runtime)
 
     # Should not trigger summarization since we'd keep everything anyway
     assert not isinstance(result, ExtendedModelResponse)
@@ -3072,8 +3028,7 @@ def test_usage_metadata_trigger() -> None:
     state = cast("AgentState[Any]", {"messages": messages})
     runtime = make_mock_runtime()
 
-    with mock_get_config():
-        result, _ = call_wrap_model_call(middleware, state, runtime)
+    result, _ = call_wrap_model_call(middleware, state, runtime)
 
     # Should trigger summarization because usage_metadata shows we exceeded 10k tokens
     assert isinstance(result, ExtendedModelResponse)
@@ -3102,9 +3057,10 @@ async def test_async_offload_and_summary_run_concurrently() -> None:
     async def slow_offload(
         be: Any,  # noqa: ANN401
         msgs: Any,  # noqa: ANN401
+        session_id: str,
     ) -> str | None:
         await asyncio.sleep(delay)
-        return await original_offload(be, msgs)
+        return await original_offload(be, msgs, session_id)
 
     async def slow_summary(
         msgs: Any,  # noqa: ANN401
@@ -3119,10 +3075,9 @@ async def test_async_offload_and_summary_run_concurrently() -> None:
     state = cast("AgentState[Any]", {"messages": messages})
     runtime = make_mock_runtime()
 
-    with mock_get_config():
-        start = time.monotonic()
-        result, _ = await call_awrap_model_call(middleware, state, runtime)
-        elapsed = time.monotonic() - start
+    start = time.monotonic()
+    result, _ = await call_awrap_model_call(middleware, state, runtime)
+    elapsed = time.monotonic() - start
 
     assert isinstance(result, ExtendedModelResponse)
     # If sequential, elapsed >= 2 * delay (0.2s). If parallel, elapsed ~ delay.
@@ -3456,8 +3411,7 @@ async def test_async_offloads_base64_images() -> None:
     state = cast("AgentState[Any]", {"messages": messages})
     runtime = make_mock_runtime()
 
-    with mock_get_config():
-        await call_awrap_model_call(middleware, state, runtime)
+    await call_awrap_model_call(middleware, state, runtime)
 
     # aupload_files delegates to upload_files in MockBackend, so write_calls captures it.
     # Identical images are deduped — only one upload despite three messages.
@@ -3518,7 +3472,7 @@ async def test_async_upload_response_error_writes_placeholder() -> None:
     state = cast("AgentState[Any]", {"messages": messages})
     runtime = make_mock_runtime()
 
-    with mock_get_config(), pytest.warns(UserWarning, match="could not be offloaded"):
+    with pytest.warns(UserWarning, match="could not be offloaded"):
         await call_awrap_model_call(middleware, state, runtime)
 
     image_uploads = [(p, c) for p, c in backend.write_calls if p.startswith("/conversation_history/media/")]
@@ -3561,7 +3515,7 @@ async def test_async_all_uploads_raise_writes_placeholders() -> None:
     state = cast("AgentState[Any]", {"messages": messages})
     runtime = make_mock_runtime()
 
-    with mock_get_config(), pytest.warns(UserWarning, match="could not be offloaded"):
+    with pytest.warns(UserWarning, match="could not be offloaded"):
         await call_awrap_model_call(middleware, state, runtime)
 
     archive_write = next((p, c) for p, c in backend.write_calls if p.endswith(".md"))

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
@@ -391,7 +391,7 @@ class TestOffloadingBasic:
         assert len(backend.write_calls) == 1
 
         path, content = backend.write_calls[0]
-        assert re.fullmatch(r"/conversation_history/session_[0-9a-f]{8}\.md", path)
+        assert re.fullmatch(r"/conversation_history/session_[0-9a-f]{32}\.md", path)
 
         assert "## Summarized at" in content
         assert '<message type="human">' in content or '<message type="ai">' in content
@@ -577,7 +577,7 @@ class TestOffloadingBasic:
         assert image_uploads[0][0] == expected_path
 
         archive_write = next((p, c) for p, c in mock_backend.write_calls if p.endswith(".md"))
-        assert re.fullmatch(r"/custom/conversation_history/session_[0-9a-f]{8}\.md", archive_write[0])
+        assert re.fullmatch(r"/custom/conversation_history/session_[0-9a-f]{32}\.md", archive_write[0])
         assert expected_path in archive_write[1]
 
     def test_offload_per_block_upload_failure(self) -> None:
@@ -1569,7 +1569,7 @@ class TestSessionIdResolution:
         result, _ = call_wrap_model_call(middleware, state, runtime)
 
         path, _ = backend.write_calls[0]
-        assert re.fullmatch(r"/conversation_history/session_[0-9a-f]{8}\.md", path)
+        assert re.fullmatch(r"/conversation_history/session_[0-9a-f]{32}\.md", path)
         # The id is persisted so later turns append to the same file.
         assert isinstance(result, ExtendedModelResponse)
         assert result.command is not None
@@ -1611,7 +1611,7 @@ class TestSessionIdResolution:
         paths = [p for p, _ in backend.write_calls]
         assert len(paths) == 2
         assert len(set(paths)) == 2, f"history files collided: {paths}"
-        assert all(re.fullmatch(r"/conversation_history/session_[0-9a-f]{8}\.md", p) for p in paths)
+        assert all(re.fullmatch(r"/conversation_history/session_[0-9a-f]{32}\.md", p) for p in paths)
 
 
 class TestAsyncBehavior:

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -17,7 +17,7 @@ from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.messages.content import ContentBlock
-from langchain_core.outputs import ChatResult
+from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool, tool
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -147,6 +147,28 @@ class FixedGenericFakeChatModel(GenericFakeChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         self.captured_messages.append(messages)
+        return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+
+class SummaryFilteringModel(FixedGenericFakeChatModel):
+    """Serves summarization's summary-generation call separately from the action script.
+
+    A summarization event makes an extra model call to write the summary, in
+    addition to the normal turn's call. Detecting that call by the summary
+    prompt's `<messages>` marker and returning a canned summary lets the scripted
+    `messages` iterator hold only the agent's turn-by-turn actions, without
+    predicting when summarization fires.
+    """
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if any(isinstance(m.content, str) and "<messages>" in m.content for m in messages):
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content="summary"))])
         return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
 
 
@@ -3234,6 +3256,79 @@ class TestArtifactsRoot:
         assert names, "expected conversation history offloaded"
         assert all(name.startswith("session_") for name in names)
         assert f"{supplied}.md" not in names
+
+    def test_parent_and_subagent_offload_to_separate_files(self) -> None:
+        """A parent and a sub-agent that both summarize write to separate history files.
+
+        Both share one backend under a single thread. The parent summarizes its
+        oversized opening context, then delegates to a sub-agent that loops tool
+        calls until its own context crosses the threshold and summarizes too.
+        The two offloads land in distinct files rather than overwriting one.
+        """
+        backend = CompositeBackend(
+            default=StoreBackend(store=InMemoryStore(), namespace=lambda _ctx: ("filesystem",)),
+            routes={},
+            artifacts_root="/workspace",
+        )
+
+        @tool(description="Return a block of filler text.")
+        def filler() -> str:
+            # ~10k tokens: accumulates toward the summarization threshold but
+            # stays under the 20k-token per-result eviction limit.
+            return "x" * 40_000
+
+        subagent_model = SummaryFilteringModel(
+            messages=iter(
+                [
+                    *(
+                        AIMessage(
+                            content="",
+                            tool_calls=[{"name": "filler", "args": {}, "id": f"filler_{i}", "type": "tool_call"}],
+                        )
+                        for i in range(5)
+                    ),
+                    AIMessage(content="subagent done"),
+                ]
+            )
+        )
+        subagent_model.profile = {"max_input_tokens": 50_000}
+
+        worker: SubAgent = {
+            "name": "worker",
+            "description": "Does a chunk of work.",
+            "system_prompt": "Do the work.",
+            "model": subagent_model,
+            "tools": [filler],
+        }
+
+        parent_model = SummaryFilteringModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {"description": "do it", "subagent_type": "worker"},
+                                "id": "call_task",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+        parent_model.profile = {"max_input_tokens": 200_000}
+
+        agent = create_deep_agent(model=parent_model, backend=backend, subagents=[worker], checkpointer=InMemorySaver())
+
+        agent.invoke({"messages": self._messages_over_threshold()}, {"configurable": {"thread_id": "shared-thread"}})
+
+        names = self._offloaded_history_names(backend)
+        assert len(names) >= 2, f"expected separate parent and sub-agent history files, got {names}"
+        assert len(set(names)) == len(names), f"history files collided: {names}"
+        assert all(name.startswith("session_") for name in names)
 
     def test_create_deep_agent_no_composite_backend(self) -> None:
         """A non-composite backend defaults artifacts_root to '/' (root prefix)."""

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -3162,6 +3162,79 @@ class TestArtifactsRoot:
         default_ls = backend.ls("/conversation_history/")
         assert not default_ls.entries, "No files should be written to /conversation_history/ when artifacts_root is set"
 
+    @staticmethod
+    def _offloaded_history_names(backend: CompositeBackend) -> list[str]:
+        """Return the basenames of offloaded history files under the artifacts root."""
+        entries = backend.ls("/workspace/conversation_history/").entries or []
+        return [e["path"].rsplit("/", 1)[-1] for e in entries if e["path"].endswith(".md")]
+
+    def _summarizing_agent(self, backend: CompositeBackend) -> CompiledStateGraph:
+        fake_model = FakeChatModelWithHistory(
+            messages=iter(
+                [
+                    AIMessage(content="summary goes here"),
+                    AIMessage(content="response"),
+                ]
+            )
+        )
+        fake_model.profile = {"max_input_tokens": 200_000}
+        return create_deep_agent(model=fake_model, backend=backend, checkpointer=InMemorySaver())
+
+    @staticmethod
+    def _messages_over_threshold() -> list[BaseMessage]:
+        small = "x" * 10_000 * NUM_CHARS_PER_TOKEN
+        large = "x" * 50_000 * NUM_CHARS_PER_TOKEN
+        return [
+            HumanMessage(content=small),
+            AIMessage(content=large),
+            HumanMessage(content=small),
+            AIMessage(content=large),
+            HumanMessage(content=small),
+            AIMessage(content=large),
+            HumanMessage(content="query"),
+        ]
+
+    def test_offload_path_uses_session_id_not_thread_id(self) -> None:
+        """The offload history file is named by an internal session id, not the thread_id."""
+        backend = CompositeBackend(
+            default=StoreBackend(store=InMemoryStore(), namespace=lambda _ctx: ("filesystem",)),
+            routes={},
+            artifacts_root="/workspace",
+        )
+        agent = self._summarizing_agent(backend)
+
+        thread_id = "conversation-alpha"
+        agent.invoke({"messages": self._messages_over_threshold()}, {"configurable": {"thread_id": thread_id}})
+
+        names = self._offloaded_history_names(backend)
+        assert names, "expected conversation history offloaded"
+        assert all(name.startswith("session_") for name in names)
+        assert all(thread_id not in name for name in names)
+
+    def test_offload_ignores_caller_supplied_session_id(self) -> None:
+        """A `_summarization_session_id` supplied on invoke input does not name the file.
+
+        The session id is a `PrivateStateAttr`, so LangGraph does not load it
+        from caller input; the internally generated id is used instead.
+        """
+        backend = CompositeBackend(
+            default=StoreBackend(store=InMemoryStore(), namespace=lambda _ctx: ("filesystem",)),
+            routes={},
+            artifacts_root="/workspace",
+        )
+        agent = self._summarizing_agent(backend)
+
+        supplied = "caller-supplied-id"
+        agent.invoke(
+            {"messages": self._messages_over_threshold(), "_summarization_session_id": supplied},
+            {"configurable": {"thread_id": "conversation-beta"}},
+        )
+
+        names = self._offloaded_history_names(backend)
+        assert names, "expected conversation history offloaded"
+        assert all(name.startswith("session_") for name in names)
+        assert f"{supplied}.md" not in names
+
     def test_create_deep_agent_no_composite_backend(self) -> None:
         """A non-composite backend defaults artifacts_root to '/' (root prefix)."""
 


### PR DESCRIPTION
Adds a private state key `_summarization_session_id` to summarization middleware. This ID determines file paths for conversation history when offloading during summarization. Matches [what JS does](https://github.com/langchain-ai/deepagentsjs/blob/44d6d3dfea650a14ccfb4efa0f2176ef2d8cc903/libs/deepagents/src/middleware/summarization.ts#L268-L269).

Problems with using `thread_id`:
1. It's shared by sub-agents, so sub agents overwrite the file when they summarize.
2. It's controllable by users.