### PR TITLE
fix(code): complete the `dcode config` surface

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -80,6 +80,15 @@ rather than forcing the default). Also settable via `[ui].collapse_pastes` in
 config.toml.
 """
 
+CURSOR_BLINK = "DEEPAGENTS_CODE_CURSOR_BLINK"
+"""Blink the chat input cursor.
+
+Enabled by default; set to a falsy value (`0`, `false`, `no`, `off`, or empty)
+for a steady cursor. Parsed by `classify_env_bool` (an unrecognized value falls
+through to the config value rather than forcing the default). Also settable via
+`[ui].cursor_blink` in config.toml.
+"""
+
 CURSOR_STYLE = "DEEPAGENTS_CODE_CURSOR_STYLE"
 """Chat input cursor style (`block` or `underline`).
 
@@ -478,6 +487,17 @@ Defaults to enabled; set to a falsy value (`0`, `false`, `no`, `off`, or empty)
 to hide replica tracing details from the splash while leaving tracing active.
 """
 
+SHOW_MESSAGE_TIMESTAMPS = "DEEPAGENTS_CODE_SHOW_MESSAGE_TIMESTAMPS"
+"""Show the timestamp footer under each chat message when enabled.
+
+Off by default; use the `/timestamps` slash command or
+`[ui].show_message_timestamps` in config.toml to toggle. Parsed by
+`classify_env_bool` (an unrecognized or empty value falls through to the config
+value rather than forcing the default). While this env var is set it outranks
+the persisted value, so a `/timestamps` toggle will not appear to "stick"
+across restarts.
+"""
+
 SHOW_SCROLLBAR = "DEEPAGENTS_CODE_SHOW_SCROLLBAR"
 """Show the vertical scrollbar in the chat area when enabled.
 
@@ -522,6 +542,16 @@ only reads canonical names, picks it up). The value you exported in your own
 shell is unaffected, since a process cannot change its parent's environment.
 Off by default; set to a truthy value (`1`, `true`, `yes`, `on`) to suppress
 the warning when this coexistence is expected. Parsed by `is_env_truthy`.
+"""
+
+TERMINAL_PROGRESS = "DEEPAGENTS_CODE_TERMINAL_PROGRESS"
+"""Report agent activity as `OSC 9;4` taskbar/dock/tab progress.
+
+Enabled by default; set to a falsy value (`0`, `false`, `no`, `off`, or empty)
+to stop emitting the sequence on terminals that render it poorly. Parsed by
+`classify_env_bool` (an unrecognized value falls through to the config value
+rather than forcing the default). Also settable via `[ui].terminal_progress` in
+config.toml. `NO_TERMINAL_ESCAPE` suppresses the sequence regardless.
 """
 
 THEME = "DEEPAGENTS_CODE_THEME"

--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -83,10 +83,12 @@ config.toml.
 CURSOR_BLINK = "DEEPAGENTS_CODE_CURSOR_BLINK"
 """Blink the chat input cursor.
 
-Enabled by default; set to a falsy value (`0`, `false`, `no`, `off`, or empty)
+Enabled by default; set to a falsy value (`0`, `false`, `no`, `off`, or blank)
 for a steady cursor. Parsed by `classify_env_bool` (an unrecognized value falls
-through to the config value rather than forcing the default). Also settable via
-`[ui].cursor_blink` in config.toml.
+through to the config value rather than forcing the default). A blank value —
+empty or whitespace-only — counts as `false` because the option declares
+`empty_env_is_false`, so it overrides `config.toml` instead of falling through.
+Also settable via `[ui].cursor_blink` in config.toml.
 """
 
 CURSOR_STYLE = "DEEPAGENTS_CODE_CURSOR_STYLE"
@@ -547,11 +549,14 @@ the warning when this coexistence is expected. Parsed by `is_env_truthy`.
 TERMINAL_PROGRESS = "DEEPAGENTS_CODE_TERMINAL_PROGRESS"
 """Report agent activity as `OSC 9;4` taskbar/dock/tab progress.
 
