### PR TITLE
fix(code): hide empty previous-thread hints

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -272,7 +272,27 @@ reason.
 _SERVER_OUTPUT_MESSAGE_TYPES: frozenset[MessageType] = frozenset(
     {MessageType.ASSISTANT, MessageType.TOOL, MessageType.SKILL}
 )
-"""Message types proving a thread contains server-backed output."""
+"""Message types marking a thread the user did conversational work in.
+
+Read via `_store_has_server_output` to decide whether a thread is worth
+offering a way back to. `USER` alone is not enough: local-only flows
+(`/update`, `!shell`, most slash commands) mount a `UserMessage` widget
+without ever invoking the server.
+
+This is deliberately *stricter* than "has a resumable checkpoint row".
+Non-conversational commands (`/goal`, `/rubric set`) persist thread state
+through `aupdate_state`, and merely registering a thread in server mode
+(`aensure_thread`) writes a row too, so `thread_exists` alone reports a
+brand-new thread as resumable. Threads holding only that state are
+intentionally treated as "nothing happened here" — `/rubric set` with no
+conversation is a config tweak, not work left behind.
+
+`SKILL` is the loosest member: `SkillMessage` mounts just *before*
+`_send_to_agent`, which can bail out without reaching the server, so a
+`SKILL` row means a turn was attempted rather than completed. That
+direction is safe — it only over-offers a hint that
+`_mount_previous_thread_hint` still validates against the checkpoint store.
+"""
 
 
 def _message_timestamp_footer_id(message_id: str) -> str:
@@ -14193,6 +14213,10 @@ class DeepAgentsApp(App):
 
             if cmd == "/force-clear":
                 self._force_interrupt_active_work()
+            # Sample before `_clear_messages` below empties the store: this
+            # describes the thread being left, not the fresh one. See
+            # `_store_has_server_output`.
+            outgoing_had_agent_output = self._store_has_server_output()
             await _wait_for_session_end(
                 self._hooks.on_session_end(SessionEndCause.CLEAR)
             )
@@ -14235,7 +14259,8 @@ class DeepAgentsApp(App):
                     thread_id=new_thread_id,
                 )
                 await self._mount_previous_thread_hint(
-                    self._session_state.previous_thread_id
+                    self._session_state.previous_thread_id,
+                    had_agent_output=outgoing_had_agent_output,
                 )
                 await self._reload_hooks()
                 if not await self._run_session_start_hook(SessionStartCause.CLEAR):
@@ -17243,16 +17268,46 @@ class DeepAgentsApp(App):
             exclusive=False,
         )
 
-    async def _mount_previous_thread_hint(self, previous_thread_id: str | None) -> bool:
+    def _store_has_server_output(self) -> bool:
+        """Return whether the live message store holds server-backed output.
+
+        Feeds `_mount_previous_thread_hint`'s `had_agent_output` gate; see
+        `_SERVER_OUTPUT_MESSAGE_TYPES` for why `USER` rows do not count.
+
+        Callers must read this *before* `_clear_messages` empties the store —
+        it describes the thread being left, not the one being loaded. Every
+        current caller snapshots it into a local at the top of its handler for
+        that reason; moving the read down next to its use would make the gate
+        permanently `False`.
+
+        Returns:
+            `True` when the store holds at least one message type implying the
+            user did conversational work in this thread.
+        """
+        return any(
+            msg.type in _SERVER_OUTPUT_MESSAGE_TYPES
+            for msg in self._message_store.get_all_messages()
+        )
+
+    async def _mount_previous_thread_hint(
+        self,
+        previous_thread_id: str | None,
+        *,
+        had_agent_output: bool,
+    ) -> bool:
         """Point the user back at the thread the session just left.
 
         Shared by every path that moves the session off a thread: `/clear`,
         `/force-clear`, a mid-session thread switch, and both agent swaps.
 
-        The hint is suppressed wherever `/threads -r` would dead-end: threads
-        with no checkpoint row (`-r` can't resume them), threads whose owning
-        agent can't be determined, and cross-agent threads on remote-server
-        sessions, which cannot perform the agent restart `-r` would need. The
+        The hint is suppressed in two situations. First, where `/threads -r`
+        would dead-end: threads with no checkpoint row (`-r` can't resume
+        them), threads whose owning agent can't be determined, and cross-agent
+        threads on remote-server sessions, which cannot perform the agent
+        restart `-r` would need. Second, where the thread holds no
+        conversational work to return to (`had_agent_output`) — a checkpoint
+        row alone is too weak a signal, since `/clear` plus a server-mode
+        thread registration produces one for a thread the user never used. The
         return value lets callers fall back to a heavier remedy — the agent
         swap offers a relaunch command — when `-r` can't reach the thread.
 
@@ -17260,12 +17315,30 @@ class DeepAgentsApp(App):
             previous_thread_id: The thread the session left. Tolerates `None`
                 by mounting nothing, since the underlying field is nullable
                 before the first reset; all current callers pass a real id.
+            had_agent_output: Whether that thread saw server-backed output,
+                from `_store_has_server_output` read before the store was
+                cleared. Keyword-only and required so a new caller has to
+                decide when to sample it rather than inherit a wrong default.
 
         Returns:
             `True` when a hint was mounted, `False` when it was suppressed or
             could not be rendered.
         """
         if not previous_thread_id:
