### PR TITLE
fix(code): refresh splash version after update

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6613,12 +6613,17 @@ class DeepAgentsApp(App):
                 AppMessage("Skipped update install (debug mode)."),
             )
             return
-        success, output = await perform_upgrade(
+        success, output, installed = await perform_upgrade(
             include_prereleases=include_prereleases,
             target_version=latest,
         )
         if success:
             self._update_available = (False, None)
+            # The install command is unpinned, so the installer may have
+            # resolved a release newer than the one the update check observed
+            # (a release published while the session sat open). Report what
+            # actually landed on disk rather than the stale check result.
+            upgraded_to = installed or latest
             # uv may have installed the upgraded shim into a directory that
             # isn't first on the user's PATH (e.g. a leftover pre-uv
             # `dcode` from a former `pipx` install). Detect that before
@@ -6629,10 +6634,10 @@ class DeepAgentsApp(App):
             # successful upgrade into a "/update failed" message.
             shadow = await asyncio.to_thread(detect_shadowed_dcode_safe)
             if shadow is None:
-                self._update_splash_version(latest)
+                self._update_splash_version(upgraded_to)
                 await self._mount_message(
                     AppMessage(
-                        f"Updated to v{latest}. Quit and relaunch dcode "
+                        f"Updated to v{upgraded_to}. Quit and relaunch dcode "
                         "to use the new version."
                     ),
                 )
@@ -22389,7 +22394,7 @@ class DeepAgentsApp(App):
                             show_toast=not progress_modal_visible,
                         )
                         return
