### PR TITLE
feat(infra): warn and close draft PRs on the same age-based schedule

### DIFF
--- a/.github/scripts/labeling/close-old-prs.js
+++ b/.github/scripts/labeling/close-old-prs.js
@@ -8,12 +8,13 @@ const DEFAULT_PENDING_DELETION_LABEL = 'pending-deletion';
 // this workflow has — is meaningless for them by construction.
 //
 // When the exemption actually fires: release PRs open as drafts
-// (`draft-pull-request: true` in release-please-config.json), and the
-// `draft:false` search plus the draft skip in processPr already exclude them
-// for most of their life. This exemption covers the ready-for-review window
-// between the curated-notes step and merge — narrow, but that is exactly
-// where #4297 was warned at 33 days old. Expect skippedRelease to read 0 on
-// most runs; a sustained 0 is not evidence the exemption is dead code.
+// (`draft-pull-request: true` in release-please-config.json) and stay drafts
+// for most of their life, and drafts go through the same warn/close schedule
+// as every other PR — so this provenance check is their only protection, on
+// every run from the day they open. skippedRelease reading non-zero is
+// expected whenever a release PR is still a draft past warningDays; a
+// sustained 0 means no release PR is currently old enough to warn, not that
+// the exemption is dead code.
 //
 // These labels do NOT gate the exemption — provenance does (see isReleasePr).
 // They are only a drift signal, matched to tell "a genuine release PR whose
