### PR TITLE
style(code): separate usage summary sections

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7953,6 +7953,7 @@ class DeepAgentsApp(App):
                         f"{priced_request_count} of {request_count} recorded requests "
                         f"{included_verb} included."
                     ),
+                    "",
                     *self._unpriced_request_lines(),
                 ]
             )
@@ -7980,7 +7981,7 @@ class DeepAgentsApp(App):
             and self._thread_stats.per_kind[kind].priced_request_count
         ]
         if priced_kinds:
-            lines.append("By type since this thread was loaded:")
+            lines.extend(["", "By type since this thread was loaded:"])
             for kind, kind_stats in priced_kinds:
                 lines.append(
                     f"- {USAGE_KIND_LABELS[kind]}: {format_cost(kind_stats.cost_usd)}"
@@ -7991,7 +7992,7 @@ class DeepAgentsApp(App):
             if model.priced_request_count
         ]
         if priced_models:
-            lines.append("By model since this thread was loaded:")
+            lines.extend(["", "By model since this thread was loaded:"])
             for model in priced_models:
                 label = (
                     f"{model.provider}:{model.model_name}"

--- a/libs/code/tests/unit_tests/test_resume_state.py
+++ b/libs/code/tests/unit_tests/test_resume_state.py
@@ -603,13 +603,14 @@ class TestCostDisplayCallbacks:
 
         summary = app._format_cost_summary()
 
-        assert "Estimated thread cost: $0.42" in summary
-        assert "By type since this thread was loaded:" in summary
-        assert "Assistant: $0.32" in summary
-        assert "Offload: $0.10" in summary
-        assert "openai:gpt-5.5: $0.42" in summary
-        assert "claude-sonnet-4-6" not in summary
-        assert "detailed usage metadata was unavailable" not in summary
+        assert summary == (
+            "Estimated thread cost: $0.42\n\n"
+            "By type since this thread was loaded:\n"
+            "- Assistant: $0.32\n"
+            "- Offload: $0.10\n\n"
+            "By model since this thread was loaded:\n"
+            "- openai:gpt-5.5: $0.42"
+        )
 
     def test_cost_summary_warns_when_current_details_are_incomplete(self) -> None:
         """Checkpoint spend missing from streamed stats is called out."""
@@ -683,12 +684,17 @@ class TestCostDisplayCallbacks:
 
         summary = app._format_cost_summary()
 
-        assert "Estimated cost for priced requests: $0.00" in summary
-        assert "1 of 2 recorded requests is included." in summary
-        assert "example:unknown-model — 1 request" in summary
-        assert "The full thread cost may be higher." in summary
-        assert "example:free-model: $0.00" in summary
-        assert "The recorded request was priced at $0.00." not in summary
+        assert summary == (
+            "Estimated cost for priced requests: $0.00\n\n"
+            "1 of 2 recorded requests is included.\n\n"
+            "Pricing was unavailable for:\n"
+            "- example:unknown-model — 1 request\n"
+            "The full thread cost may be higher.\n\n"
+            "By type since this thread was loaded:\n"
+            "- Assistant: $0.00\n\n"
+            "By model since this thread was loaded:\n"
+            "- example:free-model: $0.00"
+        )
 
     @pytest.mark.parametrize(
         ("request_count", "expected"),


### PR DESCRIPTION
Cost and token summaries now separate totals, unavailable pricing, request types, and models with blank lines.

---

Dense summary blocks were difficult to scan. This keeps individual list items compact while visually separating each logical section.

Made by [Open SWE](https://openswe.vercel.app/agents/25ecbd21-893a-42fe-fe0f-30eaaeb9f997)