-                    success, output = await perform_upgrade(
+                    success, output, installed = await perform_upgrade(
                         progress=screen.append_line,
                         log_path=log_path,
                         target_version=payload.latest,
@@ -22417,12 +22422,18 @@ class DeepAgentsApp(App):
                                 markup=False,
                             )
                             return
-                        self._update_splash_version(payload.latest)
+                        # The install command is unpinned, so the installer
+                        # may have resolved a release newer than the one this
+                        # notification advertised (a release published while
+                        # the notice sat open). Report what actually landed on
+                        # disk rather than the stale payload version.
+                        upgraded_to = installed or payload.latest
+                        self._update_splash_version(upgraded_to)
                         screen.mark_success()
                         if progress_modal_visible:
                             return
                         self.notify(
-                            f"Updated to v{payload.latest}. "
+                            f"Updated to v{upgraded_to}. "
                             "Quit and relaunch dcode to use the new version.",
                             severity="information",
                             timeout=10,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6513,6 +6513,10 @@ class DeepAgentsApp(App):
             )
             await self._mount_update_failure(exc)
 
+    def _update_splash_version(self, version: str) -> None:
+        """Show the installed version in the splash after an in-session update."""
+        self.query_one("#welcome-banner", WelcomeBanner).update_version(version)
+
     async def _perform_app_upgrade(
         self,
         *,
@@ -6625,6 +6629,7 @@ class DeepAgentsApp(App):
             # successful upgrade into a "/update failed" message.
             shadow = await asyncio.to_thread(detect_shadowed_dcode_safe)
             if shadow is None:
+                self._update_splash_version(latest)
                 await self._mount_message(
                     AppMessage(
                         f"Updated to v{latest}. Quit and relaunch dcode "
@@ -22412,6 +22417,7 @@ class DeepAgentsApp(App):
                                 markup=False,
                             )
                             return
+                        self._update_splash_version(payload.latest)
                         screen.mark_success()
                         if progress_modal_visible:
                             return

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6514,8 +6514,31 @@ class DeepAgentsApp(App):
             await self._mount_update_failure(exc)
 
     def _update_splash_version(self, version: str) -> None:
-        """Show the installed version in the splash after an in-session update."""
-        self.query_one("#welcome-banner", WelcomeBanner).update_version(version)
+        """Show the installed version in the splash after an in-session update.
+
+        Call this only once the install is known to be the version a relaunch
+        will actually run: the shadowed-`dcode` paths deliberately leave the
+        old version on the banner, because a stale shim earlier on PATH means
+        relaunching keeps the old binary.
+
+        Repainting the splash is cosmetic, so a missing banner is logged rather
+        than raised — callers emit the authoritative success messaging around
+        this call and must not have it turned into a failure report.
+
+        Args:
+            version: The newly installed `deepagents-code` version.
+        """
+        try:
+            banner = self.query_one("#welcome-banner", WelcomeBanner)
+        except NoMatches:
+            # The banner is composed once and never removed, so a miss here
+            # means it has silently vanished — surface it.
+            logger.warning("Welcome banner not found during splash version sync")
+            return
+        except ScreenStackError:
+            logger.debug("Screen stack empty during splash version sync", exc_info=True)
+            return
+        banner.update_version(version)
 
     async def _perform_app_upgrade(
         self,
@@ -6634,13 +6657,17 @@ class DeepAgentsApp(App):
             # successful upgrade into a "/update failed" message.
             shadow = await asyncio.to_thread(detect_shadowed_dcode_safe)
             if shadow is None:
-                self._update_splash_version(upgraded_to)
                 await self._mount_message(
                     AppMessage(
                         f"Updated to v{upgraded_to}. Quit and relaunch dcode "
                         "to use the new version."
                     ),
                 )
+                # After the success line: this method runs inside the caller's
+                # `except Exception -> _mount_update_failure`, so a cosmetic
+                # repaint must not be able to precede (and replace) the
+                # success message with an "/update failed" report.
+                self._update_splash_version(upgraded_to)
             else:
                 await self._mount_message(
                     ErrorMessage(format_shadowed_dcode_warning(shadow)),
@@ -22428,8 +22455,12 @@ class DeepAgentsApp(App):
                         # the notice sat open). Report what actually landed on
                         # disk rather than the stale payload version.
                         upgraded_to = installed or payload.latest
-                        self._update_splash_version(upgraded_to)
+                        # After `mark_success`: the modal stays un-dismissable
+                        # until it is marked done, and this worker runs with
+                        # Textual's default `exit_on_error`, so a cosmetic
+                        # repaint must not be able to strand the modal.
                         screen.mark_success()
+                        self._update_splash_version(upgraded_to)
                         if progress_modal_visible:
                             return
                         self.notify(

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -658,7 +658,7 @@ def _run_startup_auto_update(console: "Console") -> None:
                 markup=False,
             )
             pending_failure_version = latest
-            success, output = asyncio.run(
+            success, output, _installed = asyncio.run(
                 perform_upgrade(log_path=log_path, target_version=latest)
             )
         if success:
@@ -4680,7 +4680,7 @@ def cli_main() -> None:
                         highlight=False,
                         markup=False,
                     )
-                    success, output = asyncio.run(
+                    success, output, _installed = asyncio.run(
                         perform_upgrade(
                             log_path=log_path,
                             include_prereleases=include_prereleases,

--- a/libs/code/deepagents_code/tui/widgets/welcome.py
+++ b/libs/code/deepagents_code/tui/widgets/welcome.py
@@ -235,6 +235,7 @@ class WelcomeBanner(Static):
         self._show_cwd = is_env_truthy(SPLASH_SHOW_CWD)
         self._hide_cwd = is_env_truthy(HIDE_CWD)
         self._hide_version = is_env_truthy(HIDE_SPLASH_VERSION)
+        self._version = __version__
         # Avoid collision with Widget._thread_id (Textual internal int)
         self._cli_thread_id = thread_id
         self._mcp_tool_count = mcp_tool_count
@@ -356,6 +357,16 @@ class WelcomeBanner(Static):
         if self._show_thread_id:
             self.update(self._build_banner())
 
+    def update_version(self, version: str) -> None:
+        """Show the newly installed version after an in-session update.
+
+        Args:
+            version: The newly installed `deepagents-code` version.
+        """
+        self._version = version
+        if not self._hide_version:
+            self.update(self._build_banner())
+
     def set_connected(
         self,
         mcp_tool_count: int = 0,
@@ -448,7 +459,7 @@ class WelcomeBanner(Static):
             ("dcode", "bold"),
         ]
         if not self._hide_version:
-            parts.append((f"  v{__version__}", "dim"))
+            parts.append((f"  v{self._version}", "dim"))
         if self._debug_enabled:
             parts.append(
                 (

--- a/libs/code/deepagents_code/tui/widgets/welcome.py
+++ b/libs/code/deepagents_code/tui/widgets/welcome.py
@@ -358,11 +358,16 @@ class WelcomeBanner(Static):
             self.update(self._build_banner())
 
     def update_version(self, version: str) -> None:
-        """Show the newly installed version after an in-session update.
+        """Track a new version and re-render when it is displayed.
+
+        The banner then advertises a version installed on disk rather than the
+        one this process is running, until the user relaunches.
 
         Args:
             version: The newly installed `deepagents-code` version.
         """
+        # Tracked even when hidden, so the value stays truthful if the row is
+        # ever re-enabled — matching the other `update_*` methods above.
         self._version = version
         if not self._hide_version:
             self.update(self._build_banner())

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -290,6 +290,63 @@ def _latest_from_releases(
     return best_str
 
 
+def read_installed_distribution_version() -> str | None:
+    """Read the currently installed `deepagents-code` distribution version.
+
+    Unlike `__version__`, this does not come from the module this process
+    imported at launch: it locates the running tool environment's interpreter
+    through `sys.prefix` and parses that environment's
+    `deepagents_code-*.dist-info` directory name from disk, so it reflects the
+    install even after an in-session upgrade rewrote the environment. Used to
+    report what an upgrade actually installed.
+
+    Returns:
+        The installed version string, or `None` when it cannot be determined
+            (missing/ambiguous dist-info, unreadable directory, or a version
+            this process's `packaging` rejects).
+    """
+    version_info = sys.version_info
+    site_packages = (
+        Path(sys.prefix)
+        / "lib"
+        / f"python{version_info.major}.{version_info.minor}"
+        / "site-packages"
+    )
+    try:
+        candidates = [
+            entry
+            for entry in site_packages.iterdir()
+            if entry.name.startswith("deepagents_code-")
+            and entry.name.endswith(".dist-info")
+        ]
+    except OSError:
+        logger.debug(
+            "Could not list site-packages at %s to read the installed version",
+            site_packages,
+            exc_info=True,
+        )
+        return None
+    if len(candidates) != 1:
+        # Zero matches means the distribution is missing from this environment;
+        # more than one means leftover dist-infos make the installed version
+        # ambiguous. Neither is actionable from the caller — a successful
+        # upgrade just gets a less precise report — so debug is loud enough.
+        logger.debug(
+            "Expected exactly one deepagents_code dist-info under %s, found %d",
+            site_packages,
+            len(candidates),
+        )
+        return None
+    raw = candidates[0].name[len("deepagents_code-") : -len(".dist-info")]
+    try:
+        return str(_parse_version(raw))
+    except InvalidVersion:
+        # A newer packaging could accept a version this process's copy rejects;
+        # reporting nothing beats reporting an unparseable string.
+        logger.debug("Unparseable installed dist-info version: %s", raw)
+        return None
+
+
 def get_cached_update_available() -> tuple[bool, str | None]:
     """Check for updates using only a fresh local cache entry.
 
@@ -2256,7 +2313,7 @@ async def perform_upgrade(
     log_path: Path | None = None,
     include_prereleases: bool | None = None,
     target_version: str | None = None,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, str | None]:
     """Attempt to upgrade `deepagents-code` using the detected install method.
 
     Only tries the detected method — does not fall back to other package
@@ -2273,7 +2330,14 @@ async def perform_upgrade(
             dcode releases that intentionally depend on pre-release packages.
 
     Returns:
-        `(success, output)` — *output* is the combined stdout/stderr.
+        `(success, output, installed_version)` — *output* is the combined
+        stdout/stderr. *installed_version* is the version the successful
+        install actually resolved to, read back from the tool environment on
+        disk, or `None` when the upgrade failed or the installed version
+        could not be determined. Callers should report *installed_version*
+        rather than the version their update check observed: the install
+        command is unpinned, so a release published between check and install
+        is what lands on disk.
 
     Raises:
         OSError: Propagated from building the upgrade command or running the
@@ -2283,13 +2347,17 @@ async def perform_upgrade(
     """
     method = detect_install_method()
     if method == "unknown":
-        return False, "Editable install detected — skipping auto-update."
+        return False, "Editable install detected — skipping auto-update.", None
     if method == "other":
-        return False, (
-            "Unsupported install method detected — cannot auto-update without "
-            "knowing which environment provides `dcode`. Reinstall with "
-            "`uv tool install -U deepagents-code` or upgrade with the package "
-            "manager originally used for this install."
+        return (
+            False,
+            (
+                "Unsupported install method detected — cannot auto-update without "
+                "knowing which environment provides `dcode`. Reinstall with "
+                "`uv tool install -U deepagents-code` or upgrade with the package "
+                "manager originally used for this install."
+            ),
+            None,
         )
     resolved_include_prereleases = _resolve_include_prereleases(include_prereleases)
     # Targeted pre-release admission: a *stable* dcode target that mandates an
@@ -2310,11 +2378,11 @@ async def perform_upgrade(
     if resolved_include_prereleases or targeted_pins:
         supported, reason = prerelease_upgrade_supported(method)
         if not supported:
-            return False, reason or _PRERELEASE_UNSUPPORTED_MESSAGE
+            return False, reason or _PRERELEASE_UNSUPPORTED_MESSAGE, None
 
     # Skip brew if binary not on PATH (before touching temp files).
     if method == "brew" and not shutil.which("brew"):
-        return False, "brew not found on PATH."
+        return False, "brew not found on PATH.", None
 
     prerelease_strategy = _UV_TARGETED_PRERELEASE_STRATEGY if targeted_pins else None
     constraints_staged = False
@@ -2395,10 +2463,14 @@ async def perform_upgrade(
             target_version,
             exc_info=True,
         )
-        return False, (
-            "Could not prepare the pre-release dependency constraints required "
-            f"to install v{target_version}; the existing installation was left "
-            f"unchanged.\n{type(exc).__name__}: {exc}"
+        return (
+            False,
+            (
+                "Could not prepare the pre-release dependency constraints required "
+                f"to install v{target_version}; the existing installation was left "
+                f"unchanged.\n{type(exc).__name__}: {exc}"
+            ),
+            None,
         )
 
     if success and fell_back_to_bare_command:
@@ -2414,7 +2486,23 @@ async def perform_upgrade(
             "installed extras or extra packages may not carry over. "
             "Re-add them if a feature stops working after relaunch.",
         )
-    return success, output
+    installed_version: str | None = None
+    if success:
+        if pin_target_version is not None:
+            # The install was pinned to the exact target version, so that is
+            # what landed on disk; skip the filesystem readback.
+            installed_version = pin_target_version
+        else:
+            # The install command is unpinned (`uv tool install -U` / `brew
+            # upgrade`), so a release published between the update check and
+            # the install is what actually landed. Read the installed
+            # distribution back rather than reporting the earlier check's
+            # version; when the readback is indeterminate, the caller's
+            # checked version is still the best available answer.
+            installed_version = (
+                await asyncio.to_thread(read_installed_distribution_version)
+            ) or target_version
+    return success, output, installed_version
 
 
 async def perform_dependency_refresh(

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -22,6 +22,7 @@ import shlex
 import shutil
 import signal
 import sys
+import sysconfig
 import tempfile
 import threading
 import time
@@ -294,8 +295,7 @@ def read_installed_distribution_version() -> str | None:
     """Read the currently installed `deepagents-code` distribution version.
 
     Unlike `__version__`, this does not come from the module this process
-    imported at launch: it locates the running tool environment's interpreter
-    through `sys.prefix` and parses that environment's
+    imported at launch: it reads the running tool environment's
     `deepagents_code-*.dist-info` directory name from disk, so it reflects the
     install even after an in-session upgrade rewrote the environment. Used to
     report what an upgrade actually installed.
@@ -305,13 +305,10 @@ def read_installed_distribution_version() -> str | None:
             (missing/ambiguous dist-info, unreadable directory, or a version
             this process's `packaging` rejects).
     """
-    version_info = sys.version_info
-    site_packages = (
-        Path(sys.prefix)
-        / "lib"
-        / f"python{version_info.major}.{version_info.minor}"
-        / "site-packages"
-    )
+    # `sysconfig`'s purelib resolves the per-platform layout (`lib/pythonX.Y/
+    # site-packages` on POSIX, `Lib\site-packages` on Windows), so the
+    # readback works for uv tool environments on every supported OS.
+    site_packages = Path(sysconfig.get_path("purelib"))
     try:
         candidates = [
             entry

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -26004,6 +26004,55 @@ class TestNotificationCenterIntegration:
 
         assert app._notice_registry.get("update:available") is None
         assert "v2.0.0" in splash
+        assert f"v{__version__}" not in splash
+
+    async def test_install_success_marks_modal_without_a_banner(self) -> None:
+        """A missing splash banner cannot spoil a successful install.
+
+        The splash repaint is cosmetic, but the modal refuses to close until
+        it is marked done, and `_dispatch_notification_action` turns any
+        escaping exception into an "Install now failed" toast. So a banner
+        miss must neither precede `mark_success` (which would strand the
+        modal) nor raise (which would report a completed install as failed).
+        """
+        from deepagents_code.notifications import ActionId
+        from deepagents_code.tui.widgets.update_progress import UpdateProgressScreen
+        from deepagents_code.tui.widgets.welcome import WelcomeBanner
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        entry = _update_entry()
+        app._notice_registry.add(entry)
+
+        notified: list[str] = []
+        original_notify = app.notify
+
+        def capture_notify(message: str, **kwargs: Any) -> None:
+            notified.append(message)
+            original_notify(message, **kwargs)
+
+        app.notify = capture_notify  # ty: ignore
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.query_one("#welcome-banner", WelcomeBanner).remove()
+            await pilot.pause()
+            with patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new=AsyncMock(return_value=(True, "Updated deepagents-code", "2.0.0")),
+            ):
+                await app._dispatch_notification_action(entry.key, ActionId.INSTALL)
+                await pilot.pause()
+
+            assert isinstance(app.screen, UpdateProgressScreen)
+            status = app.screen.query(Static).filter(".up-status").first()
+            assert "Update complete" in str(status.render())
+            # The modal is dismissable, so the session is not stranded.
+            await pilot.press("escape")
+            await pilot.pause()
+            assert not isinstance(app.screen, UpdateProgressScreen)
+
+        assert app._notice_registry.get("update:available") is None
+        assert not any("failed" in m for m in notified)
 
     async def test_install_success_reports_installed_version_over_checked_version(
         self,
@@ -26186,6 +26235,7 @@ class TestNotificationCenterIntegration:
         """
         from deepagents_code.notifications import ActionId
         from deepagents_code.tui.widgets.update_progress import UpdateProgressScreen
+        from deepagents_code.tui.widgets.welcome import WelcomeBanner
         from deepagents_code.update_check import (
             ShadowedDcode,
             format_shadowed_dcode_fix_command,
@@ -26234,6 +26284,15 @@ class TestNotificationCenterIntegration:
             assert "Update complete" not in str(status.render())
             assert "/opt/stale/bin/dcode" in str(status.render())
             assert "/home/user/.local/bin/dcode" in str(status.render())
+            # The splash must keep advertising the running version: a stale
+            # shim earlier on PATH means relaunching keeps the old binary, so
+            # bumping the banner here would promise an upgrade that never
+            # takes effect.
+            splash = (
+                app.query_one("#welcome-banner", WelcomeBanner)._build_banner().plain
+            )
+            assert "v2.0.0" not in splash
+            assert f"v{__version__}" in splash
             await pilot.press("c")
             await pilot.pause()
 
@@ -26368,6 +26427,7 @@ class TestNotificationCenterIntegration:
     async def test_install_failure_removes_entry_and_toasts_manual(self) -> None:
         """Failed install removes the stale entry and surfaces the manual command."""
         from deepagents_code.notifications import ActionId
+        from deepagents_code.tui.widgets.welcome import WelcomeBanner
 
         app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
         entry = _update_entry()
@@ -26390,10 +26450,19 @@ class TestNotificationCenterIntegration:
             ):
                 await app._dispatch_notification_action(entry.key, ActionId.INSTALL)
                 await pilot.pause()
+                # Nothing was installed, so the splash must not advertise the
+                # version the notification was offering.
+                splash = (
+                    app.query_one("#welcome-banner", WelcomeBanner)
+                    ._build_banner()
+                    .plain
+                )
 
         assert app._notice_registry.get("update:available") is None
         assert any("Run manually" in m for m in notified)
         assert any("network unreachable" in m for m in notified)
+        assert "v2.0.0" not in splash
+        assert f"v{__version__}" in splash
 
     async def test_install_immediate_failure_updates_mounted_modal(self) -> None:
         """Immediate install failures still render the completed modal state."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -25992,7 +25992,7 @@ class TestNotificationCenterIntegration:
             await pilot.pause()
             with patch(
                 "deepagents_code.update_check.perform_upgrade",
-                new=AsyncMock(return_value=(True, "Updated deepagents-code")),
+                new=AsyncMock(return_value=(True, "Updated deepagents-code", "2.0.0")),
             ):
                 await app._dispatch_notification_action(entry.key, ActionId.INSTALL)
                 await pilot.pause()
@@ -26004,6 +26004,39 @@ class TestNotificationCenterIntegration:
 
         assert app._notice_registry.get("update:available") is None
         assert "v2.0.0" in splash
+
+    async def test_install_success_reports_installed_version_over_checked_version(
+        self,
+    ) -> None:
+        """The splash shows what the installer resolved, not the stale check.
+
+        The install command is unpinned, so a release published between the
+        update check and the install is what lands on disk. `perform_upgrade`
+        reads that back; the splash must use the readback version.
+        """
+        from deepagents_code.notifications import ActionId
+        from deepagents_code.tui.widgets.welcome import WelcomeBanner
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        entry = _update_entry(latest="2.0.0")
+        app._notice_registry.add(entry)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new=AsyncMock(return_value=(True, "Updated deepagents-code", "2.1.0")),
+            ):
+                await app._dispatch_notification_action(entry.key, ActionId.INSTALL)
+                await pilot.pause()
+                splash = (
+                    app.query_one("#welcome-banner", WelcomeBanner)
+                    ._build_banner()
+                    .plain
+                )
+
+        assert "v2.1.0" in splash
+        assert "v2.0.0" not in splash
 
     async def test_install_defers_to_another_session(
         self, monkeypatch: pytest.MonkeyPatch
@@ -26064,7 +26097,7 @@ class TestNotificationCenterIntegration:
         app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
         entry = _update_entry()
         app._notice_registry.add(entry)
-        upgrade_mock = AsyncMock(return_value=(False, "resolver: conflict"))
+        upgrade_mock = AsyncMock(return_value=(False, "resolver: conflict", None))
 
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -26183,7 +26216,9 @@ class TestNotificationCenterIntegration:
             with (
                 patch(
                     "deepagents_code.update_check.perform_upgrade",
-                    new=AsyncMock(return_value=(True, "Updated deepagents-code")),
+                    new=AsyncMock(
+                        return_value=(True, "Updated deepagents-code", "2.0.0")
+                    ),
                 ),
                 # Override the autouse `None` patch.
                 patch(
@@ -26263,7 +26298,9 @@ class TestNotificationCenterIntegration:
             with (
                 patch(
                     "deepagents_code.update_check.perform_upgrade",
-                    new=AsyncMock(return_value=(True, "Updated deepagents-code")),
+                    new=AsyncMock(
+                        return_value=(True, "Updated deepagents-code", "2.0.0")
+                    ),
                 ),
                 patch(
                     "deepagents_code.update_check.detect_shadowed_dcode",
@@ -26314,7 +26351,7 @@ class TestNotificationCenterIntegration:
             monkeypatch.setenv(DEBUG_UPDATE, "1")
             with patch(
                 "deepagents_code.update_check.perform_upgrade",
-                new=AsyncMock(return_value=(True, "Updated deepagents-code")),
+                new=AsyncMock(return_value=(True, "Updated deepagents-code", "2.0.0")),
             ) as mock_upgrade:
                 with patch(
                     "deepagents_code.app.asyncio.sleep",
@@ -26349,7 +26386,7 @@ class TestNotificationCenterIntegration:
             await pilot.pause()
             with patch(
                 "deepagents_code.update_check.perform_upgrade",
-                new=AsyncMock(return_value=(False, "ERROR: network unreachable")),
+                new=AsyncMock(return_value=(False, "ERROR: network unreachable", None)),
             ):
                 await app._dispatch_notification_action(entry.key, ActionId.INSTALL)
                 await pilot.pause()
@@ -26370,13 +26407,13 @@ class TestNotificationCenterIntegration:
 
         def fail_immediately(
             **kwargs: Any,
-        ) -> tuple[bool, str]:
+        ) -> tuple[bool, str, None]:
             assert kwargs["progress"] is not None
             assert kwargs["log_path"] is not None
             assert isinstance(app.screen, UpdateProgressScreen)
             assert app.screen._status_widget is not None
             assert app.screen._tail_widget is not None
-            return False, "brew: command not found"
+            return False, "brew: command not found", None
 
         async with app.run_test() as pilot:
             await pilot.pause()

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -25980,8 +25980,9 @@ class TestNotificationCenterIntegration:
         )
 
     async def test_install_success_removes_entry(self) -> None:
-        """Successful install removes the entry and toasts restart hint."""
+        """Successful install removes the entry and updates the splash version."""
         from deepagents_code.notifications import ActionId
+        from deepagents_code.tui.widgets.welcome import WelcomeBanner
 
         app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
         entry = _update_entry()
@@ -25995,8 +25996,14 @@ class TestNotificationCenterIntegration:
             ):
                 await app._dispatch_notification_action(entry.key, ActionId.INSTALL)
                 await pilot.pause()
+                splash = (
+                    app.query_one("#welcome-banner", WelcomeBanner)
+                    ._build_banner()
+                    .plain
+                )
 
         assert app._notice_registry.get("update:available") is None
+        assert "v2.0.0" in splash
 
     async def test_install_defers_to_another_session(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -164,7 +164,7 @@ class TestStartupAutoUpdate:
     def test_successful_update_restarts_before_launch(self) -> None:
         """A successful startup auto-update should exec a fresh process."""
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -224,7 +224,7 @@ class TestStartupAutoUpdate:
         from deepagents_code.update_check import ShadowedDcode
 
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
         # Embed `[` in the shadowing path — legal on POSIX filesystems —
         # so a regression that dropped `escape()` would raise a Rich
         # `MarkupError` here instead of silently emitting broken styling.
@@ -309,7 +309,7 @@ class TestStartupAutoUpdate:
         winning session's upgrade would suppress this one's next few attempts.
         """
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -358,10 +358,12 @@ class TestStartupAutoUpdate:
         held_during_install: list[bool] = []
 
         # Async to match the `perform_upgrade` it replaces, which is awaited.
-        async def _record_lock_state(**_kwargs: object) -> tuple[bool, str]:  # noqa: RUF029
+        async def _record_lock_state(  # noqa: RUF029
+            **_kwargs: object,
+        ) -> tuple[bool, str, str | None]:
             with update_install_lock() as holding:
                 held_during_install.append(holding)
-            return True, "updated"
+            return True, "updated", "9.9.9"
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -408,7 +410,7 @@ class TestStartupAutoUpdate:
         where the restart raises and this process keeps running.
         """
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
         held_during_restart: list[bool] = []
 
         def _record_lock_state() -> None:
@@ -539,7 +541,7 @@ class TestStartupAutoUpdate:
     def test_failed_update_does_not_restart_and_continues(self) -> None:
         """A failed upgrade must not restart; it surfaces the error and returns."""
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(False, "pip exploded"))
+        upgrade = AsyncMock(return_value=(False, "pip exploded", None))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -580,7 +582,7 @@ class TestStartupAutoUpdate:
     def test_unpersisted_failure_marker_warns_user(self) -> None:
         """An unwritable cooldown marker must be surfaced, not silently dropped."""
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(False, "pip exploded"))
+        upgrade = AsyncMock(return_value=(False, "pip exploded", None))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -865,7 +867,7 @@ class TestStartupAutoUpdate:
         outcome, and must not be worded as an update failure.
         """
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -920,7 +922,7 @@ class TestStartupAutoUpdate:
         from deepagents_code.update_check import ShadowedDcode
 
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
         shadow = ShadowedDcode(
             shadowing_bin=Path("C:/old/bin/dcode.cmd"),
             upgraded_bin_dir=Path("C:/uv/bin"),
@@ -979,7 +981,7 @@ class TestStartupAutoUpdate:
         log and the exit status simultaneously.
         """
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -1040,7 +1042,7 @@ class TestStartupAutoUpdate:
         from deepagents_code.update_check import ShadowedDcode
 
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
         shadow = ShadowedDcode(
             shadowing_bin=Path("/opt/old/bin/dcode"),
             upgraded_bin_dir=Path("/home/user/.local/bin"),
@@ -1105,7 +1107,7 @@ class TestStartupAutoUpdate:
         uncaught and crash startup after an otherwise-successful upgrade.
         """
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -1365,7 +1367,7 @@ class TestStartupAutoUpdate:
         stream = StringIO()
         console = Console(file=stream, force_terminal=True, no_color=True, width=80)
         monkeypatch.setenv("DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE", "9.9.8")
-        upgrade = AsyncMock(return_value=(True, ""))
+        upgrade = AsyncMock(return_value=(True, "", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -1547,7 +1549,7 @@ class TestAutoUpdateDefaultMigration:
     def test_first_run_announces_and_skips_install(self) -> None:
         """An implicit (default) opt-in announces once and skips the install."""
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -1587,7 +1589,7 @@ class TestAutoUpdateDefaultMigration:
     def test_first_run_persist_failure_warns_repeat(self) -> None:
         """A failed acknowledgement persist surfaces that the notice may repeat."""
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -1634,7 +1636,7 @@ class TestAutoUpdateDefaultMigration:
         """
         monkeypatch.setenv("DEEPAGENTS_CODE_DEBUG_UPDATE", "1")
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -1673,7 +1675,7 @@ class TestAutoUpdateDefaultMigration:
     def test_acknowledged_default_proceeds_with_install(self) -> None:
         """Once acknowledged, the install proceeds normally on later launches."""
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
@@ -1724,7 +1726,7 @@ class TestAutoUpdateDefaultMigration:
         config_path = tmp_path / "config.toml"
         state_file = tmp_path / "update_state.json"
         console = MagicMock()
-        upgrade = AsyncMock(return_value=(True, "updated"))
+        upgrade = AsyncMock(return_value=(True, "updated", "9.9.9"))
 
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1970,7 +1970,7 @@ class TestUpdateSubcommand:
             patch(
                 "deepagents_code.update_check.perform_upgrade",
                 new_callable=AsyncMock,
-                return_value=(True, ""),
+                return_value=(True, "", None),
                 side_effect=upgrade_side_effect,
             ) as perform_upgrade_mock,
             pytest.raises(SystemExit) as exc_info,
@@ -2076,10 +2076,10 @@ class TestUpdateSubcommand:
 
         held_during_install: list[bool] = []
 
-        def _record_lock_state(**_kwargs: object) -> tuple[bool, str]:
+        def _record_lock_state(**_kwargs: object) -> tuple[bool, str, None]:
             with update_install_lock() as holding:
                 held_during_install.append(holding)
-            return True, ""
+            return True, "", None
 
         code, _, perform_upgrade_mock = self._run_update(
             editable=False,

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -97,6 +97,7 @@ from deepagents_code.update_check import (
     perform_install_package,
     perform_upgrade,
     prerelease_upgrade_supported,
+    read_installed_distribution_version,
     release_prerelease_pins,
     release_requires_prereleases,
     safe_install_extra_recovery_command,
@@ -228,6 +229,67 @@ class TestInstalledVersionAtLeast:
     def test_false_when_distribution_metadata_is_older(self) -> None:
         with patch("importlib.metadata.version", return_value="1.9.9"):
             assert is_installed_version_at_least("2.0.0") is False
+
+
+class TestReadInstalledDistributionVersion:
+    """Readback of the on-disk tool environment after an upgrade.
+
+    The fake layouts mirror uv's: `<prefix>/lib/pythonX.Y/site-packages/
+    deepagents_code-<version>.dist-info`. `sys.prefix` and the version-info
+    segment are patched so the reader looks at the fake environment.
+    """
+
+    @staticmethod
+    def _fake_tool_env(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *dist_info_names: str,
+    ) -> Path:
+        site_packages = tmp_path / "lib" / "python9.9" / "site-packages"
+        site_packages.mkdir(parents=True)
+        for name in dist_info_names:
+            (site_packages / name).mkdir()
+        monkeypatch.setattr(sys, "prefix", str(tmp_path))
+
+        class _FakeVersionInfo(tuple):  # noqa: SLOT001  # mimics sys.version_info's attribute access
+            major = 9
+            minor = 9
+
+        monkeypatch.setattr(sys, "version_info", _FakeVersionInfo((9, 9, 0)))
+        return site_packages
+
+    def test_reads_dist_info_from_disk(self, tmp_path, monkeypatch) -> None:
+        """The version comes from the dist-info directory, not `__version__`."""
+        self._fake_tool_env(tmp_path, monkeypatch, "deepagents_code-2.0.1.dist-info")
+        with patch("deepagents_code.update_check.__version__", "1.0.0"):
+            assert read_installed_distribution_version() == "2.0.1"
+
+    def test_missing_dist_info_returns_none(self, tmp_path, monkeypatch) -> None:
+        self._fake_tool_env(tmp_path, monkeypatch)
+        assert read_installed_distribution_version() is None
+
+    def test_multiple_dist_infos_are_ambiguous(self, tmp_path, monkeypatch) -> None:
+        self._fake_tool_env(
+            tmp_path,
+            monkeypatch,
+            "deepagents_code-2.0.0.dist-info",
+            "deepagents_code-2.0.1.dist-info",
+        )
+        assert read_installed_distribution_version() is None
+
+    def test_unparseable_dist_info_version_returns_none(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        self._fake_tool_env(
+            tmp_path, monkeypatch, "deepagents_code-not.a.version.dist-info"
+        )
+        assert read_installed_distribution_version() is None
+
+    def test_unreadable_site_packages_returns_none(self, tmp_path, monkeypatch) -> None:
+        site_packages = self._fake_tool_env(tmp_path, monkeypatch)
+        site_packages.rmdir()
+        site_packages.write_text("not a directory", encoding="utf-8")
+        assert read_installed_distribution_version() is None
 
 
 class TestLatestFromReleases:
@@ -2380,7 +2442,7 @@ class TestUpdateLogs:
                 return_value="printf 'ok\\n'",
             ),
         ):
-            success, output = await perform_upgrade(log_path=log_path)
+            success, output, _installed = await perform_upgrade(log_path=log_path)
 
         assert success is True
         assert output == "ok"
@@ -2406,7 +2468,7 @@ class TestUpdateLogs:
             ),
             patch("pathlib.Path.open", opener),
         ):
-            success, output = await perform_upgrade(log_path=log_path)
+            success, output, _installed = await perform_upgrade(log_path=log_path)
 
         assert success is True
         assert output == "ok"
@@ -2417,7 +2479,7 @@ class TestUpdateLogs:
             "deepagents_code.update_check.detect_install_method",
             return_value="other",
         ):
-            success, output = await perform_upgrade()
+            success, output, _installed = await perform_upgrade()
 
         assert success is False
         assert "Unsupported install method" in output
@@ -2453,7 +2515,9 @@ class TestUpdateLogs:
                 return_value=(True, ""),
             ) as run_mock,
         ):
-            success, _output = await perform_upgrade(include_prereleases=True)
+            success, _output, _installed = await perform_upgrade(
+                include_prereleases=True
+            )
 
         assert success is True
         run_mock.assert_awaited_once()
@@ -2519,7 +2583,7 @@ class TestUpdateLogs:
                 side_effect=_capture,
             ),
         ):
-            success, _output = await perform_upgrade(target_version="1.1.0")
+            success, _output, _installed = await perform_upgrade(target_version="1.1.0")
 
         assert success is True
         cmd = str(seen["cmd"])
@@ -2574,7 +2638,7 @@ class TestUpdateLogs:
                 return_value=(True, ""),
             ) as run_mock,
         ):
-            success, _output = await perform_upgrade(target_version="1.1.0")
+            success, _output, _installed = await perform_upgrade(target_version="1.1.0")
 
         assert success is True
         await_args = run_mock.await_args
@@ -2615,7 +2679,7 @@ class TestUpdateLogs:
                 return_value=(True, ""),
             ) as run_mock,
         ):
-            success, _output = await perform_upgrade(target_version="1.1.0")
+            success, _output, _installed = await perform_upgrade(target_version="1.1.0")
 
         assert success is True
         run_mock.assert_awaited_once()
@@ -2656,7 +2720,7 @@ class TestUpdateLogs:
                 return_value=(True, ""),
             ) as run_mock,
         ):
-            success, output = await perform_upgrade(target_version="1.1.0")
+            success, output, _installed = await perform_upgrade(target_version="1.1.0")
 
         assert success is False
         assert "left" in output
@@ -2689,7 +2753,7 @@ class TestUpdateLogs:
                 return_value=(True, ""),
             ) as run_mock,
         ):
-            success, _output = await perform_upgrade()
+            success, _output, _installed = await perform_upgrade()
 
         assert success is True
         run_mock.assert_awaited_once()
@@ -2733,7 +2797,7 @@ class TestUpdateLogs:
                 return_value=(True, ""),
             ) as run_mock,
         ):
-            success, _output = await perform_upgrade()
+            success, _output, _installed = await perform_upgrade()
 
         assert success is True
         run_mock.assert_awaited_once()
@@ -2773,7 +2837,7 @@ class TestUpdateLogs:
                 return_value=(True, ""),
             ) as run_mock,
         ):