@@ -391,7 +392,6 @@ async function getLivePr({ github, owner, repo, number }) {
     authorLogin: pr.user?.login,
     authorType: pr.user?.type,
     createdAt: pr.created_at,
-    draft: pr.draft === true,
     headRef: pr.head?.ref,
     headRepo: pr.head?.repo?.full_name,
     labels: labelNames(pr.labels ?? []),
@@ -452,7 +452,7 @@ async function refreshLabelsUnlessBypassed({
 }
 
 async function searchOpenPrs({ github, owner, repo, maxItems, core }) {
-  const query = `repo:${owner}/${repo} is:pr is:open draft:false`;
+  const query = `repo:${owner}/${repo} is:pr is:open`;
   const items = [];
   let incomplete = false;
   try {
@@ -510,9 +510,8 @@ async function processPr({
     return 'skipped';
   }
 
-  // Re-fetch before mutating: state, draft, and labels can all change between
-  // the search and now (the PR may have been closed, or gained the bypass
-  // label / a maintainer may have marked it draft).
+  // Re-fetch before mutating: state and labels can change between the search
+  // and now (the PR may have been closed or gained the bypass label).
   let live;
   try {
     live = await getLivePr({ github, owner, repo, number });
@@ -536,18 +535,6 @@ async function processPr({
       existingLabels: live.labels,
     });
     core.info(`PR #${number} is no longer open; skipping`);
-    return 'skipped';
-  }
-  if (live.draft) {
-    await removeIssueLabel({
-      github,
-      owner,
-      repo,
-      issueNumber: number,
-      name: pendingDeletionLabel,
-      existingLabels: live.labels,
-    });
-    core.info(`PR #${number} is a draft; skipping`);
     return 'skipped';
   }
   if (isReleasePr(live, { owner, repo, core, number })) {
@@ -619,7 +606,7 @@ async function processPr({
     if (labels === null) return 'skippedRaced';
 
     // Apply at warning time so the PR is filterable until it stops being a
-    // close candidate (closed, draft, release, or bypassed).
+    // close candidate (closed, release, or bypassed).
     await ensureIssueLabel({
       github,
       owner,
@@ -716,17 +703,16 @@ async function processPr({
   return 'skipped';
 }
 
-// The primary open-PR search omits drafts (`draft:false`) and closed PRs, so a
-// separate label query is needed to clear pending-deletion after those
-// transitions (or after a manual close).
+// The primary open-PR search omits closed PRs, so a separate label query is
+// needed to clear pending-deletion after a PR is closed (manually or
+// otherwise) without the main scan seeing it.
 //
 // The `stale` expression below mirrors processPr's *label-clearing*
-// exemptions, including the release check, even though an open non-draft
-// release PR is also handled there. The duplication earns its place because
-// processPr never sees PRs past the maxItems cap or dropped by a partial
-// search failure, and because letting the two exemption sets drift is how a PR
-// ends up skipped by one path while keeping a pending-deletion label applied
-// by the other.
+// exemptions, including the release check, even though an open release PR is
+// also handled there. The duplication earns its place because processPr never
+// sees PRs past the maxItems cap or dropped by a partial search failure, and
+// because letting the two exemption sets drift is how a PR ends up skipped by
+// one path while keeping a pending-deletion label applied by the other.
 //
 // processPr's age skip is deliberately not mirrored: age only increases, and
 // pending-deletion is applied at warning time, so a labeled PR can never
@@ -782,7 +768,6 @@ async function sweepStalePendingDeletionLabels({
         }
 
         const stale = live.state !== 'open'
-          || live.draft
           || isReleasePr(live, { owner, repo, core, number: item.number, warnOnAnomaly: false })
           || live.labels.includes(bypassLabel);
         if (!stale) continue;
@@ -872,9 +857,11 @@ async function run({ github, context, core, options = {} }) {
   // `skipped` stays the total across every skip reason; `skippedRelease` is a
   // sub-count so an exemption that starts over-applying (a spoofing vector, or
   // a loosened provenance check making PRs immortal) is visible as a jump in
-  // one number rather than hidden among young/draft/closed/bypassed PRs.
-  // Because release PRs are drafts for most of their life, this normally reads
-  // 0 — see RELEASE_LABELS.
+  // one number rather than hidden among young/closed/bypassed PRs. It reads
+  // non-zero whenever an open release PR is past warningDays — the common case
+  // now that drafts are swept, since release PRs stay drafts for most of
+  // their life — so a non-zero value is expected, not an anomaly; see
+  // RELEASE_LABELS.
   const summary = {
     checked: 0,
     warned: 0,

--- a/.github/scripts/tests/labeling/close-old-prs.test.js
+++ b/.github/scripts/tests/labeling/close-old-prs.test.js
@@ -295,9 +295,11 @@ test('the release branch prefix matches release-please-config.json', () => {
     RELEASE_PLEASE_BRANCH_PREFIX, 'release-please--branches--main--components--',
   );
 
-  // The exemption only ever fires in the ready-for-review window because
-  // release PRs open as drafts and drafts are skipped earlier. If this flips,
-  // the exemption becomes load-bearing for a release PR's whole life.
+  // Drafts are warned and closed like any other PR, so if release PRs ever
+  // stop opening as drafts nothing here breaks: the provenance check above is
+  // their only protection either way. This pin keeps the "stay drafts for
+  // most of their life" assumption the comments in close-old-prs.js make
+  // verifiable against the config.
   assert.equal(
     config['draft-pull-request'], true,
     'release PRs are expected to open as drafts',
@@ -503,6 +505,7 @@ test('warns after 14 days and closes after 30 days from opening', async () => {
   const live = new Map([
     [102, { labels: ['pending-deletion'] }],
     [103, { labels: ['do-not-close'] }],
+    // Drafts get no exemption: #104 is warned like any other 30-day-old PR.
     [104, { draft: true }],
   ]);
   const { github, calls } = makeGithub({
@@ -520,17 +523,19 @@ test('warns after 14 days and closes after 30 days from opening', async () => {
   const summary = await run({ github, context, core, options: { now } });
 
   assert.deepEqual(summary, {
-    checked: 4, warned: 1, closed: 1, skipped: 2, skippedRelease: 0,
+    checked: 4, warned: 2, closed: 1, skipped: 1, skippedRelease: 0,
     skippedRaced: 0,
     staleCleared: 0, sweepNotFound: 0, sweepTruncated: false, sweepFailure: null,
     incomplete: false, truncated: false, errors: [],
   });
-  assert.equal(calls.createComment.length, 1);
+  assert.equal(calls.createComment.length, 2);
   assert.equal(calls.createComment[0].issue_number, 101);
+  assert.equal(calls.createComment[1].issue_number, 104);
   assert.match(calls.createComment[0].body, /open for at least 14 days/);
+  assert.match(calls.createComment[1].body, /open for at least 14 days/);
   assert.deepEqual(
     calls.addLabels.map(call => [call.issue_number, call.labels]),
-    [[101, ['pending-deletion']]],
+    [[101, ['pending-deletion']], [104, ['pending-deletion']]],
   );
   assert.equal(calls.updateComment.length, 1);
   assert.equal(calls.updateComment[0].comment_id, 77);
@@ -1064,7 +1069,7 @@ test('sweep counts and logs PRs that vanished before it read them', async () => 
 test('sweep does not count a PR whose label is already gone', async () => {
   const { github, calls } = makeGithub({
     labeledItems: [{ number: 112, created_at: '2026-04-01T00:00:00Z' }],
-    live: new Map([[112, { draft: true, labels: [] }]]),
+    live: new Map([[112, { labels: [] }]]),
   });
   const core = makeCore();
 
@@ -1472,24 +1477,53 @@ test('removes pending-deletion when a PR gains do-not-close', async () => {
   assert.deepEqual(calls.close, []);
 });
 
-test('removes pending-deletion when a PR becomes a draft', async () => {
+test('warns a draft PR past the warning threshold', async () => {
   const { github, calls } = makeGithub({
     items: [{ number: 322, created_at: '2026-04-23T00:00:00Z' }],
-    live: new Map([[322, { draft: true, labels: ['pending-deletion'] }]]),
+    live: new Map([[322, { draft: true, labels: [] }]]),
   });
 
   const summary = await run({ github, context, core: makeCore(), options: { now } });
 
-  assert.equal(summary.skipped, 1);
-  assert.deepEqual(calls.removeLabel, [{
+  assert.equal(summary.warned, 1);
+  assert.equal(summary.skipped, 0);
+  assert.equal(calls.createComment.length, 1);
+  assert.equal(calls.createComment[0].issue_number, 322);
+  assert.match(calls.createComment[0].body, /open for at least 14 days/);
+  assert.deepEqual(calls.addLabels, [{
     owner: 'langchain-ai',
     repo: 'deepagents',
     issue_number: 322,
+    labels: ['pending-deletion'],
+  }]);
+  assert.deepEqual(calls.close, []);
+});
+
+test('closes a draft PR past the close threshold with an old-enough warning', async () => {
+  const comments = new Map([
+    [323, [{ id: 96, body: `${COMMENT_MARKER}\nwarning`, user: workflowBot }]],
+  ]);
+  const { github, calls } = makeGithub({
+    items: [{ number: 323, created_at: '2026-04-01T00:00:00Z' }],
+    comments,
+    live: new Map([[323, { draft: true, labels: ['pending-deletion'] }]]),
+  });
+
+  const summary = await run({ github, context, core: makeCore(), options: { now } });
+
+  assert.equal(summary.closed, 1);
+  assert.deepEqual(calls.close, [323]);
+  assert.equal(calls.createComment.length, 0);
+  assert.match(calls.updateComment[0].body, /open for at least 30 days/);
+  assert.deepEqual(calls.removeLabel, [{
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    issue_number: 323,
     name: 'pending-deletion',
   }]);
 });
 
-test('sweep clears pending-deletion on closed or draft PRs missed by open search', async () => {
+test('sweep clears pending-deletion on closed PRs missed by open search', async () => {
   const { github, calls } = makeGithub({
     items: [],
     labeledItems: [
@@ -1499,6 +1533,7 @@ test('sweep clears pending-deletion on closed or draft PRs missed by open search
     ],
     live: new Map([
       [330, { state: 'closed', labels: ['pending-deletion'] }],
+      // A draft is still a close candidate, so its label is not stale.
       [331, { draft: true, labels: ['pending-deletion'] }],
       [332, { labels: ['pending-deletion'] }],
     ]),
@@ -1506,12 +1541,13 @@ test('sweep clears pending-deletion on closed or draft PRs missed by open search
 
   const summary = await run({ github, context, core: makeCore(), options: { now } });
 
-  assert.equal(summary.staleCleared, 2);
+  assert.equal(summary.staleCleared, 1);
   assert.deepEqual(
-    calls.removeLabel.map(call => call.issue_number).sort((a, b) => a - b),
-    [330, 331],
+    calls.removeLabel.map(call => call.issue_number),
+    [330],
   );
-  // Still-open non-exempt PRs keep the label.
+  // Still-open non-exempt PRs — drafts included — keep the label.
+  assert.ok(!calls.removeLabel.some(call => call.issue_number === 331));
   assert.ok(!calls.removeLabel.some(call => call.issue_number === 332));
 });
 
@@ -1620,11 +1656,11 @@ test('honors maxItems truncation', async () => {
   assert.equal(core.failed, null);
 });
 
-test('uses all non-draft open PRs and rejects invalid thresholds', async () => {
+test('uses all open PRs and rejects invalid thresholds', async () => {
   const { github, calls } = makeGithub();
   await run({ github, context, core: makeCore(), options: { now } });
 
-  assert.equal(calls.queries[0].q, 'repo:langchain-ai/deepagents is:pr is:open draft:false');
+  assert.equal(calls.queries[0].q, 'repo:langchain-ai/deepagents is:pr is:open');
   assert.equal(calls.queries[0].sort, 'created');
   assert.equal(calls.queries[0].order, 'asc');
 

--- a/.github/workflows/close_old_prs.yml
+++ b/.github/workflows/close_old_prs.yml
@@ -1,7 +1,7 @@
 # Warn on open PRs after 14 days and close them after 30 days, measured from
 # when the PR was opened (by age, not last activity). The warning also applies
-# a "pending-deletion" label. Skipped: draft PRs, PRs with the "do-not-close"
-# label, and release-please PRs (opened by "github-actions[bot]" on a
+# a "pending-deletion" label. Skipped: PRs with the "do-not-close" label, and
+# release-please PRs (opened by "github-actions[bot]" on a
 # release-please--branches--main--components--<pkg> branch in this repository —
 # identified by that provenance alone, not by any label). The "do-not-close"
 # label can also be applied by commenting `!keep-open` — see


### PR DESCRIPTION
Draft PRs now get the same treatment as all other PRs: a warning at 14 days, closure at 30 days. Only `do-not-close` (or a `!keep-open` comment) and release-please PRs are exempt.