### PR TITLE
test(code): run CLI end-to-end tests asynchronously and de-flake exit teardown

### DIFF
--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -203,6 +203,38 @@ def _clear_project_mcp_trust_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_user_hooks_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Prevent the developer's real hook config from reaching hook loading.
+
+    `_isolate_price_overrides` already redirects
+    `model_config.DEFAULT_CONFIG_DIR`, but `hooks.loading` and `hooks.runtime`
+    bind that name with a `from` import at module import. Whether they see the
+    redirect is therefore an ordering accident: imported lazily inside a test
+    they pick up `tmp_path`, but imported at collection -- which is what a
+    whole-suite run does -- they keep the developer's real `~/.deepagents`.
+
+    A `SessionEnd` entry there is the damaging case. Any `DeepAgentsApp` that
+    finishes startup during a test loads it, and `App.exit()` consults
+    `self._hooks.has_handlers(SESSION_END)` and takes the deferred-teardown
+    branch when handlers exist, so `TestExitGracefulWorkerHandoff`'s
+    synchronous-exit assertions fail. It reads as load-dependent flakiness
+    because those tests race app startup, and it never reproduces in CI, where
+    no such file exists.
+
+    Rebind both to the same `tmp_path` the price-override fixture uses, so all
+    three names agree on the user config directory, and drop the legacy
+    loader's parse cache in case it already holds real entries. Tests needing
+    hook config patch these explicitly, which still wins inside the test body.
+    """
+    for module in ("deepagents_code.hooks.loading", "deepagents_code.hooks.runtime"):
+        monkeypatch.setattr(f"{module}.DEFAULT_CONFIG_DIR", tmp_path)
+
+    import deepagents_code.hooks.legacy as hooks_legacy
+
+    monkeypatch.setattr(hooks_legacy, "_hooks_config", None)
+
+
+@pytest.fixture(autouse=True)
 def _clear_debug_notifications_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent the debug-notifications override from changing suppression tests.
 

--- a/libs/code/tests/unit_tests/test_compact_tool.py
+++ b/libs/code/tests/unit_tests/test_compact_tool.py
@@ -139,9 +139,16 @@ class TestCLICompactionMiddleware:
         summarization._compute_state_cutoff.return_value = 2
         return summarization
 
+    @pytest.mark.parametrize("is_async", [False, True])
     @pytest.mark.parametrize("overflow", [False, True])
-    async def test_auto_compaction_runs_precompact_hook(self, overflow: bool) -> None:
-        """Every automatic compaction must ask `PreCompact` before summarizing."""
+    async def test_auto_compaction_runs_precompact_hook(
+        self, overflow: bool, is_async: bool
+    ) -> None:
+        """Every automatic compaction must ask `PreCompact` before summarizing.
+
+        `wrap_model_call` and `awrap_model_call` are separately written parallel
+        implementations, so both are driven here to keep the two from drifting.
+        """
         from deepagents.middleware.summarization import SummarizationMiddleware
 
         from deepagents_code.hooks.models.domain import (
@@ -156,9 +163,14 @@ class TestCLICompactionMiddleware:
         summarization._truncate_args.return_value = (messages, False)
         summarization._should_summarize.return_value = not overflow
         summarization._determine_cutoff_index.return_value = 1
+        wrapper_name = "awrap_model_call" if is_async else "wrap_model_call"
         if overflow:
-            summarization.awrap_model_call = MethodType(
-                SummarizationMiddleware.awrap_model_call, summarization
+            setattr(
+                summarization,
+                wrapper_name,
+                MethodType(
+                    getattr(SummarizationMiddleware, wrapper_name), summarization
+                ),
             )
 
         middleware = CLICompactionMiddleware(summarization)
@@ -168,8 +180,9 @@ class TestCLICompactionMiddleware:
             state={"messages": messages},
             runtime=Runtime(context=None),
         )
-        handler = AsyncMock(
-            side_effect=ContextOverflowError("too large") if overflow else None
+        error = ContextOverflowError("too large") if overflow else None
+        handler = (
+            AsyncMock(side_effect=error) if is_async else MagicMock(side_effect=error)
         )
         invoke = MagicMock(
             return_value=PreCompactDecision(
@@ -185,11 +198,18 @@ class TestCLICompactionMiddleware:
             ),
             patch("deepagents_code.offload_middleware._invoke_hook", invoke),
         ):
+
+            async def run_middleware() -> None:
+                if is_async:
+                    await middleware.awrap_model_call(request, handler)
+                else:
+                    middleware.wrap_model_call(request, handler)
+
             if overflow:
                 with pytest.raises(ContextOverflowError, match="too large"):
-                    await middleware.awrap_model_call(request, handler)
+                    await run_middleware()
             else:
-                await middleware.awrap_model_call(request, handler)
+                await run_middleware()
 
         event = invoke.call_args.args[1]
         assert event.trigger.value == "auto"
@@ -199,9 +219,14 @@ class TestCLICompactionMiddleware:
             request.override(messages=[*messages, HumanMessage("three")])
         )
         invoke.assert_called_once()
-        handler.assert_awaited_once()
-        summarization._aoffload_to_backend.assert_not_awaited()
-        summarization._acreate_summary.assert_not_awaited()
+        if is_async:
+            handler.assert_awaited_once()
+            summarization._aoffload_to_backend.assert_not_awaited()
+            summarization._acreate_summary.assert_not_awaited()
+        else:
+            handler.assert_called_once()
+            summarization._offload_to_backend.assert_not_called()
+            summarization._create_summary.assert_not_called()
 
     async def test_force_bypasses_sdk_eligibility_gate(self) -> None:
         """Forced compaction partitions directly even below the proactive gate."""

--- a/libs/code/tests/unit_tests/test_end_to_end.py
+++ b/libs/code/tests/unit_tests/test_end_to_end.py
@@ -118,7 +118,7 @@ def mock_settings(
 class TestDeepAgentsCLIEndToEnd:
     """Test suite for end-to-end deepagents-code functionality with fake LLM."""
 
-    def test_cli_agent_with_fake_llm_basic(self, tmp_path: Path) -> None:
+    async def test_cli_agent_with_fake_llm_basic(self, tmp_path: Path) -> None:
         """Test basic CLI agent functionality with a fake LLM model.
 
         This test verifies that a CLI agent can be created and invoked with
