### PR TITLE
test(sdk): update history-path assertions for session-id naming

### DIFF
--- a/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
@@ -206,7 +206,7 @@ class TestCompactSuccess:
                 "_partition_messages",
                 side_effect=lambda msgs, idx: (msgs[:idx], msgs[idx:]),
             ),
-            patch.object(mw._summarization, "_offload_to_backend", return_value="/conversation_history/test-thread.md"),
+            patch.object(mw._summarization, "_offload_to_backend", return_value="/conversation_history/session_abc123.md"),
             patch.object(mw._summarization, "_create_summary", return_value="Summary of the conversation."),
         ):
             result = mw._run_compact(runtime)
@@ -220,7 +220,7 @@ class TestCompactSuccess:
         summary_msg = event["summary_message"]
         assert isinstance(summary_msg, HumanMessage)
         assert "Summary of the conversation." in summary_msg.content
-        assert event["file_path"] == "/conversation_history/test-thread.md"
+        assert event["file_path"] == "/conversation_history/session_abc123.md"
 
         update_messages = result.update["messages"]
         assert len(update_messages) == 1
@@ -270,7 +270,7 @@ class TestCompactSuccess:
                 "_partition_messages",
                 side_effect=lambda msgs, idx: (msgs[:idx], msgs[idx:]),
             ),
-            patch.object(mw._summarization, "_aoffload_to_backend", return_value="/conversation_history/test-thread.md"),
+            patch.object(mw._summarization, "_aoffload_to_backend", return_value="/conversation_history/session_abc123.md"),
             patch.object(mw._summarization, "_acreate_summary", return_value="Summary of the conversation."),
         ):
             result = await mw._arun_compact(runtime)


### PR DESCRIPTION
Related #5470

Updates the remaining history-path mocks/assertions in `test_compact_tool.py` to use the session-ID-based naming (`/conversation_history/session_<hex>.md`) introduced in #5470, instead of the old thread-ID-style names (`test-thread.md`, `t.md`).

---

#5470 changed summarization offload to name the history file by an internally generated session ID rather than the thread ID, and updated the assertions in `test_summarization_middleware.py` and `test_end_to_end.py`. The compact-tool tests were left with mocked `_offload_to_backend`/`_aoffload_to_backend` return values in the old thread-ID style. This brings them in line with the new naming so the mocked paths match what the SDK actually writes.
