### PR TITLE
feat(code): add `DeepSeek-V4-Pro-0813` to model picker

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -74,6 +74,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "anthropic:claude-sonnet-5": "Claude Sonnet 5",
     "baseten:deepseek-ai/DeepSeek-V4-Flash-0731": "DeepSeek V4 Flash 0731",
     "baseten:deepseek-ai/DeepSeek-V4-Pro": "DeepSeek V4 Pro",
+    "baseten:deepseek-ai/DeepSeek-V4-Pro-0813": "DeepSeek V4 Pro 0813",
     "baseten:moonshotai/Kimi-K3": "Kimi K3",
     "baseten:nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": "Nemotron 3 Ultra 550B A55B",
     "baseten:zai-org/GLM-5.2": "GLM 5.2",
@@ -82,6 +83,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
         "DeepSeek V4 Flash 0731"
     ),
     "fireworks:accounts/fireworks/models/deepseek-v4-pro": "DeepSeek V4 Pro",
+    "fireworks:accounts/fireworks/models/deepseek-v4-pro-0813": "DeepSeek V4 Pro 0813",
     "fireworks:accounts/fireworks/models/glm-5p2": "GLM 5.2",
     "fireworks:accounts/fireworks/models/kimi-k3": "Kimi K3",
     "fireworks:accounts/fireworks/models/minimax-m3": "MiniMax-M3",

--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -106,6 +106,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "openrouter:deepseek/deepseek-v4-flash-0731": "DeepSeek V4 Flash 0731",
     "openrouter:deepseek/deepseek-v4-flash:free": "DeepSeek V4 Flash (free)",
     "openrouter:deepseek/deepseek-v4-pro": "DeepSeek V4 Pro",
+    "openrouter:deepseek/deepseek-v4-pro-0813": "DeepSeek V4 Pro 0813",
     "openrouter:google/gemini-3.6-flash": "Gemini 3.6 Flash",
     "openrouter:moonshotai/kimi-k3": "Kimi K3",
     "openrouter:nvidia/nemotron-3-ultra-550b-a55b": "Nemotron 3 Ultra 550B A55B",


### PR DESCRIPTION
DeepSeek V4 Pro 0813 is now available in dcode's recommended model picker across supported endpoints.

---

Uses the documented revision-specific model IDs while preserving existing aliases.

Made by [Open SWE](https://openswe.vercel.app/agents/af2444cf-eee3-c7fe-5f16-fe0e0435a8e4)