### PR TITLE
ci(infra): exempt PRs from auto-close via `!keep-open` comment

### DIFF
--- a/.github/scripts/labeling/close-old-prs.js
+++ b/.github/scripts/labeling/close-old-prs.js
@@ -214,6 +214,30 @@ async function ensureIssueLabel({ github, owner, repo, issueNumber, name, existi
   existingLabels.push(name);
 }
 
+// Applies the bypass label unless it is already present. Unlike the write
+// side of ensureIssueLabel, the check is done live rather than against labels
+// captured earlier: keep_open_on_comment.yml races with a maintainer adding
+// the label by hand, and the redundant add would still emit a `labeled` event
+// — retriggering every workflow listening for one (clear_pending_deletion.yml
+// among them).
+async function applyBypassLabel({ github, owner, repo, issueNumber, bypassLabel = DEFAULT_BYPASS_LABEL }) {
+  const { data: issue } = await github.rest.issues.get({
+    owner,
+    repo,
+    issue_number: issueNumber,
+  });
+  if ((issue.labels ?? []).some(label => label.name === bypassLabel)) {
+    return false;
+  }
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    labels: [bypassLabel],
+  });
+  return true;
+}
+
 // Returns true only when this call actually removed the label, so callers can
 // count real removals rather than no-ops.
 async function removeIssueLabel({ github, owner, repo, issueNumber, name, existingLabels }) {
@@ -295,7 +319,7 @@ function warningBody({ warningDays, closeDays, bypassLabel }) {
     COMMENT_MARKER,
     `This PR has been open for at least ${warningDays} days.`,
     '',
-    `It will be closed automatically once it has been open for at least ${closeDays} days and this warning is at least ${noticeDays} days old, unless the \`${bypassLabel}\` label is applied.`,
+    `It will be closed automatically once it has been open for at least ${closeDays} days and this warning is at least ${noticeDays} days old, unless a maintainer applies the \`${bypassLabel}\` label or comments \`!keep-open\`.`,
   ].join('\n');
 }
 
@@ -304,7 +328,7 @@ function closeBody({ closeDays, bypassLabel }) {
     COMMENT_MARKER,
     `This PR has been open for at least ${closeDays} days and is being closed automatically.`,
     '',
-    `If this work is still active, feel free to reopen it or open a fresh PR. Add the \`${bypassLabel}\` label to exempt a PR from this cleanup.`,
+    `If this work is still active, feel free to reopen it or open a fresh PR. The \`${bypassLabel}\` label (or a maintainer commenting \`!keep-open\`) exempts a PR from this cleanup.`,
   ].join('\n');
 }
 
@@ -902,6 +926,10 @@ module.exports = {
   // label name. The workflow's `if:` expression cannot reference JS, so the
   // literal there is still duplicated — a test pins the two together.
   minimizeMarkerComment,
+  // Required by keep_open_on_comment.yml, which applies the bypass label when a
+  // maintainer comments the keep-open phrase. Sharing the helper keeps the
+  // label name from drifting from DEFAULT_BYPASS_LABEL.
+  applyBypassLabel,
   DEFAULT_PENDING_DELETION_LABEL,
   DEFAULT_BYPASS_LABEL,
   warningBody,

--- a/.github/scripts/labeling/close-old-prs.js
+++ b/.github/scripts/labeling/close-old-prs.js
@@ -313,6 +313,50 @@ async function minimizeMarkerComment({ github, core, owner, repo, issueNumber })
   }
 }
 
