### PR TITLE
feat(code): resize chat input by dragging its top border

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, assert_never
 
 from rich.cells import cell_len
 from rich.segment import Segment
+from textual.app import NoScreen
 from textual.color import Color
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.content import Content
@@ -84,13 +85,72 @@ _FILE_CACHE_WORKER_GROUP = "file-cache"
 """Textual worker group for all `@` file-completion cache warmers."""
 
 _CHAT_INPUT_AUTO_MAX_HEIGHT = 8
+"""Rows the composer grows to on its own before the draft starts scrolling.
+
+Also caps the manual-resize floor: a drag will not shrink the composer below
+the visible draft, but that refusal itself stops at this many rows, so a long
+draft cannot pin the composer open. Interpolated into `ChatInput.DEFAULT_CSS`
+as the `ChatTextArea` `max-height` so the stylesheet and the sizing math cannot
+drift apart.
+"""
+
 _CHAT_INPUT_BORDER_CORNER_COLUMNS = 2
+"""Columns the resize handle gives up so both top border corners stay drawn.
+
+The handle occludes whatever it covers (see `ChatInputResizeHandle.render`), so
+it is inset one column at each end — paired with `offset: 1 0` in the CSS — to
+leave the box's corner glyphs visible.
+"""
+
 _CHAT_INPUT_BOX_MAX_HEIGHT = 25
+"""Rows the bordered input box may occupy, including its border and any popup.
+
+`ChatInputBox._apply_manual_height` subtracts the gutter and the completion
+popup from this to derive the composer budget, so it is load-bearing arithmetic
+rather than a cosmetic cap. Interpolated into `ChatInput.DEFAULT_CSS` as the
+`#input-box` `max-height`.
+"""
+
 _CHAT_INPUT_MANUAL_MAX_HEIGHT = 20
-_CHAT_INPUT_MIN_NON_COMPOSER_ROWS = 7
+"""Rows a drag may stretch the composer to, before screen-size clamping.
+
+Five rows short of `_CHAT_INPUT_BOX_MAX_HEIGHT` so that a composer dragged to
+its limit still leaves room inside the box for the border and a few rows of
+completion popup, rather than immediately fighting the popup for space.
+"""
+
+_CHAT_INPUT_RESERVED_SCREEN_ROWS = 7
+"""Screen rows kept away from the composer text so the app stays usable.
+
+Subtracted from the screen height to bound a manual resize. It counts rows
+*outside* the composer's own text area but excludes the input box's 2-row
+border, which is charged separately via `gutter.height`. So on a 24-row
+terminal the composer maxes at 17 rows, the bordered box occupies 19, and about
+5 rows remain for the transcript and status bar.
+"""
+
 _CHAT_INPUT_RESIZE_HOVER_LIGHTEN = 0.15
+"""How far to lighten the resize line while the pointer is over it.
+
+Enough to read as a distinct affordance against the same-colored box border it
+sits on, but below the point where the top border looks like a different UI
+element from the other three sides.
+"""
+
 _COMPLETION_POPUP_MAX_HEIGHT = 12
+"""Rows the completion popup may occupy inside the input box.
+
+`ChatInputBox` reserves this much space when fitting a manual composer height,
+so it must match what the popup actually renders. Interpolated into
+`CompletionPopup.DEFAULT_CSS` as its `max-height` to keep the two in step.
+"""
+
 _DOUBLE_CLICK_CHAIN = 2
+"""Textual `Click.chain` count that marks a click as a double-click.
+
+Compared with `>=`, so triple and faster clicks also toggle rather than being
+silently ignored partway through a rapid click sequence.
+"""
 
 _REFOCUS_CLICK_SUPPRESS_WINDOW_SECONDS = 0.3
 """Window after a terminal focus regain during which a click only refocuses.
@@ -121,6 +181,7 @@ if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
     from textual.events import Click
+    from textual.screen import Screen
 
     from deepagents_code.config_manifest import CursorStyle
     from deepagents_code.input import MediaTracker, ParsedPastedPathPayload
@@ -305,19 +366,23 @@ class InputActionButton(Static):
 class CompletionPopup(VerticalScroll):
     """Popup widget that displays completion suggestions as clickable options."""
 
-    DEFAULT_CSS = """
-    CompletionPopup {
+    DEFAULT_CSS = f"""
+    CompletionPopup {{
         display: none;
         height: auto;
-        max-height: 12;
-    }
+        max-height: {_COMPLETION_POPUP_MAX_HEIGHT};
+    }}
     """
 
     class RowsChanged(Message):
-        """Message sent when the popup's visible row count changes."""
+        """Message sent when the popup's visible row count changes.
+
+        Deduplicated by the sender, so receiving this always means the rendered
+        row count actually moved.
+        """
 
         def __init__(self, rows: int) -> None:
-            """Initialize with the visible row count."""
+            """Initialize with the visible row count (0 when hidden)."""
             super().__init__()
             self.rows = rows
 
@@ -336,6 +401,7 @@ class CompletionPopup(VerticalScroll):
         self._options: list[CompletionOption] = []
         self._selected_index = 0
         self._pending_suggestions: list[tuple[str, str]] = []
+        self._reported_rows = 0
         self._pending_selected: int = 0
         self._rebuild_generation: int = 0
 
@@ -423,7 +489,7 @@ class CompletionPopup(VerticalScroll):
         if generation != self._rebuild_generation:
             return
 
-        self.show()
+        self.show(len(self._options))
 
         if 0 <= selected_index < len(self._options):
             self._options[selected_index].scroll_visible()
@@ -452,21 +518,30 @@ class CompletionPopup(VerticalScroll):
         event.stop()
         self.post_message(self.OptionClicked(event.index))
 
+    def _report_rows(self, rows: int) -> None:
+        """Announce the popup's rendered row count when it changes."""
+        if self._reported_rows != rows:
+            self._reported_rows = rows
+            self.post_message(self.RowsChanged(rows))
+
     def hide(self) -> None:
         """Hide the popup."""
         self._pending_suggestions = []
         self._rebuild_generation += 1  # Cancel any in-flight rebuild
         self.styles.display = "none"  # ty: ignore[invalid-assignment]  # Textual accepts string display values at runtime
-        self.post_message(self.RowsChanged(0))
+        self._report_rows(0)
 
-    def show(self) -> None:
-        """Show the popup."""
+    def show(self, suggestion_count: int) -> None:
+        """Show the popup and report how many rows it will render.
+
+        Args:
+            suggestion_count: Number of suggestions about to be displayed. Taken
+                as an argument rather than read from internal state so the
+                reported height is tied to the caller's list, which is the thing
+                `ChatInputBox` must reserve space for.
+        """
         self.styles.display = "block"
-        self.post_message(
-            self.RowsChanged(
-                min(len(self._pending_suggestions), _COMPLETION_POPUP_MAX_HEIGHT)
-            )
-        )
+        self._report_rows(min(suggestion_count, _COMPLETION_POPUP_MAX_HEIGHT))
 
 
 class ChatTextArea(PasteBurstTextArea):
@@ -1348,72 +1423,205 @@ class _CompletionViewAdapter:
         )
 
 
+def _manual_height_ceiling(screen_height: int) -> int:
+    """Return the largest composer height a drag may request.
+
+    Args:
+        screen_height: Current screen height in rows.
+
+    Returns:
+        The manual-resize ceiling, at least 1 row.
+    """
+    return max(
+        1,
+        min(
+            _CHAT_INPUT_MANUAL_MAX_HEIGHT,
+            screen_height - _CHAT_INPUT_RESERVED_SCREEN_ROWS,
+        ),
+    )
+
+
+def _content_height_floor(text_area: ChatTextArea) -> int:
+    """Return the rows the draft currently occupies, capped at auto growth.
+
+    Uses `virtual_size`, so soft-wrapped lines count as the rows they actually
+    render as rather than as one row per newline. A drag cannot shrink the
+    composer below this, which stops resizing from hiding visible text.
+
+    Args:
+        text_area: The composer whose draft height to measure.
+
+    Returns:
+        The floor in rows, between 1 and `_CHAT_INPUT_AUTO_MAX_HEIGHT`.
+    """
+    return max(1, min(text_area.virtual_size.height, _CHAT_INPUT_AUTO_MAX_HEIGHT))
+
+
 class ChatInputBox(Vertical):
-    """Bordered box that owns the chat composer size."""
+    """Bordered box that owns the chat composer size.
+
+    Sizing is either automatic (content-driven, the default) or manual, and
+    `_requested_height` is the discriminator: `None` means automatic.
+
+    A manual size separates *intent* from what is *rendered*. The requested
+    height is what the user dragged to and is preserved verbatim; the applied
+    height is re-derived on every relayout by fitting that request between a
+    content floor and whichever ceiling is currently tightest. So a completion
+    popup can transiently squeeze the composer and it springs back when the
+    popup closes, and a terminal shrink does not destroy the request.
+
+    `ChatInput` composes the children and drives this box through
+    `set_manual_height`, `toggle_expanded`, and `refresh_content_height`.
+    """
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize sizing state."""
         super().__init__(**kwargs)
         self._completion_rows = 0
-        self._manual_height: int | None = None
+        self._requested_height: int | None = None
+        self._applied_height: int | None = None
 
-    def _maximum_height(self) -> int:
-        """Return the largest safe manual composer height."""
-        return max(
-            1,
-            min(
-                _CHAT_INPUT_MANUAL_MAX_HEIGHT,
-                self.screen.size.height - _CHAT_INPUT_MIN_NON_COMPOSER_ROWS,
-            ),
+    def on_mount(self) -> None:
+        """Re-fit the composer whenever the screen relayouts.
+
+        A manual height pins the composer, so once it has been squeezed by a
+        smaller terminal nothing about this box's own geometry changes when the
+        terminal grows back -- it never receives another `Resize`. The screen's
+        layout-refresh signal does still fire, so that is what restores the
+        height the user asked for.
+        """
+        self.screen.screen_layout_refresh_signal.subscribe(
+            self, self._on_layout_refresh
         )
 
-    def _content_height_floor(self) -> int:
-        """Return the visual content height capped at normal auto growth."""
-        text_area = self.query_one(ChatTextArea)
-        return max(1, min(text_area.virtual_size.height, _CHAT_INPUT_AUTO_MAX_HEIGHT))
-
-    def _set_manual_height(self, height: int) -> None:
-        """Store and apply a physically clamped requested height."""
-        self._manual_height = max(1, min(height, self._maximum_height()))
+    def _on_layout_refresh(self, _screen: Screen) -> None:
+        """Re-fit a manual height against the new layout."""
         self._apply_manual_height()
 
-    def _ensure_content_height(self) -> None:
-        """Reapply a manual height as the visual content floor changes."""
-        if self._manual_height is not None:
+    def _composer(self) -> ChatTextArea | None:
+        """Return the composer, or `None` when the box is mid-teardown.
+
+        Returns:
+            The child text area, or `None` if it is no longer mounted.
+        """
+        try:
+            return self.query_one(ChatTextArea)
+        except NoMatches:
+            logger.warning("ChatInputBox: composer not found; skipping height update")
+            return None
+
+    def _screen_height(self) -> int | None:
+        """Return the screen height, or `None` when detached from a screen.
+
+        Returns:
+            The screen's row count, or `None` if this box has no screen.
+        """
+        try:
+            return self.screen.size.height
+        except NoScreen:
+            logger.warning("ChatInputBox: no screen; skipping height update")
+            return None
+
+    def set_manual_height(self, height: int) -> None:
+        """Request a manual composer height and render it.
+
+        The request is stored clamped only by the screen ceiling; the popup and
+        content constraints are applied at render time so they stay reversible.
+
+        Args:
+            height: Desired composer height in rows.
+        """
+        screen_height = self._screen_height()
+        if screen_height is None:
+            return
+        self._requested_height = max(
+            1, min(height, _manual_height_ceiling(screen_height))
+        )
+        self._apply_manual_height()
+
+    def refresh_content_height(self) -> None:
+        """Re-fit a manual height after the draft's rendered height changes."""
+        if self._requested_height is not None:
             self._apply_manual_height()
 
     def _apply_manual_height(self) -> None:
-        """Fit the requested height around content and visible completions."""
-        if self._manual_height is None:
+        """Render the requested height against the current constraints.
+
+        Three ceilings compete, and the tightest wins:
+
+        - the screen ceiling, which reserves rows for the rest of the app;
+        - the box ceiling, `_CHAT_INPUT_BOX_MAX_HEIGHT` minus the border gutter
+          and any completion popup, so the popup renders inside the border
+          rather than overflowing it;
+        - the same screen budget again but with the popup subtracted, since a
+          popup adds rows to the box that the plain screen ceiling ignores.
+
+        The result is then floored by the visible draft, so a manual height
+        never hides text. Both `height` and `max_height` are set because
+        `max_height` alone would leave Textual's `auto` growth in charge.
+        """
+        if self._requested_height is None:
             return
