### PR TITLE
ci(infra): pass `--repo` to pin-bump dispatch so it works without checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1079,5 +1079,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          gh workflow run bump_code_sdk_pin.yml --ref main
+          # `-R` is required: this job skips checkout (it only needs the API),
+          # and without a repo flag `gh` shells out to `git` to discover the
+          # repository, which fails with "fatal: not a git repository".
+          gh workflow run bump_code_sdk_pin.yml --repo "${GITHUB_REPOSITORY}" --ref main
           echo "::notice::Dispatched bump_code_sdk_pin.yml after publishing deepagents==${SDK_VERSION}."


### PR DESCRIPTION
The `deepagents` release pipeline now passes `--repo "${GITHUB_REPOSITORY}"` when dispatching `bump_code_sdk_pin.yml`, so the final release job no longer fails after a successful publish.

---

The `bump-code-sdk-pin` job in `release.yml` deliberately skips `actions/checkout` — it only needs the GitHub API. But `gh workflow run` was invoked without `-R/--repo`, so `gh` fell back to resolving the repository by shelling out to `git`, which fails in a workspace with no checkout:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This made the last job of the `deepagents` 0.7.6 release ([run 31741867100](https://github.com/langchain-ai/deepagents/actions/runs/31741867100)) report a failure even though the package had already published to PyPI and the GitHub release was tagged. The pin-bump dispatch never fired, so the `chore(deps):` pin PR for 0.7.6 was never opened.

The fix passes `--repo "${GITHUB_REPOSITORY}"` explicitly, which resolves to the repo running the workflow. A comment records why the flag is there so a future cleanup doesn't "simplify" it away.