### PR TITLE
feat(code): carry `TERM_PROGRAM` into the resume hint

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -284,6 +284,18 @@ The value is comma-separated for forward-compatibility, not because multiple
 destinations are written today.
 """
 
+LAUNCH_TERM_PROGRAM = "DEEPAGENTS_CODE_LAUNCH_TERM_PROGRAM"
+"""Internal sentinel recording the `TERM_PROGRAM` present when `dcode` started.
+
+Not user-facing. The resume hint echoes `TERM_PROGRAM` only when the launch
+environment supplied it (an inline `TERM_PROGRAM=x dcode`, a terminal's own
+export, or a shell alias), so the value set by a project or global `.env` file
+*after* launch must not leak in. The app itself never sets `TERM_PROGRAM`, so
+`cli_main` snapshotting the variable here at entry means a set sentinel always
+marks an explicit launch value; the update re-exec inherits it unchanged,
+which is correct because the relaunch runs the command the user typed.
+"""
+
 LEGACY_ENABLED_PROJECT_MCP_SERVERS = "DEEPAGENTS_CODE_ENABLED_PROJECT_MCP_SERVERS"
 """Removed project MCP allowlist env var retained for migration detection only.
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -8080,9 +8080,15 @@ class DeepAgentsApp(App):
             inputs += self._inflight_turn_stats.input_tokens
             reads += self._inflight_turn_stats.cache_read_tokens
             writes += self._inflight_turn_stats.cache_write_tokens
-        cache_display = self._status_bar.query_one("#cache-display")
-        cache_display.visible = self._thread_has_completed_turn and writes > 0
-        self._status_bar.set_cache_tokens(reads, writes, input_tokens=inputs)
+        # The usage worker can fire while `/reload` has the status bar
+        # mid-compose or mid-teardown, before `#cache-display` is queryable.
+        # `set_cache_tokens` also touches the DOM, so skip both on that race;
+        # the next usage update (or `_reset_thread_usage` on the new thread)
+        # repaints.
+        with suppress(NoMatches):
+            cache_display = self._status_bar.query_one("#cache-display")
+            cache_display.visible = self._thread_has_completed_turn and writes > 0
+            self._status_bar.set_cache_tokens(reads, writes, input_tokens=inputs)
 
     def _set_session_cost(
         self,

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1820,6 +1820,10 @@ NON_OPTION_ENV_VARS: frozenset[str] = frozenset(
         # Set by the self-update restart to carry the launched command name into
         # the re-exec'd process; never user-configured.
         _env_vars.INVOKED_AS,
+        # Launch-time snapshot of `TERM_PROGRAM` recorded by `cli_main` so the
+        # resume hint can distinguish an explicit launch value from a `.env`
+        # file that sets `TERM_PROGRAM` after launch; never user-configured.
+        _env_vars.LAUNCH_TERM_PROGRAM,
     }
 )
 """`_env_vars` constants intentionally excluded from the option catalog."""

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -271,10 +271,19 @@ def _resume_term_program() -> str | None:
         The environment value when it is set and fully printable, else `None`.
         A value carrying control characters is dropped rather than stripped:
         stripping would both write raw escape sequences into teardown output
