### PR TITLE
fix(code): hide invalid cache metrics

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7750,10 +7750,12 @@ class DeepAgentsApp(App):
             inputs += self._inflight_turn_stats.input_tokens
             reads += self._inflight_turn_stats.cache_read_tokens
             writes += self._inflight_turn_stats.cache_write_tokens
-        self._status_bar.query_one("#cache-display").display = (
-            self._thread_has_completed_turn and writes > 0
+        self._status_bar.set_cache_tokens(
+            reads,
+            writes,
+            input_tokens=inputs,
+            visible=self._thread_has_completed_turn and writes > 0,
         )
-        self._status_bar.set_cache_tokens(reads, writes, input_tokens=inputs)
 
     def _set_session_cost(
         self,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7750,12 +7750,10 @@ class DeepAgentsApp(App):
             inputs += self._inflight_turn_stats.input_tokens
             reads += self._inflight_turn_stats.cache_read_tokens
             writes += self._inflight_turn_stats.cache_write_tokens
-        self._status_bar.set_cache_tokens(
-            reads,
-            writes,
-            input_tokens=inputs,
-            visible=self._thread_has_completed_turn and writes > 0,
+        self._status_bar.query_one("#cache-display").display = (
+            self._thread_has_completed_turn and writes > 0
         )
+        self._status_bar.set_cache_tokens(reads, writes, input_tokens=inputs)
 
     def _set_session_cost(
         self,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7750,12 +7750,9 @@ class DeepAgentsApp(App):
             inputs += self._inflight_turn_stats.input_tokens
             reads += self._inflight_turn_stats.cache_read_tokens
             writes += self._inflight_turn_stats.cache_write_tokens
-        self._status_bar.set_cache_tokens(
-            reads,
-            writes,
-            input_tokens=inputs,
-            visible=self._thread_has_completed_turn and writes > 0,
-        )
+        cache_display = self._status_bar.query_one("#cache-display")
+        cache_display.visible = self._thread_has_completed_turn and writes > 0
+        self._status_bar.set_cache_tokens(reads, writes, input_tokens=inputs)
 
     def _set_session_cost(
         self,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7750,7 +7750,12 @@ class DeepAgentsApp(App):
             inputs += self._inflight_turn_stats.input_tokens
             reads += self._inflight_turn_stats.cache_read_tokens
             writes += self._inflight_turn_stats.cache_write_tokens
-        self._status_bar.set_cache_tokens(reads, writes, input_tokens=inputs)
+        self._status_bar.set_cache_tokens(
+            reads,
+            writes,
+            input_tokens=inputs,
+            visible=self._thread_has_completed_turn and writes > 0,
+        )
 
     def _set_session_cost(
         self,

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -864,7 +864,7 @@ class StatusBar(Vertical):
                 color = colors.muted
             hit_rate = Content.styled(f"{percent:.0f}% hit", color)
         elif not self.cache_read_tokens and not self.cache_write_tokens:
-            hit_rate = Content.styled("0% hit", colors.muted)
+            return Content("")
         details = (
             f"{_compact_tokens(self.cache_read_tokens)} read"
             f" / {_compact_tokens(self.cache_write_tokens)} write"

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -421,6 +421,7 @@ class StatusBar(Vertical):
         self.cache_input_tokens = 0
         self.cache_read_tokens = 0
         self.cache_write_tokens = 0
+        self._cache_visible = False
         self._status_by_source: dict[StatusMessageSource, str] = {
             "agent": "",
             "hooks": "",
@@ -903,7 +904,7 @@ class StatusBar(Vertical):
             if segment.plain
         )
         cache = self._cache_segment()
-        cache_display.segments = (cache,) if cache.plain else ()
+        cache_display.segments = (cache,) if self._cache_visible else ()
         context_display.segments = context_segments
 
     def set_rubric_label(self, label: str) -> None:
@@ -949,6 +950,7 @@ class StatusBar(Vertical):
         write_tokens: int,
         *,
         input_tokens: int = 0,
+        visible: bool = True,
     ) -> None:
         """Set cumulative input and cache token counts for the active thread.
 
@@ -957,6 +959,7 @@ class StatusBar(Vertical):
             write_tokens: Input tokens written to the provider cache.
             input_tokens: Inclusive input-token total used as the hit-rate
                 denominator.
+            visible: Whether to show cache metrics.
         """
         reads = max(read_tokens, 0)
         writes = max(write_tokens, 0)
@@ -964,6 +967,7 @@ class StatusBar(Vertical):
         self.cache_input_tokens = inputs
         self.cache_read_tokens = reads
         self.cache_write_tokens = writes
+        self._cache_visible = visible
         self._refresh_metrics()
 
     def set_cost(self, cost_usd: float) -> None:

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -421,7 +421,6 @@ class StatusBar(Vertical):
         self.cache_input_tokens = 0
         self.cache_read_tokens = 0
         self.cache_write_tokens = 0
-        self._cache_visible = False
         self._status_by_source: dict[StatusMessageSource, str] = {
             "agent": "",
             "hooks": "",
@@ -904,7 +903,7 @@ class StatusBar(Vertical):
             if segment.plain
         )
         cache = self._cache_segment()
-        cache_display.segments = (cache,) if self._cache_visible else ()
+        cache_display.segments = (cache,) if cache.plain else ()
         context_display.segments = context_segments
 
     def set_rubric_label(self, label: str) -> None:
@@ -950,7 +949,6 @@ class StatusBar(Vertical):
         write_tokens: int,
         *,
         input_tokens: int = 0,
-        visible: bool = True,
     ) -> None:
         """Set cumulative input and cache token counts for the active thread.
 
@@ -959,7 +957,6 @@ class StatusBar(Vertical):
             write_tokens: Input tokens written to the provider cache.
             input_tokens: Inclusive input-token total used as the hit-rate
                 denominator.
-            visible: Whether to show cache metrics.
         """
         reads = max(read_tokens, 0)
         writes = max(write_tokens, 0)
@@ -967,7 +964,6 @@ class StatusBar(Vertical):
         self.cache_input_tokens = inputs
         self.cache_read_tokens = reads
         self.cache_write_tokens = writes
-        self._cache_visible = visible
         self._refresh_metrics()
 
     def set_cost(self, cost_usd: float) -> None:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2589,6 +2589,33 @@ class TestAppCSSValidation:
 class TestCacheStatus:
     """Tests for active-thread cache metrics forwarded to the status bar."""
 
+    @pytest.mark.parametrize(
+        ("completed", "reads", "writes", "visible"),
+        [
+            (False, 800, 100, False),
+            (True, 0, 100, True),
+            (True, 800, 0, False),
+            (True, 800, 100, True),
+        ],
+    )
+    def test_refresh_validates_cache_metrics(
+        self, completed: bool, reads: int, writes: int, visible: bool
+    ) -> None:
+        app = DeepAgentsApp(thread_id="thread-123")
+        app._status_bar = MagicMock()
+        app._thread_stats = SessionStats(
+            input_tokens=1_000,
+            cache_read_tokens=reads,
+            cache_write_tokens=writes,
+        )
+        app._thread_has_completed_turn = completed
+
+        app._refresh_cache_display()
+
+        app._status_bar.set_cache_tokens.assert_called_once_with(
+            reads, writes, input_tokens=1_000, visible=visible
+        )
+
     def test_refresh_includes_matching_inflight_input_total(self) -> None:
         """The hit-rate denominator should cover persisted and in-flight usage."""
         app = DeepAgentsApp(thread_id="thread-123")
@@ -2604,6 +2631,7 @@ class TestCacheStatus:
             cache_write_tokens=50,
         )
         app._inflight_thread_id = app._lc_thread_id
+        app._thread_has_completed_turn = True
 
         app._refresh_cache_display()
 
@@ -2611,6 +2639,7 @@ class TestCacheStatus:
             1_200,
             150,
             input_tokens=1_500,
+            visible=True,
         )
 
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2589,33 +2589,6 @@ class TestAppCSSValidation:
 class TestCacheStatus:
     """Tests for active-thread cache metrics forwarded to the status bar."""
 
-    @pytest.mark.parametrize(
-        ("completed", "reads", "writes", "visible"),
-        [
-            (False, 800, 100, False),
-            (True, 0, 100, True),
-            (True, 800, 0, False),
-            (True, 800, 100, True),
-        ],
-    )
-    def test_refresh_validates_cache_metrics(
-        self, completed: bool, reads: int, writes: int, visible: bool
-    ) -> None:
-        app = DeepAgentsApp(thread_id="thread-123")
-        app._status_bar = MagicMock()
-        app._thread_stats = SessionStats(
-            input_tokens=1_000,
-            cache_read_tokens=reads,
-            cache_write_tokens=writes,
-        )
-        app._thread_has_completed_turn = completed
-
-        app._refresh_cache_display()
-
-        app._status_bar.set_cache_tokens.assert_called_once_with(
-            reads, writes, input_tokens=1_000, visible=visible
-        )
-
     def test_refresh_includes_matching_inflight_input_total(self) -> None:
         """The hit-rate denominator should cover persisted and in-flight usage."""
         app = DeepAgentsApp(thread_id="thread-123")
@@ -2631,7 +2604,6 @@ class TestCacheStatus:
             cache_write_tokens=50,
         )
         app._inflight_thread_id = app._lc_thread_id
-        app._thread_has_completed_turn = True
 
         app._refresh_cache_display()
 
@@ -2639,7 +2611,6 @@ class TestCacheStatus:
             1_200,
             150,
             input_tokens=1_500,
-            visible=True,
         )
 
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2611,6 +2611,7 @@ class TestCacheStatus:
             1_200,
             150,
             input_tokens=1_500,
+            visible=False,
         )
 
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2611,7 +2611,6 @@ class TestCacheStatus:
             1_200,
             150,
             input_tokens=1_500,
