### PR TITLE
feat(code): Python extensions API for middleware, tools, and commands

### DIFF
--- a/libs/code/ARCHITECTURE.md
+++ b/libs/code/ARCHITECTURE.md
@@ -67,6 +67,8 @@ The main cost is the client/server boundary. When debugging, first decide which 
 - For local setup and debugging, see [`DEVELOPMENT.md`](./DEVELOPMENT.md).
 - For command behavior, see [`COMMANDS.md`](./COMMANDS.md).
 - For lifecycle hooks (`hooks.json`), see [`HOOKS.md`](./HOOKS.md).
+- For Python extensions (middleware, tools, commands), see
+  [`EXTENSIONS.md`](./EXTENSIONS.md).
 - For cost estimates and local pricing overrides (`prices.json`), see
   [`PRICING.md`](./PRICING.md).
 - For security boundaries, see [`THREAT_MODEL.md`](./THREAT_MODEL.md).

--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -8,7 +8,7 @@ Regenerate this file with `make commands-catalog` after changing command names,
 aliases, descriptions, visibility, or hidden-command metadata.
 
 
-## Public (40)
+## Public (41)
 
 | Command | Aliases | Description |
 | --- | --- | --- |
@@ -24,6 +24,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/docs` |  | Open the docs |
 | `/editor` |  | Open prompt in an external editor ($EDITOR) |
 | `/effort` |  | Set reasoning effort for the current model |
+| `/extensions` |  | List loaded Python extensions and what they registered |
 | `/feedback` |  | Send feedback or report an issue |
 | `/force-clear` |  | Stop active work, clear the chat, and start a new thread |
 | `/goal` |  | Set and manage a persistent objective with acceptance criteria |

--- a/libs/code/EXTENSIONS.md
+++ b/libs/code/EXTENSIONS.md
@@ -50,9 +50,9 @@ file are just imports.
 resources. `d.cwd`, `d.mode`, and `d.path` describe the session the factory is
 running in.
 
-Registration also works after startup — calling `register_tool` from inside a
-command handler is supported, and new tools are picked up on the next model
-request.
+Registrations are accepted only while `extension(d)` is running. The agent graph
+is compiled from that completed registry, so retaining `d` and calling a
+registration verb later raises `ExtensionError`.
 
 Collisions resolve by load order, never by scope: the first registration of a
 tool name wins (later ones are logged and dropped), and a duplicate command name

--- a/libs/code/EXTENSIONS.md
+++ b/libs/code/EXTENSIONS.md
@@ -1,0 +1,104 @@
+# Extensions
+
+Extensions let you add middleware, tools, and slash commands to `dcode` without
+modifying its source. An extension is one Python file (or a package directory)
+exposing a single factory:
+
+```python
+from deepagents_code.extensions import ExtensionAPI
+
+
+def extension(d: ExtensionAPI) -> None:
+    def word_count(text: str) -> str:
+        """Count the words in some text."""
+        return str(len(text.split()))
+
+    d.register_tool(word_count)
+    d.register_command("hello", lambda ctx: f"Hello from {ctx.cwd}")
+```
+
+Drop that file in `~/.deepagents/extensions/` and restart `dcode`. The tool is
+offered to the model and `/hello` works in the REPL.
+
+The factory may be `async def`; it is awaited before the session starts, so
+one-time setup finishes before anything else runs.
+
+## Where extensions are loaded from
+
+Sources resolve in this order; within a directory, entries load alphabetically.
+
+| Source | Recipe | Trust-gated |
+| --- | --- | --- |
+| `~/.deepagents/extensions/` | directory scan | No |
+| Paths from `[extensions].paths` | file as-is; directory scanned | No |
+| `.deepagents/extensions/` (project) | directory scan | **Yes** |
+
+The directory scan is deliberately shallow: a direct `*.py` file is an
+extension, and a subdirectory is an extension when it contains `__init__.py` or
+`extension.py`. There is no deeper recursion, so helper modules next to an entry
+file are just imports.
+
+## Registration verbs
+
+| Verb | Accepts |
+| --- | --- |
+| `register_middleware(cls_or_instance)` | A LangChain `AgentMiddleware` subclass or instance. Interception semantics are LangChain's, so existing LangChain middleware loads unmodified. A class is instantiated by dcode; pass an instance when construction needs arguments. |
+| `register_tool(fn_or_tool)` | A plain function (schema derived from its signature and docstring) or a `BaseTool` when you want to declare the schema yourself. |
+| `register_command(name, handler, description=...)` | A `/name` handler receiving a `CommandContext` (`args`, `cwd`, `mode`). Sync or async. |
+
+`d.on_shutdown(callback)` registers deterministic teardown for session-scoped
+resources. `d.cwd`, `d.mode`, and `d.path` describe the session the factory is
+running in.
+
+Registration also works after startup — calling `register_tool` from inside a
+command handler is supported, and new tools are picked up on the next model
+request.
+
+Collisions resolve by load order, never by scope: the first registration of a
+tool name wins (later ones are logged and dropped), and a duplicate command name
+is registered under a suffixed name rather than replacing the original. Every
+registered unit carries provenance (`SourceInfo`: path, source, scope, origin),
+which `/extensions` displays.
+
+## Trust
+
+Project extensions are the first project-level resource that *executes* code, so
+`.deepagents/extensions/` is scanned only after a trust decision:
+
+1. A persisted decision for the working directory (stored under
+   `~/.deepagents/.state/extension_trust.json`).
+2. An interactive prompt at startup ("allow once" or "always allow").
+3. The configured default policy for non-interactive runs.
+
+`--trust-project-extensions` grants trust for one run, which is what headless and
+CI invocations should use.
+
+Extension code runs in-process with your privileges, and extension-registered
+tools are not added to the approval (HITL) interrupt map — install only
+extensions you trust, and gate risky work inside the extension itself (see
+`examples/extensions/audit_log.py`).
+
+## Configuration
+
+```toml
+# ~/.deepagents/config.toml
+[extensions]
+enabled = true
+paths = ["~/work/dcode-extensions", "~/scratch/one-off.py"]
+trust = "ask"  # ask | always | never
+```
+
+Environment overrides: `DEEPAGENTS_CODE_EXTENSIONS=0` disables loading,
+`DEEPAGENTS_CODE_EXTENSIONS_PATHS` is a colon-separated path list, and
+`DEEPAGENTS_CODE_EXTENSIONS_TRUST` overrides the trust policy.
+
+## Failure handling
+
+A malformed extension is reported and skipped; it never takes down the agent
+loop. Run `/extensions` to see what loaded and what failed, and set
+`DEEPAGENTS_CODE_DEBUG=1` for tracebacks.
+
+## Reference extensions
+
+See `examples/extensions/`: `audit_log.py` (permission-gate middleware),
+`scratchpad.py` (a stateful tool with teardown), and `standup.py` (a command).

--- a/libs/code/THREAT_MODEL.md
+++ b/libs/code/THREAT_MODEL.md
@@ -463,6 +463,7 @@
 | Async subagent config | DF22                  | None direct   | TOML parse; type validation in `load_async_subagents`                      | User           | URL and headers for remote subagents are user-controlled; no URL validation                 |
 | MCP subprocess env    | DF24                  | T10           | Dict type check only (`_validate_server_config`)                           | User           | No key/value filtering; arbitrary env vars forwarded to subprocess                           |
 | Offloaded history     | DF25                  | None direct   | Thread ID is UUID7 (no path injection); backend handles storage            | Shared         | Raw conversation content written to sandbox filesystem                                       |
+| Python extensions     | DF10                  | T9            | User-scoped sources are trusted by installation; project `.deepagents/extensions/` loads only after a persisted or prompted per-directory trust decision (or `--trust-project-extensions`); per-extension error isolation | User | Extension code runs in-process with full user privileges, and extension-registered tools are not added to the HITL interrupt map |
 
 ---
 

--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -209,6 +209,26 @@ values). Marks experimental runs in UI/trace metadata. Behavior behind this
 flag may change or be removed without notice.
 """
 
+EXTENSIONS = "DEEPAGENTS_CODE_EXTENSIONS"
+"""Enable loading Python extensions.
+
+Parsed as a falsey-string check; on by default. Setting it to a falsey value
+disables every extension source, including the user's own directory.
+"""
+
+EXTENSIONS_PATHS = "DEEPAGENTS_CODE_EXTENSIONS_PATHS"
+"""Colon-separated extension files or directories added to discovery.
+
+Takes precedence over `[extensions].paths` in `config.toml`.
+"""
+
+EXTENSIONS_TRUST = "DEEPAGENTS_CODE_EXTENSIONS_TRUST"
+"""Default trust policy for project extensions: `ask`, `always`, or `never`.
+
+Overrides `[extensions].trust`. Applies only when the working directory has no
+persisted trust decision.
+"""
+
 EXTERNAL_EVENT_SOCKET = "DEEPAGENTS_CODE_EXTERNAL_EVENT_SOCKET"
 """Enable the local Unix-socket external event listener.
 

--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -389,6 +389,9 @@ class ServerConfig:
     """Tri-state trust flag for project-scoped MCP servers: `True`/`False`/`None`
     (prompt user)."""
 
+    trust_project_extensions: bool = False
+    """Whether the project's `.deepagents/extensions/` directory may load."""
+
     def __post_init__(self) -> None:
         """Normalize fields and validate invariants.
 
@@ -507,6 +510,7 @@ class ServerConfig:
                 if self.trust_project_mcp is not None
                 else None
             ),
+            "TRUST_PROJECT_EXTENSIONS": str(self.trust_project_extensions).lower(),
         }
 
     @classmethod
@@ -557,6 +561,7 @@ class ServerConfig:
             mcp_config_path=_read_env_str("MCP_CONFIG_PATH"),
             no_mcp=_read_env_bool("NO_MCP"),
             trust_project_mcp=_read_env_optional_bool("TRUST_PROJECT_MCP"),
+            trust_project_extensions=_read_env_bool("TRUST_PROJECT_EXTENSIONS"),
         )
 
     # ------------------------------------------------------------------
@@ -592,6 +597,7 @@ class ServerConfig:
         mcp_config_path: str | None,
         no_mcp: bool,
         trust_project_mcp: bool | None,
+        trust_project_extensions: bool = False,
         interactive: bool,
     ) -> ServerConfig:
         """Build a `ServerConfig` from parsed CLI arguments.
@@ -636,6 +642,7 @@ class ServerConfig:
             mcp_config_path: Path to MCP config.
             no_mcp: Disable MCP.
             trust_project_mcp: Trust project MCP servers.
+            trust_project_extensions: Load the project's extensions directory.
             interactive: Whether the agent is interactive.
 
         Returns:
@@ -684,6 +691,7 @@ class ServerConfig:
             mcp_config_path=normalized_mcp,
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
+            trust_project_extensions=trust_project_extensions,
         )
 
 

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -2211,6 +2211,7 @@ def create_cli_agent(
     async_subagents: list[AsyncSubAgent] | None = None,
     goal_criteria_tools: Sequence[BaseTool | Callable[..., Any]] | None = None,
     rubric_grader_tools: Sequence[BaseTool | Callable[..., Any]] | None = None,
+    trust_project_extensions: bool = False,
 ) -> tuple[Pregel[Any, Any, Any, Any], CompositeBackend]:
     """Create a CLI-configured agent with flexible options.
 
@@ -2359,6 +2360,10 @@ def create_cli_agent(
         rubric_grader_tools: External read-only context tools available to rubric
             grading for verifying work completed in MCP-backed or web-accessible
             systems.
+        trust_project_extensions: Allow the project's
+            `.deepagents/extensions/` directory to load for this run. Project
+            extensions execute repository-authored Python, so they load only
+            with an explicit grant or a persisted trust decision.
 
     Returns:
         2-tuple of `(agent_graph, backend)`
@@ -3052,6 +3057,25 @@ def create_cli_agent(
         if rubric_max_iterations is not None:
             rubric_kwargs["max_iterations"] = rubric_max_iterations
         agent_middleware.append(ReliableRubricMiddleware(**rubric_kwargs))
+
+    # Extension-contributed units are appended last so a built-in is never
+    # displaced, and loading failures are already isolated by the loader: a
+    # malformed extension is reported and skipped, never raised here.
+    from deepagents_code.extensions import load_extensions_blocking
+    from deepagents_code.extensions.runtime import HEADLESS_MODE, INTERACTIVE_MODE
+
+    extension_result = load_extensions_blocking(
+        cwd=effective_cwd,
+        mode=INTERACTIVE_MODE if interactive else HEADLESS_MODE,
+        project_root=(
+            project_context.project_root if project_context is not None else None
+        ),
+        project_trust_granted=trust_project_extensions,
+    )
+    tools = [*tools, *(unit.unit for unit in extension_result.registry.tools)]
+    agent_middleware.extend(unit.unit for unit in extension_result.registry.middleware)
+    for message in extension_result.errors:
+        logger.warning("Extension not loaded: %s", message)
 
     # Create the agent
     all_subagents: list[SubAgent | CompiledSubAgent | AsyncSubAgent] = [

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -2391,6 +2391,24 @@ def create_cli_agent(
         else (project_context.user_cwd if project_context is not None else None)
     )
 
+    # Extension loading runs before the composite backend is assembled so that
+    # extension-registered backend routes can be merged into its route table.
+    # Loading failures are already isolated by the loader: a malformed extension
+    # is reported and skipped, never raised here.
+    from deepagents_code.extensions import load_extensions_blocking
+    from deepagents_code.extensions.runtime import HEADLESS_MODE, INTERACTIVE_MODE
+
+    extension_result = load_extensions_blocking(
+        cwd=effective_cwd,
+        mode=INTERACTIVE_MODE if interactive else HEADLESS_MODE,
+        project_root=(
+            project_context.project_root if project_context is not None else None
+        ),
+        project_trust_granted=trust_project_extensions,
+    )
+    for message in extension_result.errors:
+        logger.warning("Extension not loaded: %s", message)
+
     # Setup agent directory for persistent memory (if enabled)
     if enable_memory or enable_skills:
         agent_dir = settings.ensure_agent_dir(assistant_id)
@@ -2843,16 +2861,32 @@ def create_cli_agent(
                     virtual_mode=True,
                 )
             )
+        # Extension backend routes are additive on top of the reserved internal
+        # routes; a reserved prefix always wins over an extension route.
+        for unit in extension_result.registry.backend_routes:
+            if unit.name in artifact_routes:
+                logger.warning(
+                    "Ignoring extension backend route %r from %s: "
+                    "prefix is reserved for internal use",
+                    unit.name,
+                    unit.source.label,
+                )
+                continue
+            artifact_routes[unit.name] = unit.unit
         composite_backend = CompositeBackend(
             default=backend,
             routes=artifact_routes,
             artifacts_root=artifacts_root,
         )
     else:
-        # Sandbox mode: No special routing needed
+        # Sandbox mode: no internal routing, but extension routes still apply
+        # alongside the sandbox default.
         composite_backend = CompositeBackend(
             default=backend,
-            routes={},
+            routes={
+                unit.name: unit.unit
+                for unit in extension_result.registry.backend_routes
+            },
         )
 
     compaction_middleware = _create_cli_compaction_middleware(model, composite_backend)
@@ -3059,23 +3093,9 @@ def create_cli_agent(
         agent_middleware.append(ReliableRubricMiddleware(**rubric_kwargs))
 
     # Extension-contributed units are appended last so a built-in is never
-    # displaced, and loading failures are already isolated by the loader: a
-    # malformed extension is reported and skipped, never raised here.
-    from deepagents_code.extensions import load_extensions_blocking
-    from deepagents_code.extensions.runtime import HEADLESS_MODE, INTERACTIVE_MODE
-
-    extension_result = load_extensions_blocking(
-        cwd=effective_cwd,
-        mode=INTERACTIVE_MODE if interactive else HEADLESS_MODE,
-        project_root=(
-            project_context.project_root if project_context is not None else None
-        ),
-        project_trust_granted=trust_project_extensions,
-    )
+    # displaced; the load itself happened earlier (before backend assembly).
     tools = [*tools, *(unit.unit for unit in extension_result.registry.tools)]
     agent_middleware.extend(unit.unit for unit in extension_result.registry.middleware)
-    for message in extension_result.errors:
-        logger.warning("Extension not loaded: %s", message)
 
     # Create the agent
     all_subagents: list[SubAgent | CompiledSubAgent | AsyncSubAgent] = [

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1010,6 +1010,7 @@ if TYPE_CHECKING:
     from deepagents_code.config import ModelResult
     from deepagents_code.config_manifest import CursorStyle
     from deepagents_code.event_bus import EventSource, ExternalEvent
+    from deepagents_code.extensions import ExtensionLoadResult
     from deepagents_code.goal_rubric import GoalCreateRequest, GoalCriteriaRequest
     from deepagents_code.hooks.manager import HookSessionIdentity, HooksManager
     from deepagents_code.hooks.models.domain import (
@@ -4466,6 +4467,14 @@ class DeepAgentsApp(App):
         every invocation.
         """
 
+        self._extensions: ExtensionLoadResult | None = None
+        """Extensions loaded in the app process (populated by a startup worker).
+
+        The server process loads its own copy for middleware and tools; this one
+        exists so extension-registered slash commands and `/extensions`
+        provenance are available in the client.
+        """
+
         self._reload_task: asyncio.Task[None] | None = None
         """The in-flight detached `/reload` task, if any (see `_schedule_reload`).
 
@@ -4678,14 +4687,18 @@ class DeepAgentsApp(App):
         self._chat_input.set_cursor_style(style=self._cursor_style)
         self._chat_input.set_cursor_blink(blink=self._cursor_blink_enabled)
 
-        # Apply any skill commands discovered before the widget was mounted
-        if self._discovered_skills:
+        # Apply any skill or extension commands discovered before the widget was
+        # mounted
+        if self._discovered_skills or self._extensions is not None:
             from deepagents_code.command_registry import (
+                build_extension_commands,
                 build_skill_commands,
                 get_slash_commands,
             )
 
             cmds = build_skill_commands(self._discovered_skills)
+            if self._extensions is not None:
+                cmds += build_extension_commands(self._extensions.registry)
             merged = list(get_slash_commands()) + cmds
             self._chat_input.update_slash_commands(merged)
 
@@ -5044,6 +5057,13 @@ class DeepAgentsApp(App):
             self._discover_startup_skills(),
             exclusive=True,
             group="startup-skill-discovery",
+        )
+
+        # Extensions execute local Python, so they load off the first-frame path.
+        self.run_worker(
+            self._discover_extensions(),
+            exclusive=True,
+            group="startup-extension-discovery",
         )
 
         self.run_worker(self._init_session_state, exclusive=True, group="session-init")
@@ -5563,6 +5583,168 @@ class DeepAgentsApp(App):
                     len(skills),
                 )
         return True
+
+    async def _discover_extensions(self) -> None:
+        """Load extensions in the app process and publish their commands.
+
+        Runs as a startup worker rather than on the launch path: an extension is
+        arbitrary Python and may import heavy dependencies, which must not delay
+        the first frame. Failures are already isolated per extension, so this
+        only surfaces a summary notification.
+        """
+        from deepagents_code.command_registry import (
+            build_extension_commands,
+            build_skill_commands,
+            get_slash_commands,
+        )
+        from deepagents_code.extensions import load_extensions
+        from deepagents_code.extensions.runtime import INTERACTIVE_MODE
+
+        server_kwargs = self._server_kwargs or {}
+        cwd = Path(self._cwd)
+        project_root = self._project_root_path() or cwd
+        result = await load_extensions(
+            cwd=cwd,
+            mode=INTERACTIVE_MODE,
+            project_root=project_root,
+            project_trust_granted=bool(
+                server_kwargs.get("trust_project_extensions", False)
+            ),
+        )
+        self._extensions = result
+        if result.errors:
+            self.notify(
+                f"{len(result.errors)} extension(s) failed to load; run "
+                "/extensions for details.",
+                severity="warning",
+                timeout=8,
+                markup=False,
+            )
+        extension_commands = build_extension_commands(result.registry)
+        if extension_commands and self._chat_input:
+            merged = [
+                *get_slash_commands(),
+                *build_skill_commands(self._discovered_skills),
+                *extension_commands,
+            ]
+            self._chat_input.update_slash_commands(merged)
+
+    def _project_root_path(self) -> Path | None:
+        """Return the project root governing project-scoped resources.
+
+        Returns:
+            The enclosing project root, or `None` when it cannot be resolved.
+        """
+        from deepagents_code.project_utils import ProjectContext
+
+        try:
+            context = ProjectContext.from_user_cwd(Path(self._cwd))
+        except OSError:
+            logger.warning("Could not resolve project root", exc_info=True)
+            return None
+        return context.project_root or context.user_cwd
+
+    def _is_extension_command(self, cmd: str) -> bool:
+        """Return whether a command name belongs to a loaded extension.
+
+        Args:
+            cmd: Lowercased command text, including the leading slash.
+
+        Returns:
+            `True` when an extension registered a command with that name.
+        """
+        if self._extensions is None:
+            return False
+        name = cmd[1:].split(maxsplit=1)[0] if len(cmd) > 1 else ""
+        return bool(name) and self._extensions.registry.find_command(name) is not None
+
+    async def _run_extension_command(self, command: str) -> None:
+        """Run an extension-registered slash command.
+
+        Args:
+            command: Full command text as typed, including the leading slash.
+        """
+        import inspect
+
+        from deepagents_code.extensions.models import CommandContext
+        from deepagents_code.extensions.runtime import INTERACTIVE_MODE
+
+        await self._mount_message(UserMessage(command))
+        name, _, args = command[1:].strip().partition(" ")
+        registered = (
+            self._extensions.registry.find_command(name.lower())
+            if self._extensions is not None
+            else None
+        )
+        if registered is None:
+            await self._mount_message(AppMessage(f"Unknown command: {command}"))
+            return
+
+        ctx = CommandContext(
+            args=args.strip(),
+            cwd=Path(self._cwd),
+            mode=INTERACTIVE_MODE,
+        )
+        try:
+            output = registered.unit(ctx)
+            if inspect.isawaitable(output):
+                output = await output
+        # A failing extension command must not take down the app.
+        except Exception as exc:
+            logger.exception("Extension command %r failed", name)
+            await self._mount_message(
+                ErrorMessage(f"/{name} failed: {type(exc).__name__}: {exc}")
+            )
+            return
+        if output:
+            await self._mount_message(AppMessage(str(output)))
+
+    async def _handle_extensions_command(self, command: str) -> None:
+        """Show loaded extensions, their units, and their provenance.
+
+        Args:
+            command: Full command text as typed.
+        """
+        await self._mount_message(UserMessage(command))
+        result = self._extensions
+        if result is None:
+            await self._mount_message(
+                AppMessage("Extensions are still loading; try again in a moment.")
+            )
+            return
+
+        lines = [
+            _markdown_table(
+                ["Extension", "Scope", "Units"],
+                [
+                    (
+                        loaded.source.label,
+                        str(loaded.source.scope),
+                        ", ".join(
+                            part
+                            for part in (
+                                f"{len(loaded.middleware)} middleware"
+                                if loaded.middleware
+                                else "",
+                                f"{len(loaded.tools)} tools" if loaded.tools else "",
+                                f"/{', /'.join(loaded.commands)}"
+                                if loaded.commands
+                                else "",
+                            )
+                            if part
+                        )
+                        or "none",
+                    )
+                    for loaded in result.loaded
+                ],
+            )
+            if result.loaded
+            else "No extensions loaded."
+        ]
+        lines.extend(
+            f"- Failed: {_escape_markdown(message)}" for message in result.errors
+        )
+        await self._mount_message(AppMessage("\n\n".join(lines), markdown=True))
 
     async def _discover_startup_skills(self) -> bool:
         """Discover skills and record plugins loaded by initial startup.
@@ -14758,6 +14940,10 @@ class DeepAgentsApp(App):
             self._schedule_reload()
         elif cmd.startswith("/skill:"):
             await self._handle_skill_command(command)
+        elif cmd == "/extensions":
+            await self._handle_extensions_command(command)
+        elif self._is_extension_command(cmd):
+            await self._run_extension_command(command)
         # -- Debug commands (not in COMMANDS / autocomplete) ------------------
         elif cmd == "/debug":
             self._open_debug_console()
@@ -19454,8 +19640,19 @@ class DeepAgentsApp(App):
         if has_client_session_hooks:
             session_end_payload = None
 
+        # Extension teardown is deterministic: hooks registered via
+        # `ExtensionAPI.on_shutdown` run once, in load order, during the same
+        # deferred teardown as the other session-scoped resources.
+        extension_registry = (
+            self._extensions.registry if self._extensions is not None else None
+        )
+        should_shut_down_extensions = extension_registry is not None and bool(
+            extension_registry.shutdown_hooks
+        )
+
         if (
-            should_wait_for_agent
+            should_shut_down_extensions
+            or should_wait_for_agent
             or should_wait_for_restart
             or should_wait_for_modal_commands
             or should_drain_hooks
@@ -19521,6 +19718,14 @@ class DeepAgentsApp(App):
                             )
 
                     session_end_task = asyncio.ensure_future(_dispatch_session_end())
+                extension_shutdown_task: asyncio.Task[None] | None = None
+                if extension_registry is not None and should_shut_down_extensions:
+                    from deepagents_code.extensions import shutdown_extensions
+
+                    extension_shutdown_task = asyncio.ensure_future(
+                        shutdown_extensions(extension_registry)
+                    )
+
                 client_session_end_task: asyncio.Task[None] | None = None
                 if has_client_session_hooks:
                     from deepagents_code.hooks.models.domain import SessionEndCause
@@ -19774,6 +19979,14 @@ class DeepAgentsApp(App):
                         except BaseException:
                             logger.debug(
                                 "SessionEnd await interrupted during teardown",
+                                exc_info=True,
+                            )
+                    if extension_shutdown_task is not None:
+                        try:
+                            await extension_shutdown_task
+                        except BaseException:
+                            logger.debug(
+                                "Extension shutdown interrupted during teardown",
                                 exc_info=True,
                             )
                     logger.debug(

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5730,6 +5730,9 @@ class DeepAgentsApp(App):
                                 f"/{', /'.join(loaded.commands)}"
                                 if loaded.commands
                                 else "",
+                                f"{len(loaded.backend_routes)} routes"
+                                if loaded.backend_routes
+                                else "",
                             )
                             if part
                         )

--- a/libs/code/deepagents_code/client/launch/server.py
+++ b/libs/code/deepagents_code/client/launch/server.py
@@ -182,6 +182,7 @@ def generate_langgraph_json(
     config: dict[str, Any] = {
         "dependencies": ["."],
         "graphs": {"agent": graph_ref},
+        "http": {"app": "deepagents_code.server_lifespan:app"},
     }
     if env_file:
         config["env"] = env_file

--- a/libs/code/deepagents_code/client/launch/server_manager.py
+++ b/libs/code/deepagents_code/client/launch/server_manager.py
@@ -318,6 +318,7 @@ async def start_server_and_get_agent(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
+    trust_project_extensions: bool = False,
     interactive: bool = True,
     host: str = "127.0.0.1",
     port: int = _EPHEMERAL_PORT,
@@ -356,6 +357,8 @@ async def start_server_and_get_agent(
         mcp_config_path: Path to MCP config.
         no_mcp: Disable MCP.
         trust_project_mcp: Trust project MCP servers.
+        trust_project_extensions: Load the project's `.deepagents/extensions/`
+            directory, which executes repository-authored Python.
         interactive: Whether the agent is interactive.
         host: Server host.
         port: Server port. Defaults to `_EPHEMERAL_PORT` (0), letting the server
@@ -408,6 +411,7 @@ async def start_server_and_get_agent(
         mcp_config_path=mcp_config_path,
         no_mcp=no_mcp,
         trust_project_mcp=trust_project_mcp,
+        trust_project_extensions=trust_project_extensions,
         interactive=interactive,
     )
     _apply_server_config(config)
@@ -492,6 +496,7 @@ async def server_session(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
+    trust_project_extensions: bool = False,
     interactive: bool = True,
     host: str = "127.0.0.1",
     port: int = _EPHEMERAL_PORT,
@@ -533,6 +538,8 @@ async def server_session(
         mcp_config_path: Path to MCP config.
         no_mcp: Disable MCP.
         trust_project_mcp: Trust project MCP servers.
+        trust_project_extensions: Load the project's `.deepagents/extensions/`
+            directory, which executes repository-authored Python.
         interactive: Whether the agent is interactive.
         host: Server host.
         port: Server port. Defaults to `_EPHEMERAL_PORT` (0), letting the server
@@ -570,6 +577,7 @@ async def server_session(
             mcp_config_path=mcp_config_path,
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
+            trust_project_extensions=trust_project_extensions,
             interactive=interactive,
             host=host,
             port=port,

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -1871,6 +1871,7 @@ async def run_non_interactive(
     rubric_max_iterations: int | None = None,
     recursion_limit: int | None = None,
     trust_project_hooks: bool = False,
+    trust_project_extensions: bool = False,
 ) -> int:
     """Run a single task non-interactively and exit.
 
@@ -1952,6 +1953,12 @@ async def run_non_interactive(
 
             Defaults to `False` so untrusted repositories cannot execute hook
             commands without an explicit `--trust-project-hooks` opt-in.
+        trust_project_extensions: When `True`, load project-scoped
+            `.deepagents/extensions/` Python extensions.
+
+            Defaults to `False` so untrusted repositories cannot execute
+            extension code without an explicit
+            `--trust-project-extensions` opt-in.
 
     Returns:
         Exit code: 0 for success or an intentional hook stop, 1 for error, 124
@@ -2199,6 +2206,7 @@ async def run_non_interactive(
             mcp_config_path=mcp_config_path,
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
+            trust_project_extensions=trust_project_extensions,
             interactive=False,
         ) as (agent, _server_proc):
             # Collect MCP preload result (ran concurrently with server startup)

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -12,6 +12,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
+    from deepagents_code.extensions import ExtensionRegistry
     from deepagents_code.skills.load import ExtendedSkillMetadata
 
 
@@ -173,6 +174,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
         bypass_tier=BypassTier.SIDE_EFFECT_FREE,
         hidden_keywords="servers oauth authenticate reconnect disable enable",
         argument_hint="[login <server> | reconnect]",
+    ),
+    SlashCommand(
+        name="/extensions",
+        description="List loaded Python extensions and what they registered",
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+        hidden_keywords="extension middleware tools commands provenance",
     ),
     SlashCommand(
         name="/plugins",
@@ -560,4 +567,30 @@ def build_skill_commands(
         _skill_command_entry(skill)
         for skill in skills
         if skill["name"] not in _STATIC_SKILL_ALIASES
+    ]
+
+
+def build_extension_commands(registry: ExtensionRegistry) -> list[CommandEntry]:
+    """Build autocomplete entries for extension-registered commands.
+
+    Each entry is tagged with the extension it came from so a user can tell a
+    contributed command from a built-in one.
+
+    Args:
+        registry: Registry populated by the extension loader.
+
+    Returns:
+        Autocomplete entries in load order.
+    """
+    return [
+        CommandEntry(
+            name=f"/{command.name}",
+            description=(
+                registry.command_description(command.name)
+                or f"Command from {command.source.label}"
+            ),
+            hidden_keywords=f"extension {command.source.label}",
+            argument_hint="",
+        )
+        for command in registry.commands
     ]

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1438,6 +1438,36 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         kind=OptionKind.STR,
         env_var=_env_vars.EXTERNAL_EVENT_SOCKET_PATH,
     ),
+    # --- Extensions ---------------------------------------------------
+    ConfigOption(
+        key="extensions.enabled",
+        group="Extensions",
+        summary="Enable loading local Python extensions.",
+        kind=OptionKind.BOOL,
+        default=True,
+        env_var=_env_vars.EXTENSIONS,
+        toml_keys=("extensions", "enabled"),
+    ),
+    ConfigOption(
+        key="extensions.paths",
+        group="Extensions",
+        summary=(
+            "Additional extension files or directories; the "
+            "DEEPAGENTS_CODE_EXTENSIONS_PATHS override uses the platform path "
+            "separator."
+        ),
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("extensions", "paths"),
+    ),
+    ConfigOption(
+        key="extensions.trust",
+        group="Extensions",
+        summary="Default project-extension trust policy ('ask', 'always', or 'never').",
+        kind=OptionKind.STR,
+        default="ask",
+        env_var=_env_vars.EXTENSIONS_TRUST,
+        toml_keys=("extensions", "trust"),
+    ),
     # --- Goals ----------------------------------------------------------
     ConfigOption(
         key="goals.auto_accept_criteria",
@@ -1807,6 +1837,10 @@ NON_OPTION_ENV_VARS: frozenset[str] = frozenset(
         # Set then popped during the self-update restart handshake (main.py);
         # never user-configured.
         _env_vars.RESTARTED_AFTER_UPDATE,
+        # Env override for the STRUCTURED `[extensions].paths` list. The
+        # dedicated extensions settings loader splits it with `os.pathsep`, so
+        # it intentionally has no scalar `env_var` ConfigOption.
+        _env_vars.EXTENSIONS_PATHS,
         # Env equivalents of the STRUCTURED `[mcp]` lists. They are read by the
         # dedicated `model_config.load_mcp_server_trust_lists` loader (which the
         # `mcp.*` STRUCTURED options describe for discovery), not by the scalar

--- a/libs/code/deepagents_code/extensions/__init__.py
+++ b/libs/code/deepagents_code/extensions/__init__.py
@@ -1,0 +1,64 @@
+"""Python extension system for dcode.
+
+One pipeline discovers, trust-gates, loads, and hosts every kind of unit an
+extension can contribute. P0 ships middleware, tools, and commands; a new unit
+kind is a new verb on `ExtensionAPI`, not a new loader.
+
+Extension authors only need `ExtensionAPI` and `CommandContext`:
+
+```python
+from deepagents_code.extensions import ExtensionAPI
+
+
+def extension(d: ExtensionAPI) -> None:
+    d.register_tool(my_tool)
+```
+
+See `EXTENSIONS.md` in this package for the author guide.
+"""
+
+from deepagents_code.extensions.api import ExtensionAPI
+from deepagents_code.extensions.models import (
+    CommandContext,
+    CommandHandler,
+    ExtensionError,
+    LoadedExtension,
+    SourceInfo,
+    UnitOrigin,
+    UnitScope,
+    UnitSource,
+)
+from deepagents_code.extensions.registry import ExtensionRegistry
+from deepagents_code.extensions.runtime import (
+    ExtensionLoadResult,
+    load_extensions,
+    load_extensions_blocking,
+    project_extensions_trusted,
+    shutdown_extensions,
+)
+from deepagents_code.extensions.settings import (
+    ExtensionSettings,
+    TrustPolicy,
+    load_extension_settings,
+)
+
+__all__ = [
+    "CommandContext",
+    "CommandHandler",
+    "ExtensionAPI",
+    "ExtensionError",
+    "ExtensionLoadResult",
+    "ExtensionRegistry",
+    "ExtensionSettings",
+    "LoadedExtension",
+    "SourceInfo",
+    "TrustPolicy",
+    "UnitOrigin",
+    "UnitScope",
+    "UnitSource",
+    "load_extension_settings",
+    "load_extensions",
+    "load_extensions_blocking",
+    "project_extensions_trusted",
+    "shutdown_extensions",
+]

--- a/libs/code/deepagents_code/extensions/api.py
+++ b/libs/code/deepagents_code/extensions/api.py
@@ -1,0 +1,198 @@
+"""The public contract extensions are written against.
+
+An extension is a Python module exposing a single factory callable::
+
+    def extension(d: ExtensionAPI) -> None:
+        d.register_tool(my_tool)
+
+The factory may be `async def`; dcode awaits it before the session starts. Every
+unit kind is registered through one explicit verb on `ExtensionAPI`, and the
+factory signature never changes as new unit kinds are added.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from deepagents_code.extensions.models import ExtensionError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from langchain.agents.middleware.types import AgentMiddleware
+    from langchain_core.tools import BaseTool
+
+    from deepagents_code.extensions.models import CommandHandler, SourceInfo
+    from deepagents_code.extensions.registry import ExtensionRegistry
+
+logger = logging.getLogger(__name__)
+
+_COMMAND_NAME = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+"""Command names are restricted so a registration cannot forge slash syntax."""
+
+
+class ExtensionAPI:
+    """Registrar and session context handed to an extension factory.
+
+    One instance is created per extension file, so every registration is
+    attributed to the file it came from without the author passing provenance.
+    """
+
+    def __init__(
+        self,
+        registry: ExtensionRegistry,
+        source: SourceInfo,
+        *,
+        cwd: Path,
+        mode: str,
+    ) -> None:
+        """Bind a registrar to one extension's provenance.
+
+        Args:
+            registry: Shared registry receiving the registrations.
+            source: Provenance recorded on every unit this instance registers.
+            cwd: Working directory of the session.
+            mode: Runtime mode: `interactive` or `headless`.
+        """
+        self._registry = registry
+        self._source = source
+        self._cwd = cwd
+        self._mode = mode
+
+    @property
+    def cwd(self) -> Path:
+        """Working directory of the session."""
+        return self._cwd
+
+    @property
+    def mode(self) -> str:
+        """Runtime mode: `interactive` or `headless`."""
+        return self._mode
+
+    @property
+    def path(self) -> Path | None:
+        """File this extension was loaded from."""
+        return self._source.path
+
+    def register_middleware(
+        self,
+        middleware: AgentMiddleware[Any, Any] | type[AgentMiddleware[Any, Any]],
+    ) -> None:
+        """Install a LangChain `AgentMiddleware` on the agent.
+
+        Interception semantics (wrap, chain, short-circuit) are LangChain's;
+        dcode adds no parallel event taxonomy. A class is instantiated with no
+        arguments so dcode owns its lifecycle; pass an instance when the author
+        needs to control construction.
+
+        Args:
+            middleware: Middleware class or instance.
+
+        Raises:
+            ExtensionError: If a class cannot be instantiated without arguments.
+        """
+        instance: AgentMiddleware[Any, Any]
+        if isinstance(middleware, type):
+            try:
+                instance = middleware()
+            except TypeError as exc:
+                msg = (
+                    f"Middleware {middleware.__name__} needs constructor "
+                    "arguments; register an instance instead"
+                )
+                raise ExtensionError(msg) from exc
+        else:
+            instance = middleware
+        self._registry.add_middleware(instance, self._source)
+
+    def register_tool(self, tool: BaseTool | Callable[..., Any]) -> None:
+        """Expose an LLM-callable tool.
+
+        A plain function is converted with LangChain's `tool` decorator, which
+        derives the schema from the signature and docstring. Pass a `BaseTool`
+        when the schema needs to be declared explicitly.
+
+        Args:
+            tool: Tool instance or plain callable.
+
+        Raises:
+            ExtensionError: If a callable cannot be converted into a tool.
+        """
+        # Deferred: LangChain is heavy on the startup path.
+        from langchain_core.tools import (
+            BaseTool,
+            tool as as_tool,
+        )
+
+        if isinstance(tool, BaseTool):
+            self._registry.add_tool(tool, self._source)
+            return
+
+        try:
+            converted = as_tool(tool)
+        except Exception as exc:
+            name = getattr(tool, "__name__", repr(tool))
+            msg = f"Could not convert {name} into a tool: {exc}"
+            raise ExtensionError(msg) from exc
+        self._registry.add_tool(converted, self._source)  # type: ignore[arg-type]  # `tool()` returns a `BaseTool` for a plain callable
+
+    def on_shutdown(self, hook: Callable[[], Any]) -> None:
+        """Register a teardown callback for deterministic session cleanup.
+
+        Called once when the session ends, in load order. Not a unit kind — it is
+        the lifecycle counterpart of the async factory, so session-scoped
+        resources (connections, temp files) are released even when the session
+        ends abruptly.
+
+        Args:
+            hook: Callable invoked at shutdown; may be async.
+
+        Raises:
+            ExtensionError: If the hook is not callable.
+        """
+        if not callable(hook):
+            msg = "Shutdown hook is not callable"
+            raise ExtensionError(msg)
+        self._registry.add_shutdown_hook(hook, self._source)
+
+    def register_command(
+        self,
+        name: str,
+        handler: CommandHandler,
+        *,
+        description: str = "",
+    ) -> str:
+        """Register an executable `/name` handler.
+
+        Args:
+            name: Command name without the leading slash.
+            handler: Callable receiving a `CommandContext`; may be async.
+            description: Short user-facing description for autocomplete.
+
+        Returns:
+            The name the command was registered under; a colliding name is
+                suffixed rather than replacing the existing command.
+
+        Raises:
+            ExtensionError: If the name is not a lowercase slug or the handler
+                is not callable.
+        """
+        normalized = name.lstrip("/").strip().lower()
+        if not _COMMAND_NAME.match(normalized):
+            msg = (
+                f"Invalid command name {name!r}: use lowercase letters, digits, "
+                "hyphens, and underscores"
+            )
+            raise ExtensionError(msg)
+        if not callable(handler):
+            msg = f"Handler for command {normalized!r} is not callable"
+            raise ExtensionError(msg)
+        return self._registry.add_command(
+            normalized,
+            handler,
+            self._source,
+            description=description,
+        )

--- a/libs/code/deepagents_code/extensions/api.py
+++ b/libs/code/deepagents_code/extensions/api.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+    from deepagents.backends.protocol import BackendProtocol
     from langchain.agents.middleware.types import AgentMiddleware
     from langchain_core.tools import BaseTool
 
@@ -32,6 +33,9 @@ logger = logging.getLogger(__name__)
 
 _COMMAND_NAME = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 """Command names are restricted so a registration cannot forge slash syntax."""
+
+_ROUTE_PREFIX = re.compile(r"^/[a-z0-9][a-z0-9_/-]*/$")
+"""Route prefixes are absolute, slash-terminated virtual directory paths."""
 
 
 class ExtensionAPI:
@@ -196,3 +200,45 @@ class ExtensionAPI:
             self._source,
             description=description,
         )
+
+    def register_backend_route(self, prefix: str, backend: BackendProtocol) -> None:
+        """Mount a backend at a virtual path prefix on the agent's filesystem.
+
+        The backend is added as a route on the `CompositeBackend` that wraps the
+        agent's filesystem, so file operations under `prefix` (read, write, edit,
+        glob, grep) are routed to it instead of the default backend. This is how
+        a LangGraph memory store (via `StoreBackend`) or any other
+        `BackendProtocol` implementation becomes addressable by path, e.g.
+        mounting a store at `/memories/`.
+
+        Routing is additive: the default backend (local filesystem or sandbox) is
+        never replaced, and dcode's reserved internal routes always win over an
+        extension route. Note that routed content is reachable through the model's
+        file tools only — `execute` always runs against the default backend, so a
+        shell command cannot see routed (virtual) content.
+
+        Args:
+            prefix: Virtual path prefix to mount at. Must start and end with `/`
+                and contain no traversal (e.g. `/memories/`).
+            backend: The backend to route matching paths to.
+
+        Raises:
+            ExtensionError: If the prefix is malformed or the backend is not a
+                `BackendProtocol`.
+        """
+        # Deferred: LangChain is heavy on the startup path.
+        from deepagents.backends.protocol import BackendProtocol
+
+        if not _ROUTE_PREFIX.match(prefix) or ".." in prefix:
+            msg = (
+                f"Invalid backend route prefix {prefix!r}: use an absolute, "
+                "slash-terminated path with no traversal (e.g. '/memories/')"
+            )
+            raise ExtensionError(msg)
+        if not isinstance(backend, BackendProtocol):
+            msg = (
+                f"Backend route {prefix!r} got {type(backend).__name__}, "
+                "which is not a BackendProtocol"
+            )
+            raise ExtensionError(msg)
+        self._registry.add_backend_route(prefix, backend, self._source)

--- a/libs/code/deepagents_code/extensions/api.py
+++ b/libs/code/deepagents_code/extensions/api.py
@@ -65,6 +65,21 @@ class ExtensionAPI:
         self._source = source
         self._cwd = cwd
         self._mode = mode
+        self._closed = False
+
+    def _close(self) -> None:
+        """Close the factory-scoped registration window."""
+        self._closed = True
+
+    def _ensure_open(self) -> None:
+        """Reject registrations made after factory initialization.
+
+        Raises:
+            ExtensionError: If the extension factory has already returned.
+        """
+        if self._closed:
+            msg = "Extensions may register units only while their factory is running"
+            raise ExtensionError(msg)
 
     @property
     def cwd(self) -> Path:
@@ -98,6 +113,7 @@ class ExtensionAPI:
         Raises:
             ExtensionError: If a class cannot be instantiated without arguments.
         """
+        self._ensure_open()
         instance: AgentMiddleware[Any, Any]
         if isinstance(middleware, type):
             try:
@@ -125,6 +141,7 @@ class ExtensionAPI:
         Raises:
             ExtensionError: If a callable cannot be converted into a tool.
         """
+        self._ensure_open()
         # Deferred: LangChain is heavy on the startup path.
         from langchain_core.tools import (
             BaseTool,
@@ -157,6 +174,7 @@ class ExtensionAPI:
         Raises:
             ExtensionError: If the hook is not callable.
         """
+        self._ensure_open()
         if not callable(hook):
             msg = "Shutdown hook is not callable"
             raise ExtensionError(msg)
@@ -184,6 +202,7 @@ class ExtensionAPI:
             ExtensionError: If the name is not a lowercase slug or the handler
                 is not callable.
         """
+        self._ensure_open()
         normalized = name.lstrip("/").strip().lower()
         if not _COMMAND_NAME.match(normalized):
             msg = (
@@ -226,6 +245,7 @@ class ExtensionAPI:
             ExtensionError: If the prefix is malformed or the backend is not a
                 `BackendProtocol`.
         """
+        self._ensure_open()
         # Deferred: LangChain is heavy on the startup path.
         from deepagents.backends.protocol import BackendProtocol
 

--- a/libs/code/deepagents_code/extensions/discovery.py
+++ b/libs/code/deepagents_code/extensions/discovery.py
@@ -1,0 +1,187 @@
+"""Resolution of extension sources into an ordered flat list of files.
+
+Discovery is pure resolution: every source type is a recipe that turns a
+directory (or an explicit path) into file paths. The loader consumes that list
+and knows nothing about directories, manifests, or provenance, so adding a
+source means adding a recipe here — never changing the loader.
+
+Sources resolve in a fixed order (global user directory, configured extra
+paths, then the trust-gated project directory), and entries within a directory
+resolve alphabetically. That order is the only ordering in the system;
+collision rules downstream simply follow it.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from deepagents_code.extensions.models import (
+    ExtensionFile,
+    SourceInfo,
+    UnitOrigin,
+    UnitScope,
+    UnitSource,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+_ENTRY_FILENAMES = ("__init__.py", "extension.py")
+"""Entry files a directory extension may use, in preference order."""
+
+EXTENSIONS_DIRNAME = "extensions"
+"""Directory name holding extensions under `~/.deepagents/` and `.deepagents/`."""
+
+
+def user_extensions_dir() -> Path:
+    """Return the global extensions directory.
+
+    Returns:
+        `~/.deepagents/extensions/`.
+    """
+    return Path.home() / ".deepagents" / EXTENSIONS_DIRNAME
+
+
+def project_extensions_dir(project_root: Path) -> Path:
+    """Return a project's extensions directory.
+
+    Args:
+        project_root: Root of the project being worked in.
+
+    Returns:
+        `<project_root>/.deepagents/extensions/`.
+    """
+    return project_root / ".deepagents" / EXTENSIONS_DIRNAME
+
+
+def scan_extension_dir(directory: Path) -> list[tuple[Path, UnitOrigin]]:
+    """Resolve one directory into extension entry files.
+
+    The recipe is deliberately shallow: direct `*.py` files are extensions, and
+    a subdirectory is an extension when it has an `__init__.py` or
+    `extension.py` entry file. There is no deeper recursion, so a subdirectory
+    of helper modules cannot be mistaken for several extensions.
+
+    Args:
+        directory: Directory to scan.
+
+    Returns:
+        Entry files paired with their origin, sorted by path.
+    """
+    try:
+        entries = sorted(directory.iterdir())
+    except OSError:
+        logger.debug("Could not scan extensions directory %s", directory, exc_info=True)
+        return []
+
+    resolved: list[tuple[Path, UnitOrigin]] = []
+    for entry in entries:
+        try:
+            if entry.is_file() and entry.suffix == ".py":
+                resolved.append((entry, UnitOrigin.TOP_LEVEL))
+                continue
+            if not entry.is_dir():
+                continue
+            for filename in _ENTRY_FILENAMES:
+                candidate = entry / filename
+                if candidate.is_file():
+                    resolved.append((candidate, UnitOrigin.PACKAGE))
+                    break
+        except OSError:
+            logger.debug("Skipping unreadable extension entry %s", entry, exc_info=True)
+    return resolved
+
+
+def _files_for_source(
+    paths: Iterable[Path],
+    scope: UnitScope,
+) -> list[ExtensionFile]:
+    """Resolve configured paths (files as-is, directories by scan recipe).
+
+    Args:
+        paths: Files or directories to resolve.
+        scope: Scope recorded on the resulting provenance.
+
+    Returns:
+        Discovered extension files in the order their sources were listed.
+    """
+    discovered: list[ExtensionFile] = []
+    for path in paths:
+        expanded = path.expanduser()
+        try:
+            is_file = expanded.is_file()
+            is_dir = expanded.is_dir()
+        except OSError:
+            logger.debug("Could not stat extension path %s", expanded, exc_info=True)
+            continue
+        if is_file:
+            discovered.append(
+                ExtensionFile(
+                    path=expanded,
+                    source=SourceInfo(
+                        path=expanded,
+                        source=UnitSource.EXTENSION,
+                        scope=scope,
+                        origin=UnitOrigin.TOP_LEVEL,
+                    ),
+                )
+            )
+        elif is_dir:
+            discovered.extend(
+                ExtensionFile(
+                    path=entry,
+                    source=SourceInfo(
+                        path=entry,
+                        source=UnitSource.EXTENSION,
+                        scope=scope,
+                        origin=origin,
+                    ),
+                )
+                for entry, origin in scan_extension_dir(expanded)
+            )
+    return discovered
+
+
+def discover_extension_files(
+    *,
+    user_dir: Path | None = None,
+    extra_paths: Sequence[Path] = (),
+    project_dir: Path | None = None,
+) -> list[ExtensionFile]:
+    """Resolve every enabled source into one ordered list of entry files.
+
+    Args:
+        user_dir: Global extensions directory; defaults to
+            `~/.deepagents/extensions/`.
+        extra_paths: Files or directories from user configuration.
+        project_dir: Project extensions directory. Callers must pass `None`
+            until project trust has been resolved — this function performs no
+            trust checks of its own.
+
+    Returns:
+        Entry files in load order, deduplicated by resolved path.
+    """
+    resolved_user_dir = user_extensions_dir() if user_dir is None else user_dir
+    discovered = [
+        *_files_for_source([resolved_user_dir], UnitScope.USER),
+        *_files_for_source(extra_paths, UnitScope.USER),
+    ]
+    if project_dir is not None:
+        discovered.extend(_files_for_source([project_dir], UnitScope.PROJECT))
+
+    unique: list[ExtensionFile] = []
+    seen: set[Path] = set()
+    for candidate in discovered:
+        try:
+            key = candidate.path.resolve()
+        except OSError:
+            key = candidate.path
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(candidate)
+    return unique

--- a/libs/code/deepagents_code/extensions/loader.py
+++ b/libs/code/deepagents_code/extensions/loader.py
@@ -1,0 +1,142 @@
+"""File-in, extension-out loading of a single extension.
+
+`load_extension` is the only loading mechanism in the system. It imports one
+Python file with stdlib `importlib`, requires an `extension` factory callable,
+awaits it when it is async, and returns what the factory registered. It takes a
+path, never a directory or a manifest, so every discovery recipe funnels through
+the same code path.
+
+Extensions execute local Python code. Ungated sources (the user's own
+directories) are trusted by definition; project-scoped sources are resolved by
+`trust` before their paths ever reach this module.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import logging
+import sys
+from typing import TYPE_CHECKING
+
+from deepagents_code.extensions.api import ExtensionAPI
+from deepagents_code.extensions.models import (
+    ExtensionError,
+    LoadedExtension,
+    UnitOrigin,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from deepagents_code.extensions.models import ExtensionFile
+    from deepagents_code.extensions.registry import ExtensionRegistry
+
+logger = logging.getLogger(__name__)
+
+FACTORY_NAME = "extension"
+"""Name of the factory callable every extension module must expose."""
+
+_MODULE_PREFIX = "deepagents_code_extension_"
+"""Prefix for synthesized module names, keeping extensions out of the app namespace."""
+
+
+def _module_name(path: Path, origin: UnitOrigin) -> str:
+    """Build a unique import name for an extension file.
+
+    A directory extension is imported under its directory name so its sibling
+    modules resolve as a package; a single file gets its stem. Both are prefixed
+    and disambiguated by path hash so two extensions with the same name in
+    different sources cannot shadow each other.
+
+    Args:
+        path: Entry file being imported.
+        origin: Whether the entry file belongs to a package directory.
+
+    Returns:
+        A module name unique to this path.
+    """
+    stem = path.parent.name if origin is UnitOrigin.PACKAGE else path.stem
+    sanitized = "".join(char if char.isalnum() else "_" for char in stem)
+    digest = abs(hash(str(path))) % 1_000_000
+    return f"{_MODULE_PREFIX}{sanitized}_{digest}"
+
+
+async def load_extension(
+    file: ExtensionFile,
+    registry: ExtensionRegistry,
+    *,
+    cwd: Path,
+    mode: str,
+) -> LoadedExtension:
+    """Import one extension file and run its factory.
+
+    Args:
+        file: Discovered entry file and the provenance its units will carry.
+        registry: Registry receiving the factory's registrations.
+        cwd: Working directory of the session.
+        mode: Runtime mode: `interactive` or `headless`.
+
+    Returns:
+        A record of what the extension registered.
+
+    Raises:
+        ExtensionError: If the file cannot be imported, exposes no `extension`
+            factory, or the factory raises.
+    """
+    is_package = file.source.origin is UnitOrigin.PACKAGE
+    name = _module_name(file.path, file.source.origin)
+    spec = importlib.util.spec_from_file_location(
+        name,
+        file.path,
+        submodule_search_locations=[str(file.path.parent)] if is_package else None,
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Could not build an import spec for {file.path}"
+        raise ExtensionError(msg)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        sys.modules.pop(name, None)
+        msg = f"Failed to import {file.path}: {exc}"
+        raise ExtensionError(msg) from exc
+
+    factory = getattr(module, FACTORY_NAME, None)
+    if not callable(factory):
+        sys.modules.pop(name, None)
+        msg = f"{file.path} does not define a callable {FACTORY_NAME!r} factory"
+        raise ExtensionError(msg)
+
+    before = _snapshot(registry)
+    api = ExtensionAPI(registry, file.source, cwd=cwd, mode=mode)
+    try:
+        result = factory(api)
+        if inspect.isawaitable(result):
+            await result
+    except Exception as exc:
+        msg = f"Extension factory in {file.path} failed: {exc}"
+        raise ExtensionError(msg) from exc
+
+    return LoadedExtension(
+        path=file.path,
+        source=file.source,
+        middleware=tuple(unit.unit for unit in registry.middleware[before[0] :]),
+        tools=tuple(unit.unit for unit in registry.tools[before[1] :]),
+        commands=tuple(unit.name for unit in registry.commands[before[2] :]),
+    )
+
+
+def _snapshot(registry: ExtensionRegistry) -> tuple[int, int, int]:
+    """Return the registry's per-kind counts.
+
+    Returns:
+        Counts of middleware, tools, and commands currently registered.
+    """
+    return (
+        len(registry.middleware),
+        len(registry.tools),
+        len(registry.commands),
+    )

--- a/libs/code/deepagents_code/extensions/loader.py
+++ b/libs/code/deepagents_code/extensions/loader.py
@@ -126,17 +126,22 @@ async def load_extension(
         middleware=tuple(unit.unit for unit in registry.middleware[before[0] :]),
         tools=tuple(unit.unit for unit in registry.tools[before[1] :]),
         commands=tuple(unit.name for unit in registry.commands[before[2] :]),
+        backend_routes=tuple(
+            unit.name for unit in registry.backend_routes[before[3] :]
+        ),
     )
 
 
-def _snapshot(registry: ExtensionRegistry) -> tuple[int, int, int]:
+def _snapshot(registry: ExtensionRegistry) -> tuple[int, int, int, int]:
     """Return the registry's per-kind counts.
 
     Returns:
-        Counts of middleware, tools, and commands currently registered.
+        Counts of middleware, tools, commands, and backend routes currently
+            registered.
     """
     return (
         len(registry.middleware),
         len(registry.tools),
         len(registry.commands),
+        len(registry.backend_routes),
     )

--- a/libs/code/deepagents_code/extensions/loader.py
+++ b/libs/code/deepagents_code/extensions/loader.py
@@ -13,6 +13,7 @@ directories) are trusted by definition; project-scoped sources are resolved by
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import inspect
 import logging
@@ -27,7 +28,9 @@ from deepagents_code.extensions.models import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
+    from typing import Any
 
     from deepagents_code.extensions.models import ExtensionFile
     from deepagents_code.extensions.registry import ExtensionRegistry
@@ -62,27 +65,19 @@ def _module_name(path: Path, origin: UnitOrigin) -> str:
     return f"{_MODULE_PREFIX}{sanitized}_{digest}"
 
 
-async def load_extension(
+def _import_factory(
     file: ExtensionFile,
-    registry: ExtensionRegistry,
-    *,
-    cwd: Path,
-    mode: str,
-) -> LoadedExtension:
-    """Import one extension file and run its factory.
+) -> tuple[str, Callable[[ExtensionAPI], Any]]:
+    """Import an extension module and return its factory.
 
     Args:
-        file: Discovered entry file and the provenance its units will carry.
-        registry: Registry receiving the factory's registrations.
-        cwd: Working directory of the session.
-        mode: Runtime mode: `interactive` or `headless`.
+        file: Discovered extension entry file.
 
     Returns:
-        A record of what the extension registered.
+        Synthesized module name and its callable factory.
 
     Raises:
-        ExtensionError: If the file cannot be imported, exposes no `extension`
-            factory, or the factory raises.
+        ExtensionError: If the module cannot be imported or has no factory.
     """
     is_package = file.source.origin is UnitOrigin.PACKAGE
     name = _module_name(file.path, file.source.origin)
@@ -109,16 +104,56 @@ async def load_extension(
         sys.modules.pop(name, None)
         msg = f"{file.path} does not define a callable {FACTORY_NAME!r} factory"
         raise ExtensionError(msg)
+    return name, factory
 
-    before = _snapshot(registry)
+
+async def load_extension(
+    file: ExtensionFile,
+    registry: ExtensionRegistry,
+    *,
+    cwd: Path,
+    mode: str,
+) -> LoadedExtension:
+    """Import one extension file and run its factory.
+
+    Args:
+        file: Discovered entry file and the provenance its units will carry.
+        registry: Registry receiving the factory's registrations.
+        cwd: Working directory of the session.
+        mode: Runtime mode: `interactive` or `headless`.
+
+    Returns:
+        A record of what the extension registered.
+
+    Raises:
+        asyncio.CancelledError: If extension initialization is cancelled.
+        ExtensionError: If the file cannot be imported, exposes no `extension`
+            factory, or the factory raises.
+        KeyboardInterrupt: If the extension factory interrupts the process.
+        SystemExit: If the extension factory exits the process.
+    """
+    name, factory = await asyncio.to_thread(_import_factory, file)
+
+    before = registry._snapshot()
     api = ExtensionAPI(registry, file.source, cwd=cwd, mode=mode)
     try:
-        result = factory(api)
+        # Synchronous factories stay off the server event loop. An async factory
+        # returns its coroutine here without running it; awaiting below binds
+        # its resources to the caller's loop.
+        result = await asyncio.to_thread(factory, api)
         if inspect.isawaitable(result):
             await result
+    except (KeyboardInterrupt, SystemExit, asyncio.CancelledError):
+        registry._rollback(before)
+        sys.modules.pop(name, None)
+        raise
     except Exception as exc:
+        registry._rollback(before)
+        sys.modules.pop(name, None)
         msg = f"Extension factory in {file.path} failed: {exc}"
         raise ExtensionError(msg) from exc
+    finally:
+        api._close()
 
     return LoadedExtension(
         path=file.path,
@@ -129,19 +164,4 @@ async def load_extension(
         backend_routes=tuple(
             unit.name for unit in registry.backend_routes[before[3] :]
         ),
-    )
-
-
-def _snapshot(registry: ExtensionRegistry) -> tuple[int, int, int, int]:
-    """Return the registry's per-kind counts.
-
-    Returns:
-        Counts of middleware, tools, commands, and backend routes currently
-            registered.
-    """
-    return (
-        len(registry.middleware),
-        len(registry.tools),
-        len(registry.commands),
-        len(registry.backend_routes),
     )

--- a/libs/code/deepagents_code/extensions/models.py
+++ b/libs/code/deepagents_code/extensions/models.py
@@ -1,0 +1,151 @@
+"""Data types shared by the extension discovery, loading, and registry layers.
+
+`SourceInfo` is the provenance record attached to every registered unit. It
+exists for display, filtering, and enable/disable decisions — never for
+collision precedence, which is decided by load order alone (see
+`registry.ExtensionRegistry`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+    from pathlib import Path
+
+    from langchain.agents.middleware.types import AgentMiddleware
+    from langchain_core.tools import BaseTool
+
+
+class UnitSource(StrEnum):
+    """Where a registered unit came from."""
+
+    BUILTIN = "builtin"
+    """Shipped with dcode."""
+
+    EXTENSION = "extension"
+    """Registered by a loaded extension."""
+
+    SDK = "sdk"
+    """Registered by an embedding application through the public API."""
+
+
+class UnitScope(StrEnum):
+    """Configuration scope an extension was discovered in."""
+
+    USER = "user"
+    """Global/user-level source (e.g. `~/.deepagents/extensions/`)."""
+
+    PROJECT = "project"
+    """Project-level source (e.g. `.deepagents/extensions/`); trust-gated."""
+
+    TEMPORARY = "temporary"
+    """Supplied for a single run (e.g. an explicit path)."""
+
+
+class UnitOrigin(StrEnum):
+    """Whether a unit came from a packaged extension or a top-level file."""
+
+    PACKAGE = "package"
+    TOP_LEVEL = "top-level"
+
+
+@dataclass(frozen=True, slots=True)
+class SourceInfo:
+    """Provenance for one registered unit."""
+
+    path: Path | None
+    """File the unit was loaded from; `None` for built-in units."""
+
+    source: UnitSource
+    """Broad category of the registering party."""
+
+    scope: UnitScope
+    """Configuration scope the extension was discovered in."""
+
+    origin: UnitOrigin
+    """Whether the extension is a package directory or a single file."""
+
+    @property
+    def label(self) -> str:
+        """Short human-readable provenance label.
+
+        Returns:
+            The extension's file or directory name, or the source name when the
+                unit has no path.
+        """
+        if self.path is None:
+            return str(self.source)
+        if self.origin is UnitOrigin.PACKAGE:
+            return self.path.parent.name
+        return self.path.stem
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionFile:
+    """One discovered extension entry file, with the provenance it will carry."""
+
+    path: Path
+    source: SourceInfo
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredUnit(Generic[T]):
+    """A registered unit paired with its provenance."""
+
+    name: str
+    unit: T
+    source: SourceInfo
+
+
+class CommandHandler(Protocol):
+    """Signature an extension command handler must satisfy."""
+
+    def __call__(self, ctx: CommandContext) -> Awaitable[str | None] | str | None:
+        """Run the command.
+
+        Args:
+            ctx: Invocation context (arguments, working directory, mode).
+
+        Returns:
+            Optional text to display to the user.
+        """
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class CommandContext:
+    """Context handed to an extension command handler when it runs."""
+
+    args: str
+    """Raw argument string typed after the command name."""
+
+    cwd: Path
+    """Working directory of the session."""
+
+    mode: str
+    """Runtime mode: `interactive` or `headless`."""
+
+    data: dict[str, Any] = field(default_factory=dict)
+    """Free-form data the host may attach; reserved for future host services."""
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedExtension:
+    """Result of loading a single extension file."""
+
+    path: Path
+    source: SourceInfo
+    middleware: tuple[AgentMiddleware[Any, Any], ...] = ()
+    tools: tuple[BaseTool, ...] = ()
+    commands: tuple[str, ...] = ()
+
+
+class ExtensionError(Exception):
+    """Raised when an extension file cannot be imported or initialized."""

--- a/libs/code/deepagents_code/extensions/models.py
+++ b/libs/code/deepagents_code/extensions/models.py
@@ -145,6 +145,8 @@ class LoadedExtension:
     middleware: tuple[AgentMiddleware[Any, Any], ...] = ()
     tools: tuple[BaseTool, ...] = ()
     commands: tuple[str, ...] = ()
+    backend_routes: tuple[str, ...] = ()
+    """Path prefixes this extension mounted a backend route at."""
 
 
 class ExtensionError(Exception):

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -1,0 +1,195 @@
+"""In-memory registry of units contributed by extensions.
+
+Collisions resolve by simple per-kind rules applied in load order, never by
+scope: a tool name is claimed by its first registration, and a duplicate command
+name coexists under a suffixed name. Provenance (`SourceInfo`) is recorded for
+display and filtering only.
+
+The registry accepts registrations after startup, so `register_*` called from a
+command handler or another extension's callback behaves like one called from the
+factory.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from deepagents_code.extensions.models import (
+    RegisteredUnit,
+    UnitSource,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from langchain.agents.middleware.types import AgentMiddleware
+    from langchain_core.tools import BaseTool
+
+    from deepagents_code.extensions.models import (
+        CommandHandler,
+        SourceInfo,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class ExtensionRegistry:
+    """Holds every unit registered by loaded extensions."""
+
+    def __init__(self) -> None:
+        """Create an empty registry."""
+        self._middleware: list[RegisteredUnit[AgentMiddleware[Any, Any]]] = []
+        self._tools: list[RegisteredUnit[BaseTool]] = []
+        self._commands: list[RegisteredUnit[CommandHandler]] = []
+        self._shutdown_hooks: list[RegisteredUnit[Callable[[], Any]]] = []
+        self._descriptions: dict[str, str] = {}
+
+    @property
+    def middleware(self) -> list[RegisteredUnit[AgentMiddleware[Any, Any]]]:
+        """Registered middleware in load order."""
+        return list(self._middleware)
+
+    @property
+    def tools(self) -> list[RegisteredUnit[BaseTool]]:
+        """Registered tools in load order."""
+        return list(self._tools)
+
+    @property
+    def commands(self) -> list[RegisteredUnit[CommandHandler]]:
+        """Registered commands in load order."""
+        return list(self._commands)
+
+    @property
+    def shutdown_hooks(self) -> list[RegisteredUnit[Callable[[], Any]]]:
+        """Registered teardown callbacks in load order."""
+        return list(self._shutdown_hooks)
+
+    def add_shutdown_hook(
+        self,
+        hook: Callable[[], Any],
+        source: SourceInfo,
+    ) -> None:
+        """Record a teardown callback for deterministic session cleanup.
+
+        Args:
+            hook: Callable invoked at session shutdown; may be async.
+            source: Provenance of the registering extension.
+        """
+        self._shutdown_hooks.append(
+            RegisteredUnit(name=source.label, unit=hook, source=source)
+        )
+
+    def command_description(self, name: str) -> str:
+        """Return the description recorded for a command name.
+
+        Returns:
+            The registered description, or an empty string when none was given.
+        """
+        return self._descriptions.get(name, "")
+
+    def add_middleware(
+        self,
+        middleware: AgentMiddleware[Any, Any],
+        source: SourceInfo,
+    ) -> None:
+        """Record a middleware instance.
+
+        Middleware names must be unique for `create_agent`, so a duplicate name
+        is dropped with a warning rather than tripping the SDK's assertion.
+
+        Args:
+            middleware: Middleware instance to install on the agent.
+            source: Provenance of the registering extension.
+        """
+        name = getattr(middleware, "name", type(middleware).__name__)
+        if any(existing.name == name for existing in self._middleware):
+            logger.warning(
+                "Ignoring duplicate middleware %r from %s", name, source.label
+            )
+            return
+        self._middleware.append(
+            RegisteredUnit(name=name, unit=middleware, source=source)
+        )
+
+    def add_tool(self, tool: BaseTool, source: SourceInfo) -> None:
+        """Record a tool, keeping the first registration of a name.
+
+        Args:
+            tool: Tool to expose to the model.
+            source: Provenance of the registering extension.
+        """
+        existing = next((unit for unit in self._tools if unit.name == tool.name), None)
+        if existing is not None:
+            logger.warning(
+                "Ignoring tool %r from %s: already registered by %s",
+                tool.name,
+                source.label,
+                existing.source.label,
+            )
+            return
+        if source.source is UnitSource.EXTENSION:
+            logger.debug("Extension %s registered tool %r", source.label, tool.name)
+        self._tools.append(RegisteredUnit(name=tool.name, unit=tool, source=source))
+
+    def add_command(
+        self,
+        name: str,
+        handler: CommandHandler,
+        source: SourceInfo,
+        *,
+        description: str = "",
+    ) -> str:
+        """Record a command, suffixing the name when it is already taken.
+
+        Args:
+            name: Command name without the leading slash.
+            handler: Callable invoked when the command runs.
+            source: Provenance of the registering extension.
+            description: Short user-facing description.
+
+        Returns:
+            The name the command was registered under, which may carry a
+                numeric suffix when the requested name collided.
+        """
+        resolved = name
+        suffix = 2
+        while any(unit.name == resolved for unit in self._commands):
+            resolved = f"{name}-{suffix}"
+            suffix += 1
+        if resolved != name:
+            logger.warning(
+                "Command %r from %s renamed to %r to avoid a collision",
+                name,
+                source.label,
+                resolved,
+            )
+        self._commands.append(
+            RegisteredUnit(name=resolved, unit=handler, source=source)
+        )
+        self._descriptions[resolved] = description
+        return resolved
+
+    def find_command(self, name: str) -> RegisteredUnit[CommandHandler] | None:
+        """Look up a registered command by name.
+
+        Returns:
+            The matching command, or `None` when no command uses that name.
+        """
+        return next((unit for unit in self._commands if unit.name == name), None)
+
+    def is_empty(self) -> bool:
+        """Return whether nothing has been registered.
+
+        Returns:
+            `True` when no middleware, tools, or commands are registered.
+        """
+        return not (self._middleware or self._tools or self._commands)
+
+    def units(self) -> list[RegisteredUnit[Any]]:
+        """Return every registered unit for provenance display.
+
+        Returns:
+            Middleware, tools, and commands in that order.
+        """
+        return [*self._middleware, *self._tools, *self._commands]

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -47,6 +47,36 @@ class ExtensionRegistry:
         self._shutdown_hooks: list[RegisteredUnit[Callable[[], Any]]] = []
         self._descriptions: dict[str, str] = {}
 
+    def _snapshot(self) -> tuple[int, int, int, int, int]:
+        """Capture list lengths so a failed factory can be rolled back.
+
+        Returns:
+            Per-kind registration counts for the current registry state.
+        """
+        return (
+            len(self._middleware),
+            len(self._tools),
+            len(self._commands),
+            len(self._backend_routes),
+            len(self._shutdown_hooks),
+        )
+
+    def _rollback(self, snapshot: tuple[int, int, int, int, int]) -> None:
+        """Remove every registration made after `snapshot`.
+
+        Args:
+            snapshot: Per-kind list lengths returned by `_snapshot`.
+        """
+        middleware, tools, commands, backend_routes, shutdown_hooks = snapshot
+        removed_commands = self._commands[commands:]
+        del self._middleware[middleware:]
+        del self._tools[tools:]
+        del self._commands[commands:]
+        del self._backend_routes[backend_routes:]
+        del self._shutdown_hooks[shutdown_hooks:]
+        for command in removed_commands:
+            self._descriptions.pop(command.name, None)
+
     @property
     def middleware(self) -> list[RegisteredUnit[AgentMiddleware[Any, Any]]]:
         """Registered middleware in load order."""

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -23,6 +23,7 @@ from deepagents_code.extensions.models import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from deepagents.backends.protocol import BackendProtocol
     from langchain.agents.middleware.types import AgentMiddleware
     from langchain_core.tools import BaseTool
 
@@ -42,6 +43,7 @@ class ExtensionRegistry:
         self._middleware: list[RegisteredUnit[AgentMiddleware[Any, Any]]] = []
         self._tools: list[RegisteredUnit[BaseTool]] = []
         self._commands: list[RegisteredUnit[CommandHandler]] = []
+        self._backend_routes: list[RegisteredUnit[BackendProtocol]] = []
         self._shutdown_hooks: list[RegisteredUnit[Callable[[], Any]]] = []
         self._descriptions: dict[str, str] = {}
 
@@ -59,6 +61,11 @@ class ExtensionRegistry:
     def commands(self) -> list[RegisteredUnit[CommandHandler]]:
         """Registered commands in load order."""
         return list(self._commands)
+
+    @property
+    def backend_routes(self) -> list[RegisteredUnit[BackendProtocol]]:
+        """Registered backend routes in load order, keyed by path prefix."""
+        return list(self._backend_routes)
 
     @property
     def shutdown_hooks(self) -> list[RegisteredUnit[Callable[[], Any]]]:
@@ -170,6 +177,34 @@ class ExtensionRegistry:
         self._descriptions[resolved] = description
         return resolved
 
+    def add_backend_route(
+        self,
+        prefix: str,
+        backend: BackendProtocol,
+        source: SourceInfo,
+    ) -> None:
+        """Record a backend route, keeping the first registration of a prefix.
+
+        Args:
+            prefix: Virtual path prefix the backend is mounted at.
+            backend: Backend that handles paths under the prefix.
+            source: Provenance of the registering extension.
+        """
+        existing = next(
+            (unit for unit in self._backend_routes if unit.name == prefix), None
+        )
+        if existing is not None:
+            logger.warning(
+                "Ignoring backend route %r from %s: already registered by %s",
+                prefix,
+                source.label,
+                existing.source.label,
+            )
+            return
+        self._backend_routes.append(
+            RegisteredUnit(name=prefix, unit=backend, source=source)
+        )
+
     def find_command(self, name: str) -> RegisteredUnit[CommandHandler] | None:
         """Look up a registered command by name.
 
@@ -182,14 +217,22 @@ class ExtensionRegistry:
         """Return whether nothing has been registered.
 
         Returns:
-            `True` when no middleware, tools, or commands are registered.
+            `True` when no middleware, tools, commands, or backend routes are
+                registered.
         """
-        return not (self._middleware or self._tools or self._commands)
+        return not (
+            self._middleware or self._tools or self._commands or self._backend_routes
+        )
 
     def units(self) -> list[RegisteredUnit[Any]]:
         """Return every registered unit for provenance display.
 
         Returns:
-            Middleware, tools, and commands in that order.
+            Middleware, tools, commands, and backend routes in that order.
         """
-        return [*self._middleware, *self._tools, *self._commands]
+        return [
+            *self._middleware,
+            *self._tools,
+            *self._commands,
+            *self._backend_routes,
+        ]

--- a/libs/code/deepagents_code/extensions/runtime.py
+++ b/libs/code/deepagents_code/extensions/runtime.py
@@ -1,0 +1,213 @@
+"""Orchestration and lifecycle for the extension system.
+
+`load_extensions` walks the pipeline once: resolve settings, resolve project
+trust, resolve sources into files, then load each file. Failures are isolated per
+extension — a malformed extension is reported and skipped so it can never take
+down the agent loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from deepagents_code.extensions.discovery import (
+    discover_extension_files,
+    project_extensions_dir,
+)
+from deepagents_code.extensions.loader import load_extension
+from deepagents_code.extensions.models import ExtensionError
+from deepagents_code.extensions.registry import ExtensionRegistry
+from deepagents_code.extensions.settings import (
+    ExtensionSettings,
+    TrustPolicy,
+    load_extension_settings,
+)
+from deepagents_code.extensions.trust import is_project_extensions_trusted
+
+if TYPE_CHECKING:
+    from deepagents_code.extensions.models import LoadedExtension
+
+logger = logging.getLogger(__name__)
+
+INTERACTIVE_MODE = "interactive"
+HEADLESS_MODE = "headless"
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionLoadResult:
+    """Outcome of one pass over the discovery/loading pipeline."""
+
+    registry: ExtensionRegistry = field(default_factory=ExtensionRegistry)
+    """Registry holding everything the loaded extensions registered."""
+
+    loaded: tuple[LoadedExtension, ...] = ()
+    """Extensions that initialized successfully, in load order."""
+
+    errors: tuple[str, ...] = ()
+    """One message per extension that failed to load."""
+
+
+def project_extensions_trusted(
+    project_root: Path | str,
+    *,
+    policy: TrustPolicy,
+    granted: bool = False,
+    store_path: Path | None = None,
+) -> bool:
+    """Resolve whether a project's extensions may load.
+
+    Args:
+        project_root: Project root under consideration.
+        policy: Default policy applied when no decision is recorded.
+        granted: Whether this run was granted trust explicitly (an interactive
+            prompt answered at startup, or a CLI flag).
+        store_path: Alternate trust store path for tests.
+
+    Returns:
+        `True` when the project source may be scanned. Under `ask` with no
+            persisted decision and no explicit grant the answer is `False`, so
+            non-interactive runs stay closed by default.
+    """
+    if policy is TrustPolicy.NEVER:
+        return False
+    if granted or policy is TrustPolicy.ALWAYS:
+        return True
+    return is_project_extensions_trusted(project_root, store_path=store_path)
+
+
+async def load_extensions(
+    *,
+    cwd: Path | None = None,
+    mode: str = INTERACTIVE_MODE,
+    project_root: Path | None = None,
+    project_trust_granted: bool = False,
+    settings: ExtensionSettings | None = None,
+    trust_store_path: Path | None = None,
+) -> ExtensionLoadResult:
+    """Discover, trust-gate, and load every configured extension.
+
+    Args:
+        cwd: Working directory of the session; defaults to the process cwd.
+        mode: Runtime mode: `interactive` or `headless`.
+        project_root: Project root whose `.deepagents/extensions/` may load once
+            trust resolves. `None` skips the project source entirely.
+        project_trust_granted: Whether project trust was granted for this run.
+        settings: Pre-resolved settings; read from config when omitted.
+        trust_store_path: Alternate trust store path for tests.
+
+    Returns:
+        The populated registry alongside per-extension successes and failures.
+    """
+    resolved_settings = load_extension_settings() if settings is None else settings
+    if not resolved_settings.enabled:
+        return ExtensionLoadResult()
+
+    project_dir: Path | None = None
+    if project_root is not None and project_extensions_trusted(
+        project_root,
+        policy=resolved_settings.trust,
+        granted=project_trust_granted,
+        store_path=trust_store_path,
+    ):
+        project_dir = project_extensions_dir(project_root)
+
+    files = discover_extension_files(
+        extra_paths=resolved_settings.paths,
+        project_dir=project_dir,
+    )
+    if not files:
+        return ExtensionLoadResult()
+
+    registry = ExtensionRegistry()
+    session_cwd = Path.cwd() if cwd is None else Path(cwd)
+    loaded: list[LoadedExtension] = []
+    errors: list[str] = []
+    for file in files:
+        try:
+            loaded.append(
+                await load_extension(file, registry, cwd=session_cwd, mode=mode)
+            )
+        except ExtensionError as exc:
+            logger.warning("Skipping extension %s", file.path, exc_info=True)
+            errors.append(str(exc))
+        except (
+            Exception
+        ) as exc:  # error isolation: one bad extension must not kill the agent
+            logger.exception("Unexpected failure loading extension %s", file.path)
+            errors.append(f"{file.path}: {type(exc).__name__}: {exc}")
+
+    return ExtensionLoadResult(
+        registry=registry,
+        loaded=tuple(loaded),
+        errors=tuple(errors),
+    )
+
+
+def load_extensions_blocking(
+    *,
+    cwd: Path | None = None,
+    mode: str = INTERACTIVE_MODE,
+    project_root: Path | None = None,
+    project_trust_granted: bool = False,
+    settings: ExtensionSettings | None = None,
+) -> ExtensionLoadResult:
+    """Run `load_extensions` from synchronous code.
+
+    Extension factories may be `async def`, so loading is inherently async while
+    the agent construction path (`create_cli_agent`) is synchronous. When a loop
+    is already running in this thread, the work is handed to a short-lived worker
+    thread rather than touching the caller's loop.
+
+    Args:
+        cwd: Working directory of the session.
+        mode: Runtime mode: `interactive` or `headless`.
+        project_root: Project root whose extensions may load once trust resolves.
+        project_trust_granted: Whether project trust was granted for this run.
+        settings: Pre-resolved settings; read from config when omitted.
+
+    Returns:
+        The same result `load_extensions` produces.
+    """
+
+    def run() -> ExtensionLoadResult:
+        return asyncio.run(
+            load_extensions(
+                cwd=cwd,
+                mode=mode,
+                project_root=project_root,
+                project_trust_granted=project_trust_granted,
+                settings=settings,
+            )
+        )
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return run()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(run).result()
+
+
+async def shutdown_extensions(registry: ExtensionRegistry) -> None:
+    """Run every registered shutdown hook, isolating failures.
+
+    Args:
+        registry: Registry whose extensions are being torn down.
+    """
+    import inspect  # deferred: only needed during teardown
+
+    for hook in registry.shutdown_hooks:
+        try:
+            result = hook.unit()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:  # one failing teardown must not block the rest
+            logger.warning(
+                "Shutdown hook from %s failed", hook.source.label, exc_info=True
+            )

--- a/libs/code/deepagents_code/extensions/runtime.py
+++ b/libs/code/deepagents_code/extensions/runtime.py
@@ -31,7 +31,7 @@ from deepagents_code.extensions.settings import (
 from deepagents_code.extensions.trust import is_project_extensions_trusted
 
 if TYPE_CHECKING:
-    from deepagents_code.extensions.models import LoadedExtension
+    from deepagents_code.extensions.models import ExtensionFile, LoadedExtension
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +118,42 @@ def project_extensions_trusted(
     return is_project_extensions_trusted(project_root, store_path=store_path)
 
 
+def _prepare_extension_load(
+    *,
+    cwd: Path | None,
+    project_root: Path | None,
+    project_trust_granted: bool,
+    settings: ExtensionSettings | None,
+    trust_store_path: Path | None,
+) -> tuple[list[ExtensionFile], Path] | None:
+    """Resolve settings, trust, files, and cwd off the caller's event loop.
+
+    Returns:
+        Discovered files and session cwd, or `None` when extensions are disabled
+        or no files are found.
+    """
+    resolved_settings = load_extension_settings() if settings is None else settings
+    if not resolved_settings.enabled:
+        return None
+
+    project_dir: Path | None = None
+    if project_root is not None and project_extensions_trusted(
+        project_root,
+        policy=resolved_settings.trust,
+        granted=project_trust_granted,
+        store_path=trust_store_path,
+    ):
+        project_dir = project_extensions_dir(project_root)
+
+    files = discover_extension_files(
+        extra_paths=resolved_settings.paths,
+        project_dir=project_dir,
+    )
+    if not files:
+        return None
+    return files, Path.cwd() if cwd is None else Path(cwd)
+
+
 async def load_extensions(
     *,
     cwd: Path | None = None,
@@ -141,28 +177,19 @@ async def load_extensions(
     Returns:
         The populated registry alongside per-extension successes and failures.
     """
-    resolved_settings = load_extension_settings() if settings is None else settings
-    if not resolved_settings.enabled:
-        return ExtensionLoadResult()
-
-    project_dir: Path | None = None
-    if project_root is not None and project_extensions_trusted(
-        project_root,
-        policy=resolved_settings.trust,
-        granted=project_trust_granted,
-        store_path=trust_store_path,
-    ):
-        project_dir = project_extensions_dir(project_root)
-
-    files = discover_extension_files(
-        extra_paths=resolved_settings.paths,
-        project_dir=project_dir,
+    prepared = await asyncio.to_thread(
+        _prepare_extension_load,
+        cwd=cwd,
+        project_root=project_root,
+        project_trust_granted=project_trust_granted,
+        settings=settings,
+        trust_store_path=trust_store_path,
     )
-    if not files:
+    if prepared is None:
         return ExtensionLoadResult()
 
+    files, session_cwd = prepared
     registry = ExtensionRegistry()
-    session_cwd = Path.cwd() if cwd is None else Path(cwd)
     loaded: list[LoadedExtension] = []
     errors: list[str] = []
     for file in files:

--- a/libs/code/deepagents_code/extensions/runtime.py
+++ b/libs/code/deepagents_code/extensions/runtime.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import logging
+from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -37,6 +38,9 @@ logger = logging.getLogger(__name__)
 INTERACTIVE_MODE = "interactive"
 HEADLESS_MODE = "headless"
 
+_server_extension_result: ContextVar[ExtensionLoadResult | None]
+_server_shutdown_registry: ExtensionRegistry | None = None
+
 
 @dataclass(frozen=True, slots=True)
 class ExtensionLoadResult:
@@ -50,6 +54,40 @@ class ExtensionLoadResult:
 
     errors: tuple[str, ...] = ()
     """One message per extension that failed to load."""
+
+
+_server_extension_result = ContextVar("server_extension_result", default=None)
+
+
+def bind_server_extensions(
+    result: ExtensionLoadResult,
+) -> Token[ExtensionLoadResult | None]:
+    """Expose a server-loop result to synchronous graph construction.
+
+    `asyncio.to_thread` copies the current context, so `create_cli_agent` can
+    consume this exact registry without reloading extensions on a temporary
+    event loop. Registries with teardown hooks are also retained for the HTTP
+    server lifespan.
+
+    Args:
+        result: Extensions initialized on the server event loop.
+
+    Returns:
+        Context token used to restore the caller after graph construction.
+    """
+    global _server_shutdown_registry  # noqa: PLW0603
+    if result.registry.shutdown_hooks:
+        _server_shutdown_registry = result.registry
+    return _server_extension_result.set(result)
+
+
+def reset_server_extensions(token: Token[ExtensionLoadResult | None]) -> None:
+    """Restore the extension context after graph construction.
+
+    Args:
+        token: Token returned by `bind_server_extensions`.
+    """
+    _server_extension_result.reset(token)
 
 
 def project_extensions_trusted(
@@ -158,10 +196,9 @@ def load_extensions_blocking(
 ) -> ExtensionLoadResult:
     """Run `load_extensions` from synchronous code.
 
-    Extension factories may be `async def`, so loading is inherently async while
-    the agent construction path (`create_cli_agent`) is synchronous. When a loop
-    is already running in this thread, the work is handed to a short-lived worker
-    thread rather than touching the caller's loop.
+    A result initialized by the server loop is reused through its copied thread
+    context. Other synchronous callers run loading on a private temporary loop;
+    when their thread already owns a loop, loading moves to a worker thread.
 
     Args:
         cwd: Working directory of the session.
@@ -173,6 +210,9 @@ def load_extensions_blocking(
     Returns:
         The same result `load_extensions` produces.
     """
+    server_result = _server_extension_result.get()
+    if server_result is not None:
+        return server_result
 
     def run() -> ExtensionLoadResult:
         return asyncio.run(
@@ -211,3 +251,12 @@ async def shutdown_extensions(registry: ExtensionRegistry) -> None:
             logger.warning(
                 "Shutdown hook from %s failed", hook.source.label, exc_info=True
             )
+
+
+async def shutdown_server_extensions() -> None:
+    """Tear down the server-owned extension registry on its event loop."""
+    global _server_shutdown_registry  # noqa: PLW0603
+    registry = _server_shutdown_registry
+    _server_shutdown_registry = None
+    if registry is not None:
+        await shutdown_extensions(registry)

--- a/libs/code/deepagents_code/extensions/settings.py
+++ b/libs/code/deepagents_code/extensions/settings.py
@@ -12,7 +12,8 @@ trust = "ask"  # ask | always | never
 ```
 
 - `DEEPAGENTS_CODE_EXTENSIONS=0` disables loading entirely.