+            return False
+
+        if not had_agent_output:
+            # `info`, not `debug`, for the same reason as the store-failure
+            # branch below: the always-on ring buffer behind the Debug Console
+            # captures INFO and above, and at `debug` a vanished hint leaves no
+            # trace. Deliberately does not report a store count — by the time
+            # `_resume_thread` reaches here the store holds the *incoming*
+            # thread's history, so any count would describe the wrong thread.
+            logger.info(
+                "Suppressing previous-thread hint for %s: no server-backed "
+                "output was recorded in it",
+                previous_thread_id,
+            )
             return False
 
         import sqlite3
@@ -21358,15 +21431,9 @@ class DeepAgentsApp(App):
             self._session_state.approval_mode_key if self._session_state else None
         )
         # Only offer a resume hint if the previous thread produced agent-side
-        # output. `USER` alone is not enough: local-only flows (`/update`,
-        # `!shell`, most slash commands) mount a `UserMessage` widget without
-        # ever invoking the server, so no checkpoint exists and `-r <thread>`
-        # would fail. `ASSISTANT` / `TOOL` / `SKILL` entries only land in the
-        # store after a server round-trip, which implies a checkpoint row.
-        previous_thread_has_agent_output = any(
-            msg.type in _SERVER_OUTPUT_MESSAGE_TYPES
-            for msg in self._message_store.get_all_messages()
-        )
+        # output; see `_SERVER_OUTPUT_MESSAGE_TYPES`. Sampled here, before the
+        # Phase 1 teardown below clears the store.
+        previous_thread_has_agent_output = self._store_has_server_output()
         server_proc = self._server_proc
         if server_proc is None:
             # Guarded in _switch_agent, but the worker runs in the next tick
@@ -21674,7 +21741,10 @@ class DeepAgentsApp(App):
             # `from_markup` so a thread ID with stray brackets can't corrupt
             # rendering. See checkpoint-gating rationale on
             # `previous_thread_has_agent_output` above.
