### PR TITLE
chore(ci): collapse draft instructions into a details toggle

### DIFF
--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -359,6 +359,16 @@ function latestApplied({ comments, login, id, component, version }) {
 // limit keeps both readable. Applies to instructions only, not the command.
 const INSTRUCTIONS_MAX_LENGTH = 500;
 
+// Escape HTML metacharacters in the instructions echo so the <details>
+// wrapper cannot be broken by instruction text that mentions HTML.
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 // Tokens that must never reach the override comment via the instructions echo.
 // parseOverrideComment locates the curated section by scanning for the first
 // CONTENT_START/CONTENT_END, and validateDraftOutput rejects MARKER_PREFIX and
@@ -434,9 +444,10 @@ function overrideBody({ component, version, head, headingHash, fingerprint, sect
     `Review and edit the release notes between the content markers below as needed. Keep the version heading intact. To regenerate with steering instead of editing by hand, run \`${COMMAND_MENTION} draft <instructions>\`.`,
     // Echo the maintainer's draft instructions so the prompt that produced this
     // draft is auditable on the PR, and so a later draft with different
-    // instructions produces a visibly distinct comment.
+    // instructions produces a visibly distinct comment. Escape HTML so the
+    // instructions cannot break the <details> wrapper or inject markup.
     ...(instructions
-        ? ['', '<details>', '<summary>📝 <strong>Drafted with maintainer instructions</strong></summary>', '', instructions, '</details>']
+        ? ['', '<details>', '<summary>📝 <strong>Drafted with maintainer instructions</strong></summary>', '', escapeHtml(instructions), '</details>']
         : []),
     '',
     '---',

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -435,7 +435,9 @@ function overrideBody({ component, version, head, headingHash, fingerprint, sect
     // Echo the maintainer's draft instructions so the prompt that produced this
     // draft is auditable on the PR, and so a later draft with different
     // instructions produces a visibly distinct comment.
-    ...(instructions ? ['', `Drafted with maintainer instructions: ${instructions}`] : []),
+    ...(instructions
+        ? ['', '<details>', '<summary>📝 <strong>Drafted with maintainer instructions</strong></summary>', '', instructions, '</details>']
+        : []),
     '',
     '---',
     CONTENT_START,

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -575,6 +575,25 @@ test('posts a draft that echoes the maintainer instructions it used', async t =>
   assert.ok(body.indexOf('Drafted with maintainer instructions') < body.indexOf('release-notes-content-start'));
 });
 
+test('escapes HTML in echoed instructions so the details toggle cannot be broken', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-notes-post-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const state = path.join(dir, 'state.json');
+  const output = path.join(dir, 'output.md');
+  fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING, instructions: 'describe the section after </details> and <details open>' }));
+  fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
+  const { github, calls } = makeGithub();
+  await releaseNotes.postDraft({ github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH });
+  assert.equal(calls.createComment.length, 1);
+  const body = calls.createComment[0].body;
+  // Raw closing/opening tags must not appear inside the details block.
+  assert.match(body, /&lt;\/details&gt;/);
+  assert.match(body, /&lt;details open&gt;/);
+  // Only one real <details> and one real </details> should exist.
+  assert.equal(body.split('<details>').length - 1, 1);
+  assert.equal(body.split('</details>').length - 1, 1);
+});
+
 test('prepare apply replaces only the changelog section and records immutable hashes', async t => {
   const workspace = tempWorkspace();
   t.after(() => fs.rmSync(workspace.root, { recursive: true, force: true }));

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -548,7 +548,7 @@ test('posts a bot-authored draft and refuses stale agent output', async t => {
   assert.match(calls.createComment[0].body, /Keep the version heading intact\. To regenerate with steering/);
   assert.match(calls.createComment[0].body, /@release-bot draft <instructions>/);
   // No instructions were recorded in state, so nothing is echoed.
-  assert.ok(!calls.createComment[0].body.includes('Drafted with maintainer instructions'));
+  assert.ok(!calls.createComment[0].body.includes('<details>'));
 
   const stale = makeGithub({ pr: releasePr({ head: { ...releasePr().head, sha: 'c'.repeat(40) } }) });
   await assert.rejects(
@@ -567,7 +567,7 @@ test('posts a draft that echoes the maintainer instructions it used', async t =>
   const { github, calls } = makeGithub();
   await releaseNotes.postDraft({ github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH });
   assert.equal(calls.createComment.length, 1);
-  assert.match(calls.createComment[0].body, /Drafted with maintainer instructions: emphasize the breaking SDK change/);
+  assert.match(calls.createComment[0].body, /<details>\n<summary>📝 <strong>Drafted with maintainer instructions<\/strong><\/summary>\n\nemphasize the breaking SDK change\n<\/details>/);
   // The echo sits outside the marked metadata block and the editable content
   // markers, so it cannot corrupt either parser.
   const body = calls.createComment[0].body;


### PR DESCRIPTION
The maintainer-instructions echo that `@release-bot draft` appends to its draft comment now renders inside a collapsed `<details>` block, with a 📝 emoji and bold summary line. This keeps the draft comment cleaner while still making the steering text auditable on the PR.

---

The draft comment previously ended with a plain `Drafted with maintainer instructions: ...` line, which could be long and visually noisy. Wrapping it in a toggle preserves the audit trail without cluttering the comment body.