### PR TITLE
chore(infra): consolidate author-response automation on `waiting-on-author`

### DIFF
--- a/.github/workflows/waiting_on_author.yml
+++ b/.github/workflows/waiting_on_author.yml
@@ -1,4 +1,4 @@
-# Close issues and PRs ten days after a maintainer applies `needs-response`,
+# Close issues and PRs ten days after a maintainer applies `waiting-on-author`,
 # unless the original author explicitly replies. The timeout is measured from
 # the latest label event, so unrelated activity never resets it. Maintainers
 # can therefore ask their question before or after applying the label.
@@ -14,7 +14,7 @@
 # GitHub API before mutating a label; neither workflow checks out or executes PR
 # code.
 
-name: Needs Response
+name: Waiting On Author
 
 on:
   issue_comment:
@@ -102,12 +102,12 @@ jobs:
             const closeMessage =
               'This item has been automatically closed because we have not received a response from the original author. Please comment with any additional information if you would like us to reopen it.';
 
-            function latestNeedsResponseEvent(events) {
+            function findLatestLabelEvent(events) {
               return events
                 .filter(
                   (event) =>
                     event.event === 'labeled' &&
-                    event.label?.name === 'needs-response' &&
+                    event.label?.name === 'waiting-on-author' &&
                     event.created_at,
                 )
                 .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))[0];
@@ -151,7 +151,7 @@ jobs:
               owner,
               repo,
               state: 'open',
-              labels: 'needs-response',
+              labels: 'waiting-on-author',
               per_page: 100,
             });
 
@@ -180,11 +180,11 @@ jobs:
                 issue_number: item.number,
                 per_page: 100,
               });
-              const latestLabelEvent = latestNeedsResponseEvent(events);
+              const latestLabelEvent = findLatestLabelEvent(events);
 
               if (!latestLabelEvent) {
                 core.warning(
-                  `No needs-response label event found for #${item.number}; leaving it open.`,
+                  `No waiting-on-author label event found for #${item.number}; leaving it open.`,
                 );
                 continue;
               }
@@ -204,7 +204,7 @@ jobs:
               ).data;
               if (
                 currentItem.state !== 'open' ||
-                !currentItem.labels.some((label) => label.name === 'needs-response') ||
+                !currentItem.labels.some((label) => label.name === 'waiting-on-author') ||
                 currentItem.labels.some((label) => label.name === 'do-not-close')
               ) {
                 continue;
@@ -219,13 +219,13 @@ jobs:
                   per_page: 100,
                 },
               );
-              const currentLabelEvent = latestNeedsResponseEvent(currentEvents);
+              const currentLabelEvent = findLatestLabelEvent(currentEvents);
 
               if (
                 !currentLabelEvent ||
                 currentLabelEvent.created_at !== latestLabelEvent.created_at
               ) {
-                console.log(`needs-response was reapplied to #${item.number}; skipping.`);
+                console.log(`waiting-on-author was reapplied to #${item.number}; skipping.`);
                 continue;
               }
 
@@ -235,9 +235,9 @@ jobs:
                   owner,
                   repo,
                   issue_number: item.number,
-                  name: 'needs-response',
+                  name: 'waiting-on-author',
                 });
-                console.log(`Removed needs-response from #${item.number} after an author reply.`);
+                console.log(`Removed waiting-on-author from #${item.number} after an author reply.`);
                 continue;
               }
 
