### PR TITLE
fix(code): condition relative timestamp toggle

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/thread_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/thread_selector.py
@@ -1103,7 +1103,14 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
     def _sync_relative_time_visibility(self) -> None:
         """Show relative-time controls only when a timestamp column is visible."""
         relative_switch = self.query_one(f"#{_RELATIVE_TIME_SWITCH_ID}", Checkbox)
-        relative_switch.display = self._timestamp_columns_visible()
+        visible = self._timestamp_columns_visible()
+        if visible:
+            # Reassert the value before un-hiding so the checkbox's rendered
+            # check state and its visibility paint in the same frame; Textual
+            # skips refresh of display:none widgets, so without this the first
+            # visible frame can show a stale unchecked box.
+            relative_switch.value = self._relative_time
+        relative_switch.display = visible
 
     def _collect_agent_options(self) -> list[tuple[str, str]]:
         """Return Select option tuples for the agent dropdown.

--- a/libs/code/deepagents_code/tui/widgets/thread_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/thread_selector.py
@@ -1071,26 +1071,39 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         return self._filter_input
 
     def _filter_focus_order(self) -> list[Input | Checkbox | Select[str]]:
-        """Return the cached tab order for filter controls in the side panel."""
+        """Return the cached tab order for visible side-panel controls."""
         if self._filter_controls is None:
             filter_input = self._get_filter_input()
             scope_select = self.query_one(f"#{_SCOPE_SELECT_ID}", Select)
             sort_select = self.query_one(f"#{_SORT_SELECT_ID}", Select)
             agent_select = self.query_one(f"#{_AGENT_SELECT_ID}", Select)
             relative_switch = self.query_one(f"#{_RELATIVE_TIME_SWITCH_ID}", Checkbox)
-            column_switches = [
-                self.query_one(f"#{self._switch_id(key)}", Checkbox)
-                for key in _COLUMN_ORDER
-            ]
+            column_switches: list[Checkbox] = []
+            for key in _COLUMN_ORDER:
+                column_switches.append(
+                    self.query_one(f"#{self._switch_id(key)}", Checkbox)
+                )
+                if key == "updated_at":
+                    column_switches.append(relative_switch)
             self._filter_controls = [
                 filter_input,
                 scope_select,
                 sort_select,
                 agent_select,
-                relative_switch,
                 *column_switches,
             ]
-        return self._filter_controls
+        return [control for control in self._filter_controls if control.display]
+
+    def _timestamp_columns_visible(self) -> bool:
+        """Return whether any timestamp column is visible."""
+        return self._columns.get("created_at", False) or self._columns.get(
+            "updated_at", False
+        )
+
+    def _sync_relative_time_visibility(self) -> None:
+        """Show relative-time controls only when a timestamp column is visible."""
+        relative_switch = self.query_one(f"#{_RELATIVE_TIME_SWITCH_ID}", Checkbox)
+        relative_switch.display = self._timestamp_columns_visible()
 
     def _collect_agent_options(self) -> list[tuple[str, str]]:
         """Return Select option tuples for the agent dropdown.
@@ -1354,13 +1367,6 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                     with ThreadControlsScroll(
                         id=_CONTROLS_SCROLL_ID, classes="thread-controls-scroll"
                     ):
-                        yield Checkbox(
-                            "Relative Timestamps",
-                            self._relative_time,
-                            id=_RELATIVE_TIME_SWITCH_ID,
-                            classes="thread-column-toggle",
-                            compact=True,
-                        )
                         for key in _COLUMN_ORDER:
                             yield Checkbox(
                                 _COLUMN_TOGGLE_LABELS[key],
@@ -1369,6 +1375,18 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                                 classes="thread-column-toggle",
                                 compact=True,
                             )
