### PR TITLE
feat(code): scope subagent tools and skills via frontmatter

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -2177,6 +2177,75 @@ def _apply_inherited_pythonpath(env: dict[str, str]) -> None:
         env["PYTHONPATH"] = inherited
 
 
+def _resolve_subagent_tool_allowlist(
+    subagent_name: str, tool_names: Sequence[str], session_tools: Sequence[Any]
+) -> list[Any]:
+    """Resolve a subagent's ``tools:`` frontmatter against the session toolset.
+
+    MCP tools are addressed by their fully-qualified names (server-prefixed).
+
+    Returns:
+        The tool objects for exactly the named tools, in allowlist order.
+
+    Raises:
+        ValueError: If any listed name is not among the session tools — a
+            typo would otherwise silently strip a capability from the
+            subagent, so it aborts agent assembly instead.
+    """
+    available: dict[str, Any] = {}
+    for session_tool in session_tools:
+        name = getattr(session_tool, "name", None)
+        if isinstance(name, str) and name:
+            available.setdefault(name, session_tool)
+    missing = [n for n in tool_names if n not in available]
+    if missing:
+        msg = (
+            f"Subagent {subagent_name!r} lists unknown tool(s) in its "
+            f"'tools:' frontmatter: {', '.join(missing)}. Available session "
+            f"tools: {', '.join(sorted(available)) or '(none)'}."
+        )
+        raise ValueError(msg)
+    return [available[n] for n in tool_names]
+
+
+def _resolve_subagent_skill_sources(
+    subagent_name: str, skill_names: Sequence[str], skill_roots: Sequence[Path | None]
+) -> list[str]:
+    """Resolve a subagent's ``skills:`` frontmatter to per-skill source paths.
+
+    ``skill_roots`` is ordered lowest-precedence-first, mirroring the main
+    agent's skill source order; a name present in several roots resolves to
+    the later (overriding) one.
+
+    Returns:
+        One directory path per named skill, so only the named skills load.
+
+    Raises:
+        ValueError: If any listed name resolves in no skill root — a typo
+            would otherwise silently drop a skill the author intended.
+    """
+    by_name: dict[str, Path] = {}
+    for root in skill_roots:
+        if root is None:
+            continue
+        root_path = Path(root)
+        if not root_path.is_dir():
+            continue
+        for child in sorted(root_path.iterdir()):
+            if child.is_dir():
+                by_name[child.name] = child
+    missing = [n for n in skill_names if n not in by_name]
+    if missing:
+        available = ", ".join(sorted(by_name)) or "(none)"
+        msg = (
+            f"Subagent {subagent_name!r} lists unknown skill(s) in its "
+            f"'skills:' frontmatter: {', '.join(missing)}. Available skills: "
+            f"{available}."
+        )
+        raise ValueError(msg)
+    return [str(by_name[n]) for n in skill_names]
+
+
 def create_cli_agent(
     model: str | BaseChatModel,
     assistant_id: str,
@@ -2515,6 +2584,39 @@ def create_cli_agent(
         }
         if model_spec:
             subagent["model"] = model_spec
+        # Per-subagent tool scoping (`tools:` frontmatter): None keeps the
+        # core default of inheriting the main agent's toolset; a list —
+        # including the empty list — is an allowlist resolved against the
+        # session tools (MCP included, by fully-qualified name), unknown
+        # names abort assembly rather than silently dropping a capability.
+        tool_allowlist = subagent_meta.get("tools")
+        if tool_allowlist is not None:
+            subagent["tools"] = _resolve_subagent_tool_allowlist(
+                subagent_meta["name"], tool_allowlist, tools
+            )
+        # Per-subagent skills (`skills:` frontmatter): subagents load no
+        # skills unless named here. Resolved against the same roots the main
+        # agent reads (built-in -> user -> project, later roots override).
+        subagent_skills = subagent_meta.get("skills")
+        if subagent_skills:
+            if not enable_skills:
+                msg = (
+                    f"Subagent {subagent_meta['name']!r} lists 'skills:' "
+                    "frontmatter but skills are disabled "
+                    "(enable_skills=False)."
+                )
+                raise ValueError(msg)
+            subagent["skills"] = _resolve_subagent_skill_sources(
+                subagent_meta["name"],
+                subagent_skills,
+                (
+                    settings.get_built_in_skills_dir(),
+                    skills_dir,
+                    user_agent_skills_dir,
+                    project_skills_dir,
+                    project_agent_skills_dir,
+                ),
+            )
         subagent_middleware = _subagent_cli_middleware(
             has_explicit_model=has_explicit_model,
         )

--- a/libs/code/deepagents_code/subagents.py
+++ b/libs/code/deepagents_code/subagents.py
@@ -11,6 +11,10 @@ Example file (researcher/AGENTS.md):
     name: researcher  # optional; defaults to the folder name
     description: Research topics on the web before writing content
     model: anthropic:claude-haiku-4-5-20251001
+    tools:
+      - web_search  # restrict this subagent to named session tools
+    skills:
+      - source-citation  # and named skills, instead of inheriting everything
     ---
 
     You are a research assistant with access to web search.
@@ -18,6 +22,22 @@ Example file (researcher/AGENTS.md):
     ## Your Process
     1. Search for relevant information
     2. Summarize findings clearly
+
+## Tool and skill scoping
+
+By default a subagent inherits the main agent's full toolset (MCP tools
+included). `tools:` opts a specific subagent out of that inheritance: it is
+an allowlist of session tool names (use each tool's fully-qualified name —
+MCP tools are prefixed with their server, e.g. `github_create_issue`). An
+empty list (`tools: []`) means the subagent receives no session tools at
+all. Filesystem scaffolding tools (`ls`, `read_file`, ...) are added by the
+runtime independently of this list. Omit the field to keep the default
+inherit-everything behavior. Unknown names fail loudly at agent assembly.
+
+`skills:` loads a per-subagent subset of skills by name, resolved against
+the same user/project skill directories the main agent reads. Subagents
+load no skills unless this field names them; unknown names fail loudly at
+agent assembly. Plugin-provided skills are not yet addressable here.
 
 The `name` field is optional; when omitted it defaults to the folder name
 (e.g. `researcher`). This diverges from the Agent Skills specification
