### PR TITLE
ci(infra): backtick package name and tabulate minimums PR body

### DIFF
--- a/.github/scripts/checks/raise_langchain_minimums.py
+++ b/.github/scripts/checks/raise_langchain_minimums.py
@@ -549,11 +549,11 @@ def stale_lock_dirs(changed_manifests: Collection[str]) -> list[str]:
 
 
 def edits_markdown(edits: Sequence[RequirementEdit], *, heading: str) -> str:
-    """Render applied edits as a Markdown bullet list for the PR body/summary."""
-    lines = [heading, ""]
+    """Render applied edits as a Markdown table for the PR body/summary."""
+    lines = [heading, "", "| Manifest | Dependency | Change |", "|---|---|---|"]
     lines.extend(
-        f"- `{edit.manifest_path}`: `{edit.dependency_name}` "
-        f"`{edit.old_requirement}` → `{edit.new_requirement}`"
+        f"| `{edit.manifest_path}` | `{edit.dependency_name}` | "
+        f"`{edit.old_requirement}` → `{edit.new_requirement}` |"
         for edit in edits
     )
     return "\n".join(lines)

--- a/.github/scripts/tests/checks/test_raise_langchain_minimums.py
+++ b/.github/scripts/tests/checks/test_raise_langchain_minimums.py
@@ -344,7 +344,7 @@ class TestInScope:
 
 
 class TestEditsMarkdown:
-    def test_renders_one_bullet_per_edit(self) -> None:
+    def test_renders_one_table_row_per_edit(self) -> None:
         edit = raise_langchain_minimums.RequirementEdit(
             manifest_path="libs/code/pyproject.toml",
             dependency_name="langsmith",
@@ -355,8 +355,10 @@ class TestEditsMarkdown:
         assert edits_markdown([edit], heading="Raised 1 minimum(s):") == (
             "Raised 1 minimum(s):\n"
             "\n"
-            "- `libs/code/pyproject.toml`: `langsmith` "
-            "`langsmith>=0.1.0` → `langsmith>=0.4.0`"
+            "| Manifest | Dependency | Change |\n"
+            "|---|---|---|\n"
+            "| `libs/code/pyproject.toml` | `langsmith` | "
+            "`langsmith>=0.1.0` → `langsmith>=0.4.0` |"
         )
 
 

--- a/.github/workflows/raise_langchain_minimums.yml
+++ b/.github/workflows/raise_langchain_minimums.yml
@@ -262,7 +262,7 @@ jobs:
             lockfiles+=("$dir/uv.lock")
           done
           git add -- "${files[@]}" "${lockfiles[@]}"
-          git commit -m "chore(deps): raise dependency minimums for $PACKAGE"
+          git commit -m "chore(deps): raise dependency minimums for \`$PACKAGE\`"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH:$BRANCH"
 
           body_file="$(mktemp)"
@@ -275,7 +275,7 @@ jobs:
           pr_url=$(gh pr create \
             --head "$BRANCH" \
             --base "$DEFAULT_BRANCH" \
-            --title "chore(deps): raise dependency minimums for $PACKAGE" \
+            --title "chore(deps): raise dependency minimums for \`$PACKAGE\`" \
             --body-file "$body_file")
           echo "Opened dependency minimums PR: $pr_url"
           echo "::notice::Opened dependency minimums PR: $pr_url"


### PR DESCRIPTION
PRs opened by `raise_langchain_minimums.yml` get titles like ``chore(deps): raise dependency minimums for `deepagents-code` `` instead of the package name in plain text, and the list of raised bounds in the body becomes a Manifest / Dependency / Change table instead of bullets.

---

Two readability fixes to the automated dependency-minimums PRs, e.g. #5481:

- The package name in the title (and the workflow's commit message) was the only identifier not wrapped in backticks — the PR body, workflow comments, and our title conventions all put named entities in backticks. The title now reads ``... for `deepagents-code` ``.
- With several raised bounds in one run, the bullet format buried the actual old → new specifier change at the end of a long line led by the manifest path. Rendered as a table:

  | Manifest | Dependency | Change |
  |---|---|---|
  | `libs/code/pyproject.toml` | `langchain` | `langchain>=1.3.14,<2.0.0` → `langchain>=1.3.15,<2.0.0` |
  | `libs/code/pyproject.toml` | `langsmith` | `langsmith[sandbox]>=0.10.10` → `langsmith[sandbox]>=0.10.18` |

The title change is cosmetic only — `chore(deps):` parsing by release-please and the PR title lint are unaffected. #5481's title was already edited in place; the table format applies to the next scheduled run.