+        text_area = self._composer()
+        screen_height = self._screen_height()
+        if text_area is None or screen_height is None:
+            return
+        # The plain screen cap already allows for the composer's own gutter; a
+        # popup needs it reserved explicitly because it adds rows to the box.
+        popup_gutter = self.gutter.height if self._completion_rows else 0
+        screen_available = (
+            screen_height
+            - _CHAT_INPUT_RESERVED_SCREEN_ROWS
+            - self._completion_rows
+            - popup_gutter
+        )
         available = min(
-            self._maximum_height(),
+            _manual_height_ceiling(screen_height),
             max(
                 1,
                 _CHAT_INPUT_BOX_MAX_HEIGHT - self.gutter.height - self._completion_rows,
             ),
+            max(1, screen_available),
         )
-        minimum = min(self._content_height_floor(), available)
-        height = max(minimum, min(self._manual_height, available))
-        text_area = self.query_one(ChatTextArea)
+        minimum = min(_content_height_floor(text_area), available)
+        height = max(minimum, min(self._requested_height, available))
+        # Writing styles schedules another layout, which republishes the signal
+        # this method runs from. Bail when nothing moved so the two cannot feed
+        # each other.
+        if height == self._applied_height:
+            return
+        self._applied_height = height
         text_area.styles.height = height
         text_area.styles.max_height = height
         text_area.call_after_refresh(text_area.scroll_cursor_visible)
 
     def _reset_height(self) -> None:
         """Restore content-driven composer sizing."""
-        text_area = self.query_one(ChatTextArea)
-        self._manual_height = None
+        self._requested_height = None
+        self._applied_height = None
+        text_area = self._composer()
+        if text_area is None:
+            return
         text_area.styles.height = "auto"
         text_area.styles.max_height = _CHAT_INPUT_AUTO_MAX_HEIGHT
         text_area.call_after_refresh(text_area.scroll_cursor_visible)
 
-    def _toggle_expanded(self) -> None:
-        """Toggle between maximum manual height and automatic sizing."""
-        if self._manual_height is None:
-            self._set_manual_height(self._maximum_height())
-        else:
+    def toggle_expanded(self) -> None:
+        """Toggle between the maximum manual height and automatic sizing.
+
+        Branches on whether the composer is already at its maximum rather than
+        on whether a manual height exists at all, so a drag of a row or two
+        (including the incidental jitter of a double-click) still leaves the
+        next double-click meaning "expand".
+        """
+        screen_height = self._screen_height()
+        if screen_height is None:
+            return
+        maximum = _manual_height_ceiling(screen_height)
+        if self._requested_height == maximum:
             self._reset_height()
+        else:
+            self.set_manual_height(maximum)
 
     def on_completion_popup_rows_changed(
         self, event: CompletionPopup.RowsChanged
@@ -1424,13 +1632,25 @@ class ChatInputBox(Vertical):
         event.stop()
 
     def on_resize(self, _event: events.Resize) -> None:
-        """Clamp a manual height after terminal resizes."""
-        if self._manual_height is not None:
-            self._set_manual_height(self._manual_height)
+        """Re-fit a manual height after this box is resized.
+
+        Deliberately re-renders rather than re-requesting: the stored request
+        survives, so shrinking the terminal and growing it back restores the
+        height the user actually chose.
+        """
+        self._apply_manual_height()
 
 
 class ChatInputResizeHandle(Static):
-    """Transparent drag target over the chat input's top border."""
+    """Drag target docked over the chat input's top border.
+
+    Only the background is transparent: the handle sits on the layer above the
+    box's border and would blank the line it covers, so `render` repaints the
+    horizontal rule itself.
+
+    The handle reports pointer geometry and knows nothing about heights; the
+    parent decides what a drag means.
+    """
 
     ALLOW_SELECT = False
 
@@ -1441,9 +1661,16 @@ class ChatInputResizeHandle(Static):
         """Message sent with the current drag delta."""
 
         def __init__(self, delta: int) -> None:
-            """Initialize with an upward-positive row delta."""
+            """Initialize with a row delta, cumulative since the drag started.
+
+            Positive is upward — screen Y grows downward, so this is the
+            negation of the raw pointer movement.
+            """
             super().__init__()
             self.delta = delta
+
+    class DragEnded(Message):
+        """Message sent when a resize drag stops, however it stopped."""
 
     class HoverChanged(Message):
         """Message sent when resize hover feedback changes."""
@@ -1476,13 +1703,18 @@ class ChatInputResizeHandle(Static):
             self._highlighted = highlighted
             self.post_message(self.HoverChanged(highlighted))
 
-    def on_enter(self) -> None:
+    def on_enter(self, event: events.Enter) -> None:
         """Highlight the resize target on hover."""
-        self._set_highlighted(highlighted=True)
+        if event.node is self:
+            self._set_highlighted(highlighted=True)
 
-    def on_leave(self) -> None:
-        """Remove hover feedback outside an active drag."""
-        if self._drag_start_y is None:
+    def on_leave(self, event: events.Leave) -> None:
+        """Remove hover feedback, but never mid-drag.
+
+        A drag routinely travels outside the handle; dropping the highlight
+        there would make the border flicker off the moment resizing starts.
+        """
+        if event.node is self and self._drag_start_y is None:
             self._set_highlighted(highlighted=False)
 
     def on_mouse_down(self, event: events.MouseDown) -> None:
@@ -1500,22 +1732,62 @@ class ChatInputResizeHandle(Static):
         """Publish movement during a captured drag."""
         if self._drag_start_y is None:
             return
-        self.post_message(self.Dragged(self._drag_start_y - event.screen_y))
+        delta = self._drag_start_y - event.screen_y
+        # A double-click registers only when both presses land on the same cell,
+        # which is exactly when the pointer drifts away and back — emitting a
+        # zero-delta move. Reporting it would establish a manual height and flip
+        # the meaning of the click that follows.
+        if delta:
+            self.post_message(self.Dragged(delta))
         event.stop()
         event.prevent_default()
 
     def on_mouse_up(self, event: events.MouseUp) -> None:
-        """Finish an active left-button resize."""
+        """Finish an active left-button resize.
+
+        Hover feedback drops here rather than being re-derived from the pointer
+        position: releasing the capture makes Textual recompute what the mouse
+        is over and deliver a `Leave` anyway, and the next real movement back
+        onto the handle re-highlights it through `on_enter`.
+        """
         if self._drag_start_y is None or event.button != 1:
             return
-        self._drag_start_y = None
-        self.release_mouse()
-        self._set_highlighted(highlighted=event.screen_offset in self.region)
+        self._end_drag(highlighted=False)
         event.stop()
         event.prevent_default()
 
+    def _end_drag(self, *, highlighted: bool, notify: bool = True) -> None:
+        """Clear drag state, drop mouse capture, and settle hover feedback.
+
+        Args:
+            highlighted: Hover state to leave the handle in.
+            notify: Whether to announce `DragEnded`. Suppressed during teardown,
+                where the message pump is closing and nothing can receive it.
+        """
+        was_dragging = self._drag_start_y is not None
+        self._drag_start_y = None
+        self.release_mouse()
+        self._set_highlighted(highlighted=highlighted)
+        if was_dragging and notify:
+            self.post_message(self.DragEnded())
+
+    def on_mouse_release(self, _event: events.MouseRelease) -> None:
+        """Abandon a drag when the app revokes this widget's mouse capture.
+
+        Without this the handle keeps a phantom drag alive: `on_leave` refuses
+        to clear the highlight, and later pointer movement resizes from a stale
+        baseline with no press behind it.
+        """
+        if self._drag_start_y is not None:
+            logger.debug("Resize drag ended without a mouse up; clearing drag state")
+        self._end_drag(highlighted=False)
+
+    def on_hide(self, _event: events.Hide) -> None:
+        """Abandon a drag when the composer is hidden mid-gesture."""
+        self._end_drag(highlighted=False)
+
     def on_click(self, event: Click) -> None:
-        """Toggle expanded sizing when the handle is double-clicked."""
+        """Toggle expanded sizing on a double-click (or a faster chain)."""
         if event.button == 1 and event.chain >= _DOUBLE_CLICK_CHAIN:
             self.post_message(self.ToggleExpanded())
             event.stop()
@@ -1523,9 +1795,7 @@ class ChatInputResizeHandle(Static):
 
     def on_unmount(self) -> None:
         """Release mouse capture and hover state during teardown."""
-        self._drag_start_y = None
-        self.release_mouse()
-        self._set_highlighted(highlighted=False)
+        self._end_drag(highlighted=False, notify=False)
 
 
 class ChatInput(Vertical):
@@ -1536,9 +1806,12 @@ class ChatInput(Vertical):
     - Enter to submit, modifier key for newlines (see `config.newline_shortcut`)
     - Up/Down arrows for command history at input boundaries (start/end of text)
     - Autocomplete for @ (files) and / (commands)
+    - Drag the top border to resize the composer; double-click it to toggle
+      between the maximum height and content-driven sizing
     """
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS = (
+        """
     ChatInput {
         height: auto;
         layers: base actions;
@@ -1547,7 +1820,6 @@ class ChatInput(Vertical):
     ChatInput #input-box {
         height: auto;
         min-height: 3;
-        max-height: 25;
         padding: 0;
         background: $background;
         border: solid $primary;
@@ -1567,6 +1839,11 @@ class ChatInput(Vertical):
         border-title-style: bold;
     }
 
+    /* Pre-mount default only. `_sync_resize_handle_color` sets the color as an
+       inline style, which outranks this rule, because the hover highlight must
+       persist while a drag travels outside the handle -- something `:hover`
+       cannot express. Mode-specific rules here would be dead code, so mode
+       colors live in that method instead. */
     ChatInput #input-resize-handle {
         layer: actions;
         dock: left;
@@ -1576,18 +1853,6 @@ class ChatInput(Vertical):
         background: transparent;
         color: $primary;
         pointer: ns-resize;
-    }
-
-    ChatInput.mode-shell #input-resize-handle {
-        color: $mode-bash;
-    }
-
-    ChatInput.mode-command #input-resize-handle {
-        color: $mode-command;
-    }
-
-    ChatInput.mode-shell-incognito #input-resize-handle {
-        color: $mode-incognito;
     }
 
     /* Action buttons float on their own z-layer over the top border line, so
@@ -1632,7 +1897,6 @@ class ChatInput(Vertical):
         width: 1fr;
         height: auto;
         min-height: 1;
-        max-height: 8;
         border: none;
         background: transparent;
         padding: 0;
@@ -1648,6 +1912,20 @@ class ChatInput(Vertical):
         border: none;
     }
     """
+        f"""
+    /* Sizes the composer sizing math depends on, interpolated from the module
+       constants so the stylesheet cannot silently drift from the arithmetic in
+       `ChatInputBox`. Appended rather than inlined above to keep the rest of
+       this block free of doubled braces. */
+    ChatInput #input-box {{
+        max-height: {_CHAT_INPUT_BOX_MAX_HEIGHT};
+    }}
+
+    ChatInput ChatTextArea {{
+        max-height: {_CHAT_INPUT_AUTO_MAX_HEIGHT};
+    }}
+    """
+    )
     """Border and prompt glyph change color per mode for immediate visual feedback."""
 
     class Submitted(Message):
@@ -1699,7 +1977,7 @@ class ChatInput(Vertical):
         self._input_box: ChatInputBox | None = None
         self._resize_handle: ChatInputResizeHandle | None = None
         self._resize_hovered = False
-        self._resize_start_height = 1
+        self._resize_start_height: int | None = None
         self._action_buttons: Horizontal | None = None
         self._text_area: ChatTextArea | None = None
         self._popup: CompletionPopup | None = None
@@ -1840,11 +2118,19 @@ class ChatInput(Vertical):
 
     def _sync_resize_handle_geometry(self) -> None:
         """Inset the resize handle so border corners remain visible."""
-        if self._input_box is not None and self._resize_handle is not None:
-            self._resize_handle.styles.width = max(
-                1,
-                self._input_box.region.width - _CHAT_INPUT_BORDER_CORNER_COLUMNS,
-            )
+        if self._input_box is None or self._resize_handle is None:
+            return
+        # `Widget.region` swallows NoScreen/NoWidget and returns a null region,
+        # so a zero width means "not laid out yet" rather than a real size.
+        # Writing it through would collapse the whole drag target to one column.
+        box_width = self._input_box.region.width
+        if not box_width:
+            logger.debug("Chat input box not laid out yet; deferring handle geometry")
+            return
+        self._resize_handle.styles.width = max(
+            1,
+            box_width - _CHAT_INPUT_BORDER_CORNER_COLUMNS,
+        )
 
     def on_resize(self, _event: events.Resize) -> None:
         """Keep the resize handle aligned after layout changes."""
@@ -1860,6 +2146,14 @@ class ChatInput(Vertical):
             "command": colors.mode_command,
             "shell_incognito": colors.mode_incognito,
         }
+        if self.mode != "normal" and self.mode not in mode_colors:
+            # A mode added to config without a color here would render the resize
+            # line in the default color while the border and prompt follow the
+            # new mode -- a mismatch that is hard to trace back to this method.
+            logger.warning(
+                "No resize handle color for mode %r; falling back to primary",
+                self.mode,
+            )
         color = Color.parse(mode_colors.get(self.mode, colors.primary))
         if self._resize_hovered:
             color = color.lighten(_CHAT_INPUT_RESIZE_HOVER_LIGHTEN)
@@ -1882,8 +2176,21 @@ class ChatInput(Vertical):
         self, event: ChatInputResizeHandle.Dragged
     ) -> None:
         """Apply a drag delta to the composer height."""
+        if self._resize_start_height is None:
+            # No baseline means no DragStarted arrived; resizing from a stale
+            # one would jump the composer to an unrelated size.
+            logger.debug("Ignoring resize drag with no recorded start height")
+            event.stop()
+            return
         if self._input_box is not None:
-            self._input_box._set_manual_height(self._resize_start_height + event.delta)
+            self._input_box.set_manual_height(self._resize_start_height + event.delta)
+        event.stop()
+
+    def on_chat_input_resize_handle_drag_ended(
+        self, event: ChatInputResizeHandle.DragEnded
+    ) -> None:
+        """Drop the drag baseline so a later delta cannot reuse it."""
+        self._resize_start_height = None
         event.stop()
 
     def on_chat_input_resize_handle_hover_changed(
@@ -1898,7 +2205,7 @@ class ChatInput(Vertical):
     ) -> None:
         """Toggle maximum and automatic composer sizing."""
         if self._input_box is not None:
-            self._input_box._toggle_expanded()
+            self._input_box.toggle_expanded()
         event.stop()
 
     def _warm_file_cache(self, *, force: bool = False, exclusive: bool = False) -> None:
@@ -2034,7 +2341,7 @@ class ChatInput(Vertical):
         # whitespace-only draft is still clearable/copyable without the buttons.
         self._set_action_buttons_visible(visible=bool(text.strip()))
         if self._input_box is not None:
-            self._input_box._ensure_content_height()
+            self._input_box.refresh_content_height()
         # Drag-drop / bracketed paste arrive as one Changed event with a
         # multi-character inserted span. Normal typing arrives one character at
         # a time. Checking the changed span (rather than net length delta)
@@ -2942,6 +3249,10 @@ class ChatInput(Vertical):
                                 markup=False,
                             )
                     self.mode = "normal"
+                # The handle color is an inline style, so backing out of a mode
+                # does not repaint it on its own; a stale incognito-colored line
+                # would outlive the mode it advertises.
+                self._sync_resize_handle_color()
                 return
             prompt.update(glyph or ">")
             if self._input_box is not None:

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -1373,26 +1373,28 @@ class ChatInputBox(Vertical):
         return max(1, min(text_area.virtual_size.height, _CHAT_INPUT_AUTO_MAX_HEIGHT))
 
     def _set_manual_height(self, height: int) -> None:
-        """Store and apply a content-aware clamped composer height."""
-        maximum = self._maximum_height()
-        minimum = min(self._content_height_floor(), maximum)
-        self._manual_height = max(minimum, min(height, maximum))
+        """Store and apply a physically clamped requested height."""
+        self._manual_height = max(1, min(height, self._maximum_height()))
         self._apply_manual_height()
 
     def _ensure_content_height(self) -> None:
-        """Raise a manual height when visual content outgrows it."""
+        """Reapply a manual height as the visual content floor changes."""
         if self._manual_height is not None:
-            self._set_manual_height(self._manual_height)
+            self._apply_manual_height()
 
     def _apply_manual_height(self) -> None:
-        """Fit the manual composer height around visible completions."""
+        """Fit the requested height around content and visible completions."""
         if self._manual_height is None:
             return
-        available = max(
-            1,
-            _CHAT_INPUT_BOX_MAX_HEIGHT - self.gutter.height - self._completion_rows,
+        available = min(
+            self._maximum_height(),
+            max(
+                1,
+                _CHAT_INPUT_BOX_MAX_HEIGHT - self.gutter.height - self._completion_rows,
+            ),
         )
-        height = min(self._manual_height, available)
+        minimum = min(self._content_height_floor(), available)
+        height = max(minimum, min(self._manual_height, available))
         text_area = self.query_one(ChatTextArea)
         text_area.styles.height = height
         text_area.styles.max_height = height

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -81,6 +81,13 @@ protocol spec (functional key definitions) for background.
 _FILE_CACHE_WORKER_GROUP = "file-cache"
 """Textual worker group for all `@` file-completion cache warmers."""
 
+_CHAT_INPUT_AUTO_MAX_HEIGHT = 8
+_CHAT_INPUT_BOX_MAX_HEIGHT = 25
+_CHAT_INPUT_MANUAL_MAX_HEIGHT = 20
+_CHAT_INPUT_MIN_NON_COMPOSER_ROWS = 7
+_COMPLETION_POPUP_MAX_HEIGHT = 12
+_DOUBLE_CLICK_CHAIN = 2
+
 _REFOCUS_CLICK_SUPPRESS_WINDOW_SECONDS = 0.3
 """Window after a terminal focus regain during which a click only refocuses.
 
