### PR TITLE
fix(sdk): propagate subagent state keys for provided subagent middleware

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -941,7 +941,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     private_state_keys = private_state_field_names(*state_schemas)
     # Apply the keys after caller middleware has replaced the task middleware.
     for middleware_instance in deepagent_middleware:
-        if isinstance(SubAgentMiddleware, type) and isinstance(middleware_instance, SubAgentMiddleware):
+        if isinstance(middleware_instance, SubAgentMiddleware):
             middleware_instance.private_state_keys = middleware_instance.private_state_keys | private_state_keys
     # Verify every main-profile exclusion matched at least one middleware in
     # either the main agent stack or the GP subagent stack. An entry that

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -30,7 +30,6 @@ from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 from langgraph.typing import ContextT
 
-import deepagents.middleware.subagents as subagents_module
 from deepagents._api.deprecation import deprecated, warn_deprecated
 from deepagents._excluded_middleware import (
     _apply_excluded_middleware,
@@ -942,7 +941,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     private_state_keys = private_state_field_names(*state_schemas)
     # Apply the keys after caller middleware has replaced the task middleware.
     for middleware_instance in deepagent_middleware:
-        if isinstance(middleware_instance, subagents_module.SubAgentMiddleware):
+        if isinstance(SubAgentMiddleware, type) and isinstance(middleware_instance, SubAgentMiddleware):
             middleware_instance.private_state_keys = middleware_instance.private_state_keys | private_state_keys
     # Verify every main-profile exclusion matched at least one middleware in
     # either the main agent stack or the GP subagent stack. An entry that

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -57,6 +57,7 @@ from deepagents.middleware.subagents import (
     CompiledSubAgent,
     SubAgent,
     SubAgentMiddleware,
+    SubAgentMiddleware as _SubAgentMiddleware,
     _is_compiled_subagent,
     _is_forked_subagent,
 )
@@ -939,8 +940,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     state_schemas = [state_schema] if state_schema is not None else []
     state_schemas.extend(mw.state_schema for mw in deepagent_middleware if getattr(mw, "state_schema", None) is not None)
     private_state_keys = private_state_field_names(*state_schemas)
-    if sub_agent_middleware is not None:
-        sub_agent_middleware.private_state_keys = private_state_keys
+    # Apply the keys after caller middleware has replaced the task middleware.
+    for middleware_instance in deepagent_middleware:
+        if isinstance(middleware_instance, _SubAgentMiddleware):
+            middleware_instance.private_state_keys = middleware_instance.private_state_keys | private_state_keys
     # Verify every main-profile exclusion matched at least one middleware in
     # either the main agent stack or the GP subagent stack. An entry that
     # matched nothing across both is almost certainly a typo or a stale

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -30,6 +30,7 @@ from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 from langgraph.typing import ContextT
 
+import deepagents.middleware.subagents as subagents_module
 from deepagents._api.deprecation import deprecated, warn_deprecated
 from deepagents._excluded_middleware import (
     _apply_excluded_middleware,
@@ -57,7 +58,6 @@ from deepagents.middleware.subagents import (
     CompiledSubAgent,
     SubAgent,
     SubAgentMiddleware,
-    SubAgentMiddleware as _SubAgentMiddleware,
     _is_compiled_subagent,
     _is_forked_subagent,
 )
@@ -942,7 +942,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     private_state_keys = private_state_field_names(*state_schemas)
     # Apply the keys after caller middleware has replaced the task middleware.
     for middleware_instance in deepagent_middleware:
-        if isinstance(middleware_instance, _SubAgentMiddleware):
+        if isinstance(middleware_instance, subagents_module.SubAgentMiddleware):
             middleware_instance.private_state_keys = middleware_instance.private_state_keys | private_state_keys
     # Verify every main-profile exclusion matched at least one middleware in
     # either the main agent stack or the GP subagent stack. An entry that

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -8,12 +8,12 @@ import subprocess
 import sys
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain.agents.middleware import TodoListMiddleware
-from langchain.agents.middleware.types import AgentMiddleware
+from langchain.agents.middleware.types import AgentMiddleware, PrivateStateAttr
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, SystemMessage
 from langchain_core.tools import BaseTool, StructuredTool
@@ -1145,6 +1145,42 @@ class TestStateSchema:
         mw_stack = mock_create.call_args.kwargs["middleware"]
         sub_mw = next(m for m in mw_stack if isinstance(m, SubAgentMiddleware))
         assert sub_mw._state_schema is MyState
+
+    def test_custom_subagent_middleware_receives_private_state_keys(self) -> None:
+        """A caller-supplied task middleware filters private state like the default one."""
+
+        class _PrivateState(DeepAgentState):
+            secret: Annotated[str, PrivateStateAttr]
+
+        class _PrivateStateMiddleware(AgentMiddleware[Any, Any, Any]):
+            state_schema = _PrivateState
+
+        fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        custom_subagent_middleware = SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[
+                {
+                    "name": "worker",
+                    "description": "A worker subagent.",
+                    "system_prompt": "You are a worker.",
+                    "model": fake_model,
+                    "tools": [],
+                }
+            ],
+        )
+        fake_agent = MagicMock()
+        fake_agent.with_config.return_value = "compiled-agent"
+
+        with (
+            patch("deepagents.graph.resolve_model", return_value=fake_model),
+            patch("deepagents.graph.create_agent", return_value=fake_agent),
+        ):
+            create_deep_agent(
+                model="testprov:some-model",
+                middleware=[_PrivateStateMiddleware(), custom_subagent_middleware],
+            )
+
+        assert "secret" in custom_subagent_middleware.private_state_keys
 
     def test_declarative_subagent_compiles_with_custom_state_schema(self) -> None:
         """A declarative subagent's compiled runnable exposes the custom field as a channel."""

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -1158,6 +1158,7 @@ class TestStateSchema:
         fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
         custom_subagent_middleware = SubAgentMiddleware(
             backend=StateBackend(),
+            private_state_keys=frozenset({"explicit_secret"}),
             subagents=[
                 {
                     "name": "worker",
@@ -1180,7 +1181,7 @@ class TestStateSchema:
                 middleware=[_PrivateStateMiddleware(), custom_subagent_middleware],
             )
 
-        assert "secret" in custom_subagent_middleware.private_state_keys
+        assert {"explicit_secret", "secret"} <= custom_subagent_middleware.private_state_keys
 
     def test_declarative_subagent_compiles_with_custom_state_schema(self) -> None:
         """A declarative subagent's compiled runnable exposes the custom field as a channel."""

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -65,6 +65,51 @@ def _make_model(attrs: dict[str, Any]) -> MagicMock:
     for key, value in attrs.items():
         setattr(model, key, value)
     return model
+
+
+class _MockSubAgentMiddlewareMeta(type):
+    """Expose recorded construction calls with the mock call interface."""
+
+    @property
+    def call_args(cls) -> MagicMock:
+        args, kwargs = cls.calls[-1]
+        return MagicMock(args=args, kwargs=kwargs)
+
+    @property
+    def call_args_list(cls) -> list[MagicMock]:
+        return [MagicMock(args=args, kwargs=kwargs) for args, kwargs in cls.calls]
+
+    @property
+    def call_count(cls) -> int:
+        return len(cls.calls)
+
+    @property
+    def called(cls) -> bool:
+        return bool(cls.calls)
+
+
+class _MockSubAgentMiddleware(SubAgentMiddleware, metaclass=_MockSubAgentMiddlewareMeta):
+    """Capture construction args without compiling subagent graphs."""
+
+    calls: ClassVar[list[tuple[tuple[Any, ...], dict[str, Any]]]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append((args, kwargs))
+        self._private_state_keys = kwargs.get("private_state_keys", frozenset())
+
+    @property
+    def private_state_keys(self) -> frozenset[str]:
+        return self._private_state_keys
+
+    @private_state_keys.setter
+    def private_state_keys(self, value: frozenset[str]) -> None:
+        self._private_state_keys = value
+
+
+def _mock_subagent_middleware() -> type[_MockSubAgentMiddleware]:
+    """Replace construction while preserving `SubAgentMiddleware` type checks."""
+    _MockSubAgentMiddleware.calls = []
+    return _MockSubAgentMiddleware
 
 
 class TestCreateDeepAgentMetadata:
@@ -285,7 +330,7 @@ class TestToolDescriptionOverrideWiring:
             with (
                 patch("deepagents.graph.resolve_model", return_value=fake_model),
                 patch("deepagents.graph.FilesystemMiddleware", side_effect=[MagicMock(), MagicMock()]) as mock_fs,
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
                 patch("deepagents.graph.PatchToolCallsMiddleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_summarization_middleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_agent", return_value=fake_agent),
@@ -331,7 +376,7 @@ class TestGeneralPurposeSubagentProfileWiring:
             # middleware constructors run for real.
             with (
                 patch("deepagents.graph.resolve_model", return_value=fake_model),
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
                 patch("deepagents.graph.create_agent", return_value=fake_agent),
             ):
                 create_deep_agent(model="testprov:some-model")
@@ -396,7 +441,7 @@ class TestPromptCachingWiring:
 
         with (
             patch("deepagents.middleware._prompt_caching._create_bedrock_prompt_caching_middleware", side_effect=[gp_cache, main_cache]),
-            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+            patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
             patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
         ):
             result = create_deep_agent(model=model)
@@ -417,7 +462,7 @@ class TestPromptCachingWiring:
 
         with (
             patch("deepagents.middleware._prompt_caching._create_bedrock_prompt_caching_middleware", return_value=subagent_cache),
-            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+            patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
             patch("deepagents.graph.create_agent", return_value=fake_agent),
         ):
             create_deep_agent(
@@ -448,7 +493,7 @@ class TestPromptCachingWiring:
                 "deepagents.middleware._prompt_caching.import_module",
                 side_effect=ModuleNotFoundError(name="langchain_aws.middleware.prompt_caching"),
             ),
-            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+            patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
             patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
         ):
             result = create_deep_agent(model=bedrock_model)
@@ -476,7 +521,7 @@ class TestPromptCachingWiring:
         with (
             patch("deepagents.middleware._prompt_caching._create_bedrock_prompt_caching_middleware", return_value=None),
             patch("deepagents.middleware._prompt_caching._create_fireworks_prompt_caching_middleware", side_effect=[gp_cache, main_cache]),
-            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+            patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
             patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
         ):
             result = create_deep_agent(model=model)
@@ -497,7 +542,7 @@ class TestPromptCachingWiring:
         with (
             patch("deepagents.middleware._prompt_caching._create_bedrock_prompt_caching_middleware", return_value=None),
             patch("deepagents.middleware._prompt_caching._create_fireworks_prompt_caching_middleware", return_value=subagent_cache),
-            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+            patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
             patch("deepagents.graph.create_agent", return_value=fake_agent),
         ):
             create_deep_agent(
@@ -527,7 +572,7 @@ class TestPromptCachingWiring:
                 "deepagents.middleware._prompt_caching.import_module",
                 side_effect=ModuleNotFoundError(name="langchain_fireworks.middleware.prompt_caching"),
             ),
-            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+            patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
             patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
         ):
             result = create_deep_agent(model=model)
@@ -572,7 +617,7 @@ class TestSystemPromptAssembly:
             with (
                 patch("deepagents.graph.resolve_model", return_value=fake_model),
                 patch("deepagents.graph.FilesystemMiddleware", side_effect=[MagicMock(), MagicMock()]),
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()),
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware),
                 patch("deepagents.graph.PatchToolCallsMiddleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_summarization_middleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
@@ -743,7 +788,7 @@ class TestDuplicateToolPromptTrimming:
         patched = {
             "FilesystemMiddleware": MagicMock(),
             "SkillsMiddleware": MagicMock(),
-            "SubAgentMiddleware": MagicMock(),
+            "SubAgentMiddleware": _mock_subagent_middleware(),
             "AsyncSubAgentMiddleware": MagicMock(),
             "MemoryMiddleware": MagicMock(),
         }
@@ -870,7 +915,7 @@ class TestToolExclusionWiring:
             with (
                 patch("deepagents.graph.resolve_model", return_value=fake_model),
                 patch("deepagents.graph.FilesystemMiddleware", side_effect=[MagicMock(), MagicMock()]),
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()),
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware),
                 patch("deepagents.graph.PatchToolCallsMiddleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_summarization_middleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
@@ -901,7 +946,7 @@ class TestToolExclusionWiring:
             with (
                 patch("deepagents.graph.resolve_model", return_value=fake_model),
                 patch("deepagents.graph.FilesystemMiddleware", side_effect=[MagicMock(), MagicMock()]),
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()),
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware),
                 patch("deepagents.graph.PatchToolCallsMiddleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_summarization_middleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
@@ -933,7 +978,7 @@ class TestToolExclusionWiring:
             with (
                 patch("deepagents.graph.resolve_model", return_value=fake_model),
                 patch("deepagents.graph.FilesystemMiddleware", side_effect=[MagicMock(), MagicMock()]),
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()),
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware),
                 patch("deepagents.graph.PatchToolCallsMiddleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_summarization_middleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
@@ -1332,7 +1377,7 @@ class TestMiddlewareExclusionWiring:
 
             with (
                 patch("deepagents.graph.resolve_model", return_value=fake_model),
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
                 patch("deepagents.graph.create_agent", return_value=fake_agent),
             ):
                 create_deep_agent(model="excmwprov:some-model")
@@ -1407,7 +1452,7 @@ class TestMiddlewareExclusionWiring:
 
             with (
                 patch("deepagents.graph.resolve_model", return_value=fake_model),
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
                 patch("deepagents.graph.create_agent", return_value=fake_agent),
             ):
                 create_deep_agent(
@@ -1924,7 +1969,7 @@ class TestSubagentLevelProfileResolution:
 
             with (
                 patch("deepagents.graph.resolve_model", side_effect=fake_resolve),
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
                 patch("deepagents.graph.create_agent", return_value=fake_agent),
             ):
                 create_deep_agent(
@@ -2100,7 +2145,7 @@ class TestSubagentLevelToolExclusionAndOverrides:
 
             with (
                 patch("deepagents.graph.resolve_model", side_effect=fake_resolve),
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
                 patch("deepagents.graph.create_agent", return_value=fake_agent),
             ):
                 create_deep_agent(
@@ -2153,7 +2198,7 @@ class TestSubagentLevelToolExclusionAndOverrides:
             with (
                 patch("deepagents.graph.resolve_model", side_effect=fake_resolve),
                 patch("deepagents.graph.FilesystemMiddleware", return_value=MagicMock()) as mock_fs,
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()),
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware),
                 patch("deepagents.graph.create_agent", return_value=fake_agent),
             ):
                 create_deep_agent(
@@ -2194,7 +2239,7 @@ class TestSubagentSystemPromptWiring:
         fake_agent = MagicMock()
         fake_agent.with_config.return_value = "compiled-agent"
         with (
-            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+            patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
             patch("deepagents.graph.create_summarization_middleware", return_value=MagicMock()),
             patch("deepagents.graph.create_agent", return_value=fake_agent),
         ):
@@ -2423,7 +2468,7 @@ class TestPrebuiltSubagentModelResolvesProfile:
 
             with (
                 patch("deepagents.graph.resolve_model", side_effect=fake_resolve),
-                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+                patch("deepagents.graph.SubAgentMiddleware", new_callable=_mock_subagent_middleware) as mock_subagents,
                 patch("deepagents.graph.create_summarization_middleware", return_value=MagicMock()),
                 patch("deepagents.graph.create_agent", return_value=fake_agent),
             ):


### PR DESCRIPTION
fixes #5189

We recently added support to override the provided subagent middleware when using `create_deep_agent` (matched by name).
* some details in the internal graph constructor got missed as apart of this
* this fixes one of them: we now propagate private state keys (state keys annotated with `PrivateStateAttr`) to any instance of SubAgentMiddleware in the final middleware stack

Made by [Open SWE](https://openswe.vercel.app/agents/8788a543-9ff7-53f1-b3d1-55e146c5d597)