### PR TITLE
ci(infra): re-lock after raising `genai-prices` floor in bump workflow

### DIFF
--- a/.github/workflows/bump_genai_prices.yml
+++ b/.github/workflows/bump_genai_prices.yml
@@ -167,6 +167,16 @@ jobs:
           escaped=$(printf '%s' "$latest" | sed 's/[.+]/\\&/g')
           sed -i -E "s/\"genai-prices>=[0-9]+(\\.[0-9]+)*([a-z0-9.+-]*)/\"genai-prices>=$escaped/" libs/code/pyproject.toml
 
+          # Re-lock so the lockfile's recorded `requires-dist` specifier for
+          # genai-prices is rewritten to the floor just written above. The
+          # earlier `uv lock --upgrade-package` ran against the *old* floor, so
+          # it leaves the stale `>=<old>` specifier embedded in `uv.lock`, and
+          # `check_lockfiles` (`uv lock --check`) then fails the bump PR for an
+          # out-of-sync lockfile. A plain `uv lock` re-resolves only what the
+          # manifest change requires: the pin stays at $latest (already the
+          # newest the range permits) and only the specifier line moves.
+          uv lock --directory libs/code --python 3.12
+
           # Staleness is the pin moving or the floor lagging the pin, not
           # files changing: `uv lock` can touch unrelated lines (a lock
           # revision bump, a re-resolved transitive), and a "bump


### PR DESCRIPTION
A bot opens a daily PR to bump `genai-prices` in `libs/code`. Those PRs were failing CI (see #5511).

The bot updates two files that must agree: `pyproject.toml` (the allowed version range) and `uv.lock` (the exact pinned version, which also records that range). It was re-generating the lockfile *before* raising the range in `pyproject.toml`, then never re-generating it after. So the committed lockfile still recorded the old range, CI's "lockfile is in sync" check saw the mismatch, and the PR failed.

---

The fix adds one more lockfile regeneration after the range bump, so the two files agree. Verified locally: the sync check now passes.
