### PR TITLE
fix(sdk): throw tool error with root path input in virtual mode

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -198,9 +198,25 @@ class FilesystemBackend(BackendProtocol):
         Raises:
             ValueError: If path traversal is attempted in `virtual_mode` or if the
                 resolved path escapes the root directory.
-            OSError: If the path is a symlink loop (`ELOOP`).
+            OSError: If a host path is supplied beneath the virtual root or the path is a
+                symlink loop (`ELOOP`).
         """
         if self.virtual_mode:
+            host_path = Path(key)
+            # A shell paired with this backend reports paths on the host filesystem,
+            # while file tools consume virtual paths. Reject a host path that points
+            # inside the virtual root rather than silently nesting it below that root.
+            if host_path.is_absolute() and self.cwd != self.cwd.parent:
+                try:
+                    # `relative_to` raises ValueError outside the workspace and returns
+                    # the workspace-relative path when the input is inside it.
+                    virtual_path = "/" + host_path.resolve().relative_to(self.cwd).as_posix()
+                except ValueError:
+                    pass
+                else:
+                    msg = f"Use '{virtual_path}' instead: file-tool paths are already relative to the workspace"
+                    raise OSError(msg)
+
             vpath = key if key.startswith("/") else "/" + key
             if ".." in vpath or vpath.startswith("~"):
                 msg = "Path traversal not allowed"

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -152,6 +152,22 @@ def test_local_shell_backend_integration_shell_and_filesystem() -> None:
         assert "Shell created" in content.file_data["content"]
 
 
+def test_local_shell_backend_rejects_host_path_from_execute(tmp_path: Path) -> None:
+    """Host paths returned by the shell must not silently become virtual paths."""
+    backend = LocalShellBackend(root_dir=tmp_path, virtual_mode=True)
+
+    shell_result = backend.execute("pwd")
+    assert shell_result.exit_code == 0
+    requested_path = Path(shell_result.output.strip()) / "fib.py"
+
+    write_result = backend.write(str(requested_path), "def fib(n: int) -> int:\n    return n\n")
+
+    assert write_result.error is not None
+    assert "Use '/fib.py' instead: file-tool paths are already relative to the workspace" in write_result.error
+    assert not (tmp_path / "fib.py").exists()
+    assert not (tmp_path / str(requested_path).lstrip("/")).exists()
+
+
 def test_local_shell_backend_ls_info() -> None:
     """Test listing directory contents."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
fixes #5469

Adds a condition when `virtual_mode=True` for `FileSystemBackend` (and subsequently `LocalShellBackend`) receives the root path when the filesystem tools are invoked

* works by relying on the error logic of `.relative_to` path method to surface if the input path is a subpath of the root path. If it is we throw `OSError` which gives the agent guidance

---

Assume:

```text
root_dir = /foo/bar
virtual_mode = True
```

| Input to file tool | Detected as existing workspace path? | Result | On-disk target / error |
|---|---:|---|---|
| `fib.py` | No — relative input | Allowed | `/foo/bar/fib.py` |
| `/fib.py` | No — not beneath `/foo/bar` as an OS path | Allowed virtual workspace path | `/foo/bar/fib.py` |
| `/src/app.py` | No — not beneath `/foo/bar` as an OS path | Allowed virtual workspace path | `/foo/bar/src/app.py` |
| `/foo/bar/fib.py` | Yes | Rejected | Suggests `/fib.py` |
| `/foo/bar/src/app.py` | Yes | Rejected | Suggests `/src/app.py` |
| `/foo/bar` | Yes | Rejected | Suggests `/.` |
| `/baz/bax.txt` | No — outside `/foo/bar` | Allowed under existing virtual-path semantics | `/foo/bar/baz/bax.txt` |
| `/foo/other.txt` | No — outside `/foo/bar` | Allowed under existing virtual-path semantics | `/foo/bar/foo/other.txt` |
| `../secrets.txt` | N/A | Rejected by existing traversal check | `Path traversal not allowed` |
| `/../secrets.txt` | N/A | Rejected by existing traversal check | `Path traversal not allowed` |
| `/foo/bar/../other.txt` | N/A | Rejected by existing traversal check | `Path traversal not allowed` |

The rejected case raises because `.relative_to` doesn't throw an error if the input can be recognized as a subpath to `root_path`

```text
root_dir = /
virtual_mode = True
```

| Input to file tool | Result | Why |
|---|---|---|
| `/fib.py` | Allowed; writes `/fib.py` | The workspace is already filesystem root, so there is no duplicate workspace prefix to remove. |
| `/foo/bar/fib.py` | Allowed; writes `/foo/bar/fib.py` | Every absolute path is necessarily under `/`; rejecting it would break the virtual-path contract. |

Co-authored-by: krakenalt <44535722+krakenalt@users.noreply.github.com>
