### PR TITLE
fix(sdk): disclose per-line clipping in large-result previews

### DIFF
--- a/libs/deepagents/deepagents/middleware/_message_eviction.py
+++ b/libs/deepagents/deepagents/middleware/_message_eviction.py
@@ -38,12 +38,16 @@ You can do this by specifying an offset and limit in the read_file tool call. Fo
 {content_sample}
 """
 
-_PREVIEW_LINE_CHAR_LIMIT: Final = 1000
+PREVIEW_LINE_CHAR_LIMIT: Final = 1000
 """Per-line character budget for preview lines.
 
 Bounds previews of few-but-huge lines (a `.jsonl` dump, a minified bundle).
-Keep below `backends.utils.MAX_LINE_LENGTH`, or clipped lines also pick up
-that renderer's `N.1` continuation gutters.
+Clipping cuts within a shown line rather than dropping whole lines, so it is
+reported separately from `lines_omitted`.
+
+Keep below `backends.utils.MAX_LINE_LENGTH`, or clipped lines also pick up that
+renderer's `N.1` continuation gutters and `_CAVEAT_CLIPPED_LINES` no longer
+describes what the model sees.
 """
 
 _PREVIEW_NOTE_PLAIN = "Here is a preview of the {subject}"
@@ -52,15 +56,17 @@ _PREVIEW_NOTE_HEAD_TAIL = "Here is a preview showing the head and tail of the {s
 _CAVEAT_OMITTED_LINES = (
     f"lines of the form `{TRUNCATION_MARKER_TEMPLATE.format(omitted_lines='N')}` indicate omitted lines in the middle of the content"
 )
+_CAVEAT_CLIPPED_LINES = f"the output contains lines longer than {PREVIEW_LINE_CHAR_LIMIT} characters; this preview shows only their first {PREVIEW_LINE_CHAR_LIMIT} characters"
 
 
 @dataclass(frozen=True, slots=True)
 class ContentPreview:
     """A rendered preview plus a record of what was left out to build it.
 
-    `lines_omitted` is reported by the code that built `text`, never inferred
-    from the rendered bytes — a literal `... [N lines truncated] ...` line in
-    the content would otherwise pass for a real marker.
+    The flags are reported by the code that built `text`, never inferred from
+    the rendered bytes — a literal `... [N lines truncated] ...` line in the
+    content would otherwise pass for a real marker. The two flags track
+    independent kinds of loss; a preview can have both, so check both.
     """
 
     text: str
@@ -69,16 +75,21 @@ class ContentPreview:
     lines_omitted: bool
     """Whole lines were dropped from the middle, behind a truncation marker."""
 
+    lines_clipped: bool
+    """At least one shown line was clipped at `PREVIEW_LINE_CHAR_LIMIT` characters."""
 
-def _preview_note(*, lines_omitted: bool, subject: str = "result") -> str:
+
+def _preview_note(*, lines_omitted: bool, lines_clipped: bool = False, subject: str = "result") -> str:
     """Build the sentence introducing a preview.
 
-    Explains the truncation marker only when the preview actually has one, so
-    the model is never told to look for a marker that was not inserted.
+    Mentions only losses the preview actually has, so the model is never told
+    to look for a marker that was not inserted.
 
     Args:
         lines_omitted: Whole lines were dropped from the middle behind a
             truncation marker.
+        lines_clipped: At least one shown line was clipped at
+            `PREVIEW_LINE_CHAR_LIMIT` characters.
         subject: Noun for what is being previewed, e.g. `result`.
 
     Returns:
@@ -86,14 +97,16 @@ def _preview_note(*, lines_omitted: bool, subject: str = "result") -> str:
 
             For example:
 
-            - `lines_omitted=False`: `Here is a preview of the result:`
-            - `lines_omitted=True`: `Here is a preview showing the head and tail
-                of the result (lines of the form ... indicate omitted lines ...):`
+            - No losses: `Here is a preview of the result:`
+            - `lines_omitted`: `Here is a preview showing the head and tail of the
+                result (lines of the form ... indicate omitted lines ...):`
+            - Both losses: the head/tail sentence with both caveats in parentheses.
     """
     base = _PREVIEW_NOTE_HEAD_TAIL if lines_omitted else _PREVIEW_NOTE_PLAIN
+    caveats = [caveat for applies, caveat in ((lines_omitted, _CAVEAT_OMITTED_LINES), (lines_clipped, _CAVEAT_CLIPPED_LINES)) if applies]
     note = base.format(subject=subject)
-    if lines_omitted:
-        note += f" ({_CAVEAT_OMITTED_LINES})"
+    if caveats:
+        note += f" ({'; '.join(caveats)})"
     return f"{note}:"
 
 
@@ -113,17 +126,22 @@ def _create_content_preview(content_str: str, *, head_lines: int = 5, tail_lines
     """
     lines = content_str.splitlines()
 
