### PR TITLE
fix(infra): grant release-comment workflow `pull-requests: write`

### DIFF
--- a/.github/workflows/release_comment_update.yml
+++ b/.github/workflows/release_comment_update.yml
@@ -97,9 +97,9 @@ permissions:
   actions: read
   contents: read
   issues: write
-  # `/commits/{sha}/pulls` is a pull-requests-scoped endpoint, even though the
-  # comment itself goes through the issues API.
-  pull-requests: read
+  # `/commits/{sha}/pulls` needs read access; posting the outcome comment on the
+  # release PR needs write access, matching `trigger-releases` in release-please.yml.
+  pull-requests: write
 
 concurrency:
   # One comment attempt per completed release-please run; a rerun of this


### PR DESCRIPTION
Release outcome comments can now be posted successfully on merged release PRs instead of failing with a permissions error.

---

The workflow granted only `pull-requests: read`, while the comparable `trigger-releases` job grants `pull-requests: write` for PR comments. This mismatch stayed latent because every earlier run skipped the comment step; the first run to reach the POST failed with HTTP 403 in the [failing run](https://github.com/langchain-ai/deepagents/actions/runs/32099644447/job/95597543300).

Made by [Open SWE](https://openswe.vercel.app/agents/0d18cfc7-cb4e-51bd-5563-d15b7921bd01)