### PR TITLE
ci(infra): annotate `bump_code_sdk_pin.yml` runs when the pin is already current

### DIFF
--- a/.github/workflows/bump_code_sdk_pin.yml
+++ b/.github/workflows/bump_code_sdk_pin.yml
@@ -122,7 +122,7 @@ jobs:
         env:
           SDK_VERSION: ${{ steps.versions.outputs.sdk_version }}
           CODE_PIN: ${{ steps.versions.outputs.code_pin }}
-        run: echo "::notice::Code SDK pin $CODE_PIN is not behind the workspace SDK version $SDK_VERSION; nothing to do."
+        run: 'echo "::notice::Nothing to do: Code SDK pin $CODE_PIN is not behind the workspace SDK version $SDK_VERSION."'
 
       - name: Skip if PR already open for this version
         id: existing

--- a/.github/workflows/bump_code_sdk_pin.yml
+++ b/.github/workflows/bump_code_sdk_pin.yml
@@ -113,12 +113,16 @@ jobs:
           echo "Code pin:    $code_pin"
           echo "Stale:       $stale"
 
-      - name: Log if nothing to do
+      - name: Annotate the run if nothing to do
         # The actual skip is implemented by the `if:` guards on every
-        # subsequent step; this step only emits a log line so the run
-        # history shows why no PR was opened.
+        # subsequent step; this step only explains the skip. Use ::notice::
+        # (not plain echo) so the outcome shows up as a run annotation in
+        # the Actions UI, not just buried in the step log.
         if: steps.versions.outputs.stale != 'true'
-        run: echo "Code SDK pin is not behind the workspace SDK version; nothing to do."
+        env:
+          SDK_VERSION: ${{ steps.versions.outputs.sdk_version }}
+          CODE_PIN: ${{ steps.versions.outputs.code_pin }}
+        run: echo "::notice::Code SDK pin $CODE_PIN is not behind the workspace SDK version $SDK_VERSION; nothing to do."
 
       - name: Skip if PR already open for this version
         id: existing


### PR DESCRIPTION
The `bump_code_sdk_pin.yml` workflow now adds a run annotation when the Code pin is current. Example: "Nothing to do: Code SDK pin 0.7.5 is not behind the workspace SDK version 0.7.5." Before this change, the workflow wrote only a line in the step log.

---

See https://github.com/langchain-ai/deepagents/actions/runs/31730874462 for an example of the problem. On that run, the run summary page did not show the result. It was necessary to open the job log to see why the workflow did not open a PR. The workflow already adds annotations for its other results (`::notice::` for "PR already exists" and "Opened PR"). This change makes the skip path do the same.