@@ -302,6 +309,14 @@ class CompletionPopup(VerticalScroll):
     }
     """
 
+    class RowsChanged(Message):
+        """Message sent when the popup's visible row count changes."""
+
+        def __init__(self, rows: int) -> None:
+            """Initialize with the visible row count."""
+            super().__init__()
+            self.rows = rows
+
     class OptionClicked(Message):
         """Message sent when a completion option is clicked."""
 
@@ -438,10 +453,16 @@ class CompletionPopup(VerticalScroll):
         self._pending_suggestions = []
         self._rebuild_generation += 1  # Cancel any in-flight rebuild
         self.styles.display = "none"  # ty: ignore[invalid-assignment]  # Textual accepts string display values at runtime
+        self.post_message(self.RowsChanged(0))
 
     def show(self) -> None:
         """Show the popup."""
         self.styles.display = "block"
+        self.post_message(
+            self.RowsChanged(
+                min(len(self._pending_suggestions), _COMPLETION_POPUP_MAX_HEIGHT)
+            )
+        )
 
 
 class ChatTextArea(PasteBurstTextArea):
@@ -1323,6 +1344,123 @@ class _CompletionViewAdapter:
         )
 
 
+class ChatInputBox(Vertical):
+    """Bordered chat-input box with a draggable top edge."""
+
+    ALLOW_SELECT = False
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize drag state."""
+        super().__init__(**kwargs)
+        self._completion_rows = 0
+        self._drag_start_y: int | None = None
+        self._drag_start_height = 1
+        self._manual_height: int | None = None
+
+    def _is_top_border(self, event: events.MouseEvent) -> bool:
+        """Return whether a mouse event targets this box's top border."""
+        return event.widget is self and event.y == 0
+
+    def _maximum_height(self) -> int:
+        """Return the largest safe manual composer height."""
+        return max(
+            1,
+            min(
+                _CHAT_INPUT_MANUAL_MAX_HEIGHT,
+                self.screen.size.height - _CHAT_INPUT_MIN_NON_COMPOSER_ROWS,
+            ),
+        )
+
+    def _set_manual_height(self, height: int) -> None:
+        """Store and apply a clamped fixed height to the composer."""
+        self._manual_height = max(1, min(height, self._maximum_height()))
+        self._apply_manual_height()
+
+    def _apply_manual_height(self) -> None:
+        """Fit the manual composer height around visible completions."""
+        if self._manual_height is None:
+            return
+        available = max(
+            1,
+            _CHAT_INPUT_BOX_MAX_HEIGHT - self.gutter.height - self._completion_rows,
+        )
+        height = min(self._manual_height, available)
+        text_area = self.query_one(ChatTextArea)
+        text_area.styles.height = height
+        text_area.styles.max_height = height
+        text_area.call_after_refresh(text_area.scroll_cursor_visible)
+
+    def _reset_height(self) -> None:
+        """Restore content-driven composer sizing."""
+        text_area = self.query_one(ChatTextArea)
+        self._manual_height = None
+        text_area.styles.height = "auto"
+        text_area.styles.max_height = _CHAT_INPUT_AUTO_MAX_HEIGHT
+        text_area.call_after_refresh(text_area.scroll_cursor_visible)
+
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        """Begin resizing from a left press on the top border."""
+        if event.button != 1 or not self._is_top_border(event):
+            return
+        self._drag_start_y = event.screen_y
+        self._drag_start_height = max(1, self.query_one(ChatTextArea).size.height)
+        self.styles.pointer = "ns-resize"
+        self.capture_mouse()
+        event.stop()
+        event.prevent_default()
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        """Resize during a drag or update the border pointer."""
+        if self._drag_start_y is None:
+            self.styles.pointer = (
+                "ns-resize" if self._is_top_border(event) else "default"
+            )
+            return
+        self._set_manual_height(
+            self._drag_start_height + self._drag_start_y - event.screen_y
+        )
+        event.stop()
+        event.prevent_default()
+
+    def on_mouse_up(self, event: events.MouseUp) -> None:
+        """Finish an active left-button resize."""
+        if self._drag_start_y is None or event.button != 1:
+            return
+        self._drag_start_y = None
+        self.release_mouse()
+        event.stop()
+        event.prevent_default()
+
+    def on_click(self, event: Click) -> None:
+        """Reset automatic sizing when the top border is double-clicked."""
+        if (
+            event.button == 1
+            and event.chain >= _DOUBLE_CLICK_CHAIN
+            and self._is_top_border(event)
+        ):
+            self._reset_height()
+            event.stop()
+            event.prevent_default()
+
+    def on_completion_popup_rows_changed(
+        self, event: CompletionPopup.RowsChanged
+    ) -> None:
+        """Fit a manual composer around the completion popup."""
+        self._completion_rows = event.rows
+        self._apply_manual_height()
+        event.stop()
+
+    def on_resize(self, _event: events.Resize) -> None:
+        """Clamp a manual height after terminal resizes."""
+        if self._manual_height is not None:
+            self._set_manual_height(self._manual_height)
+
+    def on_unmount(self) -> None:
+        """Release mouse capture during teardown."""
+        self._drag_start_y = None
+        self.release_mouse()
+
+
 class ChatInput(Vertical):
     """Chat input widget with prompt, multi-line text, autocomplete, and history.
 
@@ -1468,7 +1606,7 @@ class ChatInput(Vertical):
         super().__init__(**kwargs)
         self._cwd = Path(cwd) if cwd else Path.cwd()
         self._image_tracker = image_tracker
-        self._input_box: Vertical | None = None
+        self._input_box: ChatInputBox | None = None
         self._action_buttons: Horizontal | None = None
         self._text_area: ChatTextArea | None = None
         self._popup: CompletionPopup | None = None
@@ -1540,7 +1678,7 @@ class ChatInput(Vertical):
         # The bordered box owns the prompt, text area, and completion popup so
         # the action buttons (a sibling) can float on its top border line; a
         # widget can only render on its sibling's border, not its parent's.
-        with Vertical(id="input-box"):
+        with ChatInputBox(id="input-box"):
             with Horizontal(classes="input-row"):
                 yield Static(">", classes="input-prompt", id="prompt")
                 yield ChatTextArea(id="chat-input")
@@ -1564,7 +1702,7 @@ class ChatInput(Vertical):
 
     def on_mount(self) -> None:
         """Initialize components after mount."""
-        self._input_box = self.query_one("#input-box", Vertical)
+        self._input_box = self.query_one("#input-box", ChatInputBox)
         self._action_buttons = self.query_one("#input-actions", Horizontal)
         if is_ascii_mode():
             colors = theme.get_theme_colors(self)

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -83,6 +83,7 @@ _FILE_CACHE_WORKER_GROUP = "file-cache"
 """Textual worker group for all `@` file-completion cache warmers."""
 
 _CHAT_INPUT_AUTO_MAX_HEIGHT = 8
+_CHAT_INPUT_BORDER_CORNER_COLUMNS = 2
 _CHAT_INPUT_BOX_MAX_HEIGHT = 25
 _CHAT_INPUT_MANUAL_MAX_HEIGHT = 20
 _CHAT_INPUT_MIN_NON_COMPOSER_ROWS = 7
@@ -1552,10 +1553,10 @@ class ChatInput(Vertical):
 
     ChatInput #input-resize-handle {
         layer: actions;
-        dock: right;
-        width: 1fr;
+        dock: left;
+        width: 1;
         height: 1;
-        margin-right: 1;
+        offset: 1 0;
         background: transparent;
         color: $primary;
         pointer: ns-resize;
@@ -1685,6 +1686,7 @@ class ChatInput(Vertical):
         self._image_tracker = image_tracker
         self._input_box: ChatInputBox | None = None
         self._resize_border_top: tuple[EdgeType, Color] | None = None
+        self._resize_handle: ChatInputResizeHandle | None = None
         self._resize_start_height = 1
         self._action_buttons: Horizontal | None = None
         self._text_area: ChatTextArea | None = None
@@ -1785,6 +1787,9 @@ class ChatInput(Vertical):
     def on_mount(self) -> None:
         """Initialize components after mount."""
         self._input_box = self.query_one("#input-box", ChatInputBox)
+        self._resize_handle = self.query_one(
+            "#input-resize-handle", ChatInputResizeHandle
+        )
         self._action_buttons = self.query_one("#input-actions", Horizontal)
         if is_ascii_mode():
             colors = theme.get_theme_colors(self)
@@ -1817,7 +1822,20 @@ class ChatInput(Vertical):
             _FILE_CACHE_REFRESH_INTERVAL_SECONDS,
             self._refresh_file_cache,
         )
+        self.call_after_refresh(self._sync_resize_handle_geometry)
         self._text_area.focus()
+
+    def _sync_resize_handle_geometry(self) -> None:
+        """Inset the resize handle so border corners remain visible."""
+        if self._input_box is not None and self._resize_handle is not None:
+            self._resize_handle.styles.width = max(
+                1,
+                self._input_box.region.width - _CHAT_INPUT_BORDER_CORNER_COLUMNS,
+            )
+
+    def on_resize(self, _event: events.Resize) -> None:
+        """Keep the resize handle aligned after layout changes."""
+        self.call_after_refresh(self._sync_resize_handle_geometry)
 
     def _set_resize_highlighted(self, *, highlighted: bool) -> None:
         """Toggle resize hover feedback on the top border."""

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -26,6 +26,7 @@ from deepagents_code.config import (
     MODE_DISPLAY_GLYPHS,
     MODE_PREFIXES,
     detect_mode_prefix,
+    get_glyphs,
     is_ascii_mode,
 )
 from deepagents_code.input import IMAGE_PLACEHOLDER_PATTERN, VIDEO_PLACEHOLDER_PATTERN
@@ -1439,10 +1440,19 @@ class ChatInputResizeHandle(Static):
         self._drag_start_y: int | None = None
         self._highlighted = False
 
+    def render(self) -> str:
+        """Render the border line beneath the drag target.
+
+        Returns:
+            A charset-compatible horizontal rule spanning the handle.
+        """
+        return get_glyphs().box_horizontal * self.size.width
+
     def _set_highlighted(self, *, highlighted: bool) -> None:
         """Publish top-border hover changes."""
         if self._highlighted != highlighted:
             self._highlighted = highlighted
+            self.set_class(highlighted, "resize-hover")
             self.post_message(self.HoverChanged(highlighted))
 
     def on_enter(self) -> None:
@@ -1547,7 +1557,24 @@ class ChatInput(Vertical):
         height: 1;
         margin-right: 1;
         background: transparent;
+        color: $primary;
         pointer: ns-resize;
+    }
+
+    ChatInput.mode-shell #input-resize-handle {
+        color: $mode-bash;
+    }
+
+    ChatInput.mode-command #input-resize-handle {
+        color: $mode-command;
+    }
+
+    ChatInput.mode-shell-incognito #input-resize-handle {
+        color: $mode-incognito;
+    }
+
+    ChatInput #input-resize-handle.resize-hover {
+        color: $primary-lighten-2;
     }
 
     /* Action buttons float on their own z-layer over the top border line, so

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, assert_never
 
 from rich.cells import cell_len
 from rich.segment import Segment
+from textual.color import Color
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.content import Content
 from textual.css.query import NoMatches
@@ -87,6 +88,7 @@ _CHAT_INPUT_BORDER_CORNER_COLUMNS = 2
 _CHAT_INPUT_BOX_MAX_HEIGHT = 25
 _CHAT_INPUT_MANUAL_MAX_HEIGHT = 20
 _CHAT_INPUT_MIN_NON_COMPOSER_ROWS = 7
+_CHAT_INPUT_RESIZE_HOVER_LIGHTEN = 0.15
 _COMPLETION_POPUP_MAX_HEIGHT = 12
 _DOUBLE_CLICK_CHAIN = 2
 
@@ -118,8 +120,6 @@ loop and swaps in atomically, so it never blocks typing."""
 if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
