### PR TITLE
fix(code): collapse resized chat input on double-click

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -1424,7 +1424,7 @@ class _CompletionViewAdapter:
 
 
 def _manual_height_ceiling(screen_height: int) -> int:
-    """Return the largest composer height a drag may request.
+    """Return the largest composer height a manual resize may request.
 
     Args:
         screen_height: Current screen height in rows.
@@ -1606,15 +1606,40 @@ class ChatInputBox(Vertical):
         text_area.styles.max_height = _CHAT_INPUT_AUTO_MAX_HEIGHT
         text_area.call_after_refresh(text_area.scroll_cursor_visible)
 
+    def _manual_height_is_visible(self) -> bool:
+        """Whether a manual height renders taller than automatic sizing would.
+
+        A drag that lands at or below the draft's own height is floored by
+        `_content_height_floor`, so it renders exactly as automatic sizing does
+        even though a request is stored. Distinguishing the two keeps a toggle
+        from having no visible effect.
+
+        Returns:
+            True when a manual height is set and is what pins the composer.
+        """
+        text_area = self._composer()
+        if self._requested_height is None or self._applied_height is None:
+            return False
+        if text_area is None:
+            return False
+        return self._applied_height > _content_height_floor(text_area)
+
     def toggle_expanded(self) -> None:
-        """Expand automatic sizing, or reset any manual size to automatic."""
-        screen_height = self._screen_height()
-        if screen_height is None:
-            return
-        if self._requested_height is None:
-            self.set_manual_height(_manual_height_ceiling(screen_height))
-        else:
+        """Expand to the manual-height ceiling, or drop a manual height.
+
+        Keys off whether a manual height is *visible* rather than merely stored.
+        A request floored by the draft renders identically to automatic sizing,
+        so collapsing it would leave the composer where it already is and the
+        gesture would read as broken -- expanding is the only move that
+        responds. That also covers the stray row of travel a press can emit
+        before the second half of a double-click lands.
+        """
+        if self._manual_height_is_visible():
             self._reset_height()
