### PR TITLE
fix(code): clarify dependency warning prompt

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3469,13 +3469,14 @@ def prompt_for_dep_floor_mismatch(
         console.print(f"  - {escape(v.describe())}", highlight=False)
     refresh = refresh_command()
     console.print(
-        f"Refresh the active environment:\n  {escape(refresh)}", highlight=False
+        f"\nRefresh the active environment:\n  {escape(refresh)}", highlight=False
     )
     console.print(
-        "[yellow]Running stale source against older dependencies can break "
+        "[yellow]\nRunning stale source against older dependencies can break "
         "behavior in hard-to-diagnose ways.[/yellow]",
         highlight=False,
     )
+    console.print()
     return _select_trust_action(
         console,
         remember_label="Mute until the mismatch changes",

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3479,7 +3479,7 @@ def prompt_for_dep_floor_mismatch(
     console.print()
     return _select_trust_action(
         console,
-        remember_label="Mute until the mismatch changes",
+        remember_label="Continue and hide until versions change",
         allow_label="Continue this session only",
         deny_label="Abort launch",
         deny_first=True,

--- a/libs/code/tests/unit_tests/test_dep_floor_check.py
+++ b/libs/code/tests/unit_tests/test_dep_floor_check.py
@@ -687,6 +687,27 @@ def test_dep_floor_prompt_escapes_dynamic_rich_markup(
     assert "/tmp/[bold]" in text
 
 
+def test_dep_floor_prompt_separates_guidance_and_actions(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The remediation, risk warning, and chooser each start after a blank line."""
+    from rich.console import Console
+
+    monkeypatch.setattr(dep_floor_check, "refresh_command", lambda: "uv sync")
+    monkeypatch.setattr(
+        main_module,
+        "_select_trust_action",
+        lambda *_args, **_kwargs: _TrustAction.ALLOW_ONCE,
+    )
+
+    main_module.prompt_for_dep_floor_mismatch(Console(stderr=True), _VIOLATIONS)
+
+    text = capsys.readouterr().err
+    assert "\n\nRefresh the active environment:" in text
+    assert "  uv sync\n\nRunning stale source" in text
+    assert "hard-to-diagnose ways.\n\n" in text
+
+
 def _patch_versions(monkeypatch: pytest.MonkeyPatch, versions: dict[str, str]) -> None:
     """Resolve `importlib.metadata.version` lookups from `versions` only."""
 

--- a/libs/code/tests/unit_tests/test_dep_floor_check.py
+++ b/libs/code/tests/unit_tests/test_dep_floor_check.py
@@ -693,12 +693,14 @@ def test_dep_floor_prompt_separates_guidance_and_actions(
     """The remediation, risk warning, and chooser each start after a blank line."""
     from rich.console import Console
 
+    picker: dict[str, object] = {}
+
+    def _select(*_args: object, **kwargs: object) -> _TrustAction:
+        picker.update(kwargs)
+        return _TrustAction.ALLOW_ONCE
+
     monkeypatch.setattr(dep_floor_check, "refresh_command", lambda: "uv sync")
-    monkeypatch.setattr(
-        main_module,
-        "_select_trust_action",
-        lambda *_args, **_kwargs: _TrustAction.ALLOW_ONCE,
-    )
+    monkeypatch.setattr(main_module, "_select_trust_action", _select)
 
     main_module.prompt_for_dep_floor_mismatch(Console(stderr=True), _VIOLATIONS)
 
@@ -706,6 +708,7 @@ def test_dep_floor_prompt_separates_guidance_and_actions(
     assert "\n\nRefresh the active environment:" in text
     assert "  uv sync\n\nRunning stale source" in text
     assert "hard-to-diagnose ways.\n\n" in text
+    assert picker["remember_label"] == "Continue and hide until versions change"
 
 
 def _patch_versions(monkeypatch: pytest.MonkeyPatch, versions: dict[str, str]) -> None:


### PR DESCRIPTION
Dependency-floor mismatch prompts now separate guidance and actions with blank lines and clearly label the persistent choice as “Continue and hide until versions change.”

---

The previous screen was visually dense, and “mute” did not explain that suppression ends when the stale versions change. Regression coverage pins both the spacing and approved label.

Made by [Open SWE](https://openswe.vercel.app/agents/a44e5aca-7dfa-c63d-bba8-19b1d4c3365c)