-    from textual.color import Color
-    from textual.css.types import EdgeType
     from textual.events import Click
 
     from deepagents_code.config_manifest import CursorStyle
@@ -1394,6 +1394,13 @@ class ChatInputBox(Vertical):
         text_area.styles.max_height = _CHAT_INPUT_AUTO_MAX_HEIGHT
         text_area.call_after_refresh(text_area.scroll_cursor_visible)
 
+    def _toggle_expanded(self) -> None:
+        """Toggle between maximum manual height and automatic sizing."""
+        if self._manual_height is None:
+            self._set_manual_height(self._maximum_height())
+        else:
+            self._reset_height()
+
     def on_completion_popup_rows_changed(
         self, event: CompletionPopup.RowsChanged
     ) -> None:
@@ -1432,8 +1439,8 @@ class ChatInputResizeHandle(Static):
             super().__init__()
             self.highlighted = highlighted
 
-    class Reset(Message):
-        """Message sent when automatic sizing should be restored."""
+    class ToggleExpanded(Message):
+        """Message sent when expanded sizing should be toggled."""
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize drag state."""
@@ -1453,7 +1460,6 @@ class ChatInputResizeHandle(Static):
         """Publish top-border hover changes."""
         if self._highlighted != highlighted:
             self._highlighted = highlighted
-            self.set_class(highlighted, "resize-hover")
             self.post_message(self.HoverChanged(highlighted))
 
     def on_enter(self) -> None:
@@ -1495,9 +1501,9 @@ class ChatInputResizeHandle(Static):
         event.prevent_default()
 
     def on_click(self, event: Click) -> None:
-        """Reset automatic sizing when the handle is double-clicked."""
+        """Toggle expanded sizing when the handle is double-clicked."""
         if event.button == 1 and event.chain >= _DOUBLE_CLICK_CHAIN:
-            self.post_message(self.Reset())
+            self.post_message(self.ToggleExpanded())
             event.stop()
             event.prevent_default()
 
@@ -1547,10 +1553,6 @@ class ChatInput(Vertical):
         border-title-style: bold;
     }
 
-    ChatInput #input-box.resize-hover {
-        border-top: solid $primary-lighten-2;
-    }
-
     ChatInput #input-resize-handle {
         layer: actions;
         dock: left;
@@ -1572,10 +1574,6 @@ class ChatInput(Vertical):
 
     ChatInput.mode-shell-incognito #input-resize-handle {
         color: $mode-incognito;
-    }
-
-    ChatInput #input-resize-handle.resize-hover {
-        color: $primary-lighten-2;
     }
 
     /* Action buttons float on their own z-layer over the top border line, so
@@ -1685,8 +1683,8 @@ class ChatInput(Vertical):
         self._cwd = Path(cwd) if cwd else Path.cwd()
         self._image_tracker = image_tracker
         self._input_box: ChatInputBox | None = None
-        self._resize_border_top: tuple[EdgeType, Color] | None = None
         self._resize_handle: ChatInputResizeHandle | None = None
+        self._resize_hovered = False
         self._resize_start_height = 1
         self._action_buttons: Horizontal | None = None
         self._text_area: ChatTextArea | None = None
@@ -1823,6 +1821,7 @@ class ChatInput(Vertical):
             self._refresh_file_cache,
         )
         self.call_after_refresh(self._sync_resize_handle_geometry)
+        self._sync_resize_handle_color()
         self._text_area.focus()
 
     def _sync_resize_handle_geometry(self) -> None:
@@ -1837,21 +1836,25 @@ class ChatInput(Vertical):
         """Keep the resize handle aligned after layout changes."""
         self.call_after_refresh(self._sync_resize_handle_geometry)
 
+    def _sync_resize_handle_color(self) -> None:
+        """Match the resize line to the active input mode and hover state."""
+        if self._resize_handle is None:
+            return
+        colors = theme.get_theme_colors(self)
+        mode_colors = {
+            "shell": colors.mode_bash,
+            "command": colors.mode_command,
+            "shell_incognito": colors.mode_incognito,
+        }
+        color = Color.parse(mode_colors.get(self.mode, colors.primary))
+        if self._resize_hovered:
+            color = color.lighten(_CHAT_INPUT_RESIZE_HOVER_LIGHTEN)
+        self._resize_handle.styles.color = color
+
     def _set_resize_highlighted(self, *, highlighted: bool) -> None:
-        """Toggle resize hover feedback on the top border."""
-        if self._input_box is None:
-            return
-        self._input_box.set_class(highlighted, "resize-hover")
-        if not is_ascii_mode():
-            return
-        if highlighted and self._resize_border_top is None:
-            self._resize_border_top = self._input_box.styles.border_top
-            edge, _color = self._resize_border_top
-            colors = theme.get_theme_colors(self)
-            self._input_box.styles.border_top = (edge, colors.accent)
-        elif not highlighted and self._resize_border_top is not None:
-            self._input_box.styles.border_top = self._resize_border_top
-            self._resize_border_top = None
+        """Toggle resize hover feedback on the interior border line."""
+        self._resize_hovered = highlighted
+        self._sync_resize_handle_color()
 
     def on_chat_input_resize_handle_drag_started(
         self, event: ChatInputResizeHandle.DragStarted
@@ -1876,12 +1879,12 @@ class ChatInput(Vertical):
         self._set_resize_highlighted(highlighted=event.highlighted)
         event.stop()
 
-    def on_chat_input_resize_handle_reset(
-        self, event: ChatInputResizeHandle.Reset
+    def on_chat_input_resize_handle_toggle_expanded(
+        self, event: ChatInputResizeHandle.ToggleExpanded
     ) -> None:
-        """Restore automatic composer sizing."""
+        """Toggle maximum and automatic composer sizing."""
         if self._input_box is not None:
-            self._input_box._reset_height()
+            self._input_box._toggle_expanded()
         event.stop()
 
     def _warm_file_cache(self, *, force: bool = False, exclusive: bool = False) -> None:
@@ -2929,6 +2932,7 @@ class ChatInput(Vertical):
                 self._input_box.border_title = (
                     "incognito" if mode == "shell_incognito" else None
                 )
+            self._sync_resize_handle_color()
 
         self.call_next(_apply)
         self.post_message(self.ModeChanged(mode))

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -116,6 +116,8 @@ loop and swaps in atomically, so it never blocks typing."""
 if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
+    from textual.color import Color
+    from textual.css.types import EdgeType
     from textual.events import Click
 
     from deepagents_code.config_manifest import CursorStyle
@@ -1345,21 +1347,13 @@ class _CompletionViewAdapter:
 
 
 class ChatInputBox(Vertical):
-    """Bordered chat-input box with a draggable top edge."""
-
-    ALLOW_SELECT = False
+    """Bordered box that owns the chat composer size."""
 
     def __init__(self, **kwargs: Any) -> None:
-        """Initialize drag state."""
+        """Initialize sizing state."""
         super().__init__(**kwargs)
         self._completion_rows = 0
-        self._drag_start_y: int | None = None
-        self._drag_start_height = 1
         self._manual_height: int | None = None
-
-    def _is_top_border(self, event: events.MouseEvent) -> bool:
-        """Return whether a mouse event targets this box's top border."""
-        return event.widget is self and event.y == 0
 
     def _maximum_height(self) -> int:
         """Return the largest safe manual composer height."""
@@ -1398,50 +1392,6 @@ class ChatInputBox(Vertical):
         text_area.styles.max_height = _CHAT_INPUT_AUTO_MAX_HEIGHT
         text_area.call_after_refresh(text_area.scroll_cursor_visible)
 