-- `DEEPAGENTS_CODE_EXTENSIONS_PATHS` is a colon-separated list of extra paths.
+- `DEEPAGENTS_CODE_EXTENSIONS_PATHS` uses the platform path separator (`:` on
+  POSIX and `;` on Windows).
 - `DEEPAGENTS_CODE_EXTENSIONS_TRUST` overrides the project-trust policy.
 """
 
@@ -102,7 +103,9 @@ def load_extension_settings() -> ExtensionSettings:
 
     env_paths = os.environ.get(EXTENSIONS_PATHS)
     if env_paths:
-        raw_paths: list[str] = [part for part in env_paths.split(":") if part.strip()]
+        raw_paths: list[str] = [
+            part for part in env_paths.split(os.pathsep) if part.strip()
+        ]
     else:
         configured = section.get("paths")
         raw_paths = (

--- a/libs/code/deepagents_code/extensions/settings.py
+++ b/libs/code/deepagents_code/extensions/settings.py
@@ -24,11 +24,9 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+from deepagents_code._env_vars import EXTENSIONS, EXTENSIONS_PATHS, EXTENSIONS_TRUST
 
-ENABLED_ENV = "DEEPAGENTS_CODE_EXTENSIONS"
-PATHS_ENV = "DEEPAGENTS_CODE_EXTENSIONS_PATHS"
-TRUST_ENV = "DEEPAGENTS_CODE_EXTENSIONS_TRUST"
+logger = logging.getLogger(__name__)
 
 _FALSEY = {"0", "false", "no", "off"}
 
@@ -98,11 +96,11 @@ def load_extension_settings() -> ExtensionSettings:
     section = _read_config_section()
 
     enabled = section.get("enabled", True)
-    env_enabled = os.environ.get(ENABLED_ENV)
+    env_enabled = os.environ.get(EXTENSIONS)
     if env_enabled is not None:
         enabled = env_enabled.strip().lower() not in _FALSEY
 
-    env_paths = os.environ.get(PATHS_ENV)
+    env_paths = os.environ.get(EXTENSIONS_PATHS)
     if env_paths:
         raw_paths: list[str] = [part for part in env_paths.split(":") if part.strip()]
     else:
@@ -113,7 +111,7 @@ def load_extension_settings() -> ExtensionSettings:
             else []
         )
 
-    raw_trust = os.environ.get(TRUST_ENV) or section.get("trust")
+    raw_trust = os.environ.get(EXTENSIONS_TRUST) or section.get("trust")
     try:
         trust = TrustPolicy(str(raw_trust).strip().lower())
     except ValueError:

--- a/libs/code/deepagents_code/extensions/settings.py
+++ b/libs/code/deepagents_code/extensions/settings.py
@@ -1,0 +1,128 @@
+"""User configuration for the extension system.
+
+Read from `[extensions]` in `~/.deepagents/config.toml`, with environment
+variables taking precedence so a single run can be adjusted without editing
+config:
+
+```toml
+[extensions]
+enabled = true
+paths = ["~/work/dcode-extensions", "~/scratch/one-off.py"]
+trust = "ask"  # ask | always | never
+```
+
+- `DEEPAGENTS_CODE_EXTENSIONS=0` disables loading entirely.
+- `DEEPAGENTS_CODE_EXTENSIONS_PATHS` is a colon-separated list of extra paths.
+- `DEEPAGENTS_CODE_EXTENSIONS_TRUST` overrides the project-trust policy.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+ENABLED_ENV = "DEEPAGENTS_CODE_EXTENSIONS"
+PATHS_ENV = "DEEPAGENTS_CODE_EXTENSIONS_PATHS"
+TRUST_ENV = "DEEPAGENTS_CODE_EXTENSIONS_TRUST"
+
+_FALSEY = {"0", "false", "no", "off"}
+
+
+class TrustPolicy(StrEnum):
+    """Default answer for the project-extension trust decision."""
+
+    ASK = "ask"
+    """Prompt interactively; skip project extensions when non-interactive."""
+
+    ALWAYS = "always"
+    """Load project extensions without prompting."""
+
+    NEVER = "never"
+    """Never load project extensions."""
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionSettings:
+    """Resolved extension configuration for one run."""
+
+    enabled: bool = True
+    """Whether any extension source is loaded."""
+
+    paths: tuple[Path, ...] = field(default_factory=tuple)
+    """Extra files or directories listed in user configuration."""
+
+    trust: TrustPolicy = TrustPolicy.ASK
+    """Policy applied when a project has no persisted trust decision."""
+
+
+def _read_config_section() -> dict[str, object]:
+    """Read `[extensions]` from `~/.deepagents/config.toml`.
+
+    Returns:
+        The section contents, or an empty mapping when absent or unreadable.
+    """
+    import tomllib  # deferred: only needed when config is read
+
+    from deepagents_code.model_config import (
+        DEFAULT_CONFIG_PATH,  # deferred to keep the startup path light
+    )
+
+    try:
+        with DEFAULT_CONFIG_PATH.open("rb") as handle:
+            data = tomllib.load(handle)
+    except FileNotFoundError:
+        return {}
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.warning(
+            "Could not read extensions config from %s",
+            DEFAULT_CONFIG_PATH,
+            exc_info=True,
+        )
+        return {}
+    section = data.get("extensions")
+    return section if isinstance(section, dict) else {}
+
+
+def load_extension_settings() -> ExtensionSettings:
+    """Resolve extension settings from config and environment.
+
+    Returns:
+        The effective settings, falling back to defaults for anything absent or
+            malformed.
+    """
+    section = _read_config_section()
+
+    enabled = section.get("enabled", True)
+    env_enabled = os.environ.get(ENABLED_ENV)
+    if env_enabled is not None:
+        enabled = env_enabled.strip().lower() not in _FALSEY
+
+    env_paths = os.environ.get(PATHS_ENV)
+    if env_paths:
+        raw_paths: list[str] = [part for part in env_paths.split(":") if part.strip()]
+    else:
+        configured = section.get("paths")
+        raw_paths = (
+            [entry for entry in configured if isinstance(entry, str)]
+            if isinstance(configured, list)
+            else []
+        )
+
+    raw_trust = os.environ.get(TRUST_ENV) or section.get("trust")
+    try:
+        trust = TrustPolicy(str(raw_trust).strip().lower())
+    except ValueError:
+        if raw_trust is not None:
+            logger.warning("Ignoring unknown extensions trust policy %r", raw_trust)
+        trust = TrustPolicy.ASK
+
+    return ExtensionSettings(
+        enabled=bool(enabled),
+        paths=tuple(Path(entry).expanduser() for entry in raw_paths),
+        trust=trust,
+    )

