### PR TITLE
fix(sdk): reapply permissions to caller-provided fs middleware

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -238,6 +238,27 @@ def _apply_custom_middleware(
     return result
 
 
+def _attach_filesystem_permissions(
+    stack: list[AgentMiddleware[Any, Any, Any]],
+    permissions: list[FilesystemPermission] | None,
+) -> None:
+    """Re-attach factory-configured permissions onto `FilesystemMiddleware`.
+
+    A caller-supplied `FilesystemMiddleware` replaces the factory's default in
+    place, dropping the `permissions=` rules the factory configured. The
+    built-in file tools read `permissions` at call time, so we restore them
+    here, after the merge, on whichever instance ended up in the final stack.
+
+    We only attach when the instance has no permissions, so this repairs the
+    silent drop without clobbering an explicit override.
+    """
+    if not permissions:
+        return
+    for middleware_instance in stack:
+        if isinstance(middleware_instance, FilesystemMiddleware) and not middleware_instance.permissions:
+            middleware_instance.permissions = permissions
+
+
 _REQUIRED_MIDDLEWARE: tuple[tuple[type[AgentMiddleware[Any, Any, Any]], tuple[str, ...]], ...] = (
     (FilesystemMiddleware, ()),
     (SubAgentMiddleware, ()),
@@ -739,6 +760,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 matched_classes=_subagent_matched_classes,
                 matched_names=_subagent_matched_names,
             )
+            _attach_filesystem_permissions(subagent_middleware, subagent_permissions)
             _verify_excluded_middleware_coverage(
                 _subagent_profile,
                 _subagent_matched_classes,
@@ -827,6 +849,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             matched_classes=_main_matched_classes,
             matched_names=_main_matched_names,
         )
+        _attach_filesystem_permissions(gp_middleware, permissions)
         # Tool exclusion runs last so excluded tool names are stripped after all
         # tool-injecting middleware has run.
         if _profile.excluded_tools:
@@ -941,6 +964,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     private_state_keys = private_state_field_names(*state_schemas)
     if sub_agent_middleware is not None:
         sub_agent_middleware.private_state_keys = private_state_keys
+    _attach_filesystem_permissions(deepagent_middleware, permissions)
     # Verify every main-profile exclusion matched at least one middleware in
     # either the main agent stack or the GP subagent stack. An entry that
     # matched nothing across both is almost certainly a typo or a stale

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -242,21 +242,12 @@ def _attach_filesystem_permissions(
     stack: list[AgentMiddleware[Any, Any, Any]],
     permissions: list[FilesystemPermission] | None,
 ) -> None:
-    """Re-attach factory-configured permissions onto `FilesystemMiddleware`.
-
-    A caller-supplied `FilesystemMiddleware` replaces the factory's default in
-    place, dropping the `permissions=` rules the factory configured. The
-    built-in file tools read `permissions` at call time, so we restore them
-    here, after the merge, on whichever instance ended up in the final stack.
-
-    We only attach when the instance has no permissions, so this repairs the
-    silent drop without clobbering an explicit override.
-    """
+    """Attach inherited rules without mutating caller-supplied middleware."""
     if not permissions:
         return
-    for middleware_instance in stack:
+    for index, middleware_instance in enumerate(stack):
         if isinstance(middleware_instance, FilesystemMiddleware) and not middleware_instance.permissions:
-            middleware_instance.permissions = permissions
+            stack[index] = middleware_instance.with_permissions(permissions)
 
 
 _REQUIRED_MIDDLEWARE: tuple[tuple[type[AgentMiddleware[Any, Any, Any]], tuple[str, ...]], ...] = (

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -13,7 +13,7 @@ from binascii import Error as BinasciiError
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING, Annotated, Any, Final, Literal, NotRequired, cast
+from typing import TYPE_CHECKING, Annotated, Any, Final, Literal, NotRequired, Self, cast
 
 import wcmatch.glob as wcglob
 from langchain.agents.middleware.types import (
@@ -1738,14 +1738,8 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             "type[FilesystemState]",
             FilesystemState if _uses_state_backend(self.backend) else AgentState,
         )
-        if _permissions and supports_execution(self.backend) and not _all_paths_scoped_to_routes(_permissions, self.backend):
-            msg = (
-                "FilesystemMiddleware does not yet support permissions with backends that "
-                "provide command execution (SandboxBackendProtocol). Tool-level permissions "
-                "for the execute tool are not implemented. Either remove permissions or use "
-                "a backend without execution support."
-            )
-            raise NotImplementedError(msg)
+        self._permissions = []
+        self._set_permissions(_permissions)
 
         artifacts_root = self.backend.artifacts_root if isinstance(self.backend, CompositeBackend) else "/"
         _root = artifacts_root.rstrip("/")
@@ -1765,8 +1759,6 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             self._enabled_tools = frozenset(_ALL_FS_TOOL_NAMES)
         else:  # None -- user did not specify, defaults to all tools opted-in
             self._enabled_tools = None
-        self._permissions = list(_permissions or [])
-
         # Shared executor for enforcing GLOB_TIMEOUT on the sync glob tool.
         # Timed-out worker threads keep running until the backend call returns,
         # so the semaphore rejects overload instead of queueing behind them.
@@ -1791,18 +1783,40 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         # dispatchable tool node
         self.tools = [factory() for name, factory in tool_factories if self._enabled_tools is None or name in self._enabled_tools]
 
+    def _set_permissions(self, value: list[FilesystemPermission] | None) -> None:
+        """Validate and store filesystem permission rules."""
+        if value and supports_execution(self.backend) and not _all_paths_scoped_to_routes(value, self.backend):
+            msg = (
+                "FilesystemMiddleware does not yet support permissions with backends that "
+                "provide command execution (SandboxBackendProtocol). Tool-level permissions "
+                "for the execute tool are not implemented. Either remove permissions or use "
+                "a backend without execution support."
+            )
+            raise NotImplementedError(msg)
+        self._permissions = list(value or [])
+
     @property
     def permissions(self) -> list[FilesystemPermission]:
-        """Filesystem permission rules enforced by this middleware's tools.
-
-        The built-in file tools read this list at call time, so assigning it
-        after construction takes effect on the next tool invocation.
-        """
+        """Filesystem permission rules enforced by this middleware's tools."""
         return self._permissions
 
     @permissions.setter
     def permissions(self, value: list[FilesystemPermission] | None) -> None:
-        self._permissions = list(value or [])
+        self._set_permissions(value)
+
+    def with_permissions(self, permissions: list[FilesystemPermission]) -> Self:
+        """Copy this middleware with validated filesystem permission rules."""
+        return type(self)(
+            backend=self.backend,
+            system_prompt=self._custom_system_prompt,
+            custom_tool_descriptions=self._custom_tool_descriptions,
+            tool_token_limit_before_evict=self._tool_token_limit_before_evict,
+            human_message_token_limit_before_evict=self._human_message_token_limit_before_evict,
+            max_execute_timeout=self._max_execute_timeout,
+            grep_max_count=self._grep_max_count,
+            tools=cast("list[FsToolName] | None", list(self._enabled_tools) if self._enabled_tools is not None else None),
+            _permissions=permissions,
+        )
 
     def _create_ls_tool(self) -> BaseTool:
         """Create the ls (list files) tool."""

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1791,6 +1791,19 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         # dispatchable tool node
         self.tools = [factory() for name, factory in tool_factories if self._enabled_tools is None or name in self._enabled_tools]
 
+    @property
+    def permissions(self) -> list[FilesystemPermission]:
+        """Filesystem permission rules enforced by this middleware's tools.
+
+        The built-in file tools read this list at call time, so assigning it
+        after construction takes effect on the next tool invocation.
+        """
+        return self._permissions
+
+    @permissions.setter
+    def permissions(self, value: list[FilesystemPermission] | None) -> None:
+        self._permissions = list(value or [])
+
     def _create_ls_tool(self) -> BaseTool:
         """Create the ls (list files) tool."""
         tool_description = self._custom_tool_descriptions.get("ls") or LIST_FILES_TOOL_DESCRIPTION

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1618,6 +1618,55 @@ class TestDeepAgentPermissionsEndToEnd:
         assert "permission denied" in tool_messages[0].content
         assert "write" in tool_messages[0].content
 
+    # Regression test for https://github.com/langchain-ai/deepagents/issues/5388
+    def test_filesystem_permission_deny_survives_documented_tools_override(self) -> None:
+        """A `FilesystemMiddleware(tools=...)` override must not drop `permissions`.
+
+        The docs tell callers to narrow the built-in filesystem tool set by
+        passing a `FilesystemMiddleware(tools=[...])` instance through
+        `middleware=`. Because an override replaces the factory's default
+        instance (matched by `.name`), the caller's `permissions=` deny rules
+        must still be enforced on the replacement. The write to the denied
+        `/secrets/**` path must be rejected exactly as it is without the
+        tool-set override.
+        """
+        backend = StateBackend()
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "write_file",
+                                "args": {"file_path": "/secrets/key.txt", "content": "data"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(
+            model=model,
+            backend=backend,
+            permissions=[
+                FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny"),
+            ],
+            # Documented way to restrict the filesystem tool set:
+            # https://docs.langchain.com/oss/python/deepagents/overview#restricting-filesystem-tools
+            middleware=[FilesystemMiddleware(backend=backend, tools=["read_file", "ls", "write_file"])],
+        )
+        result = agent.invoke({"messages": [HumanMessage(content="Write to secrets")]})
+
+        tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
+        assert len(tool_messages) == 1
+        assert "permission denied" in tool_messages[0].content
+        assert "write" in tool_messages[0].content
+
     def test_filesystem_permission_deny_read_blocks_read_file(self) -> None:
         """FilesystemPermission deny read blocks read_file and returns error message."""
         model = FixedGenericFakeChatModel(

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -1598,6 +1598,75 @@ class TestGeneralPurposeSubagentPermissionInheritance:
         assert _filesystem_permissions_for(agent, "general-purpose") == override_perms
 
 
+class TestPermissionsSurviveFilesystemToolsOverride:
+    """Regression tests for https://github.com/langchain-ai/deepagents/issues/5388.
+
+    Overriding the filesystem tool set the documented way --
+    `middleware=[FilesystemMiddleware(tools=[...])]` -- must not drop the
+    `permissions=` rules `create_deep_agent` configured. The override replaces
+    the factory's default `FilesystemMiddleware` by `.name`, so the factory must
+    re-attach the rules onto the surviving instance.
+    """
+
+    def test_main_agent_permissions_survive_tools_override(self):
+        perms = [FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny")]
+        backend = _make_backend()
+        agent = create_deep_agent(
+            model=GenericFakeChatModel(messages=iter([AIMessage(content="done")])),
+            backend=backend,
+            permissions=perms,
+            middleware=[FilesystemMiddleware(backend=backend, tools=["read_file", "ls", "write_file"])],
+        )
+
+        assert _filesystem_permissions_for(agent) == perms
+
+    def test_gp_subagent_permissions_survive_tools_override(self):
+        perms = [FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny")]
+        backend = _make_backend()
+        agent = create_deep_agent(
+            model=GenericFakeChatModel(messages=iter([AIMessage(content="done")])),
+            backend=backend,
+            permissions=perms,
+            middleware=[FilesystemMiddleware(backend=backend, tools=["read_file", "ls", "write_file"])],
+        )
+
+        assert _filesystem_permissions_for(agent, "general-purpose") == perms
+
+    def test_declarative_subagent_permissions_survive_tools_override(self):
+        parent_perms = [FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny")]
+        backend = _make_backend()
+        agent = create_deep_agent(
+            model=GenericFakeChatModel(messages=iter([AIMessage(content="done")])),
+            backend=backend,
+            permissions=parent_perms,
+            subagents=[
+                {
+                    "name": "worker",
+                    "description": "does work",
+                    "system_prompt": "work",
+                    "middleware": [FilesystemMiddleware(backend=backend, tools=["read_file", "ls", "write_file"])],
+                }
+            ],
+        )
+
+        # Inherits the parent's rules onto the overridden instance.
+        assert _filesystem_permissions_for(agent, "worker") == parent_perms
+
+    def test_explicit_middleware_permissions_are_not_clobbered(self):
+        """A caller instance carrying its own rules wins over the factory's."""
+        parent_perms = [FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny")]
+        own_perms = [FilesystemPermission(operations=["read"], paths=["/private/**"], mode="deny")]
+        backend = _make_backend()
+        agent = create_deep_agent(
+            model=GenericFakeChatModel(messages=iter([AIMessage(content="done")])),
+            backend=backend,
+            permissions=parent_perms,
+            middleware=[FilesystemMiddleware(backend=backend, tools=["read_file", "ls", "write_file"], _permissions=own_perms)],
+        )
+
+        assert _filesystem_permissions_for(agent) == own_perms
+
+
 class TestGlobResultPermissionFiltering:
     """`deny` rules must survive the glob result path.
 

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -798,11 +798,13 @@ class TestFilesystemMiddlewarePermissionInit:
         mem_store = InMemoryStore()
         sandbox = MockSandbox(store=mem_store, namespace=lambda _ctx: ("filesystem",))
 
+        rules = [FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")]
         with pytest.raises(NotImplementedError, match="execute"):
-            FilesystemMiddleware(
-                backend=sandbox,
-                _permissions=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
-            )
+            FilesystemMiddleware(backend=sandbox, _permissions=rules)
+
+        middleware = FilesystemMiddleware(backend=sandbox)
+        with pytest.raises(NotImplementedError, match="execute"):
+            middleware.permissions = rules
 
     def test_raises_not_implemented_for_composite_with_sandbox_default(self):
         """FilesystemMiddleware rejects CompositeBackend whose default supports execution."""
@@ -1665,6 +1667,32 @@ class TestPermissionsSurviveFilesystemToolsOverride:
         )
 
         assert _filesystem_permissions_for(agent) == own_perms
+
+    def test_shared_middleware_uses_each_stack_permissions(self):
+        """Inherited rules must not leak between stacks sharing a middleware instance."""
+        parent_perms = [FilesystemPermission(operations=["write"], paths=["/parent/**"], mode="deny")]
+        subagent_perms = [FilesystemPermission(operations=["write"], paths=["/subagent/**"], mode="deny")]
+        backend = _make_backend()
+        middleware = FilesystemMiddleware(backend=backend, tools=["read_file", "ls", "write_file"])
+        agent = create_deep_agent(
+            model=GenericFakeChatModel(messages=iter([AIMessage(content="done")])),
+            backend=backend,
+            permissions=parent_perms,
+            middleware=[middleware],
+            subagents=[
+                {
+                    "name": "worker",
+                    "description": "does work",
+                    "system_prompt": "work",
+                    "permissions": subagent_perms,
+                    "middleware": [middleware],
+                }
+            ],
+        )
+
+        assert middleware.permissions == []
+        assert _filesystem_permissions_for(agent) == parent_perms
+        assert _filesystem_permissions_for(agent, "worker") == subagent_perms
 
 
 class TestGlobResultPermissionFiltering:


### PR DESCRIPTION
fixes #5388

Similar to #5189, we don't supply middleware specific attributes to a caller-specified middleware, `permissions` being one of them.

When `FileSystemMiddleware` is provided, we look at each instance of filesystem middleware (on supervisor, subagent, etc.) before we call `create_agent` et al. If no permissions have been applied to it, we amend it with the permissions provided to the graph method

(I can do without the property/setter pair on the fs middleware, this was mostly just to align with SubAgentMiddleware, lmk)
