### PR TITLE
fix(sdk): batch concurrent `ContextHubBackend` mutations

### DIFF
--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -6,11 +6,20 @@ import fnmatch
 import logging
 import os
 import re
+import threading
+import time
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 from langsmith import Client
 from langsmith.schemas import AgentEntry, FileEntry, SkillEntry
-from langsmith.utils import LangSmithError, LangSmithNotFoundError
+from langsmith.utils import (
+    LangSmithConflictError,
+    LangSmithError,
+    LangSmithNotFoundError,
+    parse_hub_identifier,
+)
 
 from deepagents.backends.protocol import (
     FILE_NOT_FOUND,
@@ -39,8 +48,29 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Matches the ":<hash>" suffix appended by langsmith's _build_context_url.
-_URL_COMMIT_SUFFIX_RE = re.compile(r":([0-9a-f]{8,64})$")
+_COMMIT_HASH_RE = re.compile(r"[0-9a-f]{8}")
+_BATCH_WINDOW_SECONDS = 0.05
+_MAX_CONFLICT_RETRIES = 3
+_TreeSnapshot = tuple[dict[str, str], dict[str, str], str | None]
+
+
+@dataclass
+class _Mutation:
+    """One accepted mutation and the caller waiting for its durability."""
+
+    changes: dict[str, str | None]
+    done: threading.Event = field(default_factory=threading.Event)
+    error: BaseException | None = None
+
+
+@dataclass
+class _MutationQueue:
+    """Mutation overlays guarded by one condition lock."""
+
+    condition: threading.Condition = field(default_factory=threading.Condition)
+    pending: list[_Mutation] = field(default_factory=list)
+    in_flight: list[_Mutation] = field(default_factory=list)
+    deadline: float | None = None
 
 
 class ContextHubBackend(BackendProtocol):
@@ -63,74 +93,253 @@ class ContextHubBackend(BackendProtocol):
         self._cache: dict[str, str] | None = None
         self._linked_entries: dict[str, str] = {}
         self._commit_hash: str | None = None
+        self._mutations = _MutationQueue()
+        self._worker: threading.Thread | None = None
 
-    def _load_tree(self) -> None:
-        """Fetch the file tree; missing repos are treated as empty."""
+    def _fetch_tree(self) -> _TreeSnapshot:
+        """Fetch a remote snapshot; missing repos are treated as empty."""
         try:
             context: AgentContext = self._client.pull_agent(self._identifier)
         except LangSmithNotFoundError:
-            self._cache = {}
-            self._linked_entries = {}
-            self._commit_hash = None
-            return
+            return {}, {}, None
 
-        self._commit_hash = context.commit_hash
-        self._cache = {}
-        self._linked_entries = {}
+        cache: dict[str, str] = {}
+        linked_entries: dict[str, str] = {}
 
         for path, entry in context.files.items():
             if isinstance(entry, FileEntry):
-                self._cache[path] = entry.content
+                cache[path] = entry.content
             else:
-                self._linked_entries[path] = entry.repo_handle
+                linked_entries[path] = entry.repo_handle
+        return cache, linked_entries, context.commit_hash
 
-    def _ensure_cache(self) -> dict[str, str]:
-        """Load the file tree if not yet loaded."""
+    def _load_tree_locked(self) -> None:
+        cache, linked_entries, commit_hash = self._fetch_tree()
+        self._cache = cache
+        self._linked_entries = linked_entries
+        self._commit_hash = commit_hash
+
+    def _ensure_cache_locked(self) -> dict[str, str]:
         if self._cache is None:
-            self._load_tree()
+            # The state lock makes the cold remote pull single-flight.
+            self._load_tree_locked()
         if self._cache is None:
             msg = "Context Hub cache failed to initialize"
             raise RuntimeError(msg)
         return self._cache
 
+    @staticmethod
+    def _overlay(cache: dict[str, str], changes: dict[str, str | None]) -> None:
+        for path, content in changes.items():
+            if content is None:
+                cache.pop(path, None)
+            else:
+                cache[path] = content
+
+    def _visible_cache_locked(self) -> dict[str, str]:
+        visible = dict(self._ensure_cache_locked())
+        for mutations in (self._mutations.in_flight, self._mutations.pending):
+            for mutation in mutations:
+                self._overlay(visible, mutation.changes)
+        return visible
+
+    def _ensure_cache(self) -> dict[str, str]:
+        """Return a snapshot including accepted local mutation overlays."""
+        with self._mutations.condition:
+            return self._visible_cache_locked()
+
     def get_linked_entries(self) -> dict[str, str]:
         """Return linked-entry paths mapped to their repo handles."""
-        self._ensure_cache()
-        return dict(self._linked_entries)
+        with self._mutations.condition:
+            self._ensure_cache_locked()
+            return dict(self._linked_entries)
 
     def has_prior_commits(self) -> bool:
         """Return `True` if the hub repo already exists with at least one commit."""
-        self._ensure_cache()
-        return self._commit_hash is not None
+        with self._mutations.condition:
+            self._ensure_cache_locked()
+            return self._commit_hash is not None
 
-    def _commit(self, changes: dict[str, str | None]) -> None:
-        """Push `changes` as one commit; update the cache on success.
+    def _queue_changes_locked(self, changes: dict[str, str | None]) -> _Mutation:
+        mutation = _Mutation(changes=dict(changes))
+        queue = self._mutations
+        if not queue.pending:
+            queue.deadline = time.monotonic() + _BATCH_WINDOW_SECONDS
+        queue.pending.append(mutation)
 
-        Each value is either new file content or `None`. A `None` value is the
-        deletion marker: relative to `parent_commit`, the server drops that path
-        from the tree.
-        """
-        if not changes:
-            return
+        if self._worker is None:
+            try:
+                worker = threading.Thread(
+                    target=self._drain_mutations,
+                    name="context-hub-mutations",
+                    daemon=True,
+                )
+                self._worker = worker
+                worker.start()
+            except BaseException:  # Construction failure must not orphan the mutation.
+                self._worker = None
+                queue.pending.remove(mutation)
+                if not queue.pending:
+                    queue.deadline = None
+                raise
+        queue.condition.notify_all()
+        return mutation
 
+    @staticmethod
+    def _wait_for_mutation(mutation: _Mutation) -> None:
+        mutation.done.wait()
+        if mutation.error is not None:
+            raise mutation.error
+
+    def _submit_changes(self, changes: dict[str, str | None]) -> None:
+        with self._mutations.condition:
+            self._ensure_cache_locked()
+            mutation = self._queue_changes_locked(changes)
+        self._wait_for_mutation(mutation)
+
+    def _take_batch(self) -> list[_Mutation] | None:
+        queue = self._mutations
+        with queue.condition:
+            while queue.pending:
+                if queue.deadline is None:
+                    msg = "Context Hub mutation deadline is missing"
+                    raise RuntimeError(msg)
+                remaining = queue.deadline - time.monotonic()
+                if remaining > 0:
+                    queue.condition.wait(timeout=remaining)
+                    continue
+                batch = queue.pending
+                queue.pending = []
+                queue.deadline = None
+                queue.in_flight = batch
+                return batch
+            self._worker = None
+            return None
+
+    @staticmethod
+    def _merge_batch(batch: list[_Mutation]) -> dict[str, str | None]:
+        changes: dict[str, str | None] = {}
+        for mutation in batch:
+            changes.update(mutation.changes)
+        return changes
+
+    def _reload_remote(self) -> str | None:
+        cache, linked_entries, commit_hash = self._fetch_tree()
+        with self._mutations.condition:
+            self._cache = cache
+            self._linked_entries = linked_entries
+            self._commit_hash = commit_hash
+        return commit_hash
+
+    def _extract_commit_hash(self, url: str) -> str | None:
+        try:
+            path = urlsplit(url).path
+            owner, name, _ = parse_hub_identifier(self._identifier)
+        except ValueError:
+            return None
+
+        prefixes = (f"/context/{name}/", f"/hub/{owner}/{name}:")
+        for prefix in prefixes:
+            if path.startswith(prefix):
+                commit_hash = path.removeprefix(prefix)
+                if _COMMIT_HASH_RE.fullmatch(commit_hash):
+                    return commit_hash
+        return None
+
+    def _push_changes(self, changes: dict[str, str | None]) -> tuple[str, _TreeSnapshot | None]:
         payload: dict[str, FileEntry | AgentEntry | SkillEntry | None] = {
             path: FileEntry(type="file", content=content) if content is not None else None for path, content in changes.items()
         }
-        url = self._client.push_agent(
-            self._identifier,
-            files=payload,
-            parent_commit=self._commit_hash,
-        )
-        match = _URL_COMMIT_SUFFIX_RE.search(url)
-        if match:
-            self._commit_hash = match.group(1)
 
-        if self._cache is not None:
-            # Rebuild the cache rather than mutating in place: drop paths whose
-            # new content is None (deletions) and overlay the rest as updates.
-            deletions = {path for path, content in changes.items() if content is None}
-            updates = {path: content for path, content in changes.items() if content is not None}
-            self._cache = {path: content for path, content in self._cache.items() if path not in deletions} | updates
+        for attempt in range(_MAX_CONFLICT_RETRIES + 1):
+            with self._mutations.condition:
+                parent_commit = self._commit_hash
+            try:
+                url = self._client.push_agent(
+                    self._identifier,
+                    files=payload,
+                    parent_commit=parent_commit,
+                )
+            except LangSmithConflictError:
+                if attempt == _MAX_CONFLICT_RETRIES:
+                    raise
+                self._reload_remote()
+                continue
+
+            commit_hash = self._extract_commit_hash(url)
+            if commit_hash is not None:
+                return commit_hash, None
+
+            snapshot = self._fetch_tree()
+            commit_hash = snapshot[2]
+            if commit_hash is None:
+                msg = "Context Hub commit succeeded but its hash could not be resolved"
+                raise RuntimeError(msg)
+            return commit_hash, snapshot
+
+        msg = "Context Hub conflict retry loop exhausted unexpectedly"
+        raise RuntimeError(msg)
+
+    def _complete_batch(
+        self,
+        batch: list[_Mutation],
+        changes: dict[str, str | None],
+        commit_hash: str,
+        *,
+        authoritative_snapshot: _TreeSnapshot | None,
+    ) -> bool:
+        with self._mutations.condition:
+            if authoritative_snapshot is None:
+                cache = dict(self._ensure_cache_locked())
+                self._overlay(cache, changes)
+                self._cache = cache
+            else:
+                self._cache, self._linked_entries, _ = authoritative_snapshot
+            self._commit_hash = commit_hash
+            self._mutations.in_flight = []
+            drained = not self._mutations.pending
+            if drained:
+                self._worker = None
+        for mutation in batch:
+            mutation.done.set()
+        return drained
+
+    def _fail_burst(self, batch: list[_Mutation], error: BaseException) -> None:
+        with self._mutations.condition:
+            affected = [*batch, *self._mutations.pending]
+            self._mutations.in_flight = []
+            self._mutations.pending = []
+            self._mutations.deadline = None
+            self._cache = None
+            self._linked_entries = {}
+            self._commit_hash = None
+            self._worker = None
+            for mutation in affected:
+                mutation.error = error
+        for mutation in affected:
+            mutation.done.set()
+
+    def _drain_mutations(self) -> None:
+        while True:
+            batch: list[_Mutation] = []
+            try:
+                next_batch = self._take_batch()
+                if next_batch is None:
+                    return
+                batch = next_batch
+                changes = self._merge_batch(batch)
+                commit_hash, authoritative_snapshot = self._push_changes(changes)
+                drained = self._complete_batch(
+                    batch,
+                    changes,
+                    commit_hash,
+                    authoritative_snapshot=authoritative_snapshot,
+                )
+            except BaseException as exc:  # noqa: BLE001  # Every queued waiter must be settled.
+                self._fail_burst(batch, exc)
+                return
+            if drained:
+                return
 
     @staticmethod
     def _strip_prefix(path: str) -> str:
@@ -164,11 +373,9 @@ class ContextHubBackend(BackendProtocol):
         """Commit `content` to `file_path`."""
         hub_path = self._strip_prefix(file_path)
         try:
-            self._ensure_cache()  # populates _commit_hash for parent_commit on push
-            self._commit({hub_path: content})
+            self._submit_changes({hub_path: content})
         except LangSmithError as exc:
             logger.exception("Hub write failed for %r", self._identifier)
-            self._cache = None
             return WriteResult(error=f"Hub unavailable: {exc}")
         return WriteResult(path=file_path)
 
@@ -182,20 +389,20 @@ class ContextHubBackend(BackendProtocol):
         """Replace `old_string` with `new_string` in a file."""
         hub_path = self._strip_prefix(file_path)
         try:
-            cache = self._ensure_cache()
-            current = cache.get(hub_path)
-            if current is None:
-                return EditResult(error=f"Error: File '{file_path}' not found")
+            with self._mutations.condition:
+                current = self._visible_cache_locked().get(hub_path)
+                if current is None:
+                    return EditResult(error=f"Error: File '{file_path}' not found")
 
-            result = perform_string_replacement(current, old_string, new_string, replace_all)
-            if isinstance(result, str):
-                return EditResult(error=result)
+                result = perform_string_replacement(current, old_string, new_string, replace_all)
+                if isinstance(result, str):
+                    return EditResult(error=result)
 
-            new_content, occurrences = result
-            self._commit({hub_path: new_content})
+                new_content, occurrences = result
+                mutation = self._queue_changes_locked({hub_path: new_content})
+            self._wait_for_mutation(mutation)
         except LangSmithError as exc:
             logger.exception("Hub edit failed for %r", self._identifier)
-            self._cache = None
             return EditResult(error=f"Hub unavailable: {exc}")
         return EditResult(path=file_path, occurrences=occurrences)
 
@@ -214,16 +421,17 @@ class ContextHubBackend(BackendProtocol):
         """
         hub_path = self._strip_prefix(file_path)
         try:
-            cache = self._ensure_cache()
-            base = hub_path.rstrip("/")
-            prefix = base + "/"
-            to_delete = [key for key in cache if key == base or key.startswith(prefix)]
-            if not to_delete:
-                return DeleteResult(error=f"Error: File '{file_path}' not found")
-            self._commit(dict.fromkeys(to_delete, None))
+            with self._mutations.condition:
+                cache = self._visible_cache_locked()
+                base = hub_path.rstrip("/")
+                prefix = base + "/"
+                to_delete = [key for key in cache if key == base or key.startswith(prefix)]
+                if not to_delete:
+                    return DeleteResult(error=f"Error: File '{file_path}' not found")
+                mutation = self._queue_changes_locked(dict.fromkeys(to_delete, None))
+            self._wait_for_mutation(mutation)
         except LangSmithError as exc:
             logger.exception("Hub delete failed for %r", self._identifier)
-            self._cache = None
             return DeleteResult(error=f"Hub unavailable: {exc}")
         return DeleteResult(path=file_path)
 
@@ -337,11 +545,9 @@ class ContextHubBackend(BackendProtocol):
         commit_error: str | None = None
         if valid_files:
             try:
-                self._ensure_cache()
-                self._commit(valid_files)
+                self._submit_changes(valid_files)
             except LangSmithError as exc:
                 logger.exception("Hub batch upload failed for %r", self._identifier)
-                self._cache = None
                 commit_error = f"Hub unavailable: {exc}"
 
         results: list[FileUploadResponse] = []

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -54,11 +54,31 @@ _MAX_CONFLICT_RETRIES = 3
 _TreeSnapshot = tuple[dict[str, str], dict[str, str], str | None]
 
 
+@dataclass(frozen=True)
+class _WriteIntent:
+    changes: dict[str, str | None]
+
+
+@dataclass(frozen=True)
+class _EditIntent:
+    path: str
+    old_string: str
+    new_string: str
+    replace_all: bool
+
+
+@dataclass(frozen=True)
+class _DeleteIntent:
+    path: str
+
+
 @dataclass
 class _Mutation:
     """One accepted mutation and the caller waiting for its durability."""
 
+    intent: _WriteIntent | _EditIntent | _DeleteIntent
     changes: dict[str, str | None]
+    occurrences: int | None = None
     done: threading.Event = field(default_factory=threading.Event)
     error: BaseException | None = None
 
@@ -160,8 +180,19 @@ class ContextHubBackend(BackendProtocol):
             self._ensure_cache_locked()
             return self._commit_hash is not None
 
-    def _queue_changes_locked(self, changes: dict[str, str | None]) -> _Mutation:
-        mutation = _Mutation(changes=dict(changes))
+    def _queue_changes_locked(
+        self,
+        changes: dict[str, str | None],
+        *,
+        intent: _WriteIntent | _EditIntent | _DeleteIntent | None = None,
+        occurrences: int | None = None,
+    ) -> _Mutation:
+        accepted_changes = dict(changes)
+        mutation = _Mutation(
+            intent=intent or _WriteIntent(changes=dict(accepted_changes)),
+            changes=accepted_changes,
+            occurrences=occurrences,
+        )
         queue = self._mutations
         if not queue.pending:
             queue.deadline = time.monotonic() + _BATCH_WINDOW_SECONDS
@@ -223,13 +254,60 @@ class ContextHubBackend(BackendProtocol):
             changes.update(mutation.changes)
         return changes
 
-    def _reload_remote(self) -> str | None:
+    @staticmethod
+    def _rematerialize_mutation(
+        mutation: _Mutation,
+        cache: dict[str, str],
+        conflict: LangSmithConflictError,
+    ) -> tuple[dict[str, str | None], int | None]:
+        intent = mutation.intent
+        if isinstance(intent, _WriteIntent):
+            return dict(intent.changes), None
+        if isinstance(intent, _EditIntent):
+            current = cache.get(intent.path)
+            if current is None:
+                raise conflict
+            result = perform_string_replacement(
+                current,
+                intent.old_string,
+                intent.new_string,
+                intent.replace_all,
+            )
+            if isinstance(result, str):
+                raise conflict
+            content, occurrences = result
+            return {intent.path: content}, occurrences
+
+        base = intent.path
+        prefix = base + "/"
+        paths = [path for path in cache if path == base or path.startswith(prefix)]
+        return dict.fromkeys(paths, None), None
+
+    def _rematerialize_locked(
+        self,
+        mutations: list[_Mutation],
+        cache: dict[str, str],
+        conflict: LangSmithConflictError,
+    ) -> None:
+        materialized: list[tuple[_Mutation, dict[str, str | None], int | None]] = []
+        visible = dict(cache)
+        for mutation in mutations:
+            changes, occurrences = self._rematerialize_mutation(mutation, visible, conflict)
+            materialized.append((mutation, changes, occurrences))
+            self._overlay(visible, changes)
+
+        for mutation, changes, occurrences in materialized:
+            mutation.changes = changes
+            mutation.occurrences = occurrences
+
+    def _reload_after_conflict(self, conflict: LangSmithConflictError) -> None:
         cache, linked_entries, commit_hash = self._fetch_tree()
         with self._mutations.condition:
+            mutations = [*self._mutations.in_flight, *self._mutations.pending]
+            self._rematerialize_locked(mutations, cache, conflict)
             self._cache = cache
             self._linked_entries = linked_entries
             self._commit_hash = commit_hash
-        return commit_hash
 
     def _extract_commit_hash(self, url: str) -> str | None:
         try:
@@ -246,36 +324,39 @@ class ContextHubBackend(BackendProtocol):
                     return commit_hash
         return None
 
-    def _push_changes(self, changes: dict[str, str | None]) -> tuple[str, _TreeSnapshot | None]:
-        payload: dict[str, FileEntry | AgentEntry | SkillEntry | None] = {
-            path: FileEntry(type="file", content=content) if content is not None else None for path, content in changes.items()
-        }
-
+    def _push_batch(self, batch: list[_Mutation]) -> tuple[dict[str, str | None], str | None, _TreeSnapshot | None]:
         for attempt in range(_MAX_CONFLICT_RETRIES + 1):
             with self._mutations.condition:
+                changes = self._merge_batch(batch)
                 parent_commit = self._commit_hash
+            if not changes:
+                return changes, parent_commit, None
+
+            payload: dict[str, FileEntry | AgentEntry | SkillEntry | None] = {
+                path: FileEntry(type="file", content=content) if content is not None else None for path, content in changes.items()
+            }
             try:
                 url = self._client.push_agent(
                     self._identifier,
                     files=payload,
                     parent_commit=parent_commit,
                 )
-            except LangSmithConflictError:
+            except LangSmithConflictError as conflict:
                 if attempt == _MAX_CONFLICT_RETRIES:
                     raise
-                self._reload_remote()
+                self._reload_after_conflict(conflict)
                 continue
 
             commit_hash = self._extract_commit_hash(url)
             if commit_hash is not None:
-                return commit_hash, None
+                return changes, commit_hash, None
 
             snapshot = self._fetch_tree()
             commit_hash = snapshot[2]
             if commit_hash is None:
                 msg = "Context Hub commit succeeded but its hash could not be resolved"
                 raise RuntimeError(msg)
-            return commit_hash, snapshot
+            return changes, commit_hash, snapshot
 
         msg = "Context Hub conflict retry loop exhausted unexpectedly"
         raise RuntimeError(msg)
@@ -284,23 +365,39 @@ class ContextHubBackend(BackendProtocol):
         self,
         batch: list[_Mutation],
         changes: dict[str, str | None],
-        commit_hash: str,
+        commit_hash: str | None,
         *,
         authoritative_snapshot: _TreeSnapshot | None,
     ) -> bool:
+        failed_pending: list[_Mutation] = []
         with self._mutations.condition:
             if authoritative_snapshot is None:
                 cache = dict(self._ensure_cache_locked())
                 self._overlay(cache, changes)
                 self._cache = cache
             else:
-                self._cache, self._linked_entries, _ = authoritative_snapshot
+                cache, linked_entries, _ = authoritative_snapshot
+                if self._mutations.pending:
+                    msg = "Context Hub changed before a pending mutation could be applied"
+                    pending_conflict = LangSmithConflictError(msg)
+                    try:
+                        self._rematerialize_locked(self._mutations.pending, cache, pending_conflict)
+                    except LangSmithConflictError as exc:
+                        failed_pending = self._mutations.pending
+                        self._mutations.pending = []
+                        self._mutations.deadline = None
+                        for mutation in failed_pending:
+                            mutation.error = exc
+                self._cache = cache
+                self._linked_entries = linked_entries
             self._commit_hash = commit_hash
             self._mutations.in_flight = []
             drained = not self._mutations.pending
             if drained:
                 self._worker = None
         for mutation in batch:
+            mutation.done.set()
+        for mutation in failed_pending:
             mutation.done.set()
         return drained
 
@@ -327,8 +424,7 @@ class ContextHubBackend(BackendProtocol):
                 if next_batch is None:
                     return
                 batch = next_batch
-                changes = self._merge_batch(batch)
-                commit_hash, authoritative_snapshot = self._push_changes(changes)
+                changes, commit_hash, authoritative_snapshot = self._push_batch(batch)
                 drained = self._complete_batch(
                     batch,
                     changes,
@@ -399,12 +495,21 @@ class ContextHubBackend(BackendProtocol):
                     return EditResult(error=result)
 
                 new_content, occurrences = result
-                mutation = self._queue_changes_locked({hub_path: new_content})
+                mutation = self._queue_changes_locked(
+                    {hub_path: new_content},
+                    intent=_EditIntent(
+                        path=hub_path,
+                        old_string=old_string,
+                        new_string=new_string,
+                        replace_all=replace_all,
+                    ),
+                    occurrences=occurrences,
+                )
             self._wait_for_mutation(mutation)
         except LangSmithError as exc:
             logger.exception("Hub edit failed for %r", self._identifier)
             return EditResult(error=f"Hub unavailable: {exc}")
-        return EditResult(path=file_path, occurrences=occurrences)
+        return EditResult(path=file_path, occurrences=mutation.occurrences)
 
     def delete(self, file_path: str) -> DeleteResult:
         """Delete a file or directory by committing its removal from the hub repo.
@@ -428,7 +533,10 @@ class ContextHubBackend(BackendProtocol):
                 to_delete = [key for key in cache if key == base or key.startswith(prefix)]
                 if not to_delete:
                     return DeleteResult(error=f"Error: File '{file_path}' not found")
-                mutation = self._queue_changes_locked(dict.fromkeys(to_delete, None))
+                mutation = self._queue_changes_locked(
+                    dict.fromkeys(to_delete, None),
+                    intent=_DeleteIntent(path=base),
+                )
             self._wait_for_mutation(mutation)
         except LangSmithError as exc:
             logger.exception("Hub delete failed for %r", self._identifier)

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -302,12 +302,25 @@ class ContextHubBackend(BackendProtocol):
 
     def _reload_after_conflict(self, conflict: LangSmithConflictError) -> None:
         cache, linked_entries, commit_hash = self._fetch_tree()
+        failed_pending: list[_Mutation] = []
         with self._mutations.condition:
-            mutations = [*self._mutations.in_flight, *self._mutations.pending]
-            self._rematerialize_locked(mutations, cache, conflict)
+            self._rematerialize_locked(self._mutations.in_flight, cache, conflict)
+            pending_cache = dict(cache)
+            for mutation in self._mutations.in_flight:
+                self._overlay(pending_cache, mutation.changes)
+            try:
+                self._rematerialize_locked(self._mutations.pending, pending_cache, conflict)
+            except LangSmithConflictError as exc:
+                failed_pending = self._mutations.pending
+                self._mutations.pending = []
+                self._mutations.deadline = None
+                for mutation in failed_pending:
+                    mutation.error = exc
             self._cache = cache
             self._linked_entries = linked_entries
             self._commit_hash = commit_hash
+        for mutation in failed_pending:
+            mutation.done.set()
 
     def _extract_commit_hash(self, url: str) -> str | None:
         try:

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -610,11 +610,6 @@ class ContextHubBackend(BackendProtocol):
             return GrepResult(error=f"Hub unavailable: {exc}")
         matches: list[GrepMatch] = []
 
-        try:
-            regex = re.compile(pattern)
-        except re.error as e:
-            return GrepResult(error=f"Invalid regex pattern: {e}")
-
         prefix = self._strip_prefix(path).rstrip("/") if path else ""
 
         glob_re = re.compile(fnmatch.translate(os.path.normcase(glob))) if glob else None
@@ -625,7 +620,7 @@ class ContextHubBackend(BackendProtocol):
             if glob_re is not None and not glob_re.match(os.path.normcase(file_path)):
                 continue
             for i, line in enumerate(content.splitlines(), start=1):
-                if regex.search(line):
+                if pattern in line:
                     if max_count is not None and len(matches) >= max_count:
                         # A further match beyond `max_count` proves more exist;
                         # stop and flag truncation. Checked before appending so

--- a/libs/deepagents/tests/integration_tests/test_context_hub_backend.py
+++ b/libs/deepagents/tests/integration_tests/test_context_hub_backend.py
@@ -145,20 +145,41 @@ def test_persists_across_backend_instances(backend: ContextHubBackend, identifie
     assert result.file_data["content"] == "original"
 
 
-def test_parent_commit_conflict_surfaces_error(backend: ContextHubBackend, identifier: str) -> None:
-    """Concurrent writes against a stale parent_commit should be rejected."""
+def test_parent_commit_conflict_recovers(backend: ContextHubBackend, identifier: str) -> None:
+    """A stale writer reloads the remote tree and reapplies its local delta."""
     assert backend.write("/shared.md", "v0").error is None
 
-    stale = ContextHubBackend(identifier, client=Client())
-    stale.read("/shared.md")  # prime stale's commit_hash with current state
+    stale_client = Client()
+    stale = ContextHubBackend(identifier, client=stale_client)
+    primed = stale.read("/shared.md")
+    assert primed.file_data is not None
+    assert primed.file_data["content"] == "v0"
 
     # `backend` advances the repo.
     assert backend.write("/shared.md", "v1").error is None
 
-    # `stale` now has an outdated parent_commit; server rejects.
-    result = stale.write("/other.md", "should-fail")
-    assert result.error is not None
-    assert "Hub unavailable" in result.error
+    # `stale` retries against the new parent without losing the unrelated update.
+    push_calls: list[dict[str, Any]] = []
+    original_push = type(stale_client).push_agent
+
+    def spy_push(self, identifier: str, **kwargs: Any) -> str:
+        push_calls.append({"identifier": identifier, **kwargs})
+        return original_push(self, identifier, **kwargs)
+
+    with patch.object(type(stale_client), "push_agent", spy_push):
+        result = stale.write("/other.md", "recovered")
+    assert result.error is None
+    assert len(push_calls) == 2
+    first_push, retry_push = push_calls
+    assert first_push["parent_commit"] != retry_push["parent_commit"]
+
+    fresh = ContextHubBackend(identifier, client=Client())
+    shared = fresh.read("/shared.md")
+    assert shared.file_data is not None
+    assert shared.file_data["content"] == "v1"
+    other = fresh.read("/other.md")
+    assert other.file_data is not None
+    assert other.file_data["content"] == "recovered"
 
 
 def test_upload_files_produces_single_commit(identifier: str) -> None:

--- a/libs/deepagents/tests/integration_tests/test_context_hub_backend.py
+++ b/libs/deepagents/tests/integration_tests/test_context_hub_backend.py
@@ -146,19 +146,17 @@ def test_persists_across_backend_instances(backend: ContextHubBackend, identifie
 
 
 def test_parent_commit_conflict_recovers(backend: ContextHubBackend, identifier: str) -> None:
-    """A stale writer reloads the remote tree and reapplies its local delta."""
-    assert backend.write("/shared.md", "v0").error is None
+    """A stale edit preserves non-overlapping remote changes when retried."""
+    assert backend.write("/shared.md", "first\nedit me\n").error is None
 
     stale_client = Client()
     stale = ContextHubBackend(identifier, client=stale_client)
     primed = stale.read("/shared.md")
     assert primed.file_data is not None
-    assert primed.file_data["content"] == "v0"
+    assert primed.file_data["content"] == "first\nedit me\n"
 
-    # `backend` advances the repo.
-    assert backend.write("/shared.md", "v1").error is None
+    assert backend.edit("/shared.md", "first\n", "first\nremote line\n").error is None
 
-    # `stale` retries against the new parent without losing the unrelated update.
     push_calls: list[dict[str, Any]] = []
     original_push = type(stale_client).push_agent
 
@@ -167,8 +165,9 @@ def test_parent_commit_conflict_recovers(backend: ContextHubBackend, identifier:
         return original_push(self, identifier, **kwargs)
 
     with patch.object(type(stale_client), "push_agent", spy_push):
-        result = stale.write("/other.md", "recovered")
+        result = stale.edit("/shared.md", "edit me", "edited")
     assert result.error is None
+    assert result.occurrences == 1
     assert len(push_calls) == 2
     first_push, retry_push = push_calls
     assert first_push["parent_commit"] != retry_push["parent_commit"]
@@ -176,10 +175,7 @@ def test_parent_commit_conflict_recovers(backend: ContextHubBackend, identifier:
     fresh = ContextHubBackend(identifier, client=Client())
     shared = fresh.read("/shared.md")
     assert shared.file_data is not None
-    assert shared.file_data["content"] == "v1"
-    other = fresh.read("/other.md")
-    assert other.file_data is not None
-    assert other.file_data["content"] == "recovered"
+    assert shared.file_data["content"] == "first\nremote line\nedited\n"
 
 
 def test_upload_files_produces_single_commit(identifier: str) -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -555,7 +555,7 @@ def test_grep_glob_does_not_brace_expand() -> None:
     assert paths == {"/literal.{py,md}"}
 
 
-def test_grep_treats_pattern_literally() -> None:
+def test_grep_with_special_characters() -> None:
     backend, _ = _make_backend(**{"notes.md": FileEntry(type="file", content="items[0]\n")})
     result = backend.grep("[")
     assert result.error is None

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -555,11 +555,11 @@ def test_grep_glob_does_not_brace_expand() -> None:
     assert paths == {"/literal.{py,md}"}
 
 
-def test_grep_invalid_regex() -> None:
-    backend, _ = _make_backend()
-    result = backend.grep("[unclosed")
-    assert result.error is not None
-    assert "Invalid regex" in result.error
+def test_grep_treats_pattern_literally() -> None:
+    backend, _ = _make_backend(**{"notes.md": FileEntry(type="file", content="items[0]\n")})
+    result = backend.grep("[")
+    assert result.error is None
+    assert result.matches == [{"path": "/notes.md", "line": 1, "text": "items[0]"}]
 
 
 def _grep_cap_backend() -> ContextHubBackend:

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 from langsmith.schemas import AgentEntry, FileEntry, SkillEntry
-from langsmith.utils import LangSmithAPIError, LangSmithNotFoundError
+from langsmith.utils import LangSmithAPIError, LangSmithConflictError, LangSmithNotFoundError
 
 from deepagents.backends import CompositeBackend, ContextHubBackend, FilesystemBackend
 
@@ -16,7 +20,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 _COMMIT_HASH = "abcd1234" * 8  # 64-char hex
-_COMMIT_URL = "https://host/hub/-/test-agent:ef567890"
+_COMMIT_URL = "https://host/context/test-agent/ef567890?organizationId=org-id"
+_LEGACY_COMMIT_URL = "https://host/hub/-/test-agent:ef567890"
+_HASHLESS_COMMIT_URL = "https://host/context/test-agent?organizationId=org-id"
 
 
 def _make_backend(
@@ -37,6 +43,27 @@ def _make_backend(
     mock_client.push_agent.return_value = _COMMIT_URL
     backend = ContextHubBackend("-/test-agent", client=mock_client)
     return backend, mock_client
+
+
+def _wait_for_content(backend: ContextHubBackend, path: str, expected: str, *, timeout: float = 1.0) -> None:
+    """Wait until an accepted local mutation is visible through `read`."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = backend.read(path)
+        if result.file_data is not None and result.file_data["content"] == expected:
+            return
+        time.sleep(0.001)
+    msg = f"{path} never became visible with expected content"
+    raise AssertionError(msg)
+
+
+def _flush_pending(backend: ContextHubBackend, count: int) -> None:
+    """Release a batch after exactly `count` mutations have been accepted."""
+    queue = backend._mutations
+    with queue.condition:
+        assert queue.condition.wait_for(lambda: len(queue.pending) == count, timeout=1)
+        queue.deadline = time.monotonic()
+        queue.condition.notify_all()
 
 
 def test_read_returns_content() -> None:
@@ -129,7 +156,7 @@ def test_has_prior_commits_flips_after_first_write() -> None:
     """A fresh repo flips from no-prior-commits to has-prior-commits after a write."""
     mock_client = MagicMock()
     mock_client.pull_agent.side_effect = LangSmithNotFoundError("not found")
-    mock_client.push_agent.return_value = _COMMIT_URL
+    mock_client.push_agent.return_value = "https://host/context/fresh/ef567890?organizationId=org-id"
     backend = ContextHubBackend("-/fresh", client=mock_client)
 
     assert backend.has_prior_commits() is False
@@ -161,13 +188,214 @@ def test_write_sends_parent_commit_from_pull() -> None:
     assert call.kwargs["parent_commit"] == _COMMIT_HASH
 
 
-def test_write_updates_commit_hash_from_url() -> None:
+@pytest.mark.parametrize(
+    "commit_url",
+    [
+        pytest.param(_COMMIT_URL, id="current"),
+        pytest.param(_LEGACY_COMMIT_URL, id="legacy"),
+    ],
+)
+def test_write_updates_commit_hash_from_url(commit_url: str) -> None:
     backend, mock_client = _make_backend()
+    mock_client.push_agent.side_effect = [commit_url, _COMMIT_URL]
     backend.write("/a.md", "a")
     backend.write("/b.md", "b")
 
     second_call = mock_client.push_agent.call_args_list[1]
     assert second_call.kwargs["parent_commit"] == "ef567890"
+
+
+@pytest.mark.parametrize(
+    "commit_url",
+    [
+        pytest.param(_HASHLESS_COMMIT_URL, id="hashless-context-url"),
+        pytest.param("https://host/other/ef567890", id="unrelated-path"),
+        pytest.param(
+            "https://host/context/deadbeef?organizationId=org-id",
+            id="hex-repository-name",
+        ),
+        pytest.param(
+            "https://host/context/test-agent/012345678?organizationId=org-id",
+            id="nine-character-hash",
+        ),
+        pytest.param(
+            f"https://host/context/test-agent/{'a' * 64}?organizationId=org-id",
+            id="full-hash",
+        ),
+        pytest.param(
+            "https://host/context/-/test-agent/ef567890?organizationId=org-id",
+            id="multi-segment-context-path",
+        ),
+        pytest.param(
+            "https://host/context/test-agent/ef567890/?organizationId=org-id",
+            id="trailing-slash",
+        ),
+        pytest.param(
+            "https://host/context/other-agent/ef567890?organizationId=org-id",
+            id="other-context-repository",
+        ),
+        pytest.param(
+            "https://host/anything/test-agent:ef567890",
+            id="arbitrary-colon-suffix",
+        ),
+        pytest.param(
+            "https://host/hub/-/other-agent:ef567890",
+            id="other-legacy-repository",
+        ),
+        pytest.param("http://[", id="malformed-url"),
+    ],
+)
+def test_unrecognized_commit_url_reloads_remote_hash_before_next_batch(commit_url: str) -> None:
+    remote_hash = "feedface" * 8
+    initial = SimpleNamespace(
+        commit_id="initial",
+        commit_hash=_COMMIT_HASH,
+        files={"remote.md": FileEntry(type="file", content="before")},
+    )
+    reloaded = SimpleNamespace(
+        commit_id="reloaded",
+        commit_hash=remote_hash,
+        files={
+            "local.md": FileEntry(type="file", content="local"),
+            "remote.md": FileEntry(type="file", content="after"),
+        },
+    )
+    mock_client = MagicMock()
+    mock_client.pull_agent.side_effect = [initial, reloaded]
+    mock_client.push_agent.side_effect = [commit_url, _COMMIT_URL]
+    backend = ContextHubBackend("-/test-agent", client=mock_client)
+
+    assert backend.write("/local.md", "local").error is None
+    assert mock_client.pull_agent.call_count == 2
+    remote = backend.read("/remote.md")
+    assert remote.file_data is not None
+    assert remote.file_data["content"] == "after"
+
+    assert backend.write("/next.md", "next").error is None
+    second_push = mock_client.push_agent.call_args_list[1]
+    assert second_push.kwargs["parent_commit"] == remote_hash
+
+
+def test_hashless_commit_url_keeps_authoritative_reloaded_same_path_value() -> None:
+    remote_hash = "feedface" * 8
+    initial = SimpleNamespace(
+        commit_id="initial",
+        commit_hash=_COMMIT_HASH,
+        files={"shared.md": FileEntry(type="file", content="initial")},
+    )
+    reloaded = SimpleNamespace(
+        commit_id="newer",
+        commit_hash=remote_hash,
+        files={"shared.md": FileEntry(type="file", content="newer remote")},
+    )
+    mock_client = MagicMock()
+    mock_client.pull_agent.side_effect = [initial, reloaded]
+    mock_client.push_agent.side_effect = [_HASHLESS_COMMIT_URL, _COMMIT_URL]
+    backend = ContextHubBackend("-/test-agent", client=mock_client)
+
+    assert backend.write("/shared.md", "our value").error is None
+    shared = backend.read("/shared.md")
+    assert shared.file_data is not None
+    assert shared.file_data["content"] == "newer remote"
+
+    assert backend.write("/next.md", "next").error is None
+    second_push = mock_client.push_agent.call_args_list[1]
+    assert second_push.kwargs["parent_commit"] == remote_hash
+
+
+def test_hashless_snapshot_publication_is_atomic_with_in_flight_clear() -> None:
+    remote_hash = "feedface" * 8
+    initial = SimpleNamespace(
+        commit_id="initial",
+        commit_hash=_COMMIT_HASH,
+        files={"shared.md": FileEntry(type="file", content="initial")},
+    )
+    reloaded = SimpleNamespace(
+        commit_id="newer",
+        commit_hash=remote_hash,
+        files={"shared.md": FileEntry(type="file", content="newer remote")},
+    )
+    mock_client = MagicMock()
+    mock_client.pull_agent.side_effect = [initial, reloaded]
+    mock_client.push_agent.return_value = _HASHLESS_COMMIT_URL
+    backend = ContextHubBackend("-/test-agent", client=mock_client)
+    complete_started = threading.Event()
+    release_complete = threading.Event()
+    original_complete = backend._complete_batch
+
+    def gated_complete(*args: Any, **kwargs: Any) -> bool:
+        complete_started.set()
+        if not release_complete.wait(timeout=2):
+            msg = "timed out waiting to complete hashless batch"
+            raise TimeoutError(msg)
+        return original_complete(*args, **kwargs)
+
+    with patch.object(backend, "_complete_batch", side_effect=gated_complete), ThreadPoolExecutor(max_workers=1) as pool:
+        write = pool.submit(backend.write, "/shared.md", "our value")
+        assert complete_started.wait(timeout=1)
+        try:
+            with backend._mutations.condition:
+                assert backend._cache is not None
+                base_content = backend._cache["shared.md"]
+            visible = backend.read("/shared.md")
+            assert visible.file_data is not None
+            visible_content = visible.file_data["content"]
+            assert (base_content, visible_content) != ("newer remote", "our value")
+        finally:
+            release_complete.set()
+        assert write.result(timeout=2).error is None
+
+    final = backend.read("/shared.md")
+    assert final.file_data is not None
+    assert final.file_data["content"] == "newer remote"
+
+
+def test_hashless_commit_without_reloaded_hash_fails() -> None:
+    initial = SimpleNamespace(commit_id="initial", commit_hash=_COMMIT_HASH, files={})
+    unresolved = SimpleNamespace(
+        commit_id="unresolved",
+        commit_hash=None,
+        files={"local.md": FileEntry(type="file", content="local")},
+    )
+    mock_client = MagicMock()
+    mock_client.pull_agent.side_effect = [initial, unresolved]
+    mock_client.push_agent.return_value = _HASHLESS_COMMIT_URL
+    backend = ContextHubBackend("-/test-agent", client=mock_client)
+
+    with pytest.raises(RuntimeError, match="commit succeeded but its hash could not be resolved"):
+        backend.write("/local.md", "local")
+
+    assert mock_client.pull_agent.call_count == 2
+    assert backend._worker is None
+    assert backend._cache is None
+    assert backend._mutations.in_flight == []
+    assert backend._mutations.pending == []
+
+
+@pytest.mark.parametrize("failure_point", ["constructor", "start"])
+def test_worker_creation_failure_cleans_mutation_state(failure_point: str) -> None:
+    backend, mock_client = _make_backend()
+    failure = RuntimeError(f"thread {failure_point} failed")
+
+    if failure_point == "constructor":
+        worker_patch = patch("deepagents.backends.context_hub.threading.Thread", side_effect=failure)
+    else:
+        worker = MagicMock()
+        worker.start.side_effect = failure
+        worker_patch = patch("deepagents.backends.context_hub.threading.Thread", return_value=worker)
+
+    with worker_patch, pytest.raises(RuntimeError, match=f"thread {failure_point} failed"):
+        backend.write("/failed.md", "failed")
+
+    with backend._mutations.condition:
+        assert backend._mutations.pending == []
+        assert backend._mutations.in_flight == []
+        assert backend._mutations.deadline is None
+        assert backend._worker is None
+
+    result = backend.write("/recovered.md", "recovered")
+    assert result.error is None
+    mock_client.push_agent.assert_called_once()
 
 
 def test_write_updates_cache_after_commit() -> None:
@@ -715,3 +943,419 @@ async def test_adelete_missing_returns_not_found() -> None:
     assert result.error is not None
     assert "not found" in result.error
     mock_client.push_agent.assert_not_called()
+
+
+def test_batch_window_is_anchored_to_first_mutation() -> None:
+    backend, mock_client = _make_backend()
+    backend.read("/missing.md")
+    queue = backend._mutations
+
+    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0):
+        with queue.condition:
+            first = backend._queue_changes_locked({"first.md": "first"})
+            first_deadline = queue.deadline
+            second = backend._queue_changes_locked({"second.md": "second"})
+
+            assert queue.deadline == first_deadline
+            queue.deadline = time.monotonic()
+            queue.condition.notify_all()
+
+        backend._wait_for_mutation(first)
+        backend._wait_for_mutation(second)
+
+    mock_client.push_agent.assert_called_once()
+
+
+def test_eight_concurrent_writes_coalesce_into_one_commit() -> None:
+    backend, mock_client = _make_backend()
+    backend.read("/missing.md")  # Prime the remote snapshot before the burst.
+    barrier = threading.Barrier(8)
+
+    def write(index: int):
+        barrier.wait(timeout=2)
+        return backend.write(f"/file-{index}.md", f"value-{index}")
+
+    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0), ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(write, index) for index in range(8)]
+        _flush_pending(backend, 8)
+        results = [future.result(timeout=2) for future in futures]
+
+    assert all(result.error is None for result in results)
+    mock_client.push_agent.assert_called_once()
+    payload = mock_client.push_agent.call_args.kwargs["files"]
+    assert set(payload) == {f"file-{index}.md" for index in range(8)}
+    for index in range(8):
+        result = backend.read(f"/file-{index}.md")
+        assert result.file_data is not None
+        assert result.file_data["content"] == f"value-{index}"
+    assert backend._worker is None
+
+
+def test_mixed_mutations_and_upload_share_one_batch() -> None:
+    backend, mock_client = _make_backend(
+        **{
+            "edit.md": FileEntry(type="file", content="before"),
+            "delete.md": FileEntry(type="file", content="remove"),
+        }
+    )
+    backend.read("/edit.md")
+    barrier = threading.Barrier(4)
+
+    def write():
+        barrier.wait(timeout=2)
+        return backend.write("/write.md", "written")
+
+    def edit():
+        barrier.wait(timeout=2)
+        return backend.edit("/edit.md", "before", "after")
+
+    def delete():
+        barrier.wait(timeout=2)
+        return backend.delete("/delete.md")
+
+    def upload():
+        barrier.wait(timeout=2)
+        return backend.upload_files([("/upload-a.md", b"a"), ("/upload-b.md", b"b")])
+
+    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0), ThreadPoolExecutor(max_workers=4) as pool:
+        write_future = pool.submit(write)
+        edit_future = pool.submit(edit)
+        delete_future = pool.submit(delete)
+        upload_future = pool.submit(upload)
+        _flush_pending(backend, 4)
+        write_result = write_future.result(timeout=2)
+        edit_result = edit_future.result(timeout=2)
+        delete_result = delete_future.result(timeout=2)
+        upload_results = upload_future.result(timeout=2)
+
+    assert write_result.error is None
+    assert edit_result.error is None
+    assert delete_result.error is None
+    assert all(result.error is None for result in upload_results)
+    mock_client.push_agent.assert_called_once()
+    payload = mock_client.push_agent.call_args.kwargs["files"]
+    assert set(payload) == {"write.md", "edit.md", "delete.md", "upload-a.md", "upload-b.md"}
+    assert payload["write.md"].content == "written"
+    assert payload["edit.md"].content == "after"
+    assert payload["delete.md"] is None
+    assert payload["upload-a.md"].content == "a"
+    assert payload["upload-b.md"].content == "b"
+
+
+def test_follow_on_batch_waits_for_in_flight_commit() -> None:
+    backend, mock_client = _make_backend()
+    backend.read("/missing.md")
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls_lock = threading.Lock()
+    calls: list[dict[str, Any]] = []
+    active = 0
+    max_active = 0
+
+    def push_agent(identifier: str, **kwargs: Any) -> str:
+        nonlocal active, max_active
+        with calls_lock:
+            index = len(calls)
+            calls.append(kwargs)
+            active += 1
+            max_active = max(max_active, active)
+        try:
+            if index == 0:
+                first_started.set()
+                if not release_first.wait(timeout=2):
+                    msg = "timed out waiting to release first commit"
+                    raise TimeoutError(msg)
+            return f"https://host/hub/{identifier}:{index + 1:08x}"
+        finally:
+            with calls_lock:
+                active -= 1
+
+    mock_client.push_agent.side_effect = push_agent
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(backend.write, "/first.md", "first")
+        assert first_started.wait(timeout=1)
+        second = pool.submit(backend.write, "/second.md", "second")
+        try:
+            _wait_for_content(backend, "/second.md", "second")
+            with calls_lock:
+                assert len(calls) == 1
+        finally:
+            release_first.set()
+        assert first.result(timeout=2).error is None
+        assert second.result(timeout=2).error is None
+
+    assert len(calls) == 2
+    assert max_active == 1
+    assert calls[1]["parent_commit"] == "00000001"
+
+
+def test_pending_mutation_is_visible_to_cached_read_operations() -> None:
+    backend, mock_client = _make_backend()
+    backend.read("/missing.md")
+    push_started = threading.Event()
+    release_push = threading.Event()
+
+    def push_agent(_identifier: str, **_kwargs: Any) -> str:
+        push_started.set()
+        if not release_push.wait(timeout=2):
+            msg = "timed out waiting to release commit"
+            raise TimeoutError(msg)
+        return _COMMIT_URL
+
+    mock_client.push_agent.side_effect = push_agent
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(backend.write, "/pending.md", "visible pending text")
+        assert push_started.wait(timeout=1)
+        try:
+            read = backend.read("/pending.md")
+            assert read.file_data is not None
+            assert read.file_data["content"] == "visible pending text"
+            ls_result = backend.ls("/")
+            assert ls_result.entries is not None
+            assert "/pending.md" in {entry["path"] for entry in ls_result.entries}
+            grep_result = backend.grep("pending")
+            assert grep_result.matches is not None
+            assert [match["path"] for match in grep_result.matches] == ["/pending.md"]
+            glob_result = backend.glob("*.md")
+            assert glob_result.matches is not None
+            assert "/pending.md" in {match["path"] for match in glob_result.matches}
+            download = backend.download_files(["/pending.md"])
+            assert download[0].content == b"visible pending text"
+        finally:
+            release_push.set()
+        assert future.result(timeout=2).error is None
+
+
+def test_concurrent_cold_cache_access_pulls_once() -> None:
+    backend, mock_client = _make_backend()
+    start = threading.Barrier(8)
+    pull_barrier = threading.Barrier(8)
+
+    def pull_agent(_identifier: str):
+        with suppress(threading.BrokenBarrierError):
+            pull_barrier.wait(timeout=0.5)
+        return SimpleNamespace(commit_id="id", commit_hash=_COMMIT_HASH, files={})
+
+    mock_client.pull_agent.side_effect = pull_agent
+
+    def write(index: int):
+        start.wait(timeout=2)
+        return backend.write(f"/cold-{index}.md", str(index))
+
+    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0), ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(write, index) for index in range(8)]
+        _flush_pending(backend, 8)
+        results = [future.result(timeout=3) for future in futures]
+
+    assert all(result.error is None for result in results)
+    mock_client.pull_agent.assert_called_once_with("-/test-agent")
+    mock_client.push_agent.assert_called_once()
+
+
+def test_batch_failure_reaches_every_waiter_and_drains_worker() -> None:
+    backend, mock_client = _make_backend()
+    backend.read("/missing.md")
+    mock_client.push_agent.side_effect = LangSmithAPIError("503")
+    barrier = threading.Barrier(8)
+
+    def write(index: int):
+        barrier.wait(timeout=2)
+        return backend.write(f"/failed-{index}.md", str(index))
+
+    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0), ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(write, index) for index in range(8)]
+        _flush_pending(backend, 8)
+        results = [future.result(timeout=2) for future in futures]
+
+    assert all("Hub unavailable" in (result.error or "") for result in results)
+    mock_client.push_agent.assert_called_once()
+    assert backend._worker is None
+    backend.read("/missing.md")
+    assert mock_client.pull_agent.call_count == 2
+
+
+def test_in_flight_failure_rejects_queued_waiter_without_orphaning_state() -> None:
+    backend, mock_client = _make_backend()
+    backend.read("/missing.md")
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls = 0
+
+    def push_agent(_identifier: str, **_kwargs: Any) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_started.set()
+            if not release_first.wait(timeout=2):
+                msg = "timed out waiting to fail first commit"
+                raise TimeoutError(msg)
+            msg = "503"
+            raise LangSmithAPIError(msg)
+        return _COMMIT_URL
+
+    mock_client.push_agent.side_effect = push_agent
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(backend.write, "/first.md", "first")
+        assert first_started.wait(timeout=1)
+        second = pool.submit(backend.write, "/second.md", "second")
+        try:
+            _wait_for_content(backend, "/second.md", "second", timeout=0.5)
+        finally:
+            release_first.set()
+        first_result = first.result(timeout=2)
+        second_result = second.result(timeout=2)
+
+    assert "Hub unavailable" in (first_result.error or "")
+    assert "Hub unavailable" in (second_result.error or "")
+    mock_client.push_agent.assert_called_once()
+    assert backend._worker is None
+    assert backend.read("/second.md").error == "File '/second.md' not found"
+    assert mock_client.pull_agent.call_count == 2
+
+
+def test_worker_base_exception_settles_waiter_and_invalidates_state() -> None:
+    class WorkerAbort(BaseException):
+        pass
+
+    backend, mock_client = _make_backend()
+    push_started = threading.Event()
+
+    def push_agent(_identifier: str, **_kwargs: Any) -> str:
+        push_started.set()
+        msg = "worker aborted"
+        raise WorkerAbort(msg)
+
+    mock_client.push_agent.side_effect = push_agent
+    pool = ThreadPoolExecutor(max_workers=1)
+    future = None
+    try:
+        with patch("threading.excepthook"):
+            future = pool.submit(backend.write, "/failed.md", "failed")
+            assert push_started.wait(timeout=1)
+            with pytest.raises(WorkerAbort, match="worker aborted"):
+                future.result(timeout=0.5)
+    finally:
+        with backend._mutations.condition:
+            stranded = [*backend._mutations.in_flight, *backend._mutations.pending]
+            backend._mutations.in_flight = []
+            backend._mutations.pending = []
+            backend._mutations.deadline = None
+            backend._cache = None
+            backend._worker = None
+            cleanup_error = RuntimeError("test cleanup")
+            for mutation in stranded:
+                mutation.error = cleanup_error
+        for mutation in stranded:
+            mutation.done.set()
+        pool.shutdown(wait=True, cancel_futures=True)
+
+    assert future is not None
+    assert backend._worker is None
+    assert backend._cache is None
+    assert backend._mutations.in_flight == []
+    assert backend._mutations.pending == []
+
+
+def test_conflict_reloads_remote_and_retries_local_delta() -> None:
+    initial = SimpleNamespace(
+        commit_id="initial",
+        commit_hash=_COMMIT_HASH,
+        files={"base.md": FileEntry(type="file", content="base")},
+    )
+    remote_hash = "feedface" * 8
+    reloaded = SimpleNamespace(
+        commit_id="remote",
+        commit_hash=remote_hash,
+        files={
+            "base.md": FileEntry(type="file", content="base"),
+            "remote.md": FileEntry(type="file", content="remote change"),
+        },
+    )
+    mock_client = MagicMock()
+    mock_client.pull_agent.side_effect = [initial, reloaded]
+    mock_client.push_agent.side_effect = [LangSmithConflictError("409"), _COMMIT_URL]
+    backend = ContextHubBackend("-/test-agent", client=mock_client)
+
+    result = backend.write("/local.md", "local change")
+
+    assert result.error is None
+    assert mock_client.push_agent.call_count == 2
+    first, second = mock_client.push_agent.call_args_list
+    assert first.kwargs["parent_commit"] == _COMMIT_HASH
+    assert second.kwargs["parent_commit"] == remote_hash
+    assert set(second.kwargs["files"]) == {"local.md"}
+    assert second.kwargs["files"]["local.md"].content == "local change"
+    remote = backend.read("/remote.md")
+    assert remote.file_data is not None
+    assert remote.file_data["content"] == "remote change"
+    local = backend.read("/local.md")
+    assert local.file_data is not None
+    assert local.file_data["content"] == "local change"
+
+
+def test_conflict_stops_after_three_retries() -> None:
+    contexts = [SimpleNamespace(commit_id=str(index), commit_hash=f"{index + 1:064x}", files={}) for index in range(4)]
+    mock_client = MagicMock()
+    mock_client.pull_agent.side_effect = contexts
+    mock_client.push_agent.side_effect = LangSmithConflictError("409")
+    backend = ContextHubBackend("-/test-agent", client=mock_client)
+
+    result = backend.write("/local.md", "local")
+
+    assert "Hub unavailable" in (result.error or "")
+    assert mock_client.push_agent.call_count == 4
+    assert mock_client.pull_agent.call_count == 4
+    assert backend._worker is None
+
+
+def test_later_same_path_enqueue_wins_coalesced_batch() -> None:
+    backend, mock_client = _make_backend()
+    backend.read("/missing.md")
+
+    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0), ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(backend.write, "/same.md", "first")
+        _wait_for_content(backend, "/same.md", "first")
+        second = pool.submit(backend.write, "/same.md", "second")
+        _wait_for_content(backend, "/same.md", "second")
+        _flush_pending(backend, 2)
+        assert first.result(timeout=2).error is None
+        assert second.result(timeout=2).error is None
+
+    mock_client.push_agent.assert_called_once()
+    payload = mock_client.push_agent.call_args.kwargs["files"]
+    assert payload["same.md"].content == "second"
+
+
+def test_edit_uses_visible_in_flight_write_in_enqueue_order() -> None:
+    backend, mock_client = _make_backend()
+    backend.read("/missing.md")
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls: list[dict[str, Any]] = []
+
+    def push_agent(identifier: str, **kwargs: Any) -> str:
+        index = len(calls)
+        calls.append(kwargs)
+        if index == 0:
+            first_started.set()
+            if not release_first.wait(timeout=2):
+                msg = "timed out waiting to release first commit"
+                raise TimeoutError(msg)
+        return f"https://host/hub/{identifier}:{index + 1:08x}"
+
+    mock_client.push_agent.side_effect = push_agent
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        write = pool.submit(backend.write, "/chain.md", "hello")
+        assert first_started.wait(timeout=1)
+        edit = pool.submit(backend.edit, "/chain.md", "hello", "goodbye")
+        try:
+            _wait_for_content(backend, "/chain.md", "goodbye", timeout=0.5)
+        finally:
+            release_first.set()
+        assert write.result(timeout=2).error is None
+        edit_result = edit.result(timeout=2)
+
+    assert edit_result.error is None
+    assert edit_result.occurrences == 1
+    assert len(calls) == 2
+    assert calls[1]["files"]["chain.md"].content == "goodbye"

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import suppress
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
@@ -205,149 +204,112 @@ def test_write_updates_commit_hash_from_url(commit_url: str) -> None:
     assert second_call.kwargs["parent_commit"] == "ef567890"
 
 
-@pytest.mark.parametrize(
-    "commit_url",
-    [
-        pytest.param(_HASHLESS_COMMIT_URL, id="hashless-context-url"),
-        pytest.param("https://host/other/ef567890", id="unrelated-path"),
-        pytest.param(
-            "https://host/context/deadbeef?organizationId=org-id",
-            id="hex-repository-name",
-        ),
-        pytest.param(
-            "https://host/context/test-agent/012345678?organizationId=org-id",
-            id="nine-character-hash",
-        ),
-        pytest.param(
-            f"https://host/context/test-agent/{'a' * 64}?organizationId=org-id",
-            id="full-hash",
-        ),
-        pytest.param(
-            "https://host/context/-/test-agent/ef567890?organizationId=org-id",
-            id="multi-segment-context-path",
-        ),
-        pytest.param(
-            "https://host/context/test-agent/ef567890/?organizationId=org-id",
-            id="trailing-slash",
-        ),
-        pytest.param(
-            "https://host/context/other-agent/ef567890?organizationId=org-id",
-            id="other-context-repository",
-        ),
-        pytest.param(
-            "https://host/anything/test-agent:ef567890",
-            id="arbitrary-colon-suffix",
-        ),
-        pytest.param(
-            "https://host/hub/-/other-agent:ef567890",
-            id="other-legacy-repository",
-        ),
-        pytest.param("http://[", id="malformed-url"),
-    ],
-)
-def test_unrecognized_commit_url_reloads_remote_hash_before_next_batch(commit_url: str) -> None:
+def test_hashless_context_url_reloads_authoritative_tree_and_next_parent() -> None:
     remote_hash = "feedface" * 8
     initial = SimpleNamespace(
         commit_id="initial",
         commit_hash=_COMMIT_HASH,
-        files={"remote.md": FileEntry(type="file", content="before")},
+        files={"shared.md": FileEntry(type="file", content="first\nedit me\n")},
     )
     reloaded = SimpleNamespace(
         commit_id="reloaded",
         commit_hash=remote_hash,
         files={
-            "local.md": FileEntry(type="file", content="local"),
-            "remote.md": FileEntry(type="file", content="after"),
+            "batch-a.md": FileEntry(type="file", content="durable"),
+            "shared.md": FileEntry(type="file", content="first\nremote line\nedit me\n"),
         },
     )
     mock_client = MagicMock()
-    mock_client.pull_agent.side_effect = [initial, reloaded]
-    mock_client.push_agent.side_effect = [commit_url, _COMMIT_URL]
-    backend = ContextHubBackend("-/test-agent", client=mock_client)
+    authoritative_pull_started = threading.Event()
+    release_authoritative_pull = threading.Event()
+    pull_calls = 0
 
-    assert backend.write("/local.md", "local").error is None
-    assert mock_client.pull_agent.call_count == 2
-    remote = backend.read("/remote.md")
-    assert remote.file_data is not None
-    assert remote.file_data["content"] == "after"
+    def pull_agent(_identifier: str):
+        nonlocal pull_calls
+        pull_calls += 1
+        if pull_calls == 1:
+            return initial
+        authoritative_pull_started.set()
+        if not release_authoritative_pull.wait(timeout=2):
+            msg = "timed out waiting to release authoritative pull"
+            raise TimeoutError(msg)
+        return reloaded
 
-    assert backend.write("/next.md", "next").error is None
-    second_push = mock_client.push_agent.call_args_list[1]
-    assert second_push.kwargs["parent_commit"] == remote_hash
-
-
-def test_hashless_commit_url_keeps_authoritative_reloaded_same_path_value() -> None:
-    remote_hash = "feedface" * 8
-    initial = SimpleNamespace(
-        commit_id="initial",
-        commit_hash=_COMMIT_HASH,
-        files={"shared.md": FileEntry(type="file", content="initial")},
-    )
-    reloaded = SimpleNamespace(
-        commit_id="newer",
-        commit_hash=remote_hash,
-        files={"shared.md": FileEntry(type="file", content="newer remote")},
-    )
-    mock_client = MagicMock()
-    mock_client.pull_agent.side_effect = [initial, reloaded]
+    mock_client.pull_agent.side_effect = pull_agent
     mock_client.push_agent.side_effect = [_HASHLESS_COMMIT_URL, _COMMIT_URL]
     backend = ContextHubBackend("-/test-agent", client=mock_client)
 
-    assert backend.write("/shared.md", "our value").error is None
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        batch_a = pool.submit(backend.write, "/batch-a.md", "durable")
+        assert authoritative_pull_started.wait(timeout=1)
+        try:
+            batch_b = pool.submit(backend.edit, "/shared.md", "edit me", "edited")
+            with backend._mutations.condition:
+                assert backend._mutations.condition.wait_for(lambda: len(backend._mutations.pending) == 1, timeout=1)
+        finally:
+            release_authoritative_pull.set()
+        assert batch_a.result(timeout=2).error is None
+        edit_result = batch_b.result(timeout=2)
+
+    assert edit_result.error is None
+    assert edit_result.occurrences == 1
+    assert mock_client.pull_agent.call_count == 2
+    second_push = mock_client.push_agent.call_args_list[1]
+    assert second_push.kwargs["parent_commit"] == remote_hash
+    assert second_push.kwargs["files"]["shared.md"].content == "first\nremote line\nedited\n"
     shared = backend.read("/shared.md")
     assert shared.file_data is not None
-    assert shared.file_data["content"] == "newer remote"
+    assert shared.file_data["content"] == "first\nremote line\nedited\n"
+
+
+def test_hashless_snapshot_fails_only_pending_edit_with_stale_precondition() -> None:
+    backend, mock_client = _make_backend(**{"shared.md": FileEntry(type="file", content="edit me")})
+    assert backend.read("/shared.md").error is None
+    remote_hash = "feedface" * 8
+    authoritative = SimpleNamespace(
+        commit_id="authoritative",
+        commit_hash=remote_hash,
+        files={
+            "batch-a.md": FileEntry(type="file", content="durable"),
+            "shared.md": FileEntry(type="file", content="changed remotely"),
+        },
+    )
+    authoritative_pull_started = threading.Event()
+    release_authoritative_pull = threading.Event()
+
+    def pull_agent(_identifier: str):
+        authoritative_pull_started.set()
+        if not release_authoritative_pull.wait(timeout=2):
+            msg = "timed out waiting to release authoritative pull"
+            raise TimeoutError(msg)
+        return authoritative
+
+    mock_client.pull_agent.side_effect = pull_agent
+    mock_client.push_agent.side_effect = [_HASHLESS_COMMIT_URL, _COMMIT_URL]
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        batch_a = pool.submit(backend.write, "/batch-a.md", "durable")
+        assert authoritative_pull_started.wait(timeout=1)
+        try:
+            batch_b = pool.submit(backend.edit, "/shared.md", "edit me", "edited")
+            with backend._mutations.condition:
+                assert backend._mutations.condition.wait_for(lambda: len(backend._mutations.pending) == 1, timeout=1)
+                pending = backend._mutations.pending[0]
+        finally:
+            release_authoritative_pull.set()
+        assert batch_a.result(timeout=2).error is None
+        edit_result = batch_b.result(timeout=2)
+
+    assert "Hub unavailable" in (edit_result.error or "")
+    assert isinstance(pending.error, LangSmithConflictError)
+    mock_client.push_agent.assert_called_once()
+    shared = backend.read("/shared.md")
+    assert shared.file_data is not None
+    assert shared.file_data["content"] == "changed remotely"
 
     assert backend.write("/next.md", "next").error is None
     second_push = mock_client.push_agent.call_args_list[1]
     assert second_push.kwargs["parent_commit"] == remote_hash
-
-
-def test_hashless_snapshot_publication_is_atomic_with_in_flight_clear() -> None:
-    remote_hash = "feedface" * 8
-    initial = SimpleNamespace(
-        commit_id="initial",
-        commit_hash=_COMMIT_HASH,
-        files={"shared.md": FileEntry(type="file", content="initial")},
-    )
-    reloaded = SimpleNamespace(
-        commit_id="newer",
-        commit_hash=remote_hash,
-        files={"shared.md": FileEntry(type="file", content="newer remote")},
-    )
-    mock_client = MagicMock()
-    mock_client.pull_agent.side_effect = [initial, reloaded]
-    mock_client.push_agent.return_value = _HASHLESS_COMMIT_URL
-    backend = ContextHubBackend("-/test-agent", client=mock_client)
-    complete_started = threading.Event()
-    release_complete = threading.Event()
-    original_complete = backend._complete_batch
-
-    def gated_complete(*args: Any, **kwargs: Any) -> bool:
-        complete_started.set()
-        if not release_complete.wait(timeout=2):
-            msg = "timed out waiting to complete hashless batch"
-            raise TimeoutError(msg)
-        return original_complete(*args, **kwargs)
-
-    with patch.object(backend, "_complete_batch", side_effect=gated_complete), ThreadPoolExecutor(max_workers=1) as pool:
-        write = pool.submit(backend.write, "/shared.md", "our value")
-        assert complete_started.wait(timeout=1)
-        try:
-            with backend._mutations.condition:
-                assert backend._cache is not None
-                base_content = backend._cache["shared.md"]
-            visible = backend.read("/shared.md")
-            assert visible.file_data is not None
-            visible_content = visible.file_data["content"]
-            assert (base_content, visible_content) != ("newer remote", "our value")
-        finally:
-            release_complete.set()
-        assert write.result(timeout=2).error is None
-
-    final = backend.read("/shared.md")
-    assert final.file_data is not None
-    assert final.file_data["content"] == "newer remote"
 
 
 def test_hashless_commit_without_reloaded_hash_fails() -> None:
@@ -372,19 +334,16 @@ def test_hashless_commit_without_reloaded_hash_fails() -> None:
     assert backend._mutations.pending == []
 
 
-@pytest.mark.parametrize("failure_point", ["constructor", "start"])
-def test_worker_creation_failure_cleans_mutation_state(failure_point: str) -> None:
+def test_worker_start_failure_cleans_mutation_state() -> None:
     backend, mock_client = _make_backend()
-    failure = RuntimeError(f"thread {failure_point} failed")
+    failure = RuntimeError("thread start failed")
+    worker = MagicMock()
+    worker.start.side_effect = failure
 
-    if failure_point == "constructor":
-        worker_patch = patch("deepagents.backends.context_hub.threading.Thread", side_effect=failure)
-    else:
-        worker = MagicMock()
-        worker.start.side_effect = failure
-        worker_patch = patch("deepagents.backends.context_hub.threading.Thread", return_value=worker)
-
-    with worker_patch, pytest.raises(RuntimeError, match=f"thread {failure_point} failed"):
+    with (
+        patch("deepagents.backends.context_hub.threading.Thread", return_value=worker),
+        pytest.raises(RuntimeError, match="thread start failed"),
+    ):
         backend.write("/failed.md", "failed")
 
     with backend._mutations.condition:
@@ -968,7 +927,6 @@ def test_batch_window_is_anchored_to_first_mutation() -> None:
 
 def test_eight_concurrent_writes_coalesce_into_one_commit() -> None:
     backend, mock_client = _make_backend()
-    backend.read("/missing.md")  # Prime the remote snapshot before the burst.
     barrier = threading.Barrier(8)
 
     def write(index: int):
@@ -981,6 +939,7 @@ def test_eight_concurrent_writes_coalesce_into_one_commit() -> None:
         results = [future.result(timeout=2) for future in futures]
 
     assert all(result.error is None for result in results)
+    mock_client.pull_agent.assert_called_once_with("-/test-agent")
     mock_client.push_agent.assert_called_once()
     payload = mock_client.push_agent.call_args.kwargs["files"]
     assert set(payload) == {f"file-{index}.md" for index in range(8)}
@@ -1042,7 +1001,7 @@ def test_mixed_mutations_and_upload_share_one_batch() -> None:
     assert payload["upload-b.md"].content == "b"
 
 
-def test_follow_on_batch_waits_for_in_flight_commit() -> None:
+def test_follow_on_edit_uses_in_flight_write_and_waits_for_commit() -> None:
     backend, mock_client = _make_backend()
     backend.read("/missing.md")
     first_started = threading.Event()
@@ -1072,26 +1031,29 @@ def test_follow_on_batch_waits_for_in_flight_commit() -> None:
 
     mock_client.push_agent.side_effect = push_agent
     with ThreadPoolExecutor(max_workers=2) as pool:
-        first = pool.submit(backend.write, "/first.md", "first")
+        first = pool.submit(backend.write, "/chain.md", "hello")
         assert first_started.wait(timeout=1)
-        second = pool.submit(backend.write, "/second.md", "second")
+        second = pool.submit(backend.edit, "/chain.md", "hello", "goodbye")
         try:
-            _wait_for_content(backend, "/second.md", "second")
+            _wait_for_content(backend, "/chain.md", "goodbye")
             with calls_lock:
                 assert len(calls) == 1
         finally:
             release_first.set()
         assert first.result(timeout=2).error is None
-        assert second.result(timeout=2).error is None
+        edit_result = second.result(timeout=2)
 
+    assert edit_result.error is None
+    assert edit_result.occurrences == 1
     assert len(calls) == 2
     assert max_active == 1
     assert calls[1]["parent_commit"] == "00000001"
+    assert calls[1]["files"]["chain.md"].content == "goodbye"
 
 
 def test_pending_mutation_is_visible_to_cached_read_operations() -> None:
-    backend, mock_client = _make_backend()
-    backend.read("/missing.md")
+    backend, mock_client = _make_backend(**{"deleted.md": FileEntry(type="file", content="delete me")})
+    backend.read("/deleted.md")
     push_started = threading.Event()
     release_push = threading.Event()
 
@@ -1103,16 +1065,22 @@ def test_pending_mutation_is_visible_to_cached_read_operations() -> None:
         return _COMMIT_URL
 
     mock_client.push_agent.side_effect = push_agent
-    with ThreadPoolExecutor(max_workers=1) as pool:
+    with ThreadPoolExecutor(max_workers=2) as pool:
         future = pool.submit(backend.write, "/pending.md", "visible pending text")
         assert push_started.wait(timeout=1)
         try:
+            delete_future = pool.submit(backend.delete, "/deleted.md")
+            with backend._mutations.condition:
+                assert backend._mutations.condition.wait_for(lambda: len(backend._mutations.pending) == 1, timeout=1)
+
             read = backend.read("/pending.md")
             assert read.file_data is not None
             assert read.file_data["content"] == "visible pending text"
+            assert backend.read("/deleted.md").error == "File '/deleted.md' not found"
             ls_result = backend.ls("/")
             assert ls_result.entries is not None
             assert "/pending.md" in {entry["path"] for entry in ls_result.entries}
+            assert "/deleted.md" not in {entry["path"] for entry in ls_result.entries}
             grep_result = backend.grep("pending")
             assert grep_result.matches is not None
             assert [match["path"] for match in grep_result.matches] == ["/pending.md"]
@@ -1124,57 +1092,10 @@ def test_pending_mutation_is_visible_to_cached_read_operations() -> None:
         finally:
             release_push.set()
         assert future.result(timeout=2).error is None
+        assert delete_future.result(timeout=2).error is None
 
 
-def test_concurrent_cold_cache_access_pulls_once() -> None:
-    backend, mock_client = _make_backend()
-    start = threading.Barrier(8)
-    pull_barrier = threading.Barrier(8)
-
-    def pull_agent(_identifier: str):
-        with suppress(threading.BrokenBarrierError):
-            pull_barrier.wait(timeout=0.5)
-        return SimpleNamespace(commit_id="id", commit_hash=_COMMIT_HASH, files={})
-
-    mock_client.pull_agent.side_effect = pull_agent
-
-    def write(index: int):
-        start.wait(timeout=2)
-        return backend.write(f"/cold-{index}.md", str(index))
-
-    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0), ThreadPoolExecutor(max_workers=8) as pool:
-        futures = [pool.submit(write, index) for index in range(8)]
-        _flush_pending(backend, 8)
-        results = [future.result(timeout=3) for future in futures]
-
-    assert all(result.error is None for result in results)
-    mock_client.pull_agent.assert_called_once_with("-/test-agent")
-    mock_client.push_agent.assert_called_once()
-
-
-def test_batch_failure_reaches_every_waiter_and_drains_worker() -> None:
-    backend, mock_client = _make_backend()
-    backend.read("/missing.md")
-    mock_client.push_agent.side_effect = LangSmithAPIError("503")
-    barrier = threading.Barrier(8)
-
-    def write(index: int):
-        barrier.wait(timeout=2)
-        return backend.write(f"/failed-{index}.md", str(index))
-
-    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0), ThreadPoolExecutor(max_workers=8) as pool:
-        futures = [pool.submit(write, index) for index in range(8)]
-        _flush_pending(backend, 8)
-        results = [future.result(timeout=2) for future in futures]
-
-    assert all("Hub unavailable" in (result.error or "") for result in results)
-    mock_client.push_agent.assert_called_once()
-    assert backend._worker is None
-    backend.read("/missing.md")
-    assert mock_client.pull_agent.call_count == 2
-
-
-def test_in_flight_failure_rejects_queued_waiter_without_orphaning_state() -> None:
+def test_in_flight_failure_rejects_queued_waiter_and_recovers_next_burst() -> None:
     backend, mock_client = _make_backend()
     backend.read("/missing.md")
     first_started = threading.Event()
@@ -1212,63 +1133,31 @@ def test_in_flight_failure_rejects_queued_waiter_without_orphaning_state() -> No
     assert backend.read("/second.md").error == "File '/second.md' not found"
     assert mock_client.pull_agent.call_count == 2
 
-
-def test_worker_base_exception_settles_waiter_and_invalidates_state() -> None:
-    class WorkerAbort(BaseException):
-        pass
-
-    backend, mock_client = _make_backend()
-    push_started = threading.Event()
-
-    def push_agent(_identifier: str, **_kwargs: Any) -> str:
-        push_started.set()
-        msg = "worker aborted"
-        raise WorkerAbort(msg)
-
-    mock_client.push_agent.side_effect = push_agent
-    pool = ThreadPoolExecutor(max_workers=1)
-    future = None
-    try:
-        with patch("threading.excepthook"):
-            future = pool.submit(backend.write, "/failed.md", "failed")
-            assert push_started.wait(timeout=1)
-            with pytest.raises(WorkerAbort, match="worker aborted"):
-                future.result(timeout=0.5)
-    finally:
-        with backend._mutations.condition:
-            stranded = [*backend._mutations.in_flight, *backend._mutations.pending]
-            backend._mutations.in_flight = []
-            backend._mutations.pending = []
-            backend._mutations.deadline = None
-            backend._cache = None
-            backend._worker = None
-            cleanup_error = RuntimeError("test cleanup")
-            for mutation in stranded:
-                mutation.error = cleanup_error
-        for mutation in stranded:
-            mutation.done.set()
-        pool.shutdown(wait=True, cancel_futures=True)
-
-    assert future is not None
-    assert backend._worker is None
-    assert backend._cache is None
-    assert backend._mutations.in_flight == []
-    assert backend._mutations.pending == []
+    recovered = backend.write("/recovered.md", "recovered")
+    assert recovered.error is None
+    assert mock_client.push_agent.call_count == 2
+    content = backend.read("/recovered.md")
+    assert content.file_data is not None
+    assert content.file_data["content"] == "recovered"
 
 
-def test_conflict_reloads_remote_and_retries_local_delta() -> None:
+def test_conflict_replays_ordered_mutation_intent_against_remote() -> None:
     initial = SimpleNamespace(
         commit_id="initial",
         commit_hash=_COMMIT_HASH,
-        files={"base.md": FileEntry(type="file", content="base")},
+        files={
+            "base.md": FileEntry(type="file", content="before\nkeep"),
+            "folder/old.md": FileEntry(type="file", content="old"),
+        },
     )
     remote_hash = "feedface" * 8
     reloaded = SimpleNamespace(
         commit_id="remote",
         commit_hash=remote_hash,
         files={
-            "base.md": FileEntry(type="file", content="base"),
-            "remote.md": FileEntry(type="file", content="remote change"),
+            "base.md": FileEntry(type="file", content="remote header\nbefore\nkeep"),
+            "folder/old.md": FileEntry(type="file", content="old"),
+            "folder/remote.md": FileEntry(type="file", content="remote"),
         },
     )
     mock_client = MagicMock()
@@ -1276,21 +1165,28 @@ def test_conflict_reloads_remote_and_retries_local_delta() -> None:
     mock_client.push_agent.side_effect = [LangSmithConflictError("409"), _COMMIT_URL]
     backend = ContextHubBackend("-/test-agent", client=mock_client)
 
-    result = backend.write("/local.md", "local change")
+    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0), ThreadPoolExecutor(max_workers=2) as pool:
+        edit = pool.submit(backend.edit, "/base.md", "before", "after")
+        delete = pool.submit(backend.delete, "/folder")
+        _flush_pending(backend, 2)
+        edit_result = edit.result(timeout=2)
+        delete_result = delete.result(timeout=2)
 
-    assert result.error is None
+    assert edit_result.error is None
+    assert edit_result.occurrences == 1
+    assert delete_result.error is None
     assert mock_client.push_agent.call_count == 2
     first, second = mock_client.push_agent.call_args_list
     assert first.kwargs["parent_commit"] == _COMMIT_HASH
     assert second.kwargs["parent_commit"] == remote_hash
-    assert set(second.kwargs["files"]) == {"local.md"}
-    assert second.kwargs["files"]["local.md"].content == "local change"
-    remote = backend.read("/remote.md")
-    assert remote.file_data is not None
-    assert remote.file_data["content"] == "remote change"
-    local = backend.read("/local.md")
-    assert local.file_data is not None
-    assert local.file_data["content"] == "local change"
+    assert set(second.kwargs["files"]) == {
+        "base.md",
+        "folder/old.md",
+        "folder/remote.md",
+    }
+    assert second.kwargs["files"]["base.md"].content == "remote header\nafter\nkeep"
+    assert second.kwargs["files"]["folder/old.md"] is None
+    assert second.kwargs["files"]["folder/remote.md"] is None
 
 
 def test_conflict_stops_after_three_retries() -> None:
@@ -1324,38 +1220,3 @@ def test_later_same_path_enqueue_wins_coalesced_batch() -> None:
     mock_client.push_agent.assert_called_once()
     payload = mock_client.push_agent.call_args.kwargs["files"]
     assert payload["same.md"].content == "second"
-
-
-def test_edit_uses_visible_in_flight_write_in_enqueue_order() -> None:
-    backend, mock_client = _make_backend()
-    backend.read("/missing.md")
-    first_started = threading.Event()
-    release_first = threading.Event()
-    calls: list[dict[str, Any]] = []
-
-    def push_agent(identifier: str, **kwargs: Any) -> str:
-        index = len(calls)
-        calls.append(kwargs)
-        if index == 0:
-            first_started.set()
-            if not release_first.wait(timeout=2):
-                msg = "timed out waiting to release first commit"
-                raise TimeoutError(msg)
-        return f"https://host/hub/{identifier}:{index + 1:08x}"
-
-    mock_client.push_agent.side_effect = push_agent
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        write = pool.submit(backend.write, "/chain.md", "hello")
-        assert first_started.wait(timeout=1)
-        edit = pool.submit(backend.edit, "/chain.md", "hello", "goodbye")
-        try:
-            _wait_for_content(backend, "/chain.md", "goodbye", timeout=0.5)
-        finally:
-            release_first.set()
-        assert write.result(timeout=2).error is None
-        edit_result = edit.result(timeout=2)
-
-    assert edit_result.error is None
-    assert edit_result.occurrences == 1
-    assert len(calls) == 2
-    assert calls[1]["files"]["chain.md"].content == "goodbye"

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -1141,13 +1141,14 @@ def test_in_flight_failure_rejects_queued_waiter_and_recovers_next_burst() -> No
     assert content.file_data["content"] == "recovered"
 
 
-def test_conflict_replays_ordered_mutation_intent_against_remote() -> None:
+def test_conflict_replays_in_flight_batch_and_rejects_invalid_pending_edit() -> None:
     initial = SimpleNamespace(
         commit_id="initial",
         commit_hash=_COMMIT_HASH,
         files={
             "base.md": FileEntry(type="file", content="before\nkeep"),
             "folder/old.md": FileEntry(type="file", content="old"),
+            "pending.md": FileEntry(type="file", content="edit me"),
         },
     )
     remote_hash = "feedface" * 8
@@ -1158,23 +1159,45 @@ def test_conflict_replays_ordered_mutation_intent_against_remote() -> None:
             "base.md": FileEntry(type="file", content="remote header\nbefore\nkeep"),
             "folder/old.md": FileEntry(type="file", content="old"),
             "folder/remote.md": FileEntry(type="file", content="remote"),
+            "pending.md": FileEntry(type="file", content="changed remotely"),
         },
     )
+    reload_started = threading.Event()
+    release_reload = threading.Event()
     mock_client = MagicMock()
-    mock_client.pull_agent.side_effect = [initial, reloaded]
+
+    def pull_agent(_identifier: str) -> SimpleNamespace:
+        if mock_client.pull_agent.call_count == 1:
+            return initial
+        reload_started.set()
+        if not release_reload.wait(timeout=2):
+            msg = "timed out waiting to release conflict reload"
+            raise TimeoutError(msg)
+        return reloaded
+
+    mock_client.pull_agent.side_effect = pull_agent
     mock_client.push_agent.side_effect = [LangSmithConflictError("409"), _COMMIT_URL]
     backend = ContextHubBackend("-/test-agent", client=mock_client)
 
-    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0), ThreadPoolExecutor(max_workers=2) as pool:
+    with patch("deepagents.backends.context_hub._BATCH_WINDOW_SECONDS", 10.0), ThreadPoolExecutor(max_workers=3) as pool:
         edit = pool.submit(backend.edit, "/base.md", "before", "after")
         delete = pool.submit(backend.delete, "/folder")
         _flush_pending(backend, 2)
+        assert reload_started.wait(timeout=1)
+        try:
+            pending = pool.submit(backend.edit, "/pending.md", "edit me", "edited")
+            with backend._mutations.condition:
+                assert backend._mutations.condition.wait_for(lambda: len(backend._mutations.pending) == 1, timeout=1)
+        finally:
+            release_reload.set()
         edit_result = edit.result(timeout=2)
         delete_result = delete.result(timeout=2)
+        pending_result = pending.result(timeout=2)
 
     assert edit_result.error is None
     assert edit_result.occurrences == 1
     assert delete_result.error is None
+    assert "Hub unavailable" in (pending_result.error or "")
     assert mock_client.push_agent.call_count == 2
     first, second = mock_client.push_agent.call_args_list
     assert first.kwargs["parent_commit"] == _COMMIT_HASH
@@ -1187,6 +1210,9 @@ def test_conflict_replays_ordered_mutation_intent_against_remote() -> None:
     assert second.kwargs["files"]["base.md"].content == "remote header\nafter\nkeep"
     assert second.kwargs["files"]["folder/old.md"] is None
     assert second.kwargs["files"]["folder/remote.md"] is None
+    pending_read = backend.read("/pending.md")
+    assert pending_read.file_data is not None
+    assert pending_read.file_data["content"] == "changed remotely"
 
 
 def test_conflict_stops_after_three_retries() -> None:


### PR DESCRIPTION
ContextHubBackend now preserves concurrent file mutations in one durable commit and retains compatible remote changes during conflict recovery.

---

Concurrent callers previously reused the same parent commit, causing 409s. Retries could also replay stale edit or recursive-delete payloads.

Mutations now coalesce for 50 ms into serialized multi-file commits. Conflict recovery replays ordered intent against refreshed state; explicit writes remain last-writer-wins.