-            visible=False,
         )
 
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -70,7 +70,7 @@ class TestTwoLineMetrics:
 
     @pytest.mark.parametrize(
         ("read", "color"),
-        [(0, "muted"), (59, "error"), (60, "warning"), (90, "muted")],
+        [(59, "error"), (60, "warning"), (90, "muted")],
     )
     async def test_cache_hit_rate_colors(self, read: int, color: str) -> None:
         async with StatusBarApp().run_test() as pilot:

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -58,6 +58,12 @@ class TestTwoLineMetrics:
             assert str(cache.render()) == ("Cache 80% hit • 12.5K read / 750 write")
             assert str(context.render()) == "Context: 6% / Tokens: 12.5K • $0.42"
 
+            bar.set_cache_tokens(12_500, 750, input_tokens=15_625, visible=False)
+            await pilot.pause()
+
+            assert str(cache.render()) == ""
+            assert context.region.right == metrics.region.right
+
     async def test_context_percentage_color_thresholds(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -58,12 +58,6 @@ class TestTwoLineMetrics:
             assert str(cache.render()) == ("Cache 80% hit • 12.5K read / 750 write")
             assert str(context.render()) == "Context: 6% / Tokens: 12.5K • $0.42"
 
-            bar.set_cache_tokens(12_500, 750, input_tokens=15_625, visible=False)
-            await pilot.pause()
-
-            assert str(cache.render()) == ""
-            assert context.region.right == metrics.region.right
-
     async def test_context_percentage_color_thresholds(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)


### PR DESCRIPTION
Cache metrics now stay hidden until a turn completes and the provider reports cache writes.

---

Incomplete read-only metrics are not meaningful.

## Screenshots
### Cache stats hidden for fireworks (provider doesn't support cache writes)
<img width="752" height="765" alt="Screenshot 2026-08-13 at 3 32 46 PM" src="https://github.com/user-attachments/assets/9a0fed8c-bfc4-4d7e-a0f4-1bbed9bb0884" />

### Luna before first message
<img width="747" height="760" alt="Screenshot 2026-08-13 at 3 33 45 PM" src="https://github.com/user-attachments/assets/15228cc6-c723-4f48-9269-24428554495d" />
### Luna after first message
<img width="748" height="766" alt="Screenshot 2026-08-13 at 3 34 17 PM" src="https://github.com/user-attachments/assets/c9916965-cf2b-4947-8c6f-638cfa081280" />


Made by [Open SWE](https://openswe.vercel.app/agents/019ffc39-6859-7564-af5c-274b4bb92b65)