-        and name a terminal the environment never actually contained.
+        and name a terminal the environment never actually contained. Native
+        Windows shells also return `None`: VS Code and WezTerm set
+        `TERM_PROGRAM` on every platform, so its presence under `win32` does
+        not imply a POSIX shell, and the `VAR=value` prefix would be executed
+        as a command by `cmd.exe`/PowerShell. POSIX markers (`SHELL` from
+        git-bash/MSYS, `MSYSTEM`, `WSL_DISTRO_NAME`) restore the prefix there.
     """
     raw = os.environ.get("TERM_PROGRAM", "").strip()
     if not raw or not raw.isprintable():
+        return None
+    if sys.platform == "win32" and not any(
+        os.environ.get(marker) for marker in ("SHELL", "MSYSTEM", "WSL_DISTRO_NAME")
+    ):
         return None
     return raw
 
@@ -339,9 +348,10 @@ def _render_teardown_thread_hints(
     # A shell alias that exports `TERM_PROGRAM` (to select a theme, say) is
     # invisible to `invoked_name`, since an alias does not change `argv[0]`, so
     # the bare command would resume without it. Carry it as an env prefix to
-    # keep the line pasteable as-is. POSIX syntax is safe here: on Windows the
-    # variable is only set under POSIX shells (git-bash, WSL), while native
-    # `cmd.exe`/PowerShell leave it unset, so no prefix is emitted there.
+    # keep the line pasteable as-is. The prefix uses POSIX syntax, so
+    # `_resume_term_program` withholds it on native Windows, where terminals
+    # (VS Code, WezTerm) set the variable even under `cmd.exe`/PowerShell and
+    # those shells cannot parse a `VAR=value` command prefix.
     term_program = _resume_term_program()
     if term_program is not None:
         resume_command = f"TERM_PROGRAM={shlex.quote(term_program)} {resume_command}"

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -264,6 +264,21 @@ def _should_check_teardown_thread(
     return bool(thread_id)
 
 
+def _resume_term_program() -> str | None:
+    """Return a `TERM_PROGRAM` value safe to echo inside the resume hint.
+
+    Returns:
+        The environment value when it is set and fully printable, else `None`.
+        A value carrying control characters is dropped rather than stripped:
+        stripping would both write raw escape sequences into teardown output
+        and name a terminal the environment never actually contained.
+    """
+    raw = os.environ.get("TERM_PROGRAM", "").strip()
+    if not raw or not raw.isprintable():
+        return None
+    return raw
+
+
 def _render_teardown_thread_hints(
     console: "Console",
     thread_id: str,
@@ -282,6 +297,8 @@ def _render_teardown_thread_hints(
         thread_id: Thread whose checkpoints back the hints.
         return_code: Process exit code; failed sessions add a resume safety caveat.
     """
+    import shlex
+
     from rich.style import Style
     from rich.text import Text
 
