### PR TITLE
fix(infra): authenticate app-token pushes in minimums and SDK pin workflows

### DIFF
--- a/.github/workflows/bump_code_sdk_pin.yml
+++ b/.github/workflows/bump_code_sdk_pin.yml
@@ -30,6 +30,9 @@
 #   `pull_request` workflows, so the required checks would never run.
 # - Idempotent: if a PR for the target version already exists (or the pin is
 #   already current), the workflow exits without creating a duplicate.
+# - Because this runs unattended, a failure would otherwise be invisible: the
+#   final step files (or refreshes) a tracking issue so a broken bump does
+#   not just stop happening.
 
 name: "Bump Code SDK pin"
 
@@ -50,6 +53,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      # For the failure-tracking issue in the final step.
+      issues: write
     steps:
       # The clone is anonymous on purpose. The default `persist-credentials`
       # would store the read-only `GITHUB_TOKEN` as an
@@ -239,3 +244,50 @@ jobs:
             --body-file "$body_file")
           echo "Opened SDK pin bump PR: $pr_url"
           echo "::notice::Opened SDK pin bump PR: $pr_url"
+
+      - name: File a tracking issue on failure
+        # A failed dispatch is otherwise invisible until the next Code
+        # release trips the pin gate. Funnel every failure into a single
+        # deduplicated issue so the bump stopping is visible exactly once.
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const marker = '<!-- bump-code-sdk-pin-failure -->';
+            const { owner, repo } = context.repo;
+            const runUrl = process.env.RUN_URL;
+            const title = 'Code SDK pin bump is failing';
+            const body = [
+              marker,
+              '`bump_code_sdk_pin.yml` failed, so the `deepagents` pin in `libs/code/pyproject.toml` is not being bumped automatically after SDK releases.',
+              '',
+              `Most recent failed run: ${runUrl}`,
+              '',
+              'This issue is reused by later failures rather than duplicated. Close it once the workflow is green again.',
+            ].join('\n');
+
+            try {
+              const existing = await github.paginate(
+                github.rest.issues.listForRepo,
+                { owner, repo, state: 'open', per_page: 100 },
+              );
+              const found = existing.find(
+                i => !i.pull_request && (i.body ?? '').startsWith(marker),
+              );
+              if (found) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: found.number,
+                  body: `Still failing: ${runUrl}`,
+                });
+                core.info(`Commented on existing tracking issue #${found.number}.`);
+              } else {
+                const created = await github.rest.issues.create({ owner, repo, title, body });
+                core.info(`Filed tracking issue #${created.data.number}.`);
+              }
+            } catch (err) {
+              // Never mask the real failure with a reporting failure — the job
+              // is already red for the reason that matters.
+              core.warning(`Could not file the SDK pin bump tracking issue: ${err.message}`);
+            }

--- a/.github/workflows/bump_code_sdk_pin.yml
+++ b/.github/workflows/bump_code_sdk_pin.yml
@@ -51,7 +51,18 @@ jobs:
     permissions:
       contents: read
     steps:
+      # The clone is anonymous on purpose. The default `persist-credentials`
+      # would store the read-only `GITHUB_TOKEN` as an
+      # `http.https://github.com/.extraheader` credential, and git sends that
+      # `Authorization` header while ignoring the app token embedded in the
+      # push URL — git cannot send two `Authorization` headers, so the config
+      # credential wins and the push runs as `github-actions[bot]` with
+      # `contents: read` and is denied (403). The only write in this job
+      # authenticates explicitly with the app token below, so nothing is
+      # lost; the fetch path in the push step also uses that app-token URL.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python and uv
         uses: "./.github/actions/uv_setup"
@@ -141,6 +152,18 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
+
+          # The push and PR calls authenticate as the Org Membership App
+          # installation, not `github-actions[bot]` (whose `GITHUB_TOKEN` is
+          # `contents: read` here and whose PRs would not trigger
+          # `pull_request` workflows). With checkout credentials no longer
+          # persisted, an empty app token would now degrade these to an
+          # anonymous 403; fail fast instead so the cause is obvious.
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::App installation token is empty; check ORG_MEMBERSHIP_APP_CLIENT_ID and ORG_MEMBERSHIP_APP_PRIVATE_KEY."
+            exit 1
+          fi
+
           code_pyproject="libs/code/pyproject.toml"
           lockfile="libs/code/uv.lock"
 

--- a/.github/workflows/raise_langchain_minimums.yml
+++ b/.github/workflows/raise_langchain_minimums.yml
@@ -83,7 +83,18 @@ jobs:
       # duplicate-PR guard would fail open and post a second PR.
       pull-requests: read
     steps:
+      # The clone is anonymous on purpose. The default `persist-credentials`
+      # would store the read-only `GITHUB_TOKEN` as an
+      # `http.https://github.com/.extraheader` credential, and git sends that
+      # `Authorization` header while ignoring the app token embedded in the
+      # push URL — git cannot send two `Authorization` headers, so the config
+      # credential wins and the push runs as `github-actions[bot]` with
+      # `contents: read` and is denied (403). The only write in this job
+      # authenticates explicitly with the app token below, so nothing is
+      # lost; the fetch path in the push step also uses that app-token URL.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python and uv
         uses: "./.github/actions/uv_setup"
@@ -189,6 +200,17 @@ jobs:
           BOT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         run: |
           set -euo pipefail
