### PR TITLE
fix(code): hide dependency details after updates

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6252,10 +6252,11 @@ class DeepAgentsApp(App):
     async def _handle_update_command(self, command: str = "/update") -> None:
         """Handle the `/update` slash command — check for and install updates.
 
-        Parses optional `--prerelease` and `--deps` flags from the raw command
-        line; any other option is rejected with a usage message. `--deps`
+        Parses optional `--prerelease`, `--deps`, and `--log` flags from the raw
+        command line; any other option is rejected with a usage message. `--deps`
         re-resolves dependencies to their newest in-range versions even when
-        `deepagents-code` itself is already current.
+        `deepagents-code` itself is already current. `--log` displays the latest
+        persisted update log without checking for updates.
 
         Args:
             command: The raw slash-command line as typed, including any options.
@@ -6266,18 +6267,28 @@ class DeepAgentsApp(App):
         # loudly instead of silently downgrading to a stable update — mirroring
         # the headless path, which also refuses unknown options rather than
         # silently ignoring them.
-        allowed_options = {"--prerelease", "--deps"}
-        unknown = [opt for opt in parts[1:] if opt not in allowed_options]
+        options = parts[1:]
+        allowed_options = {"--prerelease", "--deps", "--log"}
+        unknown = [opt for opt in options if opt not in allowed_options]
         if unknown:
             await self._mount_message(
                 AppMessage(
                     f"Unknown option(s) for /update: {' '.join(unknown)}. "
-                    "Usage: /update [--deps] [--prerelease]",
+                    "Usage: /update [--deps] [--prerelease] | /update --log",
                 ),
             )
             return
-        prerelease_requested = "--prerelease" in parts[1:]
-        deps_only = "--deps" in parts[1:]
+        prerelease_requested = "--prerelease" in options
+        deps_only = "--deps" in options
+        log_requested = "--log" in options
+        if log_requested and options != ["--log"]:
+            await self._mount_message(
+                AppMessage(
+                    "The --log option cannot be combined with other options. "
+                    "Usage: /update --log",
+                ),
+            )
+            return
         include_prereleases = True if prerelease_requested else None
         try:
             from deepagents_code._version import __version__ as cli_version
@@ -6288,11 +6299,24 @@ class DeepAgentsApp(App):
                 format_age_suffix,
                 format_dependency_changes,
                 is_update_available,
+                latest_update_log,
                 parse_dependency_changes,
                 perform_dependency_refresh_dry_run,
                 prerelease_upgrade_supported,
                 release_requires_prereleases,
             )
+
+            if log_requested:
+                log = await asyncio.to_thread(latest_update_log)
+                if log is None:
+                    await self._mount_message(AppMessage("No update log found."))
+                    return
+                log_path, contents = log
+                body = contents.rstrip() or "(empty log)"
+                await self._mount_message(
+                    AppMessage(f"Latest update log ({log_path}):\n{body}"),
+                )
+                return
 
             if await asyncio.to_thread(_is_editable_install):
                 age_suffix = await asyncio.to_thread(format_age_suffix, cli_version)
@@ -6571,7 +6595,6 @@ class DeepAgentsApp(App):
         from deepagents_code.update_check import (
             _PRERELEASE_UNSUPPORTED_MESSAGE,
             detect_shadowed_dcode_safe,
-            format_dependency_changes,
             format_installed_age_suffix,
             format_release_age_parenthetical,
             format_shadowed_dcode_warning,
@@ -6635,8 +6658,6 @@ class DeepAgentsApp(App):
                 await self._mount_message(
                     ErrorMessage(format_shadowed_dcode_warning(shadow)),
                 )
-            # The upgrade re-resolves the whole environment, so surface any
-            # dependency bumps that rode along with the dcode release.
             dep_changes = [
                 change
                 for change in parse_dependency_changes(output)
@@ -6645,8 +6666,7 @@ class DeepAgentsApp(App):
             if dep_changes:
                 await self._mount_message(
                     AppMessage(
-                        "Dependencies updated:\n"
-                        f"{format_dependency_changes(dep_changes)}",
+                        "Dependencies updated. Run /update --log to view details.",
                     ),
                 )
         else:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6636,8 +6636,13 @@ class DeepAgentsApp(App):
             )
             return
         log_path = create_update_log_path()
+        if sys.platform == "win32":
+            quoted_log_path = str(log_path).replace("'", "''")
+            log_command = f"Get-Content -Wait -LiteralPath '{quoted_log_path}'"
+        else:
+            log_command = f"tail -f {shlex.quote(str(log_path))}"
         await self._mount_message(
-            AppMessage(f"Update log: tail -f {shlex.quote(str(log_path))}"),
+            AppMessage(f"Update log: {log_command}"),
         )
         success, output, installed = await perform_upgrade(
             log_path=log_path,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6597,9 +6597,10 @@ class DeepAgentsApp(App):
         from deepagents_code._env_vars import DEBUG_UPDATE
         from deepagents_code.update_check import (
             _PRERELEASE_UNSUPPORTED_MESSAGE,
-            create_update_log_path,
+            create_update_log_file,
             detect_shadowed_dcode_safe,
             format_installed_age_suffix,
+            format_log_follow_command,
             format_release_age_parenthetical,
             format_shadowed_dcode_warning,
             perform_upgrade,
@@ -6635,15 +6636,19 @@ class DeepAgentsApp(App):
                 AppMessage("Skipped update install (debug mode)."),
             )
             return
-        log_path = create_update_log_path()
-        if sys.platform == "win32":
-            quoted_log_path = str(log_path).replace("'", "''")
-            log_command = f"Get-Content -Wait -LiteralPath '{quoted_log_path}'"
-        else:
-            log_command = f"tail -f {shlex.quote(str(log_path))}"
-        await self._mount_message(
-            AppMessage(f"Update log: {log_command}"),
-        )
+        # Mount the log hint *before* awaiting the upgrade: the whole point of
+        # replacing the post-upgrade dependency summary with a log pointer is
+        # that the user can follow the install while it streams. Creating the
+        # file eagerly (rather than just naming it) keeps that hint honest even
+        # when `perform_upgrade` refuses before spawning an installer. Run it
+        # off the event loop — it globs and unlinks in the cache dir — and
+        # tolerate a `None` so a log-path failure can't turn an otherwise fine
+        # upgrade into an "/update failed" report.
+        log_path = await asyncio.to_thread(create_update_log_file)
+        if log_path is not None:
+            await self._mount_message(
+                AppMessage(f"Update log: {format_log_follow_command(log_path)}"),
+            )
         success, output, installed = await perform_upgrade(
             log_path=log_path,
             include_prereleases=include_prereleases,
@@ -6687,8 +6692,16 @@ class DeepAgentsApp(App):
                 version=pin_upgrade_version,
             )
             detail = f": {output[:200]}" if output else ""
+            # Repeat the log path here rather than relying on the hint above:
+            # a failed resolution streams hundreds of lines through the TUI in
+            # between, so by now that hint has scrolled away — and `detail` is
+            # truncated, making the full log the only complete record. Matches
+            # the sibling install-failure branches, which all end in `Log:`.
+            log_line = f"\nLog: {log_path}" if log_path is not None else ""
             await self._mount_message(
-                AppMessage(f"Auto-update failed{detail}\nRun manually: {cmd}"),
+                AppMessage(
+                    f"Auto-update failed{detail}{log_line}\nRun manually: {cmd}",
+                ),
             )
 
     async def _refresh_dependencies(

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6252,11 +6252,10 @@ class DeepAgentsApp(App):
     async def _handle_update_command(self, command: str = "/update") -> None:
         """Handle the `/update` slash command — check for and install updates.
 