--- a/libs/code/deepagents_code/extensions/trust.py
+++ b/libs/code/deepagents_code/extensions/trust.py
@@ -1,0 +1,125 @@
+"""Trust store for project-scoped extensions.
+
+Extensions are the first project-level dcode resource that *executes* code
+(skills, `AGENTS.md`, and agents are data), so the trust decision is part of the
+discovery pipeline rather than a check bolted on afterwards: the project source
+is not even scanned until the decision is made.
+
+Decisions are per working directory and persisted next to the other state files
+under `~/.deepagents/.state/extension_trust.json`. They are app-managed
+bookkeeping, not hand-editable configuration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_STORE_VERSION = 1
+"""Schema version stamped into `extension_trust.json`; bump on incompatible changes."""
+
+
+def _default_store_path() -> Path:
+    """Return the default trust store path.
+
+    Returns:
+        `~/.deepagents/.state/extension_trust.json`.
+    """
+    return Path.home() / ".deepagents" / ".state" / "extension_trust.json"
+
+
+def _project_key(project_root: Path | str) -> str:
+    """Return the canonical store key for a project root.
+
+    Returns:
+        The absolute, symlink-resolved path as a string.
+    """
+    return str(Path(project_root).expanduser().resolve(strict=False))
+
+
+def _load_projects(store_path: Path) -> dict[str, Any]:
+    """Read the persisted project map.
+
+    Returns:
+        The stored project map, or an empty mapping when the store is missing or
+            unreadable.
+    """
+    try:
+        data = json.loads(store_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        logger.warning(
+            "Could not read extension trust store %s", store_path, exc_info=True
+        )
+        return {}
+    projects = data.get("projects") if isinstance(data, dict) else None
+    return projects if isinstance(projects, dict) else {}
+
+
+def is_project_extensions_trusted(
+    project_root: Path | str,
+    *,
+    store_path: Path | None = None,
+) -> bool:
+    """Return whether project extensions are trusted for a project root.
+
+    Args:
+        project_root: Project root to inspect.
+        store_path: Alternate store path for tests.
+
+    Returns:
+        `True` when the project root has a persisted trust decision.
+    """
+    path = store_path or _default_store_path()
+    return _project_key(project_root) in _load_projects(path)
+
+
+def trust_project_extensions(
+    project_root: Path | str,
+    *,
+    store_path: Path | None = None,
+) -> bool:
+    """Persist a trust decision for a project root.
+
+    Written atomically via a temporary file in the same directory so a crash
+    mid-write cannot leave a partially valid store that silently grants or drops
+    trust.
+
+    Args:
+        project_root: Project root to trust.
+        store_path: Alternate store path for tests.
+
+    Returns:
+        `True` when the decision was persisted. `False` signals a real
+            persistence failure and must not be treated as an implicit grant.
+    """
+    path = store_path or _default_store_path()
+    projects = _load_projects(path)
+    projects[_project_key(project_root)] = {"trusted_at": datetime.now(UTC).isoformat()}
+    payload = json.dumps(
+        {"version": _STORE_VERSION, "projects": projects},
+        indent=2,
+    )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            delete=False,
+        ) as handle:
+            handle.write(payload)
+            temp_path = Path(handle.name)
+        os.replace(temp_path, path)  # noqa: PTH105  # atomic rename of the temp store
+    except OSError:
+        logger.warning("Could not save extension trust store %s", path, exc_info=True)
+        return False
+    return True

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2314,6 +2314,12 @@ def parse_args() -> argparse.Namespace:
         "(required for headless/CI runs that should load repository hooks)",
     )
     parser.add_argument(
+        "--trust-project-extensions",
+        action="store_true",
+        help="Trust project-level `.deepagents/extensions/` Python extensions "
+        "(required for headless/CI runs that should load repository extensions)",
+    )
+    parser.add_argument(
         "--interpreter",
         action=argparse.BooleanOptionalAction,
         default=None,
@@ -2571,6 +2577,7 @@ async def run_textual_cli_async(
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
     hook_trust: "WorkspaceTrust | None" = None,
+    trust_project_extensions: bool = False,
     enable_interpreter: bool | None = None,
     interpreter_arg: bool | None = None,
     interpreter_ptc: str | list[str] | None = None,
@@ -2632,6 +2639,8 @@ async def run_textual_cli_async(
             whole-config decision).
         hook_trust: Policy deciding which workspaces may run project-scoped hook
             commands. `None` consults only the persisted trust store.
+        trust_project_extensions: Whether the project's `.deepagents/extensions/`
+            directory may load for this session.
         enable_interpreter: Enable `CodeInterpreterMiddleware` (`js_eval`) on
             the main agent. `None` defers to the sandbox-aware/config default.
         interpreter_arg: The raw `--interpreter`/`--no-interpreter` tri-state,
@@ -2777,6 +2786,7 @@ async def run_textual_cli_async(
         "mcp_config_path": mcp_config_path,
         "no_mcp": no_mcp,
         "trust_project_mcp": trust_project_mcp,
+        "trust_project_extensions": trust_project_extensions,
         "interactive": True,
         "recursion_limit": recursion_limit,
     }
@@ -4159,6 +4169,108 @@ def _check_project_hooks_trust(
     return WorkspaceTrust.none()
 
 
+_PROJECT_EXTENSIONS_REMEMBER_LABEL = "Always allow extensions in this project"
+
+
+def _check_project_extensions_trust(
+    *,
+    trust_flag: bool = False,
+) -> "bool | _TrustPromptOutcome":
+    """Resolve trust for the project's Python extensions.
+
+    Project extensions are the first project-level resource that *executes*
+    code, so the decision is made before the session starts and before the
+    project source is scanned at all.
+
+    Args:
+        trust_flag: Whether the CLI explicitly trusted project extensions.
+
+    Returns:
+        Whether project extensions may load, `INTERRUPTED` when the user presses
+            Ctrl+C, or `CANCELLED` when the user aborts startup.
+    """
+    from rich.console import Console
+
+    from deepagents_code.extensions.discovery import project_extensions_dir
+    from deepagents_code.extensions.settings import (
+        TrustPolicy,
+        load_extension_settings,
+    )
+    from deepagents_code.extensions.trust import (
+        is_project_extensions_trusted,
+        trust_project_extensions,
+    )
+    from deepagents_code.project_utils import ProjectContext
+
+    settings = load_extension_settings()
+    if not settings.enabled or settings.trust is TrustPolicy.NEVER:
+        return False
+
+    try:
+        context = ProjectContext.from_user_cwd(Path.cwd())
+        project_root = context.project_root or context.user_cwd
+        extensions_dir = project_extensions_dir(project_root)
+        if not extensions_dir.is_dir():
+            return False
+    except OSError:
+        logger.warning("Could not inspect project extensions", exc_info=True)
+        return False
+
+    if (
+        trust_flag
+        or settings.trust is TrustPolicy.ALWAYS
+        or is_project_extensions_trusted(project_root)
+    ):
+        return True
+
+    from rich.markup import escape
+
+    prompt_console = Console(stderr=True)
+    prompt_console.print()
+    prompt_console.print(
+        "[bold yellow]Project extensions run arbitrary Python in this "
+        "session.[/bold yellow]",
+        highlight=False,
+    )
+    prompt_console.print(
+        f"Extensions directory: {escape(str(extensions_dir))}", highlight=False
+    )
+    prompt_console.print(
+        "Only trust projects you control. Allow once loads these files as they "
+        f'are now; always allow trusts "{escape(str(project_root))}" for future '
+        "sessions and future edits.",
+        style="yellow",
+        highlight=False,
+    )
+    action = _select_trust_action(
+        prompt_console,
+        remember_label=_PROJECT_EXTENSIONS_REMEMBER_LABEL,
+    )
+    if action is _TrustPromptOutcome.INTERRUPTED:
+        return action
+    if action is _TrustPromptOutcome.CANCELLED:
+        return action
+    if action is _TrustAction.ALLOW_ONCE:
+        prompt_console.print(
+            "[dim]Allowing project extensions for this session.[/dim]",
+            highlight=False,
+        )
+        return True
+    if action is _TrustAction.REMEMBER:
+        if not trust_project_extensions(project_root):
+            prompt_console.print(
+                "[yellow]Project extension trust could not be remembered; "
+                "allowing this session only.[/yellow]",
+                highlight=False,
+            )
+        return True
+    prompt_console.print(
+        "[dim]Project extensions skipped.[/dim]",
+        highlight=False,
+    )
+    return False
+
+
 def _verify_interpreter_or_exit() -> None:
     """Run the interpreter pre-flight check; print and exit on failure.
 