@@ -259,7 +259,7 @@ jobs:
               if (
                 finalItem.state !== 'open' ||
                 finalItem.updated_at !== currentItem.updated_at ||
-                !finalItem.labels.some((label) => label.name === 'needs-response') ||
+                !finalItem.labels.some((label) => label.name === 'waiting-on-author') ||
                 finalItem.labels.some((label) => label.name === 'do-not-close')
               ) {
                 console.log(`#${item.number} changed during the scan; skipping.`);

--- a/.github/workflows/waiting_on_author.yml
+++ b/.github/workflows/waiting_on_author.yml
@@ -8,6 +8,8 @@
 # replies (`pull_request_review_comment`), and submitted reviews
 # (`pull_request_review`). Pushing commits does not clear the label: a
 # maintainer must decide whether the change addressed their question.
+# Bot-authored items, draft PRs, and anything carrying `do-not-close` are
+# never closed.
 #
 # The follow-up workflow runs under `workflow_run` in the base-branch context,
 # which grants a write token for fork PRs. It validates the response against the
@@ -38,9 +40,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Fork-origin comment and review events receive a read-only token, so they
-  # cannot remove a label directly. Store only the immutable response ID for
-  # the trusted `workflow_run` consumer; it re-fetches and verifies everything.
+  # This job always runs with the workflow's read-only token — fork-origin
+  # events could not be granted write anyway — so it cannot remove a label
+  # itself. It records only immutable identifiers for the trusted
+  # `workflow_run` consumer, which re-fetches and verifies everything.
   record-author-response:
     if: >-
       github.repository == 'langchain-ai/deepagents' &&
@@ -98,16 +101,18 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
+            const waitingOnAuthorLabel = 'waiting-on-author';
             const timeoutMs = 10 * 24 * 60 * 60 * 1000;
             const closeMessage =
               'This item has been automatically closed because we have not received a response from the original author. Please comment with any additional information if you would like us to reopen it.';
 
-            function findLatestLabelEvent(events) {
+            // Mirrored inline in waiting_on_author_reply.yml; keep both in step.
+            function findLatestLabelEvent(events, label) {
               return events
                 .filter(
                   (event) =>
                     event.event === 'labeled' &&
-                    event.label?.name === 'waiting-on-author' &&
+                    event.label?.name === label &&
                     event.created_at,
                 )
                 .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))[0];
@@ -151,7 +156,7 @@ jobs:
               owner,
               repo,
               state: 'open',
-              labels: 'waiting-on-author',
+              labels: waitingOnAuthorLabel,
               per_page: 100,
             });
 
@@ -180,11 +185,11 @@ jobs:
                 issue_number: item.number,
                 per_page: 100,
               });
-              const latestLabelEvent = findLatestLabelEvent(events);
+              const latestLabelEvent = findLatestLabelEvent(events, waitingOnAuthorLabel);
 
               if (!latestLabelEvent) {
                 core.warning(
-                  `No waiting-on-author label event found for #${item.number}; leaving it open.`,
+                  `No ${waitingOnAuthorLabel} label event found for #${item.number}; leaving it open.`,
                 );
                 continue;
               }
@@ -204,7 +209,7 @@ jobs:
               ).data;
               if (
                 currentItem.state !== 'open' ||
-                !currentItem.labels.some((label) => label.name === 'waiting-on-author') ||
+                !currentItem.labels.some((label) => label.name === waitingOnAuthorLabel) ||
                 currentItem.labels.some((label) => label.name === 'do-not-close')
               ) {
                 continue;
@@ -219,13 +224,13 @@ jobs:
                   per_page: 100,
                 },
               );
-              const currentLabelEvent = findLatestLabelEvent(currentEvents);
+              const currentLabelEvent = findLatestLabelEvent(currentEvents, waitingOnAuthorLabel);
 
               if (
                 !currentLabelEvent ||
                 currentLabelEvent.created_at !== latestLabelEvent.created_at
               ) {
-                console.log(`waiting-on-author was reapplied to #${item.number}; skipping.`);
+                console.log(`${waitingOnAuthorLabel} was reapplied to #${item.number}; skipping.`);
                 continue;
               }
 
@@ -235,9 +240,11 @@ jobs:
                   owner,
                   repo,
                   issue_number: item.number,
-                  name: 'waiting-on-author',
+                  name: waitingOnAuthorLabel,
                 });
-                console.log(`Removed waiting-on-author from #${item.number} after an author reply.`);
+                console.log(
+                  `Removed ${waitingOnAuthorLabel} from #${item.number} after an author reply.`,
+                );
                 continue;
               }
 
@@ -247,8 +254,11 @@ jobs:
               // the label afterward. Re-fetch once at the mutation boundary and
               // treat any changed state (reply, close, relabel, do-not-close,
               // or a PR flipped to draft) as a signal to leave the item alone.