-    def on_mouse_down(self, event: events.MouseDown) -> None:
-        """Begin resizing from a left press on the top border."""
-        if event.button != 1 or not self._is_top_border(event):
-            return
-        self._drag_start_y = event.screen_y
-        self._drag_start_height = max(1, self.query_one(ChatTextArea).size.height)
-        self.styles.pointer = "ns-resize"
-        self.capture_mouse()
-        event.stop()
-        event.prevent_default()
-
-    def on_mouse_move(self, event: events.MouseMove) -> None:
-        """Resize during a drag or update the border pointer."""
-        if self._drag_start_y is None:
-            self.styles.pointer = (
-                "ns-resize" if self._is_top_border(event) else "default"
-            )
-            return
-        self._set_manual_height(
-            self._drag_start_height + self._drag_start_y - event.screen_y
-        )
-        event.stop()
-        event.prevent_default()
-
-    def on_mouse_up(self, event: events.MouseUp) -> None:
-        """Finish an active left-button resize."""
-        if self._drag_start_y is None or event.button != 1:
-            return
-        self._drag_start_y = None
-        self.release_mouse()
-        event.stop()
-        event.prevent_default()
-
-    def on_click(self, event: Click) -> None:
-        """Reset automatic sizing when the top border is double-clicked."""
-        if (
-            event.button == 1
-            and event.chain >= _DOUBLE_CLICK_CHAIN
-            and self._is_top_border(event)
-        ):
-            self._reset_height()
-            event.stop()
-            event.prevent_default()
-
     def on_completion_popup_rows_changed(
         self, event: CompletionPopup.RowsChanged
     ) -> None:
@@ -1455,10 +1405,96 @@ class ChatInputBox(Vertical):
         if self._manual_height is not None:
             self._set_manual_height(self._manual_height)
 
-    def on_unmount(self) -> None:
-        """Release mouse capture during teardown."""
+
+class ChatInputResizeHandle(Static):
+    """Transparent drag target over the chat input's top border."""
+
+    ALLOW_SELECT = False
+
+    class DragStarted(Message):
+        """Message sent when a resize drag begins."""
+
+    class Dragged(Message):
+        """Message sent with the current drag delta."""
+
+        def __init__(self, delta: int) -> None:
+            """Initialize with an upward-positive row delta."""
+            super().__init__()
+            self.delta = delta
+
+    class HoverChanged(Message):
+        """Message sent when resize hover feedback changes."""
+
+        def __init__(self, highlighted: bool) -> None:
+            """Initialize with the new hover state."""
+            super().__init__()
+            self.highlighted = highlighted
+
+    class Reset(Message):
+        """Message sent when automatic sizing should be restored."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize drag state."""
+        super().__init__("", markup=False, **kwargs)
+        self._drag_start_y: int | None = None
+        self._highlighted = False
+
+    def _set_highlighted(self, *, highlighted: bool) -> None:
+        """Publish top-border hover changes."""
+        if self._highlighted != highlighted:
+            self._highlighted = highlighted
+            self.post_message(self.HoverChanged(highlighted))
+
+    def on_enter(self) -> None:
+        """Highlight the resize target on hover."""
+        self._set_highlighted(highlighted=True)
+
+    def on_leave(self) -> None:
+        """Remove hover feedback outside an active drag."""
+        if self._drag_start_y is None:
+            self._set_highlighted(highlighted=False)
+
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        """Begin resizing from a left press on the handle."""
+        if event.button != 1:
+            return
+        self._drag_start_y = event.screen_y
+        self._set_highlighted(highlighted=True)
+        self.capture_mouse()
+        self.post_message(self.DragStarted())
+        event.stop()
+        event.prevent_default()
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        """Publish movement during a captured drag."""
+        if self._drag_start_y is None:
+            return
+        self.post_message(self.Dragged(self._drag_start_y - event.screen_y))
+        event.stop()
+        event.prevent_default()
+
+    def on_mouse_up(self, event: events.MouseUp) -> None:
+        """Finish an active left-button resize."""
+        if self._drag_start_y is None or event.button != 1:
+            return
         self._drag_start_y = None
         self.release_mouse()
+        self._set_highlighted(highlighted=event.screen_offset in self.region)
+        event.stop()
+        event.prevent_default()
+
+    def on_click(self, event: Click) -> None:
+        """Reset automatic sizing when the handle is double-clicked."""
+        if event.button == 1 and event.chain >= _DOUBLE_CLICK_CHAIN:
+            self.post_message(self.Reset())
+            event.stop()
+            event.prevent_default()
+
+    def on_unmount(self) -> None:
+        """Release mouse capture and hover state during teardown."""
+        self._drag_start_y = None
+        self.release_mouse()
+        self._set_highlighted(highlighted=False)
 
 
 class ChatInput(Vertical):
@@ -1498,6 +1534,20 @@ class ChatInput(Vertical):
         border: solid $mode-incognito;
         border-title-color: $mode-incognito;
         border-title-style: bold;