@@ -5100,6 +5212,9 @@ def cli_main() -> None:
                             trust_project_hooks=getattr(
                                 args, "trust_project_hooks", False
                             ),
+                            trust_project_extensions=getattr(
+                                args, "trust_project_extensions", False
+                            ),
                             enable_interpreter=enable_interpreter,
                             interpreter_ptc=interpreter_ptc,
                             allow_fs_tools=allow_fs_tools,
@@ -5215,6 +5330,20 @@ def cli_main() -> None:
                 )
                 return
 
+            extensions_trust = _check_project_extensions_trust(
+                trust_flag=getattr(args, "trust_project_extensions", False),
+            )
+            if extensions_trust is _TrustPromptOutcome.INTERRUPTED:
+                sys.exit(130)
+            if extensions_trust is _TrustPromptOutcome.CANCELLED:
+                from rich.console import Console as _Console
+
+                _Console(stderr=True).print(
+                    "[dim]Aborted; project extensions not loaded.[/dim]",
+                    highlight=False,
+                )
+                return
+
             # Run Textual TUI
             return_code = 0
             request_count = 0
@@ -5269,6 +5398,7 @@ def cli_main() -> None:
                         no_mcp=getattr(args, "no_mcp", False),
                         trust_project_mcp=mcp_trust_decision,
                         hook_trust=hook_trust,
