### PR TITLE
fix(sdk): surface sandbox glob failures instead of reporting no matches

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -18,6 +18,7 @@ from deepagents.backends.protocol import (
     FileInfo,
     FileUploadResponse,
     GlobResult,
+    GlobTruncationReason,
     GrepMatch,
     GrepResult,
     LsResult,
@@ -70,7 +71,8 @@ def _strip_route_from_pattern(pattern: str, route_prefix: str) -> str:
         route_prefix: The route prefix (e.g. `/memories/`).
 
     Returns:
-        The pattern with the route prefix stripped, or the original pattern
+        The pattern with the route prefix replaced by a leading `/`
+            (e.g. `/memories/**/*.md` -> `/**/*.md`), or the original pattern
             if it doesn't match the route.
     """
     bare_pattern = pattern.lstrip("/")
@@ -78,6 +80,30 @@ def _strip_route_from_pattern(pattern: str, route_prefix: str) -> str:
     if bare_pattern.startswith(bare_prefix):
         return f"/{bare_pattern[len(bare_prefix) :]}"
     return pattern
+
+
+def _route_glob_pattern(pattern: str, route_prefix: str) -> str | None:
+    """Adapt `pattern` for a routed backend, or `None` if the route cannot match.
+
+    A leading `/` anchors a pattern to the search root, so `/*.py` means
+    top-level files only. Every result from a routed backend is prefixed with
+    its route (`/memories/foo.py`), which is by construction deeper than the
+    anchor allows. Unless the pattern explicitly targets this route, an anchored
+    pattern therefore cannot legitimately match anything here -- forwarding it
+    anyway is what made the composite root violate the anchoring contract that
+    `BackendProtocol.glob` documents.
+
+    Args:
+        pattern: The glob pattern as supplied to the composite backend.
+        route_prefix: The route prefix (e.g. `/memories/`).
+
+    Returns:
+        The pattern to hand the routed backend, or `None` to skip the route.
+    """
+    rewritten = _strip_route_from_pattern(pattern, route_prefix)
+    if rewritten == pattern and pattern.startswith("/"):
+        return None
+    return rewritten
 
 
 def _remap_file_info_path(fi: FileInfo, route_prefix: str) -> FileInfo:
@@ -94,6 +120,25 @@ def _remap_file_info_path(fi: FileInfo, route_prefix: str) -> FileInfo:
 def _glob_truncated(result: GlobResult | list[FileInfo]) -> bool:
     """Read the `truncated` flag off a glob result, tolerating legacy list returns."""
     return result.truncated if isinstance(result, GlobResult) else False
+
+
+def _glob_truncation_reason(result: GlobResult | list[FileInfo]) -> GlobTruncationReason | None:
+    """Read `truncation_reason` off a glob result, tolerating legacy list returns."""
+    return result.truncation_reason if isinstance(result, GlobResult) else None
+
+
+def _merge_truncation_reason(
+    current: GlobTruncationReason | None,
+    incoming: GlobTruncationReason | None,
+) -> GlobTruncationReason | None:
+    """Combine truncation reasons across merged sources, most actionable first.
+
+    `unreadable` wins: it is the one cause the caller cannot fix by narrowing,
+    so it must not be masked by a co-occurring budget truncation.
+    """
+    if current == "unreadable" or incoming == "unreadable":
+        return "unreadable"
+    return current or incoming
 
 
 GlobBackendResult = GlobResult | list[FileInfo]
@@ -126,12 +171,14 @@ def _merge_glob_results(
     """
     results: list[FileInfo] = []
     truncated = False
+    reason: GlobTruncationReason | None = None
 
     if isinstance(default_result, GlobResult) and default_result.error:
         return default_result
     default_matches = default_result.matches if isinstance(default_result, GlobResult) else default_result
     results.extend(default_matches or [])
     truncated = truncated or _glob_truncated(default_result)
+    reason = _merge_truncation_reason(reason, _glob_truncation_reason(default_result))
 
     for route_prefix, sub_result in routed_results:
         if isinstance(sub_result, GlobResult) and sub_result.error:
@@ -139,9 +186,10 @@ def _merge_glob_results(
         sub_matches = sub_result.matches if isinstance(sub_result, GlobResult) else sub_result
         results.extend(_remap_file_info_path(fi, route_prefix) for fi in (sub_matches or []))
         truncated = truncated or _glob_truncated(sub_result)
+        reason = _merge_truncation_reason(reason, _glob_truncation_reason(sub_result))
 
     results.sort(key=lambda x: x.get("path", ""))
-    return GlobResult(matches=results, truncated=truncated)
+    return GlobResult(matches=results, truncated=truncated, truncation_reason=reason)
 
 
 def _route_for_path(
@@ -568,6 +616,13 @@ class CompositeBackend(BackendProtocol):
         Routes to backends based on path: a routed path searches that route,
         `"/"` or `None` searches every backend, and a non-route path searches
         only the default backend.
+
+        When merging across routes, a pattern that targets a route is rewritten
+        relative to that route's internal root (see `_strip_route_from_pattern`);
+        a bare pattern is forwarded unchanged and matches recursively within
+        every route; and a root-anchored pattern that targets no route skips the
+        routed backends entirely, since their results are always deeper than the
+        anchor permits (see `_route_glob_pattern`).
         """
         if path is not None:
             backend, backend_path, route_prefix = _route_for_path(
@@ -583,6 +638,7 @@ class CompositeBackend(BackendProtocol):
                 return GlobResult(
                     matches=[_remap_file_info_path(fi, route_prefix) for fi in (matches or [])],
                     truncated=_glob_truncated(glob_result),
+                    truncation_reason=_glob_truncation_reason(glob_result),
                 )
 
         # If path is None or "/", search default and all routed backends and merge.
@@ -594,7 +650,10 @@ class CompositeBackend(BackendProtocol):
 
             routed_results: list[tuple[str, GlobBackendResult]] = []
             for route_prefix, backend in self.routes.items():
-                sub_result = backend.glob(_strip_route_from_pattern(pattern, route_prefix), "/")
+                routed_pattern = _route_glob_pattern(pattern, route_prefix)
+                if routed_pattern is None:
+                    continue
+                sub_result = backend.glob(routed_pattern, "/")
                 routed_results.append((route_prefix, sub_result))
                 if isinstance(sub_result, GlobResult) and sub_result.error:
                     return _merge_glob_results(default_result, routed_results)
@@ -622,6 +681,7 @@ class CompositeBackend(BackendProtocol):
                 return GlobResult(
                     matches=[_remap_file_info_path(fi, route_prefix) for fi in (matches or [])],
                     truncated=_glob_truncated(glob_result),
+                    truncation_reason=_glob_truncation_reason(glob_result),
                 )
 
         # If path is None or "/", search default and all routed backends and merge.
@@ -633,7 +693,10 @@ class CompositeBackend(BackendProtocol):
 
             routed_results: list[tuple[str, GlobBackendResult]] = []
             for route_prefix, backend in self.routes.items():
-                sub_result = await backend.aglob(_strip_route_from_pattern(pattern, route_prefix), "/")
+                routed_pattern = _route_glob_pattern(pattern, route_prefix)
+                if routed_pattern is None:
+                    continue
+                sub_result = await backend.aglob(routed_pattern, "/")
                 routed_results.append((route_prefix, sub_result))
                 if isinstance(sub_result, GlobResult) and sub_result.error:
                     return _merge_glob_results(default_result, routed_results)

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -38,6 +38,7 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.utils import (
+    InvalidGlobPatternError,
     compile_grep_include_glob,
     create_file_data,
     perform_string_replacement,
@@ -599,6 +600,11 @@ class ContextHubBackend(BackendProtocol):
     ) -> GrepResult:
         """Search contents for `pattern` (optional `path` / `glob` filters).
 
+        The `glob` filter uses `fnmatch` semantics and does *not* follow the
+        shared include-glob contract that `glob()` on this class uses: `*`
+        crosses `/`, and matching is case-normalized. Do not assume the two
+        agree on a given pattern.
+
         When `max_count` is set, at most that many matches are returned; if more
         exist the search stops and the result is flagged `truncated=True`.
         Exactly `max_count` matches with none dropped is reported complete
@@ -647,8 +653,9 @@ class ContextHubBackend(BackendProtocol):
             return GlobResult(error=f"Hub unavailable: {exc}")
         try:
             matcher = compile_grep_include_glob(pattern)
-        except ValueError as exc:
-            return GlobResult(error=f"Invalid glob pattern: {exc}")
+        except InvalidGlobPatternError as exc:
+            logger.warning("Refused glob pattern %r for %r: %s", pattern, self._identifier, exc)
+            return GlobResult(error=str(exc))
         results: list[FileInfo] = [FileInfo(path=f"/{file_path}", is_dir=False) for file_path in cache if matcher(file_path)]
         return GlobResult(matches=results)
 

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -40,10 +40,10 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.utils import (
     MAX_VIDEO_INPUT_BYTES,
+    InvalidGlobPatternError,
     _get_backend_read_file_type,
     check_empty_content,
     compile_grep_include_glob,
-    compile_recursive_glob,
     perform_string_replacement,
     slice_read_response,
 )
@@ -1292,14 +1292,20 @@ class FilesystemBackend(BackendProtocol):
 
         Returns:
             `GlobResult` with matching files. `truncated` is `True` (and
-            `matches` is partial) when the walk exceeded its wall-clock budget.
+            `matches` is partial) when the walk exceeded its wall-clock budget;
+            `truncation_reason` is then `"budget"`. A pattern the matcher
+            refuses (including one containing `..`) is returned as
+            `GlobResult(error=..., matches=None)`, never raised.
         """
-        # Detect traversal on the raw pattern (including a leading `/` anchor)
-        # before compilation. Do not strip the leading `/` here: the matcher
-        # uses it for search-root anchoring (`/*.py` → top-level only).
-        if self.virtual_mode and ".." in Path(pattern.lstrip("/")).parts:
-            msg = "Path traversal not allowed in glob pattern"
-            raise ValueError(msg)
+        # Compile before touching the filesystem: a refused pattern -- brace
+        # expansion past its limit, or a `..` segment -- is a property of the
+        # pattern alone, and reporting it here keeps it distinguishable from the
+        # mid-walk aborts handled far below. `..` rejection lives in the shared
+        # matcher so every backend agrees; see `compile_grep_include_glob`.
+        try:
+            matches_pattern = compile_grep_include_glob(pattern)
+        except InvalidGlobPatternError as e:
+            return GlobResult(error=str(e), matches=None)
 
         try:
             search_path = self.cwd if path is None or path == "/" else self._resolve_path(path)
@@ -1323,12 +1329,6 @@ class FilesystemBackend(BackendProtocol):
         # ourselves -- which is deliberately *not* `rglob` semantics: bare
         # patterns are basename-scoped and dotfiles need an explicit leading `.`.
         try:
-            # Compiled inside the try so a pattern `wcmatch` refuses (e.g. brace
-            # expansion past its limit, which raises `PatternLimitException`)
-            # returns a `GlobResult(error=...)` instead of raising to a direct
-            # caller. Most malformed patterns (`*.{py`, `[a-`) do not raise at
-            # all -- they compile and simply match nothing.
-            matches_pattern = compile_recursive_glob(pattern)
             for matched_path in search_path.rglob("*"):
                 if time.monotonic() > deadline:
                     logger.warning(
@@ -1393,9 +1393,10 @@ class FilesystemBackend(BackendProtocol):
                     except OSError:
                         results.append({"path": virt, "is_dir": False})
         except (OSError, RuntimeError, ValueError) as e:
-            # The pattern failed to compile, or `rglob()` raised mid-iteration.
-            # Return whatever was accumulated but as an error so callers don't
-            # trust it as complete.
+            # `rglob()` raised mid-iteration. Return whatever was accumulated but
+            # as an error so callers don't trust it as complete. Pattern refusals
+            # are handled before the walk starts, so "aborted partway" is now
+            # only ever said about a genuine mid-walk failure.
             display_path = path if path is not None else "<default>"
             msg = f"Glob of '{display_path}' aborted partway: {e}"
             logger.warning("%s", msg, exc_info=True)
@@ -1403,7 +1404,11 @@ class FilesystemBackend(BackendProtocol):
             return GlobResult(error=msg, matches=results)
 
         results.sort(key=lambda x: x.get("path", ""))
-        return GlobResult(matches=results, truncated=truncated)
+        return GlobResult(
+            matches=results,
+            truncated=truncated,
+            truncation_reason="budget" if truncated else None,
+        )
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         """Upload multiple files to the filesystem.

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -27,6 +27,15 @@ This gives `FilesystemBackend` enough headroom to finish the worst-case sync
 path: ripgrep timeout, then Python fallback timeout.
 """
 
+ASYNC_GLOB_TIMEOUT: Final = 30
+"""Timeout in seconds for a sandbox glob round-trip.
+
+The remote script bounds its own walk (`TIME_BUDGET` in `sandbox.py`), but that
+covers neither interpreter startup, the sandbox round-trip, nor transferring up
+to `MAX_MATCHES` records. Without an outer bound a wedged sandbox hangs the
+caller indefinitely.
+"""
+
 FileOperationError = Literal[
     "file_not_found",
     "permission_denied",
@@ -356,6 +365,19 @@ def _apply_grep_max_count(result: GrepResult, max_count: int | None) -> GrepResu
     return GrepResult(error=result.error, matches=result.matches[:max_count], truncated=True)
 
 
+GlobTruncationReason = Literal["budget", "unreadable", "transport"]
+"""Why a `GlobResult` is incomplete.
+
+The distinction decides what advice is useful to the caller:
+
+- `budget`: the walk hit its time limit or match cap. Narrowing the pattern or
+  the path surfaces the rest.
+- `unreadable`: a subtree could not be read (e.g. permissions). Narrowing will
+  *never* surface those files, so advising it sends the caller in a loop.
+- `transport`: the sandbox transport clipped the output.
+"""
+
+
 @dataclass
 class GlobResult:
     """Result from backend `glob` operations.
@@ -367,11 +389,15 @@ class GlobResult:
             stopping. `None` only on a hard failure.
         truncated: True when the walk stopped early (e.g. hit its time limit)
             and `matches` is therefore incomplete but still valid.
+        truncation_reason: Why `matches` is incomplete. Set whenever the
+            producing backend can distinguish the cause; `None` when
+            `truncated` is False or the cause is unknown.
     """
 
     error: str | None = None
     matches: list["FileInfo"] | None = None
     truncated: bool = False
+    truncation_reason: GlobTruncationReason | None = None
 
 
 # @abstractmethod to avoid breaking subclasses that only implement a subset
@@ -614,8 +640,12 @@ class BackendProtocol(abc.ABC):  # noqa: B024
 
         Returns:
             `GlobResult` with matching files or error. Patterns the matcher
-            refuses (e.g. brace expansion past its limit) are reported as
-            `error`, not raised.
+            refuses -- brace expansion past its limit, or a `..` segment -- are
+            reported as `error` with `matches=None`, not raised.
+
+            `FileInfo.path` is always absolute. `_check_fs_permission` matches
+            `deny` rules against absolute patterns only, so a backend returning
+            a relative path silently bypasses every deny rule.
 
         Raises:
             NotImplementedError: If the backend does not implement `glob`.

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -21,9 +21,10 @@ import logging
 import os
 import shlex
 from abc import ABC, abstractmethod
-from typing import Any, Final
+from typing import Any, Final, Literal
 
 from deepagents.backends.protocol import (
+    ASYNC_GLOB_TIMEOUT,
     ASYNC_GREP_TIMEOUT,
     DeleteResult,
     EditResult,
@@ -34,6 +35,7 @@ from deepagents.backends.protocol import (
     FileInfo,
     FileUploadResponse,
     GlobResult,
+    GlobTruncationReason,
     GrepMatch,
     GrepResult,
     LsResult,
@@ -57,6 +59,11 @@ import time
 path = base64.b64decode('{path_b64}').decode('utf-8')
 pattern = base64.b64decode('{pattern_b64}').decode('utf-8')
 
+# Bounds on a model-supplied pattern over an untrusted tree. Exceeding any of
+# them sets the truncated flag on the result rather than failing. TIME_BUDGET is
+# the sandbox-side analogue of _DEFAULT_GLOB_TIMEOUT in filesystem.py and is
+# deliberately the same 5s; the outer round-trip is bounded separately by
+# ASYNC_GLOB_TIMEOUT. (No backticks: this comment runs through sh.)
 MAX_EXPANSIONS = 1000
 MAX_MATCHES = 10000
 TIME_BUDGET = 5.0
@@ -241,11 +248,38 @@ def _include_match(rel, pat, candidates):
 
 walk_errors = []
 
+# Pseudo-filesystems are effectively infinite and never hold user files. A bare
+# pattern is basename-at-any-depth, so a search rooted at '/' would otherwise
+# burn the entire time budget in /proc and return an arbitrary prefix.
+PRUNE_AT_ROOT = ('proc', 'sys', 'dev')
+
 
 def _on_walk_error(err):
-    walk_errors.append(type(err).__name__)
+    # Keep the failing path, not just the exception class: 'PermissionError' x40
+    # cannot distinguish one chronically unreadable mount from an unreadable tree.
+    walk_errors.append(type(err).__name__ + ':' + str(getattr(err, 'filename', '?')))
 
 
+def _emit(matches, truncated):
+    for item in sorted(matches):
+        print(json.dumps({{'path': item, 'is_dir': False}}))
+    if walk_errors:
+        print(json.dumps({{
+            'warning': 'walk_errors',
+            'count': len(walk_errors),
+            'sample': walk_errors[:5],
+        }}))
+    if truncated:
+        print(json.dumps({{'warning': 'truncated'}}))
+
+
+matches = []
+truncated = False
+# Prologue: everything that can fail before any match exists. Kept in its own
+# try so its handlers only ever fire when there is genuinely nothing to report --
+# a failure raised from inside the walk below must not be reported as an
+# inaccessible search root while discarding thousands of good matches.
+ready = False
 try:
     real_root = os.path.realpath(path)
     # os.path.realpath('/') is '/', so a naive real_root + os.sep is '//', which
@@ -261,43 +295,7 @@ try:
             print(json.dumps({{'error': 'pattern_too_broad'}}))
         else:
             candidates = [_normalize_classes(item) for item in expanded]
-            deadline = time.monotonic() + TIME_BUDGET
-            truncated = False
-            matches = []
-            # os.walk includes hidden directories; matching rules still exclude
-            # leading-dot basenames unless the pattern is explicit (no DOTMATCH).
-            # onerror is required: os.walk otherwise discards unreadable subtrees
-            # silently, shrinking the result set with no signal to the caller.
-            for dirpath, dirnames, filenames in os.walk('.', onerror=_on_walk_error):
-                if truncated:
-                    break
-                if time.monotonic() > deadline:
-                    truncated = True
-                    break
-                for name in filenames:
-                    if time.monotonic() > deadline or len(matches) >= MAX_MATCHES:
-                        truncated = True
-                        break
-                    full = name if dirpath == '.' else os.path.join(dirpath, name)
-                    rel = full.replace(chr(92), '/')
-                    if rel.startswith('./'):
-                        rel = rel[2:]
-                    if not _include_match(rel, pattern, candidates):
-                        continue
-                    candidate = os.path.realpath(full)
-                    if candidate != real_root and not candidate.startswith(root_prefix):
-                        continue
-                    # Regular files only, mirroring FilesystemBackend.glob's
-                    # is_file() filter; also drops broken symlinks.
-                    if not os.path.isfile(candidate):
-                        continue
-                    matches.append(rel)
-            for item in sorted(matches):
-                print(json.dumps({{'path': item, 'is_dir': False}}))
-            if walk_errors:
-                print(json.dumps({{'warning': 'walk_errors', 'count': len(walk_errors)}}))
-            if truncated:
-                print(json.dumps({{'warning': 'truncated'}}))
+            ready = True
 except FileNotFoundError:
     print(json.dumps({{'error': 'path_not_found'}}))
 except NotADirectoryError:
@@ -307,7 +305,51 @@ except PermissionError:
 except Exception as exc:
     # Without this, any other failure reaches stdout as a traceback that the
     # host parser cannot read, and the caller sees a successful empty search.
-    print(json.dumps({{'error': 'internal_error: ' + type(exc).__name__}}))
+    # Carry the message, bounded: 'internal_error: KeyError' alone cannot
+    # distinguish a pattern-parser bug from a surrogate in a filename.
+    print(json.dumps({{'error': 'internal_error: ' + type(exc).__name__ + ': ' + str(exc)[:200]}}))
+
+if ready:
+    deadline = time.monotonic() + TIME_BUDGET
+    at_root = real_root == os.sep
+    try:
+        # os.walk includes hidden directories; matching rules still exclude
+        # leading-dot basenames unless the pattern is explicit (no DOTMATCH).
+        # onerror is required: os.walk otherwise discards unreadable subtrees
+        # silently, shrinking the result set with no signal to the caller.
+        for dirpath, dirnames, filenames in os.walk('.', onerror=_on_walk_error):
+            if truncated:
+                break
+            if dirpath == '.' and at_root:
+                dirnames[:] = [d for d in dirnames if d not in PRUNE_AT_ROOT]
+            if time.monotonic() > deadline:
+                truncated = True
+                break
+            for name in filenames:
+                if time.monotonic() > deadline or len(matches) >= MAX_MATCHES:
+                    truncated = True
+                    break
+                full = name if dirpath == '.' else os.path.join(dirpath, name)
+                rel = full.replace(chr(92), '/')
+                if rel.startswith('./'):
+                    rel = rel[2:]
+                if not _include_match(rel, pattern, candidates):
+                    continue
+                candidate = os.path.realpath(full)
+                if candidate != real_root and not candidate.startswith(root_prefix):
+                    continue
+                # Regular files only, mirroring FilesystemBackend.glob's
+                # is_file() filter; also drops broken symlinks.
+                if not os.path.isfile(candidate):
+                    continue
+                matches.append(rel)
+    except Exception as exc:
+        # A failure mid-walk (a symlink racing a deletion, an unreadable entry
+        # os.walk raises rather than routing to onerror) must not throw away the
+        # matches already found. Record it as a walk error and emit the partial
+        # set -- valid but incomplete, which is exactly what 'walk_errors' means.
+        walk_errors.append(type(exc).__name__ + ':' + str(exc)[:100])
+    _emit(matches, truncated)
 
 " 2>&1"""
 """Find files matching a pattern.
@@ -320,8 +362,14 @@ dirs while still excluding leading-dot basenames unless the pattern is explicit.
 Emits one JSON object per matching regular file (directories are omitted, as in
 `FilesystemBackend.glob`), then an out-of-band `warning` record when the walk
 was cut short by its time/match budget or skipped an unreadable subtree, so a
-partial result is never mistaken for an exhaustive one. Every failure path emits
-a structured `error` code rather than a traceback.
+partial result is never mistaken for an exhaustive one. `walk_errors` and
+`truncated` are separate warnings because they need different remedies: the
+first cannot be fixed by narrowing the search, the second can.
+
+Every failure *inside the script* emits a structured `error` code rather than a
+traceback. Failures before it runs (no `python3`, a shell-level error) and output
+the transport clips still arrive as raw text, which `_parse_glob_output` treats
+as a hard error.
 """
 
 
@@ -981,6 +1029,20 @@ def _build_glob_cmd(pattern: str, search_path: str) -> str:
     return _GLOB_COMMAND_TEMPLATE.format(path_b64=path_b64, pattern_b64=pattern_b64)
 
 
+def _glob_search_root(path: str | None) -> str:
+    """Normalize a caller-supplied glob root to an absolute path.
+
+    `_absolutize_glob_path` joins matches onto this root, so a relative root
+    yields relative matches -- and `_check_fs_permission` only matches `deny`
+    rules against absolute patterns, so those matches would bypass every rule.
+    The middleware already forces a leading `/`, but `SandboxBackend.glob` is
+    also called directly by SDK users.
+    """
+    if not path:
+        return "/"
+    return path if path.startswith("/") else f"/{path}"
+
+
 def _absolutize_glob_path(search_path: str, rel_path: str) -> str:
     """Join a search-root-relative glob match onto its search root.
 
@@ -1000,16 +1062,25 @@ def _absolutize_glob_path(search_path: str, rel_path: str) -> str:
     return f"{search_path.rstrip('/')}/{rel_path}"
 
 
-def _classify_glob_line(line: str) -> tuple[str, Any]:
+_GlobLineKind = Literal["match", "error", "warning", "unparsed"]
+"""Classification of one line of remote glob output."""
+
+
+def _classify_glob_line(line: str) -> tuple[_GlobLineKind, Any]:
     """Classify one line of remote glob output.
+
+    Classification is total: every line lands in exactly one kind, with no
+    "skip" outcome. That is what keeps a remote crash from being mistaken for a
+    successful empty search -- see `_parse_glob_output`.
 
     Args:
         line: A single non-blank stdout line.
 
     Returns:
-        `(kind, payload)` where `kind` is `"match"` (payload is the record),
-        `"error"` (payload is the error code), `"warning"` (payload is the
-        record) or `"unparsed"` (payload is the raw line).
+        `(kind, payload)` where `kind` is `"match"` (payload is the record, and
+        its `"path"` is guaranteed to be a `str`), `"error"` (payload is the
+        error code), `"warning"` (payload is the record) or `"unparsed"`
+        (payload is the raw line).
     """
     try:
         data = json.loads(line)
@@ -1021,9 +1092,60 @@ def _classify_glob_line(line: str) -> tuple[str, Any]:
         return ("error", data["error"])
     if "warning" in data:
         return ("warning", data)
-    if "path" not in data:
+    # A non-`str` path would reach `_absolutize_glob_path` and raise at the tool
+    # boundary; treat it as unparseable so it becomes a structured error instead.
+    if not isinstance(data.get("path"), str):
         return ("unparsed", line)
     return ("match", data)
+
+
+def _glob_output_shortcut(result: ExecuteResponse, output: str, search_path: str) -> GlobResult | None:
+    """Resolve the two cases decidable without parsing any lines.
+
+    Returns `None` when the output must still be parsed.
+
+    A non-zero `exit_code` is a hard error: a killed or crashed helper otherwise
+    reports "no files found" with full confidence, and the agent concludes the
+    files do not exist. Empty output carries `result.truncated` through for the
+    same reason -- a transport that clipped the output to nothing must not read
+    as a confident empty result.
+    """
+    if result.exit_code is not None and result.exit_code != 0:
+        detail = output[:200] if output else f"exit code {result.exit_code}"
+        logger.error("Sandbox glob helper failed for path %r: %s", search_path, detail)
+        return GlobResult(matches=None, error=f"Path '{search_path}': glob helper failed: {detail}")
+    if not output:
+        return GlobResult(
+            matches=[],
+            truncated=result.truncated,
+            truncation_reason="transport" if result.truncated else None,
+        )
+    return None
+
+
+def _glob_warning_reason(
+    payload: dict[str, Any],
+    current: GlobTruncationReason | None,
+    search_path: str,
+) -> GlobTruncationReason | None:
+    """Map one remote `warning` record to a truncation reason.
+
+    Budget exhaustion and an unreadable subtree both mean "valid but partial",
+    but they need opposite advice downstream: narrowing the search recovers
+    budget-truncated matches and will never surface files under a directory we
+    could not read. `unreadable` therefore outranks any reason already set.
+    """
+    if payload.get("warning") == "walk_errors":
+        logger.warning(
+            "Sandbox glob could not read %s path(s) under %r; results are incomplete. Sample: %s",
+            payload.get("count", "an unknown number of"),
+            search_path,
+            payload.get("sample", []),
+        )
+        return "unreadable"
+    if current is None:
+        return "budget"
+    return current
 
 
 def _parse_glob_output(result: ExecuteResponse, search_path: str) -> GlobResult:
@@ -1032,8 +1154,14 @@ def _parse_glob_output(result: ExecuteResponse, search_path: str) -> GlobResult:
     Unrecognized lines are a hard error rather than a skip: with `2>&1` merging
     stderr into stdout, silently dropping them turns any remote crash into a
     successful empty search, and the agent concludes the files do not exist.
-    The sole exception is an unparseable final line when the transport reports
-    truncation, because that line may be an incomplete JSON record.
+    The sole exception is an unparseable final line when *the transport* reports
+    truncation, because that line may be an incomplete JSON record. The check
+    reads `result.truncated` rather than the accumulated `truncated` below: a
+    walk that self-reported a budget warning cannot produce a torn line, so
+    letting a warning widen the exemption would swallow a real traceback.
+
+    A non-zero `exit_code` is a hard error for the same reason -- a killed or
+    crashed helper otherwise reports "no files found" with full confidence.
 
     Args:
         result: Raw `execute` response; its `truncated` flag means the transport
@@ -1042,15 +1170,17 @@ def _parse_glob_output(result: ExecuteResponse, search_path: str) -> GlobResult:
 
     Returns:
         `GlobResult` with absolute paths. `truncated` is `True` when the walk or
-        the transport cut results short.
+        the transport cut results short, with `truncation_reason` naming which.
     """
     output = result.output.strip()
-    if not output:
-        return GlobResult(matches=[])
+    early = _glob_output_shortcut(result, output, search_path)
+    if early is not None:
+        return early
     file_infos: list[FileInfo] = []
     unparsed: list[str] = []
     error: str | None = None
     truncated = result.truncated
+    reason: GlobTruncationReason | None = "transport" if result.truncated else None
     lines = output.split("\n")
     for index, line in enumerate(lines):
         if not line.strip():
@@ -1066,12 +1196,18 @@ def _parse_glob_output(result: ExecuteResponse, search_path: str) -> GlobResult:
         elif kind == "error":
             error = payload
         elif kind == "warning":
-            # Budget exhausted or a subtree was unreadable: results are valid
-            # but partial, which `truncated` is exactly for.
             truncated = True
-        elif not (truncated and index == len(lines) - 1):
+            reason = _glob_warning_reason(payload, reason, search_path)
+        elif not (result.truncated and index == len(lines) - 1):
             unparsed.append(payload)
+        else:
+            logger.debug(
+                "Sandbox glob dropped a clipped final line for path %r: %s",
+                search_path,
+                payload[:200],
+            )
     if error is not None:
+        logger.error("Sandbox glob returned error %r for path %r", error, search_path)
         return GlobResult(matches=None, error=f"Path '{search_path}': {error}")
     if unparsed:
         logger.error(
@@ -1084,7 +1220,7 @@ def _parse_glob_output(result: ExecuteResponse, search_path: str) -> GlobResult:
             matches=None,
             error=f"Path '{search_path}': glob helper emitted unexpected output: {unparsed[0][:200]}",
         )
-    return GlobResult(matches=file_infos, truncated=truncated)
+    return GlobResult(matches=file_infos, truncated=truncated, truncation_reason=reason)
 
 
 def _build_edit_inline_cmd(file_path: str, old_string: str, new_string: str, *, replace_all: bool) -> str:
@@ -1788,15 +1924,38 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
         return _parse_grep_output(result, path, max_count)
 
     def glob(self, pattern: str, path: str | None = None) -> GlobResult:
-        """Structured glob matching returning `GlobResult`."""
-        search_path = path or "/"
+        """Structured glob matching returning `GlobResult`.
+
+        Returned paths are absolute (see `_absolutize_glob_path`), which
+        `_check_fs_permission` relies on to apply `deny` rules.
+        """
+        search_path = _glob_search_root(path)
         result = self.execute(_build_glob_cmd(pattern, search_path))
         return _parse_glob_output(result, search_path)
 
     async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:
-        """Async version of `glob`, delegating to `aexecute`."""
-        search_path = path or "/"
-        result = await self.aexecute(_build_glob_cmd(pattern, search_path))
+        """Async version of `glob`, delegating to `aexecute`.
+
+        Bounded by `ASYNC_GLOB_TIMEOUT`: the remote script's own `TIME_BUDGET`
+        covers only the walk, so without an outer timeout a wedged sandbox
+        hangs the caller with no upper bound.
+        """
+        search_path = _glob_search_root(path)
+        try:
+            result = await asyncio.wait_for(
+                self.aexecute(_build_glob_cmd(pattern, search_path)),
+                timeout=ASYNC_GLOB_TIMEOUT,
+            )
+        except TimeoutError:
+            logger.warning(
+                "aglob timed out after %ds (pattern=%r, path=%r)",
+                ASYNC_GLOB_TIMEOUT,
+                pattern,
+                search_path,
+            )
+            return GlobResult(
+                error=f"Error: glob timed out after {ASYNC_GLOB_TIMEOUT}s. Try a more specific pattern or a narrower path.",
+            )
         return _parse_glob_output(result, search_path)
 
     @property

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -22,6 +22,7 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.utils import (
+    InvalidGlobPatternError,
     _copy_file_data_with_content,
     _get_backend_read_file_type,
     _glob_search_files,
@@ -285,14 +286,22 @@ class StateBackend(BackendProtocol):
         return grep_matches_from_files(files, pattern, path if path is not None else "/", glob, max_count=max_count)
 
     def glob(self, pattern: str, path: str | None = None) -> GlobResult:
-        """Get `FileInfo` for files matching glob pattern."""
+        """Get `FileInfo` for files matching glob pattern.
+
+        Matching follows the shared backend contract -- see `BackendProtocol.glob`.
+        A bare pattern is basename-at-any-depth, so `*.py` matches nested files.
+        A refused pattern is returned as `GlobResult(error=...)`, not raised.
+        """
         files = self._read_files()
         try:
             result = _glob_search_files(files, pattern, path)
-        except ValueError as exc:
+        except InvalidGlobPatternError as exc:
             # `glob` is a tool boundary: report a refused pattern as a result
             # rather than raising, matching FilesystemBackend and SandboxBackend.
-            return GlobResult(error=f"Invalid glob pattern: {exc}")
+            # Catch the specific type -- a bare `ValueError` here would also
+            # capture path-normalization failures and mislabel them as pattern
+            # errors, sending the model off rewriting a glob that was fine.
+            return GlobResult(error=str(exc))
         if result == "No files found":
             return GlobResult(matches=[])
         paths = result.split("\n")

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -24,6 +24,7 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.utils import (
+    InvalidGlobPatternError,
     _get_backend_read_file_type,
     _glob_search_files,
     create_file_data,
@@ -610,7 +611,12 @@ class StoreBackend(BackendProtocol):
         return grep_matches_from_files(files, pattern, path, glob, max_count=max_count)
 
     def glob(self, pattern: str, path: str | None = None) -> GlobResult:
-        """Find files matching a glob pattern in the store."""
+        """Find files matching a glob pattern in the store.
+
+        Matching follows the shared backend contract -- see `BackendProtocol.glob`.
+        A bare pattern is basename-at-any-depth, so `*.py` matches nested files.
+        A refused pattern is returned as `GlobResult(error=...)`, not raised.
+        """
         store = self._get_store()
         namespace = self._get_namespace()
         items = self._search_store_paginated(store, namespace)
@@ -622,10 +628,13 @@ class StoreBackend(BackendProtocol):
                 continue
         try:
             result = _glob_search_files(files, pattern, path)
-        except ValueError as exc:
+        except InvalidGlobPatternError as exc:
             # `glob` is a tool boundary: report a refused pattern as a result
             # rather than raising, matching FilesystemBackend and SandboxBackend.
-            return GlobResult(error=f"Invalid glob pattern: {exc}")
+            # Catch the specific type -- a bare `ValueError` here would also
+            # capture path-normalization failures and mislabel them as pattern
+            # errors, sending the model off rewriting a glob that was fine.
+            return GlobResult(error=str(exc))
         if result == "No files found":
             return GlobResult(matches=[])
         paths = result.split("\n")

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -21,6 +21,19 @@ from deepagents.backends.protocol import FileData, FileInfo as _FileInfo, GrepMa
 logger = logging.getLogger(__name__)
 
 EMPTY_CONTENT_WARNING = "System reminder: File exists but has empty contents"
+
+
+class InvalidGlobPatternError(ValueError):
+    """A glob pattern the shared matcher refuses to compile.
+
+    Subclasses `ValueError` so existing `except ValueError` handlers keep
+    working. Callers that catch this specific type can label the failure a
+    *pattern* problem truthfully -- a bare `ValueError` from the same call also
+    covers path normalization, and mislabeling one as the other sends the model
+    off rewriting a glob that was fine.
+    """
+
+
 MAX_VIDEO_INPUT_BYTES: Final = 1024 * 1024 * 1024
 """Maximum raw video payload size accepted by `read_file` frame extraction."""
 
@@ -100,9 +113,17 @@ def compile_grep_include_glob(pattern: str) -> Callable[[str], bool]:
 
         Example: `/*.py` matches `top.py` but not `src/app/main.py`.
 
+    Leading-dot names match only when the pattern segment itself starts with
+    `.` (no `DOTMATCH`), and `**` will not descend into dot-directories. A bare
+    pattern is therefore *broader* than its `**/` form: `*.yml` matches
+    `.github/workflows/ci.yml`, while `**/*.yml` does not.
+
     Exclusion/negation patterns (a leading `!`) are not supported: the `!` is
     treated literally rather than inverting the match, so results for such
     patterns can diverge from `rg --glob '!...'`.
+
+    This is the single source of truth for both `grep(..., glob=...)` and
+    backend `glob()`.
 
     Args:
         pattern: Glob include pattern.
@@ -112,10 +133,18 @@ def compile_grep_include_glob(pattern: str) -> Callable[[str], bool]:
         the path is included by `pattern`.
 
     Raises:
-        ValueError: If `wcmatch` refuses the pattern (e.g. brace expansion past
-            its limit). Note most malformed patterns (`*.{py`, `[a-`) do not
-            raise -- they compile and simply match nothing.
+        InvalidGlobPatternError: If the pattern contains a `..` segment, or if
+            `wcmatch` refuses it (e.g. brace expansion past its limit). Note
+            most malformed patterns (`*.{py`, `[a-`) do not raise -- they
+            compile and simply match nothing.
     """
+    # Reject traversal here rather than per-backend: every backend routes
+    # through this function, so a single check keeps `../*.py` from being an
+    # exception in one backend and a silent empty result in another.
+    if ".." in pattern.replace("\\", "/").split("/"):
+        msg = f"Path traversal not allowed in glob pattern {pattern!r}"
+        raise InvalidGlobPatternError(msg)
+
     flags = wcglob.BRACE | wcglob.GLOBSTAR
     # A leading `/` anchors to the search root: strip it so it matches against
     # the (slash-less) relative path, but decide anchoring from the original
@@ -126,10 +155,14 @@ def compile_grep_include_glob(pattern: str) -> Callable[[str], bool]:
         compiled = wcglob.compile(pattern.lstrip("/"), flags=flags)
     except Exception as exc:
         # `wcmatch` only raises private types (`wcmatch._wcparse.PatternLimitException`),
-        # so catch broadly and re-raise as ValueError: every backend can then catch
-        # one public type instead of importing from a private module.
+        # so catch broadly and re-raise a public type: every backend can then catch
+        # one public type instead of importing from a private module. Log first --
+        # the breadth also swallows genuine bugs (a non-`str` pattern, a wcmatch
+        # version bump), which would otherwise reach the user as "invalid pattern"
+        # for a pattern that is perfectly valid.
+        logger.warning("wcmatch refused glob pattern %r (%s): %s", pattern, type(exc).__name__, exc)
         msg = f"Invalid glob pattern {pattern!r}: {exc}"
-        raise ValueError(msg) from exc
+        raise InvalidGlobPatternError(msg) from exc
 
     if anchored:
 
@@ -141,21 +174,6 @@ def compile_grep_include_glob(pattern: str) -> Callable[[str], bool]:
             return bool(compiled.match(PurePosixPath(rel_path).name))
 
     return matcher
-
-
-def compile_recursive_glob(pattern: str) -> Callable[[str], bool]:
-    """Alias for `compile_grep_include_glob`, named for the `glob()` call site.
-
-    Backend `glob()` and grep include-filters share one contract; see
-    `compile_grep_include_glob` for the rules and the `Raises` behavior.
-
-    Args:
-        pattern: Glob pattern.
-
-    Returns:
-        Predicate accepting a search-root-relative POSIX path.
-    """
-    return compile_grep_include_glob(pattern)
 
 
 def _normalize_content(file_data: FileData) -> str:
@@ -814,6 +832,11 @@ def _glob_search_files(
 
             `"No files found"` if no matches.
 
+    Raises:
+        InvalidGlobPatternError: If the matcher refuses `pattern` (see
+            `compile_grep_include_glob`). Note an unparseable `path` is *not*
+            raised -- it returns `"No files found"`.
+
     Example:
         ```python
         files = {"/src/main.py": FileData(...), "/test.py": FileData(...)}
@@ -897,7 +920,8 @@ def grep_matches_from_files(
     dropped is reported complete (`truncated=False`).
 
     We deliberately do not raise here to keep backends non-throwing in tool
-    contexts and preserve user-facing error messages.
+    contexts and preserve user-facing error messages: a refused `glob` filter
+    is returned as `GrepResult(error=...)`, not raised.
     """
     try:
         normalized_path = _normalize_path(path)
@@ -907,7 +931,10 @@ def grep_matches_from_files(
     filtered = _filter_files_by_path(files, normalized_path)
 
     if glob:
-        matcher = compile_grep_include_glob(glob)
+        try:
+            matcher = compile_grep_include_glob(glob)
+        except InvalidGlobPatternError as exc:
+            return GrepResult(error=str(exc))
         filtered = {fp: fd for fp, fd in filtered.items() if matcher(_relative_to_root(fp, normalized_path))}
 
     matches: list[GrepMatch] = []

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -47,6 +47,7 @@ from deepagents.backends.protocol import (
     FileData as FileData,  # Re-export for backwards compatibility
     FileInfo,
     GlobResult,
+    GlobTruncationReason,
     GrepMatch,
     GrepResult,
     LsResult,
@@ -778,11 +779,22 @@ def _format_file_paths(paths: list[str]) -> str:
     return str(truncate_if_too_long(paths))
 
 
-def _format_glob_tool_result(paths: list[str], *, truncated: bool) -> str:
-    """Render glob paths for the tool boundary, appending the truncation note when partial."""
+def _format_glob_tool_result(
+    paths: list[str],
+    *,
+    truncated: bool,
+    truncation_reason: GlobTruncationReason | None = None,
+) -> str:
+    """Render glob paths for the tool boundary, appending the truncation note when partial.
+
+    The note depends on *why* the result is partial. Telling the model to narrow
+    its search when a subtree was unreadable sends it into a retry loop that can
+    never succeed, so that case gets its own note.
+    """
     content = _format_file_paths(paths)
     if truncated:
-        return f"{content}\n\n{GLOB_TRUNCATION_NOTE}"
+        note = GLOB_UNREADABLE_NOTE if truncation_reason == "unreadable" else GLOB_TRUNCATION_NOTE
+        return f"{content}\n\n{note}"
     return content
 
 
@@ -864,11 +876,18 @@ GREP_TRUNCATION_NOTE = (
     "The matches above are valid but incomplete. Narrow the search (a more specific pattern or a "
     "narrower path), or raise max_count, to see the rest."
 )
-# Glob has no match-count cap and no `max_count` argument, so its note names only
-# the time/size limit and omits the (inapplicable) "raise max_count" remedy.
+# Glob takes no `max_count` argument, so its note omits the (inapplicable)
+# "raise max_count" remedy. Backends do cap matches internally (`MAX_MATCHES` in
+# the sandbox script), hence "or size limit" rather than naming only the clock.
 GLOB_TRUNCATION_NOTE = (
-    "Note: the search stopped early because it hit its time limit. The paths above are valid but "
-    "incomplete. Narrow the search (a more specific pattern or a narrower path) to see the rest."
+    "Note: the search stopped early because it hit its time or size limit. The paths above are "
+    "valid but incomplete. Narrow the search (a more specific pattern or a narrower path) to see "
+    "the rest."
+)
+GLOB_UNREADABLE_NOTE = (
+    "Note: some directories could not be read, so the paths above are valid but incomplete. "
+    "Narrowing the search will NOT reveal the missing files -- they are inaccessible. Continue "
+    "with what is listed, or report the access problem rather than retrying."
 )
 
 
@@ -2378,7 +2397,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             infos = glob_result.matches or []
             paths = _apply_permissions_to_glob_results(self._permissions, infos)
             return ToolMessage(
-                content=_format_glob_tool_result(paths, truncated=glob_result.truncated),
+                content=_format_glob_tool_result(
+                    paths,
+                    truncated=glob_result.truncated,
+                    truncation_reason=glob_result.truncation_reason,
+                ),
                 tool_call_id=runtime.tool_call_id,
                 name="glob",
                 status="success",
@@ -2442,7 +2465,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             infos = glob_result.matches or []
             paths = _apply_permissions_to_glob_results(self._permissions, infos)
             return ToolMessage(
-                content=_format_glob_tool_result(paths, truncated=glob_result.truncated),
+                content=_format_glob_tool_result(
+                    paths,
+                    truncated=glob_result.truncated,
+                    truncation_reason=glob_result.truncation_reason,
+                ),
                 tool_call_id=runtime.tool_call_id,
                 name="glob",
                 status="success",

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -1350,6 +1350,41 @@ def test_composite_root_glob_preserves_route_pattern_anchoring() -> None:
     assert [match["path"] for match in matches] == ["/memories/top.py"]
 
 
+def test_composite_root_anchored_pattern_skips_routed_backends() -> None:
+    """`/*.py` means top-level only, and every routed match is deeper than that.
+
+    Routed results are prefixed with their route (`/memories/foo.py`), so
+    forwarding a root-anchored pattern to a route makes the composite return
+    depth-2 paths for a pattern the shared contract defines as top-level only.
+    """
+    mem_store = InMemoryStore()
+    routed = StoreBackend(store=mem_store, namespace=lambda _rt: ("routed",))
+    default = StoreBackend(store=mem_store, namespace=lambda _rt: ("default",))
+    comp = CompositeBackend(default=default, routes={"/memories/": routed})
+
+    comp.write("/top.py", "top")
+    comp.write("/memories/foo.py", "routed")
+
+    matches = comp.glob("/*.py", path="/").matches
+
+    assert [match["path"] for match in matches] == ["/top.py"]
+
+
+def test_composite_root_bare_pattern_still_reaches_routes() -> None:
+    """A bare pattern is basename-at-any-depth, so routes must still be searched."""
+    mem_store = InMemoryStore()
+    routed = StoreBackend(store=mem_store, namespace=lambda _rt: ("routed",))
+    default = StoreBackend(store=mem_store, namespace=lambda _rt: ("default",))
+    comp = CompositeBackend(default=default, routes={"/memories/": routed})
+
+    comp.write("/top.py", "top")
+    comp.write("/memories/foo.py", "routed")
+
+    matches = comp.glob("*.py", path="/").matches
+
+    assert {match["path"] for match in matches} == {"/top.py", "/memories/foo.py"}
+
+
 def test_composite_glob_nested_path_in_route() -> None:
     """Test glob with nested path within route."""
     mem_store = InMemoryStore()

--- a/libs/deepagents/tests/unit_tests/backends/test_glob_semantics.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_glob_semantics.py
@@ -25,7 +25,7 @@ import pytest
 from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends.filesystem import FilesystemBackend
-from deepagents.backends.sandbox import _GLOB_COMMAND_TEMPLATE, _build_glob_cmd
+from deepagents.backends.sandbox import _build_glob_cmd
 from deepagents.backends.state import StateBackend
 from deepagents.backends.store import StoreBackend
 from deepagents.backends.utils import _glob_search_files
@@ -184,6 +184,7 @@ def _run_glob_script(
     *,
     allow_error: bool = False,
     time_budget: float | None = None,
+    max_matches: int | None = None,
 ) -> list[dict[str, Any]]:
     """Run the sandbox remote glob script the same way `_build_glob_cmd` does."""
     cmd = _build_glob_cmd(pattern, str(path))
@@ -192,6 +193,8 @@ def _run_glob_script(
     assert script, "failed to extract remote glob script from template"
     if time_budget is not None:
         script = script.replace("TIME_BUDGET = 5.0", f"TIME_BUDGET = {time_budget!r}", 1)
+    if max_matches is not None:
+        script = script.replace("MAX_MATCHES = 10000", f"MAX_MATCHES = {max_matches!r}", 1)
     proc = subprocess.run(  # noqa: S603
         [sys.executable, "-c", script],
         capture_output=True,
@@ -215,8 +218,6 @@ def _run_glob_script(
 def test_build_glob_cmd_passes_user_pattern_unchanged() -> None:
     cmd = _build_glob_cmd("*.py", "/workspace")
     assert base64.b64encode(b"*.py").decode("ascii") in cmd
-    # Bare basename expansion is handled by the remote walk matcher, not the host.
-    assert base64.b64encode(b"**/*.py").decode("ascii") not in cmd
     cmd_anchored = _build_glob_cmd("/*.py", "/workspace")
     assert base64.b64encode(b"/*.py").decode("ascii") in cmd_anchored
 
@@ -318,14 +319,6 @@ class TestSandboxGlobScriptMatrix:
         assert sb == fs, pattern
 
 
-def test_glob_command_template_uses_walk_not_stdlib_glob() -> None:
-    # Stdlib glob(recursive=True) neither expands bare basename patterns nor
-    # walks into leading-dot directories for `**` matches.
-    assert "os.walk" in _GLOB_COMMAND_TEMPLATE
-    assert "fnmatch" in _GLOB_COMMAND_TEMPLATE
-    assert "glob.glob" not in _GLOB_COMMAND_TEMPLATE
-
-
 def test_glob_directory_only_walk_honors_time_budget(tmp_path: Path) -> None:
     """An expired budget stops a walk even when no directory contains files."""
     (tmp_path / "one" / "two" / "three").mkdir(parents=True)
@@ -390,7 +383,12 @@ def test_glob_script_reports_unreadable_subtree_instead_of_shrinking(tmp_path: P
         locked.chmod(stat.S_IRWXU)
 
     assert {r["path"] for r in rows if "path" in r} == {"ok.py"}
-    assert {"warning": "walk_errors", "count": 1} in rows
+    warnings = [r for r in rows if r.get("warning") == "walk_errors"]
+    assert len(warnings) == 1
+    assert warnings[0]["count"] == 1
+    # The sample must name the offending path: a bare exception class cannot
+    # distinguish one chronically unreadable mount from an unreadable tree.
+    assert warnings[0]["sample"] == ["PermissionError:./locked"]
 
 
 class TestSandboxGlobBraceExpansionLimit:
@@ -436,3 +434,123 @@ class TestSandboxGlobBraceExpansionLimit:
         (tmp_path / "{x}b.py").write_text("x")
         rows = _run_glob_script(tmp_path, "{x}{a,b}.py")
         assert {r["path"] for r in rows} == {"{x}a.py", "{x}b.py"}
+
+
+class TestTraversalIsRefusedByEveryBackend:
+    """`..` must not be an exception in one backend and a silent empty in another.
+
+    Rejection lives in `compile_grep_include_glob`, the one function every
+    backend routes through, so the agreed shape is `GlobResult(error=...)` with
+    `matches=None` -- never a raise, and never a confident empty result that
+    hides the refusal.
+    """
+
+    @pytest.mark.parametrize("pattern", ["../*.py", "a/../../etc/*"])
+    def test_state_backend(self, pattern: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        be = StateBackend()
+        files = {p: _file_data(c) for p, c in _TREE_FILES.items()}
+        monkeypatch.setattr(be, "_read_files", lambda: files)
+        result = be.glob(pattern, path="/")
+        assert result.matches is None
+        assert result.error is not None and "traversal" in result.error
+
+    @pytest.mark.parametrize("pattern", ["../*.py", "a/../../etc/*"])
+    def test_store_backend(self, pattern: str) -> None:
+        store = InMemoryStore()
+        be = StoreBackend(store=store, namespace=lambda _rt: ("filesystem",))
+        for p, content in _TREE_FILES.items():
+            assert be.write(p, content).error is None
+        result = be.glob(pattern, path="/")
+        assert result.matches is None
+        assert result.error is not None and "traversal" in result.error
+
+    @pytest.mark.parametrize("virtual_mode", [True, False])
+    @pytest.mark.parametrize("pattern", ["../*.py", "a/../../etc/*"])
+    def test_filesystem_backend_in_both_modes(self, tmp_path: Path, pattern: str, *, virtual_mode: bool) -> None:
+        """Non-virtual mode previously returned an empty result, hiding the refusal."""
+        _write_tree_on_disk(tmp_path)
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=virtual_mode)
+        result = be.glob(pattern, path="/")
+        assert result.matches is None
+        assert result.error is not None and "traversal" in result.error
+
+    def test_filesystem_backend_does_not_raise(self, tmp_path: Path) -> None:
+        """`glob` is a tool boundary; a refusal is a result, not an exception."""
+        _write_tree_on_disk(tmp_path)
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        be.glob("../*.py", path="/")  # must not raise
+
+    def test_sandbox_script(self, tmp_path: Path) -> None:
+        rows = _run_glob_script(tmp_path, "../*.py", allow_error=True)
+        assert rows == [{"error": "invalid_pattern"}]
+
+
+class TestFilesystemBackendGlobMatrixNonVirtual:
+    """Non-virtual mode takes a different result-construction branch.
+
+    Restricted to root searches: outside virtual mode `path` is a host path
+    rather than a root-relative one, so a `/sub` search is a different operation
+    and belongs in the non-virtual path-resolution tests, not the pattern matrix.
+    """
+
+    @pytest.mark.parametrize(
+        ("pattern", "path", "expected"),
+        [case for case in _matrix_expectations() if case[1] == "/"],
+    )
+    def test_matrix(self, tmp_path: Path, pattern: str, path: str, expected: set[str]) -> None:
+        _write_tree_on_disk(tmp_path)
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+        actual = _paths_from_infos(be.glob(pattern, path=path).matches)
+        # Non-virtual mode returns absolute host paths; compare on the tail.
+        root = str(tmp_path)
+        assert {p[len(root) :] or "/" for p in actual} == expected
+
+
+def test_glob_script_match_cap_truncates(tmp_path: Path) -> None:
+    """`MAX_MATCHES` is the only unbounded-result guard; pin it like TIME_BUDGET."""
+    for i in range(5):
+        (tmp_path / f"f{i}.py").write_text("x")
+
+    rows = _run_glob_script(tmp_path, "*.py", max_matches=2)
+
+    assert len([r for r in rows if "path" in r]) == 2
+    assert {"warning": "truncated"} in rows
+
+
+def test_glob_script_does_not_follow_symlink_loops(tmp_path: Path) -> None:
+    """`os.walk` defaults to `followlinks=False`; a future flip would hang the walk."""
+    (tmp_path / "a.py").write_text("a")
+    loop = tmp_path / "loop"
+    loop.mkdir()
+    (loop / "self").symlink_to(loop, target_is_directory=True)
+
+    rows = _run_glob_script(tmp_path, "*.py")
+
+    assert {r["path"] for r in rows if "path" in r} == {"a.py"}
+
+
+def test_filesystem_glob_does_not_follow_symlink_loops(tmp_path: Path) -> None:
+    """`Path.rglob` defaults to not recursing symlinks; pin it alongside the script."""
+    (tmp_path / "a.py").write_text("a")
+    loop = tmp_path / "loop"
+    loop.mkdir()
+    (loop / "self").symlink_to(loop, target_is_directory=True)
+
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    assert _paths_from_infos(be.glob("*.py", path="/").matches) == {"/a.py"}
+
+
+def test_glob_script_does_not_prune_pseudo_fs_names_below_root(tmp_path: Path) -> None:
+    """Pruning applies only when the search root is `/`.
+
+    A user directory named `proc`, `sys` or `dev` is ordinary content; pruning it
+    would silently drop real matches with no warning.
+    """
+    for name in ("proc", "sys", "dev"):
+        (tmp_path / name).mkdir()
+        (tmp_path / name / "f.py").write_text("x")
+
+    rows = _run_glob_script(tmp_path, "*.py")
+
+    assert {r["path"] for r in rows if "path" in r} == {"proc/f.py", "sys/f.py", "dev/f.py"}

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -6,6 +6,7 @@ temp files with a server-side replace script, and command templates format
 correctly.
 """
 
+import asyncio
 import base64
 import json
 import os
@@ -34,6 +35,7 @@ from deepagents.backends.sandbox import (
     _build_grep_cmd,
     _build_read_cmd,
     _check_preflight_result,
+    _glob_search_root,
     _map_edit_error,
     _parse_glob_output,
     _parse_grep_output,
@@ -2050,6 +2052,123 @@ def test_glob_unparseable_output_is_an_error_not_an_empty_search(output: str) ->
     assert "unexpected output" in result.error
 
 
+@pytest.mark.parametrize(
+    ("exit_code", "output"),
+    [
+        pytest.param(137, "", id="sigkill_no_output"),
+        pytest.param(127, "", id="missing_interpreter"),
+        pytest.param(1, '{"path": "a.py", "is_dir": false}', id="partial_then_failure"),
+    ],
+)
+def test_glob_nonzero_exit_is_an_error_not_an_empty_search(exit_code: int, output: str) -> None:
+    """A killed helper must not report "no files found" with full confidence.
+
+    This is the most damaging failure a search tool has: the agent concludes the
+    files do not exist and may recreate them. The partial case matters too -- a
+    crash after some matches must not be presented as an exhaustive result.
+    """
+    resp = ExecuteResponse(output=output, exit_code=exit_code)
+
+    result = _parse_glob_output(resp, "/w")
+
+    assert result.matches is None
+    assert result.error is not None
+    assert "glob helper failed" in result.error
+
+
+def test_glob_empty_output_preserves_transport_truncation() -> None:
+    """Output clipped to nothing is not a confident empty result."""
+    resp = ExecuteResponse(output="", exit_code=0, truncated=True)
+
+    result = _parse_glob_output(resp, "/w")
+
+    assert result.matches == []
+    assert result.truncated is True
+    assert result.truncation_reason == "transport"
+
+
+def test_glob_empty_output_without_truncation_is_a_clean_empty_result() -> None:
+    """The ordinary "nothing matched" case stays untruncated."""
+    result = _parse_glob_output(ExecuteResponse(output="", exit_code=0), "/w")
+
+    assert result.matches == []
+    assert result.truncated is False
+    assert result.truncation_reason is None
+
+
+def test_glob_walk_warning_does_not_excuse_a_trailing_traceback() -> None:
+    """The clipped-final-line exemption belongs to transport truncation only.
+
+    A walk that self-reported a budget warning cannot produce a torn JSON
+    record, so a trailing traceback after one must still be a hard error --
+    otherwise the exemption swallows exactly the crash it was built to surface.
+    """
+    lines = [
+        json.dumps({"path": "a.py", "is_dir": False}),
+        json.dumps({"warning": "truncated"}),
+        "Traceback (most recent call last):",
+    ]
+    resp = ExecuteResponse(output="\n".join(lines), exit_code=0, truncated=False)
+
+    result = _parse_glob_output(resp, "/w")
+
+    assert result.matches is None
+    assert result.error is not None
+    assert "unexpected output" in result.error
+
+
+def test_glob_transport_truncation_still_excuses_a_clipped_final_line() -> None:
+    """The exemption itself must keep working when the transport did clip."""
+    lines = [
+        json.dumps({"path": "a.py", "is_dir": False}),
+        '{"path": "b.py", "is_d',
+    ]
+    resp = ExecuteResponse(output="\n".join(lines), exit_code=0, truncated=True)
+
+    result = _parse_glob_output(resp, "/w")
+
+    assert result.matches == [{"path": "/w/a.py", "is_dir": False}]
+    assert result.truncated is True
+
+
+def test_glob_unreadable_subtree_is_distinguished_from_budget() -> None:
+    """The two truncation causes need opposite advice, so they must not collapse."""
+    budget = _parse_glob_output(ExecuteResponse(output=json.dumps({"warning": "truncated"}), exit_code=0), "/w")
+    unreadable = _parse_glob_output(
+        ExecuteResponse(
+            output=json.dumps({"warning": "walk_errors", "count": 2, "sample": ["PermissionError:./x"]}),
+            exit_code=0,
+        ),
+        "/w",
+    )
+
+    assert budget.truncation_reason == "budget"
+    assert unreadable.truncation_reason == "unreadable"
+
+
+def test_glob_unreadable_outranks_budget_when_both_are_reported() -> None:
+    """`unreadable` is the cause narrowing cannot fix, so it must not be masked."""
+    lines = [
+        json.dumps({"warning": "walk_errors", "count": 1, "sample": ["PermissionError:./x"]}),
+        json.dumps({"warning": "truncated"}),
+    ]
+    resp = ExecuteResponse(output="\n".join(lines), exit_code=0)
+
+    result = _parse_glob_output(resp, "/w")
+
+    assert result.truncation_reason == "unreadable"
+
+
+def test_glob_non_string_path_is_an_error_not_a_crash() -> None:
+    """A non-`str` path would raise inside `_absolutize_glob_path`."""
+    resp = ExecuteResponse(output=json.dumps({"path": 5, "is_dir": False}), exit_code=0)
+
+    result = _parse_glob_output(resp, "/w")
+
+    assert result.matches is None
+    assert result.error is not None
+
+
 def test_glob_pattern_too_broad_is_distinct_from_traversal() -> None:
     """Over-broad and rejected patterns need different codes to be actionable."""
     too_broad = _parse_glob_output(ExecuteResponse(output=json.dumps({"error": "pattern_too_broad"}), exit_code=0), "/w")
@@ -2397,3 +2516,41 @@ class TestSandboxDelete:
         assert result.path is None
         assert result.error is not None
         assert "not found" in result.error
+
+
+class _HangingSandbox(MockSandbox):
+    """Sandbox whose async execute never returns, standing in for a wedged host."""
+
+    async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ASYNC109  # Mirrors the BaseSandbox.aexecute signature under test
+        await asyncio.sleep(3600)
+        msg = "unreachable"
+        raise AssertionError(msg)
+
+
+@pytest.mark.asyncio
+async def test_aglob_is_bounded_by_a_transport_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The script's own TIME_BUDGET bounds only the walk, not the round-trip.
+
+    Without an outer bound a wedged sandbox hangs the caller indefinitely, and
+    `aglob` was the one search entry point with no such bound.
+    """
+    monkeypatch.setattr("deepagents.backends.sandbox.ASYNC_GLOB_TIMEOUT", 0.05)
+    be = _HangingSandbox()
+
+    result = await be.aglob("*.py", "/w")
+
+    assert result.matches is None
+    assert result.error is not None
+    assert "timed out" in result.error
+
+
+def test_glob_search_root_is_forced_absolute() -> None:
+    """A relative root yields relative matches, which bypass every deny rule.
+
+    `_check_fs_permission` only matches `deny` patterns against absolute paths,
+    so a relative path silently escapes them (see test_permissions.py).
+    """
+    assert _glob_search_root("workspace") == "/workspace"
+    assert _glob_search_root("/workspace") == "/workspace"
+    assert _glob_search_root(None) == "/"
+    assert _glob_search_root("") == "/"

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -9,12 +9,12 @@ from pydantic import TypeAdapter
 from deepagents.backends.protocol import FileData, ReadResult
 from deepagents.backends.utils import (
     _EXTENSION_TO_FILE_TYPE,
+    InvalidGlobPatternError,
     _get_backend_read_file_type,
     _get_file_type,
     _glob_search_files,
     _looks_like_regex,
     compile_grep_include_glob,
-    compile_recursive_glob,
     grep_matches_from_files,
     perform_string_replacement,
     regex_literal_hint,
@@ -291,25 +291,28 @@ class TestGlobSearchFiles:
         assert "/foo/b.txt" not in result
 
 
-class TestCompileRecursiveGlobSharesIncludeContract:
-    """`compile_recursive_glob` is the walk entry-point for the shared contract."""
+class TestCompileGrepIncludeGlobRefusals:
+    """Refusals are a public `ValueError` subtype backends can catch precisely."""
 
-    def test_delegates_to_include_glob_matcher(self) -> None:
-        paths = ["top.py", "src/app/main.py", "readme.md"]
-        for pattern in ("*.py", "**/*.py", "/*.py", "src/**/*.py"):
-            expected = [p for p in paths if compile_grep_include_glob(pattern)(p)]
-            actual = [p for p in paths if compile_recursive_glob(pattern)(p)]
-            assert actual == expected, pattern
+    def test_pattern_wcmatch_refuses_raises_invalid_glob_pattern(self) -> None:
+        """Backends catch `InvalidGlobPatternError`; wcmatch's own type is private."""
+        with pytest.raises(InvalidGlobPatternError, match="Invalid glob pattern"):
+            compile_grep_include_glob("{a,b}" * 40 + "*.py")
 
-    def test_pattern_wcmatch_refuses_raises_value_error(self) -> None:
-        """Backends catch `ValueError`; wcmatch's own type is private."""
-        with pytest.raises(ValueError, match="Invalid glob pattern"):
-            compile_recursive_glob("{a,b}" * 40 + "*.py")
+    def test_refusal_is_a_value_error(self) -> None:
+        """Subclassing `ValueError` keeps pre-existing handlers working."""
+        assert issubclass(InvalidGlobPatternError, ValueError)
+
+    def test_traversal_pattern_is_refused(self) -> None:
+        """`..` is rejected in the shared matcher so every backend agrees."""
+        for pattern in ("../*.py", "a/../../etc/*", "/../*.py"):
+            with pytest.raises(InvalidGlobPatternError, match="traversal"):
+                compile_grep_include_glob(pattern)
 
     def test_malformed_but_compilable_patterns_do_not_raise(self) -> None:
         """`*.{py` and `[a-` compile fine and simply match nothing."""
         for pattern in ("*.{py", "[a-", "a{b,c"):
-            assert compile_recursive_glob(pattern)("a.py") is False
+            assert compile_grep_include_glob(pattern)("a.py") is False
 
 
 class TestGrepIncludeGlob:
@@ -671,3 +674,23 @@ class TestGrepMaxCount:
         assert result.matches is not None
         assert len(result.matches) == 3
         assert result.truncated is False
+
+
+class TestGrepRefusedGlobIsAResultNotAnException:
+    """`grep(glob=...)` is a tool boundary too, and `sync_grep` has no try/except."""
+
+    def test_refused_glob_returns_error(self) -> None:
+        files = {"/a.py": {"content": "x", "created_at": "", "modified_at": ""}}
+
+        result = grep_matches_from_files(files, "x", "/", "{a,b}" * 40 + "*.py")
+
+        assert result.error is not None
+        assert "Invalid glob pattern" in result.error
+
+    def test_traversal_glob_returns_error(self) -> None:
+        files = {"/a.py": {"content": "x", "created_at": "", "modified_at": ""}}
+
+        result = grep_matches_from_files(files, "x", "/", "../*.py")
+
+        assert result.error is not None
+        assert "traversal" in result.error

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -54,6 +54,7 @@ from deepagents.middleware.filesystem import (
     FilesystemPermission,
     FilesystemState,
     GrepSchema,
+    _format_glob_tool_result,
     supports_execution,
 )
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
@@ -3708,3 +3709,33 @@ class TestBuiltinTruncationTools:
 
         with pytest.raises(ValueError, match="max_execute_timeout must be positive"):
             FilesystemMiddleware(max_execute_timeout=-1)
+
+
+class TestGlobTruncationNoteMatchesTheCause:
+    """The remedy differs by cause, so the note must not assert the wrong one."""
+
+    def test_budget_truncation_advises_narrowing(self):
+        content = _format_glob_tool_result(["/a.py"], truncated=True, truncation_reason="budget")
+
+        assert "Narrow the search" in content
+
+    def test_unreadable_truncation_does_not_advise_narrowing(self):
+        """Narrowing can never surface files under a directory we cannot read.
+
+        Telling the model to narrow here sends it into a retry loop that cannot
+        succeed, which is why the cause is carried through `GlobResult`.
+        """
+        content = _format_glob_tool_result(["/a.py"], truncated=True, truncation_reason="unreadable")
+
+        assert "could not be read" in content
+        assert "will NOT reveal" in content
+
+    def test_unknown_cause_falls_back_to_the_generic_note(self):
+        content = _format_glob_tool_result(["/a.py"], truncated=True, truncation_reason=None)
+
+        assert "Narrow the search" in content
+
+    def test_complete_result_has_no_note(self):
+        content = _format_glob_tool_result(["/a.py"], truncated=False)
+
+        assert "Note:" not in content


### PR DESCRIPTION
`SandboxBackend.glob` can report an empty search when the remote helper failed. The agent then concludes that the files do not exist. The agent can write a file again that is already there.

## The three failure paths

`_parse_glob_output` reads JSON lines from a helper script. The script runs in the sandbox with `2>&1`.

- The code did not examine `exit_code`. If the system stopped the helper, or if `python3` was not there, the function returned `matches=[], truncated=False`. `_parse_grep_output` examines `exit_code`. The glob function now does the same.
- If the output was empty, the function returned before it read `result.truncated`. An output clipped to zero bytes thus looked like a correct empty result.
- The test for an unreadable last line used the wrong variable. The parse loop changes that variable when the walk reports a limit. The test thus also removed a traceback. The code now uses `result.truncated`.

## The truncation cause

One boolean showed four conditions: the time limit, the match limit, an unreadable directory, and a clipped output. The note to the model always told it to make the search more narrow. For an unreadable directory that advice is wrong. A more narrow pattern cannot show files in a directory that the sandbox cannot read. The agent thus retries without end.

`GlobResult` now has a `truncation_reason` field. The values are `budget`, `unreadable` and `transport`. The `unreadable` note tells the model that a more narrow search does not help.

## Traversal patterns

`glob("../*.py")` gave four different results. `FilesystemBackend` raised an error in virtual mode, but returned `[]` in the other mode. `StateBackend` and `StoreBackend` returned `[]`. The sandbox returned a structured error. The protocol says that a refusal is an `error`, not an exception.

The rejection moves into `compile_grep_include_glob`. All backends use that function. All five backends thus give `GlobResult(error=..., matches=None)`. A refusal raises the new `InvalidGlobPatternError`. This class is a subclass of `ValueError`, thus the current handlers continue to operate.

## Other changes

- `ASYNC_GLOB_TIMEOUT` limits `aglob`. The script limit applies only to the walk. A stopped sandbox thus held the caller with no limit.
- A refused `grep(glob=...)` is now a result. It went through `sync_grep`, which has no `try` block.
- A failure during the walk keeps the matches that the script found before the failure.
- The script does not walk `/proc`, `/sys` and `/dev` when the root is `/`.
- The sandbox search root is now absolute. `_check_fs_permission` compares `deny` rules with absolute paths only.
- The code writes remote errors, walk errors and refusals to the log.
- In `CompositeBackend`, a root-anchored pattern does not go to the routed backends. Their results always have the route as a prefix, thus they are deeper than the anchor permits.
- `compile_recursive_glob` is removed. It was an alias of `compile_grep_include_glob` with one caller.

## Compatibility

`truncation_reason` is a new field with the default `None`. `InvalidGlobPatternError` is a subclass of `ValueError`. `compile_recursive_glob` was internal and was never exported.