+// The full "PR is exempt now" cleanup: drop pending-deletion and minimize the
+// stale auto-close warning posted alongside it. Shared by
+// clear_pending_deletion.yml (when a maintainer adds do-not-close by hand)
+// and keep_open_on_comment.yml, which cannot rely on that workflow firing:
+// its addLabels call uses the default GITHUB_TOKEN, and GitHub does not emit
+// a `labeled` event for actions taken by that token.
+//
+// Returns true only when this call actually removed the label, so a caller
+// logging the outcome can distinguish a real removal from a no-op.
+async function clearPendingDeletion({ github, core, owner, repo, issueNumber, pendingLabel = DEFAULT_PENDING_DELETION_LABEL }) {
+  let removed = true;
+  try {
+    await github.rest.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      name: pendingLabel,
+    });
+  } catch (error) {
+    if (error.status !== 404) throw error;
+    // clear_pending_deletion.yml's `if:` already saw the label in the event
+    // payload, so a 404 there means a genuine race: the daily close_old_prs
+    // sweep, or a maintainer, got there first. keep_open_on_comment.yml
+    // reaches this branch routinely — the PR may never have carried the
+    // label. (Before the name came from the shared constant, a drifted label
+    // name produced an identical 404 and turned clear_pending_deletion.yml
+    // into a permanent no-op — hence a warning rather than a routine log
+    // line.)
+    core.warning(
+      `removeLabel returned 404 for '${pendingLabel}' on PR ` +
+      `#${issueNumber}; something else removed it first (or it was never ` +
+      `applied): ${error.message}`,
+    );
+    removed = false;
+  }
+
+  // The label is only half of what a maintainer sees: close-old-prs.js posts
+  // a warning comment alongside it that claims the PR will be auto-closed.
+  // Minimize it so the PR does not keep advertising a fate that no longer
+  // applies. Best-effort — the label removal above is the load-bearing part.
+  await minimizeMarkerComment({ github, core, owner, repo, issueNumber });
+  return removed;
+}
+
 function warningBody({ warningDays, closeDays, bypassLabel }) {
   const noticeDays = closeDays - warningDays;
   return [
@@ -930,6 +974,11 @@ module.exports = {
   // maintainer comments the keep-open phrase. Sharing the helper keeps the
   // label name from drifting from DEFAULT_BYPASS_LABEL.
   applyBypassLabel,
+  // Required by both workflows that exempt a PR: clear_pending_deletion.yml
+  // (manual label) and keep_open_on_comment.yml (comment command, whose
+  // GITHUB_TOKEN-authored `labeled` event GitHub suppresses, so it must run
+  // the cleanup itself).
+  clearPendingDeletion,
   DEFAULT_PENDING_DELETION_LABEL,
   DEFAULT_BYPASS_LABEL,
   warningBody,

--- a/.github/scripts/tests/labeling/close-old-prs.test.js
+++ b/.github/scripts/tests/labeling/close-old-prs.test.js
@@ -7,6 +7,7 @@ const closeOldPrs = require('../../labeling/close-old-prs.js');
 
 const {
   run,
+  applyBypassLabel,
   closeBody,
   ageInDays,
   COMMENT_MARKER,
@@ -18,6 +19,9 @@ const {
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
 const CLEAR_PENDING_DELETION_YML = path.join(
   REPO_ROOT, '.github/workflows/clear_pending_deletion.yml',
+);
+const KEEP_OPEN_ON_COMMENT_YML = path.join(
+  REPO_ROOT, '.github/workflows/keep_open_on_comment.yml',
 );
 
 // clear_pending_deletion.yml destructures helpers out of close-old-prs.js at
@@ -80,6 +84,116 @@ test('clear_pending_deletion.yml grants the scopes its steps need', () => {
   for (const scope of ['contents: read', 'issues: write', 'pull-requests: write']) {
     assert.match(jobPermissions[1], new RegExp(scope));
   }
+});
+
+// keep_open_on_comment.yml is the comment-driven entry point for the same
+// bypass: it requires applyBypassLabel out of close-old-prs.js, and nothing
+// else connects the two. Same failure shape as clear_pending_deletion.yml —
+// a missing export destructures to undefined and the job dies on every run.
+test('keep_open_on_comment.yml only requires exported symbols', () => {
+  const workflow = fs.readFileSync(KEEP_OPEN_ON_COMMENT_YML, 'utf8');
+  const requires = [...workflow.matchAll(
+    /const \{([^}]*)\} = require\('\.\/\.github\/scripts\/labeling\/close-old-prs\.js'\)/g,
+  )];
+  assert.ok(requires.length > 0, 'expected the workflow to require close-old-prs.js');
+
+  for (const [, destructured] of requires) {
+    const names = destructured
+      .split(',')
+      .map(entry => entry.split(':')[0].trim())
+      .filter(Boolean);
+    assert.ok(names.length > 0, 'expected at least one destructured name');
+    for (const name of names) {
+      assert.ok(
+        Object.hasOwn(closeOldPrs, name),
+        `keep_open_on_comment.yml requires ${name}, which close-old-prs.js does not export`,
+      );
+    }
+  }
+});
+
+// The trigger phrase and the actor gate live only in the workflow's `if:` —
+// there is no JS constant to share, and a workflow expression cannot call one.
+// Drift is invisible at runtime: rename the phrase and keep-open comments
+// silently stop doing anything; loosen the actor gate and any passerby can
+// exempt a PR from cleanup. Pin both. The label name is deliberately absent:
+// the workflow takes it from DEFAULT_BYPASS_LABEL via applyBypassLabel.
+test('keep_open_on_comment.yml gates on the phrase and maintainer association', () => {
+  const workflow = fs.readFileSync(KEEP_OPEN_ON_COMMENT_YML, 'utf8');
+  const condition = workflow.match(/if: >-\n([\s\S]*?)\n {4}runs-on:/);
+  assert.ok(condition, 'expected to find the job-level if: expression');
+
+  assert.match(
+    condition[1],
+    /github\.event\.issue\.pull_request/,
+    'expected the trigger to require a PR conversation comment',
+  );
+  assert.match(
+    condition[1],
+    /contains\(github\.event\.comment\.body, '!keep-open'\)/,
+    'expected the trigger to gate on the keep-open phrase',
+  );
+  assert.match(
+    condition[1],
+    /author_association/,
+    'expected the trigger to gate on the commenter',
+  );
+  for (const association of ['MEMBER', 'OWNER', 'COLLABORATOR']) {
+    assert.match(
+      condition[1],
+      new RegExp(`"${association}"`),
+      `expected the actor gate to include ${association}`,
+    );
+  }
+});
+
+// A job-level permissions block replaces the workflow-level one rather than
+// merging, so every scope the job needs must be listed on the job itself.
+test('keep_open_on_comment.yml grants the scopes its steps need', () => {
+  const workflow = fs.readFileSync(KEEP_OPEN_ON_COMMENT_YML, 'utf8');
+  const jobPermissions = workflow.match(
+    /runs-on: ubuntu-latest\n[\s\S]*?permissions:\n([\s\S]*?)\n\n/,
+  );
+  assert.ok(jobPermissions, 'expected job-level permissions');
+
+  for (const scope of ['contents: read', 'issues: write', 'pull-requests: write']) {
+    assert.match(jobPermissions[1], new RegExp(scope));
+  }
+});
+
+// applyBypassLabel is the workflow's only mutation. These two arms are its
+// whole contract: apply when absent (which emits the `labeled` event that
+// clear_pending_deletion.yml listens for), no-op when present so a maintainer
+// racing the bot does not cause a duplicate event.
+test('applyBypassLabel adds the default bypass label when absent', async () => {
+  const { github, calls } = makeGithub();
+  github.rest.issues.get = async () => ({ data: { labels: [] } });
+
+  const applied = await applyBypassLabel({
+    github, owner: 'langchain-ai', repo: 'deepagents', issueNumber: 42,
+  });
+
+  assert.equal(applied, true);
+  assert.deepEqual(calls.addLabels, [{
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    issue_number: 42,
+    labels: [DEFAULT_BYPASS_LABEL],
+  }]);
+});
+
+test('applyBypassLabel no-ops when the label is already present', async () => {
+  const { github, calls } = makeGithub();
+  github.rest.issues.get = async () => ({
+    data: { labels: [{ name: DEFAULT_BYPASS_LABEL }, { name: 'other' }] },
+  });
+
+  const applied = await applyBypassLabel({
+    github, owner: 'langchain-ai', repo: 'deepagents', issueNumber: 42,
+  });
+
+  assert.equal(applied, false);
+  assert.deepEqual(calls.addLabels, []);
 });
 
 // RELEASE_PLEASE_BRANCH_PREFIX is a hardcoded literal, not derived, and the

--- a/.github/scripts/tests/labeling/close-old-prs.test.js
+++ b/.github/scripts/tests/labeling/close-old-prs.test.js
@@ -8,6 +8,7 @@ const closeOldPrs = require('../../labeling/close-old-prs.js');
 const {
   run,
   applyBypassLabel,
+  clearPendingDeletion,
   closeBody,
   ageInDays,
   COMMENT_MARKER,
@@ -194,6 +195,73 @@ test('applyBypassLabel no-ops when the label is already present', async () => {
 
   assert.equal(applied, false);
   assert.deepEqual(calls.addLabels, []);
+});
+
+// clearPendingDeletion is the shared "PR is exempt now" cleanup behind both
+// clear_pending_deletion.yml (manual do-not-close) and keep_open_on_comment.yml
+// (whose GITHUB_TOKEN-authored `labeled` event GitHub suppresses, so the
+// cleanup has to run inline). Its contract: remove pending-deletion, tolerate
+// its absence, and always attempt to minimize the stale warning.
+test('clearPendingDeletion removes the label and minimizes the warning', async () => {
+  const { github, calls } = makeGithub({
+    comments: new Map([[42, [{
+      id: 1,
+      body: COMMENT_MARKER,
+      user: { login: 'github-actions[bot]', type: 'Bot' },
+    }]]]),
+  });
+  const core = makeCore();
+
+  const removed = await clearPendingDeletion({
+    github, core, owner: 'langchain-ai', repo: 'deepagents', issueNumber: 42,
+  });
+
+  assert.equal(removed, true);
+  assert.deepEqual(calls.removeLabel, [{
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    issue_number: 42,
+    name: DEFAULT_PENDING_DELETION_LABEL,
+  }]);
+  assert.equal(calls.graphql.length, 1);
+  assert.match(calls.graphql[0].query, /minimizeComment/);
+});
+
+// keep_open_on_comment.yml reaches this branch routinely — a !keep-open PR
+// may never have carried pending-deletion. A 404 must not fail the run, and
+// the warning minimization must still happen: the label and the comment are
+// applied separately, so one can exist without the other.
+test('clearPendingDeletion tolerates an absent label and still minimizes', async () => {
+  const { github, calls } = makeGithub({
+    removeLabelErrors: new Map([[42, httpError('gone', 404)]]),
+    comments: new Map([[42, [{
+      id: 1,
+      body: COMMENT_MARKER,
+      user: { login: 'github-actions[bot]', type: 'Bot' },
+    }]]]),
+  });
+  const core = makeCore();
+
+  const removed = await clearPendingDeletion({
+    github, core, owner: 'langchain-ai', repo: 'deepagents', issueNumber: 42,
+  });
+
+  assert.equal(removed, false);
+  assert.equal(core.warnings.length, 1);
+  assert.equal(calls.graphql.length, 1);
+});
+
+test('clearPendingDeletion propagates non-404 removal failures', async () => {
+  const { github } = makeGithub({
+    removeLabelErrors: new Map([[42, httpError('forbidden', 403)]]),
+  });
+
+  await assert.rejects(
+    clearPendingDeletion({
+      github, core: makeCore(), owner: 'langchain-ai', repo: 'deepagents', issueNumber: 42,
+    }),
+    /forbidden/,
+  );
 });
 
 // RELEASE_PLEASE_BRANCH_PREFIX is a hardcoded literal, not derived, and the

--- a/.github/workflows/clear_pending_deletion.yml
+++ b/.github/workflows/clear_pending_deletion.yml
@@ -1,5 +1,8 @@
 # Remove the "pending-deletion" label as soon as a PR gains "do-not-close",
 # and minimize the stale auto-close warning comment that was posted with it.
+# Only hand-applied labels reach this workflow: GitHub suppresses the
+# `labeled` event when the label was applied by the default GITHUB_TOKEN, so
+# keep_open_on_comment.yml runs the same cleanup inline instead.
 #
 # .github/scripts/labeling/close-old-prs.js already strips the label when it
 # notices a bypassed PR, but that script runs on a daily schedule; this
@@ -88,13 +91,14 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
 
-            // Take the label name from the script rather than repeating the
-            // literal, so the removal below cannot drift from what the daily
-            // sweep applies. The `if:` expression above still hardcodes both
-            // names because workflow expressions cannot reference JS; a test in
-            // close-old-prs.test.js pins those literals to these constants.
+            // The label name comes from the script's constant rather than
+            // repeating the literal, so the removal cannot drift from what
+            // the daily sweep applies. The `if:` expression above still
+            // hardcodes both names because workflow expressions cannot
+            // reference JS; a test in close-old-prs.test.js pins those
+            // literals to these constants.
             const {
-              minimizeMarkerComment,
+              clearPendingDeletion,
               DEFAULT_PENDING_DELETION_LABEL: pendingDeletionLabel,
             } = require('./.github/scripts/labeling/close-old-prs.js');
 
@@ -102,38 +106,4 @@ jobs:
               `PR #${issue_number} gained do-not-close — removing ${pendingDeletionLabel}`,
             );
 
-            try {
-              await github.rest.issues.removeLabel({
-                owner,
-                repo,
-                issue_number,
-                name: pendingDeletionLabel,
-              });
-            } catch (e) {
-              if (e.status !== 404) throw e;
-              // The job's `if:` already saw pending-deletion in the event
-              // payload, so a 404 here means a genuine race: the daily
-              // close_old_prs sweep, or a maintainer, got there first. (Before
-              // the constant above was shared, a drifted label name produced an
-              // identical 404 and turned this workflow into a permanent no-op —
-              // hence a warning rather than a routine log line.)
-              core.warning(
-                `removeLabel returned 404 for '${pendingDeletionLabel}' on PR ` +
-                `#${issue_number}; the label was present in the event payload, ` +
-                `so something else removed it first: ${e.message}`,
-              );
-            }
-
-            // The label is only half of what a maintainer sees: close-old-prs.js
-            // posts a warning comment alongside it that claims the PR will be
-            // auto-closed. Minimize it so the PR does not keep advertising a
-            // fate that no longer applies. Best-effort — the label removal
-            // above is the load-bearing part.
-            //
-            // Shared with the daily script, which calls the same helper from
-            // refreshLabelsUnlessBypassed when do-not-close lands between
-            // posting the warning and applying the label. In that race the PR
-            // never carries pending-deletion, so this workflow's `if:` is never
-            // met — which is why that branch minimizes the warning itself
-            // instead of waiting for this workflow.
-            await minimizeMarkerComment({ github, core, owner, repo, issueNumber: issue_number });
+            await clearPendingDeletion({ github, core, owner, repo, issueNumber: issue_number });

--- a/.github/workflows/close_old_prs.yml
+++ b/.github/workflows/close_old_prs.yml
@@ -3,8 +3,10 @@
 # a "pending-deletion" label. Skipped: draft PRs, PRs with the "do-not-close"
 # label, and release-please PRs (opened by "github-actions[bot]" on a
 # release-please--branches--main--components--<pkg> branch in this repository —
-# identified by that provenance alone, not by any label). Thresholds and labels
-# are defined in .github/scripts/labeling/close-old-prs.js.
+# identified by that provenance alone, not by any label). The "do-not-close"
+# label can also be applied by commenting `!keep-open` — see
+# keep_open_on_comment.yml. Thresholds and labels are defined in
+# .github/scripts/labeling/close-old-prs.js.
 
 name: Close Old PRs
 

--- a/.github/workflows/keep_open_on_comment.yml
+++ b/.github/workflows/keep_open_on_comment.yml
@@ -1,12 +1,13 @@
 # Apply "do-not-close" when a maintainer comments `!keep-open` on a PR, so
 # exempting a PR from the close_old_prs.yml sweep does not require a trip to
-# the label picker. Applying the label emits the `labeled` event, so
-# clear_pending_deletion.yml then removes any "pending-deletion" label and
-# minimizes the stale auto-close warning — the same end state as adding the
-# label by hand. The reaction toggles 👀 -> 🚀 so the acknowledgement stays
-# correct if the comment is edited or deleted (the edit/delete events do not
-# re-run this workflow, so a removed comment leaves the label behind — the
-# stale 🚀 is the visible trace of why).
+# the label picker. The step also removes any "pending-deletion" label and
+# minimizes the stale auto-close warning itself — the same end state as
+# adding the label by hand — because it cannot rely on
+# clear_pending_deletion.yml for that cleanup (see the token note below).
+# The reaction toggles 👀 -> 🚀 so the acknowledgement stays correct if the
+# comment is edited or deleted (the edit/delete events do not re-run this
+# workflow, so a removed comment leaves the label behind — the stale 🚀 is
+# the visible trace of why).
 #
 # issue_comment runs in the base repository's context and GITHUB_TOKEN is
 # writable here regardless of where the PR head lives (that read-only
@@ -25,12 +26,13 @@
 #
 # No app token is passed to the github-script step, so it runs with the
 # default GITHUB_TOKEN and the resulting `labeled` event does NOT retrigger
-# workflows beyond what a manual label application would do. That is load
-# bearing: sync_priority_labels.yml and a dozen other workflows listen for
-# label events on PRs; an app token would arm all of them from every
-# keep-open comment. clear_pending_deletion.yml is pull_request_target and
-# fires on `labeled` regardless of actor, so the pending-deletion cleanup
-# still runs.
+# workflows at all: GitHub suppresses events produced by the default token.
+# That suppression is load bearing in one direction — sync_priority_labels.yml
+# and a dozen other workflows listen for label events on PRs, and an app
+# token would arm all of them from every keep-open comment — and worked
+# around in the other: clear_pending_deletion.yml listens for exactly that
+# suppressed `labeled` event, so the pending-deletion cleanup runs inline
+# here via the shared clearPendingDeletion helper instead.
 #
 # `!keep-open` (rather than a bare-word match) keeps ordinary prose from
 # exempting a PR, and a substring match (rather than exact equality) lets a
@@ -66,23 +68,24 @@ jobs:
     timeout-minutes: 10
     # A job-level `permissions` block replaces the workflow-level one outright
     # rather than merging with it, so `contents: read` has to be repeated here
-    # or the checkout below has no read access. `issues: write` covers both
-    # addLabels and createReaction (PR conversation labels and comments are
-    # the issues API).
+    # or the checkout below has no read access. `issues: write` covers
+    # addLabels, removeLabel, createReaction, and the minimizeComment mutation
+    # in clearPendingDeletion (PR conversation labels and comments are the
+    # issues API).
     permissions:
       contents: read
       issues: write
       pull-requests: write
 
     steps:
-      # Checked out only so the script step can require the shared
-      # applyBypassLabel helper from close-old-prs.js. This is an issue_comment
-      # workflow, so GITHUB_REF is already the repository default branch —
-      # pinning `ref` (the way clear_pending_deletion.yml must under
-      # pull_request_target) is unnecessary here.
+      # Checked out only so the script step can require the shared helpers
+      # from close-old-prs.js. This is an issue_comment workflow, so
+      # GITHUB_REF is already the repository default branch — pinning `ref`
+      # (the way clear_pending_deletion.yml must under pull_request_target)
+      # is unnecessary here.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Apply do-not-close label
+      - name: Apply do-not-close label and clear pending deletion
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # `created` fires exactly once per comment, so unlike the daily
@@ -105,11 +108,16 @@ jobs:
               content: 'eyes',
             });
 
-            const { applyBypassLabel } = require('./.github/scripts/labeling/close-old-prs.js');
+            const {
+              applyBypassLabel,
+              clearPendingDeletion,
+              DEFAULT_PENDING_DELETION_LABEL: pendingDeletionLabel,
+            } = require('./.github/scripts/labeling/close-old-prs.js');
 
-            // The name comes from the script's DEFAULT_BYPASS_LABEL rather
-            // than repeating the literal here, so it cannot drift from what
-            // close_old_prs.yml and clear_pending_deletion.yml use.
+            // The bypass label name comes from the script's
+            // DEFAULT_BYPASS_LABEL rather than repeating the literal here, so
+            // it cannot drift from what close_old_prs.yml and
+            // clear_pending_deletion.yml use.
             const applied = await applyBypassLabel({
               github,
               owner,
@@ -119,7 +127,27 @@ jobs:
 
             if (!applied) {
               console.log(
-                `PR #${issue_number} already carries the bypass label; nothing to do`,
+                `PR #${issue_number} already carries the bypass label`,
+              );
+            }
+
+            // This step's addLabels call uses the default GITHUB_TOKEN, so
+            // GitHub emits no `labeled` event for it and
+            // clear_pending_deletion.yml never runs for a !keep-open comment.
+            // Do the same cleanup inline: drop pending-deletion and minimize
+            // the stale auto-close warning. Unconditional (not gated on
+            // `applied`) because a PR can already carry do-not-close while
+            // still wearing pending-deletion from the daily sweep.
+            const cleared = await clearPendingDeletion({
+              github,
+              core,
+              owner,
+              repo,
+              issueNumber: issue_number,
+            });
+            if (cleared) {
+              console.log(
+                `Removed ${pendingDeletionLabel} from PR #${issue_number}`,
               );
             }
 

--- a/.github/workflows/keep_open_on_comment.yml
+++ b/.github/workflows/keep_open_on_comment.yml
@@ -1,0 +1,134 @@
+# Apply "do-not-close" when a maintainer comments `!keep-open` on a PR, so
+# exempting a PR from the close_old_prs.yml sweep does not require a trip to
+# the label picker. Applying the label emits the `labeled` event, so
+# clear_pending_deletion.yml then removes any "pending-deletion" label and
+# minimizes the stale auto-close warning — the same end state as adding the
+# label by hand. The reaction toggles 👀 -> 🚀 so the acknowledgement stays
+# correct if the comment is edited or deleted (the edit/delete events do not
+# re-run this workflow, so a removed comment leaves the label behind — the
+# stale 🚀 is the visible trace of why).
+#
+# issue_comment runs in the base repository's context and GITHUB_TOKEN is
+# writable here regardless of where the PR head lives (that read-only
+# downgrade is specific to pull_request), so this works on fork PRs without
+# pull_request_target. Only the event payload is read and labels/reactions are
+# managed — no PR code is checked out or executed.
+#
+# The actor gate is `author_association`, not a hardcoded user list, and the
+# label is only applied by applyBypassLabel in close-old-prs.js — commenters
+# cannot name a label. MEMBER/OWNER/COLLABORATOR covers everyone with triage
+# access, which is exactly the set of people who could apply the label through
+# the UI anyway, so this grants no one a new power. CONTRIBUTOR (has merged
+# code but no triage access) and bots are deliberately excluded. Bots are out
+# because an app comment (Kodiak, a status bot) must never exempt a PR; a
+# bot-authored exemption would survive a PR everyone has abandoned.
+#
+# No app token is passed to the github-script step, so it runs with the
+# default GITHUB_TOKEN and the resulting `labeled` event does NOT retrigger
+# workflows beyond what a manual label application would do. That is load
+# bearing: sync_priority_labels.yml and a dozen other workflows listen for
+# label events on PRs; an app token would arm all of them from every
+# keep-open comment. clear_pending_deletion.yml is pull_request_target and
+# fires on `labeled` regardless of actor, so the pending-deletion cleanup
+# still runs.
+#
+# `!keep-open` (rather than a bare-word match) keeps ordinary prose from
+# exempting a PR, and a substring match (rather than exact equality) lets a
+# maintainer write "still relevant — !keep-open" instead of a lone command.
+
+name: Apply do-not-close on !keep-open comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+# One comment-created event per comment, and applyBypassLabel is idempotent,
+# so this is only a guard against a maintainer commenting the phrase twice in
+# quick succession.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  apply-bypass-label:
+    # `contains(github.event.comment.body, '!keep-open')` and
+    # `github.event.issue.pull_request` are duplicated in the script-side
+    # fixture tests — keep_open_on_comment cannot reference JS constants, so
+    # the phrase lives only here; a test pins it against this file.
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '!keep-open') &&
+      contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # A job-level `permissions` block replaces the workflow-level one outright
+    # rather than merging with it, so `contents: read` has to be repeated here
+    # or the checkout below has no read access. `issues: write` covers both
+    # addLabels and createReaction (PR conversation labels and comments are
+    # the issues API).
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      # Checked out only so the script step can require the shared
+      # applyBypassLabel helper from close-old-prs.js. This is an issue_comment
+      # workflow, so GITHUB_REF is already the repository default branch —
+      # pinning `ref` (the way clear_pending_deletion.yml must under
+      # pull_request_target) is unnecessary here.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Apply do-not-close label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          # `created` fires exactly once per comment, so unlike the daily
+          # close_old_prs sweep there is no next run to pick up a transient
+          # failure. Retry 429/5xx; the action's default
+          # retry-exempt-status-codes still leaves 403/404 alone.
+          retries: 3
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+            const comment_id = context.payload.comment.id;
+
+            // Signal receipt immediately so a maintainer is not left guessing
+            // whether the command registered — the label application below
+            // can still fail, but the common case gets instant feedback.
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id,
+              content: 'eyes',
+            });
+
+            const { applyBypassLabel } = require('./.github/scripts/labeling/close-old-prs.js');
+
+            // The name comes from the script's DEFAULT_BYPASS_LABEL rather
+            // than repeating the literal here, so it cannot drift from what
+            // close_old_prs.yml and clear_pending_deletion.yml use.
+            const applied = await applyBypassLabel({
+              github,
+              owner,
+              repo,
+              issueNumber: issue_number,
+            });
+
+            if (!applied) {
+              console.log(
+                `PR #${issue_number} already carries the bypass label; nothing to do`,
+              );
+            }
+
+            // Confirmation of completion. If the label step failed, this line
+            // never runs and the comment keeps its 👀 — a visible "seen but
+            // not processed" state.
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id,
+              content: 'rocket',
+            });


### PR DESCRIPTION
Commenting `!keep-open` on a PR now exempts it from the auto-close sweep, same as adding the `do-not-close` label — easier to fire off a quick comment than to open the label picker.

---

The new `keep_open_on_comment.yml` workflow listens for `issue_comment: created` on PRs. When a MEMBER/OWNER/COLLABORATOR comments anything containing `!keep-open`, it reacts 👀, applies `do-not-close` via a shared `applyBypassLabel` helper, then reacts 🚀. Applying the label fires the `labeled` event, so the existing `clear_pending_deletion.yml` workflow removes `pending-deletion` and minimizes the stale warning comment — the end state is identical to adding the label by hand.

- The actor gate is `author_association` rather than a user list, so anyone with triage access can use it and no one gains a power they didn't already have. Bots and CONTRIBUTORs are excluded.
- The match is a substring, not exact equality, so `still relevant — !keep-open` works. The `!` prefix keeps ordinary prose from accidentally exempting a PR.
- Only `created` is handled: editing or deleting the comment later does not remove the label, matching the label's own manual semantics.
- The warning and close notices posted by the sweep now mention `!keep-open` alongside the label.
