### PR TITLE
feat(code): add Anthropic prompt-cache TTL setting

### DIFF
--- a/libs/code/CHANGELOG.md
+++ b/libs/code/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Deep Agents Code Changelog
 
+## Unreleased
+
+### Features
+
+- Added `models.anthropic_cache_ttl` for choosing a five-minute or one-hour Anthropic prompt-cache lifetime.
+
 ## [0.1.56](https://github.com/langchain-ai/deepagents/compare/deepagents-code==0.1.55...deepagents-code==0.1.56) (2026-08-14)
 
 ### Features

--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -30,6 +30,9 @@ import os
 # Keep alphabetically sorted by constant name.
 # ---------------------------------------------------------------------------
 
+ANTHROPIC_CACHE_TTL = "DEEPAGENTS_CODE_ANTHROPIC_CACHE_TTL"
+"""Anthropic prompt-cache lifetime (`5m` or `1h`), defaulting to `5m`."""
+
 AUTO_CLASSIFIER_MODEL = "DEEPAGENTS_CODE_AUTO_CLASSIFIER_MODEL"
 """Model spec (`provider:model`) used by the Auto approval-mode classifier.
 

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -80,6 +80,7 @@ from deepagents_code.config import (
     _ShellAllowAll,
     config,
     console,
+    get_anthropic_cache_ttl,
     get_default_coding_instructions,
     get_glyphs,
     get_langsmith_project_name,
@@ -3073,5 +3074,6 @@ def create_cli_agent(
         checkpointer=checkpointer,
         subagents=all_subagents or None,
         name=_sanitize_agent_message_name(assistant_id),
+        anthropic_cache_ttl=get_anthropic_cache_ttl(),
     ).with_config({**config, "recursion_limit": effective_recursion_limit})
     return agent, composite_backend

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field as dataclass_field
 from enum import StrEnum
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -34,6 +34,8 @@ from deepagents_code._env_vars import (
 from deepagents_code._git import resolve_git_branch
 from deepagents_code._version import __version__
 from deepagents_code.config_manifest import (
+    ANTHROPIC_CACHE_TTL_DEFAULT,
+    ANTHROPIC_CACHE_TTL_VALUES,
     INTERPRETER_ENABLE_DEFAULT,
     INTERPRETER_MAX_PTC_CALLS_DEFAULT,
     INTERPRETER_MAX_RESULT_CHARS_DEFAULT,
@@ -42,6 +44,7 @@ from deepagents_code.config_manifest import (
     INTERPRETER_PTC_DEFAULT,
     INTERPRETER_TIMEOUT_SECONDS_DEFAULT,
     RECURSION_LIMIT_DEFAULT,
+    AnthropicCacheTtl,
 )
 
 logger = logging.getLogger(__name__)
@@ -3495,6 +3498,36 @@ def is_yolo_switcher_enabled() -> bool:
         return True
     value, _ = resolve_scalar(option, toml_data=load_config_toml())
     return bool(value)
+
+
+def get_anthropic_cache_ttl() -> AnthropicCacheTtl:
+    """Return the validated Anthropic prompt-cache lifetime.
+
+    Raises:
+        ModelConfigError: If the configured lifetime is invalid.
+    """
+    from deepagents_code.config_manifest import (
+        get_option,
+        load_config_toml,
+        resolve_scalar,
+    )
+    from deepagents_code.model_config import ModelConfigError
+
+    option = get_option("models.anthropic_cache_ttl")
+    if option is None:
+        return ANTHROPIC_CACHE_TTL_DEFAULT
+    try:
+        value, source = resolve_scalar(option, toml_data=load_config_toml())
+    except ValueError as exc:
+        raise ModelConfigError(str(exc)) from exc
+    if not isinstance(value, str) or value not in ANTHROPIC_CACHE_TTL_VALUES:
+        expected = ", ".join(repr(item) for item in ANTHROPIC_CACHE_TTL_VALUES)
+        msg = (
+            f"Invalid {source} value for models.anthropic_cache_ttl: {value!r}; "
+            f"expected one of {expected}"
+        )
+        raise ModelConfigError(msg)
+    return cast("AnthropicCacheTtl", value)
 
 
 def is_openai_prompt_cache_key_enabled() -> bool:

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -12,8 +12,9 @@ can never drift from what the app actually reads. Resolution precedence mirrors
 the loaders: a `DEEPAGENTS_CODE_`-prefixed env var beats the canonical name,
 env beats `config.toml`, and the typed default is the final fallback. A
 malformed numeric/list/PTC value, an unrecognized boolean token, or a
-wrong-typed TOML value is logged and falls back to the next layer rather than
-raising, so a bad config never blocks startup.
+wrong-typed TOML value is logged and falls back to the next layer. Options with
+an explicit string allowlist instead raise so invalid safety- or cost-sensitive
+settings cannot silently change behavior.
 
 Structured, user-defined config is *not* a flat scalar option and is parsed by
 dedicated typed loaders elsewhere. The manifest references `[threads].columns`
@@ -50,6 +51,10 @@ logger = logging.getLogger(__name__)
 # --- Canonical typed defaults ----------------------------------------------
 # These are single sources of truth for defaults shared across the manifest and
 # their runtime consumers.
+
+AnthropicCacheTtl = Literal["5m", "1h"]
+ANTHROPIC_CACHE_TTL_DEFAULT: AnthropicCacheTtl = "5m"
+ANTHROPIC_CACHE_TTL_VALUES: tuple[AnthropicCacheTtl, ...] = ("5m", "1h")
 
 INTERPRETER_ENABLE_DEFAULT = True
 INTERPRETER_TIMEOUT_SECONDS_DEFAULT = 5.0
@@ -243,6 +248,9 @@ class ConfigOption:
     default: Any = None
     """Typed default value, or `None` when there is no static default."""
 
+    allowed_values: tuple[str, ...] = ()
+    """Accepted values for a strict string option; invalid values hard-error."""
+
     env_var: str | None = None
     """Primary environment variable name the loader reads, or `None`.
 