-              // A same-author `updated_at` bump can only mean new activity; a
-              // false positive just defers closure to the next scheduled run.
+              // `updated_at` moves on anyone's activity, not just the author's,
+              // so this is deliberately coarse: a false positive only defers
+              // closure to the next scheduled run. It is not a complete guard
+              // either — activity that leaves `updated_at` untouched (review-
+              // thread replies may not bump it) still slips through the window.
               const finalItem = (
                 await github.rest.issues.get({
                   owner,
@@ -259,7 +269,7 @@ jobs:
               if (
                 finalItem.state !== 'open' ||
                 finalItem.updated_at !== currentItem.updated_at ||
-                !finalItem.labels.some((label) => label.name === 'waiting-on-author') ||
+                !finalItem.labels.some((label) => label.name === waitingOnAuthorLabel) ||
                 finalItem.labels.some((label) => label.name === 'do-not-close')
               ) {
                 console.log(`#${item.number} changed during the scan; skipping.`);

--- a/.github/workflows/waiting_on_author_reply.yml
+++ b/.github/workflows/waiting_on_author_reply.yml
@@ -2,15 +2,20 @@
 #
 # `workflow_run` executes this definition from the default branch and receives
 # a write-capable token for fork-origin events. The artifact is untrusted input:
-# this workflow uses it only as an opaque response ID, then fetches the comment
-# or review and the current item directly from GitHub before removing a label.
+# this workflow uses it only as an event-kind selector plus an ID pair that the
+# GitHub API cross-validates (a review ID that does not belong to the given PR
+# number 404s), then fetches the comment or review and the current item directly
+# from GitHub and re-verifies authorship before removing a label.
 # It never checks out or executes contributor-controlled code.
 
 name: Clear Waiting On Author After Author Reply
 
 on:
   workflow_run:
-    workflows: ["Waiting On Author"]
+    # `workflow_run` consumers always run from the default branch, so runs of
+    # the producer that were in flight when this rename merged still report the
+    # old name. Drop "Needs Response" once no such run can be pending.
+    workflows: ["Waiting On Author", "Needs Response"]
     types: [completed]
 
 permissions:
@@ -54,6 +59,7 @@ jobs:
               fs.readFileSync('response/author-response.json', 'utf8'),
             );
             const { owner, repo } = context.repo;
+            const waitingOnAuthorLabel = 'waiting-on-author';
 
             function numberFromUrl(url, resource) {
               const match = new URL(url).pathname.match(
@@ -124,7 +130,7 @@ jobs:
 
             if (
               item.state !== 'open' ||
-              !item.labels.some((label) => label.name === 'waiting-on-author') ||
+              !item.labels.some((label) => label.name === waitingOnAuthorLabel) ||
               item.user.type === 'Bot' ||
               responseData.user.type === 'Bot' ||
               responseData.user.login !== item.user.login
@@ -142,25 +148,26 @@ jobs:
               issue_number: issueNumber,
               per_page: 100,
             });
+            // Mirrors findLatestLabelEvent in waiting_on_author.yml; keep in step.
             const latestLabelEvent = events
               .filter(
                 (event) =>
                   event.event === 'labeled' &&
-                  event.label?.name === 'waiting-on-author' &&
+                  event.label?.name === waitingOnAuthorLabel &&
                   event.created_at,
               )
               .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))[0];
 
             if (!latestLabelEvent) {
               core.warning(
-                `No waiting-on-author label event found for #${issueNumber}; leaving it intact.`,
+                `No ${waitingOnAuthorLabel} label event found for #${issueNumber}; leaving it intact.`,
               );
               return;
             }
 
             if (Date.parse(responseTime) <= Date.parse(latestLabelEvent.created_at)) {
               console.log(
-                `Response on #${issueNumber} predates its current waiting-on-author label.`,
+                `Response on #${issueNumber} predates its current ${waitingOnAuthorLabel} label.`,
               );
               return;
             }
@@ -170,12 +177,12 @@ jobs:
                 owner,
                 repo,
                 issue_number: issueNumber,
-                name: 'waiting-on-author',
+                name: waitingOnAuthorLabel,
               });
             } catch (error) {
               if (error.status !== 404) throw error;
-              console.log(`waiting-on-author was already absent from #${issueNumber}.`);
+              console.log(`${waitingOnAuthorLabel} was already absent from #${issueNumber}.`);
               return;
             }
 