+    }
+
+    ChatInput #input-box.resize-hover {
+        border-top: solid $primary-lighten-2;
+    }
+
+    ChatInput #input-resize-handle {
+        layer: actions;
+        dock: right;
+        width: 1fr;
+        height: 1;
+        margin-right: 1;
+        background: transparent;
+        pointer: ns-resize;
     }
 
     /* Action buttons float on their own z-layer over the top border line, so
@@ -1607,6 +1657,8 @@ class ChatInput(Vertical):
         self._cwd = Path(cwd) if cwd else Path.cwd()
         self._image_tracker = image_tracker
         self._input_box: ChatInputBox | None = None
+        self._resize_border_top: tuple[EdgeType, Color] | None = None
+        self._resize_start_height = 1
         self._action_buttons: Horizontal | None = None
         self._text_area: ChatTextArea | None = None
         self._popup: CompletionPopup | None = None
@@ -1678,11 +1730,14 @@ class ChatInput(Vertical):
         # The bordered box owns the prompt, text area, and completion popup so
         # the action buttons (a sibling) can float on its top border line; a
         # widget can only render on its sibling's border, not its parent's.
-        with ChatInputBox(id="input-box"):
+        input_box = ChatInputBox(id="input-box")
+        with input_box:
             with Horizontal(classes="input-row"):
                 yield Static(">", classes="input-prompt", id="prompt")
                 yield ChatTextArea(id="chat-input")
             yield CompletionPopup(id="completion-popup")
+
+        yield ChatInputResizeHandle(id="input-resize-handle")
 
         # Action buttons float on their own z-layer over the top border line so
         # they cost no content row and never overlap the draft text.
@@ -1736,6 +1791,53 @@ class ChatInput(Vertical):
             self._refresh_file_cache,
         )
         self._text_area.focus()
+
+    def _set_resize_highlighted(self, *, highlighted: bool) -> None:
+        """Toggle resize hover feedback on the top border."""
+        if self._input_box is None:
+            return
+        self._input_box.set_class(highlighted, "resize-hover")
+        if not is_ascii_mode():
+            return
+        if highlighted and self._resize_border_top is None:
+            self._resize_border_top = self._input_box.styles.border_top
+            edge, _color = self._resize_border_top
+            colors = theme.get_theme_colors(self)
+            self._input_box.styles.border_top = (edge, colors.accent)
+        elif not highlighted and self._resize_border_top is not None:
+            self._input_box.styles.border_top = self._resize_border_top
+            self._resize_border_top = None
+
+    def on_chat_input_resize_handle_drag_started(
+        self, event: ChatInputResizeHandle.DragStarted
+    ) -> None:
+        """Record the composer height at the start of a drag."""
+        if self._text_area is not None:
+            self._resize_start_height = max(1, self._text_area.size.height)
+        event.stop()
+
+    def on_chat_input_resize_handle_dragged(
+        self, event: ChatInputResizeHandle.Dragged
+    ) -> None:
+        """Apply a drag delta to the composer height."""
+        if self._input_box is not None:
+            self._input_box._set_manual_height(self._resize_start_height + event.delta)
+        event.stop()
+
+    def on_chat_input_resize_handle_hover_changed(
+        self, event: ChatInputResizeHandle.HoverChanged
+    ) -> None:
+        """Update top-border hover feedback."""
+        self._set_resize_highlighted(highlighted=event.highlighted)
+        event.stop()
+
+    def on_chat_input_resize_handle_reset(
+        self, event: ChatInputResizeHandle.Reset
+    ) -> None:
+        """Restore automatic composer sizing."""
+        if self._input_box is not None:
+            self._input_box._reset_height()
+        event.stop()
 
     def _warm_file_cache(self, *, force: bool = False, exclusive: bool = False) -> None:
         """Schedule an `@` file-completion cache warmer.

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -1367,10 +1367,22 @@ class ChatInputBox(Vertical):
             ),
         )
 
+    def _content_height_floor(self) -> int:
+        """Return the visual content height capped at normal auto growth."""
+        text_area = self.query_one(ChatTextArea)
+        return max(1, min(text_area.virtual_size.height, _CHAT_INPUT_AUTO_MAX_HEIGHT))
+
     def _set_manual_height(self, height: int) -> None:
-        """Store and apply a clamped fixed height to the composer."""
-        self._manual_height = max(1, min(height, self._maximum_height()))
+        """Store and apply a content-aware clamped composer height."""
+        maximum = self._maximum_height()
+        minimum = min(self._content_height_floor(), maximum)
+        self._manual_height = max(minimum, min(height, maximum))
         self._apply_manual_height()
+
+    def _ensure_content_height(self) -> None:
+        """Raise a manual height when visual content outgrows it."""
+        if self._manual_height is not None:
+            self._set_manual_height(self._manual_height)
 
     def _apply_manual_height(self) -> None:
         """Fit the manual composer height around visible completions."""
@@ -2019,6 +2031,8 @@ class ChatInput(Vertical):
         # paths (esc+esc clear, Ctrl+C copy), which act on the raw value so a
         # whitespace-only draft is still clearable/copyable without the buttons.
         self._set_action_buttons_visible(visible=bool(text.strip()))
+        if self._input_box is not None:
+            self._input_box._ensure_content_height()
         # Drag-drop / bracketed paste arrive as one Changed event with a
         # multi-character inserted span. Normal typing arrives one character at
         # a time. Checking the changed span (rather than net length delta)

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -39,6 +39,7 @@ _TIPS: dict[str, int] = {
     "Ask for a workflow to fan work out to subagents in parallel": 3,
     "Use /timestamps to show or hide message timestamp footers": 1,
     "Click a collapsed message or press Ctrl+O to expand it": 1,
+    "Drag the chat input's top border to resize it": 1,
     "Use /agents to browse and switch between your available agents": 2,
     "Use /auto model to review Auto actions with a faster, cheaper model": 1,
     _TIP_SHIFT_TAB_WITH_YOLO: 2,

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -497,17 +497,23 @@ class TestChatInputResize:
             handle = app.query_one(ChatInputResizeHandle)
             await pilot.pause()
             default_border = box.styles.border_top
+            default_handle_color = handle.styles.color
+            rendered_border = handle.render()
+            assert rendered_border.strip()
+            assert len(rendered_border) == handle.size.width
 
             await pilot.hover(handle, offset=(5, 0))
 
             assert box.has_class("resize-hover")
             assert box.styles.border_top != default_border
+            assert handle.styles.color != default_handle_color
             assert handle.styles.pointer == "ns-resize"
 
             await pilot.hover("#spacer")
 
             assert not box.has_class("resize-hover")
             assert box.styles.border_top == default_border
+            assert handle.styles.color == default_handle_color
 
     async def test_non_left_press_does_not_start_drag(self) -> None:
         """A non-left press on the handle leaves resize inactive."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -24,6 +24,7 @@ from deepagents_code.tui.widgets import (
 from deepagents_code.tui.widgets.autocomplete import MAX_SUGGESTIONS
 from deepagents_code.tui.widgets.chat_input import (
     ChatInput,
+    ChatInputBox,
     ChatTextArea,
     CompletionOption,
     CompletionPopup,
@@ -218,6 +219,24 @@ class _ChatInputTestApp(App[None]):
         yield ChatInput(id="chat-input")
 
 
+class _ChatInputResizeTestApp(App[None]):
+    """App that positions the chat input at the bottom for drag tests."""
+
+    CSS = """
+    Screen {
+        layout: vertical;
+    }
+
+    #spacer {
+        height: 1fr;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Static(id="spacer")
+        yield ChatInput(id="chat-input")
+
+
 class _RecordingApp(App[None]):
     """App that records ChatInput.Submitted events for assertion."""
 
@@ -363,6 +382,154 @@ class TestChatInputFileCacheRefresh:
                 chat_input_module._FILE_CACHE_REFRESH_INTERVAL_SECONDS,
                 chat._refresh_file_cache,
             ) in interval_calls
+
+
+class TestChatInputResize:
+    """Tests for resizing the chat input from its top border."""
+
+    async def test_drag_resizes_and_releases_capture(self) -> None:
+        """Dragging the top border adjusts rows and releases outside the box."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            box = app.query_one(ChatInputBox)
+            text_area = app.query_one(ChatTextArea)
+            await pilot.pause()
+            start_y = box.region.y
+            x = box.region.x + 5
+
+            assert text_area.size.height == 1
+            await pilot.mouse_down(box, offset=(5, 0))
+            assert app.mouse_captured is box
+
+            await pilot.hover(offset=(x, start_y - 4))
+            assert text_area.size.height == 5
+
+            await pilot.mouse_up(offset=(x, start_y - 4))
+            assert app.mouse_captured is None
+
+            start_y = box.region.y
+            await pilot.mouse_down(box, offset=(5, 0))
+            await pilot.hover(offset=(x, start_y + 3))
+            await pilot.mouse_up(offset=(x, start_y + 3))
+
+            assert text_area.size.height == 2
+
+    async def test_drag_height_is_clamped(self) -> None:
+        """Manual resizing stays within one row and the screen-aware maximum."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            box = app.query_one(ChatInputBox)
+            text_area = app.query_one(ChatTextArea)
+            await pilot.pause()
+            x = box.region.x + 5
+
+            await pilot.mouse_down(box, offset=(5, 0))
+            await pilot.hover(offset=(x, 0))
+            await pilot.mouse_up(offset=(x, 0))
+            assert text_area.size.height == 17
+
+            await pilot.mouse_down(box, offset=(5, 0))
+            await pilot.hover(offset=(x, 23))
+            await pilot.mouse_up(offset=(x, 23))
+            assert text_area.size.height == 1
+
+    async def test_double_click_restores_auto_height(self) -> None:
+        """Double-clicking the top border restores content-driven sizing."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            box = app.query_one(ChatInputBox)
+            text_area = app.query_one(ChatTextArea)
+            await pilot.pause()
+            box._set_manual_height(5)
+            await pilot.pause()
+            assert text_area.size.height == 5
+
+            await pilot.double_click(box, offset=(5, 0))
+            await pilot.pause()
+
+            assert box._manual_height is None
+            assert text_area.size.height == 1
+            assert text_area._settled_content_height() == 8
+
+    async def test_completion_popup_temporarily_reduces_manual_height(self) -> None:
+        """Visible completions fit inside the box without losing manual size."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, 30)) as pilot:
+            box = app.query_one(ChatInputBox)
+            text_area = app.query_one(ChatTextArea)
+            popup = app.query_one(CompletionPopup)
+            box._set_manual_height(20)
+            popup.update_suggestions([(str(i), str(i)) for i in range(12)], 0)
+            await pilot.pause()
+            await pilot.pause()
+
+            assert box._manual_height == 20
+            assert text_area.size.height == 11
+            assert popup.region.bottom <= box.region.bottom
+
+            popup.hide()
+            await pilot.pause()
+
+            assert text_area.size.height == 20
+
+    async def test_terminal_resize_reclamps_manual_height(self) -> None:
+        """Shrinking the terminal reduces an oversized manual composer."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            box = app.query_one(ChatInputBox)
+            text_area = app.query_one(ChatTextArea)
+            box._set_manual_height(17)
+            await pilot.pause()
+            assert text_area.size.height == 17
+
+            await pilot.resize_terminal(80, 12)
+
+            assert box._manual_height == 5
+            assert text_area.size.height == 5
+
+    async def test_only_left_press_on_top_border_starts_drag(self) -> None:
+        """Other buttons and descendant presses leave resize inactive."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test() as pilot:
+            box = app.query_one(ChatInputBox)
+            text_area = app.query_one(ChatTextArea)
+            await pilot.pause()
+            y = box.region.y
+
+            box.on_mouse_down(
+                events.MouseDown(
+                    box,
+                    1,
+                    0,
+                    0,
+                    0,
+                    2,
+                    False,
+                    False,
+                    False,
+                    screen_x=box.region.x + 1,
+                    screen_y=y,
+                )
+            )
+            assert box._drag_start_y is None
+
+            box.on_mouse_down(
+                events.MouseDown(
+                    text_area,
+                    1,
+                    0,
+                    0,
+                    0,
+                    1,
+                    False,
+                    False,
+                    False,
+                    screen_x=text_area.region.x + 1,
+                    screen_y=text_area.region.y,
+                )
+            )
+            assert box._drag_start_y is None
+            assert app.mouse_captured is None
 
 
 class TestChatInputScrollbar:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -777,6 +777,8 @@ class TestInputActionButtons:
 
             # The resize handle and buttons render on the top border row.
             assert handle.region.y == box.region.y
+            assert handle.region.x == box.region.x + 1
+            assert handle.region.right == box.region.right - 1
             assert clear.region.y == box.region.y
             assert copy.region.y == box.region.y
             assert text_area.region.y > box.region.y

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -434,17 +434,22 @@ class TestChatInputResize:
             await pilot.mouse_up(offset=(x, 23))
             assert text_area.size.height == 1
 
-    async def test_double_click_restores_auto_height(self) -> None:
-        """Double-clicking the top border restores content-driven sizing."""
+    async def test_double_click_toggles_expanded_and_auto_height(self) -> None:
+        """Double-click expands auto sizing and collapses any manual height."""
         app = _ChatInputResizeTestApp()
         async with app.run_test(size=(80, 24)) as pilot:
             box = app.query_one(ChatInputBox)
             handle = app.query_one(ChatInputResizeHandle)
             text_area = app.query_one(ChatTextArea)
             await pilot.pause()
-            box._set_manual_height(5)
+            assert box._manual_height is None
+            assert text_area.size.height == 1
+
+            await pilot.double_click(handle, offset=(5, 0))
             await pilot.pause()
-            assert text_area.size.height == 5
+
+            assert box._manual_height == 17
+            assert text_area.size.height == 17
 
             await pilot.double_click(handle, offset=(5, 0))
             await pilot.pause()
@@ -452,6 +457,14 @@ class TestChatInputResize:
             assert box._manual_height is None
             assert text_area.size.height == 1
             assert text_area._settled_content_height() == 8
+
+            box._set_manual_height(5)
+            await pilot.pause()
+            await pilot.double_click(handle, offset=(5, 0))
+            await pilot.pause()
+
+            assert box._manual_height is None
+            assert text_area.size.height == 1
 
     async def test_completion_popup_temporarily_reduces_manual_height(self) -> None:
         """Visible completions fit inside the box without losing manual size."""
@@ -489,10 +502,11 @@ class TestChatInputResize:
             assert box._manual_height == 5
             assert text_area.size.height == 5
 
-    async def test_hover_highlights_only_the_top_border(self) -> None:
-        """Hovering the explicit handle highlights the box's top edge."""
+    async def test_hover_highlights_interior_with_mode_color(self) -> None:
+        """Hover changes only the inset rule using the active mode's color."""
         app = _ChatInputResizeTestApp()
         async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
             box = app.query_one(ChatInputBox)
             handle = app.query_one(ChatInputResizeHandle)
             await pilot.pause()
@@ -504,16 +518,31 @@ class TestChatInputResize:
 
             await pilot.hover(handle, offset=(5, 0))
 
-            assert box.has_class("resize-hover")
-            assert box.styles.border_top != default_border
-            assert handle.styles.color != default_handle_color
+            normal_hover_color = handle.styles.color
+            assert box.styles.border_top == default_border
+            assert normal_hover_color != default_handle_color
             assert handle.styles.pointer == "ns-resize"
 
             await pilot.hover("#spacer")
 
-            assert not box.has_class("resize-hover")
             assert box.styles.border_top == default_border
             assert handle.styles.color == default_handle_color
+
+            chat_input.mode = "shell"
+            await pilot.pause()
+            await pilot.pause()
+            shell_border = box.styles.border_top
+            shell_handle_color = handle.styles.color
+            assert shell_handle_color != default_handle_color
+
+            await pilot.hover(handle, offset=(5, 0))
+
+            assert box.styles.border_top == shell_border
+            assert handle.styles.color != shell_handle_color
+            assert handle.styles.color != normal_hover_color
+
+            await pilot.hover("#spacer")
+            assert handle.styles.color == shell_handle_color
 
     async def test_non_left_press_does_not_start_drag(self) -> None:
         """A non-left press on the handle leaves resize inactive."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -23,6 +23,10 @@ from deepagents_code.tui.widgets import (
 )
 from deepagents_code.tui.widgets.autocomplete import MAX_SUGGESTIONS
 from deepagents_code.tui.widgets.chat_input import (
+    _CHAT_INPUT_AUTO_MAX_HEIGHT,
+    _CHAT_INPUT_MANUAL_MAX_HEIGHT,
+    _CHAT_INPUT_RESERVED_SCREEN_ROWS,
+    _COMPLETION_POPUP_MAX_HEIGHT,
     ChatInput,
     ChatInputBox,
     ChatInputResizeHandle,
@@ -385,18 +389,29 @@ class TestChatInputFileCacheRefresh:
             ) in interval_calls
 
 
+_RESIZE_SCREEN_HEIGHT = 24
+"""Terminal height the resize tests run at, so expectations can be derived."""
+
+_EXPANDED_HEIGHT = min(
+    _CHAT_INPUT_MANUAL_MAX_HEIGHT,
+    _RESIZE_SCREEN_HEIGHT - _CHAT_INPUT_RESERVED_SCREEN_ROWS,
+)
+"""Composer height a fully expanded drag reaches at `_RESIZE_SCREEN_HEIGHT`."""
+
+
 class TestChatInputResize:
     """Tests for resizing the chat input from its top border."""
 
     async def test_drag_resizes_and_releases_capture(self) -> None:
         """Dragging the top border adjusts rows and releases outside the box."""
         app = _ChatInputResizeTestApp()
-        async with app.run_test(size=(80, 24)) as pilot:
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
             handle = app.query_one(ChatInputResizeHandle)
             text_area = app.query_one(ChatTextArea)
             await pilot.pause()
             start_y = handle.region.y
             x = handle.region.x + 5
+            default_handle_color = handle.styles.color
 
             assert text_area.size.height == 1
             await pilot.mouse_down(handle, offset=(5, 0))
@@ -404,9 +419,17 @@ class TestChatInputResize:
 
             await pilot.hover(offset=(x, start_y - 4))
             assert text_area.size.height == 5
+            # The pointer is now well above the handle: the highlight has to
+            # survive the Leave, or the border flickers off mid-drag.
+            assert handle._highlighted is True
 
             await pilot.mouse_up(offset=(x, start_y - 4))
             assert app.mouse_captured is None
+            # Releasing away from the handle is the normal end of a drag, so the
+            # highlight must clear rather than stay lit forever.
+            assert handle._highlighted is False
+            assert handle.styles.color == default_handle_color
+            assert text_area.has_focus
 
             start_y = handle.region.y
             await pilot.mouse_down(handle, offset=(5, 0))
@@ -418,7 +441,7 @@ class TestChatInputResize:
     async def test_drag_height_is_clamped(self) -> None:
         """Manual resizing stays within one row and the screen-aware maximum."""
         app = _ChatInputResizeTestApp()
-        async with app.run_test(size=(80, 24)) as pilot:
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
             handle = app.query_one(ChatInputResizeHandle)
             text_area = app.query_one(ChatTextArea)
             await pilot.pause()
@@ -427,46 +450,65 @@ class TestChatInputResize:
             await pilot.mouse_down(handle, offset=(5, 0))
             await pilot.hover(offset=(x, 0))
             await pilot.mouse_up(offset=(x, 0))
-            assert text_area.size.height == 17
+            assert text_area.size.height == _EXPANDED_HEIGHT
 
             await pilot.mouse_down(handle, offset=(5, 0))
-            await pilot.hover(offset=(x, 23))
-            await pilot.mouse_up(offset=(x, 23))
+            await pilot.hover(offset=(x, _RESIZE_SCREEN_HEIGHT - 1))
+            await pilot.mouse_up(offset=(x, _RESIZE_SCREEN_HEIGHT - 1))
+            assert text_area.size.height == 1
+
+    async def test_pointer_movement_without_a_press_does_not_resize(self) -> None:
+        """Hovering across the handle leaves the composer height alone."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
+            text_area = app.query_one(ChatTextArea)
+            await pilot.pause()
+
+            await pilot.hover(handle, offset=(5, 0))
+            await pilot.hover(handle, offset=(9, 0))
+
+            assert box._requested_height is None
             assert text_area.size.height == 1
 
     async def test_drag_cannot_shrink_below_visible_draft(self) -> None:
         """A draft at the auto-growth cap keeps all eight rows visible."""
         app = _ChatInputResizeTestApp()
-        async with app.run_test(size=(80, 24)) as pilot:
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
             box = app.query_one(ChatInputBox)
             handle = app.query_one(ChatInputResizeHandle)
             text_area = app.query_one(ChatTextArea)
-            text_area.insert("\n".join(str(index) for index in range(8)))
+            text_area.insert(
+                "\n".join(str(index) for index in range(_CHAT_INPUT_AUTO_MAX_HEIGHT))
+            )
             await pilot.pause()
-            assert text_area.virtual_size.height == 8
-            assert text_area.size.height == 8
+            assert text_area.virtual_size.height == _CHAT_INPUT_AUTO_MAX_HEIGHT
+            assert text_area.size.height == _CHAT_INPUT_AUTO_MAX_HEIGHT
 
             x = handle.region.x + 5
             await pilot.mouse_down(handle, offset=(5, 0))
-            await pilot.hover(offset=(x, 23))
-            await pilot.mouse_up(offset=(x, 23))
+            await pilot.hover(offset=(x, _RESIZE_SCREEN_HEIGHT - 1))
+            await pilot.mouse_up(offset=(x, _RESIZE_SCREEN_HEIGHT - 1))
 
-            assert box._manual_height == 1
-            assert text_area.size.height == 8
+            assert box._requested_height == 1
+            assert text_area.size.height == _CHAT_INPUT_AUTO_MAX_HEIGHT
 
     async def test_manual_height_tracks_growing_and_shrinking_draft(self) -> None:
         """The viewport follows content while preserving its requested height."""
         app = _ChatInputResizeTestApp()
-        async with app.run_test(size=(80, 24)) as pilot:
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
             box = app.query_one(ChatInputBox)
             text_area = app.query_one(ChatTextArea)
-            box._set_manual_height(1)
-            text_area.insert("\n".join(str(index) for index in range(8)))
+            box.set_manual_height(1)
+            text_area.insert(
+                "\n".join(str(index) for index in range(_CHAT_INPUT_AUTO_MAX_HEIGHT))
+            )
             await pilot.pause()
 
-            assert text_area.virtual_size.height == 8
-            assert box._manual_height == 1
-            assert text_area.size.height == 8
+            assert text_area.virtual_size.height == _CHAT_INPUT_AUTO_MAX_HEIGHT
+            assert box._requested_height == 1
+            assert text_area.size.height == _CHAT_INPUT_AUTO_MAX_HEIGHT
 
             text_area.move_cursor_to_end()
             await pilot.press(*("backspace" for _ in range(len(text_area.text) - 1)))
@@ -474,78 +516,209 @@ class TestChatInputResize:
 
             assert text_area.text == "0"
             assert text_area.virtual_size.height == 1
-            assert box._manual_height == 1
+            assert box._requested_height == 1
             assert text_area.size.height == 1
 
-    async def test_double_click_toggles_expanded_and_auto_height(self) -> None:
-        """Double-click expands auto sizing and collapses any manual height."""
+    async def test_manual_height_above_content_survives_draft_shrinking(self) -> None:
+        """A composer dragged taller than its draft stays put as text is cut."""
         app = _ChatInputResizeTestApp()
-        async with app.run_test(size=(80, 24)) as pilot:
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            box = app.query_one(ChatInputBox)
+            text_area = app.query_one(ChatTextArea)
+            requested = _EXPANDED_HEIGHT - 2
+            box.set_manual_height(requested)
+            await pilot.pause()
+            assert text_area.size.height == requested
+
+            text_area.insert(
+                "\n".join(str(index) for index in range(_CHAT_INPUT_AUTO_MAX_HEIGHT))
+            )
+            await pilot.pause()
+            assert text_area.size.height == requested
+
+            text_area.move_cursor_to_end()
+            await pilot.press(*("backspace" for _ in range(len(text_area.text) - 1)))
+            await pilot.pause()
+
+            # The draft is one row again, but the user asked for `requested`.
+            assert text_area.virtual_size.height == 1
+            assert box._requested_height == requested
+            assert text_area.size.height == requested
+
+    async def test_double_click_toggles_expanded_and_auto_height(self) -> None:
+        """Double-click expands to the maximum, and toggles back to auto."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
             box = app.query_one(ChatInputBox)
             handle = app.query_one(ChatInputResizeHandle)
             text_area = app.query_one(ChatTextArea)
             await pilot.pause()
-            assert box._manual_height is None
+            assert box._requested_height is None
             assert text_area.size.height == 1
 
             await pilot.double_click(handle, offset=(5, 0))
             await pilot.pause()
 
-            assert box._manual_height == 17
-            assert text_area.size.height == 17
+            assert box._requested_height == _EXPANDED_HEIGHT
+            assert text_area.size.height == _EXPANDED_HEIGHT
 
             await pilot.double_click(handle, offset=(5, 0))
             await pilot.pause()
 
-            assert box._manual_height is None
+            assert box._requested_height is None
             assert text_area.size.height == 1
-            assert text_area._settled_content_height() == 8
+            assert text_area._settled_content_height() == _CHAT_INPUT_AUTO_MAX_HEIGHT
 
-            box._set_manual_height(5)
+    async def test_double_click_from_a_partial_manual_height_expands(self) -> None:
+        """A part-way manual height still expands rather than collapsing.
+
+        The toggle keys off "already at the maximum", so a drag of a row or two
+        -- including the incidental jitter of a real double-click -- cannot
+        invert what the next double-click means.
+        """
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
+            text_area = app.query_one(ChatTextArea)
+            box.set_manual_height(5)
             await pilot.pause()
+
             await pilot.double_click(handle, offset=(5, 0))
             await pilot.pause()
 
-            assert box._manual_height is None
+            assert box._requested_height == _EXPANDED_HEIGHT
+            assert text_area.size.height == _EXPANDED_HEIGHT
+
+    async def test_zero_delta_move_does_not_establish_a_manual_height(self) -> None:
+        """Pointer jitter within one cell leaves sizing automatic.
+
+        A double-click only registers when both presses land on the same cell,
+        which is exactly when the pointer drifts away and back, emitting a
+        zero-delta move mid-gesture.
+        """
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
+            text_area = app.query_one(ChatTextArea)
+            await pilot.pause()
+
+            await pilot.mouse_down(handle, offset=(5, 0))
+            await pilot.hover(handle, offset=(5, 0))
+            await pilot.mouse_up(handle, offset=(5, 0))
+            await pilot.pause()
+
+            assert box._requested_height is None
+            assert text_area.size.height == 1
+
+    async def test_single_click_does_not_toggle_expanded(self) -> None:
+        """One click near the top border leaves the composer size alone.
+
+        The handle spans nearly the whole border, so a click that expanded the
+        composer would fire constantly during ordinary use.
+        """
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
+            text_area = app.query_one(ChatTextArea)
+            await pilot.pause()
+
+            await pilot.click(handle, offset=(5, 0))
+            await pilot.pause()
+
+            assert box._requested_height is None
             assert text_area.size.height == 1
 
     async def test_completion_popup_temporarily_reduces_manual_height(self) -> None:
-        """Visible completions fit inside the box without losing manual size."""
+        """Visible completions fit on screen without losing manual size."""
         app = _ChatInputResizeTestApp()
-        async with app.run_test(size=(80, 30)) as pilot:
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
             box = app.query_one(ChatInputBox)
             text_area = app.query_one(ChatTextArea)
             popup = app.query_one(CompletionPopup)
-            box._set_manual_height(20)
-            popup.update_suggestions([(str(i), str(i)) for i in range(12)], 0)
+            box.set_manual_height(_CHAT_INPUT_MANUAL_MAX_HEIGHT)
+            popup.update_suggestions(
+                [(str(i), str(i)) for i in range(_COMPLETION_POPUP_MAX_HEIGHT)], 0
+            )
             await pilot.pause()
             await pilot.pause()
 
-            assert box._manual_height == 20
-            assert text_area.size.height == 11
-            assert popup.region.bottom <= box.region.bottom
+            assert box._requested_height == _EXPANDED_HEIGHT
+            assert text_area.size.height == 3
+            assert box.region.bottom <= app.screen.region.bottom
 
             popup.hide()
             await pilot.pause()
 
-            assert text_area.size.height == 20
+            assert text_area.size.height == _EXPANDED_HEIGHT
 
-    async def test_terminal_resize_reclamps_manual_height(self) -> None:
-        """Shrinking the terminal reduces an oversized manual composer."""
+    async def test_overlong_completion_list_is_clamped_to_the_popup_cap(self) -> None:
+        """More suggestions than the popup renders do not over-shrink the box.
+
+        Without the clamp the reserved rows would exceed what is on screen and
+        crush the composer to its floor.
+        """
         app = _ChatInputResizeTestApp()
-        async with app.run_test(size=(80, 24)) as pilot:
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
             box = app.query_one(ChatInputBox)
             text_area = app.query_one(ChatTextArea)
-            text_area.insert("\n".join(str(index) for index in range(8)))
+            popup = app.query_one(CompletionPopup)
+            box.set_manual_height(_CHAT_INPUT_MANUAL_MAX_HEIGHT)
+            popup.update_suggestions(
+                [(str(i), str(i)) for i in range(_COMPLETION_POPUP_MAX_HEIGHT + 8)],
+                0,
+            )
             await pilot.pause()
-            box._set_manual_height(17)
             await pilot.pause()
-            assert text_area.size.height == 17
 
-            await pilot.resize_terminal(80, 12)
+            assert text_area.size.height == 3
+            assert box.region.bottom <= app.screen.region.bottom
 
-            assert box._manual_height == 5
-            assert text_area.size.height == 5
+    async def test_terminal_resize_preserves_the_requested_height(self) -> None:
+        """Shrinking the terminal squeezes the composer but keeps the request."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            box = app.query_one(ChatInputBox)
+            text_area = app.query_one(ChatTextArea)
+            text_area.insert(
+                "\n".join(str(index) for index in range(_CHAT_INPUT_AUTO_MAX_HEIGHT))
+            )
+            await pilot.pause()
+            box.set_manual_height(_EXPANDED_HEIGHT)
+            await pilot.pause()
+            assert text_area.size.height == _EXPANDED_HEIGHT
+
+            short_screen = 12
+            await pilot.resize_terminal(80, short_screen)
+
+            assert text_area.size.height == (
+                short_screen - _CHAT_INPUT_RESERVED_SCREEN_ROWS
+            )
+            # The request survives the squeeze, so restoring the terminal
+            # restores the size the user actually chose.
+            assert box._requested_height == _EXPANDED_HEIGHT
+
+            await pilot.resize_terminal(80, _RESIZE_SCREEN_HEIGHT)
+
+            assert text_area.size.height == _EXPANDED_HEIGHT
+
+    async def test_handle_geometry_follows_terminal_resizes(self) -> None:
+        """The handle keeps both border corners clear at any terminal width."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
+            await pilot.pause()
+            assert handle.region.x == box.region.x + 1
+            assert handle.region.right == box.region.right - 1
+
+            await pilot.resize_terminal(50, 20)
+            await pilot.pause()
+
+            assert handle.region.x == box.region.x + 1
+            assert handle.region.right == box.region.right - 1
 
     async def test_hover_highlights_interior_with_mode_color(self) -> None:
         """Hover changes only the inset rule using the active mode's color."""
@@ -589,32 +762,83 @@ class TestChatInputResize:
             await pilot.hover("#spacer")
             assert handle.styles.color == shell_handle_color
 
+    async def test_each_mode_gives_the_handle_a_distinct_color(self) -> None:
+        """Every input mode maps the resize line to its own color."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
+            handle = app.query_one(ChatInputResizeHandle)
+            await pilot.pause()
+
+            colors: dict[str, object] = {}
+            for mode in ("normal", "shell", "command", "shell_incognito"):
+                chat_input.mode = mode
+                await pilot.pause()
+                await pilot.pause()
+                colors[mode] = handle.styles.color
+
+            assert len(set(colors.values())) == len(colors)
+
     async def test_non_left_press_does_not_start_drag(self) -> None:
         """A non-left press on the handle leaves resize inactive."""
         app = _ChatInputResizeTestApp()
         async with app.run_test() as pilot:
             handle = app.query_one(ChatInputResizeHandle)
             await pilot.pause()
-            y = handle.region.y
 
-            handle.on_mouse_down(
-                events.MouseDown(
-                    handle,
-                    1,
-                    0,
-                    0,
-                    0,
-                    2,
-                    False,
-                    False,
-                    False,
-                    screen_x=handle.region.x + 1,
-                    screen_y=y,
-                )
-            )
+            await pilot.mouse_down(handle, offset=(5, 0), button=2)
 
             assert handle._drag_start_y is None
             assert app.mouse_captured is None
+
+    async def test_unmount_mid_drag_releases_mouse_capture(self) -> None:
+        """Tearing the input down during a drag does not strand the capture.
+
+        A leaked capture would leave the whole app deaf to mouse input.
+        """
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            chat_input = app.query_one(ChatInput)
+            handle = app.query_one(ChatInputResizeHandle)
+            await pilot.pause()
+
+            await pilot.mouse_down(handle, offset=(5, 0))
+            assert app.mouse_captured is handle
+
+            await chat_input.remove()
+            await pilot.pause()
+
+            assert app.mouse_captured is None
+
+    async def test_losing_mouse_capture_abandons_the_drag(self) -> None:
+        """A revoked capture clears drag state instead of leaving it stuck.
+
+        Otherwise the handle keeps a phantom drag alive: the highlight never
+        clears and later pointer movement resizes with no press behind it.
+        """
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
+            text_area = app.query_one(ChatTextArea)
+            await pilot.pause()
+            x = handle.region.x + 5
+            start_y = handle.region.y
+
+            await pilot.mouse_down(handle, offset=(5, 0))
+            # Another widget taking the capture posts MouseRelease to the handle.
+            app.capture_mouse(box)
+            await pilot.pause()
+
+            assert handle._drag_start_y is None
+            assert handle._highlighted is False
+
+            app.capture_mouse(None)
+            await pilot.hover(offset=(x, start_y - 4))
+            await pilot.pause()
+
+            assert box._requested_height is None
+            assert text_area.size.height == 1
 
 
 class TestChatInputScrollbar:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -434,6 +434,40 @@ class TestChatInputResize:
             await pilot.mouse_up(offset=(x, 23))
             assert text_area.size.height == 1
 
+    async def test_drag_cannot_shrink_below_visible_draft(self) -> None:
+        """A draft at the auto-growth cap keeps all eight rows visible."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
+            text_area = app.query_one(ChatTextArea)
+            text_area.insert("\n".join(str(index) for index in range(8)))
+            await pilot.pause()
+            assert text_area.virtual_size.height == 8
+            assert text_area.size.height == 8
+
+            x = handle.region.x + 5
+            await pilot.mouse_down(handle, offset=(5, 0))
+            await pilot.hover(offset=(x, 23))
+            await pilot.mouse_up(offset=(x, 23))
+
+            assert box._manual_height == 8
+            assert text_area.size.height == 8
+
+    async def test_manual_height_grows_with_visible_draft(self) -> None:
+        """New content raises a short manual viewport up to the auto cap."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            box = app.query_one(ChatInputBox)
+            text_area = app.query_one(ChatTextArea)
+            box._set_manual_height(1)
+            text_area.insert("\n".join(str(index) for index in range(8)))
+            await pilot.pause()
+
+            assert text_area.virtual_size.height == 8
+            assert box._manual_height == 8
+            assert text_area.size.height == 8
+
     async def test_double_click_toggles_expanded_and_auto_height(self) -> None:
         """Double-click expands auto sizing and collapses any manual height."""
         app = _ChatInputResizeTestApp()
@@ -493,6 +527,8 @@ class TestChatInputResize:
         async with app.run_test(size=(80, 24)) as pilot:
             box = app.query_one(ChatInputBox)
             text_area = app.query_one(ChatTextArea)
+            text_area.insert("\n".join(str(index) for index in range(8)))
+            await pilot.pause()
             box._set_manual_height(17)
             await pilot.pause()
             assert text_area.size.height == 17

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -25,6 +25,7 @@ from deepagents_code.tui.widgets.autocomplete import MAX_SUGGESTIONS
 from deepagents_code.tui.widgets.chat_input import (
     ChatInput,
     ChatInputBox,
+    ChatInputResizeHandle,
     ChatTextArea,
     CompletionOption,
     CompletionPopup,
@@ -391,15 +392,15 @@ class TestChatInputResize:
         """Dragging the top border adjusts rows and releases outside the box."""
         app = _ChatInputResizeTestApp()
         async with app.run_test(size=(80, 24)) as pilot:
-            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
             text_area = app.query_one(ChatTextArea)
             await pilot.pause()
-            start_y = box.region.y
-            x = box.region.x + 5
+            start_y = handle.region.y
+            x = handle.region.x + 5
 
             assert text_area.size.height == 1
-            await pilot.mouse_down(box, offset=(5, 0))
-            assert app.mouse_captured is box
+            await pilot.mouse_down(handle, offset=(5, 0))
+            assert app.mouse_captured is handle
 
             await pilot.hover(offset=(x, start_y - 4))
             assert text_area.size.height == 5
@@ -407,8 +408,8 @@ class TestChatInputResize:
             await pilot.mouse_up(offset=(x, start_y - 4))
             assert app.mouse_captured is None
 
-            start_y = box.region.y
-            await pilot.mouse_down(box, offset=(5, 0))
+            start_y = handle.region.y
+            await pilot.mouse_down(handle, offset=(5, 0))
             await pilot.hover(offset=(x, start_y + 3))
             await pilot.mouse_up(offset=(x, start_y + 3))
 
@@ -418,17 +419,17 @@ class TestChatInputResize:
         """Manual resizing stays within one row and the screen-aware maximum."""
         app = _ChatInputResizeTestApp()
         async with app.run_test(size=(80, 24)) as pilot:
-            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
             text_area = app.query_one(ChatTextArea)
             await pilot.pause()
-            x = box.region.x + 5
+            x = handle.region.x + 5
 
-            await pilot.mouse_down(box, offset=(5, 0))
+            await pilot.mouse_down(handle, offset=(5, 0))
             await pilot.hover(offset=(x, 0))
             await pilot.mouse_up(offset=(x, 0))
             assert text_area.size.height == 17
 
-            await pilot.mouse_down(box, offset=(5, 0))
+            await pilot.mouse_down(handle, offset=(5, 0))
             await pilot.hover(offset=(x, 23))
             await pilot.mouse_up(offset=(x, 23))
             assert text_area.size.height == 1
@@ -438,13 +439,14 @@ class TestChatInputResize:
         app = _ChatInputResizeTestApp()
         async with app.run_test(size=(80, 24)) as pilot:
             box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
             text_area = app.query_one(ChatTextArea)
             await pilot.pause()
             box._set_manual_height(5)
             await pilot.pause()
             assert text_area.size.height == 5
 
-            await pilot.double_click(box, offset=(5, 0))
+            await pilot.double_click(handle, offset=(5, 0))
             await pilot.pause()
 
             assert box._manual_height is None
@@ -487,18 +489,37 @@ class TestChatInputResize:
             assert box._manual_height == 5
             assert text_area.size.height == 5
 
-    async def test_only_left_press_on_top_border_starts_drag(self) -> None:
-        """Other buttons and descendant presses leave resize inactive."""
+    async def test_hover_highlights_only_the_top_border(self) -> None:
+        """Hovering the explicit handle highlights the box's top edge."""
         app = _ChatInputResizeTestApp()
         async with app.run_test() as pilot:
             box = app.query_one(ChatInputBox)
-            text_area = app.query_one(ChatTextArea)
+            handle = app.query_one(ChatInputResizeHandle)
             await pilot.pause()
-            y = box.region.y
+            default_border = box.styles.border_top
 
-            box.on_mouse_down(
+            await pilot.hover(handle, offset=(5, 0))
+
+            assert box.has_class("resize-hover")
+            assert box.styles.border_top != default_border
+            assert handle.styles.pointer == "ns-resize"
+
+            await pilot.hover("#spacer")
+
+            assert not box.has_class("resize-hover")
+            assert box.styles.border_top == default_border
+
+    async def test_non_left_press_does_not_start_drag(self) -> None:
+        """A non-left press on the handle leaves resize inactive."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test() as pilot:
+            handle = app.query_one(ChatInputResizeHandle)
+            await pilot.pause()
+            y = handle.region.y
+
+            handle.on_mouse_down(
                 events.MouseDown(
-                    box,
+                    handle,
                     1,
                     0,
                     0,
@@ -507,28 +528,12 @@ class TestChatInputResize:
                     False,
                     False,
                     False,
-                    screen_x=box.region.x + 1,
+                    screen_x=handle.region.x + 1,
                     screen_y=y,
                 )
             )
-            assert box._drag_start_y is None
 
-            box.on_mouse_down(
-                events.MouseDown(
-                    text_area,
-                    1,
-                    0,
-                    0,
-                    0,
-                    1,
-                    False,
-                    False,
-                    False,
-                    screen_x=text_area.region.x + 1,
-                    screen_y=text_area.region.y,
-                )
-            )
-            assert box._drag_start_y is None
+            assert handle._drag_start_y is None
             assert app.mouse_captured is None
 
 
@@ -757,13 +762,15 @@ class TestInputActionButtons:
             await pilot.pause()
 
             box = chat_input.query_one("#input-box")
+            handle = chat_input.query_one(ChatInputResizeHandle)
             clear = chat_input.query_one("#clear-button", Static)
             copy = chat_input.query_one("#copy-button", Static)
 
             # Text area spans the full width inside the border.
             assert text_area.region.right == box.content_region.right
 
-            # Buttons render on the top border row, above the first text row.
+            # The resize handle and buttons render on the top border row.
+            assert handle.region.y == box.region.y
             assert clear.region.y == box.region.y
             assert copy.region.y == box.region.y
             assert text_area.region.y > box.region.y
@@ -771,8 +778,11 @@ class TestInputActionButtons:
             # The top-right corner stays visible (buttons stop short of the edge).
             assert copy.region.right < box.region.right
 
-            # No overlap: a first-row click reaches the text area, and a click on
-            # a button hits the button.
+            # No overlap: each cell resolves to its intended interaction target.
+            handle_widget, _ = app.screen.get_widget_at(
+                handle.region.x + 1, handle.region.y
+            )
+            assert handle_widget is handle
             left_widget, _ = app.screen.get_widget_at(
                 text_area.region.x + 1, text_area.region.y
             )

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -451,11 +451,11 @@ class TestChatInputResize:
             await pilot.hover(offset=(x, 23))
             await pilot.mouse_up(offset=(x, 23))
 
-            assert box._manual_height == 8
+            assert box._manual_height == 1
             assert text_area.size.height == 8
 
-    async def test_manual_height_grows_with_visible_draft(self) -> None:
-        """New content raises a short manual viewport up to the auto cap."""
+    async def test_manual_height_tracks_growing_and_shrinking_draft(self) -> None:
+        """The viewport follows content while preserving its requested height."""
         app = _ChatInputResizeTestApp()
         async with app.run_test(size=(80, 24)) as pilot:
             box = app.query_one(ChatInputBox)
@@ -465,8 +465,17 @@ class TestChatInputResize:
             await pilot.pause()
 
             assert text_area.virtual_size.height == 8
-            assert box._manual_height == 8
+            assert box._manual_height == 1
             assert text_area.size.height == 8
+
+            text_area.move_cursor_to_end()
+            await pilot.press(*("backspace" for _ in range(len(text_area.text) - 1)))
+            await pilot.pause()
+
+            assert text_area.text == "0"
+            assert text_area.virtual_size.height == 1
+            assert box._manual_height == 1
+            assert text_area.size.height == 1
 
     async def test_double_click_toggles_expanded_and_auto_height(self) -> None:
         """Double-click expands auto sizing and collapses any manual height."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_startup_tip.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_startup_tip.py
@@ -142,6 +142,10 @@ class TestStartupTip:
         """The `/copy` command keeps a discoverability tip."""
         assert any("/copy" in tip for tip in _TIPS)
 
+    def test_chat_input_resize_tip_registered(self) -> None:
+        """The draggable chat input keeps a discoverability tip."""
+        assert any("top border" in tip and "resize" in tip for tip in _TIPS)
+
     def test_workflow_subagent_tip_registered(self) -> None:
         """The workflow trigger phrase keeps an above-baseline weight."""
         tip = "Ask for a workflow to fan work out to subagents in parallel"


### PR DESCRIPTION
The chat input can now be resized by dragging its highlighted top border; double-clicking toggles between maximum and automatic sizing.

---

An explicit inset handle makes mouse targeting reliable while preserving corner colors, and only the interior rule highlights with the active mode color. Manual resizing remembers the requested height while temporarily expanding to keep up to eight visual draft rows visible, so deleting/backspacing lines retracts the composer again; screen and autocomplete space remain authoritative. Focused Textual interaction, content growth/retraction, hover, mode-color, geometry, scrollbar, action-button, autocomplete, and startup-tip tests cover the behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/16618e76-ab37-1337-98ab-692ff2967371)