### PR TITLE
ci(infra): clarify release guard annotations

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -615,7 +615,7 @@ jobs:
           MAX_WAIT=2700 # 45 min
           MAX_QUERY_FAILS=5
           WAITED=0
-          echo "::notice::Publish in flight; waiting up to $((MAX_WAIT / 60))m for it to finish before running release-please: $PENDING"
+          echo "::notice title=Release publish in progress::Waiting up to $((MAX_WAIT / 60)) minutes for the current publish to finish before updating release PRs. Pending publish: $PENDING"
 
           while [ -n "$PENDING" ] && [ "$WAITED" -lt "$MAX_WAIT" ]; do
             if [ "$QUERY_FAILS" -ge "$MAX_QUERY_FAILS" ]; then
@@ -646,7 +646,7 @@ jobs:
           # next push rather than failing — a hung publish is outside this run's
           # control and the operator must clear it manually.
           echo "skip=true" >> "$GITHUB_OUTPUT"
-          echo "::warning::release-please deferred after waiting ${WAITED}s: publish still in flight (or release state unverifiable): $PENDING"
+          echo "::warning title=Release publish still in progress::Waited $((WAITED / 60)) minutes, but the publish is still running or its status could not be verified. Release PR updates are deferred until the next push. Pending publish: $PENDING"
           {
             echo "## release-please deferred"
             echo ""


### PR DESCRIPTION
Release guard annotations now use descriptive titles and plain-English wait/defer messages, making in-flight publish status easier to scan in Actions.

---

The prior messages compressed timing, state, and the next action into one jargon-heavy line. The revised annotations separate the title from the explanation, spell out minutes, and clearly identify pending publishes without changing release behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/55231642-5eba-0c26-43f3-db13b6a92d46)