-            success, _output = await perform_upgrade()
+            success, _output, _installed = await perform_upgrade()
 
         assert success is True
         run_mock.assert_awaited_once()
@@ -2808,7 +2872,7 @@ class TestUpdateLogs:
                 return_value=(True, ""),
             ) as run_mock,
         ):
-            success, _output = await perform_upgrade()
+            success, _output, _installed = await perform_upgrade()
 
         assert success is True
         run_mock.assert_awaited_once()
@@ -2845,7 +2909,9 @@ class TestUpdateLogs:
                 return_value=(True, ""),
             ),
         ):
-            success, _output = await perform_upgrade(progress=progress_lines.append)
+            success, _output, _installed = await perform_upgrade(
+                progress=progress_lines.append
+            )
 
         assert success is True
         assert any("may not carry over" in line for line in progress_lines)
@@ -2862,7 +2928,9 @@ class TestUpdateLogs:
                 new_callable=AsyncMock,
             ) as run_mock,
         ):
-            success, output = await perform_upgrade(include_prereleases=True)
+            success, output, _installed = await perform_upgrade(
+                include_prereleases=True
+            )
 
         assert success is False
         assert "Pre-release updates aren't supported for this install" in output
@@ -2887,11 +2955,176 @@ class TestUpdateLogs:
                 new_callable=AsyncMock,
             ) as run_mock,
         ):
