### PR TITLE
hotfix(code): wait for terminal resize layout

### DIFF
--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -692,6 +692,9 @@ class TestChatInputResize:
 
             short_screen = 12
             await pilot.resize_terminal(80, short_screen)
+            # Textual queues the Resize handler and its resulting layout work.
+            # Wait for that second pass before reading the applied composer size.
+            await pilot.pause()
 
             assert text_area.size.height == (
                 short_screen - _CHAT_INPUT_RESERVED_SCREEN_ROWS
@@ -701,6 +704,7 @@ class TestChatInputResize:
             assert box._requested_height == _EXPANDED_HEIGHT
 
             await pilot.resize_terminal(80, _RESIZE_SCREEN_HEIGHT)
+            await pilot.pause()
 
             assert text_area.size.height == _EXPANDED_HEIGHT
 


### PR DESCRIPTION
Waits for Textual to process the queued resize and layout cycle before the chat-input resize regression test reads the applied composer height. This removes the timing race that can observe the pre-resize 17-row value instead of the 5-row constrained value.