@@ -318,10 +335,18 @@ def _render_teardown_thread_hints(
     console.print("[dim]Resume this thread with:[/dim]")
     # Echo the command the user actually launched (a shim or the
     # `deepagents-code` alias), not a hardcoded `dcode` they may not have.
-    hint = Text(invoked_name(), style="cyan")
-    hint.append(" -r ", style="cyan")
-    hint.append(str(thread_id), style="cyan")
-    console.print(hint)
+    resume_command = shlex.join([invoked_name(), "-r", str(thread_id)])
+    # A shell alias that exports `TERM_PROGRAM` (to select a theme, say) is
+    # invisible to `invoked_name`, since an alias does not change `argv[0]`, so
+    # the bare command would resume without it. Carry it as an env prefix to
+    # keep the line pasteable as-is. POSIX syntax is safe here: on Windows the
+    # variable is only set under POSIX shells (git-bash, WSL), while native
+    # `cmd.exe`/PowerShell leave it unset, so no prefix is emitted there.
+    term_program = _resume_term_program()
+    if term_program is not None:
+        resume_command = f"TERM_PROGRAM={shlex.quote(term_program)} {resume_command}"
+    console.print(Text(resume_command, style="cyan"))
+
     if return_code != 0:
         console.print(
             "[dim]Note: the session exited with a non-zero status. Attempting "

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 # Suppress Pydantic v1 compatibility warnings from langchain on Python 3.14+
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
 
+from deepagents_code._env_vars import LAUNCH_TERM_PROGRAM
 from deepagents_code._version import __version__
 
 logger = logging.getLogger(__name__)
@@ -267,8 +268,14 @@ def _should_check_teardown_thread(
 def _resume_term_program() -> str | None:
     """Return a `TERM_PROGRAM` value safe to echo inside the resume hint.
 
+    The value is read from `LAUNCH_TERM_PROGRAM` — the snapshot `cli_main`
+    takes at process entry — rather than live `TERM_PROGRAM`, so only a value
+    the launch environment supplied (inline prefix, terminal export, or shell
+    alias) is echoed back. A `TERM_PROGRAM` that appears later, from a project
+    or global `.env` file, never reaches the hint.
+
     Returns:
-        The environment value when it is set and fully printable, else `None`.
+        The launch-time value when it is set and fully printable, else `None`.
         A value carrying control characters is dropped rather than stripped:
         stripping would both write raw escape sequences into teardown output
         and name a terminal the environment never actually contained. Native
@@ -278,7 +285,7 @@ def _resume_term_program() -> str | None:
         as a command by `cmd.exe`/PowerShell. POSIX markers (`SHELL` from
         git-bash/MSYS, `MSYSTEM`, `WSL_DISTRO_NAME`) restore the prefix there.
     """
-    raw = os.environ.get("TERM_PROGRAM", "").strip()
+    raw = os.environ.get(LAUNCH_TERM_PROGRAM, "").strip()
     if not raw or not raw.isprintable():
         return None
     if sys.platform == "win32" and not any(
@@ -347,11 +354,13 @@ def _render_teardown_thread_hints(
     resume_command = shlex.join([invoked_name(), "-r", str(thread_id)])
     # A shell alias that exports `TERM_PROGRAM` (to select a theme, say) is
     # invisible to `invoked_name`, since an alias does not change `argv[0]`, so
-    # the bare command would resume without it. Carry it as an env prefix to
-    # keep the line pasteable as-is. The prefix uses POSIX syntax, so
-    # `_resume_term_program` withholds it on native Windows, where terminals
-    # (VS Code, WezTerm) set the variable even under `cmd.exe`/PowerShell and
-    # those shells cannot parse a `VAR=value` command prefix.
+    # the bare command would resume without it. Carry the launch-time value as
+    # an env prefix to keep the line pasteable as-is; the launch snapshot (not
+    # the live variable) is what keeps a `.env`-supplied `TERM_PROGRAM` out of
+    # the hint. The prefix uses POSIX syntax, so `_resume_term_program`
+    # withholds it on native Windows, where terminals (VS Code, WezTerm) set
+    # the variable even under `cmd.exe`/PowerShell and those shells cannot
+    # parse a `VAR=value` command prefix.
     term_program = _resume_term_program()
     if term_program is not None:
         resume_command = f"TERM_PROGRAM={shlex.quote(term_program)} {resume_command}"
@@ -4230,6 +4239,14 @@ def cli_main() -> None:
     # https://github.com/grpc/grpc/issues/37642
     if sys.platform == "darwin":
         os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "0"
+
+    # Snapshot `TERM_PROGRAM` before settings bootstrap loads any `.env` file,
+    # so the resume hint echoes the variable only when the launch environment
+    # (inline prefix, terminal export, or shell alias) supplied it. The app
+    # itself never sets `TERM_PROGRAM`, and the update re-exec inherits this
+    # sentinel, so a set value here always marks an explicit launch value.
+    if "TERM_PROGRAM" in os.environ and LAUNCH_TERM_PROGRAM not in os.environ:
+        os.environ[LAUNCH_TERM_PROGRAM] = os.environ["TERM_PROGRAM"]
 
     # Note: LANGSMITH_PROJECT override is handled lazily by config.py's
     # _ensure_bootstrap() (triggered on first access of `settings`).

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2615,6 +2615,17 @@ class TestCacheStatus:
             input_tokens=1_500,
         )
 
+    def test_refresh_swallows_uncomposed_status_bar(self) -> None:
+        """A usage update racing `/reload` compose/teardown must not raise."""
+        app = DeepAgentsApp(thread_id="thread-123")
+        app._status_bar = MagicMock()
+        app._status_bar.query_one.side_effect = NoMatches(
+            "No nodes match '#cache-display'"
+        )
+
+        # Should not raise despite the status bar lacking `#cache-display`.
+        app._refresh_cache_display()
+
 
 class TestThreadCachePrewarm:
     """Tests for startup thread-cache prewarming."""

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -1871,6 +1871,7 @@ class TestRenderTeardownThreadHints:
         thread_url: str | None,
         return_code: int = 0,
         launch_name: str = "dcode",
+        term_program: str = "",
     ) -> str:
         """Render the hints with patched dependencies, returning the output."""
         buffer = StringIO()
@@ -1883,7 +1884,13 @@ class TestRenderTeardownThreadHints:
                 "deepagents_code.config.build_langsmith_thread_url",
                 return_value=thread_url,
             ),
-            patch.dict(os.environ, {INVOKED_AS: launch_name}),
+            # Always set explicitly: an ambient `TERM_PROGRAM` from the
+            # developer's or CI runner's shell would otherwise leak into the
+            # rendered command and flake the assertions here.
+            patch.dict(
+                os.environ,
+                {INVOKED_AS: launch_name, "TERM_PROGRAM": term_program},
+            ),
         ):
             _render_teardown_thread_hints(console, "test123", return_code=return_code)
         return buffer.getvalue()
@@ -1917,6 +1924,77 @@ class TestRenderTeardownThreadHints:
 
         assert "abc -r test123" in output
         assert "dcode" not in output
+
+    @pytest.mark.parametrize("return_code", [0, 1])
+    def test_resume_hint_carries_term_program(self, return_code: int) -> None:
+        """A set `TERM_PROGRAM` rides along as an env prefix on the command.
+
+        A shell alias that exports the variable cannot be recovered from
+        `argv[0]`, so pasting a bare `dcode -r ...` would drop it (and with it
+        anything keyed off it, such as theme selection).
+        """
+        thread_exists_mock = AsyncMock(return_value=True)
+
+        output = self._render(
+            thread_exists_mock=thread_exists_mock,
+            thread_url=None,
+            return_code=return_code,
+            term_program="WezTerm",
+        )
+
+        assert "TERM_PROGRAM=WezTerm dcode -r test123" in output
+
+    def test_resume_hint_omits_prefix_when_term_program_unset(self) -> None:
+        """An unset `TERM_PROGRAM` leaves the command bare, with no empty prefix."""
+        thread_exists_mock = AsyncMock(return_value=True)
+
+        output = self._render(thread_exists_mock=thread_exists_mock, thread_url=None)
+
+        assert "dcode -r test123" in output
+        assert "TERM_PROGRAM" not in output
+
+    @pytest.mark.parametrize("term_program", ["   ", "\t"])
+    def test_resume_hint_omits_blank_term_program(self, term_program: str) -> None:
+        """A whitespace-only value is treated as unset, matching other readers."""
+        thread_exists_mock = AsyncMock(return_value=True)
+
+        output = self._render(
+            thread_exists_mock=thread_exists_mock,
+            thread_url=None,
+            term_program=term_program,
+        )
+
+        assert "TERM_PROGRAM" not in output
+
+    def test_resume_hint_quotes_term_program_needing_quotes(self) -> None:
+        """A value the shell would split is quoted, keeping the line pasteable."""
+        thread_exists_mock = AsyncMock(return_value=True)
+
+        output = self._render(
+            thread_exists_mock=thread_exists_mock,
+            thread_url=None,
+            term_program="Wez Term&whoami",
+        )
+
+        assert "TERM_PROGRAM='Wez Term&whoami' dcode -r test123" in output
+
+    def test_resume_hint_drops_term_program_with_control_characters(self) -> None:
+        """Terminal metadata cannot inject control sequences into teardown output.
+
+        The value is dropped rather than stripped: a stripped value would name a
+        terminal the environment never contained.
+        """
+        thread_exists_mock = AsyncMock(return_value=True)
+
+        output = self._render(
+            thread_exists_mock=thread_exists_mock,
+            thread_url=None,
+            term_program="Wez\x1b\nTerm",
+        )
+
+        assert "TERM_PROGRAM" not in output
+        assert "\x1b" not in output
+        assert "dcode -r test123" in output
 
     def test_prints_langsmith_link_when_available(self) -> None:
         """A configured LangSmith URL is shown alongside the resume hint."""

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -1891,6 +1891,9 @@ class TestRenderTeardownThreadHints:
                 os.environ,
                 {INVOKED_AS: launch_name, "TERM_PROGRAM": term_program},
             ),