-        Parses optional `--prerelease`, `--deps`, and `--log` flags from the raw
-        command line; any other option is rejected with a usage message. `--deps`
+        Parses optional `--prerelease` and `--deps` flags from the raw command
+        line; any other option is rejected with a usage message. `--deps`
         re-resolves dependencies to their newest in-range versions even when
-        `deepagents-code` itself is already current. `--log` displays the latest
-        persisted update log without checking for updates.
+        `deepagents-code` itself is already current.
 
         Args:
             command: The raw slash-command line as typed, including any options.
@@ -6267,28 +6266,18 @@ class DeepAgentsApp(App):
         # loudly instead of silently downgrading to a stable update — mirroring
         # the headless path, which also refuses unknown options rather than
         # silently ignoring them.
-        options = parts[1:]
-        allowed_options = {"--prerelease", "--deps", "--log"}
-        unknown = [opt for opt in options if opt not in allowed_options]
+        allowed_options = {"--prerelease", "--deps"}
+        unknown = [opt for opt in parts[1:] if opt not in allowed_options]
         if unknown:
             await self._mount_message(
                 AppMessage(
                     f"Unknown option(s) for /update: {' '.join(unknown)}. "
-                    "Usage: /update [--deps] [--prerelease] | /update --log",
+                    "Usage: /update [--deps] [--prerelease]",
                 ),
             )
             return
-        prerelease_requested = "--prerelease" in options
-        deps_only = "--deps" in options
-        log_requested = "--log" in options
-        if log_requested and options != ["--log"]:
-            await self._mount_message(
-                AppMessage(
-                    "The --log option cannot be combined with other options. "
-                    "Usage: /update --log",
-                ),
-            )
-            return
+        prerelease_requested = "--prerelease" in parts[1:]
+        deps_only = "--deps" in parts[1:]
         include_prereleases = True if prerelease_requested else None
         try:
             from deepagents_code._version import __version__ as cli_version
@@ -6299,24 +6288,11 @@ class DeepAgentsApp(App):
                 format_age_suffix,
                 format_dependency_changes,
                 is_update_available,
-                latest_update_log,
                 parse_dependency_changes,
                 perform_dependency_refresh_dry_run,
                 prerelease_upgrade_supported,
                 release_requires_prereleases,
             )
-
-            if log_requested:
-                log = await asyncio.to_thread(latest_update_log)
-                if log is None:
-                    await self._mount_message(AppMessage("No update log found."))
-                    return
-                log_path, contents = log
-                body = contents.rstrip() or "(empty log)"
-                await self._mount_message(
-                    AppMessage(f"Latest update log ({log_path}):\n{body}"),
-                )
-                return
 
             if await asyncio.to_thread(_is_editable_install):
                 age_suffix = await asyncio.to_thread(format_age_suffix, cli_version)
@@ -6594,11 +6570,11 @@ class DeepAgentsApp(App):
         from deepagents_code._env_vars import DEBUG_UPDATE
         from deepagents_code.update_check import (
             _PRERELEASE_UNSUPPORTED_MESSAGE,
+            create_update_log_path,
             detect_shadowed_dcode_safe,
             format_installed_age_suffix,
             format_release_age_parenthetical,
             format_shadowed_dcode_warning,
-            parse_dependency_changes,
             perform_upgrade,
             prerelease_upgrade_supported,
             upgrade_command,
@@ -6632,7 +6608,12 @@ class DeepAgentsApp(App):
                 AppMessage("Skipped update install (debug mode)."),
             )
             return
+        log_path = create_update_log_path()
+        await self._mount_message(
+            AppMessage(f"Update log: tail -f {shlex.quote(str(log_path))}"),
+        )
         success, output = await perform_upgrade(
+            log_path=log_path,
             include_prereleases=include_prereleases,
             target_version=latest,
         )
