### PR TITLE
test(code): close leaked resources behind unraisable warnings

### DIFF
--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -658,3 +658,56 @@ def wait_for_modal() -> WaitForModal:
         raise AssertionError(msg)
 
     return _wait
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_sessionfinish() -> Generator[None, None, None]:
+    """Close any debug-log file handlers still attached at session end.
+
+    Companion to `_close_leaked_debug_handlers`: the per-test fixture sweeps
+    between tests, and this catches anything installed during the final test so
+    the handler's file is not closed by the GC at interpreter exit (where the
+    `ResourceWarning` would escape pytest entirely).
+    """
+    try:
+        yield
+    finally:
+        _sweep_debug_handlers()
+
+
+def _sweep_debug_handlers() -> None:
+    """Detach and close leaked `configure_debug_logging` file handlers.
+
+    `configure_debug_logging` tags the `FileHandler`s it installs with
+    `_deepagents_code_debug_handler`. A test that leaves one on a global logger
+    hands it to the GC, which reports the unclosed file as a
+    `PytestUnraisableExceptionWarning` against whichever test happens to be
+    running — or at interpreter exit, where pytest never sees it at all.
+    """
+    import logging
+
+    from deepagents_code._debug import _DEBUG_HANDLER_ATTR
+
+    for name in list(logging.root.manager.loggerDict):
+        target = logging.getLogger(name)
+        for handler in target.handlers[:]:
+            if isinstance(handler, logging.FileHandler) and getattr(
+                handler, _DEBUG_HANDLER_ATTR, False
+            ):
+                target.removeHandler(handler)
+                handler.close()
+
+
+@pytest.fixture(autouse=True)
+def _close_leaked_debug_handlers() -> None:
+    """Sweep debug-log file handlers installed before each test starts.
+
+    `deepagents_code.__init__` calls `configure_debug_logging` at import time,
+    so a `DEEPAGENTS_CODE_DEBUG` exported in the environment (a developer shell,
+    or a CI runner configured that way) attaches a real file handler to the
+    package logger before collection — and per-test checks then blame whichever
+    test first clears that logger's handlers. Individual tests are responsible
+    for closing handlers they install themselves; this only catches ones leaked
+    from import time or from a prior test that forgot.
+    """
+    _sweep_debug_handlers()

--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -664,13 +664,17 @@ def wait_for_modal() -> WaitForModal:
 def pytest_sessionfinish() -> Generator[None, None, None]:
     """Close any debug-log file handlers still attached at session end.
 
-    Companion to `_close_leaked_debug_handlers`: the per-test fixture sweeps
-    between tests, and this catches anything installed during the final test so
-    the handler's file is not closed by the GC at interpreter exit (where the
-    `ResourceWarning` would escape pytest entirely).
+    Companion to `_close_leaked_debug_handlers`, which is setup-only and so
+    sweeps *before* each test — leaving nothing to sweep after the last one. A
+    handler installed during that final test would otherwise stay attached, and
+    its file open, for the remainder of the process.
+
+    This is a tidiness guarantee, not a warning fix: `logging.shutdown()` runs
+    at `atexit` and closes still-attached handlers, so an unswept handler does
+    not produce a `ResourceWarning` at interpreter exit.
     """
     try:
-        yield
+        return (yield)
     finally:
         _sweep_debug_handlers()
 
@@ -679,10 +683,13 @@ def _sweep_debug_handlers() -> None:
     """Detach and close leaked `configure_debug_logging` file handlers.
 
     `configure_debug_logging` tags the `FileHandler`s it installs with
-    `_deepagents_code_debug_handler`. A test that leaves one on a global logger
-    hands it to the GC, which reports the unclosed file as a
-    `PytestUnraisableExceptionWarning` against whichever test happens to be
-    running — or at interpreter exit, where pytest never sees it at all.
+    `_DEBUG_HANDLER_ATTR`. Leaving one attached is not itself the bug: the
+    logger holds a strong reference, so the handler is not collected. The
+    failure comes one step later, when some *other* test clears or replaces
+    that logger's handlers and drops the last reference — the GC then reports
+    the unclosed file as a `PytestUnraisableExceptionWarning` against whichever
+    test happens to be running, which is why the blame lands on an innocent
+    test.
     """
     import logging
 
@@ -698,6 +705,16 @@ def _sweep_debug_handlers() -> None:
                 handler.close()
 
 