+            # These cases describe POSIX behavior; pin the platform so they do
+            # not take the native-Windows path when run on a Windows machine.
+            patch.object(sys, "platform", "darwin"),
         ):
             _render_teardown_thread_hints(console, "test123", return_code=return_code)
         return buffer.getvalue()
@@ -1995,6 +1998,65 @@ class TestRenderTeardownThreadHints:
         assert "TERM_PROGRAM" not in output
         assert "\x1b" not in output
         assert "dcode -r test123" in output
+
+    def _render_on_platform(
+        self,
+        platform: str,
+        *,
+        extra_env: dict[str, str] | None = None,
+    ) -> str:
+        """Render the resume hint as if running on `platform`.
+
+        `patch.dict` only merges, so POSIX markers the developer's own shell
+        exports (`SHELL`, at minimum) are deleted first to make the simulated
+        native Windows environment hermetic.
+        """
+        thread_exists_mock = AsyncMock(return_value=True)
+        buffer = StringIO()
+        console = Console(file=buffer, width=200)
+        invoked_name.cache_clear()
+        env = {INVOKED_AS: "dcode", "TERM_PROGRAM": "vscode", **(extra_env or {})}
+        with (
+            patch("deepagents_code.sessions.thread_exists", thread_exists_mock),
+            patch(
+                "deepagents_code.config.build_langsmith_thread_url",
+                return_value=None,
+            ),
+            patch.object(sys, "platform", platform),
+            patch.dict(os.environ, env),
+        ):
+            for marker in ("SHELL", "MSYSTEM", "WSL_DISTRO_NAME"):
+                if marker not in env:
+                    os.environ.pop(marker, None)
+            _render_teardown_thread_hints(console, "test123", return_code=0)
+        return buffer.getvalue()
+
+    def test_resume_hint_omits_prefix_on_native_windows(self) -> None:
+        """Native `cmd.exe`/PowerShell cannot parse a POSIX `VAR=value` prefix.
+
+        VS Code and WezTerm set `TERM_PROGRAM` on every platform, so its
+        presence under `win32` says nothing about the user's shell.
+        """
+        output = self._render_on_platform("win32")
+
+        assert "TERM_PROGRAM" not in output
+        assert "dcode -r test123" in output
+
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            {"SHELL": "C:\\Program Files\\Git\\bin\\bash.exe"},
+            {"MSYSTEM": "MINGW64"},
+            {"WSL_DISTRO_NAME": "Ubuntu"},
+        ],
+    )
+    def test_resume_hint_keeps_prefix_on_windows_posix_shells(
+        self, marker: dict[str, str]
+    ) -> None:
+        """git-bash/MSYS/WSL expose POSIX markers, so the prefix is valid there."""
+        output = self._render_on_platform("win32", extra_env=marker)
+
+        assert "TERM_PROGRAM=vscode dcode -r test123" in output
 
     def test_prints_langsmith_link_when_available(self) -> None:
         """A configured LangSmith URL is shown alongside the resume hint."""

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -18,7 +18,7 @@ from rich.console import Console
 if TYPE_CHECKING:
     from prompt_toolkit.layout import Layout
 
