### PR TITLE
fix(sdk): preserve legacy large-result templates behind deprecation

### DIFF
--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -828,13 +828,29 @@ class ExecuteOffloadResult:
     offloaded: bool
     """Whether the output was left at the capture path.
 
-    When `True`, `response.output` holds only a head/tail preview and the full
-    output lives at the capture path on the sandbox filesystem. When `False`,
-    `response.output` is the complete output.
+    When `True`, `response.output` holds only a preview of the output and the
+    full output lives at the capture path on the sandbox filesystem.
+
+    When `False`, `response.output` is the complete output.
     """
 
     response: ExecuteResponse
     """The command result. `response.truncated` indicates the output hit the size cap."""
+
+    preview_has_truncation_marker: bool = False
+    """Whether the preview contains a `... [N lines truncated] ...` marker.
+
+    Set by the code that builds the preview. This is the only reliable way to
+    know the marker was inserted, as the command output itself can contain
+    a line that looks the same (scanning the text is unsafe).
+
+    This flag covers only the `... [N lines truncated] ...` marker. A preview
+    may disclose other losses through its own in-band clip notices, which need
+    no flag because they carry their own explanation; see
+    `_build_capture_execute_cmd` in `backends.sandbox` for the wording.
+
+    When `offloaded` is `False`, this flag is always `False`.
+    """
 
 
 class SandboxBackendProtocol(BackendProtocol):

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -42,7 +42,7 @@ from deepagents.backends.protocol import (
     WriteResult,
     execute_accepts_timeout,
 )
-from deepagents.backends.utils import _get_backend_read_file_type, normalize_read_bounds
+from deepagents.backends.utils import TRUNCATION_MARKER_TEMPLATE, _get_backend_read_file_type, normalize_read_bounds
 
 logger = logging.getLogger(__name__)
 