-            hinted = await self._mount_previous_thread_hint(previous_thread_id)
+            hinted = await self._mount_previous_thread_hint(
+                previous_thread_id,
+                had_agent_output=previous_thread_has_agent_output,
+            )
             if not hinted and previous_thread_id and previous_thread_has_agent_output:
                 resume_hint = Content.from_markup(
                     "[dim]Relaunch with[/dim] $command -r $thread "
@@ -26043,11 +26113,12 @@ class DeepAgentsApp(App):
         prev_thread_id = self._lc_thread_id
         prev_session_thread = self._session_state.thread_id
         prev_previous_thread = self._session_state.previous_thread_id
-        previous_thread_has_agent_output = any(
-            msg.type in _SERVER_OUTPUT_MESSAGE_TYPES
-            for msg in self._message_store.get_all_messages()
-        )
         prev_cwd = Path(self._cwd)
+
+        # Not rollback state, unlike the block above: sampled here because
+        # `_clear_messages` further down empties the store, and this has to
+        # describe the outgoing thread. See `_store_has_server_output`.
+        previous_thread_has_agent_output = self._store_has_server_output()
 
         cwd_choice = await self._offer_thread_cwd_switch(
             thread_id,
@@ -26134,9 +26205,14 @@ class DeepAgentsApp(App):
             # just left — the same affordance `/clear` offers. Deliberately not
             # described as sitting under the "Resumed thread" note: that note is
             # only mounted on `_load_thread_history`'s happy path, so an empty
-            # or failed load leaves the hint under something else.
-            if previous_thread_has_agent_output:
-                await self._mount_previous_thread_hint(prev_session_thread)
+            # or failed load leaves the hint under something else. Suppressed
+            # entirely for a thread the user did no work in — chiefly the
+            # `/clear` then bare `/threads -r` round trip, where the thread
+            # being left was created moments ago and never used.
+            await self._mount_previous_thread_hint(
+                prev_session_thread,
+                had_agent_output=previous_thread_has_agent_output,
+            )
 
             # Landing on a new thread re-arms the same-thread toast, so stepping
             # back to a thread and re-selecting it announces itself again.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -279,6 +279,10 @@ offering a way back to. `USER` alone is not enough: local-only flows
 (`/update`, `!shell`, most slash commands) mount a `UserMessage` widget
 without ever invoking the server.
 
+Membership in this set is necessary but not sufficient — non-incognito `!`
+shell output renders through `AssistantMessage`, so `_store_has_server_output`
+also excludes rows flagged `assistant_local_only`.
+
 This is deliberately *stricter* than "has a resumable checkpoint row".
 Non-conversational commands (`/goal`, `/rubric set`) persist thread state
 through `aupdate_state`, and merely registering a thread in server mode
@@ -11127,7 +11131,7 @@ class DeepAgentsApp(App):
                         AppMessage(f"```text\n{output}\n```", markdown=True),
                     )
                 else:
-                    msg = AssistantMessage(f"```text\n{output}\n```")
+                    msg = AssistantMessage(f"```text\n{output}\n```", local_only=True)
                     await self._mount_message(msg)
                     await msg.write_initial_content()
             else:
@@ -17557,6 +17561,9 @@ class DeepAgentsApp(App):
 
         Feeds `_mount_previous_thread_hint`'s `had_agent_output` gate; see
         `_SERVER_OUTPUT_MESSAGE_TYPES` for why `USER` rows do not count.
+        `assistant_local_only` rows are excluded too: non-incognito `!` shell
+        output borrows `AssistantMessage` to render, so the row type alone
+        would let a thread that only ran a shell command look like agent work.
 
         Callers must read this *before* `_clear_messages` empties the store —
         it describes the thread being left, not the one being loaded. Every
@@ -17569,7 +17576,7 @@ class DeepAgentsApp(App):
             user did conversational work in this thread.
         """
         return any(
-            msg.type in _SERVER_OUTPUT_MESSAGE_TYPES
+            msg.type in _SERVER_OUTPUT_MESSAGE_TYPES and not msg.assistant_local_only
             for msg in self._message_store.get_all_messages()
         )
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -269,6 +269,11 @@ feedback) are not conversation turns, so they do not get timestamp footers.
 reason.
 """
 
+_SERVER_OUTPUT_MESSAGE_TYPES: frozenset[MessageType] = frozenset(
+    {MessageType.ASSISTANT, MessageType.TOOL, MessageType.SKILL}
+)
+"""Message types proving a thread contains server-backed output."""
+
 
 def _message_timestamp_footer_id(message_id: str) -> str:
     """Return the DOM id for a message timestamp footer."""
@@ -21218,13 +21223,8 @@ class DeepAgentsApp(App):
         # ever invoking the server, so no checkpoint exists and `-r <thread>`
         # would fail. `ASSISTANT` / `TOOL` / `SKILL` entries only land in the
         # store after a server round-trip, which implies a checkpoint row.
-        checkpoint_signal_types = {
-            MessageType.ASSISTANT,
-            MessageType.TOOL,
-            MessageType.SKILL,
-        }
         previous_thread_has_agent_output = any(
-            msg.type in checkpoint_signal_types
+            msg.type in _SERVER_OUTPUT_MESSAGE_TYPES
             for msg in self._message_store.get_all_messages()
         )
         server_proc = self._server_proc
@@ -25877,6 +25877,10 @@ class DeepAgentsApp(App):
         prev_thread_id = self._lc_thread_id
         prev_session_thread = self._session_state.thread_id
         prev_previous_thread = self._session_state.previous_thread_id
+        previous_thread_has_agent_output = any(
+            msg.type in _SERVER_OUTPUT_MESSAGE_TYPES
+            for msg in self._message_store.get_all_messages()
+        )
         prev_cwd = Path(self._cwd)
 
         cwd_choice = await self._offer_thread_cwd_switch(
@@ -25965,7 +25969,8 @@ class DeepAgentsApp(App):
             # described as sitting under the "Resumed thread" note: that note is
             # only mounted on `_load_thread_history`'s happy path, so an empty
             # or failed load leaves the hint under something else.
-            await self._mount_previous_thread_hint(prev_session_thread)
+            if previous_thread_has_agent_output:
+                await self._mount_previous_thread_hint(prev_session_thread)
 
             # Landing on a new thread re-arms the same-thread toast, so stepping
             # back to a thread and re-selecting it announces itself again.

--- a/libs/code/deepagents_code/tui/widgets/message_store.py
+++ b/libs/code/deepagents_code/tui/widgets/message_store.py
@@ -273,6 +273,16 @@ class MessageData:
     chunks and should not be pruned or re-hydrated.
     """
 
+    assistant_local_only: bool = False
+    """Whether an `ASSISTANT` row holds client-side output, not agent output.
+
+    Set for non-incognito `!` shell output, which renders through
+    `AssistantMessage` without invoking the agent. Lets callers ask whether the
+    *agent* produced anything in a thread rather than trusting the row type.
+    Never set on a restored transcript: shell output reaches thread state as a
+    `<user_shell_command>` human message, not as an assistant turn.
+    """
+
     is_markdown: bool = False
     """For APP messages, whether `content` is a markdown source string.
 
@@ -352,7 +362,12 @@ class MessageData:
                 return widget
 
             case MessageType.ASSISTANT:
-                return AssistantMessage(self.content, id=self.id)
+                # Carry `local_only` back so a row pruned by virtualization and
+                # rehydrated does not read as agent output on the next
+                # `from_widget` round trip.
+                return AssistantMessage(
+                    self.content, id=self.id, local_only=self.assistant_local_only
+                )
 
             case MessageType.TOOL:
                 widget = ToolCallMessage(
@@ -482,6 +497,7 @@ class MessageData:
                 content=widget._content,
                 id=widget_id,
                 is_streaming=widget._stream is not None,
+                assistant_local_only=widget._local_only,
             )
 
         if isinstance(widget, ToolCallMessage):

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -1207,14 +1207,22 @@ class AssistantMessage(Vertical):
     }
     """
 
-    def __init__(self, content: str = "", **kwargs: Any) -> None:
+    def __init__(
+        self, content: str = "", *, local_only: bool = False, **kwargs: Any
+    ) -> None:
         """Initialize an assistant message.
 
         Args:
             content: Initial markdown content
+            local_only: `True` when the content came from the client rather
+                than the agent — currently only non-incognito `!` shell
+                output, which borrows this widget for its markdown rendering
+                and streaming. Callers that ask "did the agent do anything in
+                this thread" must not count such a message.
             **kwargs: Additional arguments passed to parent
         """
         super().__init__(**kwargs)
+        self._local_only = local_only
         self._content_parts: list[str] = [content] if content else []
         self._markdown: Markdown | None = None
         self._stream: MarkdownStream | None = None

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -7339,11 +7339,18 @@ class TestClearCommand:
 
     async def test_clear_points_back_to_previous_thread(self) -> None:
         """/clear should surface the abandoned thread and a resume hint."""
+        from deepagents_code.tui.widgets.message_store import MessageData, MessageType
+
         app = DeepAgentsApp(thread_id="old-thread")
         async with app.run_test() as pilot:
             await pilot.pause()
             app._session_state = TextualSessionState(thread_id="old-thread")
             app._lc_thread_id = "old-thread"
+            # The hint is only offered for a thread the user did work in;
+            # `/clear` samples the store before emptying it.
+            app._message_store.append(
+                MessageData(type=MessageType.ASSISTANT, content="existing response")
+            )
 
             with (
                 patch("deepagents_code.app._new_thread_id", return_value="new-thread"),
@@ -7401,6 +7408,39 @@ class TestClearCommand:
             assert "Previous thread: old-thread" not in contents
             assert not any("Resume it with /threads -r" in text for text in contents)
             schedule.assert_called_once()
+
+    async def test_clear_omits_previous_thread_without_agent_output(self) -> None:
+        """Back-to-back `/clear` must not point at the untouched thread.
+
+        `thread_exists` is stubbed `True` because a brand-new thread can pick
+        up a checkpoint row from server-mode registration alone, so the
+        resumability check does not cover this on its own.
+        """
+        app = DeepAgentsApp(thread_id="old-thread")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._session_state = TextualSessionState(thread_id="old-thread")
+            app._lc_thread_id = "old-thread"
+            thread_exists = AsyncMock(return_value=True)
+
+            with (
+                patch("deepagents_code.app._new_thread_id", return_value="new-thread"),
+                patch("deepagents_code.sessions.thread_exists", thread_exists),
+                patch(
+                    "deepagents_code.sessions.get_thread_agent",
+                    AsyncMock(return_value="agent"),
+                ),
+            ):
+                await app._handle_command("/clear")
+                await pilot.pause()
+
+            contents = [str(widget._content) for widget in app.query(AppMessage)]
+            assert not any(text.startswith("Previous thread:") for text in contents), (
+                contents
+            )
+            # The switch itself still happened.
+            assert app._session_state.previous_thread_id == "old-thread"
+            thread_exists.assert_not_awaited()
 
 
 class TestCopyCommand:
@@ -24404,7 +24444,7 @@ class TestRestartServerForAgentSwap:
             preloaded_payload=payload,
             resolve_pending_goal=False,
         )
-        mount_previous.assert_awaited_once_with("old-thread")
+        mount_previous.assert_awaited_once_with("old-thread", had_agent_output=False)
         save_mock.assert_not_called()
         plain = [str(getattr(message, "_content", message)) for message in mounted]
         assert any(
@@ -24476,7 +24516,13 @@ class TestRestartServerForAgentSwap:
         Telling the user to relaunch when a single command suffices sends them
         the long way around.
         """
+        from deepagents_code.tui.widgets.message_store import MessageData, MessageType
+
         app, _server_proc = self._make_app()
+        # Only a thread the user did work in is worth pointing back at.
+        app._message_store.append(
+            MessageData(type=MessageType.ASSISTANT, content="existing response")
+        )
 
         mounted: list[object] = []
         async with app.run_test() as pilot:

--- a/libs/code/tests/unit_tests/test_threads_resume.py
+++ b/libs/code/tests/unit_tests/test_threads_resume.py
@@ -454,6 +454,31 @@ class TestCrossAgentResume:
 class TestPreviousThreadHintOwnership:
     """The advertised resume action must be executable in this session."""
 
+    async def test_hint_suppressed_without_agent_output(self) -> None:
+        """A thread the user did no work in is not worth pointing back at.
+
+        The resumability check is deliberately not reached: a brand-new thread
+        can acquire a checkpoint row from server-mode registration alone, so
+        `thread_exists` would wave this through.
+        """
+        app = _make_app()
+        app._assistant_id = "coder"
+        app._server_kwargs = {"assistant_id": "coder"}
+        thread_exists = AsyncMock(return_value=True)
+
+        with (
+            patch("deepagents_code.sessions.thread_exists", thread_exists),
+            patch.object(app, "_schedule_thread_message_link") as schedule,
+        ):
+            hinted = await app._mount_previous_thread_hint(
+                "research-thread", had_agent_output=False
+            )
+
+        assert hinted is False
+        app._mount_message.assert_not_awaited()  # ty: ignore
+        schedule.assert_not_called()
+        thread_exists.assert_not_awaited()
+
     async def test_local_cross_agent_hint_is_shown(self) -> None:
         """Owned local servers can honor the hint through confirmation."""
         app = _make_app()
@@ -471,7 +496,9 @@ class TestPreviousThreadHintOwnership:
             ),
             patch.object(app, "_schedule_thread_message_link") as schedule,
         ):