@@ -315,10 +323,10 @@ class ConfigOption:
         `resolve_scalar`. Catching it here fails the import (and the test suite).
 
         Raises:
-            TypeError: When `fallback_env_vars` is not a tuple of non-empty
-                strings, `empty_env_is_false` is set on a non-bool option,
-                `default` is mutable, a `STRUCTURED` option declares a default,
-                or a scalar option's default has the wrong type.
+            TypeError: When `fallback_env_vars` or `allowed_values` is invalid,
+                `empty_env_is_false` is set on a non-bool option, `default` is
+                mutable, a `STRUCTURED` option declares a default, or a scalar
+                option's default has the wrong type.
         """
         # Guard `fallback_env_vars` independently of `default` (which has its own
         # early-return path below): like `default`, it is shared by reference
@@ -336,6 +344,30 @@ class ConfigOption:
         if self.empty_env_is_false and self.kind is not OptionKind.BOOL:
             msg = f"{self.key}: empty_env_is_false requires a bool option kind"
             raise TypeError(msg)
+        if not isinstance(self.allowed_values, tuple):
+            msg = (
+                f"{self.key}: allowed_values must be a tuple of unique, "
+                f"non-empty strings, got {self.allowed_values!r}"
+            )
+            raise TypeError(msg)
+        if self.allowed_values:
+            if self.kind is not OptionKind.STR:
+                msg = f"{self.key}: allowed_values requires a str option kind"
+                raise TypeError(msg)
+            if any(
+                not isinstance(value, str) or not value for value in self.allowed_values
+            ) or len(set(self.allowed_values)) != len(self.allowed_values):
+                msg = (
+                    f"{self.key}: allowed_values must be a tuple of unique, "
+                    f"non-empty strings, got {self.allowed_values!r}"
+                )
+                raise TypeError(msg)
+            if self.default is not None and self.default not in self.allowed_values:
+                msg = (
+                    f"{self.key}: default {self.default!r} is not in "
+                    f"allowed_values {self.allowed_values!r}"
+                )
+                raise TypeError(msg)
 
         default = self.default
         if default is None:
@@ -449,6 +481,9 @@ def _coerce_env(option: ConfigOption, raw: str, name: str) -> object:
 
     Returns:
         The typed value, or `_INVALID` when the raw value cannot be coerced.
+
+    Raises:
+        ValueError: If a strict string option is outside its allowlist.
     """
     kind = option.kind
     if kind is OptionKind.BOOL:
@@ -464,6 +499,10 @@ def _coerce_env(option: ConfigOption, raw: str, name: str) -> object:
     if kind is OptionKind.BOOL_PRESENCE:
         return bool(raw)
     if kind is OptionKind.STR:
+        if option.allowed_values and raw not in option.allowed_values:
+            expected = ", ".join(repr(value) for value in option.allowed_values)
+            msg = f"Invalid {name}={raw!r}; expected one of {expected}"
+            raise ValueError(msg)
         return raw
     if kind is OptionKind.LOG_LEVEL_DELEGATE:
         from deepagents_code._debug import LOG_LEVELS
@@ -545,6 +584,9 @@ def _coerce_toml(option: ConfigOption, raw: object) -> object:
 
     Returns:
         The typed value, or `_INVALID` when the raw value has the wrong shape.
+
+    Raises:
+        ValueError: If a strict string option is outside its allowlist.
     """
     kind = option.kind
     label = option.toml_path or option.key
@@ -559,6 +601,12 @@ def _coerce_toml(option: ConfigOption, raw: object) -> object:
         if isinstance(raw, (int, float)) and not isinstance(raw, bool):
             return float(raw)
     elif kind is OptionKind.STR:
+        if option.allowed_values:
+            if not isinstance(raw, str) or raw not in option.allowed_values:
+                expected = ", ".join(repr(value) for value in option.allowed_values)
+                msg = f"Invalid {label}={raw!r}; expected one of {expected}"
+                raise ValueError(msg)
+            return raw
         if isinstance(raw, str):
             return raw
     elif kind is OptionKind.SKILLS_DIRS_DELEGATE:
@@ -686,8 +734,9 @@ def resolve_scalar(
         normally treated as unset (mirroring `resolve_env_var`), so it falls
         through to the next env var, then `config.toml`/`default`, rather than
         counting as set. Options declaring `empty_env_is_false` instead resolve
-        an explicitly present empty value to `False`. Theme resolution
-        (`THEME_DELEGATE`) reports its own richer `config.toml [ui.*]` sources.
+        an explicitly present empty value to `False`. Strict string options treat
+        an empty env value as invalid. Theme resolution (`THEME_DELEGATE`) reports
+        its own richer `config.toml [ui.*]` sources.
     """
     if option.kind is OptionKind.THEME_DELEGATE:
         return _resolve_theme(toml_data)
@@ -700,15 +749,15 @@ def resolve_scalar(
             names.append(resolved_env_var_name(option.env_var))
         names.extend(option.fallback_env_vars)
         # An empty string normally counts as unset, matching `resolve_env_var`,
-        # so it is skipped and the loop continues to the next name. Options
-        # with an explicitly documented empty-value opt-out declare
-        # `empty_env_is_false`. Names are tried in order, so the primary
-        # `env_var` wins over any fallback.
+        # so it is skipped and the loop continues to the next name. Strict string
+        # options validate it instead, while documented boolean opt-outs declare
+        # `empty_env_is_false`. Names are tried in order, so the primary `env_var`
+        # wins over any fallback.
         for name in names:
             raw = os.environ.get(name)
             if raw is None:
                 continue
-            if not raw:
+            if not raw and not option.allowed_values:
                 if option.empty_env_is_false:
                     return False, f"env ({name})"
                 continue
@@ -1387,6 +1436,16 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         kind=OptionKind.BOOL,
         default=True,
         env_var=_env_vars.OLLAMA_DISCOVERY,
+    ),
+    ConfigOption(
+        key="models.anthropic_cache_ttl",
+        group="Tools",
+        summary="Set the Anthropic prompt-cache lifetime for all agents.",
+        kind=OptionKind.STR,
+        default=ANTHROPIC_CACHE_TTL_DEFAULT,
+        allowed_values=ANTHROPIC_CACHE_TTL_VALUES,
+        env_var=_env_vars.ANTHROPIC_CACHE_TTL,
+        toml_keys=("models", "anthropic_cache_ttl"),
     ),
     ConfigOption(
         key="models.openai_prompt_cache_key",

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "deepagents==0.7.6",
+    "deepagents==0.7.7",
     "langchain>=1.3.15,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.1.1,<4.0.0",
 

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -1756,6 +1756,9 @@ class TestCreateCliAgentInteractiveForwarding:
                 "deepagents_code.agent.create_deep_agent", side_effect=create_agent
             ) as mock_create_deep_agent,
             patch(
+                "deepagents_code.agent.get_anthropic_cache_ttl", return_value="1h"
+            ) as mock_cache_ttl,
+            patch(
                 "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
@@ -1781,6 +1784,8 @@ class TestCreateCliAgentInteractiveForwarding:
             mock_create_deep_agent.call_args.kwargs["context_schema"]
             is CLIContextSchema
         )
