### PR TITLE
fix(sdk): normalize host paths inside `root_dir` in virtual mode

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -201,6 +201,24 @@ class FilesystemBackend(BackendProtocol):
             OSError: If the path is a symlink loop (`ELOOP`).
         """
         if self.virtual_mode:
+            # When an agent passes a host absolute path that actually lives
+            # inside ``root_dir`` (e.g. the output of ``execute("pwd")``),
+            # normalize it to the corresponding virtual path instead of
+            # treating it as a virtual sub-path and creating a nested
+            # duplicate directory tree (#5469).
+            if key.startswith("/"):
+                try:
+                    candidate = Path(key).resolve()
+                    candidate.relative_to(self.cwd)
+                    # The host path is inside root_dir — re-anchor it as a
+                    # virtual path and fall through to the normal virtual
+                    # resolution below.
+                    key = "/" + str(candidate.relative_to(self.cwd))
+                    if key == "/":
+                        key = "/"
+                except (ValueError, OSError):
+                    pass  # Outside root_dir — let normal virtual handling reject it
+
             vpath = key if key.startswith("/") else "/" + key
             if ".." in vpath or vpath.startswith("~"):
                 msg = "Path traversal not allowed"

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -320,7 +320,54 @@ class TestLocalShellVirtualModeDefault:
 
         deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning) and "virtual_mode" in str(w.message)]
         assert deprecations == []
-        assert be.virtual_mode is True
+
+
+def test_virtual_mode_host_path_normalization(tmp_path: Path) -> None:
+    """A host absolute path pointing inside ``root_dir`` is normalized to its
+    virtual equivalent instead of being nested under ``root_dir`` (#5469).
+
+    When ``execute("pwd")`` returns the host working directory, an agent may
+    pass that host path to ``write()`` thinking it is a virtual path.  Without
+    normalization, ``_resolve_path`` treats the host path as a virtual
+    sub-path and creates a nested duplicate directory tree inside ``root_dir``.
+    """
+    backend = LocalShellBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    # Simulate what an agent does: get the host pwd, then write to it
+    result = backend.execute("pwd")
+    host_pwd = result.output.strip()
+
+    # Write using the host absolute path
+    write_result = backend.write(f"{host_pwd}/fib.py", "print('hello')")
+    assert write_result.error is None
+
+    # The file must land at root_dir/fib.py, not root_dir/<host_pwd>/fib.py
+    assert (tmp_path / "fib.py").exists()
+    nested = tmp_path / host_pwd.lstrip("/") / "fib.py"
+    assert not nested.exists(), f"file was nested under root_dir: {nested}"
+
+
+def test_virtual_mode_host_path_read(tmp_path: Path) -> None:
+    """Reading via a host absolute path inside ``root_dir`` resolves to the
+    correct virtual file (#5469).
+    """
+    backend = LocalShellBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    # Write a file at the virtual path
+    backend.write("/data.txt", "hello world")
+
+    # Get the host pwd and read using the host absolute path
+    result = backend.execute("pwd")
+    host_pwd = result.output.strip()
+
+    read_result = backend.read(f"{host_pwd}/data.txt")
+    assert read_result.error is None
+    assert read_result.file_data is not None
+    assert "hello world" in read_result.file_data["content"]
+
+
+class TestLocalShellVirtualModeExplicit:
+    """Explicit ``virtual_mode`` values do not warn."""
 
     def test_explicit_virtual_mode_does_not_warn(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir, warnings.catch_warnings(record=True) as captured:


### PR DESCRIPTION
Closes #5469

`LocalShellBackend(virtual_mode=True)` normalizes host absolute paths inside `root_dir` to their virtual equivalent, preventing a nested duplicate directory tree when an agent passes shell output (e.g. `execute("pwd")`) back to file operations.

---

When `execute("pwd")` returns the host working directory, an agent may pass that host path to `write()` or `read()` thinking it is a virtual path. `_resolve_path` in virtual mode treated the host path as a virtual sub-path, creating a nested duplicate directory tree inside `root_dir` — the file appeared to write successfully but was invisible at the expected virtual location.

The fix checks whether an incoming absolute path resolves inside `root_dir` and, if so, re-anchors it as a virtual path before the normal virtual-mode resolution. Paths outside `root_dir` are rejected as before.

<details>
<summary>Test plan</summary>

- Two new regression tests in `test_local_shell_backend.py`:
  - `test_virtual_mode_host_path_normalization` — writes via a host `pwd` path, asserts the file lands at `root_dir/fib.py` (not nested)
  - `test_virtual_mode_host_path_read` — reads via a host `pwd` path, asserts the correct content is returned
- RED→GREEN proof: with the fix reverted (stashed), both tests fail (file nested / file not found). With the fix applied, both pass.
- Full backend test suite: 852 passed, 2 xfailed, 0 failed.
- Full unit test suite: 2473 passed, 101 skipped, 4 xfailed, 0 failed.

</details>