-            hinted = await app._mount_previous_thread_hint("research-thread")
+            hinted = await app._mount_previous_thread_hint(
+                "research-thread", had_agent_output=True
+            )
 
         app._mount_message.assert_awaited_once()  # ty: ignore
         schedule.assert_called_once()
@@ -496,7 +523,9 @@ class TestPreviousThreadHintOwnership:
             ),
             patch.object(app, "_schedule_thread_message_link") as schedule,
         ):
-            hinted = await app._mount_previous_thread_hint("research-thread")
+            hinted = await app._mount_previous_thread_hint(
+                "research-thread", had_agent_output=True
+            )
 
         app._mount_message.assert_not_awaited()  # ty: ignore
         schedule.assert_not_called()
@@ -528,6 +557,8 @@ class TestPreviousThreadHintOwnership:
             ),
             patch.object(app, "_schedule_thread_message_link"),
         ):
-            hinted = await app._mount_previous_thread_hint("research-thread")
+            hinted = await app._mount_previous_thread_hint(
+                "research-thread", had_agent_output=True
+            )
 
         assert hinted is False

--- a/libs/code/tests/unit_tests/tui/widgets/test_message_store.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_message_store.py
@@ -105,6 +105,33 @@ class TestMessageData:
         assert restored._content == "# Hello\n\nThis is **markdown**."
         assert restored.id == "test-asst-1"
 