+        mock_cache_ttl.assert_called_once_with()
+        assert mock_create_deep_agent.call_args.kwargs["anthropic_cache_ttl"] == "1h"
         assert call_order == ["register_profile", "create_agent"]
 
     def test_explicit_system_prompt_ignores_interactive(self, tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -177,6 +177,75 @@ def test_is_memory_auto_save_enabled_reads_toml(monkeypatch) -> None:
     assert is_memory_auto_save_enabled() is False
 
 
+def test_get_anthropic_cache_ttl_defaults_to_five_minutes(monkeypatch) -> None:
+    """Anthropic prompt caching keeps the upstream five-minute default."""
+    from deepagents_code import config_manifest
+    from deepagents_code.config import get_anthropic_cache_ttl
+
+    monkeypatch.delenv(_env_vars.ANTHROPIC_CACHE_TTL, raising=False)
+    monkeypatch.setattr(config_manifest, "load_config_toml", dict)
+
+    assert get_anthropic_cache_ttl() == "5m"
+
+
+def test_get_anthropic_cache_ttl_reads_env(monkeypatch) -> None:
+    """The env override selects the one-hour Anthropic cache lifetime."""
+    from deepagents_code import config_manifest
+    from deepagents_code.config import get_anthropic_cache_ttl
+
+    monkeypatch.setattr(config_manifest, "load_config_toml", dict)
+    monkeypatch.setenv(_env_vars.ANTHROPIC_CACHE_TTL, "1h")
+
+    assert get_anthropic_cache_ttl() == "1h"
+
+
+def test_get_anthropic_cache_ttl_reads_toml(monkeypatch) -> None:
+    """The `[models]` config value is used when the env var is unset."""
+    from deepagents_code import config_manifest
+    from deepagents_code.config import get_anthropic_cache_ttl
+
+    monkeypatch.delenv(_env_vars.ANTHROPIC_CACHE_TTL, raising=False)
+    monkeypatch.setattr(
+        config_manifest,
+        "load_config_toml",
+        lambda: {"models": {"anthropic_cache_ttl": "1h"}},
+    )
+
+    assert get_anthropic_cache_ttl() == "1h"
+
+
+@pytest.mark.parametrize("raw", ["2h", "60m", "junk", ""])
+def test_get_anthropic_cache_ttl_rejects_invalid_env(monkeypatch, raw) -> None:
+    """Invalid env values fail instead of silently falling through."""
+    from deepagents_code import config_manifest
+    from deepagents_code.config import get_anthropic_cache_ttl
+    from deepagents_code.model_config import ModelConfigError
+
+    monkeypatch.setattr(config_manifest, "load_config_toml", dict)
+    monkeypatch.setenv(_env_vars.ANTHROPIC_CACHE_TTL, raw)
+
+    with pytest.raises(ModelConfigError, match="ANTHROPIC_CACHE_TTL"):
+        get_anthropic_cache_ttl()
+
+
+@pytest.mark.parametrize("raw", ["2h", "60m", "junk", 60])
+def test_get_anthropic_cache_ttl_rejects_invalid_toml(monkeypatch, raw) -> None:
+    """Invalid TOML values fail instead of reverting to five minutes."""
+    from deepagents_code import config_manifest
+    from deepagents_code.config import get_anthropic_cache_ttl
+    from deepagents_code.model_config import ModelConfigError
+
+    monkeypatch.delenv(_env_vars.ANTHROPIC_CACHE_TTL, raising=False)
+    monkeypatch.setattr(
+        config_manifest,
+        "load_config_toml",
+        lambda: {"models": {"anthropic_cache_ttl": raw}},
+    )
+
+    with pytest.raises(ModelConfigError, match=r"models\]\.anthropic_cache_ttl"):
+        get_anthropic_cache_ttl()
+
+
 def test_is_openai_prompt_cache_key_enabled_reads_env(monkeypatch) -> None:
     """`is_openai_prompt_cache_key_enabled` honors the env override."""
     from deepagents_code import config_manifest


### PR DESCRIPTION
Depends on #5540

Deep Agents Code users can set `models.anthropic_cache_ttl` to `5m` or `1h`, with `5m` remaining the default.

---

The setting resolves from `DEEPAGENTS_CODE_ANTHROPIC_CACHE_TTL` or `config.toml` on every agent rebuild and hard-errors on invalid values. The SDK pin advances to the anticipated `0.7.7` release.

Made by [Open SWE](https://openswe.vercel.app/agents/faf836d2-dce2-7a94-b63e-9363fbb49dc6)