### PR TITLE
fix(code): thread `session_id` through forced-compaction fork

### DIFF
--- a/libs/code/deepagents_code/offload_middleware.py
+++ b/libs/code/deepagents_code/offload_middleware.py
@@ -705,17 +705,20 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
             if cutoff == 0:
                 return self._nothing_to_compact(tool_call_id)
 
+            session_id = summarization._get_session_id(runtime.state)
             to_summarize, _ = summarization._partition_messages(effective, cutoff)
             summary = summarization._create_summary(to_summarize)
             backend = self._guarded_backend()
-            file_path = summarization._offload_to_backend(backend, to_summarize)
+            file_path = summarization._offload_to_backend(
+                backend, to_summarize, session_id
+            )
             # The inherited `_build_compact_result` produces the same event and
             # tool message as the SDK's gated path via model-independent helpers
             # (string formatting + a staticmethod), so the runtime-selected
             # summarizer is not needed to build it. Kept inside the `try` so a
             # failure here still returns a ToolMessage rather than raising.
             return self._build_compact_result(
-                runtime, to_summarize, summary, file_path, event, cutoff
+                runtime, to_summarize, summary, file_path, event, cutoff, session_id
             )
         except Exception as exc:  # tool errors must surface as ToolMessages
             logger.exception("forced compact_conversation failed")
@@ -740,14 +743,17 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
             if cutoff == 0:
                 return self._nothing_to_compact(tool_call_id)
 
+            session_id = summarization._get_session_id(runtime.state)
             to_summarize, _ = summarization._partition_messages(effective, cutoff)
             summary = await summarization._acreate_summary(to_summarize)
             backend = self._guarded_backend()
-            file_path = await summarization._aoffload_to_backend(backend, to_summarize)
+            file_path = await summarization._aoffload_to_backend(
+                backend, to_summarize, session_id
+            )
             # See `_run_forced_compact` for why the inherited builder is reused
             # and why it stays inside the `try`.
             return self._build_compact_result(
-                runtime, to_summarize, summary, file_path, event, cutoff
+                runtime, to_summarize, summary, file_path, event, cutoff, session_id
             )
         except Exception as exc:  # tool errors must surface as ToolMessages
             logger.exception("forced compact_conversation failed")

--- a/libs/code/tests/unit_tests/test_compact_tool.py
+++ b/libs/code/tests/unit_tests/test_compact_tool.py
@@ -537,10 +537,10 @@ class TestCLICompactionMiddleware:
         summarization._filter_summary_messages.side_effect = lambda messages: messages
 
         async def sdk_offload(
-            guarded: BackendProtocol, messages: list[AnyMessage]
+            guarded: BackendProtocol, messages: list[AnyMessage], session_id: str
         ) -> str | None:
             return await SummarizationMiddleware._aoffload_to_backend(
-                summarization, guarded, messages
+                summarization, guarded, messages, session_id
             )
 
         summarization._aoffload_to_backend = AsyncMock(side_effect=sdk_offload)

--- a/libs/code/tests/unit_tests/test_end_to_end.py
+++ b/libs/code/tests/unit_tests/test_end_to_end.py
@@ -241,9 +241,10 @@ class TestDeepAgentsCLIEndToEnd:
             # mode the history prefix lives under the backend's `artifacts_root`
             # (a per-session temp dir), routed to persistent storage.
             assert backend.ls(f"{backend.artifacts_root}/conversation_history/").entries
-            assert (
-                tmp_path / ".deepagents" / "conversation_history" / f"{thread_id}.md"
-            ).exists()
+            history_files = list(
+                (tmp_path / ".deepagents" / "conversation_history").glob("session_*.md")
+            )
+            assert history_files, "expected a session-id-named history file"
 
     def test_cli_agent_with_fake_llm_with_tools(self, tmp_path: Path) -> None:
         """Test CLI agent with tools using a fake LLM model.


### PR DESCRIPTION
Fix `ty` failures in `deepagents-code` after the SDK's `summarization` flow added a required `session_id: str` parameter in #5470 (`fix(sdk): offload conversation history to distinct session ID when summarizing`).

The forced-compaction fork in `offload_middleware` mirrors the SDK's `_run_compact`/`_arun_compact` step sequence, but still called `_offload_to_backend` / `_aoffload_to_backend` / `_build_compact_result` without the new argument, producing 5 `error[missing-argument]` diagnostics under `make -C libs/code lint`. The fork now computes `session_id = summarization._get_session_id(runtime.state)` — placed after the cutoff-0 early return, exactly where the SDK computes it — and threads it through both calls, in sync and async paths alike. A side benefit: repeated `/offload` calls now reuse the persisted `_summarization_session_id`, so history appends to one file per session instead of fragmenting across thread-id-named files.

The `sdk_offload` wrapper in `test_read_failure_never_reaches_truncating_archive_write` gains the matching parameter; the rest of the test file only touches mocks or existence guards, so no other call sites needed updating.

**Release note:** this change must not ship against `deepagents==0.7.5`. It calls private SDK methods with the new `session_id` signature introduced after 0.7.5, so the `deepagents-code` release must wait until the SDK releases (pending `fix(sdk):` commit on `main`) and the pin in `pyproject.toml` is bumped to that version in a separate `chore(deps):` PR.
