### PR TITLE
feat(evals): link the PR at the top of the failure-analysis summary

### DIFF
--- a/.github/scripts/evals/analyze_eval_failures.py
+++ b/.github/scripts/evals/analyze_eval_failures.py
@@ -84,6 +84,11 @@ def _format_markdown(results: list[dict[str, str]]) -> str:
     """
     lines = [
         f"## Failure analysis ({len(results)} failure{'s' if len(results) != 1 else ''})\n",
+    ]
+    pr_url = os.environ.get("EVAL_PR_URL", "")
+    if pr_url:
+        lines.append(f"**PR:** {pr_url}\n")
+    lines += [
         "<details>",
         "<summary>(click to expand)</summary>",
         "",

--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -363,6 +363,8 @@ jobs:
         continue-on-error: true
         env:
           ANALYSIS_MODEL: ${{ inputs.analysis_model }}
+          # Empty for workflow_dispatch runs, so no PR line is added there.
+          EVAL_PR_URL: ${{ github.event.pull_request.html_url }}
           ANTHROPIC_API_KEY: ${{ startsWith(inputs.analysis_model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
           BASETEN_API_KEY: ${{ startsWith(inputs.analysis_model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
           FIREWORKS_API_KEY: ${{ startsWith(inputs.analysis_model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}

--- a/libs/evals/tests/unit_tests/test_analyze_eval_failures.py
+++ b/libs/evals/tests/unit_tests/test_analyze_eval_failures.py
@@ -73,6 +73,28 @@ class TestFormatMarkdown:
         close_idx = md.index("</details>")
         assert heading_idx < details_idx < summary_idx < close_idx
 
+    def test_pr_url_shown_when_set(self, monkeypatch):
+        monkeypatch.setenv("EVAL_PR_URL", "https://github.com/langchain-ai/deepagents/pull/123")
+        results = [{**_SAMPLE_FAILURE, "analysis": "analysis"}]
+        md = _format_markdown(results)
+        # PR link renders above the details toggle, directly under the heading.
+        heading_idx = md.index("## Failure analysis")
+        pr_idx = md.index("**PR:** https://github.com/langchain-ai/deepagents/pull/123")
+        details_idx = md.index("<details>")
+        assert heading_idx < pr_idx < details_idx
+
+    def test_pr_url_omitted_when_unset(self, monkeypatch):
+        monkeypatch.delenv("EVAL_PR_URL", raising=False)
+        results = [{**_SAMPLE_FAILURE, "analysis": "analysis"}]
+        md = _format_markdown(results)
+        assert "**PR:**" not in md
+
+    def test_pr_url_omitted_when_empty(self, monkeypatch):
+        monkeypatch.setenv("EVAL_PR_URL", "")
+        results = [{**_SAMPLE_FAILURE, "analysis": "analysis"}]
+        md = _format_markdown(results)
+        assert "**PR:**" not in md
+
 
 class TestAnalyzeOne:
     async def test_returns_analysis(self):


### PR DESCRIPTION
The LLM failure-analysis block in the eval job summary now shows a link to the triggering pull request directly under the "Failure analysis" heading, when the run was triggered by a pull request.

---

The failure-analysis section previously had no reference to the PR that triggered the run, so correlating results back to a pull request meant matching run times manually.

The workflow passes `github.event.pull_request.html_url` to the script as `EVAL_PR_URL`. For `workflow_dispatch` runs (the usual way evals are launched) that context property is empty, so the script omits the line and those summaries are unchanged.
