### PR TITLE
fix(code): stop passing removed `checkpoint_metadata`

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3006,7 +3006,6 @@ async def _run_acp_cli_async(
                 build_agent,
                 models=models,
                 load_sessions=True,
-                checkpoint_metadata={"agent_name": assistant_id},
             )
             await run_acp_agent(server)
     except KeyboardInterrupt:

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -6,11 +6,13 @@ import argparse
 import asyncio
 import sys
 from contextlib import asynccontextmanager
+from inspect import signature
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from deepagents_acp.server import AgentServerACP
 
 from deepagents_code.main import _preload_session_mcp_server_info, cli_main
 
@@ -33,7 +35,8 @@ def test_acp_checkpointer() -> Generator[SimpleNamespace]:
 def _build_agent_server(server: object) -> Callable[..., object]:
     """Stand in for `AgentServerACP`, exercising the agent factory it is handed."""
 
-    def build(agent_factory: Callable[..., object], **_kwargs: object) -> object:
+    def build(agent_factory: Callable[..., object], **kwargs: object) -> object:
+        signature(AgentServerACP).bind(agent_factory, **kwargs)
         agent_factory(SimpleNamespace(cwd="/tmp", model=None))
         return server
 
@@ -208,9 +211,6 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server(
         "name": "anthropic:claude-sonnet-4-6",
     }
     assert mock_server_cls.call_args.kwargs["load_sessions"] is True
-    assert mock_server_cls.call_args.kwargs["checkpoint_metadata"] == {
-        "agent_name": "agent"
-    }
     run_agent.assert_awaited_once_with(server)
     mcp_manager.cleanup.assert_awaited_once_with()
 


### PR DESCRIPTION
`dcode --acp` starts successfully with the released `deepagents-acp` constructor.

---

The ACP persistence integration retained `checkpoint_metadata` after that parameter was removed from `AgentServerACP` before release, causing every ACP startup to exit before initialization. Remove the stale argument and bind the existing test double to the real constructor signature so dependency API drift fails the focused test.