+                            if key == "updated_at":
+                                relative_switch = Checkbox(
+                                    "Relative Timestamps",
+                                    self._relative_time,
+                                    id=_RELATIVE_TIME_SWITCH_ID,
+                                    classes="thread-column-toggle",
+                                    compact=True,
+                                )
+                                relative_switch.display = (
+                                    self._timestamp_columns_visible()
+                                )
+                                yield relative_switch
                     yield Static(
                         get_glyphs().ellipsis,
                         id=_CONTROLS_OVERFLOW_ID,
@@ -1512,6 +1530,8 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             return
 
         self._columns[column_key] = event.value
+        if column_key in {"created_at", "updated_at"}:
+            self._sync_relative_time_visibility()
         self._apply_sort()
         self._sync_selected_index()
         self._update_help_widgets()

--- a/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
@@ -613,54 +613,33 @@ class TestThreadSelectorTabSort:
                 assert isinstance(screen, ThreadSelectorScreen)
 
                 filter_input = screen.query_one("#thread-filter", Input)
-                scope_select = screen.query_one("#thread-scope-select", Select)
-                sort_select = screen.query_one("#thread-sort-select", Select)
-                thread_id_switch = screen.query_one(
-                    f"#{ThreadSelectorScreen._switch_id('thread_id')}",
-                    Checkbox,
-                )
-                agent_name_switch = screen.query_one(
-                    f"#{ThreadSelectorScreen._switch_id('agent_name')}",
-                    Checkbox,
-                )
-                messages_switch = screen.query_one(
-                    f"#{ThreadSelectorScreen._switch_id('messages')}",
-                    Checkbox,
-                )
-
-                agent_select = screen.query_one("#thread-agent-select", Select)
+                expected_controls = [
+                    screen.query_one("#thread-scope-select", Select),
+                    screen.query_one("#thread-sort-select", Select),
+                    screen.query_one("#thread-agent-select", Select),
+                    screen.query_one(
+                        f"#{ThreadSelectorScreen._switch_id('thread_id')}", Checkbox
+                    ),
+                    screen.query_one(
+                        f"#{ThreadSelectorScreen._switch_id('agent_name')}", Checkbox
+                    ),
+                    screen.query_one(
+                        f"#{ThreadSelectorScreen._switch_id('messages')}", Checkbox
+                    ),
+                    screen.query_one(
+                        f"#{ThreadSelectorScreen._switch_id('created_at')}", Checkbox
+                    ),
+                    screen.query_one(
+                        f"#{ThreadSelectorScreen._switch_id('updated_at')}", Checkbox
+                    ),
+                    screen.query_one("#thread-relative-time", Checkbox),
+                ]
                 assert filter_input.has_focus
 
-                screen.action_focus_next_filter()
-                await pilot.pause()
-                assert scope_select.has_focus
-
-                screen.action_focus_next_filter()
-                await pilot.pause()
-                assert sort_select.has_focus
-
-                screen.action_focus_next_filter()
-                await pilot.pause()
-                assert agent_select.has_focus
-
-                relative_time_switch = screen.query_one(
-                    "#thread-relative-time", Checkbox
-                )
-                screen.action_focus_next_filter()
-                await pilot.pause()
-                assert relative_time_switch.has_focus
-
-                screen.action_focus_next_filter()
-                await pilot.pause()
-                assert thread_id_switch.has_focus
-
-                screen.action_focus_next_filter()
-                await pilot.pause()
-                assert agent_name_switch.has_focus
-
-                screen.action_focus_next_filter()
-                await pilot.pause()
-                assert messages_switch.has_focus
+                for control in expected_controls:
+                    screen.action_focus_next_filter()
+                    await pilot.pause()
+                    assert control.has_focus
 
     async def test_shift_tab_moves_focus_backward_through_controls(self) -> None:
         """Shift+Tab should move focus backward through the controls."""
@@ -820,10 +799,7 @@ class TestThreadSelectorTabSort:
                 relative_switch = screen.query_one("#thread-relative-time", Checkbox)
                 filter_input = screen.query_one("#thread-filter", Input)
 
-                await pilot.press("tab")
-                await pilot.press("tab")
-                await pilot.press("tab")
-                await pilot.press("tab")
+                relative_switch.focus()
                 await pilot.pause()
                 assert relative_switch.has_focus
 
@@ -847,10 +823,7 @@ class TestThreadSelectorTabSort:
                 filter_input = screen.query_one("#thread-filter", Input)
                 relative_switch = screen.query_one("#thread-relative-time", Checkbox)
 
-                await pilot.press("tab")
-                await pilot.press("tab")
-                await pilot.press("tab")
-                await pilot.press("tab")
+                relative_switch.focus()
                 await pilot.pause()
                 assert relative_switch.has_focus
 
@@ -877,10 +850,7 @@ class TestThreadSelectorTabSort:
                 filter_input = screen.query_one("#thread-filter", Input)
                 relative_switch = screen.query_one("#thread-relative-time", Checkbox)
 
-                await pilot.press("tab")
-                await pilot.press("tab")
-                await pilot.press("tab")
-                await pilot.press("tab")
+                relative_switch.focus()
                 await pilot.pause()
                 assert relative_switch.has_focus
 
@@ -909,10 +879,7 @@ class TestThreadSelectorTabSort:
                 filter_input = screen.query_one("#thread-filter", Input)
                 relative_switch = screen.query_one("#thread-relative-time", Checkbox)
 
-                await pilot.press("tab")
-                await pilot.press("tab")
-                await pilot.press("tab")
-                await pilot.press("tab")
+                relative_switch.focus()
                 await pilot.pause()
                 assert relative_switch.has_focus
                 assert relative_switch.value is True
@@ -2928,6 +2895,81 @@ class TestThreadSelectorColumnConfig:
         with _patch_columns():
             screen = ThreadSelectorScreen(current_thread=None)
         assert screen._columns == THREAD_COLUMN_DEFAULTS
+
+    async def test_relative_time_follows_timestamp_columns(self) -> None:
+        """Relative timestamps should appear after both timestamp columns."""
+        with _patch_list_threads(), _patch_columns():
+            app = ThreadSelectorTestApp()
+            async with app.run_test() as pilot:
+                app.show_selector()
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+                toggle_ids = [
+                    toggle.id
+                    for toggle in screen.query(".thread-column-toggle").results(
+                        Checkbox
+                    )
+                ]
+
+                created_id = screen._switch_id("created_at")
+                updated_id = screen._switch_id("updated_at")
+                relative_index = toggle_ids.index("thread-relative-time")
+                assert toggle_ids[relative_index - 2 : relative_index] == [
+                    created_id,
+                    updated_id,
+                ]
+
+    async def test_relative_time_visibility_tracks_timestamp_columns(self) -> None:
+        """Relative timestamps should hide unless a timestamp column is enabled."""
+        from deepagents_code.model_config import THREAD_COLUMN_DEFAULTS
+
+        columns = {
+            **THREAD_COLUMN_DEFAULTS,
+            "created_at": False,
+            "updated_at": False,
+        }
+        with (
+            _patch_list_threads(),
+            _patch_columns(columns),
+            patch(
+                "deepagents_code.model_config.save_thread_columns",
+                return_value=True,
+            ),
+        ):
+            app = ThreadSelectorTestApp()
+            async with app.run_test() as pilot:
+                app.show_selector()
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+                created_switch = screen.query_one(
+                    f"#{screen._switch_id('created_at')}", Checkbox
+                )
+                updated_switch = screen.query_one(
+                    f"#{screen._switch_id('updated_at')}", Checkbox
+                )
+                relative_switch = screen.query_one("#thread-relative-time", Checkbox)
+
+                assert relative_switch.display is False
+                assert relative_switch not in screen._filter_focus_order()
+
+                created_switch.value = True
+                await pilot.pause()
+                assert relative_switch.display is True
+                assert relative_switch in screen._filter_focus_order()
+
+                updated_switch.value = True
+                created_switch.value = False
+                await pilot.pause()
+                assert relative_switch.display is True
+
+                updated_switch.value = False
+                await pilot.pause()
+                assert relative_switch.display is False
+                assert relative_switch not in screen._filter_focus_order()
 
     async def test_switch_toggles_column_and_persists(self) -> None:
         """Clicking a column switch should hide the column and save the choice."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
@@ -2960,6 +2960,10 @@ class TestThreadSelectorColumnConfig:
                 await pilot.pause()
                 assert relative_switch.display is True
                 assert relative_switch in screen._filter_focus_order()
+                # Value must be reasserted when un-hidden so the first visible
+                # frame renders the persisted check state, not a stale box.
+                assert relative_switch.value is True
+                assert relative_switch.value == screen._relative_time
 
                 updated_switch.value = True
                 created_switch.value = False


### PR DESCRIPTION
Relative timestamp controls now appear after Created At and Updated At, and only when at least one timestamp column is visible.

---

Keeps the formatting option adjacent to the columns it affects and removes a no-op control when neither timestamp is shown.

Made by [Open SWE](https://openswe.vercel.app/agents/9260c3bf-bdc7-de2d-b68b-bd6e1a8c367d)