+    def test_assistant_message_defaults_to_agent_output(self):
+        """A plain assistant message is agent output, not client output."""
+        data = MessageData.from_widget(AssistantMessage("hi", id="asst-plain"))
+
+        assert data.assistant_local_only is False
+
+    def test_local_only_assistant_message_roundtrip(self):
+        """`local_only` survives serialization and rehydration.
+
+        `!` shell output renders through `AssistantMessage`, and callers asking
+        whether the agent did anything in a thread rely on this flag. Losing it
+        on a virtualization round trip would make shell output read as a turn.
+        """
+        original = AssistantMessage(
+            "```text\nREADME.md\n```", id="asst-shell-1", local_only=True
+        )
+
+        data = MessageData.from_widget(original)
+        assert data.type == MessageType.ASSISTANT
+        assert data.assistant_local_only is True
+
+        restored = data.to_widget()
+        assert isinstance(restored, AssistantMessage)
+        assert restored._local_only is True
+        # A second round trip must not lose the flag either.
+        assert MessageData.from_widget(restored).assistant_local_only is True
+
     def test_tool_message_roundtrip(self):
         """Test ToolCallMessage serialization and deserialization."""
         original = ToolCallMessage(

--- a/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
@@ -3473,6 +3473,46 @@ class TestResumeThread:
         assert app._session_state is not None
         assert app._session_state.thread_id == "new-thread"
 
+    async def test_switch_omits_previous_thread_with_only_shell_output(self) -> None:
+        """`!` shell output is not agent work, despite rendering as ASSISTANT.
+
+        Non-incognito `!` borrows `AssistantMessage` for markdown rendering, so
+        a thread where the user only ran a shell command would otherwise look
+        like it held a real turn.
+        """
+        from deepagents_code.tui.widgets.message_store import MessageData, MessageType
+
+        app = self._switch_app()
+        app._message_store.clear()
+        app._message_store.append(MessageData(type=MessageType.USER, content="!ls"))
+        app._message_store.append(
+            MessageData(
+                type=MessageType.ASSISTANT,
+                content="```text\nREADME.md\n```",
+                assistant_local_only=True,
+            )
+        )
+        mount_message = AsyncMock()
+        _app_test_double(app)._mount_message = mount_message
+        thread_exists = AsyncMock(return_value=True)
+
+        with (
+            patch("deepagents_code.sessions.thread_exists", thread_exists),
+            patch(
+                "deepagents_code.sessions.get_thread_agent",
+                AsyncMock(return_value="agent"),
+            ),
+            patch.object(app, "_schedule_thread_message_link") as schedule,
+        ):
+            await app._resume_thread("new-thread")
+
+        contents = [
+            _get_widget_text(call.args[0]) for call in mount_message.call_args_list
+        ]
+        assert not any(text.startswith("Previous thread:") for text in contents)
+        schedule.assert_not_called()
+        thread_exists.assert_not_awaited()
+
     @pytest.mark.parametrize(
         "output_type",
         ["ASSISTANT", "TOOL", "SKILL"],

--- a/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
@@ -3314,9 +3314,14 @@ class TestResumeThread:
     def _switch_app() -> DeepAgentsApp:
         from textual.css.query import NoMatches as _NoMatches
 
+        from deepagents_code.tui.widgets.message_store import MessageData, MessageType
+
         app = DeepAgentsApp(thread_id="old-thread")
         app._agent = MagicMock()
         app._session_state = _mock_session_state("old-thread")
+        app._message_store.append(
+            MessageData(type=MessageType.ASSISTANT, content="existing response")
+        )
         app._pending_messages = MagicMock()
         app._queued_widgets = MagicMock()
         _app_test_double(app)._clear_messages = AsyncMock()
@@ -3407,6 +3412,36 @@ class TestResumeThread:
         linked = schedule.call_args.args[0]
         assert _get_widget_text(linked) == hint
         assert any(widget is linked for widget in mounted)
+
+    async def test_switch_omits_untouched_previous_thread(self) -> None:
+        """A thread with only the resume command does not get a return hint."""
+        from deepagents_code.tui.widgets.message_store import MessageData, MessageType
+
+        app = self._switch_app()
+        app._message_store.clear()
+        app._message_store.append(
+            MessageData(type=MessageType.USER, content="/threads -r")
+        )
+        mount_message = AsyncMock()
+        _app_test_double(app)._mount_message = mount_message
+        thread_exists = AsyncMock(return_value=True)
+
+        with (
+            patch("deepagents_code.sessions.thread_exists", thread_exists),
+            patch(
+                "deepagents_code.sessions.get_thread_agent",
+                AsyncMock(return_value="agent"),
+            ),
+            patch.object(app, "_schedule_thread_message_link") as schedule,
+        ):
+            await app._resume_thread("new-thread")
+
+        contents = [
+            _get_widget_text(call.args[0]) for call in mount_message.call_args_list
+        ]
+        assert not any(text.startswith("Previous thread:") for text in contents)
+        schedule.assert_not_called()
+        thread_exists.assert_not_awaited()
 
     async def test_switch_mounts_previous_thread_hint_after_history(self) -> None:
         """The hint lands below the restored transcript, not above it.

--- a/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
@@ -3319,12 +3319,22 @@ class TestResumeThread:
         app = DeepAgentsApp(thread_id="old-thread")
         app._agent = MagicMock()
         app._session_state = _mock_session_state("old-thread")
+        # Seed server-backed output so `_mount_previous_thread_hint`'s
+        # `had_agent_output` gate passes; cases that need the no-work path
+        # reset the store themselves. Load-bearing for every hint assertion
+        # in this class, so do not drop it as unused setup.
         app._message_store.append(
             MessageData(type=MessageType.ASSISTANT, content="existing response")
         )
         app._pending_messages = MagicMock()
         app._queued_widgets = MagicMock()
-        _app_test_double(app)._clear_messages = AsyncMock()
+        # A faithful double: the real `_clear_messages` empties the store, and
+        # the hint gate is only correct because `_resume_thread` samples the
+        # store *before* calling it. A bare `AsyncMock` here would let the
+        # sample move below the clear with every test still green.
+        _app_test_double(app)._clear_messages = AsyncMock(
+            side_effect=lambda *_, **__: app._message_store.clear()
+        )
         _app_test_double(app)._update_status = MagicMock()
         mock_payload = MagicMock()
         mock_payload.messages = []
@@ -3413,14 +3423,28 @@ class TestResumeThread:
         assert _get_widget_text(linked) == hint
         assert any(widget is linked for widget in mounted)
 
-    async def test_switch_omits_untouched_previous_thread(self) -> None:
-        """A thread with only the resume command does not get a return hint."""
+    @pytest.mark.parametrize(
+        "local_only_type",
+        ["USER", "APP"],
+        ids=["user-only", "app-only"],
+    )
+    async def test_switch_omits_untouched_previous_thread(
+        self, local_only_type: str
+    ) -> None:
+        """A thread the user did no work in does not get a return hint.
+
+        Covers `/clear` then a bare `/threads -r`: the thread being left was
+        created moments ago and holds only local widgets. `thread_exists` is
+        stubbed `True` on purpose — server-mode thread registration writes a
+        checkpoint row for a brand-new thread, so the checkpoint check alone
+        would let the hint through.
+        """
         from deepagents_code.tui.widgets.message_store import MessageData, MessageType
 
         app = self._switch_app()
         app._message_store.clear()
         app._message_store.append(
-            MessageData(type=MessageType.USER, content="/threads -r")
+            MessageData(type=MessageType[local_only_type], content="/threads -r")
         )
         mount_message = AsyncMock()
         _app_test_double(app)._mount_message = mount_message
@@ -3441,7 +3465,59 @@ class TestResumeThread:
         ]
         assert not any(text.startswith("Previous thread:") for text in contents)
         schedule.assert_not_called()
+        # Distinguishes "suppressed by the work gate" from "suppressed by the
+        # resumability check" — the primary assertion above cannot tell them
+        # apart, and the stub would have said the thread *is* resumable.
         thread_exists.assert_not_awaited()
+        # A suppressed hint must not derail the switch itself.
+        assert app._session_state is not None
+        assert app._session_state.thread_id == "new-thread"
+
+    @pytest.mark.parametrize(
+        "output_type",
+        ["ASSISTANT", "TOOL", "SKILL"],
+    )
+    async def test_switch_hints_for_any_server_output_type(
+        self, output_type: str
+    ) -> None:
+        """Every `_SERVER_OUTPUT_MESSAGE_TYPES` member counts as work done.
+
+        A turn can leave behind tool calls or a skill invocation without any
+        assistant text, so narrowing the constant to `ASSISTANT` would strand
+        those threads.
+        """
+        from deepagents_code.tui.widgets.message_store import MessageData, MessageType
+
+        app = self._switch_app()
+        app._message_store.clear()
+        # `MessageData.__post_init__` requires a name for TOOL and SKILL.
+        app._message_store.append(
+            MessageData(
+                type=MessageType[output_type],
+                content="output",
+                tool_name="Read" if output_type == "TOOL" else None,
+                skill_name="review" if output_type == "SKILL" else None,
+            )
+        )
+        mount_message = AsyncMock()
+        _app_test_double(app)._mount_message = mount_message
+        thread_exists = AsyncMock(return_value=True)
+
+        with (
+            patch("deepagents_code.sessions.thread_exists", thread_exists),
+            patch(
+                "deepagents_code.sessions.get_thread_agent",
+                AsyncMock(return_value="agent"),
+            ),
+            patch.object(app, "_schedule_thread_message_link"),
+        ):
+            await app._resume_thread("new-thread")
+
+        contents = [
+            _get_widget_text(call.args[0]) for call in mount_message.call_args_list
+        ]
+        assert any(text.startswith("Previous thread: old-thread") for text in contents)
+        thread_exists.assert_awaited_once_with("old-thread")
 
     async def test_switch_mounts_previous_thread_hint_after_history(self) -> None:
         """The hint lands below the restored transcript, not above it.
@@ -3600,11 +3676,9 @@ class TestResumeThread:
         app = self._switch_app()
         mount_message = AsyncMock()
         _app_test_double(app)._mount_message = mount_message
+        thread_exists = AsyncMock(side_effect=error)
 
-        with patch(
-            "deepagents_code.sessions.thread_exists",
-            AsyncMock(side_effect=error),
-        ):
+        with patch("deepagents_code.sessions.thread_exists", thread_exists):
             await app._resume_thread("new-thread")
 
         contents = [
@@ -3614,6 +3688,9 @@ class TestResumeThread:
         assert app._session_state.thread_id == "new-thread"
         assert not any(text.startswith("Previous thread:") for text in contents)
         assert not any("Failed to switch" in text for text in contents)
+        # Anchor: without this the test passes when the work gate suppresses
+        # the hint before the lookup, never reaching the failure it covers.
+        thread_exists.assert_awaited_once_with("old-thread")
 
     async def test_switch_survives_previous_thread_hint_mount_failure(self) -> None:
         """A hint that cannot be mounted must not fail the switch.
@@ -3623,10 +3700,13 @@ class TestResumeThread:
         """
         app = self._switch_app()
         mounted: list[str] = []
+        mount_raised = False
 
         def mount(widget: Static) -> None:
+            nonlocal mount_raised
             text = _get_widget_text(widget)
             if text.startswith("Previous thread:"):
+                mount_raised = True
                 msg = "container is detached"
                 raise MountError(msg)
             mounted.append(text)
@@ -3649,6 +3729,9 @@ class TestResumeThread:
         assert app._session_state is not None
         assert app._session_state.thread_id == "new-thread"
         assert not any("Failed to switch" in text for text in mounted)
+        # Anchor: without this the test passes when the hint is suppressed
+        # before mounting, so the MountError branch is never exercised.
+        assert mount_raised
 
     async def test_successful_switch_rearms_already_on_thread_toast(self) -> None:
         """A real switch clears suppression so the next no-op toasts again.


### PR DESCRIPTION
Offering a way back to an empty thread is noise — it lands you somewhere no different from the new thread you already have.

---

`/clear` and a thread switch both offer a `Previous thread: <id> (Resume with /threads -r)` hint. That hint was gated only on `thread_exists`, and registering a thread with the server writes a checkpoint row, so a thread you never typed into still looked resumable. Leaving a fresh thread — with `/threads -r`, another `/clear`, or an agent swap — therefore pointed you back at nothing.

Resuming such a thread works; it just isn't worth suggesting. So the hint now also asks whether the thread recorded any server output — an `ASSISTANT`, `TOOL`, or `SKILL` message — and stays quiet when it didn't. Every path that leaves a thread samples the message store through the new `_store_has_server_output` before clearing it, so the answer describes the thread being left rather than the one arriving.

The question is "did you do anything here", not "can this be resumed". A thread holding only `/goal` or `/rubric set` state is resumable but still unused, so it gets no hint either. Suppression logs at `info`, so a missing hint is still visible in the Debug Console.

Made by [Open SWE](https://openswe.vercel.app/agents/e649f343-b71e-bb41-c988-9d422829699c)