@@ -6657,17 +6638,6 @@ class DeepAgentsApp(App):
             else:
                 await self._mount_message(
                     ErrorMessage(format_shadowed_dcode_warning(shadow)),
-                )
-            dep_changes = [
-                change
-                for change in parse_dependency_changes(output)
-                if change.name != "deepagents-code"
-            ]
-            if dep_changes:
-                await self._mount_message(
-                    AppMessage(
-                        "Dependencies updated. Run /update --log to view details.",
-                    ),
                 )
         else:
             cmd = upgrade_command(

--- a/libs/code/deepagents_code/client/commands/extras.py
+++ b/libs/code/deepagents_code/client/commands/extras.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import shlex
 import sys
 from typing import TYPE_CHECKING
 
@@ -25,11 +24,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
-
-
-def _tail_log_command(log_path: Path | str) -> str:
-    """Return a copy-pasteable command for following a log file."""
-    return f"tail -f {shlex.quote(str(log_path))}"
 
 
 def run_install_command(args: argparse.Namespace) -> int:
@@ -87,6 +81,7 @@ def _run_install_package(*, name: str, yes: bool) -> int:
     from deepagents_code.update_check import (
         create_update_log_path,
         editable_package_hint,
+        format_log_follow_command,
         is_valid_package_name,
         perform_install_package,
     )
@@ -143,7 +138,7 @@ def _run_install_package(*, name: str, yes: bool) -> int:
         console.print(f"Installing package '{package}'...")
         pkg_log_path = create_update_log_path()
         console.print(
-            f"Install log: {_tail_log_command(pkg_log_path)}",
+            f"Install log: {format_log_follow_command(pkg_log_path)}",
             style="dim",
             highlight=False,
             markup=False,
@@ -193,6 +188,7 @@ def _run_install_extra(*, name: str, yes: bool) -> int:
     from deepagents_code.update_check import (
         create_update_log_path,
         editable_extra_hint,
+        format_log_follow_command,
         install_extra_command,
         install_extras_command,
         is_valid_extra_name,
@@ -254,7 +250,7 @@ def _run_install_extra(*, name: str, yes: bool) -> int:
         console.print(f"Installing extra '{extra}'...")
         log_path = create_update_log_path()
         console.print(
-            f"Install log: {_tail_log_command(log_path)}",
+            f"Install log: {format_log_follow_command(log_path)}",
             style="dim",
             highlight=False,
             markup=False,

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -284,8 +284,8 @@ COMMANDS: tuple[SlashCommand, ...] = (
         name="/update",
         description="Check for and install updates",
         bypass_tier=BypassTier.QUEUED,
-        hidden_keywords="upgrade dependencies deps refresh",
-        argument_hint="[--deps] [--prerelease]",
+        hidden_keywords="upgrade dependencies deps refresh log",
+        argument_hint="[--deps] [--prerelease] | --log",
     ),
     SlashCommand(
         name="/install",

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -284,8 +284,8 @@ COMMANDS: tuple[SlashCommand, ...] = (
         name="/update",
         description="Check for and install updates",
         bypass_tier=BypassTier.QUEUED,
-        hidden_keywords="upgrade dependencies deps refresh log",
-        argument_hint="[--deps] [--prerelease] | --log",
+        hidden_keywords="upgrade dependencies deps refresh",
+        argument_hint="[--deps] [--prerelease]",
     ),
     SlashCommand(
         name="/install",

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -15,7 +15,6 @@ import importlib.util
 import json
 import logging
 import os
-import shlex
 import shutil
 import signal
 import sys
@@ -110,11 +109,6 @@ def _install_termination_signal_handlers() -> None:
     if sys.platform != "win32":
         for signum in (signal.SIGHUP, signal.SIGTERM, signal.SIGQUIT):
             signal.signal(signum, _handle_termination_signal)
-
-
-def _tail_log_command(log_path: Path | str) -> str:
-    """Return a copy-pasteable command for following a log file."""
-    return f"tail -f {shlex.quote(str(log_path))}"
 
 
 def build_version_text() -> str:
@@ -505,6 +499,7 @@ def _run_startup_auto_update(console: "Console") -> None:
         clear_startup_auto_update_failure,
         create_update_log_path,
         detect_shadowed_dcode_safe,
+        format_log_follow_command,
         format_release_age_parenthetical,
         format_shadowed_dcode_warning,
         get_cached_update_available,
@@ -652,7 +647,7 @@ def _run_startup_auto_update(console: "Console") -> None:
                 return
             log_path = create_update_log_path()
             console.print(
-                f"Update log: {_tail_log_command(log_path)}",
+                f"Update log: {format_log_follow_command(log_path)}",
                 style="dim",
                 highlight=False,
                 markup=False,
@@ -4586,6 +4581,7 @@ def cli_main() -> None:
                     create_update_log_path,
                     format_age_suffix,
                     format_installed_age_suffix,
+                    format_log_follow_command,
                     format_release_age_parenthetical,
                     is_update_available,
                     perform_upgrade,
@@ -4675,7 +4671,7 @@ def cli_main() -> None:
                         sys.exit(0)
                     log_path = create_update_log_path()
                     console.print(
-                        f"Update log: {_tail_log_command(log_path)}",
+                        f"Update log: {format_log_follow_command(log_path)}",
                         style="dim",
                         highlight=False,
                         markup=False,

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -497,7 +497,7 @@ def _run_startup_auto_update(console: "Console") -> None:
     from deepagents_code.config import _is_editable_install
     from deepagents_code.update_check import (
         clear_startup_auto_update_failure,
-        create_update_log_path,
+        create_update_log_file,
         detect_shadowed_dcode_safe,
         format_log_follow_command,
         format_release_age_parenthetical,
@@ -645,13 +645,14 @@ def _run_startup_auto_update(console: "Console") -> None:
             if os.environ.get(DEBUG_UPDATE):
                 console.print("Skipped update install (debug mode).", style="dim")
                 return
-            log_path = create_update_log_path()
-            console.print(
-                f"Update log: {format_log_follow_command(log_path)}",
-                style="dim",
-                highlight=False,
-                markup=False,
-            )
+            log_path = create_update_log_file()
+            if log_path is not None:
+                console.print(
+                    f"Update log: {format_log_follow_command(log_path)}",
+                    style="dim",
+                    highlight=False,
+                    markup=False,
+                )
             pending_failure_version = latest
             success, output, _installed = asyncio.run(
                 perform_upgrade(log_path=log_path, target_version=latest)
@@ -4608,7 +4609,7 @@ def cli_main() -> None:
                 from deepagents_code.config import _is_editable_install
                 from deepagents_code.update_check import (
                     _PRERELEASE_UNSUPPORTED_MESSAGE,
-                    create_update_log_path,
+                    create_update_log_file,
                     format_age_suffix,
                     format_installed_age_suffix,
                     format_log_follow_command,
@@ -4699,13 +4700,14 @@ def cli_main() -> None:
                             "Skipped update install (debug mode).", style="dim"
                         )
                         sys.exit(0)
-                    log_path = create_update_log_path()
-                    console.print(
-                        f"Update log: {format_log_follow_command(log_path)}",
-                        style="dim",
-                        highlight=False,
-                        markup=False,
-                    )
+                    log_path = create_update_log_file()
+                    if log_path is not None:
+                        console.print(
+                            f"Update log: {format_log_follow_command(log_path)}",
+                            style="dim",
+                            highlight=False,
+                            markup=False,
+                        )
                     success, output, _installed = asyncio.run(
                         perform_upgrade(
                             log_path=log_path,

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -1911,29 +1911,6 @@ def cleanup_update_logs(
         logger.debug("Failed to clean up update logs", exc_info=True)
 
 
-def latest_update_log() -> tuple[Path, str] | None:
-    """Return the newest readable update log and its contents."""
-    try:
-        logs = sorted(
-            (
-                (path.stat().st_mtime, path)
-                for path in UPDATE_LOG_DIR.glob("*.log")
-                if path.is_file()
-            ),
-            reverse=True,
-        )
-    except OSError:
-        logger.debug("Could not list update logs", exc_info=True)
-        return None
-
-    for _, path in logs:
-        try:
-            return path, path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            logger.debug("Could not read update log at %s", path, exc_info=True)
-    return None
-
-
 def create_update_log_path() -> Path:
     """Return a new timestamped update log path and clean stale logs."""
     cleanup_update_logs()

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -1911,6 +1911,29 @@ def cleanup_update_logs(
         logger.debug("Failed to clean up update logs", exc_info=True)
 
 
+def latest_update_log() -> tuple[Path, str] | None:
+    """Return the newest readable update log and its contents."""
+    try:
+        logs = sorted(
+            (
+                (path.stat().st_mtime, path)
+                for path in UPDATE_LOG_DIR.glob("*.log")
+                if path.is_file()
+            ),
+            reverse=True,
+        )
+    except OSError:
+        logger.debug("Could not list update logs", exc_info=True)
+        return None
+
+    for _, path in logs:
+        try:
+            return path, path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            logger.debug("Could not read update log at %s", path, exc_info=True)
+    return None
+
+
 def create_update_log_path() -> Path:
     """Return a new timestamped update log path and clean stale logs."""
     cleanup_update_logs()

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -1972,6 +1972,56 @@ def create_update_log_path() -> Path:
     return UPDATE_LOG_DIR / f"{stamp}-update.log"
 
 
+def create_update_log_file() -> Path | None:
+    """Create an empty update log file and return its path.
+
+    Callers that *advertise* the log to a user — "Update log: tail -f <path>" —
+    must use this rather than `create_update_log_path`, which only computes a
+    path. `perform_upgrade` refuses some upgrades before ever spawning an
+    installer (unknown or unsupported install method, `brew` missing from
+    `PATH`, the pre-release gate), and `_run_install_subprocess` degrades to
+    not persisting output when the log cannot be opened. In all of those cases
+    the path alone would name a file that never comes into existence, leaving
+    the user tailing an `ENOENT`.
+
+    Returns:
+        The created log path, or `None` if it could not be created — callers
+            should then omit the log hint rather than point at a missing file.
+    """
+    log_path = create_update_log_path()
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.touch()
+    except OSError:
+        logger.warning(
+            "Could not create update log at %s; not advertising it",
+            log_path,
+            exc_info=True,
+        )
+        return None
+    return log_path
+
+
+def format_log_follow_command(log_path: Path | str) -> str:
+    """Return a copy-pasteable command for following a log file as it is written.
+
+    Args:
+        log_path: Log file to follow.
+
+    Returns:
+        A `tail -f` invocation on POSIX, or its PowerShell equivalent on
+            Windows, where `tail` is not available.
+    """
+    if sys.platform == "win32":
+        # PowerShell, the default Windows shell. Single-quote the literal path
+        # so `$`, `$()`, and backticks in it are not expanded, doubling any
+        # embedded quote as PowerShell requires. `-LiteralPath` additionally
+        # keeps `[`/`]` in a cache path from being read as wildcards.
+        quoted = str(log_path).replace("'", "''")
+        return f"Get-Content -Wait -LiteralPath '{quoted}'"
+    return f"tail -f {shlex.quote(str(log_path))}"
+
+
 async def _emit_progress(callback: UpgradeProgressCallback | None, line: str) -> None:
     """Send a progress line to *callback*, supporting sync or async callbacks."""
     if callback is None:

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -185,9 +185,9 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
-            ),
+            ) as create_log_file,
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
             patch(
                 "deepagents_code.update_check.clear_startup_auto_update_failure"
@@ -206,6 +206,7 @@ class TestStartupAutoUpdate:
         # `pytest.raises(SystemExit)` would swallow that and pass.
         assert exit_info.value.code == 0
         upgrade.assert_awaited_once()
+        create_log_file.assert_called_once_with()
         clear_failure.assert_called_once_with("9.9.9")
         printed = " ".join(str(c.args[0]) for c in console.print.call_args_list)
         assert "tail -f /tmp/dcode-update.log" in printed
@@ -252,7 +253,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
@@ -384,7 +385,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", _record_lock_state),
@@ -437,7 +438,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
@@ -558,7 +559,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch(
@@ -599,7 +600,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch(
@@ -642,7 +643,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
@@ -884,7 +885,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
@@ -944,7 +945,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
@@ -998,7 +999,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
@@ -1063,7 +1064,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
@@ -1124,7 +1125,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
@@ -1394,7 +1395,7 @@ class TestStartupAutoUpdate:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
@@ -1700,7 +1701,7 @@ class TestAutoUpdateDefaultMigration:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),
@@ -1741,7 +1742,7 @@ class TestAutoUpdateDefaultMigration:
                 return_value="",
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=Path("/tmp/dcode-update.log"),
             ),
             patch("deepagents_code.update_check.perform_upgrade", upgrade),

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1964,7 +1964,7 @@ class TestUpdateSubcommand:
                 return_value=release_requires_prereleases,
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=log_path,
             ),
             patch(

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -86,6 +86,7 @@ from deepagents_code.update_check import (
     is_update_cache_fresh,
     is_valid_extra_name,
     is_valid_package_name,
+    latest_update_log,
     mark_auto_update_default_acknowledged,
     mark_startup_auto_update_failed,
     mark_update_notified,
@@ -2340,6 +2341,21 @@ class TestUpdateLogs:
         path = create_update_log_path()
         assert path.parent == update_log_dir
         assert path.name.endswith("-update.log")
+
+    def test_latest_update_log_reads_newest_file(self, update_log_dir) -> None:
+        update_log_dir.mkdir(parents=True)
+        older = update_log_dir / "older-update.log"
+        newer = update_log_dir / "newer-update.log"
+        older.write_text("old", encoding="utf-8")
+        newer.write_text("new", encoding="utf-8")
+        os.utime(older, (1, 1))
+        os.utime(newer, (2, 2))
+
+        assert latest_update_log() == (newer, "new")
+
+    def test_latest_update_log_returns_none_without_logs(self, update_log_dir) -> None:
+        assert not update_log_dir.exists()
+        assert latest_update_log() is None
 
     def test_cleanup_update_logs_removes_old_and_excess(self, update_log_dir) -> None:
         update_log_dir.mkdir(parents=True)

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -86,7 +86,6 @@ from deepagents_code.update_check import (
     is_update_cache_fresh,
     is_valid_extra_name,
     is_valid_package_name,
-    latest_update_log,
     mark_auto_update_default_acknowledged,
     mark_startup_auto_update_failed,
     mark_update_notified,
@@ -2341,21 +2340,6 @@ class TestUpdateLogs:
         path = create_update_log_path()
         assert path.parent == update_log_dir
         assert path.name.endswith("-update.log")
-
-    def test_latest_update_log_reads_newest_file(self, update_log_dir) -> None:
-        update_log_dir.mkdir(parents=True)
-        older = update_log_dir / "older-update.log"
-        newer = update_log_dir / "newer-update.log"
-        older.write_text("old", encoding="utf-8")
-        newer.write_text("new", encoding="utf-8")
-        os.utime(older, (1, 1))
-        os.utime(newer, (2, 2))
-
-        assert latest_update_log() == (newer, "new")
-
-    def test_latest_update_log_returns_none_without_logs(self, update_log_dir) -> None:
-        assert not update_log_dir.exists()
-        assert latest_update_log() is None
 
     def test_cleanup_update_logs_removes_old_and_excess(self, update_log_dir) -> None:
         update_log_dir.mkdir(parents=True)

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -50,6 +50,7 @@ from deepagents_code.update_check import (
     clear_resume_auto_update_deferral,
     clear_startup_auto_update_failure,
     clear_update_notified,
+    create_update_log_file,
     create_update_log_path,
     dependency_refresh_command,
     dependency_refresh_dry_run_command,
@@ -62,6 +63,7 @@ from deepagents_code.update_check import (
     format_age_suffix,
     format_dependency_changes,
     format_installed_age_suffix,
+    format_log_follow_command,
     format_release_age,
     format_release_age_parenthetical,
     format_sdk_age_suffix,
@@ -2405,6 +2407,44 @@ class TestUpdateLogs:
         path = create_update_log_path()
         assert path.parent == update_log_dir
         assert path.name.endswith("-update.log")
+
+    def test_create_update_log_file_creates_the_file(self, update_log_dir) -> None:
+        """The advertised log must exist even before an installer writes to it."""
+        path = create_update_log_file()
+        assert path is not None
+        assert path.parent == update_log_dir
+        assert path.is_file()
+
+    @pytest.mark.usefixtures("update_log_dir")
+    def test_create_update_log_file_returns_none_when_uncreatable(self, caplog) -> None:
+        """An unwritable cache dir yields `None` so callers can skip the hint."""
+        with (
+            patch.object(Path, "mkdir", side_effect=OSError("read-only")),
+            caplog.at_level(logging.WARNING, logger="deepagents_code.update_check"),
+        ):
+            assert create_update_log_file() is None
+        assert any("Could not create update log" in r.message for r in caplog.records)
+
+    def test_format_log_follow_command_quotes_posix_paths(self) -> None:
+        with patch("deepagents_code.update_check.sys.platform", "linux"):
+            assert (
+                format_log_follow_command(Path("/tmp/dcode update.log"))
+                == "tail -f '/tmp/dcode update.log'"
+            )
+
+    def test_format_log_follow_command_uses_powershell_on_windows(self) -> None:
+        """`tail` does not exist on Windows; PowerShell's `Get-Content` does."""
+        with patch("deepagents_code.update_check.sys.platform", "win32"):
+            assert format_log_follow_command(Path(r"C:\Users\a b.log")) == (
+                r"Get-Content -Wait -LiteralPath 'C:\Users\a b.log'"
+            )
+
+    def test_format_log_follow_command_escapes_powershell_quotes(self) -> None:
+        """PowerShell escapes a literal single quote by doubling it."""
+        with patch("deepagents_code.update_check.sys.platform", "win32"):
+            assert format_log_follow_command("C:\\o'brien.log") == (
+                "Get-Content -Wait -LiteralPath 'C:\\o''brien.log'"
+            )
 
     def test_cleanup_update_logs_removes_old_and_excess(self, update_log_dir) -> None:
         update_log_dir.mkdir(parents=True)

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -68,6 +68,20 @@ def _block_sdk_pypi_fetch(tmp_path: Path) -> Iterator[None]:
         yield
 
 
+@pytest.fixture(autouse=True)
+def _isolate_update_log_dir(tmp_path: Path) -> Iterator[None]:
+    """Keep `/update` tests out of the developer's real update-log directory.
+
+    `UPDATE_LOG_DIR` is a module-level constant baked from `default_cache_dir()`
+    at import, so no environment variable redirects it. Any test that reaches
+    `create_update_log_path` therefore runs `cleanup_update_logs` against the
+    real cache dir, pruning a user's genuine logs past `UPDATE_LOG_MAX_FILES`.
+    Tests that assert on a specific path override this with their own patch.
+    """
+    with patch("deepagents_code.update_check.UPDATE_LOG_DIR", tmp_path / "update_logs"):
+        yield
+
+
 def test_version_matches_pyproject() -> None:
     """Verify `__version__` in `_version.py` matches version in `pyproject.toml`."""
     # Get the project root directory
@@ -726,7 +740,7 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
 async def test_update_slash_command_links_log_instead_of_listing_dependencies() -> None:
     """A normal app upgrade keeps dependency churn in its exact update log."""
     from deepagents_code.app import DeepAgentsApp
-    from deepagents_code.tui.widgets.messages import AppMessage
+    from deepagents_code.tui.widgets.messages import AppMessage, ErrorMessage
 
     log_path = Path("/tmp/dcode update.log")
     app = DeepAgentsApp()
@@ -742,7 +756,7 @@ async def test_update_slash_command_links_log_instead_of_listing_dependencies() 
                 return_value=(True, "99.0.0"),
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=log_path,
             ),
             patch(
@@ -772,10 +786,15 @@ async def test_update_slash_command_links_log_instead_of_listing_dependencies() 
             str(m._content) for m in app.query(AppMessage) if not m._is_markdown
         )
         assert "Update log: tail -f '/tmp/dcode update.log'" in content
+        # Pin the success branch. The negative assertions below are only
+        # meaningful if the flow actually reached the branch that used to print
+        # the dependency summary — a swallowed exception (e.g. a `perform_upgrade`
+        # arity change) would otherwise make them pass vacuously. `ErrorMessage`
+        # is not an `AppMessage` subclass, so `content` cannot see failures.
         assert "Updated to v99.0.0" in content
-        assert "/update failed" not in content
+        assert not app.query(ErrorMessage)
         assert "Dependencies updated:" not in content
-        assert "anthropic  0.120.2 -> 0.122.0" not in content
+        assert "anthropic" not in content
 
 
 async def test_update_slash_command_uses_powershell_to_follow_logs() -> None:
@@ -797,10 +816,10 @@ async def test_update_slash_command_uses_powershell_to_follow_logs() -> None:
                 return_value=(True, "99.0.0"),
             ),
             patch(
-                "deepagents_code.update_check.create_update_log_path",
+                "deepagents_code.update_check.create_update_log_file",
                 return_value=log_path,
             ),
-            patch("deepagents_code.app.sys.platform", "win32"),
+            patch("deepagents_code.update_check.sys.platform", "win32"),
             patch(
                 "deepagents_code.update_check.perform_upgrade",
                 new_callable=AsyncMock,
@@ -1961,6 +1980,99 @@ async def test_perform_app_upgrade_failure_surfaces_manual_command() -> None:
         assert "Auto-update failed" in content
         assert "resolver: conflict" in content
         assert "uv tool install -U 'deepagents-code==1.1.0'" in content
+
+
+async def test_perform_app_upgrade_failure_repeats_log_path() -> None:
+    """A failed upgrade names its log again, not just in the pre-install hint.
+
+    The failure detail is truncated to 200 characters, so the log is the only
+    complete record — and the hint mounted before the install has scrolled away
+    behind the installer's streamed output by the time the failure lands.
+    """
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage
+
+    log_path = Path("/tmp/dcode failed-update.log")
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.update_check.create_update_log_file",
+                return_value=log_path,
+            ),
+            patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+                return_value=(False, "resolver: conflict", None),
+            ),
+            patch(
+                "deepagents_code.update_check.upgrade_command",
+                return_value="uv tool install -U 'deepagents-code==1.1.0'",
+            ),
+        ):
+            await app._perform_app_upgrade(
+                current="1.0.0",
+                latest="1.1.0",
+                include_prereleases=None,
+                upgrade_include_prereleases=None,
+                pin_upgrade_version="1.1.0",
+            )
+            await pilot.pause()
+
+        failures = [
+            str(m._content)
+            for m in app.query(AppMessage)
+            if not m._is_markdown and "Auto-update failed" in str(m._content)
+        ]
+        assert failures
+        assert f"Log: {log_path}" in failures[0]
+
+
+async def test_perform_app_upgrade_omits_log_hint_when_log_uncreatable() -> None:
+    """An uncreatable log is silently skipped, never advertised as a dead path.
+
+    `create_update_log_file` returns `None` when the cache dir cannot be
+    written. Pointing the user at `tail -f <path>` for a file that will never
+    exist is worse than saying nothing, and the upgrade itself must still run.
+    """
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage, ErrorMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.update_check.create_update_log_file",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+                return_value=(True, "", "1.1.0"),
+            ) as perform_upgrade_mock,
+        ):
+            await app._perform_app_upgrade(
+                current="1.0.0",
+                latest="1.1.0",
+                include_prereleases=None,
+                upgrade_include_prereleases=None,
+                pin_upgrade_version="1.1.0",
+            )
+            await pilot.pause()
+
+        perform_upgrade_mock.assert_awaited_once_with(
+            log_path=None,
+            include_prereleases=None,
+            target_version="1.1.0",
+        )
+        content = "\n".join(
+            str(m._content) for m in app.query(AppMessage) if not m._is_markdown
+        )
+        assert "Update log:" not in content
+        assert "Updated to v1.1.0" in content
+        assert not app.query(ErrorMessage)
 
 
 async def test_perform_app_upgrade_defers_to_another_session() -> None:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -756,6 +756,7 @@ async def test_update_slash_command_links_log_instead_of_listing_dependencies() 
                         " - anthropic==0.120.2\n"
                         " + anthropic==0.122.0\n"
                     ),
+                    "99.0.0",
                 ),
             ) as perform_upgrade_mock,
         ):
@@ -771,8 +772,50 @@ async def test_update_slash_command_links_log_instead_of_listing_dependencies() 
             str(m._content) for m in app.query(AppMessage) if not m._is_markdown
         )
         assert "Update log: tail -f '/tmp/dcode update.log'" in content
+        assert "Updated to v99.0.0" in content
+        assert "/update failed" not in content
         assert "Dependencies updated:" not in content
         assert "anthropic  0.120.2 -> 0.122.0" not in content
+
+
+async def test_update_slash_command_uses_powershell_to_follow_logs() -> None:
+    """Windows updates show a PowerShell-compatible log-follow command."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage
+
+    log_path = Path(r"C:\Users\dcode update.log")
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+                return_value=(True, "99.0.0"),
+            ),
+            patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=log_path,
+            ),
+            patch("deepagents_code.app.sys.platform", "win32"),
+            patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+                return_value=(True, "", "99.0.0"),
+            ),
+        ):
+            await app._handle_command("/update")
+            await pilot.pause()
+
+        content = "\n".join(
+            str(m._content) for m in app.query(AppMessage) if not m._is_markdown
+        )
+        assert (
+            "Update log: Get-Content -Wait -LiteralPath 'C:\\Users\\dcode update.log'"
+        ) in content
 
 
 async def test_update_slash_command_stable_prerelease_deps_keep_intent_none() -> None:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -714,6 +714,47 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
         assert "Updated to v99.0.0" in str(app_msgs[-1]._content)
 
 
+async def test_update_slash_command_hides_dependency_details_by_default() -> None:
+    """A normal app upgrade keeps dependency churn behind `/update --log`."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+                return_value=(True, "99.0.0"),
+            ),
+            patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+                return_value=(
+                    True,
+                    (
+                        " - deepagents-code==1.0.0\n"
+                        " + deepagents-code==99.0.0\n"
+                        " - anthropic==0.120.2\n"
+                        " + anthropic==0.122.0\n"
+                    ),
+                ),
+            ),
+        ):
+            await app._handle_command("/update")
+            await pilot.pause()
+
+        content = "\n".join(
+            str(m._content) for m in app.query(AppMessage) if not m._is_markdown
+        )
+        assert "Dependencies updated. Run /update --log to view details." in content
+        assert "anthropic  0.120.2 -> 0.122.0" not in content
+
+
 async def test_update_slash_command_stable_prerelease_deps_keep_intent_none() -> None:
     """Stable releases with pre-release deps let `perform_upgrade` pin the app."""
     from deepagents_code.app import DeepAgentsApp
@@ -919,6 +960,74 @@ async def test_update_slash_command_rejects_unknown_option() -> None:
         assert "Unknown option(s) for /update: --prereleases" in str(
             app_msgs[-1]._content
         )
+
+
+async def test_update_slash_command_displays_latest_log() -> None:
+    """`/update --log` shows the latest persisted updater output."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.update_check.latest_update_log",
+                return_value=(
+                    Path("/tmp/latest-update.log"),
+                    "$ uv tool upgrade\n+ dep==2",
+                ),
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+            ) as is_update_mock,
+        ):
+            await app._handle_command("/update --log")
+            await pilot.pause()
+
+        is_update_mock.assert_not_called()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        content = str(app_msgs[-1]._content)
+        assert "Latest update log (/tmp/latest-update.log):" in content
+        assert "$ uv tool upgrade\n+ dep==2" in content
+
+
+async def test_update_slash_command_reports_missing_log() -> None:
+    """`/update --log` explains when no persisted updater output exists."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with patch(
+            "deepagents_code.update_check.latest_update_log",
+            return_value=None,
+        ):
+            await app._handle_command("/update --log")
+            await pilot.pause()
+
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert "No update log found." in str(app_msgs[-1]._content)
+
+
+async def test_update_slash_command_rejects_log_with_other_options() -> None:
+    """`--log` is a read-only action and cannot trigger an update."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with patch(
+            "deepagents_code.update_check.latest_update_log",
+        ) as latest_log_mock:
+            await app._handle_command("/update --log --deps")
+            await pilot.pause()
+
+        latest_log_mock.assert_not_called()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert "The --log option cannot be combined" in str(app_msgs[-1]._content)
 
 
 async def test_update_deps_refreshes_when_dcode_current() -> None:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -9,7 +9,7 @@ import tomllib
 from importlib.metadata import version as pkg_version
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
 
@@ -707,6 +707,7 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
             include_prereleases=None,
         )
         perform_upgrade_mock.assert_awaited_once_with(
+            log_path=ANY,
             include_prereleases=None,
             target_version="99.0.0",
         )
@@ -714,11 +715,12 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
         assert "Updated to v99.0.0" in str(app_msgs[-1]._content)
 
 
-async def test_update_slash_command_hides_dependency_details_by_default() -> None:
-    """A normal app upgrade keeps dependency churn behind `/update --log`."""
+async def test_update_slash_command_links_log_instead_of_listing_dependencies() -> None:
+    """A normal app upgrade keeps dependency churn in its exact update log."""
     from deepagents_code.app import DeepAgentsApp
     from deepagents_code.tui.widgets.messages import AppMessage
 
+    log_path = Path("/tmp/dcode update.log")
     app = DeepAgentsApp()
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -732,6 +734,10 @@ async def test_update_slash_command_hides_dependency_details_by_default() -> Non
                 return_value=(True, "99.0.0"),
             ),
             patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=log_path,
+            ),
+            patch(
                 "deepagents_code.update_check.perform_upgrade",
                 new_callable=AsyncMock,
                 return_value=(
@@ -743,15 +749,21 @@ async def test_update_slash_command_hides_dependency_details_by_default() -> Non
                         " + anthropic==0.122.0\n"
                     ),
                 ),
-            ),
+            ) as perform_upgrade_mock,
         ):
             await app._handle_command("/update")
             await pilot.pause()
 
+        perform_upgrade_mock.assert_awaited_once_with(
+            log_path=log_path,
+            include_prereleases=None,
+            target_version="99.0.0",
+        )
         content = "\n".join(
             str(m._content) for m in app.query(AppMessage) if not m._is_markdown
         )
-        assert "Dependencies updated. Run /update --log to view details." in content
+        assert "Update log: tail -f '/tmp/dcode update.log'" in content
+        assert "Dependencies updated:" not in content
         assert "anthropic  0.120.2 -> 0.122.0" not in content
 
 
@@ -789,6 +801,7 @@ async def test_update_slash_command_stable_prerelease_deps_keep_intent_none() ->
             await pilot.pause()
 
     perform_upgrade_mock.assert_awaited_once_with(
+        log_path=ANY,
         include_prereleases=None,
         target_version="99.0.0",
     )
@@ -832,6 +845,7 @@ async def test_update_slash_command_prerelease_updates_channel() -> None:
             include_prereleases=True,
         )
         perform_upgrade_mock.assert_awaited_once_with(
+            log_path=ANY,
             include_prereleases=True,
             target_version="99.0.0rc1",
         )
@@ -960,74 +974,6 @@ async def test_update_slash_command_rejects_unknown_option() -> None:
         assert "Unknown option(s) for /update: --prereleases" in str(
             app_msgs[-1]._content
         )
-
-
-async def test_update_slash_command_displays_latest_log() -> None:
-    """`/update --log` shows the latest persisted updater output."""
-    from deepagents_code.app import DeepAgentsApp
-    from deepagents_code.tui.widgets.messages import AppMessage
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        with (
-            patch(
-                "deepagents_code.update_check.latest_update_log",
-                return_value=(
-                    Path("/tmp/latest-update.log"),
-                    "$ uv tool upgrade\n+ dep==2",
-                ),
-            ),
-            patch(
-                "deepagents_code.update_check.is_update_available",
-            ) as is_update_mock,
-        ):
-            await app._handle_command("/update --log")
-            await pilot.pause()
-
-        is_update_mock.assert_not_called()
-        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
-        content = str(app_msgs[-1]._content)
-        assert "Latest update log (/tmp/latest-update.log):" in content
-        assert "$ uv tool upgrade\n+ dep==2" in content
-
-
-async def test_update_slash_command_reports_missing_log() -> None:
-    """`/update --log` explains when no persisted updater output exists."""
-    from deepagents_code.app import DeepAgentsApp
-    from deepagents_code.tui.widgets.messages import AppMessage
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        with patch(
-            "deepagents_code.update_check.latest_update_log",
-            return_value=None,
-        ):
-            await app._handle_command("/update --log")
-            await pilot.pause()
-
-        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
-        assert "No update log found." in str(app_msgs[-1]._content)
-
-
-async def test_update_slash_command_rejects_log_with_other_options() -> None:
-    """`--log` is a read-only action and cannot trigger an update."""
-    from deepagents_code.app import DeepAgentsApp
-    from deepagents_code.tui.widgets.messages import AppMessage
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        with patch(
-            "deepagents_code.update_check.latest_update_log",
-        ) as latest_log_mock:
-            await app._handle_command("/update --log --deps")
-            await pilot.pause()
-
-        latest_log_mock.assert_not_called()
-        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
-        assert "The --log option cannot be combined" in str(app_msgs[-1]._content)
 
 
 async def test_update_deps_refreshes_when_dcode_current() -> None:
@@ -1194,6 +1140,7 @@ async def test_update_deps_skips_refresh_prompt_when_refresh_unsupported(
         confirm_mock.assert_not_awaited()
         refresh_mock.assert_not_awaited()
         perform_upgrade_mock.assert_awaited_once_with(
+            log_path=ANY,
             include_prereleases=None,
             target_version="1.1.0",
         )


### PR DESCRIPTION
Normal `/update` output no longer lists every transitive dependency change and instead shows a command for the exact persisted update log.

---

The updater now allocates a per-operation log path and passes it through to the install, matching the existing startup-update convention without adding a new slash-command API. Explicit dependency refreshes remain detailed.

Made by [Open SWE](https://openswe.vercel.app/agents/53250091-9fc0-c98e-0296-31e4b1aded04)