### PR TITLE
feat(sdk): configure Anthropic prompt-cache TTL

### DIFF
--- a/libs/deepagents/CHANGELOG.md
+++ b/libs/deepagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Deep Agents Changelog
 
+## Unreleased
+
+### Features
+
+- Added configurable Anthropic prompt-cache TTL support for main agents and subagents.
+
 ## [0.7.6](https://github.com/langchain-ai/deepagents/compare/deepagents==0.7.5...deepagents==0.7.6) (2026-08-13)
 
 ### Bug Fixes

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -7,7 +7,7 @@ subagent, and summarization middleware.
 
 import logging
 from collections.abc import Callable, Sequence
-from typing import Annotated, Any, Required, cast
+from typing import Annotated, Any, Literal, Required, cast
 
 from langchain.agents import AgentState, create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig
@@ -285,6 +285,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache | None = None,
+    anthropic_cache_ttl: Literal["5m", "1h"] | None = None,
 ) -> CompiledStateGraph[AgentState[ResponseT], ContextT, InputAgentState, OutputAgentState[ResponseT]]:  # ty: ignore[invalid-type-arguments]  # ty can't verify generic TypedDicts satisfy StateLike bound
     r"""Create a deep agent.
 
@@ -560,6 +561,9 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         cache: The cache to use for the agent.
 
             Passed through to [`create_agent`][langchain.agents.create_agent].
+        anthropic_cache_ttl: Prompt-cache lifetime for Anthropic models. `None`
+            preserves the middleware's default (`"5m"`). Applied to the main
+            agent and all subagents.
 
     Returns:
         A configured deep agent.
@@ -681,7 +685,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             # Harness-profile middleware for this subagent's model
             subagent_middleware.extend(_subagent_profile.materialize_extra_middleware())
 
-            append_prompt_caching_middleware(subagent_middleware)
+            append_prompt_caching_middleware(
+                subagent_middleware,
+                anthropic_cache_ttl=anthropic_cache_ttl,
+            )
 
             _subagent_matched_classes: set[type[AgentMiddleware[Any, Any, Any]]] = set()
             _subagent_matched_names: set[str] = set()
@@ -764,7 +771,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         # Add harness-profile middleware, if any
         gp_middleware.extend(_profile.materialize_extra_middleware())
 
-        append_prompt_caching_middleware(gp_middleware)
+        append_prompt_caching_middleware(
+            gp_middleware,
+            anthropic_cache_ttl=anthropic_cache_ttl,
+        )
         _gp_original_name_to_index = {m.name: i for i, m in enumerate(gp_middleware)}
         gp_middleware = _apply_excluded_middleware(
             gp_middleware,
@@ -857,7 +867,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     # that memory updates (which change the system prompt) don't invalidate the
     # Anthropic prompt cache prefix.
     deepagent_middleware.extend(_profile.materialize_extra_middleware())
-    append_prompt_caching_middleware(deepagent_middleware)
+    append_prompt_caching_middleware(
+        deepagent_middleware,
+        anthropic_cache_ttl=anthropic_cache_ttl,
+    )
     if memory is not None:
         # MemoryMiddleware applies the cache_control breakpoint only when the
         # request model is Anthropic, making it safe to enable unconditionally.

--- a/libs/deepagents/deepagents/middleware/_prompt_caching.py
+++ b/libs/deepagents/deepagents/middleware/_prompt_caching.py
@@ -2,12 +2,14 @@
 
 import logging
 from importlib import import_module
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 
 logger = logging.getLogger(__name__)
+
+AnthropicCacheTtl = Literal["5m", "1h"]
 
 
 def _create_bedrock_prompt_caching_middleware() -> AgentMiddleware[Any, Any, Any] | None:
@@ -38,9 +40,20 @@ def _create_fireworks_prompt_caching_middleware() -> AgentMiddleware[Any, Any, A
     return cast("AgentMiddleware[Any, Any, Any]", middleware_cls(unsupported_model_behavior="ignore"))
 
 
-def append_prompt_caching_middleware(middleware: list[AgentMiddleware[Any, Any, Any]]) -> None:
+def append_prompt_caching_middleware(
+    middleware: list[AgentMiddleware[Any, Any, Any]],
+    *,
+    anthropic_cache_ttl: AnthropicCacheTtl | None = None,
+) -> None:
     """Append provider-specific prompt caching middleware."""
-    middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+    if anthropic_cache_ttl is None:
+        anthropic_middleware = AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore")
+    else:
+        anthropic_middleware = AnthropicPromptCachingMiddleware(
+            ttl=anthropic_cache_ttl,
+            unsupported_model_behavior="ignore",
+        )
+    middleware.append(anthropic_middleware)
     bedrock_middleware = _create_bedrock_prompt_caching_middleware()
     if bedrock_middleware is not None:
         middleware.append(bedrock_middleware)

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -9,7 +9,7 @@ import sys
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from langchain.agents.middleware import TodoListMiddleware
@@ -386,6 +386,80 @@ class TestGeneralPurposeSubagentProfileWiring:
 
 class TestPromptCachingWiring:
     """Tests for provider-specific prompt caching middleware wiring."""
+
+    def test_anthropic_cache_ttl_applies_to_main_and_all_subagents(self) -> None:
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        explicit_cache = MagicMock()
+        gp_cache = MagicMock()
+        main_cache = MagicMock()
+        fake_agent = MagicMock()
+        fake_agent.with_config.return_value = "compiled-agent"
+
+        with (
+            patch(
+                "deepagents.middleware._prompt_caching.AnthropicPromptCachingMiddleware",
+                side_effect=[explicit_cache, gp_cache, main_cache],
+            ) as mock_anthropic,
+            patch(
+                "deepagents.middleware._prompt_caching._create_bedrock_prompt_caching_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deepagents.middleware._prompt_caching._create_fireworks_prompt_caching_middleware",
+                return_value=None,
+            ),
+            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+            patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
+        ):
+            result = create_deep_agent(
+                model=model,
+                anthropic_cache_ttl="1h",
+                subagents=[
+                    {
+                        "name": "worker",
+                        "description": "Does work.",
+                        "system_prompt": "Help with tasks.",
+                    }
+                ],
+            )
+
+        assert result == "compiled-agent"
+        assert mock_anthropic.call_args_list == [
+            call(ttl="1h", unsupported_model_behavior="ignore"),
+            call(ttl="1h", unsupported_model_behavior="ignore"),
+            call(ttl="1h", unsupported_model_behavior="ignore"),
+        ]
+        subagents = mock_subagents.call_args.kwargs["subagents"]
+        worker = next(spec for spec in subagents if spec["name"] == "worker")
+        general_purpose = next(spec for spec in subagents if spec["name"] == "general-purpose")
+        assert explicit_cache in worker["middleware"]
+        assert gp_cache in general_purpose["middleware"]
+        assert main_cache in mock_create.call_args.kwargs["middleware"]
+
+    def test_anthropic_cache_ttl_none_preserves_middleware_default(self) -> None:
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        fake_agent = MagicMock()
+        fake_agent.with_config.return_value = "compiled-agent"
+
+        with (
+            patch("deepagents.middleware._prompt_caching.AnthropicPromptCachingMiddleware") as mock_anthropic,
+            patch(
+                "deepagents.middleware._prompt_caching._create_bedrock_prompt_caching_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deepagents.middleware._prompt_caching._create_fireworks_prompt_caching_middleware",
+                return_value=None,
+            ),
+            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()),
+            patch("deepagents.graph.create_agent", return_value=fake_agent),
+        ):
+            create_deep_agent(model=model, anthropic_cache_ttl=None)
+
+        assert mock_anthropic.call_args_list == [
+            call(unsupported_model_behavior="ignore"),
+            call(unsupported_model_behavior="ignore"),
+        ]
 
     def test_main_and_general_purpose_agents_get_bedrock_prompt_caching(self) -> None:
         model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))


### PR DESCRIPTION
Deep Agents callers can now choose a five-minute or one-hour Anthropic prompt-cache lifetime across the main agent and every subagent.

---

The additive keyword-only `anthropic_cache_ttl` parameter preserves the upstream five-minute default when omitted and leaves other providers unchanged. Focused graph tests cover explicit, general-purpose, and main-agent wiring.

Made by [Open SWE](https://openswe.vercel.app/agents/faf836d2-dce2-7a94-b63e-9363fbb49dc6)