+@pytest.fixture
+def sweep_debug_handlers() -> Callable[[], None]:
+    """Expose `_sweep_debug_handlers` so tests can pin its behaviour.
+
+    The sweep runs autouse at setup, before any test body, so a test cannot
+    otherwise observe it acting on handlers the test itself installed.
+    """
+    return _sweep_debug_handlers
+
+
 @pytest.fixture(autouse=True)
 def _close_leaked_debug_handlers() -> None:
     """Sweep debug-log file handlers installed before each test starts.
@@ -706,8 +723,15 @@ def _close_leaked_debug_handlers() -> None:
     so a `DEEPAGENTS_CODE_DEBUG` exported in the environment (a developer shell,
     or a CI runner configured that way) attaches a real file handler to the
     package logger before collection — and per-test checks then blame whichever
-    test first clears that logger's handlers. Individual tests are responsible
-    for closing handlers they install themselves; this only catches ones leaked
-    from import time or from a prior test that forgot.
+    test first clears that logger's handlers. `config._quiet_sdk_logging` is the
+    other producer, tagging handlers on every SDK and MCP transport logger it
+    touches; the sweep walks the whole `loggerDict`, so both are in scope.
+
+    Individual tests are responsible for closing handlers they install
+    themselves; this only catches ones leaked from import time or from a prior
+    test that forgot. Sweeping rather than failing on a stray handler does mean
+    a test that forgets to close its own now passes quietly — accepted because
+    the goal here is to stop misattributed failures, and a detect-and-fail
+    variant would reintroduce them for the import-time handler nobody owns.
     """
     _sweep_debug_handlers()

--- a/libs/code/tests/unit_tests/test_debug.py
+++ b/libs/code/tests/unit_tests/test_debug.py
@@ -345,3 +345,54 @@ class TestInstalledDebugLogPath:
             # suite with DEEPAGENTS_CODE_DEBUG exported in their shell).
             with patch.dict(os.environ, {}, clear=True):
                 importlib.reload(deepagents_code)
