### PR TITLE
feat(middleware): allow host to supply repair callback for dangling tool calls

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -21,7 +21,13 @@ from langchain.agents.middleware.types import (
 from langchain.agents.structured_output import ResponseFormat
 from langchain_anthropic import ChatAnthropic
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AnyMessage, SystemMessage
+from langchain_core.messages import (
+    AnyMessage,
+    InvalidToolCall,
+    SystemMessage,
+    ToolCall,
+    ToolMessage,
+)
 from langchain_core.tools import BaseTool
 from langgraph.cache.base import BaseCache
 from langgraph.channels.delta import DeltaChannel
@@ -285,6 +291,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache | None = None,
+    patch_tool_calls_handler: Callable[[ToolCall | InvalidToolCall], ToolMessage] | None = None,
 ) -> CompiledStateGraph[AgentState[ResponseT], ContextT, InputAgentState, OutputAgentState[ResponseT]]:  # ty: ignore[invalid-type-arguments]  # ty can't verify generic TypedDicts satisfy StateLike bound
     r"""Create a deep agent.
 
@@ -560,6 +567,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         cache: The cache to use for the agent.
 
             Passed through to [`create_agent`][langchain.agents.create_agent].
+        patch_tool_calls_handler: Optional callback to repair dangling tool calls.
+            Allows the host environment to dictate the failure message.
 
     Returns:
         A configured deep agent.
@@ -671,7 +680,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                     _permissions=subagent_permissions,
                 ),
                 create_summarization_middleware(subagent_model, backend),
-                PatchToolCallsMiddleware(),
+                PatchToolCallsMiddleware(repair_callback=patch_tool_calls_handler),
             ]
             subagent_skills = spec.get("skills")
             if subagent_skills:
@@ -756,7 +765,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 _permissions=permissions,
             ),
             create_summarization_middleware(model, backend),
-            PatchToolCallsMiddleware(),
+            PatchToolCallsMiddleware(repair_callback=patch_tool_calls_handler),
         ]
         if skills is not None:
             gp_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
@@ -841,7 +850,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     deepagent_middleware.extend(
         [
             create_summarization_middleware(model, backend),
-            PatchToolCallsMiddleware(),
+            PatchToolCallsMiddleware(repair_callback=patch_tool_calls_handler),
         ]
     )
 

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -1,15 +1,28 @@
 """Middleware to patch dangling tool calls in the messages history."""
 
+from collections.abc import Callable
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware, AgentState
-from langchain_core.messages import AIMessage, AnyMessage, RemoveMessage, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    AnyMessage,
+    InvalidToolCall,
+    RemoveMessage,
+    ToolCall,
+    ToolMessage,
+)
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime
 
 
 class PatchToolCallsMiddleware(AgentMiddleware):
     """Middleware to patch dangling tool calls in the messages history."""
+
+    def __init__(self, repair_callback: Callable[[ToolCall | InvalidToolCall], ToolMessage] | None = None) -> None:
+        """Initialize the middleware with an optional repair callback."""
+        super().__init__()
+        self.repair_callback = repair_callback
 
     def before_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
         """Before the agent runs, handle dangling tool calls from any AIMessage."""
@@ -36,11 +49,15 @@ class PatchToolCallsMiddleware(AgentMiddleware):
                 tool_call_id = tool_call["id"]
                 if tool_call_id is None or tool_call_id in answered_ids:
                     continue
+                if self.repair_callback:
+                    patched_messages.append(self.repair_callback(tool_call))
+                    continue
+
                 name = tool_call["name"] or "unknown"
                 if tool_call.get("type") == "invalid_tool_call":
                     content = f"Tool call {name} with id {tool_call_id} could not be executed - arguments were malformed or truncated."
                 else:
-                    content = f"Tool call {name} with id {tool_call_id} was cancelled - another message came in before it could be completed."
-                patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id))
+                    content = f"Tool call {name} with id {tool_call_id} has no recorded result."
+                patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id, status="error"))
 
         return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *patched_messages]}


### PR DESCRIPTION
Fixes #5547
This PR fixes the false-success logic in `PatchToolCallsMiddleware` by introducing Dependency Injection. It adds an optional `repair_callback` to the middleware and surfaces it as `patch_tool_calls_handler` in `create_deep_agent`. If no callback is provided, it falls back to a cause-neutral string and correctly injects `status="error"`.