### PR TITLE
fix(infra): authenticate genai-prices bump push as the app installation

### DIFF
--- a/.github/workflows/bump_genai_prices.yml
+++ b/.github/workflows/bump_genai_prices.yml
@@ -72,7 +72,18 @@ jobs:
       # For the failure-tracking issue in the final step.
       issues: write
     steps:
+      # The clone is anonymous on purpose. The default `persist-credentials`
+      # would store the read-only `GITHUB_TOKEN` as an
+      # `http.https://github.com/.extraheader` credential, and git sends that
+      # `Authorization` header while ignoring the app token embedded in the
+      # push URL — git cannot send two `Authorization` headers, so the config
+      # credential wins and the push runs as `github-actions[bot]` with
+      # `contents: read` and is denied (403). The only write in this job
+      # authenticates explicitly with the app token below, so nothing is
+      # lost; the fetch path in the push step also uses that app-token URL.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python and uv
         uses: "./.github/actions/uv_setup"
@@ -189,6 +200,18 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
+
+          # The push and PR calls authenticate as the Org Membership App
+          # installation, not `github-actions[bot]` (whose `GITHUB_TOKEN` is
+          # `contents: read` here and whose PRs would not trigger
+          # `pull_request` workflows). With checkout credentials no longer
+          # persisted, an empty app token would now degrade these to an
+          # anonymous 403; fail fast instead so the cause is obvious.
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::App installation token is empty; check ORG_MEMBERSHIP_APP_CLIENT_ID and ORG_MEMBERSHIP_APP_PRIVATE_KEY."
+            exit 1
+          fi
+
           lockfile="libs/code/uv.lock"
           remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 


### PR DESCRIPTION
Fixes #5468

The daily `genai-prices` bump PR opens again. The push now authenticates as the Org Membership App installation, not as `github-actions[bot]`. The PR it opens now triggers `pull_request` workflows, so the required checks run.

---

## Root cause

The push step put the app token in the push URL: `https://x-access-token:${GH_TOKEN}@github.com/...`.

But `actions/checkout` ran first with its default `persist-credentials: true`. This stored the read-only `GITHUB_TOKEN` as an `http.https://github.com/.extraheader` credential. The run log shows this: `http.https://github.com/.extraheader AUTHORIZATION: basic ***`.

git cannot send two `Authorization` headers on one request. When a credential is in the config, git uses it and ignores the token in the URL. So git sent the `GITHUB_TOKEN` header and dropped the app token.

The push ran as `github-actions[bot]`. That token has only `contents: read` on this job. GitHub denied the push:

```
remote: Permission to langchain-ai/deepagents.git denied to github-actions[bot].
```

The error names `github-actions[bot]`, not the app's bot. This shows the app token never reached the remote.

### Why not the other causes

- **Empty app token:** No. The token step succeeded. The step env showed `GH_TOKEN: ***` (a value, not empty). The `client-id` matched the repo variable. The token existed but was not used.
- **App lacks `contents: write`:** No. A valid token with wrong permissions would name the app's bot in the error, not `github-actions[bot]`.

This bug is not specific to this workflow. Every workflow that pushes with an `x-access-token` URL after a default `actions/checkout` fails the same way. Examples: `bump_code_sdk_pin.yml` (run 30938354665) and `raise_langchain_minimums.yml` (run 31374913489). No app-token push ever succeeded.

## Fix

- `actions/checkout` now uses `persist-credentials: false`. The clone is anonymous. The app token in the push URL is now the only credential. The `ls-remote`, `fetch`, and `push` all use that URL, so they authenticate as the app installation.
- Added a check: if the app token is empty, the step fails with a clear message. Before, an empty token caused a confusing anonymous 403.

## What did not change

- The job `permissions:` block is the same: `contents: read`, `pull-requests: read`, `issues: write`. The push uses the app token, not `GITHUB_TOKEN`.
- The idempotency logic, the never-force-push-a-human-tip guard, and the `--force-with-lease` logic are unchanged.
- The failure-tracking issue step is unchanged. It still uses `issues: write`.

## Verification

- `actionlint` on the workflow: clean (exit 0).
- The YAML parses. The push step's script passes `bash -n`.
- I could not dry-run `workflow_dispatch` from this branch. GitHub offers `workflow_dispatch` only for workflows on the default branch. A real dispatch would push the real bump branch. The fix is verified by the credential-resolution logic above, not by a live push.