+    def _clip(shown: list[str]) -> tuple[list[str], bool]:
+        """Clip each line to the per-line budget, reporting whether any was."""
+        return [line[:PREVIEW_LINE_CHAR_LIMIT] for line in shown], any(len(line) > PREVIEW_LINE_CHAR_LIMIT for line in shown)
+
     if len(lines) <= head_lines + tail_lines:
         # If file is small enough, show all lines
-        preview_lines = [line[:_PREVIEW_LINE_CHAR_LIMIT] for line in lines]
+        preview_lines, clipped = _clip(lines)
         return ContentPreview(
             format_content_with_line_numbers(preview_lines, start_line=1),
             lines_omitted=False,
+            lines_clipped=clipped,
         )
 
     # Show head and tail with truncation marker
-    head = [line[:_PREVIEW_LINE_CHAR_LIMIT] for line in lines[:head_lines]]
-    tail = [line[:_PREVIEW_LINE_CHAR_LIMIT] for line in lines[-tail_lines:]]
+    head, head_clipped = _clip(lines[:head_lines])
+    tail, tail_clipped = _clip(lines[-tail_lines:])
 
     head_sample = format_content_with_line_numbers(head, start_line=1)
     marker = TRUNCATION_MARKER_TEMPLATE.format(omitted_lines=len(lines) - head_lines - tail_lines)
@@ -133,6 +151,7 @@ def _create_content_preview(content_str: str, *, head_lines: int = 5, tail_lines
     return ContentPreview(
         head_sample + truncation_notice + tail_sample,
         lines_omitted=True,
+        lines_clipped=head_clipped or tail_clipped,
     )
 
 
@@ -206,7 +225,7 @@ def _render_preview_stub(template: str, preview: ContentPreview, *, subject: str
         The rendered stub, ready to use as message content.
     """
     return template.format(
-        preview_note=_preview_note(lines_omitted=preview.lines_omitted, subject=subject),
+        preview_note=_preview_note(lines_omitted=preview.lines_omitted, lines_clipped=preview.lines_clipped, subject=subject),
         content_sample=preview.text,
         **fields,
     )

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -2808,7 +2808,15 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         content_sample = f"{status_line}\n{response.output}"
         return _render_preview_stub(
             _TOO_LARGE_TOOL_MSG,
-            ContentPreview(content_sample, lines_omitted="lines truncated" in response.output),
+            ContentPreview(
+                content_sample,
+                lines_omitted="lines truncated" in response.output,
+                # A `PREVIEW_LINE_CHAR_LIMIT` caveat, and the wrapper has no
+                # per-line character budget, so it never applies here. The
+                # wrapper's byte caps can still cut a shown line mid-line; it
+                # discloses that in-band rather than through this note.
+                lines_clipped=False,
+            ),
             tool_call_id=tool_call_id,
             file_path=capture_path,
         )

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -41,6 +41,7 @@ from deepagents.backends.utils import (
     update_file_data,
 )
 from deepagents.middleware._message_eviction import (
+    PREVIEW_LINE_CHAR_LIMIT,
     _build_evicted_content,
     _create_content_preview,
     _extract_text_from_message,
@@ -3202,6 +3203,58 @@ class TestPreviewNote:
     def test_custom_subject(self):
         assert _preview_note(lines_omitted=False, subject="content") == "Here is a preview of the content:"
 
+    def test_explains_per_line_clipping(self):
+        assert _preview_note(lines_omitted=False, lines_clipped=True) == (
+            f"Here is a preview of the result (the output contains lines longer than {PREVIEW_LINE_CHAR_LIMIT} characters; "
+            f"this preview shows only their first {PREVIEW_LINE_CHAR_LIMIT} characters):"
+        )
+
+    def test_explains_both_kinds_of_loss(self):
+        """Exact wording, so a separator or ordering change is a deliberate edit."""
+        assert _preview_note(lines_omitted=True, lines_clipped=True) == (
+            "Here is a preview showing the head and tail of the result "
+            "(lines of the form `... [N lines truncated] ...` indicate omitted lines "
+            f"in the middle of the content; the output contains lines longer than {PREVIEW_LINE_CHAR_LIMIT} "
+            f"characters; this preview shows only their first {PREVIEW_LINE_CHAR_LIMIT} characters):"
+        )
+
+    def test_clipping_in_the_tail_is_reported(self):
+        """Clipping in the tail must be reported too.
+
+        A long *last* line is the common `.jsonl`/log shape, so the tail half of the
+        clipping check has to be live or its loss goes undisclosed.
+        """
+        content = "\n".join([f"line {i}" for i in range(20)] + ["Z" * (PREVIEW_LINE_CHAR_LIMIT + 1)])
+        preview = _create_content_preview(content)
+
+        assert preview.lines_omitted is True
+        assert preview.lines_clipped is True
+
+    def test_line_at_exactly_the_limit_is_not_reported_as_clipped(self):
+        """A line exactly at the limit is not clipped.
+
+        `PREVIEW_LINE_CHAR_LIMIT` characters survive whole, so claiming loss here
+        would be the same untruth as omitting a caveat, in the other direction.
+        """
+        assert _create_content_preview("C" * PREVIEW_LINE_CHAR_LIMIT).lines_clipped is False
+        assert _create_content_preview("C" * (PREVIEW_LINE_CHAR_LIMIT + 1)).lines_clipped is True
+
+    def test_offloaded_tool_message_explains_both_losses_together(self):
+        """Both caveats must be reachable from a real preview.
+
+        Otherwise the combined wording is only ever verified against hand-set flags.
+        """
+        backend, _ = _make_backend()
+        middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=10)
+        content = "\n".join([f"line {i}" for i in range(20)] + ["Z" * (PREVIEW_LINE_CHAR_LIMIT + 1)])
+        tool_message = ToolMessage(content=content, tool_call_id="test_both")
+
+        result = middleware._intercept_large_tool_result(tool_message)
+
+        assert isinstance(result, ToolMessage)
+        assert "lines of the form" in result.content
+        assert f"this preview shows only their first {PREVIEW_LINE_CHAR_LIMIT} characters" in result.content
+
     def test_marker_explanation_quotes_the_shared_template(self):
         """The shape the note describes comes from the marker's single source of truth."""
         assert TRUNCATION_MARKER_TEMPLATE.format(omitted_lines="N") in _preview_note(lines_omitted=True)
@@ -3218,6 +3271,21 @@ class TestPreviewNote:
         # numbering that shows nothing was dropped.
         assert "2  ... [42 lines truncated] ..." in preview.text
 
+    def test_offloaded_tool_message_discloses_clipping_for_one_long_line(self):
+        """A single huge line omits no lines, but the preview still loses most of it."""
+        backend, _ = _make_backend()
+        middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=10)
+        tool_message = ToolMessage(content="x" * 5000, tool_call_id="test_short")
+
+        result = middleware._intercept_large_tool_result(tool_message)
+
+        assert isinstance(result, ToolMessage)
+        # No lines were dropped, so no marker is explained...
+        assert "lines of the form" not in result.content
+        # ...but ~4000 characters were clipped away, and the note says so rather
+        # than presenting the excerpt as the whole result.
+        assert f"this preview shows only their first {PREVIEW_LINE_CHAR_LIMIT} characters" in result.content
+
     def test_offloaded_tool_message_explains_marker_when_lines_dropped(self):
         backend, _ = _make_backend()
         middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=10)