+                        trust_project_extensions=bool(extensions_trust),
                         enable_interpreter=enable_interpreter,
                         interpreter_arg=args.interpreter,
                         interpreter_ptc=interpreter_ptc,

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -15,6 +15,7 @@ import asyncio
 import atexit
 import logging
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from deepagents_code._server_config import ServerConfig
@@ -366,7 +367,42 @@ async def _make_graph() -> Any:  # noqa: ANN401
         )
         return agent
 
-    return await asyncio.to_thread(_create_cli_agent_sync)
+    # Extension factories initialize on the server's persistent event loop so
+    # loop-bound clients and tasks remain valid for the full process lifetime.
+    # The result is propagated through `asyncio.to_thread`'s copied context to
+    # `create_cli_agent`, which consumes it instead of reloading extensions.
+    from deepagents_code.extensions import load_extensions
+    from deepagents_code.extensions.runtime import (
+        HEADLESS_MODE,
+        INTERACTIVE_MODE,
+        bind_server_extensions,
+        reset_server_extensions,
+        shutdown_server_extensions,
+    )
+
+    extension_cwd = (
+        project_context.user_cwd
+        if project_context is not None
+        else Path(config.cwd)
+        if config.cwd is not None
+        else None
+    )
+    extension_result = await load_extensions(
+        cwd=extension_cwd,
+        mode=INTERACTIVE_MODE if config.interactive else HEADLESS_MODE,
+        project_root=(
+            project_context.project_root if project_context is not None else None
+        ),
+        project_trust_granted=config.trust_project_extensions,
+    )
+    token = bind_server_extensions(extension_result)
+    try:
+        return await asyncio.to_thread(_create_cli_agent_sync)
+    except BaseException:
+        await shutdown_server_extensions()
+        raise
+    finally:
+        reset_server_extensions(token)
 
 
 def _build_graph_factory(

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -362,6 +362,7 @@ async def _make_graph() -> Any:  # noqa: ANN401
             async_subagents=async_subagents,
             goal_criteria_tools=read_only_context_tools,
             rubric_grader_tools=read_only_context_tools,
+            trust_project_extensions=config.trust_project_extensions,
         )
         return agent
 