+        else:
+            # Clamped to the screen ceiling inside `set_manual_height`, so
+            # asking for the absolute maximum lands on whatever fits now.
+            self.set_manual_height(_CHAT_INPUT_MANUAL_MAX_HEIGHT)
 
     def on_completion_popup_rows_changed(
         self, event: CompletionPopup.RowsChanged
@@ -1728,8 +1753,9 @@ class ChatInputResizeHandle(Static):
         delta = self._drag_start_y - event.screen_y
         # A double-click registers only when both presses land on the same cell,
         # which is exactly when the pointer drifts away and back — emitting a
-        # zero-delta move. Reporting it would establish a manual height and flip
-        # the meaning of the click that follows.
+        # zero-delta move. Reporting it would pin the composer to a manual height
+        # the user never asked for, freezing the auto-growth they expect as they
+        # keep typing.
         if delta:
             self.post_message(self.Dragged(delta))
         event.stop()
@@ -1799,8 +1825,9 @@ class ChatInput(Vertical):
     - Enter to submit, modifier key for newlines (see `config.newline_shortcut`)
     - Up/Down arrows for command history at input boundaries (start/end of text)
     - Autocomplete for @ (files) and / (commands)
-    - Drag the top border to resize the composer; double-click it to toggle
-      between the maximum height and content-driven sizing
+    - Drag the top border to resize the composer; double-click it to expand to
+      the maximum height, or to drop a manual height back to content-driven
+      sizing
     """
 
     DEFAULT_CSS = (
@@ -2196,7 +2223,7 @@ class ChatInput(Vertical):
     def on_chat_input_resize_handle_toggle_expanded(
         self, event: ChatInputResizeHandle.ToggleExpanded
     ) -> None:
-        """Toggle maximum and automatic composer sizing."""
+        """Expand the composer, or drop a manual height back to automatic."""
         if self._input_box is not None:
             self._input_box.toggle_expanded()
         event.stop()

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -1607,21 +1607,14 @@ class ChatInputBox(Vertical):
         text_area.call_after_refresh(text_area.scroll_cursor_visible)
 
     def toggle_expanded(self) -> None:
-        """Toggle between the maximum manual height and automatic sizing.
-
-        Branches on whether the composer is already at its maximum rather than
-        on whether a manual height exists at all, so a drag of a row or two
-        (including the incidental jitter of a double-click) still leaves the
-        next double-click meaning "expand".
-        """
+        """Expand automatic sizing, or reset any manual size to automatic."""
         screen_height = self._screen_height()
         if screen_height is None:
             return
-        maximum = _manual_height_ceiling(screen_height)
-        if self._requested_height == maximum:
-            self._reset_height()
+        if self._requested_height is None:
+            self.set_manual_height(_manual_height_ceiling(screen_height))
         else:
-            self.set_manual_height(maximum)
+            self._reset_height()
 
     def on_completion_popup_rows_changed(
         self, event: CompletionPopup.RowsChanged

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -569,26 +569,23 @@ class TestChatInputResize:
             assert text_area.size.height == 1
             assert text_area._settled_content_height() == _CHAT_INPUT_AUTO_MAX_HEIGHT
 
-    async def test_double_click_from_a_partial_manual_height_expands(self) -> None:
-        """A part-way manual height still expands rather than collapsing.
-
-        The toggle keys off "already at the maximum", so a drag of a row or two
-        -- including the incidental jitter of a real double-click -- cannot
-        invert what the next double-click means.
-        """
+    async def test_double_click_from_a_partial_manual_height_collapses(self) -> None:
+        """Any manually resized height collapses around the current draft."""
         app = _ChatInputResizeTestApp()
         async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
             box = app.query_one(ChatInputBox)
             handle = app.query_one(ChatInputResizeHandle)
             text_area = app.query_one(ChatTextArea)
+            text_area.insert("one\ntwo\nthree")
             box.set_manual_height(5)
             await pilot.pause()
+            assert text_area.size.height == 5
 
             await pilot.double_click(handle, offset=(5, 0))
             await pilot.pause()
 
-            assert box._requested_height == _EXPANDED_HEIGHT
-            assert text_area.size.height == _EXPANDED_HEIGHT
+            assert box._requested_height is None
+            assert text_area.size.height == 3
 
     async def test_zero_delta_move_does_not_establish_a_manual_height(self) -> None:
         """Pointer jitter within one cell leaves sizing automatic.

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -570,7 +570,12 @@ class TestChatInputResize:
             assert text_area._settled_content_height() == _CHAT_INPUT_AUTO_MAX_HEIGHT
 
     async def test_double_click_from_a_partial_manual_height_collapses(self) -> None:
-        """Any manually resized height collapses around the current draft."""
+        """A part-way manual height collapses rather than expanding.
+
+        Deliberate: the gesture keys off whether a manual height is what pins
+        the composer, not off whether it reached the maximum, so one
+        double-click undoes any drag the user can see.
+        """
         app = _ChatInputResizeTestApp()
         async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
             box = app.query_one(ChatInputBox)
@@ -586,13 +591,82 @@ class TestChatInputResize:
 
             assert box._requested_height is None
             assert text_area.size.height == 3
+            # Genuinely automatic again, not a height that happens to equal the
+            # draft: auto growth is back in charge and a further toggle expands.
+            assert text_area._settled_content_height() == _CHAT_INPUT_AUTO_MAX_HEIGHT
+            await pilot.double_click(handle, offset=(5, 0))
+            await pilot.pause()
+            assert box._requested_height == _EXPANDED_HEIGHT
+
+    async def test_double_click_expands_a_manual_height_hidden_by_the_draft(
+        self,
+    ) -> None:
+        """A drag floored by the draft expands instead of collapsing.
+
+        Dragging a tall draft smaller stores a request the content floor then
+        refuses to render, so the composer never moves. Collapsing that request
+        would not move it either, leaving the user with two dead gestures in a
+        row -- so this case expands.
+        """
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
+            text_area = app.query_one(ChatTextArea)
+            text_area.insert("one\ntwo\nthree\nfour\nfive\nsix")
+            await pilot.pause()
+            assert text_area.size.height == 6
+
+            # Drag downward to shrink; the floor keeps all six rows visible.
+            await pilot.mouse_down(handle, offset=(5, 0))
+            await pilot.hover(handle, offset=(5, 3))
+            await pilot.mouse_up(handle, offset=(5, 3))
+            await pilot.pause()
+            assert box._requested_height == 3
+            assert text_area.size.height == 6
+
+            await pilot.double_click(handle, offset=(5, 0))
+            await pilot.pause()
+
+            assert box._requested_height == _EXPANDED_HEIGHT
+            assert text_area.size.height == _EXPANDED_HEIGHT
+
+    async def test_double_click_expands_after_a_one_row_drag_jitter(self) -> None:
+        """A single row of travel during a press still leaves "expand" next.
+
+        `on_mouse_move` only suppresses sub-cell jitter, so drifting a whole row
+        and back within one press does establish a manual height. It renders no
+        differently from automatic sizing, so the double-click that follows must
+        still expand.
+        """
+        app = _ChatInputResizeTestApp()
+        async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:
+            box = app.query_one(ChatInputBox)
+            handle = app.query_one(ChatInputResizeHandle)
+            text_area = app.query_one(ChatTextArea)
+            await pilot.pause()
+
+            await pilot.mouse_down(handle, offset=(5, 0))
+            await pilot.hover(handle, offset=(5, 1))
+            await pilot.hover(handle, offset=(5, 0))
+            await pilot.mouse_up(handle, offset=(5, 0))
+            await pilot.pause()
+            assert box._requested_height == 1
+            assert text_area.size.height == 1
+
+            await pilot.double_click(handle, offset=(5, 0))
+            await pilot.pause()
+
+            assert box._requested_height == _EXPANDED_HEIGHT
+            assert text_area.size.height == _EXPANDED_HEIGHT
 
     async def test_zero_delta_move_does_not_establish_a_manual_height(self) -> None:
         """Pointer jitter within one cell leaves sizing automatic.
 
         A double-click only registers when both presses land on the same cell,
         which is exactly when the pointer drifts away and back, emitting a
-        zero-delta move mid-gesture.
+        zero-delta move mid-gesture. Storing a height there would pin the
+        composer and stop it growing as the user keeps typing.
         """
         app = _ChatInputResizeTestApp()
         async with app.run_test(size=(80, _RESIZE_SCREEN_HEIGHT)) as pilot:


### PR DESCRIPTION
Follow-up to #5524

Double-clicking the chat input resize handle now expands only from automatic sizing and collapses every manually resized height around the current draft.

---

`ChatInputBox.toggle_expanded` now treats any `_requested_height` as resized state instead of only recognizing the maximum. The regression test covers a partial manual size with a multiline draft.

Made by [Open SWE](https://openswe.vercel.app/agents/f022b6eb-54bd-1086-033e-5b3afc57c85b)