-            success, output = await perform_upgrade()
+            success, output, _installed = await perform_upgrade()
 
         assert success is False
         assert output == "brew not found on PATH."
         run_mock.assert_not_awaited()
+
+    async def test_perform_upgrade_reports_installed_version_from_disk(self) -> None:
+        """An unpinned install reports what landed, not the earlier check.
+
+        The update check observes `latest` before the install runs, and the
+        install command is unpinned — a release published in between is what
+        `uv tool install -U` resolves. The returned installed version must come
+        from the post-install readback so the UI never congratulates the user
+        on the stale checked version.
+        """
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset(),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=(),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "deepagents_code.update_check.read_installed_distribution_version",
+                return_value="1.2.0",
+            ),
+        ):
+            success, _output, installed = await perform_upgrade(target_version="1.1.0")
+
+        assert success is True
+        assert installed == "1.2.0"
+
+    async def test_perform_upgrade_falls_back_to_target_when_readback_fails(
+        self,
+    ) -> None:
+        """An indeterminate readback leaves the checked version as the answer."""
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset(),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=(),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "deepagents_code.update_check.read_installed_distribution_version",
+                return_value=None,
+            ),
+        ):
+            success, _output, installed = await perform_upgrade(target_version="1.1.0")
+
+        assert success is True
+        assert installed == "1.1.0"
+
+    async def test_perform_upgrade_pinned_install_skips_readback(
+        self, cache_file
+    ) -> None:
+        """A version-pinned install already knows what it installed.
+
+        The targeted-constraints path pins `deepagents-code==<target>` in the
+        install command, so the disk readback would only repeat the pin — and
+        must not run at all.
+        """
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_prerelease_pins": {"1.1.0": ["deepagents==0.7.0a7"]},
+                    "checked_at": time.time(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset(),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=(),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "deepagents_code.update_check.read_installed_distribution_version",
+            ) as readback_mock,
+        ):
+            success, _output, installed = await perform_upgrade(target_version="1.1.0")
+
+        assert success is True
+        assert installed == "1.1.0"
+        readback_mock.assert_not_called()
+
+    async def test_perform_upgrade_failed_install_reports_no_version(self) -> None:
+        """A failed install must not report a version it did not install."""
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset(),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=(),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(False, "resolver: conflict"),
+            ),
+            patch(
+                "deepagents_code.update_check.read_installed_distribution_version",
+            ) as readback_mock,
+        ):
+            success, _output, installed = await perform_upgrade(target_version="1.1.0")
+
+        assert success is False
+        assert installed is None
+        readback_mock.assert_not_called()
 
     def test_upgrade_command_prerelease(self) -> None:
         """Manual fallback command includes uv's pre-release strategy.

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -12,6 +12,7 @@ import signal
 import stat
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import threading
 import time
@@ -232,12 +233,7 @@ class TestInstalledVersionAtLeast:
 
 
 class TestReadInstalledDistributionVersion:
-    """Readback of the on-disk tool environment after an upgrade.
-
-    The fake layouts mirror uv's: `<prefix>/lib/pythonX.Y/site-packages/
-    deepagents_code-<version>.dist-info`. `sys.prefix` and the version-info
-    segment are patched so the reader looks at the fake environment.
-    """
+    """Readback of the on-disk tool environment after an upgrade."""
 
     @staticmethod
     def _fake_tool_env(
@@ -245,17 +241,11 @@ class TestReadInstalledDistributionVersion:
         monkeypatch: pytest.MonkeyPatch,
         *dist_info_names: str,
     ) -> Path:
-        site_packages = tmp_path / "lib" / "python9.9" / "site-packages"
+        site_packages = tmp_path / "site-packages"
         site_packages.mkdir(parents=True)
         for name in dist_info_names:
             (site_packages / name).mkdir()
-        monkeypatch.setattr(sys, "prefix", str(tmp_path))
-
-        class _FakeVersionInfo(tuple):  # noqa: SLOT001  # mimics sys.version_info's attribute access
-            major = 9
-            minor = 9
-
-        monkeypatch.setattr(sys, "version_info", _FakeVersionInfo((9, 9, 0)))
+        monkeypatch.setattr(sysconfig, "get_path", lambda _key: str(site_packages))
         return site_packages
 
     def test_reads_dist_info_from_disk(self, tmp_path, monkeypatch) -> None:
@@ -290,6 +280,19 @@ class TestReadInstalledDistributionVersion:
         site_packages.rmdir()
         site_packages.write_text("not a directory", encoding="utf-8")
         assert read_installed_distribution_version() is None
+
+    def test_windows_layout_resolves(self, tmp_path, monkeypatch) -> None:
+        """Windows tool envs live at `<prefix>/Lib/site-packages`, not POSIX's.
+
+        Regression guard for the hard-coded `lib/pythonX.Y/site-packages`
+        layout that made every Windows readback return `None`: the reader must
+        go through `sysconfig`'s purelib instead of building the path by hand.
+        """
+        site_packages = tmp_path / "Lib" / "site-packages"
+        site_packages.mkdir(parents=True)
+        (site_packages / "deepagents_code-2.0.1.dist-info").mkdir()
+        monkeypatch.setattr(sysconfig, "get_path", lambda _key: str(site_packages))
+        assert read_installed_distribution_version() == "2.0.1"
 
 
 class TestLatestFromReleases:

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -2964,7 +2964,9 @@ class TestUpdateLogs:
         assert output == "brew not found on PATH."
         run_mock.assert_not_awaited()
 
-    async def test_perform_upgrade_reports_installed_version_from_disk(self) -> None:
+    async def test_perform_upgrade_reports_installed_version_from_disk(
+        self, cache_file
+    ) -> None:
         """An unpinned install reports what landed, not the earlier check.
 
         The update check observes `latest` before the install runs, and the
@@ -2973,6 +2975,13 @@ class TestUpdateLogs:
         from the post-install readback so the UI never congratulates the user
         on the stale checked version.
         """
+        # Seed an empty pin set so the targeted-constraint lookup resolves from
+        # cache instead of fetching PyPI — the readback path under test is the
+        # unpinned one.
+        cache_file.write_text(
+            json.dumps({"release_prerelease_pins": {"1.1.0": []}}),
+            encoding="utf-8",
+        )
         with (
             patch("deepagents_code.update_check.__version__", "1.0.0"),
             patch(
@@ -3007,9 +3016,15 @@ class TestUpdateLogs:
         assert installed == "1.2.0"
 
     async def test_perform_upgrade_falls_back_to_target_when_readback_fails(
-        self,
+        self, cache_file
     ) -> None:
         """An indeterminate readback leaves the checked version as the answer."""
+        # Seed an empty pin set so the targeted-constraint lookup resolves from
+        # cache instead of fetching PyPI.
+        cache_file.write_text(
+            json.dumps({"release_prerelease_pins": {"1.1.0": []}}),
+            encoding="utf-8",
+        )
         with (
             patch("deepagents_code.update_check.__version__", "1.0.0"),
             patch(
@@ -3094,8 +3109,16 @@ class TestUpdateLogs:
         assert installed == "1.1.0"
         readback_mock.assert_not_called()
 
-    async def test_perform_upgrade_failed_install_reports_no_version(self) -> None:
+    async def test_perform_upgrade_failed_install_reports_no_version(
+        self, cache_file
+    ) -> None:
         """A failed install must not report a version it did not install."""
+        # Seed an empty pin set so the targeted-constraint lookup resolves from
+        # cache instead of fetching PyPI.
+        cache_file.write_text(
+            json.dumps({"release_prerelease_pins": {"1.1.0": []}}),
+            encoding="utf-8",
+        )
         with (
             patch("deepagents_code.update_check.__version__", "1.0.0"),
             patch(

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -697,7 +697,7 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
             patch(
                 "deepagents_code.update_check.perform_upgrade",
                 new_callable=AsyncMock,
-                return_value=(True, ""),
+                return_value=(True, "", "99.0.0"),
             ) as perform_upgrade_mock,
         ):
             await app._handle_command("/update")
@@ -747,7 +747,7 @@ async def test_update_slash_command_stable_prerelease_deps_keep_intent_none() ->
             patch(
                 "deepagents_code.update_check.perform_upgrade",
                 new_callable=AsyncMock,
-                return_value=(True, ""),
+                return_value=(True, "", "99.0.0"),
             ) as perform_upgrade_mock,
         ):
             await app._handle_command("/update")
@@ -786,7 +786,7 @@ async def test_update_slash_command_prerelease_updates_channel() -> None:
             patch(
                 "deepagents_code.update_check.perform_upgrade",
                 new_callable=AsyncMock,
-                return_value=(True, ""),
+                return_value=(True, "", "99.0.0rc1"),
             ) as perform_upgrade_mock,
         ):
             await app._handle_command("/update --prerelease")
@@ -842,7 +842,7 @@ async def test_update_slash_command_replaces_success_with_shadow_warning() -> No
             patch(
                 "deepagents_code.update_check.perform_upgrade",
                 new_callable=AsyncMock,
-                return_value=(True, ""),
+                return_value=(True, "", "99.0.0"),
             ),
             # Override the module-level autouse `None` patch with the
             # positive case. Innermost patch wins.
@@ -1034,6 +1034,7 @@ async def test_update_deps_routes_outdated_dcode_through_regular_update(
                 return_value=(
                     True,
                     " - deepagents-code==1.0.0\n + deepagents-code==1.1.0\n",
+                    "1.1.0",
                 ),
             ),
         ):
@@ -1087,6 +1088,7 @@ async def test_update_deps_skips_refresh_prompt_when_refresh_unsupported(
                 return_value=(
                     True,
                     " - deepagents-code==1.0.0\n + deepagents-code==1.1.0\n",
+                    "1.1.0",
                 ),
             ) as perform_upgrade_mock,
         ):
@@ -1788,7 +1790,7 @@ async def test_perform_app_upgrade_failure_surfaces_manual_command() -> None:
             patch(
                 "deepagents_code.update_check.perform_upgrade",
                 new_callable=AsyncMock,
-                return_value=(False, "resolver: conflict"),
+                return_value=(False, "resolver: conflict", None),
             ),
             patch(
                 "deepagents_code.update_check.upgrade_command",
@@ -1862,10 +1864,12 @@ async def test_perform_app_upgrade_holds_the_lock_during_install() -> None:
 
     held_during_install: list[bool] = []
 
-    async def _record_lock_state(**_kwargs: object) -> tuple[bool, str]:  # noqa: RUF029
+    async def _record_lock_state(  # noqa: RUF029
+        **_kwargs: object,
+    ) -> tuple[bool, str, str | None]:
         with update_install_lock() as holding:
             held_during_install.append(holding)
-        return True, ""
+        return True, "", "1.1.0"
 
     app = DeepAgentsApp()
     async with app.run_test() as pilot:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -680,6 +680,7 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
     """`/update` lets update helpers infer the channel from the installed version."""
     from deepagents_code.app import DeepAgentsApp
     from deepagents_code.tui.widgets.messages import AppMessage
+    from deepagents_code.tui.widgets.welcome import WelcomeBanner
 
     app = DeepAgentsApp()
     async with app.run_test() as pilot:
@@ -701,6 +702,9 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
         ):
             await app._handle_command("/update")
             await pilot.pause()
+            splash = (
+                app.query_one("#welcome-banner", WelcomeBanner)._build_banner().plain
+            )
 
         is_update_mock.assert_called_once_with(
             bypass_cache=True,
@@ -712,6 +716,8 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
         )
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         assert "Updated to v99.0.0" in str(app_msgs[-1]._content)
+        assert "v99.0.0" in splash
+        assert f"v{__version__}" not in splash
 
 
 async def test_update_slash_command_stable_prerelease_deps_keep_intent_none() -> None:
@@ -814,6 +820,7 @@ async def test_update_slash_command_replaces_success_with_shadow_warning() -> No
     """
     from deepagents_code.app import DeepAgentsApp
     from deepagents_code.tui.widgets.messages import AppMessage, ErrorMessage
+    from deepagents_code.tui.widgets.welcome import WelcomeBanner
     from deepagents_code.update_check import ShadowedDcode
 
     shadow = ShadowedDcode(
@@ -846,6 +853,9 @@ async def test_update_slash_command_replaces_success_with_shadow_warning() -> No
         ):
             await app._handle_command("/update")
             await pilot.pause()
+            splash = (
+                app.query_one("#welcome-banner", WelcomeBanner)._build_banner().plain
+            )
 
         plain_msgs = [
             str(m._content) for m in app.query(AppMessage) if not m._is_markdown
@@ -854,6 +864,8 @@ async def test_update_slash_command_replaces_success_with_shadow_warning() -> No
         # would not actually use the new version. A regression that kept the
         # success line would show both messages, contradicting itself.
         assert not any("Updated to v99.0.0" in m for m in plain_msgs)
+        assert f"v{__version__}" in splash
+        assert "v99.0.0" not in splash
         # The warning is mounted as an `ErrorMessage` (red), not a generic
         # `AppMessage`, so it visually stands apart from neutral status text.
         error_msgs = [str(m._content) for m in app.query(ErrorMessage)]

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -677,7 +677,7 @@ async def test_update_slash_command_pypi_unreachable_short_circuits() -> None:
 
 
 async def test_update_slash_command_omitted_prerelease_preserves_channel() -> None:
-    """`/update` lets update helpers infer the channel from the installed version."""
+    """`/update` infers the channel from the installed version and bumps the splash."""
     from deepagents_code.app import DeepAgentsApp
     from deepagents_code.tui.widgets.messages import AppMessage
     from deepagents_code.tui.widgets.welcome import WelcomeBanner
@@ -702,6 +702,8 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
         ):
             await app._handle_command("/update")
             await pilot.pause()
+            # Captured inside `run_test`: the app is torn down on exit, so the
+            # banner is unreachable by the time the assertions below run.
             splash = (
                 app.query_one("#welcome-banner", WelcomeBanner)._build_banner().plain
             )
@@ -806,6 +808,49 @@ async def test_update_slash_command_prerelease_updates_channel() -> None:
         assert "Updated to v99.0.0rc1" in str(app_msgs[-1]._content)
 
 
+async def test_update_slash_command_reports_success_without_a_banner() -> None:
+    """A missing splash banner cannot turn a successful `/update` into a failure.
+
+    `_perform_app_upgrade` runs inside the caller's broad
+    `except Exception -> _mount_update_failure`, so an unguarded banner lookup
+    would report a completed upgrade as "Update failed" and name an internal
+    CSS selector at the user. The repaint is cosmetic; the success line is not.
+    """
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage, ErrorMessage
+    from deepagents_code.tui.widgets.welcome import WelcomeBanner
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.query_one("#welcome-banner", WelcomeBanner).remove()
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+                return_value=(True, "99.0.0"),
+            ),
+            patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+                return_value=(True, "", "99.0.0"),
+            ),
+        ):
+            await app._handle_command("/update")
+            await pilot.pause()
+
+        plain_msgs = [
+            str(m._content) for m in app.query(AppMessage) if not m._is_markdown
+        ]
+        assert any("Updated to v99.0.0" in m for m in plain_msgs)
+        error_msgs = [str(m._content) for m in app.query(ErrorMessage)]
+        assert not any("Update failed" in m for m in error_msgs)
+
+
 async def test_update_slash_command_replaces_success_with_shadow_warning() -> None:
     """A shadowed `dcode` after a successful upgrade swaps success line for warning.
 
@@ -816,7 +861,8 @@ async def test_update_slash_command_replaces_success_with_shadow_warning() -> No
     `ErrorMessage` with the warning and skip the success `AppMessage`
     entirely; a regression that flipped the `if/else` (or kept the
     success line unconditionally) would ship a reassuring success line
-    over a broken upgrade.
+    over a broken upgrade. The splash version carries the same guarantee
+    for the same reason, and is asserted here too.
     """
     from deepagents_code.app import DeepAgentsApp
     from deepagents_code.tui.widgets.messages import AppMessage, ErrorMessage
@@ -864,6 +910,10 @@ async def test_update_slash_command_replaces_success_with_shadow_warning() -> No
         # would not actually use the new version. A regression that kept the
         # success line would show both messages, contradicting itself.
         assert not any("Updated to v99.0.0" in m for m in plain_msgs)
+        # Same reasoning for the splash: bumping the banner here would promise
+        # an upgrade that a relaunch will not actually deliver. This is the
+        # only guard on `_update_splash_version` staying inside the
+        # `shadow is None` branch, so do not drop it as redundant.
         assert f"v{__version__}" in splash
         assert "v99.0.0" not in splash
         # The warning is mounted as an `ErrorMessage` (red), not a generic

--- a/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
@@ -294,14 +294,27 @@ class TestTitle:
         assert "(local)" not in plain
 
     def test_updates_version_after_in_session_install(self) -> None:
-        """The banner can show a version installed while the app is running."""
+        """`update_version` re-renders and replaces the version shown."""
         banner = _make_banner()
 
-        banner.update_version("99.0.0")
+        with patch.object(banner, "update") as mock_update:
+            banner.update_version("99.0.0")
+            mock_update.assert_called_once()
 
         plain = banner._build_banner().plain
         assert "v99.0.0" in plain
         assert f"v{__version__}" not in plain
+
+    def test_update_version_does_not_render_when_hidden(self) -> None:
+        """`update_version` tracks the version but skips re-render when hidden."""
+        banner = _make_banner(env={HIDE_SPLASH_VERSION: "1"})
+
+        with patch.object(banner, "update") as mock_update:
+            banner.update_version("99.0.0")
+            mock_update.assert_not_called()
+
+        assert banner._version == "99.0.0"
+        assert "v99.0.0" not in banner._build_banner().plain
 
     def test_hides_version_and_local_tag_when_env_set(self) -> None:
         """`HIDE_SPLASH_VERSION` removes version and local-install details."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
@@ -293,6 +293,16 @@ class TestTitle:
         assert f"v{__version__}" in plain
         assert "(local)" not in plain
 
+    def test_updates_version_after_in_session_install(self) -> None:
+        """The banner can show a version installed while the app is running."""
+        banner = _make_banner()
+
+        banner.update_version("99.0.0")
+
+        plain = banner._build_banner().plain
+        assert "v99.0.0" in plain
+        assert f"v{__version__}" not in plain
+
     def test_hides_version_and_local_tag_when_env_set(self) -> None:
         """`HIDE_SPLASH_VERSION` removes version and local-install details."""
         with patch(_EDITABLE, return_value=True):


### PR DESCRIPTION
The splash header now reflects the newly installed dcode version immediately after successful in-session updates.

---

The banner previously read only the running process's baked-in version, leaving the old value visible until relaunch. Both slash-command and notification installs now refresh it only after a successful, non-shadowed upgrade.

Made by [Open SWE](https://openswe.vercel.app/agents/52dccf6f-be51-fd9e-c81c-4f2ea5d3f541)