--- a/libs/code/deepagents_code/server_lifespan.py
+++ b/libs/code/deepagents_code/server_lifespan.py
@@ -1,0 +1,26 @@
+"""Custom LangGraph HTTP lifespan for server-owned extension resources."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from starlette.applications import Starlette
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+@asynccontextmanager
+async def _lifespan(_: Starlette) -> AsyncIterator[None]:
+    """Release server extension resources before the server loop closes."""
+    try:
+        yield
+    finally:
+        from deepagents_code.extensions.runtime import shutdown_server_extensions
+
+        await shutdown_server_extensions()
+
+
+app = Starlette(lifespan=_lifespan)
+"""Route-free app merged into LangGraph's server solely for lifespan cleanup."""

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -34,6 +34,7 @@ _TIPS: dict[str, int] = {
     "Use /effort to change the current model's reasoning effort": 1,
     _TIP_EXTERNAL_EDITOR: 1,
     "Use /skill:<name> to invoke a skill directly": 1,
+    "Drop a Python file in ~/.deepagents/extensions and run /extensions": 1,
     "Use /theme to customize the TUI's colors": 1,
     "Use /skill-creator to build reusable agent skills": 1,
     "Ask for a workflow to fan work out to subagents in parallel": 3,

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -186,6 +186,9 @@ def show_help() -> None:
         "  --trust-project-hooks      Trust project hooks.json command handlers"
     )
     console.print(
+        "  --trust-project-extensions Trust project .deepagents/extensions Python"
+    )
+    console.print(
         "  --interpreter, --no-interpreter"
         "  Enable or disable JS interpreter (`js_eval`) middleware"
     )