@@ -156,7 +156,7 @@ class TestDeepAgentsCLIEndToEnd:
             )
 
             # Invoke the agent with a simple message
-            result = agent.invoke(
+            result = await agent.ainvoke(
                 {"messages": [HumanMessage(content="Hello, agent!")]},
                 {"configurable": {"thread_id": str(uuid.uuid4())}},
             )
@@ -173,7 +173,7 @@ class TestDeepAgentsCLIEndToEnd:
             final_ai_message = ai_messages[-1]
             assert "Task completed successfully!" in final_ai_message.content
 
-    def test_cli_agent_summarizes(self, tmp_path: Path) -> None:
+    async def test_cli_agent_summarizes(self, tmp_path: Path) -> None:
         """Test summarization."""
         with mock_settings(tmp_path):
             model = FixedGenericFakeChatModel(
@@ -207,7 +207,7 @@ class TestDeepAgentsCLIEndToEnd:
                 AIMessage(content=text_50_000_tokens),  # 180,000 tokens (summarizes)
                 HumanMessage(content="query"),
             ]
-            result = agent.invoke(
+            result = await agent.ainvoke(
                 {"messages": input_messages},
                 {"configurable": {"thread_id": thread_id}},
             )
@@ -246,7 +246,7 @@ class TestDeepAgentsCLIEndToEnd:
             )
             assert history_files, "expected a session-id-named history file"
 
-    def test_cli_agent_with_fake_llm_with_tools(self, tmp_path: Path) -> None:
+    async def test_cli_agent_with_fake_llm_with_tools(self, tmp_path: Path) -> None:
         """Test CLI agent with tools using a fake LLM model.
 
         This test verifies that a CLI agent can handle tool calls correctly
@@ -284,7 +284,7 @@ class TestDeepAgentsCLIEndToEnd:
             )
 
             # Invoke the agent
-            result = agent.invoke(
+            result = await agent.ainvoke(
                 {"messages": [HumanMessage(content="Use the sample tool")]},
                 {"configurable": {"thread_id": "test-thread-2"}},
             )
@@ -299,7 +299,9 @@ class TestDeepAgentsCLIEndToEnd:
             # Verify the tool message contains our expected input
             assert any("test input" in msg.content for msg in tool_messages)
 
-    def test_cli_agent_with_fake_llm_filesystem_tool(self, tmp_path: Path) -> None:
+    async def test_cli_agent_with_fake_llm_filesystem_tool(
+        self, tmp_path: Path
+    ) -> None:
         """Test CLI agent with filesystem tools using a fake LLM model.
 
         This test verifies that a CLI agent can use the built-in filesystem
@@ -341,7 +343,7 @@ class TestDeepAgentsCLIEndToEnd:
             )
 
             # Invoke the agent