@@ -1131,7 +1131,46 @@ def _build_edit_tmpfile_cmd(file_path: str, old_tmp: str, new_tmp: str, *, repla
 
 
 _EXECUTE_CAPTURE_SENTINEL: Final = "__DEEPAGENTS_EXEC_META__"
-"""First-line marker identifying capture-wrapper output: `<sentinel> <exit_code> <offloaded> <capped>`."""
+"""First-line marker identifying capture-wrapper output: `<sentinel> <exit_code> <offloaded> <capped> <omitted_lines>`."""
+
+_EXECUTE_CAPTURE_META_FIELDS: Final = 5
+"""Number of space-separated fields on the capture wrapper's meta line."""
+
+_EXECUTE_CAPTURE_CLIP_NOTICE: Final = "... [output clipped here; {captured_bytes} bytes total, full output at the path above] ..."
+"""Appended to a byte-excerpt preview when the excerpt is shorter than the captured output."""
+
+_EXECUTE_CAPTURE_CLIP_NOTICE_CAPPED: Final = (
+    "... [output clipped here; capture stopped at its {captured_bytes}-byte limit, so the file at the path above is also incomplete] ..."
+)
+"""Variant of `_EXECUTE_CAPTURE_CLIP_NOTICE` for when capture hit its byte cap.
+
+Output past `max_capture_bytes` is discarded uncounted, so the byte count is
+the cap, not the output's real size, and the saved file is also incomplete.
+
+For example, with a 10 MB cap and 25 MB of output, the notice reads `capture
+stopped at its 10485760-byte limit` — not `26214400 bytes total`.
+"""
+
+_EXECUTE_CAPTURE_EXCERPT_CLIP_NOTICE: Final = (
+    "... [the excerpts above and below are byte-capped, so the lines bordering this marker may be cut mid-line] ..."
+)
+"""Inserted before the marker in a head/tail preview whose excerpts hit their
+byte caps.
+
+The wrapper keeps the first/last 2000 bytes of output, then takes up to 5 lines
+from each. So this fires when those 5 lines total more than 2000 bytes — i.e.
+output with very long lines (JSONL logs, minified JS, base64 blobs). The 2000
+bytes can then end mid-line and show fewer than 5 lines:
+
+    {"event":"pageview","properties":{"url":"https://exa   <- head excerpt: cut at byte 2000, mid-line
+    ... [the excerpts above and below are byte-capped, so the lines bordering this marker may be cut mid-line] ...
+    ... [42 lines truncated] ...
+    pv},{"event":"click","properties":{"button":"signup"}}  <- tail excerpt: starts mid-line
+    {"event":"purchase","properties":{"total":49.99}}
+
+The truncation marker counts whole lines dropped from the middle, so without
+this notice nothing would mention the cut.
+"""
 
 _EXECUTE_CAPTURE_HEAD_LINES: Final = 5
 _EXECUTE_CAPTURE_TAIL_LINES: Final = 5
@@ -1159,8 +1198,12 @@ beyond the cap is truncated and flagged.
 # issues; the (internal, sanitized) path is shell-quoted.
 _EXECUTE_CAPTURE_CMD_TEMPLATE = """# ===== deepagents capture-at-source offload (auto-generated wrapper) =====
 # Runs the requested command below, capturing its combined output to a file in
-# the sandbox: returned inline when small, or as a head/tail preview when large
-# (the full result stays at the path for read_file). Disable this wrapping with
+# the sandbox: returned inline when small, or as a preview when large (the full
+# result stays at the path for read_file). Large output is previewed as a
+# head/tail excerpt around a truncation marker when it has more lines than the
+# head+tail budget, otherwise as a leading byte excerpt that ends with an
+# in-band clip notice. Either shape discloses byte-cap losses in-band. Disable
+# this wrapping with
 # BaseSandbox.enable_capture_offload = False.
 __da_f=__PATH_Q__
 __da_ecf="$__da_f.ec"
@@ -1180,20 +1223,45 @@ __da_bytes=$(wc -c < "$__da_f" 2>/dev/null | tr -d ' ')
 __da_capped=0
 [ "$__da_bytes" -ge __MAXBYTES__ ] && __da_capped=1
 if [ "$__da_bytes" -le __BUDGET__ ]; then
-  printf '%s %s %s %s\\n' '__SENTINEL__' "$__da_ec" 0 0
+  printf '%s %s %s %s %s\\n' '__SENTINEL__' "$__da_ec" 0 0 0
   cat "$__da_f"
   rm -f "$__da_f"
 else
   __da_lines=$(wc -l < "$__da_f" 2>/dev/null | tr -d ' ')
   : "${__da_lines:=0}"
   __da_omitted=$((__da_lines - __HEADLINES__ - __TAILLINES__))
-  printf '%s %s %s %s\\n' '__SENTINEL__' "$__da_ec" 1 "$__da_capped"
+  printf '%s %s %s %s %s\\n' '__SENTINEL__' "$__da_ec" 1 "$__da_capped" "$__da_omitted"
   if [ "$__da_omitted" -gt 0 ]; then
+    # The byte caps run before the line caps, so long lines make these excerpts
+    # show fewer lines than the budget and cut the outermost ones mid-line. Detect
+    # that by asking how big the line-capped excerpts would have been, and say so
+    # in-band -- the marker only accounts for whole lines dropped from the middle.
+    __da_head_bytes=$(head -n __HEADLINES__ "$__da_f" 2>/dev/null | wc -c | tr -d ' ')
+    : "${__da_head_bytes:=0}"
+    __da_tail_bytes=$(tail -n __TAILLINES__ "$__da_f" 2>/dev/null | wc -c | tr -d ' ')
+    : "${__da_tail_bytes:=0}"
     head -c __HEAD__ "$__da_f" | head -n __HEADLINES__
-    printf '... [%s lines truncated] ...\\n' "$__da_omitted"
+    if [ "$__da_head_bytes" -gt __HEAD__ ] || [ "$__da_tail_bytes" -gt __TAIL__ ]; then
+      # Also guarantees the marker starts its own line: a byte-clipped head
+      # excerpt has no trailing newline, which would otherwise glue the two.
+      printf '\\n__EXCERPT_CLIP_NOTICE__\\n'
+    fi
+    printf '__MARKER_FMT__\\n' "$__da_omitted"
     tail -c __TAIL__ "$__da_f" | tail -n __TAILLINES__
   else
+    # Fewer lines than the head+tail budget, so there is no middle to drop:
+    # emit a leading byte excerpt. That silently loses the end of the output, so
+    # close it with an in-band notice whenever anything was actually left out.
+    # When capture was capped, __da_bytes is the cap rather than the output's real
+    # size and the saved file is incomplete too, so use the capped wording.
     head -c $((__HEAD__ + __TAIL__)) "$__da_f"
+    if [ "$__da_bytes" -gt $((__HEAD__ + __TAIL__)) ]; then
+      if [ "$__da_capped" -eq 1 ]; then
+        printf '\\n__CLIP_NOTICE_CAPPED_FMT__\\n' "$__da_bytes"
+      else
+        printf '\\n__CLIP_NOTICE_FMT__\\n' "$__da_bytes"
+      fi
+    fi
   fi
 fi
 """
@@ -1208,11 +1276,12 @@ def _new_heredoc_delim() -> str:
 def _build_capture_execute_cmd(command: str, capture_path: str, *, inline_budget: int, max_capture_bytes: int | None = None) -> str:
     """Build the capture-at-source wrapper command for `execute`.
 
-    `inline_budget` is the byte threshold at or below which output is returned
-    inline; above it the output is left at `capture_path` and only a head/tail
-    preview is returned. Captured output is hard-capped at `max_capture_bytes`
-    (defaulting to `_EXECUTE_CAPTURE_MAX_BYTES`, resolved here so it stays
-    overridable/patchable); beyond that it is truncated and flagged.
+    Output at or below `inline_budget` bytes is returned inline. Above it, the
+    full output is left at `capture_path` and only a preview is returned: a
+    head/tail excerpt around a truncation marker when there are more lines than
+    the head+tail budget, otherwise a leading byte excerpt ending in a clip
+    notice. Captured output is hard-capped at `max_capture_bytes` (default
+    `_EXECUTE_CAPTURE_MAX_BYTES`); beyond that it is truncated and flagged.
     """
     cap = max_capture_bytes if max_capture_bytes is not None else _EXECUTE_CAPTURE_MAX_BYTES
     # The command is embedded in a quoted heredoc; guarantee the delimiter cannot
@@ -1229,6 +1298,14 @@ def _build_capture_execute_cmd(command: str, capture_path: str, *, inline_budget
         .replace("__MAXBYTES__", str(cap))
         .replace("__BUDGET__", str(inline_budget))
         .replace("__SENTINEL__", _EXECUTE_CAPTURE_SENTINEL)
+        # Both notices become `printf` format strings, so the count/byte total is
+        # the single `%s` operand. Deriving the marker from the shared template
+        # keeps the wrapper's output and the note describing it in lockstep.
+        .replace("__MARKER_FMT__", TRUNCATION_MARKER_TEMPLATE.format(omitted_lines="%s"))
+        .replace("__CLIP_NOTICE_CAPPED_FMT__", _EXECUTE_CAPTURE_CLIP_NOTICE_CAPPED.format(captured_bytes="%s"))
+        .replace("__CLIP_NOTICE_FMT__", _EXECUTE_CAPTURE_CLIP_NOTICE.format(captured_bytes="%s"))
+        # Takes no operand, so it is a literal `printf` format with no `%`.
+        .replace("__EXCERPT_CLIP_NOTICE__", _EXECUTE_CAPTURE_EXCERPT_CLIP_NOTICE)
         .replace("__HEADLINES__", str(_EXECUTE_CAPTURE_HEAD_LINES))
         .replace("__TAILLINES__", str(_EXECUTE_CAPTURE_TAIL_LINES))
         .replace("__HEAD__", str(_EXECUTE_CAPTURE_HEAD_BYTES))
@@ -1242,33 +1319,76 @@ def _parse_capture_execute_output(output: str, *, backend_truncated: bool = Fals
 
     The wrapper emits a meta line followed by the body:
 
-        <sentinel> <exit_code> <offloaded> <capped>\n<inline output or preview>
+        <sentinel> <exit_code> <offloaded> <capped> <omitted_lines>\n<inline output or preview>
 
-    i.e. four space-separated fields on the first line — the sentinel, the
-    command's exit code, `1`/`0` for whether output was offloaded to the capture
-    file, and `1`/`0` for whether it hit the size cap — then everything after the
-    first newline is the body (full output when inline, head/tail preview when
-    offloaded).
+    i.e. five space-separated fields on the first line, then everything after
+    the first newline is the body (full output when inline, preview when
+    offloaded). For example:
 
-    Falls back to `offloaded=False` with the raw output when the meta line is
-    absent or malformed — e.g. if the backend truncated transport; the caller
-    must not re-run the command in that case. `response.truncated` is set when the
-    captured output hit the size cap (the saved file is incomplete) or
+        __DEEPAGENTS_EXEC_META__ 0 1 0 14\n<head lines>... [14 lines truncated] ...<tail lines>
+
+    The surplus is `captured_lines - head_lines - tail_lines`. A value `> 0`
+    means lines were dropped from the middle behind a truncation marker; zero or
+    negative means the output fit within the head+tail budget and the preview is
+    a leading byte excerpt instead (see
+    `ExecuteOffloadResult.preview_has_truncation_marker`). `captured_lines` comes
+    from `wc -l`, which counts newlines, so a final unterminated line does not
+    count toward the budget.
+
+    When the meta line is absent or malformed (e.g. the backend truncated
+    transport), the result falls back to `offloaded=False` with the raw output —
+    logged, since this silently reframes a preview as complete output. The
+    caller must not re-run the command in that case. `response.truncated` is set
+    when the captured output hit the size cap (the saved file is incomplete) or
     `backend_truncated` is passed through from the underlying `execute`.
     """
     first, _, body = output.partition("\n")
-    parts = first.split(" ")
-    # Expect exactly the four meta fields described above; anything else is not
-    # our wrapper's output, so fall back to returning it verbatim.
-    if len(parts) != 4 or parts[0] != _EXECUTE_CAPTURE_SENTINEL:  # noqa: PLR2004
+
+    def _unoffloaded() -> ExecuteOffloadResult:
         return ExecuteOffloadResult(offloaded=False, response=ExecuteResponse(output=output, truncated=backend_truncated))
+
+    # Reject non-wrapper output before splitting: with the wrapper disabled the
+    # first line can be the whole output on one line (minified JS, single-line
+    # JSON), and splitting allocates a string per space only to discard them.
+    if not first.startswith(_EXECUTE_CAPTURE_SENTINEL):
+        logger.warning("Capture wrapper meta line absent or malformed (no sentinel); returning output unoffloaded: %r", first[:200])
+        return _unoffloaded()
+
+    parts = first.split(" ")
+    # Expect exactly the meta fields described above; anything else is not our
+    # wrapper's output, so fall back to returning it verbatim.
+    if len(parts) != _EXECUTE_CAPTURE_META_FIELDS or parts[0] != _EXECUTE_CAPTURE_SENTINEL:
+        logger.warning(
+            "Capture wrapper meta line absent or malformed (%d fields, expected %d); returning output unoffloaded: %r",
+            len(parts),
+            _EXECUTE_CAPTURE_META_FIELDS,
+            first[:200],
+        )
+        return _unoffloaded()
     try:
         exit_code = int(parts[1])
     except ValueError:
-        return ExecuteOffloadResult(offloaded=False, response=ExecuteResponse(output=output, truncated=backend_truncated))
+        logger.warning("Capture wrapper emitted a non-integer exit code %r; returning output unoffloaded", parts[1][:50])
+        return _unoffloaded()
+    # Parsed separately from the exit code: an unreadable surplus only costs us
+    # the preview note's wording, and must not discard a good exit code or cap
+    # flag by falling back to the raw-output path.
+    try:
+        surplus_lines = int(parts[4])
+    except ValueError:
+        logger.warning(
+            "Capture wrapper emitted a non-integer preview line surplus %r; assuming no truncation marker",
+            parts[4][:50],
+        )
+        surplus_lines = 0
+    offloaded = parts[2] == "1"
     return ExecuteOffloadResult(
-        offloaded=parts[2] == "1",
+        offloaded=offloaded,
         response=ExecuteResponse(output=body, exit_code=exit_code, truncated=parts[3] == "1" or backend_truncated),
+        # `and offloaded` upholds the field's documented invariant by construction:
+        # the two fields are parsed from independent meta columns, so a wrapper bug
+        # could otherwise report a marker on output that carries no preview.
+        preview_has_truncation_marker=surplus_lines > 0 and offloaded,
     )
 
 
@@ -1338,7 +1458,7 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
 
         Captures the command's combined output: returned inline when it is at or
         below `max_inline_bytes`, otherwise left at `capture_path` (so the caller
-        can surface a `read_file` pointer) with only a head/tail preview returned.
+        can surface a `read_file` pointer) with only a preview returned.
         Captured output is hard-capped at `max_capture_bytes` (default
         `_EXECUTE_CAPTURE_MAX_BYTES`) without killing the command, so the exit
         code is preserved. When `enable_capture_offload` is `False`, the command
@@ -1346,9 +1466,11 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
         callers can fall back to their own handling (e.g. generic eviction).
 
         Returns:
-            An `ExecuteOffloadResult`. `offloaded=True` when the result was left
-            at `capture_path` and `response.output` holds only the preview;
-            `offloaded=False` when `response.output` is the complete output.
+            An `ExecuteOffloadResult`: `offloaded=True` when the result was left
+                at `capture_path` and `response.output` holds only the preview,
+                with `preview_has_truncation_marker` recording whether the
+                preview dropped middle lines behind a marker; `offloaded=False`
+                when `response.output` is the complete output.
         """
         use_timeout = timeout is not None and execute_accepts_timeout(type(self))
         if not self.enable_capture_offload:

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -33,6 +33,10 @@ in `backends.sandbox` so both emit identical marker text.
 Never scan preview text for this marker to detect truncation: output can
 contain a literal marker line. Producers report marker presence out of band
 instead (see `ExecuteOffloadResult.preview_has_truncation_marker`).
+
+Note: `middleware.filesystem._LEGACY_TOO_LARGE_TOOL_MSG` keeps a frozen copy of
+the old wording for a deprecated import and deliberately does not use this
+template.
 """
 
 FileType = Literal["text", "image", "audio", "video", "file"]

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -2805,12 +2805,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         status_line = f"[Command {cmd_status} with exit code {response.exit_code}]"
         if response.truncated:
             status_line += "\n[Output exceeded the capture size limit and was truncated; the saved file is incomplete]"
-        content_sample = f"{status_line}\n{response.output}"
         return _render_preview_stub(
             _TOO_LARGE_TOOL_MSG,
             ContentPreview(
-                content_sample,
-                lines_omitted="lines truncated" in response.output,
+                f"{status_line}\n{response.output}",
+                lines_omitted=offload.preview_has_truncation_marker,
                 # A `PREVIEW_LINE_CHAR_LIMIT` caveat, and the wrapper has no
                 # per-line character budget, so it never applies here. The
                 # wrapper's byte caps can still cut a shown line mid-line; it

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -35,6 +35,7 @@ from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.types import Command
 from pydantic import BaseModel, Field
 
+from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends import CompositeBackend, FilesystemBackend, LocalShellBackend, StateBackend
 from deepagents.backends.composite import _route_for_path
 from deepagents.backends.protocol import (
@@ -91,6 +92,54 @@ from deepagents.middleware._video import (
     extract_video_frames,
     video_dependencies_available,
 )
+
+_LEGACY_TOO_LARGE_TOOL_MSG: Final = """Tool result too large, the result of this tool call {tool_call_id} was saved in the filesystem at this path: {file_path}
+
+You can read the result from the filesystem by using the read_file tool, but make sure to only read part of the result at a time.
+
+You can do this by specifying an offset and limit in the read_file tool call. For example, to read the first 100 lines, you can use the read_file tool with offset=0 and limit=100.
+
+Here is a preview showing the head and tail of the result (lines of the form `... [N lines truncated] ...` indicate omitted lines in the middle of the content):
+
+{content_sample}
+"""
+"""Legacy `TOO_LARGE_TOOL_MSG` value available until `deepagents==0.9.0`."""
+
+_LEGACY_TOO_LARGE_HUMAN_MSG: Final = """Message content too large and was saved to the filesystem at: {file_path}
+
+You can read the full content using the read_file tool with pagination (offset and limit parameters).
+
+Here is a preview showing the head and tail of the content:
+
+{content_sample}
+"""
+"""Legacy `TOO_LARGE_HUMAN_MSG` value available until `deepagents==0.9.0`."""
+
+_LEGACY_LARGE_RESULT_TEMPLATES: Final = {
+    "TOO_LARGE_TOOL_MSG": _LEGACY_TOO_LARGE_TOOL_MSG,
+    "TOO_LARGE_HUMAN_MSG": _LEGACY_TOO_LARGE_HUMAN_MSG,
+}
+
+
+def __getattr__(name: str) -> str:
+    """Provide deprecated compatibility access to legacy prompt templates."""
+    if (template := _LEGACY_LARGE_RESULT_TEMPLATES.get(name)) is not None:
+        warn_deprecated(
+            since="0.7.7",
+            removal="0.9.0",
+            message=(
+                f"`{name}` was deprecated in `deepagents==0.7.7` and will be removed in "
+                "`deepagents==0.9.0`. Large-result prompt templates are internal "
+                "implementation details and should not be imported. This frozen copy "
+                "keeps the released wording; the live template now derives its preview "
+                "note from what the preview actually elided."
+            ),
+            package="deepagents",
+        )
+        return template
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
 
 # `ChatOpenAI`, `AzureChatOpenAI`, and `ChatGoogleGenerativeAI` accept non-PDF
 # `file` blocks such as `.docx` and `.pptx`. `ModelProfile` only encodes PDF

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -8,12 +8,14 @@ correctly.
 
 import base64
 import json
+import logging
 import os
 import re
 import stat
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
+from typing import Final
 
 import pytest
 
@@ -26,19 +28,30 @@ from deepagents.backends.sandbox import (
     _EDIT_COMMAND_TEMPLATE,
     _EDIT_INLINE_MAX_BYTES,
     _EDIT_TMPFILE_TEMPLATE,
+    _EXECUTE_CAPTURE_CLIP_NOTICE,
+    _EXECUTE_CAPTURE_CLIP_NOTICE_CAPPED,
+    _EXECUTE_CAPTURE_EXCERPT_CLIP_NOTICE,
+    _EXECUTE_CAPTURE_HEAD_BYTES,
+    _EXECUTE_CAPTURE_HEAD_LINES,
+    _EXECUTE_CAPTURE_SENTINEL,
+    _EXECUTE_CAPTURE_TAIL_BYTES,
+    _EXECUTE_CAPTURE_TAIL_LINES,
     _GLOB_COMMAND_TEMPLATE,
     _GREP_PATH_GLOB_TEMPLATE,
     _READ_COMMAND_TEMPLATE,
     _WRITE_CHECK_TEMPLATE,
     BaseSandbox,
+    _build_capture_execute_cmd,
     _build_grep_cmd,
     _build_read_cmd,
     _check_preflight_result,
     _map_edit_error,
+    _parse_capture_execute_output,
     _parse_glob_output,
     _parse_grep_output,
     _parse_read_output,
 )
+from deepagents.backends.utils import TRUNCATION_MARKER_TEMPLATE
 
 
 class MockSandbox(BaseSandbox):
@@ -2397,3 +2410,166 @@ class TestSandboxDelete:
         assert result.path is None
         assert result.error is not None
         assert "not found" in result.error
+
+
+class TestParseCaptureExecuteOutput:
+    """Meta-line parsing for capture-at-source `execute` offload.
+
+    Pure-function coverage, so these run everywhere -- unlike the end-to-end
+    offload tests, which need a real shell and are gated on `RUN_SANDBOX_TESTS`.
+    """
+
+    @staticmethod
+    def _meta(*fields: object) -> str:
+        return " ".join([_EXECUTE_CAPTURE_SENTINEL, *(str(f) for f in fields)]) + "\nBODY"
+
+    @pytest.mark.parametrize(
+        ("surplus", "expected_marker"),
+        [
+            (-10, False),  # single huge line: wc -l counted fewer lines than the budget
+            (-1, False),
+            # The wrapper only inserts a marker when the surplus is strictly
+            # positive, so `0` -- exactly head+tail lines, no middle to drop --
+            # must not select the marker-explaining note.
+            (0, False),
+            (1, True),
+            (4990, True),
+        ],
+    )
+    def test_marker_flag_set_only_by_positive_surplus(self, *, surplus: int, expected_marker: bool) -> None:
+        result = _parse_capture_execute_output(self._meta(0, 1, 0, surplus))
+
+        assert result.offloaded is True
+        assert result.preview_has_truncation_marker is expected_marker
+
+    def test_parses_exit_code_and_cap_flag(self) -> None:
+        result = _parse_capture_execute_output(self._meta(3, 1, 1, 7))
+
+        assert result.offloaded is True
+        assert result.response.exit_code == 3
+        assert result.response.truncated is True
+        assert result.response.output == "BODY"
+        assert result.preview_has_truncation_marker is True
+
+    def test_inline_output_is_not_offloaded(self) -> None:
+        result = _parse_capture_execute_output(self._meta(0, 0, 0, 0))
+
+        assert result.offloaded is False
+        assert result.preview_has_truncation_marker is False
+
+    @pytest.mark.parametrize(
+        "bad_surplus",
+        ["junk", "", "1.5"],
+    )
+    def test_unparseable_surplus_keeps_exit_code_and_cap_flag(self, bad_surplus: str) -> None:
+        """An unreadable surplus costs only the note's wording, never the exit code.
+
+        The surplus is parsed separately from the exit code precisely so a garbled
+        fifth field cannot discard a good exit code and cap flag by dropping the
+        whole result onto the raw-output fallback path -- which would also frame a
+        preview as complete output and leak the sentinel line to the model.
+        """
+        result = _parse_capture_execute_output(self._meta(3, 1, 1, bad_surplus))
+
+        assert result.offloaded is True
+        assert result.response.exit_code == 3
+        assert result.response.truncated is True
+        assert result.response.output == "BODY"
+        # Unknown surplus degrades to "no marker" rather than claiming one.
+        assert result.preview_has_truncation_marker is False
+
+    @pytest.mark.parametrize(
+        ("bad_meta", "reason"),
+        [
+            (f"{_EXECUTE_CAPTURE_SENTINEL} 0 1 0\nBODY", "legacy four-field meta line"),
+            (f"{_EXECUTE_CAPTURE_SENTINEL} 0 1 0 0 0\nBODY", "too many fields"),
+            (f"{_EXECUTE_CAPTURE_SENTINEL} junk 1 0 0\nBODY", "non-integer exit code"),
+            ("no sentinel here at all\nBODY", "sentinel absent"),
+            ("sh: warning: banner\n" + f"{_EXECUTE_CAPTURE_SENTINEL} 0 1 0 0\nBODY", "banner before sentinel"),
+        ],
+    )
+    def test_malformed_meta_falls_back_to_raw_output(self, bad_meta: str, reason: str) -> None:
+        result = _parse_capture_execute_output(bad_meta)
+
+        assert result.offloaded is False, reason
+        assert result.response.output == bad_meta, reason
+        assert result.preview_has_truncation_marker is False, reason
+
+    def test_malformed_meta_is_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The fallback reframes a preview as complete output, so it must not be silent."""
+        with caplog.at_level(logging.WARNING, logger="deepagents.backends.sandbox"):
+            _parse_capture_execute_output(f"{_EXECUTE_CAPTURE_SENTINEL} 0 1 0\nBODY")
+
+        assert any("meta line absent or malformed" in r.getMessage() for r in caplog.records)
+
+    def test_unparseable_exit_code_is_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Same reason as its two sibling fallbacks: the caller cannot tell it happened."""
+        with caplog.at_level(logging.WARNING, logger="deepagents.backends.sandbox"):
+            _parse_capture_execute_output(f"{_EXECUTE_CAPTURE_SENTINEL} junk 1 0 0\nBODY")
+
+        assert any("non-integer exit code" in r.getMessage() for r in caplog.records)
+
+    def test_marker_flag_requires_offloaded(self) -> None:
+        """A response carrying no preview can never claim a marker, whatever the surplus."""
+        result = _parse_capture_execute_output(self._meta(0, 0, 0, 5))
+
+        assert result.offloaded is False
+        assert result.preview_has_truncation_marker is False
+
+    def test_unparseable_surplus_is_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="deepagents.backends.sandbox"):
+            _parse_capture_execute_output(self._meta(0, 1, 0, "junk"))
+
+        assert any("non-integer preview line surplus" in r.getMessage() for r in caplog.records)
+
+    def test_backend_truncation_propagates_through_fallback(self) -> None:
+        result = _parse_capture_execute_output("garbage", backend_truncated=True)
+
+        assert result.offloaded is False
+        assert result.response.truncated is True
+
+
+class TestCaptureWrapperNotices:
+    """The wrapper's in-band notices must match what the note promises the model.
+
+    Every assertion here is on the static parts of the generated wrapper, so one
+    build shared across the class is enough.
+    """
+
+    cmd: Final = _build_capture_execute_cmd("echo hi", "/sandbox/cap", inline_budget=100)
+
+    def test_marker_format_derives_from_shared_template(self) -> None:
+        """Wrapper marker and preview note render the same shape, from one template."""
+        # The wrapper emits the marker via printf with the count as the operand.
+        assert TRUNCATION_MARKER_TEMPLATE.format(omitted_lines="%s") in self.cmd
+        # And nothing hardcodes a second, drifting copy of the shape.
+        assert TRUNCATION_MARKER_TEMPLATE.format(omitted_lines="%s") == "... [%s lines truncated] ..."
+
+    def test_wrapper_emits_clip_notice_only_in_byte_excerpt_branch(self) -> None:
+        # Guarded by a byte comparison, so a preview that loses nothing stays quiet.
+        assert _EXECUTE_CAPTURE_CLIP_NOTICE.format(captured_bytes="%s") in self.cmd
+        assert f'[ "$__da_bytes" -gt $(({_EXECUTE_CAPTURE_HEAD_BYTES} + {_EXECUTE_CAPTURE_TAIL_BYTES})) ]' in self.cmd
+
+    def test_clip_notice_has_a_capped_variant_selected_by_the_cap_flag(self) -> None:
+        """A capped capture must not advertise the cap as the total, nor promise the full output."""
+        assert '[ "$__da_capped" -eq 1 ]' in self.cmd
+        assert _EXECUTE_CAPTURE_CLIP_NOTICE_CAPPED.format(captured_bytes="%s") in self.cmd
+        assert _EXECUTE_CAPTURE_CLIP_NOTICE.format(captured_bytes="%s") in self.cmd
+        # Only the uncapped wording may claim the path holds everything.
+        assert _EXECUTE_CAPTURE_CLIP_NOTICE_CAPPED.count("full output at the path above") == 0
+
+    def test_head_tail_branch_discloses_its_byte_caps(self) -> None:
+        """The marker counts whole middle lines only, so byte-cap losses need their own notice.
+
+        Guarded by comparing the line-capped excerpt sizes against the byte caps, so a
+        preview whose excerpts fit stays quiet.
+        """
+        assert _EXECUTE_CAPTURE_EXCERPT_CLIP_NOTICE in self.cmd
+        assert f'[ "$__da_head_bytes" -gt {_EXECUTE_CAPTURE_HEAD_BYTES} ]' in self.cmd
+        assert f'[ "$__da_tail_bytes" -gt {_EXECUTE_CAPTURE_TAIL_BYTES} ]' in self.cmd
+        # Takes no operand, so it must not smuggle in a printf conversion.
+        assert "%" not in _EXECUTE_CAPTURE_EXCERPT_CLIP_NOTICE
+
+    def test_head_tail_line_budget_matches_surplus_arithmetic(self) -> None:
+        """The surplus the wrapper reports is relative to these two constants."""
+        assert f"$((__da_lines - {_EXECUTE_CAPTURE_HEAD_LINES} - {_EXECUTE_CAPTURE_TAIL_LINES}))" in self.cmd

--- a/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
+++ b/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
@@ -1610,6 +1610,24 @@ class TestLocalSandboxOperations:
 # 5000 of these lines (~250 KB) clear the default eviction budget (~80 KB).
 _BIG_OUTPUT_CMD = 'for i in $(seq 1 5000); do echo "line $i: padding text to make the output long enough to offload"; done'
 
+# ~120 KB over only 3 lines: clears the eviction budget, but has fewer lines than
+# the wrapper's head+tail budget, so there is no middle to drop. The wrapper falls
+# back to a leading byte excerpt (the meta field is a negative surplus, -7) and
+# closes it with the in-band clip notice instead of a truncation marker.
+_FEW_LONG_LINES_CMD = "for i in 1 2 3; do printf 'line %s: ' \"$i\"; head -c 40000 /dev/zero | tr '\\0' x; echo; done"
+
+# 20 lines of 3 KB each: more lines than the head+tail budget, so this takes the
+# head/tail branch -- but `head -c 2000`/`tail -c 2000` bite before the line caps,
+# so the excerpts show fewer than 5 lines each and cut the outermost ones mid-line.
+# The truncation marker counts only whole middle lines, so that extra loss has to be
+# disclosed in-band.
+_MANY_LONG_LINES_CMD = "for i in $(seq 1 20); do printf 'line %s: ' \"$i\"; head -c 3000 /dev/zero | tr '\\0' x; echo; done"
+
+# 200 KB on a single line (no newlines at all). Paired with a 5 KB capture cap it
+# is both capped and too few lines for the head/tail branch, so the byte excerpt
+# has to report the cap rather than the output's real size.
+_ONE_HUGE_LINE_CMD = 'head -c 200000 /dev/zero | tr "\\0" x'
+
 
 class TestExecuteCaptureOffload:
     """End-to-end capture-at-source offload via the execute tool on a real shell.
@@ -1696,11 +1714,142 @@ class TestExecuteCaptureOffload:
         assert "lines truncated" in result.content
         # A middle line is absent from the preview...
         assert "line 2500:" not in result.content
+        # ...and the note explains the marker standing in for it. Asserted on the
+        # note's own wording rather than "lines truncated", which the note quotes
+        # and so matches whether or not a marker was inserted.
+        assert "lines of the form" in result.content
 
         # ...but recoverable in full via read_file on the offload path: a middle
         # slice the preview never showed is present on disk.
         read = read_tool.invoke({"file_path": capture_path, "offset": 2499, "limit": 3, "runtime": rt})
         assert "line 2500:" in read.content
+
+    def test_offloaded_preview_reports_truncation_marker(self, sandbox: LocalSubprocessSandbox) -> None:
+        offload = sandbox.execute_with_offload(_BIG_OUTPUT_CMD, self._capture_path("c_omit"), max_inline_bytes=100)
+
+        assert offload.offloaded is True
+        assert offload.preview_has_truncation_marker is True
+        assert "lines truncated] ..." in offload.response.output
+
+    def test_offloaded_byte_excerpt_reports_no_marker_but_says_it_clipped(self, tools: tuple, sandbox: LocalSubprocessSandbox) -> None:
+        """Few-but-huge lines: no marker to explain, yet the end is still dropped."""
+        offload = sandbox.execute_with_offload(_FEW_LONG_LINES_CMD, self._capture_path("c_few"), max_inline_bytes=100)
+
+        assert offload.offloaded is True
+        assert offload.preview_has_truncation_marker is False
+        # No marker is claimed because none was inserted...
+        assert "lines truncated" not in offload.response.output
+        # ...but the excerpt drops the end of the output, so it says so in-band.
+        assert "output clipped here" in offload.response.output
+        assert "full output at the path above" in offload.response.output
+
+        # The tool message therefore drops the truncation-marker explanation while
+        # the body still discloses the clip.
+        execute_tool, _ = tools
+        result = execute_tool.invoke({"command": _FEW_LONG_LINES_CMD, "runtime": self._runtime("c_few_tool")})
+        assert "Here is a preview of the result:" in result.content
+        assert "lines of the form" not in result.content
+        assert "output clipped here" in result.content
+
+    def test_capped_byte_excerpt_does_not_claim_the_path_holds_the_full_output(self, sandbox: LocalSubprocessSandbox) -> None:
+        """When capture hits its cap, neither the byte count nor the path is the whole story.
+
+        The wrapper only ever sees the capped file, so its byte count is the cap
+        rather than the command's real output size, and the saved file is itself
+        incomplete. The notice must not contradict the `truncated` status line the
+        caller renders next to it.
+        """
+        offload = sandbox.execute_with_offload(
+            _ONE_HUGE_LINE_CMD,
+            self._capture_path("c_capped"),
+            max_inline_bytes=100,
+            max_capture_bytes=5000,
+        )
+
+        assert offload.offloaded is True
+        assert offload.response.truncated is True
+        assert offload.preview_has_truncation_marker is False
+
+        notice = offload.response.output.splitlines()[-1]
+        assert "capture stopped at its 5000-byte limit" in notice
+        # The real output was 200000 bytes, so the cap must not be sold as the total...
+        assert "5000 bytes total" not in notice
+        # ...and the saved file is incomplete, so it must not be sold as the full output.
+        assert "full output at the path above" not in notice
+        assert "incomplete" in notice
+
+    def test_uncapped_byte_excerpt_reports_the_true_total_and_full_recovery(self, sandbox: LocalSubprocessSandbox) -> None:
+        """Below the cap, the captured file really is the whole output."""
+        offload = sandbox.execute_with_offload(_FEW_LONG_LINES_CMD, self._capture_path("c_uncapped"), max_inline_bytes=100)
+
+        assert offload.response.truncated is False
+        notice = offload.response.output.splitlines()[-1]
+        assert "bytes total, full output at the path above" in notice
+        assert "capture stopped at its" not in notice
+
+    def test_capped_head_tail_preview_has_no_clip_notice(self, sandbox: LocalSubprocessSandbox) -> None:
+        """The clip notice belongs to the byte-excerpt branch only, capped or not."""
+        offload = sandbox.execute_with_offload(
+            _BIG_OUTPUT_CMD,
+            self._capture_path("c_capped_marker"),
+            max_inline_bytes=100,
+            max_capture_bytes=5000,
+        )
+
+        assert offload.response.truncated is True
+        assert offload.preview_has_truncation_marker is True
+        assert "output clipped here" not in offload.response.output
+
+    def test_offloaded_preview_shorter_than_excerpt_budget_omits_clip_notice(self, sandbox: LocalSubprocessSandbox) -> None:
+        """Output above the inline budget but below the excerpt budget loses nothing."""
+        cmd = 'printf "a\\nb\\nc\\n"; head -c 300 /dev/zero | tr "\\0" x; echo'
+        offload = sandbox.execute_with_offload(cmd, self._capture_path("c_fits"), max_inline_bytes=100)
+
+        assert offload.offloaded is True
+        assert offload.preview_has_truncation_marker is False
+        # Nothing was dropped, so neither notice appears.
+        assert "lines truncated" not in offload.response.output
+        assert "output clipped here" not in offload.response.output
+
+    def test_head_tail_excerpts_disclose_their_byte_caps(self, sandbox: LocalSubprocessSandbox) -> None:
+        """Long lines make the head/tail excerpts lose content the marker never counts.
+
+        `head -c`/`tail -c` run before the line caps, so the outermost shown lines are
+        cut mid-line and fewer lines appear than the budget. The marker only accounts
+        for whole middle lines, so the preview must say the rest out loud.
+        """
+        offload = sandbox.execute_with_offload(_MANY_LONG_LINES_CMD, self._capture_path("c_ht_clip"), max_inline_bytes=100)
+
+        assert offload.offloaded is True
+        assert offload.preview_has_truncation_marker is True
+        assert "byte-capped" in offload.response.output
+        # The marker keeps its own line rather than being glued onto a mid-line cut.
+        marker_lines = [line for line in offload.response.output.splitlines() if line.startswith("... [") and "lines truncated" in line]
+        assert len(marker_lines) == 1
+
+    def test_head_tail_excerpts_stay_quiet_when_byte_caps_do_not_bite(self, sandbox: LocalSubprocessSandbox) -> None:
+        """Short lines fit inside the byte caps, so there is no extra loss to disclose."""
+        offload = sandbox.execute_with_offload(_BIG_OUTPUT_CMD, self._capture_path("c_ht_noclip"), max_inline_bytes=100)
+
+        assert offload.preview_has_truncation_marker is True
+        assert "byte-capped" not in offload.response.output
+
+    def test_capped_byte_excerpt_notice_agrees_with_the_status_line(self, sandbox: LocalSubprocessSandbox) -> None:
+        """The capped wording exists to not contradict the `truncated` status line.
+
+        That pairing is the whole reason for the variant, so assert both halves on the
+        composed message rather than only on the raw backend value.
+        """
+        capture_path = self._capture_path("c_capped_msg")
+        offload = sandbox.execute_with_offload(_ONE_HUGE_LINE_CMD, capture_path, max_inline_bytes=100, max_capture_bytes=5000)
+
+        middleware = FilesystemMiddleware(backend=sandbox)
+        content = middleware._interpret_capture_output(offload, capture_path, "c_capped_msg")
+
+        # The status line and the in-band notice must tell the model the same story.
+        assert "the saved file is incomplete" in content
+        assert "capture stopped at its 5000-byte limit" in content
+        assert "full output at the path above" not in content
 
     async def test_nonzero_exit_code_preserved(self, tools: tuple, invoke: Callable) -> None:
         execute_tool, _ = tools

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1,5 +1,6 @@
 import mimetypes
 import time
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,6 +21,7 @@ from langgraph.types import Command
 from pydantic import ValidationError
 
 import deepagents.middleware.filesystem as filesystem_middleware
+from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
 from deepagents.backends.protocol import (
     BackendProtocol,
@@ -3342,6 +3344,51 @@ class TestTooLargeToolMessage:
         assert "/large_tool_results/call_1" in rendered
         assert "lines of the form" in rendered
         assert "lines truncated] ..." in rendered
+
+
+class TestLargeResultTemplateDeprecation:
+    """Legacy public templates keep their released contract while warning."""
+
+    def test_tool_template_import_warns_and_preserves_formatting(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            from deepagents.middleware.filesystem import TOO_LARGE_TOOL_MSG  # noqa: PLC0415  # verifies legacy import
+
+        rendered = TOO_LARGE_TOOL_MSG.format(
+            tool_call_id="call_1",
+            file_path="/large_tool_results/call_1",
+            content_sample="preview",
+        )
+
+        assert "call_1" in rendered
+        assert "/large_tool_results/call_1" in rendered
+        assert rendered.endswith("preview\n")
+        self._assert_deprecation(caught, "TOO_LARGE_TOOL_MSG")
+
+    def test_human_template_import_warns_and_preserves_formatting(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            from deepagents.middleware.filesystem import TOO_LARGE_HUMAN_MSG  # noqa: PLC0415  # verifies legacy import
+
+        rendered = TOO_LARGE_HUMAN_MSG.format(
+            file_path="/large_tool_results/message_1",
+            content_sample="preview",
+        )
+
+        assert "/large_tool_results/message_1" in rendered
+        assert rendered.endswith("preview\n")
+        self._assert_deprecation(caught, "TOO_LARGE_HUMAN_MSG")
+
+    @staticmethod
+    def _assert_deprecation(caught: list[warnings.WarningMessage], name: str) -> None:
+        deprecations = [warning for warning in caught if issubclass(warning.category, DeprecationWarning)]
+
+        assert len(deprecations) == 1
+        assert deprecations[0].category is LangChainDeprecationWarning
+        assert name in str(deprecations[0].message)
+        assert "deepagents==0.7.7" in str(deprecations[0].message)
+        assert "deepagents==0.9.0" in str(deprecations[0].message)
+        assert deprecations[0].filename == __file__
 
 
 class TestExtractTextFromMessage:


### PR DESCRIPTION
Stacked on #5567.

`TOO_LARGE_TOOL_MSG` (re-exported from `deepagents.middleware.filesystem`) and `TOO_LARGE_HUMAN_MSG` shipped through `deepagents==0.7.6` as importable module attributes. The preceding PRs in this stack rename them to private `_TOO_LARGE_*` and change the template wording, which would break any downstream `from deepagents.middleware.filesystem import TOO_LARGE_TOOL_MSG`. This preserves the released formatting contract behind a deprecated compatibility path.

---

Importing either name from `deepagents.middleware.filesystem` still succeeds and returns a frozen copy of the released template text (placeholders and wording unchanged), but now emits a `LangChainDeprecationWarning` via a module-level `__getattr__`, noting deprecation in `deepagents==0.7.7` and removal in `deepagents==0.9.0`. The frozen copies deliberately keep the old fixed wording rather than the shared `TRUNCATION_MARKER_TEMPLATE`, so the compatibility surface does not drift as the live templates evolve.