--- a/libs/code/examples/extensions/audit_log.py
+++ b/libs/code/examples/extensions/audit_log.py
@@ -1,0 +1,71 @@
+"""Reference extension: middleware that gates and records shell commands.
+
+Copy this file into `~/.deepagents/extensions/` to try it. It shows the shape of
+a permission-gate middleware: the agent's `execute` calls are inspected, denied
+commands are turned into a tool error the model can read, and everything else is
+appended to an audit log.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import ToolMessage
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from langchain.agents.middleware.types import ToolCallRequest
+    from langgraph.types import Command
+
+    from deepagents_code.extensions import ExtensionAPI
+
+DENIED = ("rm -rf /", "curl", "wget")
+AUDIT_LOG = Path.home() / ".deepagents" / "shell-audit.log"
+
+
+class ShellAudit(AgentMiddleware):
+    """Records every shell command and blocks a small deny-list."""
+
+    name = "ShellAudit"
+
+    def wrap_tool_call(  # noqa: PLR6301  # AgentMiddleware hook signature
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Inspect an outgoing tool call before it executes.
+
+        Args:
+            request: The pending tool call.
+            handler: The next handler in the middleware chain.
+
+        Returns:
+            An error `ToolMessage` for a denied command, otherwise whatever the
+                downstream handler returns.
+        """
+        if request.tool_call["name"] != "execute":
+            return handler(request)
+
+        command = str(request.tool_call["args"].get("command", ""))
+        if any(pattern in command for pattern in DENIED):
+            return ToolMessage(
+                content=f"Blocked by the ShellAudit extension: {command}",
+                tool_call_id=request.tool_call["id"] or "",
+                status="error",
+            )
+
+        with AUDIT_LOG.open("a", encoding="utf-8") as handle:
+            handle.write(f"{command}\n")
+        return handler(request)
+
+
+def extension(d: ExtensionAPI) -> None:
+    """Register the audit middleware.
+
+    Args:
+        d: The dcode extension API.
+    """
+    d.register_middleware(ShellAudit)

--- a/libs/code/examples/extensions/scratchpad.py
+++ b/libs/code/examples/extensions/scratchpad.py
@@ -1,0 +1,46 @@
+"""Reference extension: a stateful tool.
+
+State lives in the extension instance, created once when the factory runs, so the
+tool accumulates notes for the life of the session. The registered shutdown hook
+flushes them, showing the lifecycle contract: load → init → active → shutdown.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deepagents_code.extensions import ExtensionAPI
+
+
+def extension(d: ExtensionAPI) -> None:
+    """Register a session-scoped scratchpad tool.
+
+    Args:
+        d: The dcode extension API.
+    """
+    notes: list[str] = []
+
+    def remember_note(note: str) -> str:
+        """Save a short note for the rest of this session.
+
+        Args:
+            note: Text to remember.
+
+        Returns:
+            Confirmation including the current note count.
+        """
+        notes.append(note)
+        return f"Saved. {len(notes)} note(s) in the scratchpad."
+
+    def read_notes() -> str:
+        """Return every note saved during this session.
+
+        Returns:
+            The saved notes, one per line.
+        """
+        return "\n".join(notes) if notes else "The scratchpad is empty."
+
+    d.register_tool(remember_note)
+    d.register_tool(read_notes)
+    d.on_shutdown(notes.clear)

--- a/libs/code/examples/extensions/standup.py
+++ b/libs/code/examples/extensions/standup.py
@@ -1,0 +1,48 @@
+"""Reference extension: a slash command.
+
+Registers `/standup`, which summarizes today's commits in the working directory.
+Command handlers may be sync or async and receive a `CommandContext` carrying the
+arguments, the session's working directory, and the runtime mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deepagents_code.extensions import CommandContext, ExtensionAPI
+
+
+async def standup(ctx: CommandContext) -> str:
+    """Summarize commits in the working directory since a given date.
+
+    Args:
+        ctx: Invocation context; the argument is a git `--since` expression.
+
+    Returns:
+        The commit list, or a message explaining why it is unavailable.
+    """
+    since = ctx.args or "yesterday"
+    process = await asyncio.create_subprocess_exec(
+        "git",
+        "log",
+        f"--since={since}",
+        "--pretty=- %s",
+        cwd=ctx.cwd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    if process.returncode != 0:
+        return f"git log failed: {stderr.decode().strip()}"
+    return stdout.decode().strip() or f"No commits since {since}."
+
+
+def extension(d: ExtensionAPI) -> None:
+    """Register the `/standup` command.
+
+    Args:
+        d: The dcode extension API.
+    """
+    d.register_command("standup", standup, description="Summarize recent commits")

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -98,6 +98,30 @@ def test_manifest_covers_every_deepagents_env_var() -> None:
     )
 
 
+def test_manifest_describes_extension_settings() -> None:
+    """Extension scalars and the structured path list stay discoverable."""
+    enabled = get_option("extensions.enabled")
+    paths = get_option("extensions.paths")
+    trust = get_option("extensions.trust")
+
+    assert enabled is not None
+    assert enabled.kind is OptionKind.BOOL
+    assert enabled.default is True
+    assert enabled.env_var == _env_vars.EXTENSIONS
+    assert enabled.toml_keys == ("extensions", "enabled")
+
+    assert paths is not None
+    assert paths.kind is OptionKind.STRUCTURED
+    assert paths.toml_keys == ("extensions", "paths")
+    assert _env_vars.EXTENSIONS_PATHS in NON_OPTION_ENV_VARS
+
+    assert trust is not None
+    assert trust.kind is OptionKind.STR
+    assert trust.default == "ask"
+    assert trust.env_var == _env_vars.EXTENSIONS_TRUST
+    assert trust.toml_keys == ("extensions", "trust")
+
+
 def test_manifest_covers_every_provider_credential() -> None:
     """Every provider in `PROVIDER_API_KEY_ENV` must have a credential option."""
     manifest_env_vars = {opt.env_var for opt in get_config_options() if opt.env_var}

