### PR TITLE
ci(infra): tolerate Code SDK pin bump dispatch failures after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1074,10 +1074,15 @@ jobs:
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
           permission-actions: write
 
+      # Post-publish convenience only: the SDK is already live and the GitHub
+      # release is already tagged by the time this runs, and the pin-bump PR
+      # can always be opened by dispatching bump_code_sdk_pin.yml manually.
+      # Never let a dispatch hiccup mark the release run failed.
       - name: Dispatch bump_code_sdk_pin.yml
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          gh workflow run bump_code_sdk_pin.yml --ref main
+          gh workflow run bump_code_sdk_pin.yml --ref main --repo langchain-ai/deepagents
           echo "::notice::Dispatched bump_code_sdk_pin.yml after publishing deepagents==${SDK_VERSION}."


### PR DESCRIPTION
A release run no longer fails when the post-publish Code SDK pin bump dispatch does.

---

The `bump-code-sdk-pin` job runs after PyPI publish and the GitHub release tag have both succeeded, so by that point the release has already shipped. The pin-bump PR it kicks off is a convenience that can always be opened by dispatching `bump_code_sdk_pin.yml` manually, so a dispatch hiccup should never mark an otherwise-successful release run failed — as happened on the [0.7.6 run](https://github.com/langchain-ai/deepagents/actions/runs/31741867100/job/94587711541).

Marks the dispatch step `continue-on-error: true` and records why in a comment.