-from deepagents_code._env_vars import INVOKED_AS
+from deepagents_code._env_vars import INVOKED_AS, LAUNCH_TERM_PROGRAM
 from deepagents_code._invocation import invoked_name
 from deepagents_code.app import (
     AppResult,
@@ -1535,6 +1535,51 @@ class TestStartupAutoUpdate:
         assert "Aborted; no project MCP servers loaded" in capsys.readouterr().err
 
 
+class TestLaunchTermProgramSnapshot:
+    """`cli_main` records launch-time `TERM_PROGRAM` for the resume hint."""
+
+    def _run_cli_main(self) -> None:
+        """Run `cli_main` through its early exit, past the snapshot."""
+        with (
+            patch.object(sys, "argv", ["dcode", "--version"]),
+            pytest.raises(SystemExit),
+        ):
+            cli_main()
+
+    def test_snapshots_launch_term_program(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `TERM_PROGRAM` present at entry is recorded for the resume hint."""
+        monkeypatch.setenv("TERM_PROGRAM", "WezTerm")
+        monkeypatch.delenv(LAUNCH_TERM_PROGRAM, raising=False)
+
+        self._run_cli_main()
+
+        assert os.environ[LAUNCH_TERM_PROGRAM] == "WezTerm"
+
+    def test_skips_snapshot_when_term_program_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without a launch `TERM_PROGRAM` no sentinel is written."""
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+        monkeypatch.delenv(LAUNCH_TERM_PROGRAM, raising=False)
+
+        self._run_cli_main()
+
+        assert LAUNCH_TERM_PROGRAM not in os.environ
+
+    def test_inherited_snapshot_wins_over_launch_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The update re-exec's inherited sentinel is not overwritten."""
+        monkeypatch.setenv("TERM_PROGRAM", "WezTerm")
+        monkeypatch.setenv(LAUNCH_TERM_PROGRAM, "iTerm.app")
+
+        self._run_cli_main()
+
+        assert os.environ[LAUNCH_TERM_PROGRAM] == "iTerm.app"
+
+
 class TestAutoUpdateDefaultMigration:
     """First-run consent/migration notice for the auto-update opt-out default."""
 
@@ -1872,29 +1917,40 @@ class TestRenderTeardownThreadHints:
         return_code: int = 0,
         launch_name: str = "dcode",
         term_program: str = "",
+        launch_term_program: str | None = None,
     ) -> str:
-        """Render the hints with patched dependencies, returning the output."""
+        """Render the hints with patched dependencies, returning the output.
+
+        `term_program` is the live variable; `launch_term_program` is the
+        launch snapshot the hint actually reads. Passing only `term_program`
+        exercises the no-snapshot path (hint stays bare); passing both
+        exercises the launch-time-carry path.
+        """
         buffer = StringIO()
         console = Console(file=buffer, width=200)
         # `launch_name` is resolved (and cached) inside the renderer.
         invoked_name.cache_clear()
+        env = {INVOKED_AS: launch_name, "TERM_PROGRAM": term_program}
+        if launch_term_program is not None:
+            env[LAUNCH_TERM_PROGRAM] = launch_term_program
         with (
             patch("deepagents_code.sessions.thread_exists", thread_exists_mock),
             patch(
                 "deepagents_code.config.build_langsmith_thread_url",
                 return_value=thread_url,
             ),
-            # Always set explicitly: an ambient `TERM_PROGRAM` from the
-            # developer's or CI runner's shell would otherwise leak into the
-            # rendered command and flake the assertions here.
-            patch.dict(
-                os.environ,
-                {INVOKED_AS: launch_name, "TERM_PROGRAM": term_program},
-            ),
+            # Always set explicitly: an ambient `TERM_PROGRAM` or launch
+            # snapshot from the developer's or CI runner's shell would
+            # otherwise leak into the rendered command and flake assertions.
+            patch.dict(os.environ, env),
             # These cases describe POSIX behavior; pin the platform so they do
             # not take the native-Windows path when run on a Windows machine.
             patch.object(sys, "platform", "darwin"),
         ):
+            # `patch.dict` only merges, so drop an inherited launch snapshot
+            # when the case wants no snapshot at all.
+            if launch_term_program is None:
+                os.environ.pop(LAUNCH_TERM_PROGRAM, None)
             _render_teardown_thread_hints(console, "test123", return_code=return_code)
         return buffer.getvalue()
 
@@ -1930,7 +1986,7 @@ class TestRenderTeardownThreadHints:
 
     @pytest.mark.parametrize("return_code", [0, 1])
     def test_resume_hint_carries_term_program(self, return_code: int) -> None:
-        """A set `TERM_PROGRAM` rides along as an env prefix on the command.
+        """A launch-time `TERM_PROGRAM` rides along as an env prefix.
 
         A shell alias that exports the variable cannot be recovered from
         `argv[0]`, so pasting a bare `dcode -r ...` would drop it (and with it
@@ -1943,9 +1999,23 @@ class TestRenderTeardownThreadHints:
             thread_url=None,
             return_code=return_code,
             term_program="WezTerm",
+            launch_term_program="WezTerm",
         )
 
         assert "TERM_PROGRAM=WezTerm dcode -r test123" in output
+
+    def test_resume_hint_omits_term_program_without_launch_snapshot(self) -> None:
+        """A `TERM_PROGRAM` set only after launch (a `.env` file) stays out."""
+        thread_exists_mock = AsyncMock(return_value=True)
+
+        output = self._render(
+            thread_exists_mock=thread_exists_mock,
+            thread_url=None,
+            term_program="WezTerm",
+        )
+
+        assert "TERM_PROGRAM" not in output
+        assert "dcode -r test123" in output
 
     def test_resume_hint_omits_prefix_when_term_program_unset(self) -> None:
         """An unset `TERM_PROGRAM` leaves the command bare, with no empty prefix."""
@@ -1965,6 +2035,7 @@ class TestRenderTeardownThreadHints:
             thread_exists_mock=thread_exists_mock,
             thread_url=None,
             term_program=term_program,
+            launch_term_program=term_program,
         )
 
         assert "TERM_PROGRAM" not in output