-Enabled by default; set to a falsy value (`0`, `false`, `no`, `off`, or empty)
+Enabled by default; set to a falsy value (`0`, `false`, `no`, `off`, or blank)
 to stop emitting the sequence on terminals that render it poorly. Parsed by
 `classify_env_bool` (an unrecognized value falls through to the config value
-rather than forcing the default). Also settable via `[ui].terminal_progress` in
-config.toml. `NO_TERMINAL_ESCAPE` suppresses the sequence regardless.
+rather than forcing the default). A blank value — empty or whitespace-only —
+counts as `false` because the option declares `empty_env_is_false`, so it
+overrides `config.toml` instead of falling through. Also settable via
+`[ui].terminal_progress` in config.toml. `NO_TERMINAL_ESCAPE` suppresses the
+sequence regardless.
 """
 
 THEME = "DEEPAGENTS_CODE_THEME"

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1411,13 +1411,16 @@ def _load_bool_display_preference(key: str, *, fallback: bool) -> bool:
 
     Args:
         key: Manifest key of the option, e.g. `"display.cursor_blink"`.
-        fallback: Value to use when `key` is not in the manifest at all, which
-            only happens if a caller and the manifest disagree.
+        fallback: Value to use when `key` is not in the manifest at all, or is
+            not a `BOOL` option — both mean a caller and the manifest disagree.
+            `test_bool_display_preference_keys_match_the_manifest` pins it to
+            each option's declared default so the two cannot drift.
 
     Returns:
         The resolved value.
     """
     from deepagents_code.config_manifest import (
+        OptionKind,
         get_option,
         load_config_toml,
         resolve_scalar,
@@ -1426,6 +1429,16 @@ def _load_bool_display_preference(key: str, *, fallback: bool) -> bool:
     option = get_option(key)
     if option is None:
         logger.warning("Unknown config option %r; falling back to %r", key, fallback)
+        return fallback
+    if option.kind is not OptionKind.BOOL:
+        # Without this, a mistyped key naming a STR option would return
+        # `bool("block")` — silently `True` forever, with no warning at all.
+        logger.warning(
+            "Config option %r is %s, not a bool; falling back to %r",
+            key,
+            option.kind.value,
+            fallback,
+        )
         return fallback
     value, _ = resolve_scalar(option, toml_data=load_config_toml())
     return bool(value)
@@ -1449,24 +1462,16 @@ def _load_message_timestamps_visible() -> bool:
 def _load_show_diff_line_numbers() -> bool:
     """Resolve whether diff hunks show file line numbers.
 
-    Returns:
-        Whether file-relative line numbers are enabled.
-    """
-    from deepagents_code.config_manifest import (
-        get_option,
-        load_config_toml,
-        resolve_scalar,
-    )
+    Toggled in-app with `/line-numbers`, or preset with
+    `[ui].show_diff_line_numbers`. There is no env var for this option.
 
-    option = get_option("display.show_diff_line_numbers")
-    if option is None:
-        logger.warning(
-            "Unknown config option %r; showing diff line numbers",
-            "display.show_diff_line_numbers",
-        )
-        return True
-    value, _ = resolve_scalar(option, toml_data=load_config_toml())
-    return bool(value)
+    Returns:
+        Whether file-relative line numbers are enabled, defaulting to `True`
+        when unset, unreadable, or malformed.
+    """
+    return _load_bool_display_preference(
+        "display.show_diff_line_numbers", fallback=True
+    )
 
 
 def _load_show_scrollbar() -> bool:
@@ -1485,8 +1490,10 @@ def _load_show_scrollbar() -> bool:
 def _load_debug_console_click_to_copy() -> bool:
     r"""Resolve whether the `Ctrl+\` Debug Console copies a row on click.
 
-    Preset with `DEEPAGENTS_CODE_DEBUG_CONSOLE_CLICK_TO_COPY` or
-    `[ui].debug_console_click_to_copy`. Enter-to-copy is always available.
+    Toggled from the console's own "Click to copy" checkbox, or preset with
+    `DEEPAGENTS_CODE_DEBUG_CONSOLE_CLICK_TO_COPY` /
+    `[ui].debug_console_click_to_copy`; while the env var is set the checkbox
+    will not appear to stick. Enter-to-copy is always available.
 
     Returns:
         The resolved preference, or `False` when unset, unreadable, or
@@ -21836,15 +21843,15 @@ class DeepAgentsApp(App):
         """Pause the chat input cursor blink when the terminal loses OS focus.
 
         Textual's own `AppBlur` handling already drops screen focus, which stops
-        the blink via `has_focus`; pausing `cursor_blink` here keeps the cursor
-        hidden even in the paths that restore widget focus while the app itself
-        stays blurred.
+        the blink via `has_focus`, so this is belt-and-braces: `Screen.set_focus`
+        does not gate on `app_focus`, so anything that refocuses the input while
+        the app stays blurred would restart the blink.
 
         Either way this only runs when the terminal reports focus changes. tmux
         withholds them from its panes unless `focus-events` is on, so an
         unfocused pane keeps showing a blinking cursor until the user sets
-        `set -g focus-events on`; `[ui].cursor_blink = false` is the in-app
-        workaround.
+        `set -g focus-events on`; the workaround is
+        `DEEPAGENTS_CODE_CURSOR_BLINK=0` or `[ui].cursor_blink = false`.
         """
         if self._chat_input is None:
             return

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1399,44 +1399,51 @@ def _load_theme_preference() -> str:
     return theme.DEFAULT_THEME
 
 
-def _load_message_timestamps_visible() -> bool:
-    """Load the saved message-timestamp-footer visibility preference.
+def _load_bool_display_preference(key: str, *, fallback: bool) -> bool:
+    """Resolve a boolean `Display` option through the config manifest.
 
-    Reads `[ui].show_message_timestamps` from `~/.deepagents/config.toml`.
+    Precedence follows `resolve_scalar`: the option's `DEEPAGENTS_CODE_*` env
+    var wins, then its `[ui]` key in `~/.deepagents/config.toml`, then the
+    option's declared default. Resolution is intentionally forgiving — an
+    unreadable config, a non-table `[ui]`, or a wrong-typed value is logged by
+    the resolver and falls through, so a typo in a cosmetic setting never
+    breaks startup.
+
+    Args:
+        key: Manifest key of the option, e.g. `"display.cursor_blink"`.
+        fallback: Value to use when `key` is not in the manifest at all, which
+            only happens if a caller and the manifest disagree.
 
     Returns:
-        The saved preference, or `False` when it is unset or unreadable.
+        The resolved value.
     """
-    import tomllib
+    from deepagents_code.config_manifest import (
+        get_option,
+        load_config_toml,
+        resolve_scalar,
+    )
 
-    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
+    option = get_option(key)
+    if option is None:
+        logger.warning("Unknown config option %r; falling back to %r", key, fallback)
+        return fallback
+    value, _ = resolve_scalar(option, toml_data=load_config_toml())
+    return bool(value)
 
-    if not DEFAULT_CONFIG_PATH.exists():
-        return False
-    try:
-        with DEFAULT_CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
-        logger.warning("Could not read config for timestamp preference: %s", exc)
-        return False
 
-    ui = data.get("ui", {})
-    if not isinstance(ui, dict):
-        logger.warning(
-            "[ui] should be a table; got %s while loading timestamp preference",
-            type(ui).__name__,
-        )
-        return False
+def _load_message_timestamps_visible() -> bool:
+    """Resolve whether chat messages show a timestamp footer.
 
-    value = ui.get("show_message_timestamps")
-    if isinstance(value, bool):
-        return value
-    if value is not None:
-        logger.warning(
-            "[ui].show_message_timestamps should be a boolean; got %s",
-            type(value).__name__,
-        )
-    return False
+    Toggled in-app with `/timestamps`, or preset with
+    `DEEPAGENTS_CODE_SHOW_MESSAGE_TIMESTAMPS` / `[ui].show_message_timestamps`.
+
+    Returns:
+        The resolved preference, or `False` when unset, unreadable, or
+        malformed.
+    """
+    return _load_bool_display_preference(
+        "display.show_message_timestamps", fallback=False
+    )
 
 
 def _load_show_diff_line_numbers() -> bool:
@@ -1463,109 +1470,31 @@ def _load_show_diff_line_numbers() -> bool:
 
 
 def _load_show_scrollbar() -> bool:
-    """Load the chat scrollbar visibility preference.
+    """Resolve whether the chat area shows a vertical scrollbar.
 
-    Reads `DEEPAGENTS_CODE_SHOW_SCROLLBAR` env var, falling back to
-    `[ui].show_scrollbar` from `~/.deepagents/config.toml`, and finally `False`.
+    Toggled in-app with `/scrollbar`, or preset with
+    `DEEPAGENTS_CODE_SHOW_SCROLLBAR` / `[ui].show_scrollbar`.
 
     Returns:
-        The resolved preference.
+        The resolved preference, or `False` when unset, unreadable, or
+        malformed.
     """
-    from deepagents_code._env_vars import SHOW_SCROLLBAR, classify_env_bool
-
-    raw = os.environ.get(SHOW_SCROLLBAR)
-    if raw is not None and raw.strip():
-        env = classify_env_bool(raw)
-        if env is not None:
-            return env
-
-    import tomllib
-
-    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
-
-    if not DEFAULT_CONFIG_PATH.exists():
-        return False
-    try:
-        with DEFAULT_CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
-        logger.warning("Could not read config for scrollbar preference: %s", exc)
-        return False
-
-    ui = data.get("ui", {})
-    if not isinstance(ui, dict):
-        logger.warning(
-            "[ui] should be a table; got %s while loading scrollbar preference",
-            type(ui).__name__,
-        )
-        return False
-
-    value = ui.get("show_scrollbar")
-    if isinstance(value, bool):
-        return value
-    if value is not None:
-        logger.warning(
-            "[ui].show_scrollbar should be a boolean; got %s",
-            type(value).__name__,
-        )
-    return False
+    return _load_bool_display_preference("display.show_scrollbar", fallback=False)
 
 
 def _load_debug_console_click_to_copy() -> bool:
-    r"""Load the `Ctrl+\` Debug Console click-to-copy preference.
+    r"""Resolve whether the `Ctrl+\` Debug Console copies a row on click.
 
-    Reads `DEEPAGENTS_CODE_DEBUG_CONSOLE_CLICK_TO_COPY` env var, falling back to
-    `[ui].debug_console_click_to_copy` from `~/.deepagents/config.toml`, and
-    finally `False` (click-to-copy off; Enter-to-copy is always available).
+    Preset with `DEEPAGENTS_CODE_DEBUG_CONSOLE_CLICK_TO_COPY` or
+    `[ui].debug_console_click_to_copy`. Enter-to-copy is always available.
 
     Returns:
-        The resolved preference.
+        The resolved preference, or `False` when unset, unreadable, or
+        malformed.
     """
-    from deepagents_code._env_vars import (
-        DEBUG_CONSOLE_CLICK_TO_COPY,
-        classify_env_bool,
+    return _load_bool_display_preference(
+        "display.debug_console_click_to_copy", fallback=False
     )
-
-    raw = os.environ.get(DEBUG_CONSOLE_CLICK_TO_COPY)
-    if raw is not None and raw.strip():
-        env = classify_env_bool(raw)
-        if env is not None:
-            return env
-
-    import tomllib
-
-    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
-
-    if not DEFAULT_CONFIG_PATH.exists():
-        return False
-    try:
-        with DEFAULT_CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
-        logger.warning(
-            "Could not read config for debug console click-to-copy preference: %s",
-            exc,
-        )
-        return False
-
-    ui = data.get("ui", {})
-    if not isinstance(ui, dict):
-        logger.warning(
-            "[ui] should be a table; got %s while loading debug console "
-            "click-to-copy preference",
-            type(ui).__name__,
-        )
-        return False
-
-    value = ui.get("debug_console_click_to_copy")
-    if isinstance(value, bool):
-        return value
-    if value is not None:
-        logger.warning(
-            "[ui].debug_console_click_to_copy should be a boolean; got %s",
-            type(value).__name__,
-        )
-    return False
 
 
 def _replace_malformed_ui(
@@ -1666,68 +1595,17 @@ def save_theme_preference(name: str) -> bool:
     return _save_theme_preference_result(name).ok
 
 
-def _load_bool_ui_preference(key: str, *, log_label: str) -> bool:
-    """Load a boolean `[ui]` preference from `~/.deepagents/config.toml`.
-
-    These preferences have no in-app command; the file is edited manually. The
-    loader is intentionally forgiving: any problem reading or parsing the config
-    falls back to `True` (the feature stays on) after logging a warning, so a
-    typo in a cosmetic setting never breaks startup.
-
-    Args:
-        key: The key to read from the `[ui]` table.
-        log_label: Human-readable name of the preference, used in warning logs.
-
-    Returns:
-        The saved `[ui].<key>` value, or `True` when unset, unreadable,
-            or malformed.
-    """
-    import tomllib
-
-    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
-
-    if not DEFAULT_CONFIG_PATH.exists():
-        return True
-    try:
-        with DEFAULT_CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
-        logger.warning("Could not read config for %s preference: %s", log_label, exc)
-        return True
-
-    ui = data.get("ui", {})
-    if not isinstance(ui, dict):
-        logger.warning(
-            "[ui] should be a table; got %s while loading %s preference",
-            type(ui).__name__,
-            log_label,
-        )
-        return True
-
-    value = ui.get(key)
-    if isinstance(value, bool):
-        return value
-    if value is not None:
-        logger.warning(
-            "[ui].%s should be a boolean; got %s",
-            key,
-            type(value).__name__,
-        )
-    return True
-
-
 def _load_cursor_blink_preference() -> bool:
-    """Load the saved cursor-blink preference from `~/.deepagents/config.toml`.
+    """Resolve whether the chat input cursor should blink.
 
-    The chat input cursor blink can be turned off by setting
-    `[ui].cursor_blink = false` in the config file. There is no in-app command
-    for this; the file is edited manually.
+    The blink can be turned off with `DEEPAGENTS_CODE_CURSOR_BLINK=0` or
+    `[ui].cursor_blink = false`. There is no in-app command for this.
 
     Returns:
-        The saved `[ui].cursor_blink` value, or `True` (blink on) when unset,
+        The resolved cursor-blink preference, or `True` (blink on) when unset,
         unreadable, or malformed.
     """
-    return _load_bool_ui_preference("cursor_blink", log_label="cursor blink")
+    return _load_bool_display_preference("display.cursor_blink", fallback=True)
 
 
 def _load_cursor_style_preference() -> CursorStyle:
@@ -1758,19 +1636,19 @@ def _load_cursor_style_preference() -> CursorStyle:
 
 
 def _load_terminal_progress_preference() -> bool:
-    """Load the `OSC 9;4` progress preference from `~/.deepagents/config.toml`.
+    """Resolve whether to emit `OSC 9;4` terminal progress.
 
-    The terminal taskbar/dock/tab progress indicator (where supported) can be
-    turned off by setting `[ui].terminal_progress = false` in the config file.
-    There is no in-app command for this; the file is edited manually. The
+    The taskbar/dock/tab progress indicator (where supported) can be turned off
+    with `DEEPAGENTS_CODE_TERMINAL_PROGRESS=0` or
+    `[ui].terminal_progress = false`. There is no in-app command for this. The
     `DEEPAGENTS_CODE_NO_TERMINAL_ESCAPE` environment variable still disables all
     terminal escapes regardless of this value.
 
     Returns:
-        The saved `[ui].terminal_progress` value, or `True` (progress on) when
+        The resolved terminal-progress preference, or `True` (progress on) when
         unset, unreadable, or malformed.
     """
-    return _load_bool_ui_preference("terminal_progress", log_label="terminal progress")
+    return _load_bool_display_preference("display.terminal_progress", fallback=True)
 
 
 def _save_terminal_theme_mapping_result(
@@ -21957,9 +21835,16 @@ class DeepAgentsApp(App):
     def on_app_blur(self) -> None:
         """Pause the chat input cursor blink when the terminal loses OS focus.
 
-        `TextArea` pauses its own blink when its `has_focus` flips, but
-        `AppBlur` does not change widget focus, so we toggle `cursor_blink`
-        manually.
+        Textual's own `AppBlur` handling already drops screen focus, which stops
+        the blink via `has_focus`; pausing `cursor_blink` here keeps the cursor
+        hidden even in the paths that restore widget focus while the app itself
+        stays blurred.
+
+        Either way this only runs when the terminal reports focus changes. tmux
+        withholds them from its panes unless `focus-events` is on, so an
+        unfocused pane keeps showing a blinking cursor until the user sets
+        `set -g focus-events on`; `[ui].cursor_blink = false` is the in-app
+        workaround.
         """
         if self._chat_input is None:
             return

--- a/libs/code/deepagents_code/client/commands/config.py
+++ b/libs/code/deepagents_code/client/commands/config.py
@@ -231,6 +231,7 @@ def _resolve(
         came from the typed default.
     """
     from deepagents_code.config_manifest import (
+        resolve_auto_classifier_model_with_source,
         resolve_auto_classifier_timeout_with_source,
         resolve_scalar,
     )
@@ -246,6 +247,14 @@ def _resolve(
         key = stored.keys.get(option.provider)
         if key is not None:
             return True, ProviderAuthSource.STORED.value, key
+
+    if option.key == "models.auto_classifier":
+        # A blank env var vetoes `config.toml` for this option, so `resolve_scalar`
+        # alone would report a classifier the runtime does not use. Share the
+        # runtime's resolver instead — this option decides which model reviews
+        # gated actions, so a wrong reading here is a security-relevant lie.
+        spec, source = resolve_auto_classifier_model_with_source(toml_data=toml_data)
+        return source != "default", source, spec
 
     if option.key == "models.auto_classifier_timeout":
         # `resolve_scalar` alone would credit an out-of-range env value that the
@@ -275,9 +284,12 @@ def _display_value(option: ConfigOption, *, is_set: bool, value: object) -> str:
 
     Returns:
         `configured`/`not configured` for credential options, otherwise the value
-            as text. A redacted option never renders its raw value — it reports
-            `configured`/`(unset)` instead — so a table carrying credentials
-            (e.g. `[async_subagents]` headers) cannot leak into the output.
+            as text. A redacted option never renders its raw value here: a
+            credential reports `configured`/`not configured`, and a redacted
+            table (e.g. `[async_subagents]` headers) reports `configured`/
+            `(unset)`. This function is one of three enforcement points —
+            `_config_json_row` and the single-key JSON payload apply the same
+            redaction — so keep them in step when adding an output path.
     """
     if option.group == "Credentials":
         if value is None:
@@ -290,8 +302,11 @@ def _display_value(option: ConfigOption, *, is_set: bool, value: object) -> str:
     if option.redacted:
         # Redacted tables (async subagents, custom model/sandbox providers) are
         # dicts, so the credential presence wording above does not fit; a bare
-        # presence marker still keeps the table off the screen.
-        return "configured" if is_set else "(unset)"
+        # presence marker still keeps the table off the screen. Keyed on the
+        # value rather than `is_set` so a present-but-empty table reads as unset
+        # (nothing is configured) and a future non-`None` default is not
+        # mislabelled `(unset)` while it is in effect.
+        return "configured" if value else "(unset)"
     if option.key == "display.charset" and value == "auto":
         return _charset_display_value()
     text = str(value)

--- a/libs/code/deepagents_code/client/commands/config.py
+++ b/libs/code/deepagents_code/client/commands/config.py
@@ -275,7 +275,9 @@ def _display_value(option: ConfigOption, *, is_set: bool, value: object) -> str:
 
     Returns:
         `configured`/`not configured` for credential options, otherwise the value
-            as text.
+            as text. A redacted option never renders its raw value — it reports
+            `configured`/`(unset)` instead — so a table carrying credentials
+            (e.g. `[async_subagents]` headers) cannot leak into the output.
     """
     if option.group == "Credentials":
         if value is None:
@@ -285,6 +287,11 @@ def _display_value(option: ConfigOption, *, is_set: bool, value: object) -> str:
             return _with_availability(option, status)
     if value is None:
         return "(unset)"
+    if option.redacted:
+        # Redacted tables (async subagents, custom model/sandbox providers) are
+        # dicts, so the credential presence wording above does not fit; a bare
+        # presence marker still keeps the table off the screen.
+        return "configured" if is_set else "(unset)"
     if option.key == "display.charset" and value == "auto":
         return _charset_display_value()
     text = str(value)

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3538,32 +3538,45 @@ def resolve_auto_classifier_model_with_problem() -> tuple[str | None, str | None
     own actions. The caller gets a description so it can say so on a surface the
     user actually reads; a log line alone is not that surface.
 
+    A present-but-blank env var is an explicit "inherit" and outranks
+    `config.toml`, so it is detected before resolution rather than being skipped
+    as unset the way `resolve_scalar` treats every other option's blank env
+    value. `dcode config` shares that veto via
+    `resolve_auto_classifier_model_with_source`, so the two surfaces cannot
+    disagree about which model grades gated actions.
+
     Returns:
         `(spec, problem)`. `spec` is a `provider:model` spec, or `None` when the
             classifier should inherit. `problem` is a one-line description when a
             configured value was ignored, else `None`.
     """
     from deepagents_code.config_manifest import (
+        blank_auto_classifier_env_name,
         get_option,
         load_config_toml,
         resolve_scalar,
     )
-    from deepagents_code.model_config import resolved_env_var_name
 
     option = get_option("models.auto_classifier")
     if option is None:
         return None, None
-    if option.env_var is not None:
-        env_name = resolved_env_var_name(option.env_var)
-        raw_env = os.environ.get(env_name)
-        if raw_env is not None and not raw_env.strip():
-            problem = (
-                f"Ignoring blank env ({env_name}) auto_classifier model; the Auto "
-                "approval classifier will review with the main agent model."
-            )
-            logger.warning("%s", problem)
-            return None, problem
     toml_data = load_config_toml()
+    blank_env = blank_auto_classifier_env_name()
+    if blank_env is not None:
+        # Name the config.toml value being overridden: without it the warning
+        # sends the user to a config file that still shows their setting.
+        shadowed, shadowed_source = resolve_scalar(option, toml_data=toml_data)
+        overridden = (
+            f" (overriding {shadowed_source} {shadowed!r})"
+            if isinstance(shadowed, str) and shadowed.strip()
+            else ""
+        )
+        problem = (
+            f"Ignoring blank env ({blank_env}) auto_classifier model{overridden}; "
+            "the Auto approval classifier will review with the main agent model."
+        )
+        logger.warning("%s", problem)
+        return None, problem
     value, source = resolve_scalar(option, toml_data=toml_data)
     if isinstance(value, str) and value.strip():
         return value.strip(), None

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3548,10 +3548,21 @@ def resolve_auto_classifier_model_with_problem() -> tuple[str | None, str | None
         load_config_toml,
         resolve_scalar,
     )
+    from deepagents_code.model_config import resolved_env_var_name
 
     option = get_option("models.auto_classifier")
     if option is None:
         return None, None
+    if option.env_var is not None:
+        env_name = resolved_env_var_name(option.env_var)
+        raw_env = os.environ.get(env_name)
+        if raw_env is not None and not raw_env.strip():
+            problem = (
+                f"Ignoring blank env ({env_name}) auto_classifier model; the Auto "
+                "approval classifier will review with the main agent model."
+            )
+            logger.warning("%s", problem)
+            return None, problem
     toml_data = load_config_toml()
     value, source = resolve_scalar(option, toml_data=toml_data)
     if isinstance(value, str) and value.strip():

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -690,8 +690,8 @@ def resolve_scalar(
         `(value, source)`, where `source` is `env (<name>)`, `config.toml`, or
         `default`. A malformed `int`/`float`/list/PTC value, an unrecognized
         boolean token, or any TOML value of the wrong type is logged and skipped
-        so the next layer (or the typed default) applies. An empty env value is
-        normally treated as unset (mirroring `resolve_env_var`), so it falls
+        so the next layer (or the typed default) applies. An empty or whitespace-only
+        env value is treated as unset (mirroring `resolve_env_var`), so it falls
         through to the next env var, then `config.toml`/`default`, rather than
         counting as set. Options declaring `empty_env_is_false` instead resolve
         an explicitly present empty value to `False`. Theme resolution
@@ -716,7 +716,7 @@ def resolve_scalar(
             raw = os.environ.get(name)
             if raw is None:
                 continue
-            if not raw:
+            if not raw.strip():
                 if option.empty_env_is_false:
                     return False, f"env ({name})"
                 continue
@@ -1146,6 +1146,50 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         toml_keys=("ui", "cursor_style"),
     ),
     ConfigOption(
+        key="display.cursor_blink",
+        group="Display",
+        summary=(
+            "Blink the chat input cursor (tmux needs 'focus-events on' to hide "
+            "it in unfocused panes)."
+        ),
+        kind=OptionKind.BOOL,
+        default=True,
+        env_var=_env_vars.CURSOR_BLINK,
+        toml_keys=("ui", "cursor_blink"),
+    ),
+    ConfigOption(
+        key="display.terminal_progress",
+        group="Display",
+        summary="Report agent activity as terminal taskbar/dock/tab progress.",
+        kind=OptionKind.BOOL,
+        default=True,
+        env_var=_env_vars.TERMINAL_PROGRESS,
+        toml_keys=("ui", "terminal_progress"),
+    ),
+    ConfigOption(
+        key="display.show_message_timestamps",
+        group="Display",
+        summary="Show the timestamp footer under each chat message.",
+        kind=OptionKind.BOOL,
+        default=False,
+        env_var=_env_vars.SHOW_MESSAGE_TIMESTAMPS,
+        toml_keys=("ui", "show_message_timestamps"),
+    ),
+    ConfigOption(
+        key="display.themes",
+        group="Display",
+        summary="User-defined themes, each a table of theme colors.",
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("themes",),
+    ),
+    ConfigOption(
+        key="display.terminal_themes",
+        group="Display",
+        summary="Per-`TERM_PROGRAM` default theme, written by the theme picker.",
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("ui", "terminal_themes"),
+    ),
+    ConfigOption(
         key="display.show_header",
         group="Display",
         summary="Show Textual's native header bar at the top of the TUI.",
@@ -1324,6 +1368,66 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         default=AUTO_CLASSIFIER_TIMEOUT_SECONDS_DEFAULT,
         env_var=_env_vars.AUTO_CLASSIFIER_TIMEOUT,
         toml_keys=("models", "auto_classifier_timeout"),
+    ),
+    ConfigOption(
+        key="models.providers",
+        group="Models",
+        summary=(
+            "Custom chat-model providers. A `class_path` entry is imported at "
+            "model creation, so its module runs with your privileges."
+        ),
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("models", "providers"),
+    ),
+    ConfigOption(
+        key="retries.max_retries",
+        group="Models",
+        summary=(
+            "Default provider retry count; override per provider with "
+            "`[retries.<provider>]`."
+        ),
+        kind=OptionKind.INT,
+        toml_keys=("retries", "max_retries"),
+    ),
+    # --- Agents ---------------------------------------------------------
+    ConfigOption(
+        key="agents.default",
+        group="Agents",
+        summary="Agent used at launch when `--agent` is omitted.",
+        kind=OptionKind.STR,
+        toml_keys=("agents", "default"),
+    ),
+    ConfigOption(
+        key="agents.recent",
+        group="Agents",
+        summary="Most recently switched-to agent (managed by the app).",
+        kind=OptionKind.STR,
+        toml_keys=("agents", "recent"),
+    ),
+    ConfigOption(
+        key="agents.async_subagents",
+        group="Agents",
+        summary="Remote LangGraph deployments exposed to the agent as subagents.",
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("async_subagents",),
+    ),
+    # --- Sandboxes ------------------------------------------------------
+    ConfigOption(
+        key="sandboxes.default",
+        group="Sandboxes",
+        summary="Sandbox backend used when none is named on the command line.",
+        kind=OptionKind.STR,
+        toml_keys=("sandboxes", "default"),
+    ),
+    ConfigOption(
+        key="sandboxes.providers",
+        group="Sandboxes",
+        summary=(
+            "Custom sandbox backends. A `class_path` entry is imported at "
+            "sandbox creation, so its module runs with your privileges."
+        ),
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("sandboxes", "providers"),
     ),
     # --- Tracing -------------------------------------------------------
     ConfigOption(

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -139,7 +139,8 @@ class OptionKind(Enum):
     """How an option's raw env/TOML value is coerced to a typed value.
 
     All kinds flow through `resolve_scalar`. The scalar kinds (`BOOL`,
-    `BOOL_PRESENCE`, `INT`, `FLOAT`, `STR`) are coerced inline by
+    `BOOL_PRESENCE`, `INT`, `NON_NEGATIVE_INT`, `FLOAT`, `STR`, and
+    `NON_EMPTY_STR`) are coerced inline by
     `_coerce_env`/`_coerce_toml`. `LOG_LEVEL_DELEGATE`, `SHELL_LIST_DELEGATE`,
     `SKILLS_DIRS_DELEGATE`, `PTC_DELEGATE`, and `STARTUP_MODE_DELEGATE` defer to
     bespoke parsers (their semantics — dynamic debug fallback, colon-split Path
@@ -159,9 +160,15 @@ class OptionKind(Enum):
 
     INT = "int"
 
+    NON_NEGATIVE_INT = "non_negative_int"
+    """An integer count that must be zero or greater."""
+
     FLOAT = "float"
 
     STR = "str"
+
+    NON_EMPTY_STR = "non_empty_str"
+    """A string stripped of surrounding whitespace; blank values are unset."""
 
     LOG_LEVEL_DELEGATE = "log_level"
     """Validates log levels and resolves the default from debug mode."""
@@ -192,8 +199,10 @@ _KIND_TYPE_LABEL: dict[OptionKind, str] = {
     OptionKind.BOOL: "bool",
     OptionKind.BOOL_PRESENCE: "bool",
     OptionKind.INT: "int",
+    OptionKind.NON_NEGATIVE_INT: "int (>= 0)",
     OptionKind.FLOAT: "float",
     OptionKind.STR: "str",
+    OptionKind.NON_EMPTY_STR: "non-empty str",
     OptionKind.LOG_LEVEL_DELEGATE: "str",
     OptionKind.SHELL_LIST_DELEGATE: "list[str]",
     OptionKind.SKILLS_DIRS_DELEGATE: "list[path]",
@@ -218,8 +227,10 @@ _KIND_DEFAULT_TYPES: dict[OptionKind, tuple[type, ...]] = {
     OptionKind.BOOL: (bool,),
     OptionKind.BOOL_PRESENCE: (bool,),
     OptionKind.INT: (int,),
+    OptionKind.NON_NEGATIVE_INT: (int,),
     OptionKind.FLOAT: (int, float),
     OptionKind.STR: (str,),
+    OptionKind.NON_EMPTY_STR: (str,),
     OptionKind.CURSOR_STYLE_DELEGATE: (str,),
     OptionKind.STARTUP_MODE_DELEGATE: (str,),
 }
@@ -361,15 +372,21 @@ class ConfigOption:
         if expected is None:
             # Delegate kinds validate their own (immutable) default shapes.
             return
-        # `bool` is an `int` subclass; an INT/FLOAT default must not be a bool.
+        # `bool` is an `int` subclass; integer/float defaults must not be bools.
         if not isinstance(default, expected) or (
-            self.kind in {OptionKind.INT, OptionKind.FLOAT}
+            self.kind in {OptionKind.INT, OptionKind.NON_NEGATIVE_INT, OptionKind.FLOAT}
             and isinstance(default, bool)
         ):
             msg = (
                 f"{self.key}: default {default!r} is not valid for kind "
                 f"{self.kind.value}"
             )
+            raise TypeError(msg)
+        if self.kind is OptionKind.NON_NEGATIVE_INT and default < 0:
+            msg = f"{self.key}: default {default!r} must be >= 0"
+            raise TypeError(msg)
+        if self.kind is OptionKind.NON_EMPTY_STR and not default.strip():
+            msg = f"{self.key}: default must not be blank"
             raise TypeError(msg)
 
     def _validate_invert_toml_bool(self) -> None:
@@ -474,6 +491,12 @@ def _coerce_env(option: ConfigOption, raw: str, name: str) -> object:
         return bool(raw)
     if kind is OptionKind.STR:
         return raw
+    if kind is OptionKind.NON_EMPTY_STR:
+        value = raw.strip()
+        if value:
+            return value
+        logger.warning("Ignoring %s=%r (expected non-empty string)", name, raw)
+        return _INVALID
     if kind is OptionKind.LOG_LEVEL_DELEGATE:
         from deepagents_code._debug import LOG_LEVELS
 
@@ -489,6 +512,16 @@ def _coerce_env(option: ConfigOption, raw: str, name: str) -> object:
         except ValueError:
             logger.warning("Ignoring %s=%r (expected int)", name, raw)
             return _INVALID
+    if kind is OptionKind.NON_NEGATIVE_INT:
+        try:
+            value = int(raw.strip())
+        except ValueError:
+            logger.warning("Ignoring %s=%r (expected int >= 0)", name, raw)
+            return _INVALID
+        if value >= 0:
+            return value
+        logger.warning("Ignoring %s=%r (expected int >= 0)", name, raw)
+        return _INVALID
     if kind is OptionKind.FLOAT:
         try:
             return float(raw.strip())
@@ -564,12 +597,18 @@ def _coerce_toml(option: ConfigOption, raw: object) -> object:
     elif kind is OptionKind.INT:
         if isinstance(raw, int) and not isinstance(raw, bool):
             return raw
+    elif kind is OptionKind.NON_NEGATIVE_INT:
+        if isinstance(raw, int) and not isinstance(raw, bool) and raw >= 0:
+            return raw
     elif kind is OptionKind.FLOAT:
         if isinstance(raw, (int, float)) and not isinstance(raw, bool):
             return float(raw)
     elif kind is OptionKind.STR:
         if isinstance(raw, str):
             return raw
+    elif kind is OptionKind.NON_EMPTY_STR:
+        if isinstance(raw, str) and (value := raw.strip()):
+            return value
     elif kind is OptionKind.SKILLS_DIRS_DELEGATE:
         if isinstance(raw, list):
             from deepagents_code.config import _parse_extra_skills_dirs
@@ -1392,7 +1431,7 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
             "Default provider retry count; override per provider with "
             "`[retries.<provider>]`."
         ),
-        kind=OptionKind.INT,
+        kind=OptionKind.NON_NEGATIVE_INT,
         toml_keys=("retries", "max_retries"),
     ),
     # --- Agents ---------------------------------------------------------
@@ -1400,14 +1439,14 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         key="agents.default",
         group="Agents",
         summary="Agent used at launch when `--agent` is omitted.",
-        kind=OptionKind.STR,
+        kind=OptionKind.NON_EMPTY_STR,
         toml_keys=("agents", "default"),
     ),
     ConfigOption(
         key="agents.recent",
         group="Agents",
         summary="Most recently switched-to agent (managed by the app).",
-        kind=OptionKind.STR,
+        kind=OptionKind.NON_EMPTY_STR,
         toml_keys=("agents", "recent"),
     ),
     ConfigOption(

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -456,15 +456,36 @@ def load_config_toml() -> dict[str, Any]:
         return {}
 
 
+_warned_non_table_paths: set[tuple[str, ...]] = set()
+
+
 def _toml_lookup(data: dict[str, Any], keys: tuple[str, ...]) -> tuple[bool, Any]:
     """Navigate nested `keys` in `data`.
+
+    A traversal that stops because an intermediate node is not a table (say
+    `ui = "dark"` shadowing the whole `[ui]` table) is logged, because it
+    silently defaults *every* option under that table and the value the user
+    edited is nowhere in the output. The warning is emitted once per path per
+    process: `config` resolves the full manifest in one pass, so logging per
+    option would print the same line ~100 times for a single typo.
 
     Returns:
         `(found, value)`, where `found` is `False` if any key was missing.
     """
     node: Any = data
-    for key in keys:
-        if not isinstance(node, dict) or key not in node:
+    for index, key in enumerate(keys):
+        if not isinstance(node, dict):
+            path = keys[:index]
+            if path not in _warned_non_table_paths:
+                _warned_non_table_paths.add(path)
+                logger.warning(
+                    "Ignoring config.toml [%s]; expected a table, got %s — every "
+                    "option under it falls back to its default",
+                    ".".join(path),
+                    type(node).__name__,
+                )
+            return False, None
+        if key not in node:
             return False, None
         node = node[key]
     return True, node
@@ -730,11 +751,12 @@ def resolve_scalar(
         `(value, source)`, where `source` is `env (<name>)`, `config.toml`, or
         `default`. A malformed `int`/`float`/list/PTC value, an unrecognized
         boolean token, or any TOML value of the wrong type is logged and skipped
-        so the next layer (or the typed default) applies. An empty or whitespace-only
-        env value is treated as unset (mirroring `resolve_env_var`), so it falls
-        through to the next env var, then `config.toml`/`default`, rather than
-        counting as set. Options declaring `empty_env_is_false` instead resolve
-        an explicitly present empty value to `False`. Theme resolution
+        so the next layer (or the typed default) applies. An empty or
+        whitespace-only env value is treated as unset, so it falls through to
+        the next env var, then `config.toml`/`default`, rather than counting as
+        set; this is deliberately stricter than `resolve_env_var`, which keeps a
+        whitespace-only value. Options declaring `empty_env_is_false` instead
+        resolve an empty *or* whitespace-only value to `False`. Theme resolution
         (`THEME_DELEGATE`) reports its own richer `config.toml [ui.*]` sources.
     """
     if option.kind is OptionKind.THEME_DELEGATE:
@@ -747,9 +769,10 @@ def resolve_scalar(
         if option.env_var:
             names.append(resolved_env_var_name(option.env_var))
         names.extend(option.fallback_env_vars)
-        # An empty string normally counts as unset, matching `resolve_env_var`,
-        # so it is skipped and the loop continues to the next name. Options
-        # with an explicitly documented empty-value opt-out declare
+        # A blank (empty or whitespace-only) value normally counts as unset, so
+        # it is skipped and the loop continues to the next name. This is
+        # stricter than `resolve_env_var`, which keeps a whitespace-only value.
+        # Options with an explicitly documented empty-value opt-out declare
         # `empty_env_is_false`. Names are tried in order, so the primary
         # `env_var` wins over any fallback.
         for name in names:
@@ -758,7 +781,26 @@ def resolve_scalar(
                 continue
             if not raw.strip():
                 if option.empty_env_is_false:
+                    # Documented opt-out: an empty value means "off". Logged
+                    # because a whitespace-only value reads as unset to the user
+                    # while it actively forces `False` over their config.toml.
+                    logger.debug(
+                        "%s is blank (%r); resolving %s to False",
+                        name,
+                        raw,
+                        option.key,
+                    )
                     return False, f"env ({name})"
+                if raw:
+                    # Empty is a normal "unset" idiom, but whitespace-only is
+                    # almost always an accident (`export X="$UNSET "`), and
+                    # discarding it silently was the one unlogged rejection path
+                    # in this resolver.
+                    logger.warning(
+                        "Ignoring %s=%r (whitespace-only; treated as unset)",
+                        name,
+                        raw,
+                    )
                 continue
             value = _coerce_env(option, raw, name)
             if value is not _INVALID:
@@ -913,6 +955,72 @@ def resolve_auto_classifier_timeout(
     """
     value, _ = resolve_auto_classifier_timeout_with_source(toml_data=toml_data)
     return value
+
+
+def blank_auto_classifier_env_name() -> str | None:
+    """Return the env var blanking the Auto classifier model, if any.
+
+    A present-but-blank `DEEPAGENTS_CODE_AUTO_CLASSIFIER_MODEL` means "inherit
+    the main agent model" and deliberately outranks `config.toml`, unlike every
+    other option, where `resolve_scalar` treats a blank env value as unset. That
+    veto is why this cannot go through `resolve_scalar`.
+
+    Returns:
+        The name of the blank env var, or `None` when no env var is set or the
+            highest-precedence one carries a usable value.
+    """
+    option = get_option("models.auto_classifier")
+    if option is None:
+        return None
+    from deepagents_code.model_config import resolved_env_var_name
+
+    names: list[str] = []
+    if option.env_var:
+        names.append(resolved_env_var_name(option.env_var))
+    names.extend(option.fallback_env_vars)
+    for name in names:
+        raw = os.environ.get(name)
+        if raw is None:
+            continue
+        # The first *set* name decides; a blank fallback must not veto a usable
+        # primary.
+        return name if not raw.strip() else None
+    return None
+
+
+def resolve_auto_classifier_model_with_source(
+    *, toml_data: dict[str, Any] | None = None
+) -> tuple[str | None, str]:
+    """Resolve the effective Auto classifier model spec and its source.
+
+    Shares the blank-env veto with
+    `config.resolve_auto_classifier_model_with_problem` so `dcode config` cannot
+    report a classifier the runtime does not use. `None` means the classifier
+    inherits the main agent model.
+
+    Args:
+        toml_data: Parsed `config.toml`; loaded automatically when omitted.
+
+    Returns:
+        `(spec, source)`. `source` credits the layer that decided the outcome,
+            including the env var whose blank value forced the inherit, so the
+            source never points at a value the runtime ignored.
+    """
+    data = load_config_toml() if toml_data is None else toml_data
+    option = get_option("models.auto_classifier")
+    if option is None:
+        return None, "default"
+
+    blank_env = blank_auto_classifier_env_name()
+    if blank_env is not None:
+        return None, f"env ({blank_env})"
+
+    value, source = resolve_scalar(option, toml_data=data)
+    if isinstance(value, str) and value.strip():
+        return value.strip(), source
+    # A blank or wrong-typed `config.toml` entry reverts to the main agent model;
+    # keep the source so the surface still shows where the ignored value lives.
+    return None, source
 
 
 def _is_valid_recursion_limit(value: object) -> bool:
@@ -1220,7 +1328,9 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
     ConfigOption(
         key="display.themes",
         group="Display",
-        summary="User-defined themes, each a table of theme colors.",
+        summary=(
+            "User-defined themes and built-in theme overrides, keyed by theme name."
+        ),
         kind=OptionKind.STRUCTURED,
         toml_keys=("themes",),
     ),
@@ -1420,8 +1530,9 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         ),
         kind=OptionKind.STRUCTURED,
         toml_keys=("models", "providers"),
-        # A provider table can carry credentials (`api_key`, `params`), so the
-        # value is never printed — `config` reports source and presence only.
+        # A provider table's `params` are forwarded verbatim to the constructor
+        # and can carry credentials, so the value is never printed — `config`
+        # reports source and presence only.
         redacted=True,
     ),
     ConfigOption(
@@ -1438,14 +1549,20 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
     ConfigOption(
         key="agents.default",
         group="Agents",
-        summary="Agent used at launch when `--agent` is omitted.",
+        summary=(
+            "Sticky default agent; used when neither `--agent` nor `-r <thread>` "
+            "is given, and ignored if it names an agent that no longer exists."
+        ),
         kind=OptionKind.NON_EMPTY_STR,
         toml_keys=("agents", "default"),
     ),
     ConfigOption(
         key="agents.recent",
         group="Agents",
-        summary="Most recently switched-to agent (managed by the app).",
+        summary=(
+            "Last switched-to agent, written by the app; the fallback behind "
+            "`agents.default`."
+        ),
         kind=OptionKind.NON_EMPTY_STR,
         toml_keys=("agents", "recent"),
     ),
@@ -1463,7 +1580,10 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
     ConfigOption(
         key="sandboxes.default",
         group="Sandboxes",
-        summary="Sandbox backend used when none is named on the command line.",
+        summary=(
+            "Sandbox backend used by a bare `--sandbox` (passed with no value); "
+            "omitting the flag entirely runs unsandboxed."
+        ),
         kind=OptionKind.STR,
         toml_keys=("sandboxes", "default"),
     ),
@@ -1476,8 +1596,9 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         ),
         kind=OptionKind.STRUCTURED,
         toml_keys=("sandboxes", "providers"),
-        # A provider table can carry credentials (`api_key`, `params`), so the
-        # value is never printed — `config` reports source and presence only.
+        # A provider table's `params` are forwarded verbatim to the constructor
+        # and can carry credentials, so the value is never printed — `config`
+        # reports source and presence only.
         redacted=True,
     ),
     # --- Tracing -------------------------------------------------------

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -16,10 +16,11 @@ wrong-typed TOML value is logged and falls back to the next layer rather than
 raising, so a bad config never blocks startup.
 
 Structured, user-defined config is *not* a flat scalar option and is parsed by
-dedicated typed loaders elsewhere. The manifest references `[threads].columns`
-and `[warnings].suppress` as `STRUCTURED` options for discovery; other tables
-such as `[models.providers.*]` and `[themes.*]` are handled entirely by their
-own loaders and the manifest does not enumerate them at all.
+dedicated typed loaders elsewhere; the manifest references those tables as
+`STRUCTURED` options for discovery only. Tables that can carry credentials —
+`[async_subagents]` headers, `[models.providers]` auth/`params`, and
+`[sandboxes.providers]` settings — are additionally flagged `redacted`, so
+`dcode config` reports their source and presence but never prints the table.
 
 Import discipline: the module top level stays stdlib + `_env_vars` only (both
 light) so it is safe to import from `config.py` at class-definition time without
@@ -1156,6 +1157,7 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         default=True,
         env_var=_env_vars.CURSOR_BLINK,
         toml_keys=("ui", "cursor_blink"),
+        empty_env_is_false=True,
     ),
     ConfigOption(
         key="display.terminal_progress",
@@ -1165,6 +1167,7 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         default=True,
         env_var=_env_vars.TERMINAL_PROGRESS,
         toml_keys=("ui", "terminal_progress"),
+        empty_env_is_false=True,
     ),
     ConfigOption(
         key="display.show_message_timestamps",
@@ -1378,6 +1381,9 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         ),
         kind=OptionKind.STRUCTURED,
         toml_keys=("models", "providers"),
+        # A provider table can carry credentials (`api_key`, `params`), so the
+        # value is never printed — `config` reports source and presence only.
+        redacted=True,
     ),
     ConfigOption(
         key="retries.max_retries",
@@ -1410,6 +1416,9 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         summary="Remote LangGraph deployments exposed to the agent as subagents.",
         kind=OptionKind.STRUCTURED,
         toml_keys=("async_subagents",),
+        # A subagent `headers` table can carry `Authorization` tokens, so the
+        # value is never printed — `config` reports source and presence only.
+        redacted=True,
     ),
     # --- Sandboxes ------------------------------------------------------
     ConfigOption(
@@ -1428,6 +1437,9 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         ),
         kind=OptionKind.STRUCTURED,
         toml_keys=("sandboxes", "providers"),
+        # A provider table can carry credentials (`api_key`, `params`), so the
+        # value is never printed — `config` reports source and presence only.
+        redacted=True,
     ),
     # --- Tracing -------------------------------------------------------
     ConfigOption(

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -15926,25 +15926,22 @@ class TestScrollbarToggle:
         config = tmp_path / "config.toml"
         config.write_text("this is = = not valid toml [[[\n")
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
-        with caplog.at_level("WARNING", logger="deepagents_code.app"):
+        with caplog.at_level("WARNING", logger="deepagents_code.config_manifest"):
             assert _load_show_scrollbar() is False
-        assert any("scrollbar" in record.getMessage() for record in caplog.records)
+        assert any("Could not read config" in r.getMessage() for r in caplog.records)
 
     def test_load_ignores_non_table_ui(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A scalar `[ui]` value is ignored with a warning on load."""
+        """A scalar `[ui]` value reads as unset rather than raising."""
         from deepagents_code.app import _load_show_scrollbar
 
         config = tmp_path / "config.toml"
         config.write_text('ui = "oops"\n')
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
-        with caplog.at_level("WARNING", logger="deepagents_code.app"):
-            assert _load_show_scrollbar() is False
-        assert any("ui" in record.getMessage() for record in caplog.records)
+        assert _load_show_scrollbar() is False
 
     def test_save_repairs_malformed_ui_table(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -16189,7 +16186,6 @@ class TestDebugConsoleClickToCopyPreference:
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """A `[ui]` value that is not a table degrades to the off default."""
         from deepagents_code.app import _load_debug_console_click_to_copy
@@ -16197,9 +16193,7 @@ class TestDebugConsoleClickToCopyPreference:
         config = tmp_path / "config.toml"
         config.write_text('ui = "not-a-table"\n')
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
-        with caplog.at_level("WARNING", logger="deepagents_code.app"):
-            assert _load_debug_console_click_to_copy() is False
-        assert any("[ui]" in record.getMessage() for record in caplog.records)
+        assert _load_debug_console_click_to_copy() is False
 
     def test_load_handles_unreadable_config(
         self,
@@ -16213,9 +16207,9 @@ class TestDebugConsoleClickToCopyPreference:
         config = tmp_path / "config.toml"
         config.write_text("[ui]\ndebug_console_click_to_copy = tru\n")  # invalid TOML
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
-        with caplog.at_level("WARNING", logger="deepagents_code.app"):
+        with caplog.at_level("WARNING", logger="deepagents_code.config_manifest"):
             assert _load_debug_console_click_to_copy() is False
-        assert any("click-to-copy" in record.getMessage() for record in caplog.records)
+        assert any("Could not read config" in r.getMessage() for r in caplog.records)
 
     def test_save_round_trips(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -16271,7 +16265,7 @@ class TestDebugConsoleClickToCopyPreference:
 
 
 class TestAppBlurPausesCursorBlink:
-    """Test `on_app_blur` pauses cursor blink without changing widget focus."""
+    """Test the chat input cursor stops drawing when the terminal is blurred."""
 
     async def test_app_blur_pauses_blink(self) -> None:
         """Losing terminal focus should pause the chat input cursor blink."""
@@ -16287,8 +16281,8 @@ class TestAppBlurPausesCursorBlink:
 
             assert app._chat_input._text_area.cursor_blink is False
 
-    async def test_app_blur_preserves_widget_focus(self) -> None:
-        """Pausing blink must not blur the chat input widget."""
+    async def test_handler_alone_preserves_widget_focus(self) -> None:
+        """Pausing blink must not itself blur the chat input widget."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -16301,6 +16295,36 @@ class TestAppBlurPausesCursorBlink:
             await pilot.pause()
 
             assert app._chat_input._text_area.has_focus is True
+
+    async def test_blur_event_hides_cursor_and_focus_restores_it(self) -> None:
+        """A real `AppBlur` must stop drawing the cursor; `AppFocus` restores it.
+
+        This is the symptom users see in an unfocused tmux pane, so drive the
+        real events rather than calling the handlers: Textual's own `AppBlur`
+        handling drops screen focus, and only the combination of that and our
+        handler decides whether a cursor is painted.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+            text_area = app._chat_input._text_area
+            assert text_area is not None
+            text_area.focus()
+            await pilot.pause()
+            assert text_area._draw_cursor is True
+
+            app.post_message(events.AppBlur())
+            await pilot.pause()
+            await pilot.pause()
+
+            assert text_area._draw_cursor is False
+
+            app.post_message(events.AppFocus())
+            await pilot.pause()
+            await pilot.pause()
+
+            assert text_area._draw_cursor is True
 
     async def test_app_blur_noop_before_mount(self) -> None:
         """`on_app_blur` should silently ignore blur events before mount."""
@@ -30463,18 +30487,20 @@ class TestSetSpinnerTerminalProgress:
 
     @pytest.fixture(autouse=True)
     def _isolate_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Point the config path at an empty temp dir.
+        """Point the config path at an empty temp dir and clear the env override.
 
         Without this, `_load_terminal_progress_preference` reads the developer's
         real `~/.deepagents/config.toml` during `DeepAgentsApp.__init__`, so a
-        local `[ui].terminal_progress = false` would silently flip the
-        positive-path tests below to failing. Tests that need a specific config
-        write to and re-point at this same path.
+        local `[ui].terminal_progress = false` — or an exported
+        `DEEPAGENTS_CODE_TERMINAL_PROGRESS`, which outranks it — would silently
+        flip the positive-path tests below to failing. Tests that need a
+        specific config write to and re-point at this same path.
         """
         monkeypatch.setattr(
             "deepagents_code.model_config.DEFAULT_CONFIG_PATH",
             tmp_path / "config.toml",
         )
+        monkeypatch.delenv("DEEPAGENTS_CODE_TERMINAL_PROGRESS", raising=False)
 
     async def test_status_triggers_indeterminate_progress(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -15918,17 +15918,20 @@ class TestScrollbarToggle:
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Unparsable config falls back to the hidden default with a warning."""
+        """Unparsable config falls back to the hidden default, never raising.
+
+        The resolver owns the warning (see
+        `test_load_config_toml_corrupt_returns_empty_with_warning`); asserting its exact
+        text here would couple this test to a sibling module's log string without
+        distinguishing which preference failed to load.
+        """
         from deepagents_code.app import _load_show_scrollbar
 
         config = tmp_path / "config.toml"
         config.write_text("this is = = not valid toml [[[\n")
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
-        with caplog.at_level("WARNING", logger="deepagents_code.config_manifest"):
-            assert _load_show_scrollbar() is False
-        assert any("Could not read config" in r.getMessage() for r in caplog.records)
+        assert _load_show_scrollbar() is False
 
     def test_load_ignores_non_table_ui(
         self,
@@ -16199,17 +16202,14 @@ class TestDebugConsoleClickToCopyPreference:
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Malformed TOML degrades to the off default with a warning."""
+        """Malformed TOML degrades to the off default, never raising."""
         from deepagents_code.app import _load_debug_console_click_to_copy
 
         config = tmp_path / "config.toml"
         config.write_text("[ui]\ndebug_console_click_to_copy = tru\n")  # invalid TOML
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
-        with caplog.at_level("WARNING", logger="deepagents_code.config_manifest"):
-            assert _load_debug_console_click_to_copy() is False
-        assert any("Could not read config" in r.getMessage() for r in caplog.records)
+        assert _load_debug_console_click_to_copy() is False
 
     def test_save_round_trips(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -16262,6 +16262,38 @@ class TestDebugConsoleClickToCopyPreference:
         assert result.ok is False
         assert result.severity == "error"
         assert result.message is not None
+
+
+@pytest.mark.parametrize(
+    ("key", "fallback"),
+    [
+        ("display.cursor_blink", True),
+        ("display.terminal_progress", True),
+        ("display.show_message_timestamps", False),
+        ("display.show_scrollbar", False),
+        ("display.debug_console_click_to_copy", False),
+        ("display.show_diff_line_numbers", True),
+    ],
+)
+def test_bool_display_preference_keys_match_the_manifest(
+    key: str, fallback: bool
+) -> None:
+    """Every `_load_bool_display_preference` key must exist and be a bool option.
+
+    The `fallback` argument duplicates the manifest default, and a mistyped key
+    silently resolves to it — with both in agreement that produces no symptom at
+    all until someone actually sets the option. Pinning existence, kind, and
+    default here is what makes the duplication safe.
+    """
+    from deepagents_code.config_manifest import OptionKind, get_option
+
+    option = get_option(key)
+    assert option is not None, f"{key} is not in the manifest"
+    assert option.kind is OptionKind.BOOL
+    assert option.default is fallback, (
+        f"{key} default {option.default!r} disagrees with the loader fallback "
+        f"{fallback!r}; they must match or the fallback path changes behavior"
+    )
 
 
 class TestAppBlurPausesCursorBlink:

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -111,6 +111,107 @@ def test_manifest_covers_every_provider_credential() -> None:
     )
 
 
+_UI_READER_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Theme resolution predates the manifest and keeps bespoke semantics
+        # (terminal-program mapping, unknown-name fallback), so these read
+        # `[ui]` directly rather than through `resolve_scalar`.
+        "app.py:_load_terminal_default",
+        "app.py:_load_theme_preference",
+        "config_manifest.py:_resolve_theme",
+        # Reads `[ui]` only to repair and rewrite it; not a value reader.
+        "app.py:_replace_malformed_ui",
+    }
+)
+"""Functions permitted to read the `[ui]` table without using the manifest."""
+
+
+def test_no_hand_rolled_ui_config_readers() -> None:
+    """`[ui]` scalars must be read through the manifest, not re-parsed by hand.
+
+    A bespoke loader re-implements env parsing, the `[ui]` lookup, the type
+    check, and the fallback — which is how the app came to read values that
+    `dcode config` did not report, and vice versa.
+    """
+    import ast
+    from pathlib import Path
+
+    from deepagents_code import config_manifest
+
+    package_root = Path(config_manifest.__file__).parent
+    readers: set[str] = set()
+    for source in sorted(package_root.rglob("*.py")):
+        text = source.read_text(encoding="utf-8")
+        if '.get("ui"' not in text:
+            continue
+        hits = [
+            number
+            for number, line in enumerate(text.splitlines(), start=1)
+            if '.get("ui"' in line
+        ]
+        functions = [
+            node
+            for node in ast.walk(ast.parse(text))
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        for hit in hits:
+            # Smallest enclosing span, so a nested helper is not attributed to
+            # the function it happens to live in.
+            enclosing = min(
+                (
+                    node
+                    for node in functions
+                    if node.lineno <= hit <= (node.end_lineno or node.lineno)
+                ),
+                key=lambda node: (node.end_lineno or node.lineno) - node.lineno,
+                default=None,
+            )
+            name = enclosing.name if enclosing else "<module>"
+            readers.add(f"{source.name}:{name}")
+
+    assert readers == _UI_READER_ALLOWLIST, (
+        f"Unexpected `[ui]` readers: {sorted(readers - _UI_READER_ALLOWLIST)}. "
+        "Register the option in config_manifest.py and resolve it with "
+        "`resolve_scalar` instead of parsing config.toml by hand."
+    )
+
+
+@pytest.mark.parametrize(
+    ("key", "toml_keys"),
+    [
+        ("display.show_message_timestamps", ("ui", "show_message_timestamps")),
+        ("display.themes", ("themes",)),
+        ("display.terminal_themes", ("ui", "terminal_themes")),
+        ("models.providers", ("models", "providers")),
+        ("retries.max_retries", ("retries", "max_retries")),
+        ("agents.default", ("agents", "default")),
+        ("agents.recent", ("agents", "recent")),
+        ("agents.async_subagents", ("async_subagents",)),
+        ("sandboxes.default", ("sandboxes", "default")),
+        ("sandboxes.providers", ("sandboxes", "providers")),
+    ],
+)
+def test_config_toml_sections_are_discoverable(
+    key: str, toml_keys: tuple[str, ...]
+) -> None:
+    """Every `config.toml` section the app reads must be listed by `dcode config`."""
+    option = get_option(key)
+    assert option is not None, f"{key} is missing from the manifest"
+    assert option.toml_keys == toml_keys
+
+
+def test_show_message_timestamps_env_overrides_config(monkeypatch) -> None:
+    """The env var must outrank a persisted `/timestamps` toggle."""
+    option = get_option("display.show_message_timestamps")
+    assert option is not None
+    monkeypatch.setenv(_env_vars.SHOW_MESSAGE_TIMESTAMPS, "1")
+    value, source = resolve_scalar(
+        option, toml_data={"ui": {"show_message_timestamps": False}}
+    )
+    assert value is True
+    assert source == f"env ({_env_vars.SHOW_MESSAGE_TIMESTAMPS})"
+
+
 def test_option_keys_unique() -> None:
     """Manifest keys must be unique so `config get` lookups are unambiguous."""
     keys = option_keys()

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -710,6 +710,22 @@ def test_display_value_uses_credential_language_for_non_secret_unset() -> None:
     assert _display_value(option, is_set=False, value=None) == "not configured"
 
 
+def test_display_value_redacts_structured_table() -> None:
+    """A redacted table never renders its dict, only its presence."""
+    option = ConfigOption(
+        key="agents.async_subagents",
+        group="Agents",
+        summary="",
+        kind=OptionKind.STRUCTURED,
+        redacted=True,
+    )
+    secret = {"researcher": {"headers": {"Authorization": "Bearer sk-secret"}}}
+    rendered = _display_value(option, is_set=True, value=secret)
+    assert rendered == "configured"
+    assert "sk-secret" not in rendered
+    assert _display_value(option, is_set=False, value=None) == "(unset)"
+
+
 def test_missing_extra_hint_checks_provider_dependency(monkeypatch) -> None:
     """Credential rows can show when their provider integration is unavailable."""
     option = ConfigOption(
@@ -1372,6 +1388,47 @@ def test_run_config_json_redacts_every_secret(monkeypatch, capsys) -> None:
     rows = json.loads(capsys.readouterr().out)["data"]
     assert any(r["key"] == "credentials.anthropic" and r["set"] for r in rows)
     assert all(r["value"] is None for r in rows if r["redacted"])
+
+
+def test_run_get_json_redacts_credential_bearing_tables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """`config get --json` reports a credential-bearing table's presence only.
+
+    `[async_subagents]` headers, `[models.providers]`, and
+    `[sandboxes.providers]` can hold tokens, so their rows carry `redacted`
+    and a `None` value instead of the raw table.
+    """
+    from deepagents_code import model_config
+
+    secret = "Bearer sk-secret"
+    config = tmp_path / "config.toml"
+    config.write_text(
+        "[async_subagents.researcher]\n"
+        'description = "Research agent"\n'
+        'graph_id = "agent"\n'
+        "headers = { Authorization = '" + secret + "' }\n"
+        "[models.providers.acme]\n"
+        'class_path = "acme.Chat:AcmeChat"\n'
+        'api_key = "sk-secret"\n'
+        "[sandboxes.providers.acme]\n"
+        'class_path = "acme.Sandbox:AcmeSandbox"\n'
+        "params = { token = 'sk-secret' }\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config)
+
+    for key, source in (
+        ("agents.async_subagents", "config.toml"),
+        ("models.providers", "config.toml"),
+        ("sandboxes.providers", "config.toml"),
+    ):
+        data = _get_json_object(key, capsys)
+        assert data["redacted"] is True
+        assert data["set"] is True
+        assert data["source"] == source
+        assert data["value"] is None
+    assert "sk-secret" not in capsys.readouterr().out
 
 
 def test_resolve_int_falls_back_to_toml_then_default() -> None:

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -3324,3 +3324,194 @@ def test_load_config_toml_tolerates_an_undecodable_file(
         assert load_config_toml() == {}
 
     assert "using defaults" in caplog.text
+
+
+def test_whitespace_env_is_ignored_with_a_warning(monkeypatch, caplog) -> None:
+    """A whitespace-only env value falls through and says so.
+
+    Empty is a normal "unset" idiom, but whitespace-only is nearly always an
+    accident (`export X="$UNSET "`). Discarding it without a word was the only
+    unlogged rejection path in `resolve_scalar`, so a user could lose an
+    override with no evidence anywhere.
+    """
+    option = get_option("models.auto_classifier")
+    assert option is not None
+    assert option.env_var is not None
+    monkeypatch.setenv(option.env_var, "   ")
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.config_manifest"):
+        value, source = resolve_scalar(
+            option, toml_data={"models": {"auto_classifier": "openai:gpt-5"}}
+        )
+
+    assert (value, source) == ("openai:gpt-5", "config.toml")
+    assert any("whitespace-only" in r.getMessage() for r in caplog.records)
+
+
+def test_whitespace_env_opts_out_when_empty_means_false(monkeypatch) -> None:
+    """`empty_env_is_false` treats whitespace like empty, outranking config.toml.
+
+    The asymmetry with the test above is the resolver's contract, so pin both
+    sides: a blank value is an opt-out only where the option declares one.
+    """
+    option = get_option("display.cursor_blink")
+    assert option is not None
+    assert option.empty_env_is_false is True
+    assert option.env_var is not None
+    monkeypatch.setenv(option.env_var, "  \t ")
+
+    assert resolve_scalar(option, toml_data={"ui": {"cursor_blink": True}}) == (
+        False,
+        f"env ({option.env_var})",
+    )
+
+
+def test_non_table_toml_section_is_reported_once(caplog) -> None:
+    """A scalar shadowing a whole table is logged, not silently defaulted.
+
+    `ui = "dark"` defaults every `[ui]` option at once; the pre-manifest loaders
+    each warned about it, and dropping that left the user's edited value absent
+    from the output with no explanation. Logged once per path per process
+    because `config` resolves the whole manifest in one pass.
+    """
+    from deepagents_code import config_manifest
+
+    config_manifest._warned_non_table_paths.clear()
+    scrollbar = get_option("display.show_scrollbar")
+    blink = get_option("display.cursor_blink")
+    assert scrollbar is not None
+    assert blink is not None
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.config_manifest"):
+        assert resolve_scalar(scrollbar, toml_data={"ui": "dark"}) == (False, "default")
+        assert resolve_scalar(blink, toml_data={"ui": "dark"}) == (True, "default")
+
+    warnings = [r for r in caplog.records if "expected a table" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "[ui]" in warnings[0].getMessage()
+    config_manifest._warned_non_table_paths.clear()
+
+
+def test_blank_env_auto_classifier_reports_a_problem(monkeypatch) -> None:
+    """A blank env classifier must be described, not just logged.
+
+    The blank value reverts authorization review to the main agent model — the
+    agent grading its own actions. A `logger.warning` lands in the debug log,
+    which is not a surface the user reads, so the caller needs the description.
+    """
+    from deepagents_code import config_manifest
+    from deepagents_code.config import resolve_auto_classifier_model_with_problem
+
+    monkeypatch.setattr(
+        config_manifest,
+        "load_config_toml",
+        lambda: {"models": {"auto_classifier": "openai:gpt-5"}},
+    )
+    monkeypatch.setenv(_env_vars.AUTO_CLASSIFIER_MODEL, "   ")
+
+    spec, problem = resolve_auto_classifier_model_with_problem()
+
+    assert spec is None
+    assert problem is not None
+    assert _env_vars.AUTO_CLASSIFIER_MODEL in problem
+    # The message must name the value it overrode; without it the user checks
+    # config.toml, still sees their setting, and learns nothing.
+    assert "openai:gpt-5" in problem
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_config_surface_agrees_with_runtime_on_blank_env_classifier(
+    blank: str, monkeypatch
+) -> None:
+    """`config` must not credit a classifier the runtime refuses to use.
+
+    A blank env var vetoes `config.toml` for this option only, so resolving it
+    with the generic scalar path would report the config.toml model while the
+    runtime inherits the main agent model.
+    """
+    from deepagents_code import config_manifest
+    from deepagents_code.config import resolve_auto_classifier_model_with_problem
+
+    toml_data = {"models": {"auto_classifier": "openai:gpt-5"}}
+    monkeypatch.setattr(config_manifest, "load_config_toml", lambda: toml_data)
+    monkeypatch.setenv(_env_vars.AUTO_CLASSIFIER_MODEL, blank)
+
+    option = get_option("models.auto_classifier")
+    assert option is not None
+    runtime_spec, _ = resolve_auto_classifier_model_with_problem()
+    is_set, source, displayed = _resolve(option, toml_data=toml_data)
+
+    assert runtime_spec is None
+    assert displayed == runtime_spec
+    assert source == f"env ({_env_vars.AUTO_CLASSIFIER_MODEL})"
+    assert is_set is True
+    assert _display_value(option, is_set=is_set, value=displayed) == "(unset)"
+
+
+def test_usable_env_classifier_is_still_reported(monkeypatch) -> None:
+    """The veto must not swallow a real env value."""
+    from deepagents_code import config_manifest
+
+    toml_data = {"models": {"auto_classifier": "openai:gpt-5"}}
+    monkeypatch.setattr(config_manifest, "load_config_toml", lambda: toml_data)
+    monkeypatch.setenv(_env_vars.AUTO_CLASSIFIER_MODEL, "anthropic:claude-haiku-4-5")
+
+    option = get_option("models.auto_classifier")
+    assert option is not None
+    is_set, source, value = _resolve(option, toml_data=toml_data)
+
+    assert (is_set, value) == (True, "anthropic:claude-haiku-4-5")
+    assert source == f"env ({_env_vars.AUTO_CLASSIFIER_MODEL})"
+
+
+def test_config_text_output_redacts_credential_bearing_tables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """The human-readable surfaces must not print a credential-bearing table.
+
+    The JSON path redacts through `_config_json_row`; the table, `--verbose`,
+    and `config get` text paths go through `_display_value` instead, so they
+    need their own guard against a renderer that forgets.
+    """
+    from deepagents_code import model_config
+
+    config = tmp_path / "config.toml"
+    config.write_text(
+        "[async_subagents.researcher]\n"
+        'description = "Research agent"\n'
+        'graph_id = "agent"\n'
+        "headers = { Authorization = 'Bearer sk-secret' }\n"
+        "[models.providers.acme]\n"
+        'class_path = "acme.Chat:AcmeChat"\n'
+        'api_key = "sk-secret"\n'
+        "[sandboxes.providers.acme]\n"
+        'class_path = "acme.Sandbox:AcmeSandbox"\n'
+        "params = { token = 'sk-secret' }\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config)
+
+    for args in (
+        argparse.Namespace(config_command=None, output_format="text", verbose=False),
+        argparse.Namespace(config_command=None, output_format="text", verbose=True),
+        argparse.Namespace(
+            config_command="get",
+            key="agents.async_subagents",
+            output_format="text",
+            verbose=False,
+        ),
+    ):
+        assert run_config_command(args) == 0
+        out = capsys.readouterr().out
+        assert "sk-secret" not in out
+        assert "Authorization" not in out
+    assert "configured" in out
+
+
+def test_empty_redacted_table_reads_as_unset() -> None:
+    """A present-but-empty table has nothing configured, so say so."""
+    option = get_option("agents.async_subagents")
+    assert option is not None
+    assert option.redacted is True
+    assert _display_value(option, is_set=True, value={}) == "(unset)"
+    assert _display_value(option, is_set=True, value={"a": {}}) == "configured"

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -200,6 +200,50 @@ def test_config_toml_sections_are_discoverable(
     assert option.toml_keys == toml_keys
 
 
+def test_negative_retry_count_is_not_reported_as_effective(caplog) -> None:
+    """A retry value the runtime rejects must not appear active in `config`."""
+    import logging
+
+    option = get_option("retries.max_retries")
+    assert option is not None
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.config_manifest"):
+        assert resolve_scalar(option, toml_data={"retries": {"max_retries": -1}}) == (
+            None,
+            "default",
+        )
+    assert any(
+        "[retries].max_retries" in record.getMessage() for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize("key", ["agents.default", "agents.recent"])
+def test_blank_saved_agent_is_not_reported_as_effective(key: str, caplog) -> None:
+    """Blank agent preferences fall through just as the launch loader does."""
+    import logging
+
+    option = get_option(key)
+    assert option is not None
+    field = key.removeprefix("agents.")
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.config_manifest"):
+        assert resolve_scalar(option, toml_data={"agents": {field: "   "}}) == (
+            None,
+            "default",
+        )
+    assert any(f"[agents].{field}" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.parametrize("key", ["agents.default", "agents.recent"])
+def test_saved_agent_is_trimmed_like_the_launch_loader(key: str) -> None:
+    """The manifest reports the normalized saved-agent value used at launch."""
+    option = get_option(key)
+    assert option is not None
+    field = key.removeprefix("agents.")
+    assert resolve_scalar(option, toml_data={"agents": {field: "  coder  "}}) == (
+        "coder",
+        "config.toml",
+    )
+
+
 def test_show_message_timestamps_env_overrides_config(monkeypatch) -> None:
     """The env var must outrank a persisted `/timestamps` toggle."""
     option = get_option("display.show_message_timestamps")

--- a/libs/code/tests/unit_tests/test_cursor_blink.py
+++ b/libs/code/tests/unit_tests/test_cursor_blink.py
@@ -83,3 +83,13 @@ class TestLoadCursorBlinkPreference:
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
         monkeypatch.setenv(CURSOR_BLINK, "maybe")
         assert _load_cursor_blink_preference() is False
+
+    def test_empty_env_var_opts_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicitly empty env value disables blinking (`empty_env_is_false`)."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\ncursor_blink = true\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(CURSOR_BLINK, "")
+        assert _load_cursor_blink_preference() is False

--- a/libs/code/tests/unit_tests/test_cursor_blink.py
+++ b/libs/code/tests/unit_tests/test_cursor_blink.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
+from deepagents_code._env_vars import CURSOR_BLINK
 from deepagents_code.app import (
     _load_cursor_blink_preference,
 )
@@ -11,11 +14,14 @@ from deepagents_code.app import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-
 
 class TestLoadCursorBlinkPreference:
-    """_load_cursor_blink_preference reads config.toml correctly."""
+    """_load_cursor_blink_preference resolves env then config.toml."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Drop a developer's exported override so config tests stay honest."""
+        monkeypatch.delenv(CURSOR_BLINK, raising=False)
 
     def test_default_true_when_no_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -57,3 +63,23 @@ class TestLoadCursorBlinkPreference:
         config.write_text('ui = "not a table"\n', encoding="utf-8")
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
         assert _load_cursor_blink_preference() is True
+
+    def test_env_var_wins_over_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The env var overrides an enabling `config.toml` value."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\ncursor_blink = true\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(CURSOR_BLINK, "0")
+        assert _load_cursor_blink_preference() is False
+
+    def test_unrecognized_env_falls_through_to_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-boolean env token is ignored in favor of `config.toml`."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\ncursor_blink = false\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(CURSOR_BLINK, "maybe")
+        assert _load_cursor_blink_preference() is False

--- a/libs/code/tests/unit_tests/test_terminal_progress_preference.py
+++ b/libs/code/tests/unit_tests/test_terminal_progress_preference.py
@@ -92,3 +92,13 @@ class TestLoadTerminalProgressPreference:
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
         monkeypatch.setenv(TERMINAL_PROGRESS, "maybe")
         assert _load_terminal_progress_preference() is False
+
+    def test_empty_env_var_opts_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicitly empty env value stops progress (`empty_env_is_false`)."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\nterminal_progress = true\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(TERMINAL_PROGRESS, "")
+        assert _load_terminal_progress_preference() is False

--- a/libs/code/tests/unit_tests/test_terminal_progress_preference.py
+++ b/libs/code/tests/unit_tests/test_terminal_progress_preference.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
+from deepagents_code._env_vars import TERMINAL_PROGRESS
 from deepagents_code.app import (
     _load_terminal_progress_preference,
 )
@@ -11,11 +14,14 @@ from deepagents_code.app import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-
 
 class TestLoadTerminalProgressPreference:
-    """_load_terminal_progress_preference reads config.toml correctly."""
+    """_load_terminal_progress_preference resolves env then config.toml."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Drop a developer's exported override so config tests stay honest."""
+        monkeypatch.delenv(TERMINAL_PROGRESS, raising=False)
 
     def test_default_true_when_no_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -66,3 +72,23 @@ class TestLoadTerminalProgressPreference:
         config.write_text('ui = "not a table"\n', encoding="utf-8")
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
         assert _load_terminal_progress_preference() is True
+
+    def test_env_var_wins_over_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The env var overrides an enabling `config.toml` value."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\nterminal_progress = true\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(TERMINAL_PROGRESS, "0")
+        assert _load_terminal_progress_preference() is False
+
+    def test_unrecognized_env_falls_through_to_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-boolean env token is ignored in favor of `config.toml`."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\nterminal_progress = false\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(TERMINAL_PROGRESS, "maybe")
+        assert _load_terminal_progress_preference() is False


### PR DESCRIPTION
Supersedes #5219, #5225

`dcode config` had four ways it could mislead you about your own settings. This PR fixes all of them: it could report a value the running app ignores, it could print tables that contain credentials, several `config.toml` sections the app reads were invisible to it, and two kinds of bad input failed silently. The command and the app now share one resolver, so they can't disagree.

---

## The specific gaps

**1. `dcode config` could show a classifier model the app isn't using.**
A blank `DEEPAGENTS_CODE_AUTO_CLASSIFIER_MODEL` means "inherit the main agent model" and deliberately outranks `config.toml`. The CLI resolved options through the generic scalar path, which treats a blank env var as unset — so with a blank env var and a `config.toml` value set, the app uses your main model while `dcode config get models.auto_classifier` reported the config-file model. This option picks which model reviews gated actions, so the two surfaces disagreeing here is the worst case. Both now call the same resolver (`resolve_auto_classifier_model_with_source`), and the source line credits the blank env var that forced the inherit.

**2. Tables that can hold credentials were printed raw, or rejected as unknown.**
`[async_subagents]` headers, `[models.providers]`, and `[sandboxes.providers]` can carry `Authorization` tokens and constructor params. They weren't in the manifest at all, so `dcode config` either said "unknown option" or printed the full table. They're now flagged `redacted`: presence and source are reported, the values never are.

```
$ dcode config get agents.async_subagents
agents.async_subagents = configured  (config.toml)
```

Redaction is enforced in all three output paths (table display, `config --json` rows, and single-key JSON), so a new output path can't accidentally leak them.

**3. Whole sections the app reads were missing from the manifest.**
`[models.providers]`, `[sandboxes]`, `[agents]`, `[retries]`, and `[themes]` now show up in `dcode config list`. Three display settings that were previously hardcoded one-off readers — cursor blink, terminal progress, and message timestamps — are now manifest options with their own env vars (`DEEPAGENTS_CODE_CURSOR_BLINK`, `DEEPAGENTS_CODE_TERMINAL_PROGRESS`, `DEEPAGENTS_CODE_SHOW_MESSAGE_TIMESTAMPS`), so they follow the same env → config → default precedence as everything else. The four copy-pasted TOML readers in `app.py` collapsed into one shared `_load_bool_display_preference`, and a test pins each caller's fallback to the manifest default so they can't drift.

**4. Two silent failure modes now log.**
- A whitespace-only env var (`export DEEPAGENTS_CODE_THEME="$UNSET "`) was discarded with no trace — and for `empty_env_is_false` options it actually forced `False` over your `config.toml`. Both cases now log.
- A scalar shadowing a table (`ui = "dark"` at the top level of `config.toml`) silently defaulted every option under `[ui]`. This now logs once per path, since the manifest resolves ~100 options in one pass and per-option logging would print the same line ~100 times.

**5. `dcode config` credited values the app refuses.**
Two new option kinds enforce the runtime's validation at read time: `NON_NEGATIVE_INT` rejects a negative retry count, `NON_EMPTY_STR` rejects a blank agent name. Both now correctly read `(unset)`.

## Why one resolver

The root cause of gaps 1 and 5 was the CLI maintaining its own resolution logic that didn't know the runtime's override rules. Every fix above routes both surfaces through the manifest, so the CLI reports what the app does by construction rather than by convention. A manifest-drift test rejects new hand-written readers (like the old `[ui]` loaders) so the manifest stays the single source.