+
+
+class TestSweepDebugHandlers:
+    """Tests for the conftest sweep that closes leaked debug handlers.
+
+    The negative case is the one worth pinning: every other test in this file
+    installs its handlers inside the test body, i.e. after the setup-only
+    `_close_leaked_debug_handlers` fixture has already run, so none of them
+    would notice if the sweep started closing handlers it did not own.
+    """
+
+    def test_leaves_untagged_file_handler_attached_and_open(
+        self, tmp_path, sweep_debug_handlers
+    ) -> None:
+        """An unrelated `FileHandler` must survive the sweep untouched."""
+        logger = logging.getLogger("test.sweep.untagged")
+        foreign = logging.FileHandler(tmp_path / "foreign.log")
+        logger.addHandler(foreign)
+        try:
+            sweep_debug_handlers()
+
+            assert foreign in logger.handlers
+            assert foreign.stream is not None
+            assert not foreign.stream.closed
+        finally:
+            logger.removeHandler(foreign)
+            foreign.close()
+
+    def test_closes_and_detaches_tagged_file_handler(
+        self, tmp_path, sweep_debug_handlers
+    ) -> None:
+        """A `configure_debug_logging` handler is removed and closed."""
+        logger = logging.getLogger("test.sweep.tagged")
+        with patch.dict(
+            os.environ,
+            {
+                "DEEPAGENTS_CODE_DEBUG": "1",
+                "DEEPAGENTS_CODE_DEBUG_FILE": str(tmp_path / "debug.log"),
+            },
+        ):
+            configure_debug_logging(logger)
+        tagged = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+        assert tagged, "configure_debug_logging installed no FileHandler"
+
+        sweep_debug_handlers()
+
+        assert not [h for h in logger.handlers if isinstance(h, logging.FileHandler)], (
+            "sweep left a tagged handler attached"
+        )
+        for handler in tagged:
+            assert handler.stream is None or handler.stream.closed

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -360,7 +360,9 @@ def _invoke_interactive(
     for line in answers:
         payload = b"\x04" if line is _CTRL_D else f"{line}\n".encode()
         os.write(primary, payload)
-    output = proc.stdout.read() if proc.stdout else ""
+    assert proc.stdout is not None
+    with proc.stdout:
+        output = proc.stdout.read()
     proc.wait(timeout=30)
     os.close(primary)
     clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
@@ -5346,7 +5348,9 @@ def _invoke_with_local_dcode_not_on_path(
         )
         os.close(secondary)
         os.write(primary, f"{answer}\n".encode())
-        output = proc.stdout.read() if proc.stdout else ""
+        assert proc.stdout is not None
+        with proc.stdout:
+            output = proc.stdout.read()
         proc.wait(timeout=30)
         os.close(primary)
         clean = re.sub(r"\x1b\[[0-9;]*m", "", output)

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -357,14 +357,23 @@ def _invoke_interactive(
         text=True,
     )
     os.close(secondary)
-    for line in answers:
-        payload = b"\x04" if line is _CTRL_D else f"{line}\n".encode()
-        os.write(primary, payload)
-    assert proc.stdout is not None
-    with proc.stdout:
+    try:
+        for line in answers:
+            payload = b"\x04" if line is _CTRL_D else f"{line}\n".encode()
+            os.write(primary, payload)
+        assert proc.stdout is not None
         output = proc.stdout.read()
-    proc.wait(timeout=30)
-    os.close(primary)
+        proc.wait(timeout=30)
+    finally:
+        # A `TimeoutExpired` here would otherwise leak the pipe and the pty and
+        # orphan the child — precisely when a cascade of unraisable warnings
+        # would obscure the real failure.
+        if proc.stdout is not None:
+            proc.stdout.close()
+        os.close(primary)
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
     clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
     return proc.returncode, clean, tmp_path / "uv-args.txt"
 
@@ -5347,12 +5356,20 @@ def _invoke_with_local_dcode_not_on_path(
             text=True,
         )
         os.close(secondary)
-        os.write(primary, f"{answer}\n".encode())
-        assert proc.stdout is not None
-        with proc.stdout:
+        try:
+            os.write(primary, f"{answer}\n".encode())
+            assert proc.stdout is not None
             output = proc.stdout.read()
-        proc.wait(timeout=30)
-        os.close(primary)
+            proc.wait(timeout=30)
+        finally:
+            # See `_invoke_interactive`: the timeout path must not leak the
+            # pipe and pty or orphan the child.
+            if proc.stdout is not None:
+                proc.stdout.close()
+            os.close(primary)
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
         clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
         return subprocess.CompletedProcess(
             args=["bash", str(SCRIPT)],

--- a/libs/code/tests/unit_tests/test_server.py
+++ b/libs/code/tests/unit_tests/test_server.py
@@ -1300,7 +1300,13 @@ class TestServerProcessStopIdempotency:
         with contextlib.suppress(RuntimeError):
             await server.start()
 
-        assert server._stopped is False
+        try:
+            assert server._stopped is False
+        finally:
+            # The failed `start()` allocated the workspace `TemporaryDirectory`
+            # before raising; without a second `stop()` its finalizer would
+            # warn about implicit cleanup at GC time.
+            server.stop()
 
 
 class TestPreservedLogNotice:

--- a/libs/code/tests/unit_tests/test_server.py
+++ b/libs/code/tests/unit_tests/test_server.py
@@ -1304,8 +1304,9 @@ class TestServerProcessStopIdempotency:
             assert server._stopped is False
         finally:
             # The failed `start()` allocated the workspace `TemporaryDirectory`
-            # before raising; without a second `stop()` its finalizer would
-            # warn about implicit cleanup at GC time.
+            # before raising, and did so outside `_start`'s cleanup `finally` —
+            # so without an explicit `stop()` its finalizer would warn about
+            # implicit cleanup at GC time.
             server.stop()
 
 


### PR DESCRIPTION
This change closes three resource leaks in the test suite. Each one produces a warning that is reported against the wrong test, which makes the output misleading.

---

**The problem**

Tests can leave files and folders open. Python does not close them immediately. It closes them later, during garbage collection, which runs at unpredictable times — often in the middle of a different test. The warning is reported there.

So the test named in the output is whichever test happened to be running when garbage collection occurred, not the test that left the resource open. The same leak can point at a different test on each run.

These warnings are printed rather than fatal: `pyproject.toml` sets `filterwarnings = ["error", ..., "default::pytest.PytestUnraisableExceptionWarning"]`, and the later entry wins. So this is noise and misdirection in the output, not a failing build. Closing the leaks is also what makes it possible to promote that filter to `error::` later.

**The three leaks**

1. **An open pipe.** Two test helpers start a subprocess and read its output without closing the pipe.
2. **A folder that is not removed.** One test stops a server mid-startup. Startup has already created a temporary folder, allocated before the failure and outside the cleanup path, so nothing removes it.
3. **A log file that stays open.** When `DEEPAGENTS_CODE_DEBUG` is set, the package opens a log file at import time. A later test clears the logger, dropping the handle without closing it.

**The fix**

- The helpers close the pipe after reading it, and also release the pipe, pty, and child process if the wait times out.
- The server test calls `stop()`, which removes the folder.
- A new fixture closes any tagged debug-log handler left attached, sweeping before each test and once at session end. A test covers the invariant that the sweep leaves handlers it does not own untouched.

**On the third leak**

Leaving a handler attached is not itself the bug — the logger holds a strong reference, so the handler is not collected. The failure comes one step later, when a different test clears or replaces that logger's handlers and drops the last reference. That is why the blame lands on an unrelated test.

Handlers still attached at interpreter exit are closed cleanly by `logging.shutdown()` via `atexit`, so they produce no warning. The session-end sweep is therefore tidiness — the per-test fixture is setup-only, so nothing would otherwise sweep after the final test.