@@ -1977,6 +2048,7 @@ class TestRenderTeardownThreadHints:
             thread_exists_mock=thread_exists_mock,
             thread_url=None,
             term_program="Wez Term&whoami",
+            launch_term_program="Wez Term&whoami",
         )
 
         assert "TERM_PROGRAM='Wez Term&whoami' dcode -r test123" in output
@@ -1993,6 +2065,7 @@ class TestRenderTeardownThreadHints:
             thread_exists_mock=thread_exists_mock,
             thread_url=None,
             term_program="Wez\x1b\nTerm",
+            launch_term_program="Wez\x1b\nTerm",
         )
 
         assert "TERM_PROGRAM" not in output
@@ -2015,7 +2088,12 @@ class TestRenderTeardownThreadHints:
         buffer = StringIO()
         console = Console(file=buffer, width=200)
         invoked_name.cache_clear()
-        env = {INVOKED_AS: "dcode", "TERM_PROGRAM": "vscode", **(extra_env or {})}
+        env = {
+            INVOKED_AS: "dcode",
+            "TERM_PROGRAM": "vscode",
+            LAUNCH_TERM_PROGRAM: "vscode",
+            **(extra_env or {}),
+        }
         with (
             patch("deepagents_code.sessions.thread_exists", thread_exists_mock),
             patch(

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -924,7 +924,10 @@ class TestToolCallMessageDuration:
         async with app.run_test() as pilot:
             await pilot.pause()
             app.msg.set_running()
-            app.msg._start_time -= 5  # ty: ignore
+            # 4.9 keeps the faked elapsed off the `.05` rounding boundary: the
+            # wall clock keeps running between the subtraction and
+            # `set_success`, so an exact `-5` can render as `5.1s`.
+            app.msg._start_time -= 4.9  # ty: ignore
             app.msg.set_success("done")
             await pilot.pause()
 
@@ -933,7 +936,7 @@ class TestToolCallMessageDuration:
             assert status.display is True
             content = status._Static__content  # ty: ignore
             assert isinstance(content, Content)
-            assert content.plain == "Took 5s"
+            assert content.plain == "Took 4.9s"
 
     async def test_execute_shows_fractional_seconds(self) -> None:
         """Sub-minute `execute` runs report tenths — `elapsed` is a float.


### PR DESCRIPTION
The teardown resume hint prints a pasteable command for getting back into a thread. A shell alias that exports `TERM_PROGRAM` cannot be recovered from `argv[0]`, so the printed command drops it — along with anything keyed off it, such as conditional theme selection. Pasting the hint gets you the thread back, but not the environment it was launched in.

The variable now rides along as an env prefix when the launch environment supplied it (an inline `TERM_PROGRAM=x dcode`, a terminal's own export, or a shell alias):

```
Resume this thread with:
TERM_PROGRAM=WezTerm dcode -r a1b2c3
```

The value is snapshotted at process entry, so a `TERM_PROGRAM` that appears only later — from a project or global `.env` file — is not echoed back. The value is shell-quoted, so a terminal name containing spaces or shell metacharacters cannot change what the pasted line does. A value containing control characters is omitted rather than stripped: stripping would both write raw escape sequences into teardown output and name a terminal the environment never actually contained.

The prefix uses POSIX syntax, so it is withheld on native Windows even when the variable is set — VS Code and WezTerm set `TERM_PROGRAM` on every platform, and `cmd.exe`/PowerShell cannot parse a `VAR=value` command prefix. POSIX markers (`SHELL`, `MSYSTEM`, `WSL_DISTRO_NAME`) restore the prefix under git-bash/MSYS/WSL.