### PR TITLE
ci(infra): add SDK path filter edge for all editable-install packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
           # NOT in that glob" — causing unrelated files (e.g. .github/
           # templates) to match every filter and trigger full CI.
           # See: https://github.com/dorny/paths-filter/issues/97
+          # Packages that editable-install the SDK (`deepagents = { path = ... }`)
+          # must include 'libs/deepagents/**' so an SDK change runs their tests
+          # too — otherwise a breaking SDK change merges green and only fails
+          # on main, where every job runs unconditionally.
           filters: |
             deepagents:
               - 'libs/deepagents/**'
@@ -84,6 +88,7 @@ jobs:
               - '.github/actions/**'
             code:
               - 'libs/code/**'
+              - 'libs/deepagents/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'
@@ -98,6 +103,7 @@ jobs:
               - '.github/actions/**'
             evals:
               - 'libs/evals/**'
+              - 'libs/deepagents/**'
               # The evals test suite asserts on its own workflow files (e.g.
               # test_harbor_langsmith_integration.py reads harbor.yml and
               # _eval.yml), so editing any eval workflow must run the evals
@@ -122,18 +128,21 @@ jobs:
               - '.github/actions/**'
             daytona:
               - 'libs/partners/daytona/**'
+              - 'libs/deepagents/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'
               - '.github/actions/**'
             modal:
               - 'libs/partners/modal/**'
+              - 'libs/deepagents/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'
               - '.github/actions/**'
             runloop:
               - 'libs/partners/runloop/**'
+              - 'libs/deepagents/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'
@@ -146,6 +155,7 @@ jobs:
               - '.github/actions/**'
             quickjs:
               - 'libs/partners/quickjs/**'
+              - 'libs/deepagents/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
               - '.github/actions/**'
             vercel:
               - 'libs/partners/vercel/**'
+              - 'libs/deepagents/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'


### PR DESCRIPTION
The `code`, `evals`, and all five partner path filters in `ci.yml` were missing `libs/deepagents/**`, so an SDK-only PR could merge green while breaking packages that editable-install the SDK. This happened with #5470: it changed SDK-internal signatures used by `deepagents_code`, but no `code` job ran — the failure only surfaced on `main`.

Adds `libs/deepagents/**` to those filters, matching what `cli`, `acp`, and `talon` already had, plus a comment stating the rule.
