### PR TITLE
ci(infra): render `!keep-open` as a fenced block in the stale-PR warning

### DIFF
--- a/.github/scripts/labeling/close-old-prs.js
+++ b/.github/scripts/labeling/close-old-prs.js
@@ -363,7 +363,12 @@ function warningBody({ warningDays, closeDays, bypassLabel }) {
     COMMENT_MARKER,
     `This PR has been open for at least ${warningDays} days.`,
     '',
-    `It will be closed automatically once it has been open for at least ${closeDays} days and this warning is at least ${noticeDays} days old, unless a maintainer applies the \`${bypassLabel}\` label or comments \`!keep-open\`.`,
+    `It will be closed automatically once it has been open for at least ${closeDays} days and this warning is at least ${noticeDays} days old, unless a maintainer applies the \`${bypassLabel}\` label or comments:`,
+      '',
+      // Fenced block so GitHub renders a copy button for the exact phrase.
+      '```',
+      '!keep-open',
+      '```',
   ].join('\n');
 }
 


### PR DESCRIPTION
The stale-PR warning comment now renders the keep-open command as its own fenced code block, so GitHub shows a copy button next to it — a maintainer can copy the exact phrase instead of selecting it out of a sentence.

---

The warning posted by `close-old-prs.js` previously ended with "...or comments `!keep-open`." inline. It now ends with "...or comments:" followed by:

```
!keep-open
```

Only the warning body changes; the post-close message keeps its inline mention (no copy affordance needed once the PR is already closed), and the `keep_open_on_comment.yml` trigger still matches the phrase anywhere in a comment body, so comments posted via the copy button work the same as before.