--- a/libs/code/tests/unit_tests/test_extensions.py
+++ b/libs/code/tests/unit_tests/test_extensions.py
@@ -1,0 +1,130 @@
+"""Unit tests for the extension discovery, loading, and trust pipeline."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deepagents_code.extensions import (
+    ExtensionSettings,
+    TrustPolicy,
+    load_extensions,
+    project_extensions_trusted,
+)
+from deepagents_code.extensions.discovery import scan_extension_dir
+from deepagents_code.extensions.models import UnitOrigin
+from deepagents_code.extensions.trust import trust_project_extensions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_TOOL_EXTENSION = '''
+def extension(d):
+    def echo(text: str) -> str:
+        """Echo text."""
+        return text
+
+    d.register_tool(echo)
+    d.register_command("demo", lambda ctx: f"ran in {ctx.cwd}")
+'''
+
+_ASYNC_EXTENSION = """
+async def extension(d):
+    d.register_command("demo", lambda ctx: "second")
+"""
+
+_BROKEN_EXTENSION = """
+raise RuntimeError("boom")
+"""
+
+
+def _write(directory: Path, name: str, body: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_scan_resolves_files_and_package_entry_points(tmp_path: Path) -> None:
+    """Direct modules and one-level package entry files are both discovered."""
+    _write(tmp_path, "single.py", _TOOL_EXTENSION)
+    _write(tmp_path / "pkg", "extension.py", _TOOL_EXTENSION)
+    _write(tmp_path / "pkg" / "nested", "extension.py", _TOOL_EXTENSION)
+    _write(tmp_path, "notes.md", "ignored")
+
+    resolved = scan_extension_dir(tmp_path)
+
+    assert resolved == [
+        (tmp_path / "pkg" / "extension.py", UnitOrigin.PACKAGE),
+        (tmp_path / "single.py", UnitOrigin.TOP_LEVEL),
+    ]
+
+
+async def test_loads_units_and_suffixes_colliding_commands(tmp_path: Path) -> None:
+    """Both extensions load, and the duplicate command name is suffixed."""
+    extensions_dir = tmp_path / "extensions"
+    _write(extensions_dir, "a_first.py", _TOOL_EXTENSION)
+    _write(extensions_dir, "b_second.py", _ASYNC_EXTENSION)
+
+    result = await load_extensions(
+        cwd=tmp_path,
+        settings=ExtensionSettings(paths=(extensions_dir,)),
+    )
+
+    assert not result.errors
+    assert [unit.name for unit in result.registry.tools] == ["echo"]
+    assert [unit.name for unit in result.registry.commands] == ["demo", "demo-2"]
+    assert result.registry.command_description("demo") == ""
+
+
+async def test_broken_extension_is_isolated(tmp_path: Path) -> None:
+    """A failing extension is reported without preventing the others."""
+    extensions_dir = tmp_path / "extensions"
+    _write(extensions_dir, "a_broken.py", _BROKEN_EXTENSION)
+    _write(extensions_dir, "b_good.py", _TOOL_EXTENSION)
+
+    result = await load_extensions(
+        cwd=tmp_path,
+        settings=ExtensionSettings(paths=(extensions_dir,)),
+    )
+
+    assert len(result.errors) == 1
+    assert "a_broken.py" in result.errors[0]
+    assert [unit.name for unit in result.registry.tools] == ["echo"]
+
+
+async def test_project_extensions_load_only_once_trusted(tmp_path: Path) -> None:
+    """The project source stays unscanned until a trust decision exists."""
+    project_root = tmp_path / "repo"
+    _write(project_root / ".deepagents" / "extensions", "ext.py", _TOOL_EXTENSION)
+    store = tmp_path / "trust.json"
+    settings = ExtensionSettings(paths=())
+
+    untrusted = await load_extensions(
+        cwd=project_root,
+        project_root=project_root,
+        settings=settings,
+        trust_store_path=store,
+    )
+    assert untrusted.registry.is_empty()
+
+    assert trust_project_extensions(project_root, store_path=store)
+    trusted = await load_extensions(
+        cwd=project_root,
+        project_root=project_root,
+        settings=settings,
+        trust_store_path=store,
+    )
+    assert [unit.name for unit in trusted.registry.tools] == ["echo"]
+
+
+def test_never_policy_overrides_persisted_trust(tmp_path: Path) -> None:
+    """`never` refuses project extensions even with a stored decision."""
+    store = tmp_path / "trust.json"
+    assert trust_project_extensions(tmp_path, store_path=store)
+
+    assert not project_extensions_trusted(
+        tmp_path, policy=TrustPolicy.NEVER, store_path=store
+    )
+    assert project_extensions_trusted(
+        tmp_path, policy=TrustPolicy.ASK, store_path=store
+    )

--- a/libs/code/tests/unit_tests/test_extensions.py
+++ b/libs/code/tests/unit_tests/test_extensions.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import pytest
+from blockbuster import blockbuster_ctx
 
 from deepagents_code.extensions import (
     ExtensionSettings,
@@ -236,6 +237,23 @@ async def test_loads_units_and_suffixes_colliding_commands(tmp_path: Path) -> No
     assert [unit.name for unit in result.registry.tools] == ["echo"]
     assert [unit.name for unit in result.registry.commands] == ["demo", "demo-2"]
     assert result.registry.command_description("demo") == ""
+
+
+async def test_extension_discovery_runs_off_event_loop(tmp_path: Path) -> None:
+    """Server extension discovery must not block LangGraph's event loop."""
+    extensions_dir = tmp_path / "extensions"
+    _write(extensions_dir, "extension.py", _ASYNC_EXTENSION)
+
+    with blockbuster_ctx() as blockbuster:
+        try:
+            result = await load_extensions(
+                cwd=tmp_path,
+                settings=ExtensionSettings(paths=(extensions_dir,)),
+            )
+        finally:
+            blockbuster.deactivate()
+
+    assert [unit.name for unit in result.registry.commands] == ["demo"]
 
 
 async def test_broken_extension_is_isolated(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_extensions.py
+++ b/libs/code/tests/unit_tests/test_extensions.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path  # noqa: TC003  # used at runtime (Path.cwd() in tests)
-from typing import TYPE_CHECKING
+import asyncio
+import os
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -16,6 +19,11 @@ from deepagents_code.extensions import (
 from deepagents_code.extensions.discovery import scan_extension_dir
 from deepagents_code.extensions.models import UnitOrigin
 from deepagents_code.extensions.trust import trust_project_extensions
+
+if TYPE_CHECKING:
+    from types import FunctionType
+
+    from deepagents.backends.protocol import BackendProtocol
 
 
 @pytest.fixture(autouse=True)
@@ -69,6 +77,48 @@ def extension(d):
     d.register_backend_route("memories", FilesystemBackend(virtual_mode=False))
 """
 
+_PARTIAL_EXTENSION = """
+from deepagents.backends import FilesystemBackend
+
+
+def extension(d):
+    def partial_tool(value: str) -> str:
+        \"\"\"Return a value.\"\"\"
+        return value
+
+    d.register_middleware(object())
+    d.register_tool(partial_tool)
+    d.register_command("partial", lambda ctx: None, description="partial command")
+    d.register_backend_route("/partial/", FilesystemBackend(virtual_mode=False))
+    d.on_shutdown(lambda: None)
+    raise RuntimeError("factory failed")
+"""
+
+_RETAINED_API_EXTENSION = """
+def extension(d):
+    def register_late(ctx):
+        d.register_command("too-late", lambda inner: None)
+
+    d.register_command("register-late", register_late)
+"""
+
+_ASYNC_RESOURCE_EXTENSION = """
+import asyncio
+import threading
+
+events = []
+import_thread = threading.get_ident()
+
+
+async def extension(d):
+    events.append(("start", id(asyncio.get_running_loop())))
+
+    async def shutdown():
+        events.append(("stop", id(asyncio.get_running_loop())))
+
+    d.on_shutdown(shutdown)
+"""
+
 
 def test_route_prefixes_must_be_absolute_and_slash_terminated() -> None:
     """A malformed route prefix is rejected with an ExtensionError."""
@@ -99,7 +149,8 @@ def test_route_prefixes_must_be_absolute_and_slash_terminated() -> None:
     with pytest.raises(ExtensionError):
         api.register_backend_route("/../etc/", FilesystemBackend(virtual_mode=False))
     with pytest.raises(ExtensionError):
-        api.register_backend_route("/memories/", object())
+        # A wrong runtime type is intentional: this exercises API validation.
+        api.register_backend_route("/memories/", cast("BackendProtocol", object()))
 
 
 async def test_registers_backend_routes_in_load_order(tmp_path: Path) -> None:
@@ -201,6 +252,99 @@ async def test_broken_extension_is_isolated(tmp_path: Path) -> None:
     assert len(result.errors) == 1
     assert "a_broken.py" in result.errors[0]
     assert [unit.name for unit in result.registry.tools] == ["echo"]
+
+
+async def test_failed_factory_rolls_back_every_registration(tmp_path: Path) -> None:
+    """A failed factory cannot leave partially initialized units active."""
+    extensions_dir = tmp_path / "extensions"
+    _write(extensions_dir, "partial.py", _PARTIAL_EXTENSION)
+
+    result = await load_extensions(
+        cwd=tmp_path,
+        settings=ExtensionSettings(paths=(extensions_dir,)),
+    )
+
+    assert len(result.errors) == 1
+    assert result.registry.middleware == []
+    assert result.registry.tools == []
+    assert result.registry.commands == []
+    assert result.registry.backend_routes == []
+    assert result.registry.shutdown_hooks == []
+    assert result.registry.command_description("partial") == ""
+
+
+async def test_registration_closes_when_factory_returns(tmp_path: Path) -> None:
+    """An API retained by a command cannot mutate the compiled registry."""
+    from deepagents_code.extensions.models import CommandContext, ExtensionError
+
+    extensions_dir = tmp_path / "extensions"
+    _write(extensions_dir, "retained.py", _RETAINED_API_EXTENSION)
+    result = await load_extensions(
+        cwd=tmp_path,
+        settings=ExtensionSettings(paths=(extensions_dir,)),
+    )
+
+    command = result.registry.find_command("register-late")
+    assert command is not None
+    with pytest.raises(ExtensionError, match="only while their factory is running"):
+        command.unit(CommandContext(args="", cwd=tmp_path, mode="interactive"))
+    assert [unit.name for unit in result.registry.commands] == ["register-late"]
+
+
+async def test_server_extensions_initialize_and_shutdown_on_same_loop(
+    tmp_path: Path,
+) -> None:
+    """Server factories and teardown share the persistent server event loop."""
+    from deepagents_code.extensions.runtime import (
+        bind_server_extensions,
+        load_extensions_blocking,
+        reset_server_extensions,
+    )
+    from deepagents_code.server_lifespan import _lifespan, app
+
+    extensions_dir = tmp_path / "extensions"
+    _write(extensions_dir, "resource.py", _ASYNC_RESOURCE_EXTENSION)
+    result = await load_extensions(
+        cwd=tmp_path,
+        settings=ExtensionSettings(paths=(extensions_dir,)),
+    )
+    hook = result.registry.shutdown_hooks[0].unit
+    globals_ = cast("FunctionType", hook).__globals__
+    events = globals_["events"]
+    assert globals_["import_thread"] != threading.get_ident()
+
+    token = bind_server_extensions(result)
+    try:
+        async with _lifespan(app):
+            reused = await asyncio.to_thread(
+                load_extensions_blocking,
+                settings=ExtensionSettings(enabled=False),
+            )
+            assert reused is result
+            assert events == [("start", id(asyncio.get_running_loop()))]
+    finally:
+        reset_server_extensions(token)
+
+    assert events == [
+        ("start", id(asyncio.get_running_loop())),
+        ("stop", id(asyncio.get_running_loop())),
+    ]
+
+
+def test_extension_paths_use_platform_separator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows drive letters are preserved when `;` separates path entries."""
+    from deepagents_code._env_vars import EXTENSIONS_PATHS
+    from deepagents_code.extensions import settings as settings_module
+
+    monkeypatch.setattr(os, "pathsep", ";")
+    monkeypatch.setenv(EXTENSIONS_PATHS, r"C:\work\one.py;D:\work\two.py")
+    monkeypatch.setattr(settings_module, "_read_config_section", dict)
+
+    settings = settings_module.load_extension_settings()
+
+    assert settings.paths == (Path(r"C:\work\one.py"), Path(r"D:\work\two.py"))
 
 
 async def test_project_extensions_load_only_once_trusted(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_extensions.py
+++ b/libs/code/tests/unit_tests/test_extensions.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path  # noqa: TC003  # used at runtime (Path.cwd() in tests)
 from typing import TYPE_CHECKING
+
+import pytest
 
 from deepagents_code.extensions import (
     ExtensionSettings,
@@ -14,8 +17,22 @@ from deepagents_code.extensions.discovery import scan_extension_dir
 from deepagents_code.extensions.models import UnitOrigin
 from deepagents_code.extensions.trust import trust_project_extensions
 
-if TYPE_CHECKING:
-    from pathlib import Path
+
+@pytest.fixture(autouse=True)
+def _isolate_user_extensions_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Point the global extensions dir at a tmp path.
+
+    `load_extensions` always scans `~/.deepagents/extensions/`, so a real user
+    extension would otherwise leak into these tests and break assertions that
+    expect an empty registry.
+    """
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.user_extensions_dir",
+        lambda: tmp_path / "user-extensions",
+    )
+
 
 _TOOL_EXTENSION = '''
 def extension(d):
@@ -35,6 +52,100 @@ async def extension(d):
 _BROKEN_EXTENSION = """
 raise RuntimeError("boom")
 """
+
+_ROUTE_EXTENSION = """
+from deepagents.backends import FilesystemBackend
+
+
+def extension(d):
+    d.register_backend_route("/memories/", FilesystemBackend(virtual_mode=False))
+"""
+
+_BAD_ROUTE_EXTENSION = """
+from deepagents.backends import FilesystemBackend
+
+
+def extension(d):
+    d.register_backend_route("memories", FilesystemBackend(virtual_mode=False))
+"""
+
+
+def test_route_prefixes_must_be_absolute_and_slash_terminated() -> None:
+    """A malformed route prefix is rejected with an ExtensionError."""
+    from pathlib import Path
+
+    import pytest
+
+    from deepagents_code.extensions import ExtensionAPI, ExtensionRegistry
+    from deepagents_code.extensions.models import (
+        ExtensionError,
+        SourceInfo,
+        UnitOrigin,
+        UnitScope,
+        UnitSource,
+    )
+
+    source = SourceInfo(
+        path=None,
+        source=UnitSource.EXTENSION,
+        scope=UnitScope.USER,
+        origin=UnitOrigin.TOP_LEVEL,
+    )
+    api = ExtensionAPI(ExtensionRegistry(), source, cwd=Path.cwd(), mode="interactive")
+    from deepagents.backends import FilesystemBackend
+
+    with pytest.raises(ExtensionError):
+        api.register_backend_route("memories", FilesystemBackend(virtual_mode=False))
+    with pytest.raises(ExtensionError):
+        api.register_backend_route("/../etc/", FilesystemBackend(virtual_mode=False))
+    with pytest.raises(ExtensionError):
+        api.register_backend_route("/memories/", object())
+
+
+async def test_registers_backend_routes_in_load_order(tmp_path: Path) -> None:
+    """A route registers cleanly and is recorded with its prefix as its name."""
+    extensions_dir = tmp_path / "extensions"
+    _write(extensions_dir, "routes.py", _ROUTE_EXTENSION)
+
+    result = await load_extensions(
+        cwd=tmp_path,
+        settings=ExtensionSettings(paths=(extensions_dir,)),
+    )
+
+    assert not result.errors
+    assert [unit.name for unit in result.registry.backend_routes] == ["/memories/"]
+    assert not result.registry.is_empty()
+
+
+def test_duplicate_route_prefix_is_dropped() -> None:
+    """The first registration of a prefix wins; the second is dropped."""
+    from pathlib import Path
+
+    from deepagents.backends import FilesystemBackend
+
+    from deepagents_code.extensions import ExtensionAPI, ExtensionRegistry
+    from deepagents_code.extensions.models import (
+        SourceInfo,
+        UnitOrigin,
+        UnitScope,
+        UnitSource,
+    )
+
+    source = SourceInfo(
+        path=None,
+        source=UnitSource.EXTENSION,
+        scope=UnitScope.USER,
+        origin=UnitOrigin.TOP_LEVEL,
+    )
+    registry = ExtensionRegistry()
+    api = ExtensionAPI(registry, source, cwd=Path.cwd(), mode="interactive")
+    first = FilesystemBackend(virtual_mode=False)
+    second = FilesystemBackend(virtual_mode=False)
+    api.register_backend_route("/memories/", first)
+    api.register_backend_route("/memories/", second)
+
+    assert [unit.name for unit in registry.backend_routes] == ["/memories/"]
+    assert registry.backend_routes[0].unit is first
 
 
 def _write(directory: Path, name: str, body: str) -> Path:

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from deepagents_code._env_vars import SERVER_ENV_PREFIX
+from deepagents_code._env_vars import EXTENSIONS, SERVER_ENV_PREFIX
 from deepagents_code._server_config import ServerConfig
 
 
@@ -27,6 +27,12 @@ def _module_with_attrs(name: str, **attrs: object) -> ModuleType:
     for key, value in attrs.items():
         setattr(module, key, value)
     return module
+
+
+@pytest.fixture(autouse=True)
+def _disable_extensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep server bootstrap tests independent of user extension files."""
+    monkeypatch.setenv(EXTENSIONS, "0")
 
 
 class TestServerGraph:

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -325,6 +325,7 @@ class TestServerGraph:
             async_subagents=None,
             goal_criteria_tools=[fetch_tool, web_tool, mcp_tool],
             rubric_grader_tools=[fetch_tool, web_tool, mcp_tool],
+            trust_project_extensions=False,
         )
 
     async def test_build_tools_skips_mcp_when_disabled(self) -> None:

--- a/libs/code/tests/unit_tests/test_server_manager.py
+++ b/libs/code/tests/unit_tests/test_server_manager.py
@@ -549,6 +549,7 @@ class TestStartServerAndGetAgent:
         config = json.loads((tmp_path / "langgraph.json").read_text())
         assert config["graphs"]["agent"] == "./server_graph.py:make_graph"
         assert config["checkpointer"]["path"] == "./checkpointer.py:create_checkpointer"
+        assert config["http"]["app"] == "deepagents_code.server_lifespan:app"
 
 
 class TestWritePyproject:


### PR DESCRIPTION
`dcode` can now be extended with local Python: drop a file in `~/.deepagents/extensions/` that defines `extension(d)` and register middleware, tools, and `/commands` without modifying source. `/extensions` lists what loaded and where it came from.

---

Enterprise deployments need to configure the harness without forking it. The design follows the PRD: one pipeline for discovery, trust, loading, and hosting, plus a stable public API extensions are written against.

- **One loader.** Discovery is pure resolution (`dir -> list[Path]`); `load_extension` takes a single file path, requires one `extension` factory, awaits it when async, and collects registrations. Adding a source is a new resolution recipe, never a loader change.
- **One registrar.** `register_middleware`, `register_tool`, `register_command` — plus `on_shutdown` for deterministic teardown. Middleware is a LangChain `AgentMiddleware`, so interception semantics and existing middleware are inherited rather than re-invented. A fourth unit kind is a fourth verb; the factory signature and loader stay fixed.
- **Trust is part of the pipeline.** Extensions are the first project-level resource that *executes* code, so `.deepagents/extensions/` is not even scanned until trust resolves: a persisted per-directory decision, an interactive prompt, a config default (`ask`/`always`/`never`), or `--trust-project-extensions` for non-interactive runs. This mirrors the existing project-hooks trust flow.
- **Provenance and collisions.** Every unit carries a `SourceInfo` (path, source, scope, origin) used for display only. Collisions resolve by load order: first tool registration wins, duplicate command names coexist under a suffix. There is deliberately no scope-override matrix.
- **Error isolation.** A malformed extension is reported and skipped; it can never take down the agent loop.

Extensions load in the server process (middleware and tools) and, on a background worker after mount, in the client process (slash commands) so the first frame is never delayed.

Worth a careful look: the placement of extension middleware/tools at the end of the stack in `create_cli_agent`, the trust-gating path, and the teardown hook added to the app's deferred exit sequence. `EXTENSIONS.md` is the author guide; `examples/extensions/` has three reference extensions (permission-gate middleware, stateful tool, command). Extension-registered tools are not added to the HITL interrupt map — noted in the docs and the threat model.

<details>
<summary>Test plan</summary>

- New unit tests cover scan resolution, load + registration, command-collision suffixing, per-extension error isolation, and project trust gating.
- Verified end-to-end against a temporary `HOME`: all three reference extensions load, and extension middleware appears in the compiled graph built by `create_cli_agent`.

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/01a011a6-0fa7-72c6-aac6-2748d928e9ef)