-            console.log(`Removed waiting-on-author from #${issueNumber}.`);
+            console.log(`Removed ${waitingOnAuthorLabel} from #${issueNumber}.`);

--- a/.github/workflows/waiting_on_author_reply.yml
+++ b/.github/workflows/waiting_on_author_reply.yml
@@ -1,4 +1,4 @@
-# Clear `needs-response` after an author reply recorded by needs_response.yml.
+# Clear `waiting-on-author` after an author reply recorded by waiting_on_author.yml.
 #
 # `workflow_run` executes this definition from the default branch and receives
 # a write-capable token for fork-origin events. The artifact is untrusted input:
@@ -6,11 +6,11 @@
 # or review and the current item directly from GitHub before removing a label.
 # It never checks out or executes contributor-controlled code.
 
-name: Clear Needs Response After Author Reply
+name: Clear Waiting On Author After Author Reply
 
 on:
   workflow_run:
-    workflows: ["Needs Response"]
+    workflows: ["Waiting On Author"]
     types: [completed]
 
 permissions:
@@ -124,7 +124,7 @@ jobs:
 
             if (
               item.state !== 'open' ||
-              !item.labels.some((label) => label.name === 'needs-response') ||
+              !item.labels.some((label) => label.name === 'waiting-on-author') ||
               item.user.type === 'Bot' ||
               responseData.user.type === 'Bot' ||
               responseData.user.login !== item.user.login
@@ -146,21 +146,21 @@ jobs:
               .filter(
                 (event) =>
                   event.event === 'labeled' &&
-                  event.label?.name === 'needs-response' &&
+                  event.label?.name === 'waiting-on-author' &&
                   event.created_at,
               )
               .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))[0];
 
             if (!latestLabelEvent) {
               core.warning(
-                `No needs-response label event found for #${issueNumber}; leaving it intact.`,
+                `No waiting-on-author label event found for #${issueNumber}; leaving it intact.`,
               );
               return;
             }
 
             if (Date.parse(responseTime) <= Date.parse(latestLabelEvent.created_at)) {
               console.log(
-                `Response on #${issueNumber} predates its current needs-response label.`,
+                `Response on #${issueNumber} predates its current waiting-on-author label.`,
               );
               return;
             }
@@ -170,12 +170,12 @@ jobs:
                 owner,
                 repo,
                 issue_number: issueNumber,
-                name: 'needs-response',
+                name: 'waiting-on-author',
               });
             } catch (error) {
               if (error.status !== 404) throw error;
-              console.log(`needs-response was already absent from #${issueNumber}.`);
+              console.log(`waiting-on-author was already absent from #${issueNumber}.`);
               return;
             }
 
-            console.log(`Removed needs-response from #${issueNumber}.`);
+            console.log(`Removed waiting-on-author from #${issueNumber}.`);


### PR DESCRIPTION
`waiting-on-author` is now the single label for author-response automation: it is removed automatically when the author replies, and the item auto-closes after 10 days without a reply (with a comment explaining how to reopen).

---

The repo had two labels with the same intent: `needs-response` (which had the reply-detection and auto-close automation) and `waiting-on-author` (manual only, though its description claimed it was removed automatically — it wasn't). Maintainers had to remember which of the two actually did something.

This consolidates on `waiting-on-author`, the more memorable name, by renaming the two workflows (`needs_response.yml` → `waiting_on_author.yml`, `needs_response_author_reply.yml` → `waiting_on_author_reply.yml`) and pointing them at the `waiting-on-author` label. Behavior is unchanged otherwise: replies via conversation comments, review-thread replies, and submitted reviews all clear the label; pushing commits does not; the 10-day timeout is measured from the latest label event; `do-not-close` and draft PRs are skipped.

Already done outside this PR (label state isn't version-controlled):
- Migrated the one open item carrying `needs-response` (#2982) to `waiting-on-author`
- Deleted the `needs-response` label
- Updated the `waiting-on-author` description to "Maintainer awaits author reply. Removed on reply. Auto-closes after 10 days."