+
+          # The push and PR calls authenticate as the Org Membership App
+          # installation, not `github-actions[bot]` (whose `GITHUB_TOKEN` is
+          # `contents: read` here and whose PRs would not trigger
+          # `pull_request` workflows). With checkout credentials no longer
+          # persisted, an empty app token would now degrade these to an
+          # anonymous 403; fail fast instead so the cause is obvious.
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::App installation token is empty; check ORG_MEMBERSHIP_APP_CLIENT_ID and ORG_MEMBERSHIP_APP_PRIVATE_KEY."
+            exit 1
+          fi
 
           # Recreate an orphan branch from a prior run that pushed but failed
           # before `gh pr create` (the no-open-PR check above already ran, so any

--- a/.github/workflows/raise_langchain_minimums.yml
+++ b/.github/workflows/raise_langchain_minimums.yml
@@ -37,6 +37,9 @@
 #   no bound needs raising), the workflow exits without creating a duplicate. A
 #   cron `all` run and a manual single-package run use different branches, so
 #   they are not serialized against each other.
+# - Because this runs unattended, a failure would otherwise be invisible: the
+#   final step files (or refreshes) a tracking issue so a broken bump does
+#   not just stop happening.
 
 name: "Raise dependency minimums"
 
@@ -82,6 +85,8 @@ jobs:
       # `gh pr list` below reads with `github.token`; without this the
       # duplicate-PR guard would fail open and post a second PR.
       pull-requests: read
+      # For the failure-tracking issue in the final step.
+      issues: write
     steps:
       # The clone is anonymous on purpose. The default `persist-credentials`
       # would store the read-only `GITHUB_TOKEN` as an
@@ -274,3 +279,51 @@ jobs:
             --body-file "$body_file")
           echo "Opened dependency minimums PR: $pr_url"
           echo "::notice::Opened dependency minimums PR: $pr_url"
+
+      - name: File a tracking issue on failure
+        # Nobody watches a green cron, and nobody watches a red one either
+        # once it has been red for a week. Funnel every failure into a single
+        # deduplicated issue so the minimums raising stopping is visible
+        # exactly once.
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const marker = '<!-- raise-langchain-minimums-failure -->';
+            const { owner, repo } = context.repo;
+            const runUrl = process.env.RUN_URL;
+            const title = 'Dependency minimums raising is failing';
+            const body = [
+              marker,
+              '`raise_langchain_minimums.yml` failed, so LangChain-ecosystem dependency lower bounds are no longer being raised weekly.',
+              '',
+              `Most recent failed run: ${runUrl}`,
+              '',
+              'This issue is reused by later failures rather than duplicated. Close it once the workflow is green again.',
+            ].join('\n');
+
+            try {
+              const existing = await github.paginate(
+                github.rest.issues.listForRepo,
+                { owner, repo, state: 'open', per_page: 100 },
+              );
+              const found = existing.find(
+                i => !i.pull_request && (i.body ?? '').startsWith(marker),
+              );
+              if (found) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: found.number,
+                  body: `Still failing: ${runUrl}`,
+                });
+                core.info(`Commented on existing tracking issue #${found.number}.`);
+              } else {
+                const created = await github.rest.issues.create({ owner, repo, title, body });
+                core.info(`Filed tracking issue #${created.data.number}.`);
+              }
+            } catch (err) {
+              // Never mask the real failure with a reporting failure — the job
+              // is already red for the reason that matters.
+              core.warning(`Could not file the minimums tracking issue: ${err.message}`);
+            }


### PR DESCRIPTION
The dependency minimums and Code SDK pin workflows can push branches and open PRs again. Before this change, both workflows failed with `Permission to langchain-ai/deepagents.git denied to github-actions[bot]`. The pushes now authenticate as the Org Membership App installation. If the app token is empty, the step stops with a clear error message. A failure in either workflow also files a tracking issue, or updates the existing one. This matches the genai-prices bump workflow.

---

## Cause

This is the same bug that #5474 fixed in `bump_genai_prices.yml`.

The push step puts the app token in the push URL (`https://x-access-token:${GH_TOKEN}@github.com/...`). But `actions/checkout` ran first with the default `persist-credentials: true`. This stores the read-only `GITHUB_TOKEN` as an `http.https://github.com/.extraheader` credential. git cannot send two `Authorization` headers in one request. The credential in the config wins. git drops the app token from the URL. The push runs as `github-actions[bot]`. That token has only `contents: read` in these jobs. GitHub denies the push with a 403. The error names `github-actions[bot]`, not the app bot.

Observed failures:

- `raise_langchain_minimums.yml`, run 31374913489. The job raised 18 minimums and committed them. Then the push failed with a 403.
- `bump_code_sdk_pin.yml`, run 30938354665. Listed in the #5474 investigation.

## Fix

The changes match #5474 in both workflows:

- `actions/checkout` now uses `persist-credentials: false`. The clone is anonymous. The app token in the push URL is the only credential. The `ls-remote`, `fetch`, and `push` commands authenticate as the app installation.
- The push step stops immediately if the app token is empty. Before, an empty token caused an anonymous 403 with no clear cause.

Both workflows also get the failure-tracking issue step from `bump_genai_prices.yml`. A step with `if: failure()` uses `github-script` to file one issue. The step finds the issue again by a marker comment. Later failures add a comment to the existing issue. They do not open a new one. This makes a stopped scheduled workflow visible exactly once. Both jobs get `issues: write` for this step. If the reporting step itself fails, it writes a warning and lets the job continue. A reporting failure never hides the real failure.