-            result = agent.invoke(
+            result = await agent.ainvoke(
                 {"messages": [HumanMessage(content="List files")]},
                 {"configurable": {"thread_id": "test-thread-3"}},
             )
@@ -353,7 +355,9 @@ class TestDeepAgentsCLIEndToEnd:
             tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
             assert len(tool_messages) > 0
 
-    def test_cli_agent_with_fake_llm_multiple_tool_calls(self, tmp_path: Path) -> None:
+    async def test_cli_agent_with_fake_llm_multiple_tool_calls(
+        self, tmp_path: Path
+    ) -> None:
         """Test CLI agent with multiple tool calls using a fake LLM model.
 
         This test verifies that a CLI agent can handle multiple sequential
@@ -401,7 +405,7 @@ class TestDeepAgentsCLIEndToEnd:
             )
 
             # Invoke the agent
-            result = agent.invoke(
+            result = await agent.ainvoke(
                 {"messages": [HumanMessage(content="Use sample tool twice")]},
                 {"configurable": {"thread_id": "test-thread-4"}},
             )

--- a/libs/code/tests/unit_tests/test_end_to_end.py
+++ b/libs/code/tests/unit_tests/test_end_to_end.py
@@ -50,7 +50,12 @@ class FixedGenericFakeChatModel(GenericFakeChatModel):
         run_manager: CallbackManagerForLLMRun | None = None,
         **kwargs: Any,
     ) -> ChatResult:
-        """Override _generate to capture inputs and outputs."""
+        """Override _generate to capture inputs and outputs.
+
+        Only the non-streaming path is intercepted. `ainvoke` reaches this
+        through `BaseChatModel._agenerate`, but a future switch to streaming
+        would route through `_stream` instead and leave `captured_calls` empty.
+        """
         result = super()._generate(
             messages, stop=stop, run_manager=run_manager, **kwargs
         )
@@ -116,7 +121,16 @@ def mock_settings(
 
 
 class TestDeepAgentsCLIEndToEnd:
-    """Test suite for end-to-end deepagents-code functionality with fake LLM."""
+    """Test suite for end-to-end deepagents-code functionality with fake LLM.
+
+    These invoke the graph asynchronously because that is what the CLI does:
+    every production entrypoint streams (`app.py`, `tui/textual_adapter.py`,
+    `client/non_interactive.py`, `client/remote_client.py`), so the synchronous
+    path these tests once used covered a graph traversal no user reaches. Driving
+    the async path also keeps them off the bounded synchronous Pregel executor,
+    which starves under `pytest-xdist` oversubscription and presents as a hang.
+    Do not convert these back to `invoke`.
+    """
 
     async def test_cli_agent_with_fake_llm_basic(self, tmp_path: Path) -> None:
         """Test basic CLI agent functionality with a fake LLM model.

--- a/libs/code/tests/unit_tests/test_managed_tools.py
+++ b/libs/code/tests/unit_tests/test_managed_tools.py
@@ -755,11 +755,16 @@ async def test_ensure_ripgrep_reports_missing_artifact_on_404(
         raise err
 
     monkeypatch.setattr(managed_tools, "_download_to", _boom)
-    with (
-        mock.patch("shutil.which", return_value=None),
-        pytest.raises(ManagedToolUnavailableError) as exc_info,
-    ):
-        await managed_tools.ensure_ripgrep()
+    try:
+        with (
+            mock.patch("shutil.which", return_value=None),
+            pytest.raises(ManagedToolUnavailableError) as exc_info,
+        ):
+            await managed_tools.ensure_ripgrep()
+    finally:
+        # HTTPError wraps a file-like response; close it so its temp-file
+        # deallocator doesn't emit a ResourceWarning at GC time.
+        err.close()
     assert exc_info.value.reason == "artifact_not_found"
     assert "linux/x86_64" in exc_info.value.message
 
@@ -811,8 +816,13 @@ async def test_ensure_ripgrep_returns_none_on_http_download_failure(
         raise err
 
     monkeypatch.setattr(managed_tools, "_download_to", _boom)
-    with mock.patch("shutil.which", return_value=None):
-        assert await managed_tools.ensure_ripgrep() is None
+    try:
+        with mock.patch("shutil.which", return_value=None):
+            assert await managed_tools.ensure_ripgrep() is None
+    finally:
+        # HTTPError wraps a file-like response; close it so its temp-file
+        # deallocator doesn't emit a ResourceWarning at GC time.
+        err.close()
 
 
 async def test_ensure_ripgrep_preserves_stale_on_download_failure(


### PR DESCRIPTION
## End-to-end tests follow the CLI's async path

The CLI never invokes its agent graph synchronously. Every production entrypoint streams — `app.py`, `tui/textual_adapter.py`, `client/non_interactive.py`, and `client/remote_client.py` all call `astream` — so the end-to-end tests in `test_end_to_end.py` were exercising a graph traversal no user reaches. They now `await agent.ainvoke(...)`, preserving the checkpointer, middleware stack, fake-model responses, and every existing assertion.

A secondary benefit: the synchronous Pregel path runs on a bounded `ContextThreadPoolExecutor` sized from `max_concurrency`, which oversubscribes under `pytest-xdist` and can present as a hang against the suite's 30s global timeout. This is load-dependent and did not reproduce in isolation locally (8 runs at `-n 16`), so it is offered as motivation rather than a diagnosis.

`CLICompactionMiddleware.wrap_model_call` and `awrap_model_call` are separately written parallel implementations, and the summarization end-to-end test was the only thing driving the synchronous one. To keep that branch from drifting, `test_auto_compaction_runs_precompact_hook` now parametrizes over sync and async in addition to the existing overflow axis, covering both twins directly at the unit level.

Full-graph synchronous coverage is retained elsewhere on purpose: `test_reliable_rubric.py`, `test_goal_rubric.py`, `hooks/test_server_lifecycle.py`, and `smoke_tests/test_system_prompt.py` still use `invoke`, and `goal_rubric.py` and `reliable_rubric.py` each have genuine synchronous invocation arms in production.

## Unit tests no longer read the developer's hook config

Nine tests in `TestExitGracefulWorkerHandoff` fail on any machine whose `~/.deepagents/hooks.json` declares a `SessionEnd` handler, and pass everywhere else — including CI, where no such file exists.

`hooks/loading.py` and `hooks/runtime.py` bind `DEFAULT_CONFIG_DIR` with a `from` import at module import. Whether they observe the redirect installed by the existing `_isolate_price_overrides` fixture is therefore an ordering accident: imported lazily inside a test they pick up `tmp_path`, but imported at collection — which a whole-suite run does — they keep the real user directory.

Once real hooks load, any app that finishes startup during a test has session-end handlers, and `exit()` consults `self._hooks.has_handlers(SESSION_END)` and takes the deferred-teardown branch. `super().exit()` is then never called synchronously, so the class's synchronous-exit assertions fail. Because the tests race app startup, this reads as load-dependent flakiness rather than a machine-configuration dependency.

A new autouse fixture rebinds both names to the same `tmp_path` the price-override fixture uses, so all three agree on one user config directory, and drops the legacy loader's parse cache. `hooks/runtime.py` carried the same latent bug without yet causing a visible failure.

<details>
<summary>Test plan</summary>

- Full `tests/unit_tests` suite: **12597 passed, 0 failed**, three consecutive runs (two ordered, one randomized). Before: 9-12 failures per run, all in `test_app.py`, with a set that varied between runs.
- Mechanism verified directly rather than inferred — same probe module, only the fixture differing: `user_hooks_path()` resolves to `/Users/<dev>/.deepagents/hooks.json` without the fixture and to an empty `tmp_path` with it.
- `offload_middleware.py` coverage across `test_compact_tool.py` + `test_end_to_end.py`: 82% → 89% (the whole synchronous `wrap_model_call` body was uncovered before).
- Mutation check: disabling the overflow gate in the synchronous branch fails exactly the new `[True-False]` case, confirming the parametrization is not vacuous.
- `make format`, `make lint`, `make type`: clean.

</details>