@@ -3228,6 +3296,8 @@ class TestPreviewNote:
         assert isinstance(result, ToolMessage)
         assert "Here is a preview showing the head and tail of the result" in result.content
         assert "lines of the form" in result.content
+        # Short lines, so nothing was clipped and that caveat stays out.
+        assert "this preview shows only their first" not in result.content
 
 
 class TestTruncatedHumanMessage:
@@ -3250,6 +3320,14 @@ class TestTruncatedHumanMessage:
 
         assert "Here is a preview of the content:" in result.content
         assert "lines of the form" not in result.content
+
+    def test_discloses_clipping_for_one_long_line(self):
+        message = HumanMessage(content="y" * 5000, id="h3")
+
+        result = _build_truncated_human_message(message, "/evicted/h3")
+
+        assert f"this preview shows only their first {PREVIEW_LINE_CHAR_LIMIT} characters" in result.content
+        assert "of the content (" in result.content
 
 
 class TestTooLargeToolMessage:


### PR DESCRIPTION
Stacked on #5563.

When a previewed line exceeds the per-line character budget, the preview silently showed only its leading characters — presenting an excerpt as the whole result. Previews now add a disclosure when any displayed line is clipped, alongside (and independently of) the omitted-middle-lines marker explanation.

---

`_create_content_preview` clips each shown line to `PREVIEW_LINE_CHAR_LIMIT` and records whether any line was actually cut, surfacing it as a second `ContentPreview` flag alongside `lines_omitted`. The two flags track independent kinds of loss — a preview can omit middle lines, clip long displayed lines, both, or neither — so `_preview_note` reports each only when it occurred. A line exactly at the limit is not reported as clipped.

The capture-offload path in `FilesystemMiddleware` has no per-line budget (its losses are byte-based and disclosed in-band), so it passes `lines_clipped=False` explicitly rather than leaving the flag to be inferred.