@@ -57,11 +77,47 @@ class SubagentMetadata(TypedDict):
     model: str | None
     """Optional model override in 'provider:model-name' format."""
 
+    tools: list[str] | None
+    """Optional allowlist of session tool names for this subagent.
+
+    When set, the subagent receives exactly these tools from the session
+    toolset (MCP tools included, addressed by their fully-qualified names)
+    instead of inheriting the main agent's tools. An empty list means no
+    session tools. None (the default, when the frontmatter omits `tools:`)
+    keeps the inherit-everything behavior. Filesystem scaffolding tools are
+    unaffected — they are added by the runtime regardless.
+    """
+
+    skills: list[str] | None
+    """Optional list of skill names this subagent may load.
+
+    None (frontmatter omits `skills:`) means the subagent loads no skills,
+    which is also the default behavior. Names are resolved against the
+    user/project skill directories at agent assembly; unknown names raise.
+    """
+
     source: str
     """Where this subagent was loaded from ('user' or 'project')."""
 
     path: str
     """Absolute path to the subagent definition file."""
+
+
+def _is_name_list(value: object) -> bool:
+    """True when `value` is a valid optional list-of-names frontmatter field.
+
+    Accepts None (field omitted), any list whose entries are all non-empty
+    strings (an empty list is a valid, meaningful choice — e.g. `tools: []`
+    scopes a subagent to zero session tools), and rejects everything else.
+
+    Returns:
+        True when the value is a valid optional list-of-names field.
+    """
+    if value is None:
+        return True
+    if not isinstance(value, list):
+        return False
+    return all(isinstance(item, str) and item.strip() for item in value)
 
 
 def _parse_subagent_file(
@@ -124,6 +180,8 @@ def _parse_subagent_file(
     name_value = frontmatter.get("name", fallback_name)
     description_value = frontmatter.get("description")
     model = frontmatter.get("model")
+    tools = frontmatter.get("tools")
+    skills = frontmatter.get("skills")
 
     # Validate types: name and description must be non-empty strings (leading and
     # trailing whitespace is stripped, so a whitespace-only value is rejected).
@@ -139,8 +197,16 @@ def _parse_subagent_file(
         else None
     )
     model_valid = model is None or isinstance(model, str)
+    tools_valid = _is_name_list(tools)
+    skills_valid = _is_name_list(skills)
 
-    if name is None or description is None or not model_valid:
+    if (
+        name is None
+        or description is None
+        or not model_valid
+        or not tools_valid
+        or not skills_valid
+    ):
         invalid_fields: list[str] = []
         if name is None:
             invalid_fields.append("name (non-empty string required)")
@@ -148,6 +214,14 @@ def _parse_subagent_file(
             invalid_fields.append("description (non-empty string required)")
         if not model_valid:
             invalid_fields.append("model (string required when present)")
+        if not tools_valid:
+            invalid_fields.append(
+                "tools (list of non-empty strings required when present)"
+            )
+        if not skills_valid:
+            invalid_fields.append(
+                "skills (list of non-empty strings required when present)"
+            )
         logger.warning(
             "Skipping subagent %s: invalid or missing frontmatter field(s): %s",
             file_path,
@@ -169,6 +243,8 @@ def _parse_subagent_file(
         "description": description,
         "system_prompt": match.group(2).strip(),
         "model": model,
+        "tools": tools,
+        "skills": skills,
         "source": "",  # Set by caller
         "path": str(file_path),
     }

--- a/libs/code/tests/unit_tests/test_subagent_scoping.py
+++ b/libs/code/tests/unit_tests/test_subagent_scoping.py
@@ -1,0 +1,106 @@
+"""Unit tests for per-subagent tool/skill scoping resolution."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.tools import tool
+
+from deepagents_code.agent import (
+    _resolve_subagent_skill_sources,
+    _resolve_subagent_tool_allowlist,
+)
+
+
+@tool
+def web_search(query: str) -> str:
+    """Search the web."""
+    return query
+
+
+@tool
+def github_create_issue(title: str) -> str:
+    """Create an issue."""
+    return title
+
+
+class TestToolAllowlistResolution:
+    """Test _resolve_subagent_tool_allowlist."""
+
+    def test_resolves_named_tools_in_allowlist_order(self) -> None:
+        """The allowlist picks session tools by name, order preserved."""
+        session = [web_search, github_create_issue]
+
+        resolved = _resolve_subagent_tool_allowlist(
+            "researcher", ["github_create_issue", "web_search"], session
+        )
+
+        assert resolved == [github_create_issue, web_search]
+
+    def test_duck_typed_tools_without_name_are_skipped(self) -> None:
+        """Entries without a usable .name never enter the pool."""
+        resolved = _resolve_subagent_tool_allowlist(
+            "researcher", ["web_search"], [SimpleNamespace(), web_search]
+        )
+
+        assert resolved == [web_search]
+
+    def test_unknown_tool_raises_with_available_names(self) -> None:
+        """A typo aborts assembly and names what IS available."""
+        with pytest.raises(ValueError, match=r"unknown tool.*web-serch") as excinfo:
+            _resolve_subagent_tool_allowlist("researcher", ["web-serch"], [web_search])
+
+        assert "web_search" in str(excinfo.value)
+
+    def test_empty_allowlist_yields_no_tools(self) -> None:
+        """tools: [] resolves to an empty list, not to inheritance."""
+        assert _resolve_subagent_tool_allowlist("analyst", [], [web_search]) == []
+
+
+class TestSkillSourceResolution:
+    """Test _resolve_subagent_skill_sources."""
+
+    def test_resolves_named_skills_to_their_directories(self, tmp_path: Path) -> None:
+        """Only the named skill directories are returned, in name order."""
+        root = tmp_path / "skills"
+        (root / "source-citation").mkdir(parents=True)
+        (root / "browser-flows").mkdir()
+        (root / "not-a-skill.txt").write_text("stray file")
+
+        sources = _resolve_subagent_skill_sources(
+            "researcher", ["browser-flows"], [root]
+        )
+
+        assert sources == [str(root / "browser-flows")]
+
+    def test_later_roots_override_earlier_ones(self, tmp_path: Path) -> None:
+        """Precedence mirrors the main agent's source order."""
+        user = tmp_path / "user"
+        project = tmp_path / "project"
+        (user / "shared").mkdir(parents=True)
+        (project / "shared").mkdir(parents=True)
+
+        sources = _resolve_subagent_skill_sources("coder", ["shared"], [user, project])
+
+        assert sources == [str(project / "shared")]
+
+    def test_none_and_missing_roots_are_skipped(self, tmp_path: Path) -> None:
+        """None roots (skills disabled dirs) and absent dirs are ignored."""
+        root = tmp_path / "skills"
+        (root / "alpha").mkdir(parents=True)
+
+        sources = _resolve_subagent_skill_sources(
+            "coder", ["alpha"], [None, tmp_path / "does-not-exist", root]
+        )
+
+        assert sources == [str(root / "alpha")]
+
+    def test_unknown_skill_raises_with_available_names(self, tmp_path: Path) -> None:
+        """A typo aborts assembly and lists resolvable skills."""
+        root = tmp_path / "skills"
+        (root / "alpha").mkdir(parents=True)
+
+        with pytest.raises(ValueError, match=r"unknown skill.*alph") as excinfo:
+            _resolve_subagent_skill_sources("coder", ["alph"], [root])
+
+        assert "alpha" in str(excinfo.value)

--- a/libs/code/tests/unit_tests/test_subagents.py
+++ b/libs/code/tests/unit_tests/test_subagents.py
@@ -251,6 +251,101 @@ Content
 
         assert _parse_subagent_file(subagent_file) is None
 
+    def test_parse_subagent_with_tools_and_skills(self, tmp_path: Path) -> None:
+        """tools:/skills: frontmatter parse into lists of names."""
+        subagent_file = tmp_path / "scoped.md"
+        subagent_file.write_text(
+            """---
+name: scoped
+description: Test
+tools:
+  - web_search
+  - github_create_issue
+skills:
+  - source-citation
+---
+
+Content
+"""
+        )
+
+        result = _parse_subagent_file(subagent_file)
+
+        assert result is not None
+        assert result["tools"] == ["web_search", "github_create_issue"]
+        assert result["skills"] == ["source-citation"]
+
+    def test_parse_subagent_without_tools_and_skills(self, tmp_path: Path) -> None:
+        """Omitted tools:/skills: parse to None (inherit / no skills)."""
+        subagent_file = tmp_path / "default.md"
+        subagent_file.write_text(
+            """---
+name: default
+description: Test
+---
+
+Content
+"""
+        )
+
+        result = _parse_subagent_file(subagent_file)
+
+        assert result is not None
+        assert result["tools"] is None
+        assert result["skills"] is None
+
+    def test_parse_subagent_empty_tools_list(self, tmp_path: Path) -> None:
+        """tools: [] is valid and meaningful (zero session tools)."""
+        subagent_file = tmp_path / "empty.md"
+        subagent_file.write_text(
+            """---
+name: empty
+description: Test
+tools: []
+---
+
+Content
+"""
+        )
+
+        result = _parse_subagent_file(subagent_file)
+
+        assert result is not None
+        assert result["tools"] == []
+
+    def test_parse_subagent_non_list_tools(self, tmp_path: Path) -> None:
+        """A non-list tools: value is rejected (skip the subagent)."""
+        subagent_file = tmp_path / "bad.md"
+        subagent_file.write_text(
+            """---
+name: bad
+description: Test
+tools: web_search
+---
+
+Content
+"""
+        )
+
+        assert _parse_subagent_file(subagent_file) is None
+
+    def test_parse_subagent_non_string_skill_entry(self, tmp_path: Path) -> None:
+        """A skills: list with a non-string entry is rejected."""
+        subagent_file = tmp_path / "badskills.md"
+        subagent_file.write_text(
+            """---
+name: badskills
+description: Test
+skills:
+  - 42
+---
+
+Content
+"""
+        )
+
+        assert _parse_subagent_file(subagent_file) is None
+
     def test_parse_subagent_frontmatter_not_dict(self, tmp_path: Path) -> None:
         """Test that non-dict frontmatter is rejected."""
         subagent_file = tmp_path / "invalid.md"


### PR DESCRIPTION
# Per-subagent `tools:` / `skills:` frontmatter

## Problem

A subagent inherits the main agent's **entire** toolset — every MCP tool
included. There is no way to scope a specialist, so with N MCP servers
loaded, every subagent's delegated context carries every server's full
schema set, and every specialist holds every capability.

Measured on a real workspace with 3 MCP servers (~50 tools) and 10
subagents, capturing what `create_sub_agent` receives for each: **all 10
held all 50 tools** — including a prose-writing subagent whose job never
touches a single one of them, holding tools that create, mutate and
delete project resources. The intent "only the repo-specialist drives
the issue tracker" is inexpressible today: the persona *prompt* can say
it, but the capability is structurally granted to every subagent.

That is both a blast-radius problem (a hallucinating or prompt-injected
subagent can fire any tool the session owns) and a context-tax problem
(dozens of unwanted schemas ride into every delegation).

## Solution

Two optional frontmatter fields, wired onto the seams deepagents core
already exposes (`SubAgent["tools"]`, `SubAgent["skills"]` — both honored
by graph assembly, simply never authored by dcode):

```markdown
---
name: issue-triage
description: Searches issues and drafts replies; never merges or pushes
tools:
  - github_search_issues
  - github_get_file_contents
skills:
  - reply-conventions
---
```

| field | omitted | `[]` | list |
|---|---|---|---|
| `tools:` | inherit the main agent's tools (unchanged) | zero session tools | exactly these, by fully-qualified name |
| `skills:` | no skills (unchanged default) | no skills | exactly these skill directories |

- **Filesystem scaffolding is unaffected** — `ls`/`read_file`/... are added
  by the runtime middleware regardless; `tools:` scopes the *session*
  toolset (caller tools + MCP).
- **MCP names are fully-qualified** (server-prefixed, e.g.
  `github_create_issue`) — the exact names the model sees, no ambiguity.
- **Unknown names fail loudly.** A typo in an allowlist would otherwise
  silently strip a capability; instead assembly aborts with the unknown
  names and the available ones listed. Same for `skills:`. Syntax-level
  mistakes (non-list, non-string entries) keep the existing
  skip-with-warning parse behavior.
- **Skill resolution mirrors the main agent's source order**
  (built-in -> user -> project; later roots override), and returns
  per-skill directories so only the named skills load.

## Compatibility

Definitions without the new fields compile **identically** — the fields
default to `None`, and `None` maps to today's behavior at both seams.
`general-purpose` (auto-added) is untouched by this change.

## Testing

- 13 new unit tests: parser coverage (present / omitted / empty list /
  non-list / non-string entries) and both resolvers (order preservation,
  duck-typed pools, precedence override, `None`/missing roots,
  fail-loud messages naming what *is* available).
- Full unit suite, run twice at different terminal widths: 12,624 and
  12,623 passed, 3 skipped. The one failure per run is a pre-existing,
  width-sensitive test on main — `test_main.py`'s trust-prompt
  assertion (rich wraps the warning at default width and the flattened
  assert drops the wrap space; passes at `COLUMNS=200`) and
  `tui/widgets/test_messages.py`'s todo-alignment assertion (the
  reverse). Both files are untouched by this PR (byte-identical to
  main); all 13 new tests pass in every run. `ruff check`,
  `ruff format`, and `ty check` clean on the touched files.
- End-to-end against the real `create_cli_agent` (capture hook on
  `create_sub_agent`), synthetic session of three tools
  (`github_search_code`, `db_query`, `web_search`) and a scratch project
  root:

```
scoped                  tools=['github_search_code']            skills=['…/.deepagents/skills/reply-conventions']
inherits-everything     tools=['github_search_code','db_query','web_search']  skills=None
zero-tools              tools=[]                                skills=None
general-purpose         tools=['github_search_code','db_query','web_search']  skills=None   # untouched
PASS: allowlist exact | default inheritance intact | tools: [] -> zero
PASS: skills resolved to the named skill directory only
PASS: unknown tool name (github_search_cod) aborts assembly, naming github_search_code as available
```

## Non-goals / follow-ups

- Plugin-provided skills are not yet addressable in `skills:` (namespaced
  `{plugin_id}:{skill_name}` resolution is a natural follow-up).
- Scoping the auto-added `general-purpose` subagent (a frontmatter
  override for it would need a different mechanism).
- Removing built-in scaffolding per subagent remains the `HarnessProfile`
  mechanism; this PR scopes the session toolset only.
