### PR TITLE
style(code): restore active-question side line for multi-question `ask_user` menus

### DIFF
--- a/libs/code/deepagents_code/app.tcss
+++ b/libs/code/deepagents_code/app.tcss
@@ -369,11 +369,22 @@ ToolCallMessage.-ascii:hover {
 .ask-user-menu .ask-user-question {
     height: auto;
     margin-bottom: 1;
-    padding-left: 2;
 }
 
 .ask-user-menu .ask-user-question-inactive {
     opacity: 0.5;
+}
+
+/* Multi-question prompts mark the active question with a left border;
+inactive questions keep the same total left inset so text does not shift
+horizontally when focus moves between questions. */
+.ask-user-menu-multi .ask-user-question-active {
+    border-left: thick $success;
+    padding-left: 1;
+}
+
+.ask-user-menu-multi .ask-user-question-inactive {
+    padding-left: 2;
 }
 
 .ask-user-menu .ask-user-question-text {

--- a/libs/code/deepagents_code/app.tcss
+++ b/libs/code/deepagents_code/app.tcss
@@ -369,6 +369,7 @@ ToolCallMessage.-ascii:hover {
 .ask-user-menu .ask-user-question {
     height: auto;
     margin-bottom: 1;
+    padding-left: 2;
 }
 
 .ask-user-menu .ask-user-question-inactive {

--- a/libs/code/deepagents_code/app.tcss
+++ b/libs/code/deepagents_code/app.tcss
@@ -369,7 +369,6 @@ ToolCallMessage.-ascii:hover {
 .ask-user-menu .ask-user-question {
     height: auto;
     margin-bottom: 1;
-    padding-left: 2;
 }
 
 .ask-user-menu .ask-user-question-inactive {
@@ -378,7 +377,8 @@ ToolCallMessage.-ascii:hover {
 
 /* Multi-question prompts mark the active question with a left border;
 inactive questions keep the same total left inset so text does not shift
-horizontally when focus moves between questions. */
+horizontally when focus moves between questions. Single-question prompts
+stay borderless and flush-left. */
 .ask-user-menu-multi .ask-user-question-active {
     border-left: thick $success;
     padding-left: 1;

--- a/libs/code/deepagents_code/tui/widgets/ask_user.py
+++ b/libs/code/deepagents_code/tui/widgets/ask_user.py
@@ -136,9 +136,14 @@ class AskUserMenu(Container):
         id: str | None = None,  # noqa: A002
         **kwargs: Any,
     ) -> None:
+        classes = "inline-prompt ask-user-menu"
+        if len(questions) > 1:
+            # Gates the active question's left border in CSS; single-question
+            # prompts stay borderless.
+            classes += " ask-user-menu-multi"
         super().__init__(
             id=id or "ask-user-menu",
-            classes="inline-prompt ask-user-menu",
+            classes=classes,
             **kwargs,
         )
         self._questions = questions

--- a/libs/code/tests/unit_tests/tui/widgets/test_ask_user.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_ask_user.py
@@ -1190,6 +1190,51 @@ class TestAskUserMenu:
                 "**2.** Color? *(required)*",
             ]
 
+    async def test_multi_question_menu_marks_active_question_with_border(self) -> None:
+        """Multi-question menus restore the side line on the active question.
+
+        The `ask-user-menu-multi` class on the menu gates the border in CSS
+        (`.ask-user-menu-multi .ask-user-question-active`), so the highlight
+        appears only when there are 2+ questions.
+        """
+        app = _AskUserTestApp(
+            [
+                {"question": "Name?", "type": "text"},
+                {"question": "Color?", "type": "text"},
+            ]
+        )
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu = app.query_one("#ask-user-menu", AskUserMenu)
+            assert menu.has_class("ask-user-menu-multi")
+
+            active, inactive = menu._question_widgets
+            assert active.has_class("ask-user-question-active")
+            assert not active.has_class("ask-user-question-inactive")
+            assert inactive.has_class("ask-user-question-inactive")
+            assert not inactive.has_class("ask-user-question-active")
+
+            # The border applies only to the active question; the inactive one
+            # carries matching padding instead so the two stay left-aligned.
+            border, _ = active.styles.border_left
+            assert border == "thick"
+            assert active.styles.padding.left != inactive.styles.padding.left
+
+    async def test_single_question_menu_has_no_active_border(self) -> None:
+        """Single-question prompts stay flat: no multi class, no side border."""
+        app = _AskUserTestApp([{"question": "Name?", "type": "text"}])
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu = app.query_one("#ask-user-menu", AskUserMenu)
+            assert not menu.has_class("ask-user-menu-multi")
+
+            question = menu._question_widgets[0]
+            assert question.has_class("ask-user-question-active")
+            border, _ = question.styles.border_left
+            assert not border
+
     async def test_required_label_shown_for_required_question(self) -> None:
         """Required questions display a (required) indicator."""
         app = _AskUserTestApp([{"question": "Name?", "type": "text", "required": True}])


### PR DESCRIPTION
Multi-question `ask_user` prompts again show a green line on the left side of the active question. Single-question prompts do not change: no number, no line.

---

PR #5444 removed this line from all prompts. With two or more questions, only a `>` marker and dimmed text showed which question was active. These signs were hard to see.

This change adds the class `ask-user-menu-multi` to prompts that have more than one question. The CSS shows the line only when this class is present:

- The active question gets the line and `padding-left: 1`.
- The inactive questions get `padding-left: 2`.

The line is one column wide, so active and inactive questions have the same total left space. The text stays in position when the active question changes.
