### PR TITLE
fix(sdk): use placeholder in subagent middleware prompting

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -861,8 +861,8 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             Each SubAgent must specify `model` and `tools`.
 
             Optional `interrupt_on` on individual subagents is respected.
-        system_prompt: Instructions appended to main agent's system prompt
-            about how to use the task tool.
+        system_prompt: Instructions appended to the main agent's system prompt.
+            Include `{available_agents}` to render the available subagent types.
         task_description: Custom description for the task tool.
         state_schema: Base graph state schema forwarded to raw `SubAgent`
             specs when their runnables are compiled.
@@ -933,7 +933,6 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             state_schema=self._state_schema,
         )
 
-        # Build system prompt with available agents
         if system_prompt and subagents:
             agents_desc = "\n".join(
                 _describe_subagent_for_tool(
@@ -943,7 +942,8 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                 )
                 for s in subagents
             )
-            self.system_prompt = system_prompt + "\n\nAvailable subagent types:\n\n" + agents_desc
+            available_agents = "Available subagent types:\n\n" + agents_desc
+            self.system_prompt = system_prompt.replace("{available_agents}", available_agents)
         else:
             self.system_prompt = system_prompt
 

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -772,6 +772,24 @@ class TestSubagentMiddlewareInit:
         # Custom system prompt plus available subagent types
         assert middleware.system_prompt.startswith("Use the task tool to call a subagent.")
 
+    def test_subagent_middleware_renders_available_agents_in_system_prompt(self) -> None:
+        """Test that the system prompt renders subagents at the explicit placeholder."""
+        middleware = SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[
+                {
+                    "name": "weather",
+                    "description": "Weather subagent",
+                    "system_prompt": "Get weather.",
+                    "model": "gpt-5.4-mini",
+                    "tools": [],
+                }
+            ],
+            system_prompt="{available_agents}",
+        )
+
+        assert middleware.system_prompt == "Available subagent types:\n\n- weather: Weather subagent"
+
     def test_requires_subagents(self) -> None:
         """Test that at least one subagent is required."""
         with pytest.raises(ValueError, match="At least one subagent"):


### PR DESCRIPTION
fixes #4538

This is technically not an issue anymore since we removed alot of our existing prompting, but it's still technically a mis-nomer that we automatically append more guidance when `system_prompt` is truthy. We restrict this a bit more by making this middleware-rendered guidance a placeholder in the system prompt.
* accompanying docs PR coming soon to illustrate this behavior for SubAgentMiddleware
