### PR TITLE
feat(code): separate writable memory from instructions

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -334,7 +334,7 @@ MEMORY_AUTO_SAVE = "DEEPAGENTS_CODE_MEMORY_AUTO_SAVE"
 """Toggle automatic memory saving (defaults to on).
 
 When enabled, the memory prompt tells the agent to proactively persist
-learnings to the `AGENTS.md` memory files. Set to a falsy value (`0`, `false`,
+learnings to dedicated `MEMORY.md` files. Set to a falsy value (`0`, `false`,
 `no`, `off`, or empty) to keep loading memory into context while disabling the
 auto-save guidance; explicit saves (e.g. the `remember` skill) still work.
 """

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -23,6 +23,7 @@ from deepagents.middleware import (
     MemoryMiddleware,
     SkillsMiddleware,  # noqa: F401
 )
+from deepagents.middleware.memory import MEMORY_SYSTEM_PROMPT
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping, Sequence
@@ -144,6 +145,61 @@ _MEMORY_READONLY_SYSTEM_PROMPT = (
     "echo or save it.\n"
     "</memory_guidelines>\n"
 )
+
+_WRITABLE_MEMORY_PATH_SENTINEL = "__DEEPAGENTS_WRITABLE_MEMORY_PATH__"
+
+_MEMORY_WRITABLE_OWNERSHIP_PROMPT = (
+    "<memory_ownership>\n"
+    "Files named `AGENTS.md` are user-authored instructions and are read-only "
+    "during agent execution. Persist long-term memory only in these writable "
+    f"destinations:\n{_WRITABLE_MEMORY_PATH_SENTINEL}\nUse `write_file` to create "
+    "a destination when needed and `edit_file` for later updates. Never write "
+    "memory to an `AGENTS.md` source.\n"
+    "</memory_ownership>\n\n"
+)
+
+_MEMORY_WRITABLE_SYSTEM_PROMPT = (
+    _MEMORY_WRITABLE_OWNERSHIP_PROMPT
+    + MEMORY_SYSTEM_PROMPT.replace(
+        "don't just fix the immediate issue, update your instructions",
+        "don't just fix the immediate issue, update your writable memory",
+    )
+)
+
+_MEMORY_READONLY_OWNERSHIP_PROMPT = (
+    "<memory_ownership>\n"
+    "Files named `AGENTS.md` are user-authored instructions and are read-only "
+    "during agent execution. Dedicated writable memory destinations are:\n"
+    f"{_WRITABLE_MEMORY_PATH_SENTINEL}\nAutomatic memory saving is disabled, so "
+    "only update those dedicated files when the user explicitly asks you to "
+    "remember something.\n"
+    "</memory_ownership>\n\n" + _MEMORY_READONLY_SYSTEM_PROMPT
+)
+
+
+def _memory_system_prompt(memory_paths: Sequence[Path], *, auto_save: bool) -> str:
+    """Build memory guidance with one explicit writable destination.
+
+    Args:
+        memory_paths: Dedicated files for agent-authored long-term memory. The
+            first path is user-scoped; an optional second path is project-scoped.
+        auto_save: Whether to encourage proactive memory updates.
+
+    Returns:
+        A `MemoryMiddleware` prompt that separates read-only instructions from
+        writable memory.
+    """
+    template = (
+        _MEMORY_WRITABLE_SYSTEM_PROMPT
+        if auto_save
+        else _MEMORY_READONLY_OWNERSHIP_PROMPT
+    )
+    destinations = [f"- User memory: `{memory_paths[0]}`"]
+    if len(memory_paths) > 1:
+        destinations.append(f"- Project memory: `{memory_paths[1]}`")
+    escaped_destinations = "\n".join(destinations).replace("{", "{{").replace("}", "}}")
+    return template.replace(_WRITABLE_MEMORY_PATH_SENTINEL, escaped_destinations)
+
 
 REQUIRE_COMPACT_TOOL_APPROVAL: bool = True
 """When `True`, `compact_conversation` requires HITL approval like other gated tools."""
@@ -2289,7 +2345,8 @@ def create_cli_agent(
             `enable_ask_user=False`.
         enable_memory: Enable `MemoryMiddleware` for persistent memory
         memory_auto_save: When `True` (default), the memory prompt tells the
-            agent to proactively persist learnings to the `AGENTS.md` sources.
+            agent to proactively persist learnings to its dedicated `MEMORY.md`
+            file. Loaded `AGENTS.md` instruction sources remain read-only.
 
             When `False`, memory is still loaded into context but the read-only
             prompt is used instead, so the agent does not auto-save; explicit
@@ -2372,6 +2429,8 @@ def create_cli_agent(
             non-`None` `sandbox`, when `settings.interpreter_ptc` contains
             unknown tool names, or when `interpreter_ptc="all"` is used
             without `auto_approve` or `interpreter_ptc_acknowledge_unsafe`.
+        RuntimeError: If memory is enabled but its dedicated path could not be
+            initialized.
     """
     tools = tools or []
     mcp_tools = tuple(mcp_tools or ())
@@ -2386,7 +2445,8 @@ def create_cli_agent(
         else (project_context.user_cwd if project_context is not None else None)
     )
 
-    # Setup agent directory for persistent memory (if enabled)
+    # Setup agent directory for persistent instructions and memory (if enabled)
+    memory_paths: list[Path] = []
     if enable_memory or enable_skills:
         agent_dir = settings.ensure_agent_dir(assistant_id)
         agent_md = agent_dir / "AGENTS.md"
@@ -2394,6 +2454,10 @@ def create_cli_agent(
             # Create empty file for user customizations
             # Base instructions are loaded fresh from get_system_prompt()
             agent_md.touch()
+        if enable_memory:
+            user_memory_path = agent_dir / "MEMORY.md"
+            user_memory_path.touch(exist_ok=True)
+            memory_paths.append(user_memory_path)
 
     # Skills directories (if enabled)
     skills_dir = None
@@ -2451,6 +2515,25 @@ def create_cli_agent(
         else settings.get_project_agents_dir()
     )
 
+    instruction_paths: list[Path] = []
+    if enable_memory:
+        project_agent_md_paths = (
+            project_context.project_agent_md_paths()
+            if project_context is not None
+            else settings.get_project_agent_md_path()
+        )
+        instruction_paths = [
+            settings.get_user_agent_md_path(assistant_id),
+            *project_agent_md_paths,
+        ]
+        project_root = (
+            project_context.project_root
+            if project_context is not None
+            else settings.project_root
+        )
+        if project_root is not None:
+            memory_paths.append(Path(project_root) / ".deepagents" / "MEMORY.md")
+
     def _subagent_cli_middleware(
         *,
         has_explicit_model: bool,
@@ -2487,16 +2570,15 @@ def create_cli_agent(
                 mcp_tools=mcp_tools,
             )
         )
-        # Subagents share the on-disk filesystem backend and can edit the user
-        # AGENTS.md, so they get the same managed onboarding-name block guard as
-        # the main agent. Gated on memory because the block only exists when
-        # memory is enabled.
+        # Subagents share the on-disk filesystem backend, so they must observe
+        # the same read-only instruction boundary as the main agent.
         if enable_memory:
             from deepagents_code.memory_guard import ManagedMemoryGuardMiddleware
 
             middleware.append(
                 ManagedMemoryGuardMiddleware(
-                    [settings.get_user_agent_md_path(assistant_id)]
+                    [settings.get_user_agent_md_path(assistant_id)],
+                    read_only_paths=instruction_paths,
                 )
             )
         return middleware
@@ -2599,38 +2681,30 @@ def create_cli_agent(
 
     # Add memory middleware
     if enable_memory:
-        memory_sources = [str(settings.get_user_agent_md_path(assistant_id))]
-        project_agent_md_paths = (
-            project_context.project_agent_md_paths()
-            if project_context is not None
-            else settings.get_project_agent_md_path()
-        )
-        memory_sources.extend(str(p) for p in project_agent_md_paths)
+        if not memory_paths:  # pragma: no cover - established during setup
+            msg = "Memory paths were not initialized"
+            raise RuntimeError(msg)
+        memory_sources = [str(path) for path in instruction_paths]
+        memory_sources.extend(str(path) for path in memory_paths)
 
-        # Loading memory stays on either way; a read-only prompt drops the
-        # "proactively persist learnings" guidance when auto-save is disabled.
-        if memory_auto_save:
-            memory_middleware = MemoryMiddleware(
-                backend=FilesystemBackend(virtual_mode=False),
-                sources=memory_sources,
-            )
-        else:
-            memory_middleware = MemoryMiddleware(
-                backend=FilesystemBackend(virtual_mode=False),
-                sources=memory_sources,
-                system_prompt=_MEMORY_READONLY_SYSTEM_PROMPT,
-            )
+        memory_middleware = MemoryMiddleware(
+            backend=FilesystemBackend(virtual_mode=False),
+            sources=memory_sources,
+            system_prompt=_memory_system_prompt(
+                memory_paths, auto_save=memory_auto_save
+            ),
+        )
         agent_middleware.append(memory_middleware)
 
-        # Protect the machine-managed onboarding-name block in the user
-        # AGENTS.md from being rewritten by agent file edits. The block's
-        # markers are HTML comments stripped before injection, so the model
-        # can't see the boundary and would otherwise clobber it.
+        # Enforce instruction ownership below the prompt layer. The existing
+        # managed-block protection remains for compatibility with callers that
+        # use this middleware without the full read-only source list.
         from deepagents_code.memory_guard import ManagedMemoryGuardMiddleware
 
         agent_middleware.append(
             ManagedMemoryGuardMiddleware(
-                [settings.get_user_agent_md_path(assistant_id)]
+                [settings.get_user_agent_md_path(assistant_id)],
+                read_only_paths=instruction_paths,
             )
         )
 

--- a/libs/code/deepagents_code/built_in_skills/remember/SKILL.md
+++ b/libs/code/deepagents_code/built_in_skills/remember/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remember
-description: "Review the current conversation and capture valuable knowledge — best practices, coding conventions, architecture decisions, workflows, and user feedback — into persistent memory (AGENTS.md) or reusable skills. Use when the user says: (1) remember this, (2) save what we learned, (3) update memory, (4) capture learnings."
+description: "Review the current conversation and capture valuable knowledge — best practices, coding conventions, architecture decisions, workflows, and user feedback — into persistent memory (MEMORY.md) or reusable skills. Use when the user says: (1) remember this, (2) save what we learned, (3) update memory, (4) capture learnings."
 license: MIT
 compatibility: designed for deepagents-code
 ---
@@ -28,14 +28,16 @@ Scan the conversation for:
 
 For each best practice or learning, choose the right destination:
 
-### -> Memory (AGENTS.md) for preferences and guidelines
+### -> Memory (MEMORY.md) for preferences and guidelines
 Use memory when the knowledge is:
 - A preference or guideline (not a multi-step process)
 - Something to always keep in mind
 - A simple rule or pattern
 
-**Global** (`~/.deepagents/agent/AGENTS.md`): Universal preferences across all projects
-**Project** (`.deepagents/AGENTS.md`): Project-specific conventions and decisions
+**Global** (`~/.deepagents/<agent>/MEMORY.md`): Universal preferences across all projects
+**Project** (`.deepagents/MEMORY.md`): Project-specific conventions and decisions
+
+Files named `AGENTS.md` are user-authored instructions and must remain unchanged.
 
 ### -> Skill for reusable workflows and methodologies
 **Create a skill when** we developed:

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -4356,7 +4356,8 @@ def get_default_coding_instructions() -> str:
     """Get the default coding agent instructions.
 
     These are the immutable base instructions that cannot be modified by the agent.
-    Long-term memory (AGENTS.md) is handled separately by the middleware.
+    User instructions (AGENTS.md) and long-term memory (MEMORY.md) are handled
+    separately by the middleware.
 
     Returns:
         The default agent instructions as a string.

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1414,7 +1414,7 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         key="memory.auto_save",
         group="Tools",
         summary=(
-            "Let the agent proactively save learnings to memory (AGENTS.md); "
+            "Let the agent proactively save learnings to MEMORY.md files; "
             "disable to keep loading memory but stop auto-saving."
         ),
         kind=OptionKind.BOOL,

--- a/libs/code/deepagents_code/default_agent_prompt.md
+++ b/libs/code/deepagents_code/default_agent_prompt.md
@@ -1,7 +1,8 @@
 # Project Notes
 
-This file is for tracking project-specific context as you work.
-You can update this file to remember decisions, patterns, and context about this project.
+This file contains user-authored instructions and project context.
+Treat it as read-only during agent execution. Store learned decisions, patterns,
+and context in the appropriate user or project `MEMORY.md` file instead.
 
 ## Architecture Notes
 

--- a/libs/code/deepagents_code/memory_guard.py
+++ b/libs/code/deepagents_code/memory_guard.py
@@ -78,6 +78,12 @@ _DELETE_REJECTION_MESSAGE = (
 )
 """Error returned when a delete would remove a managed memory block."""
 
+_READ_ONLY_REJECTION_MESSAGE = (
+    "The instruction file {path} is user-owned and read-only during agent "
+    "execution. Store durable learnings in the dedicated MEMORY.md file instead."
+)
+"""Error returned before a tool mutates a read-only instruction source."""
+
 
 class _RestoreOutcome(Enum):
     """Result of attempting to restore a managed block after a tool call."""
@@ -93,9 +99,10 @@ class _RestoreOutcome(Enum):
 
 
 class ManagedMemoryGuardMiddleware(AgentMiddleware):
-    """Revert agent edits to the managed onboarding-name memory block.
+    """Protect read-only instructions and managed memory blocks from edits.
 
-    Guards the managed onboarding-name block in a fixed set of memory files. A
+    Rejects mutations of configured read-only files before tools run. It also
+    guards the managed onboarding-name block in a fixed set of memory files. A
     `write_file`/`edit_file` that leaves the managed block untouched passes
     through; one that alters or drops it has the block restored (other edits
     kept) and returns an error. A `delete` targeting a guarded file (or a parent
@@ -104,13 +111,21 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
     itself fails, an error is still returned so the failure is never silent.
     """
 
-    def __init__(self, guarded_paths: Iterable[str | Path]) -> None:
+    def __init__(
+        self,
+        guarded_paths: Iterable[str | Path],
+        *,
+        read_only_paths: Iterable[str | Path] = (),
+    ) -> None:
         """Initialize the guard with the memory files to protect.
 
         Args:
             guarded_paths: Paths whose managed onboarding-name block must be
                 protected from agent edits. Resolved to absolute form for
                 matching; unresolvable entries are skipped.
+            read_only_paths: User-owned instruction files that agent tools must
+                not write, edit, or delete. Deleting a parent directory that
+                contains one of these files is also rejected.
         """
         super().__init__()
         requested = list(guarded_paths)
@@ -132,6 +147,79 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
                 "managed memory-block protection is disabled",
                 requested,
             )
+        self._read_only = self._resolve_paths(read_only_paths, kind="read-only")
+
+    @staticmethod
+    def _resolve_paths(paths: Iterable[str | Path], *, kind: str) -> frozenset[Path]:
+        """Resolve configured paths for exact tool-target matching.
+
+        Args:
+            paths: Paths to resolve.
+            kind: Human-readable path category for diagnostics.
+
+        Returns:
+            Successfully resolved absolute paths.
+        """
+        requested = list(paths)
+        resolved: set[Path] = set()
+        for raw in requested:
+            try:
+                resolved.add(Path(raw).expanduser().resolve())
+            except (OSError, RuntimeError, ValueError):
+                logger.warning(
+                    "Could not resolve %s memory path %r", kind, raw, exc_info=True
+                )
+        if requested and not resolved:
+            logger.error(
+                "ManagedMemoryGuardMiddleware resolved no %s paths from %r",
+                kind,
+                requested,
+            )
+        return frozenset(resolved)
+
+    def _read_only_path(self, request: ToolCallRequest) -> Path | None:
+        """Return the protected instruction path targeted by a mutation.
+
+        Returns:
+            The matching read-only path, or `None` for unrelated calls.
+        """
+        tool_name = request.tool_call["name"]
+        if tool_name not in _GUARDED_TOOLS:
+            return None
+        args = request.tool_call.get("args") or {}
+        file_path = args.get("file_path")
+        if not isinstance(file_path, str) or not file_path:
+            return None
+        try:
+            target = Path(file_path).expanduser().resolve()
+        except (OSError, RuntimeError, ValueError):
+            logger.warning(
+                "Could not resolve target path %r for %s",
+                file_path,
+                tool_name,
+                exc_info=True,
+            )
+            return None
+        if tool_name == "delete":
+            return next(
+                (path for path in self._read_only if path.is_relative_to(target)),
+                None,
+            )
+        return target if target in self._read_only else None
+
+    @staticmethod
+    def _read_only_error(request: ToolCallRequest, path: Path) -> ToolMessage:
+        """Build an error result for a blocked instruction mutation.
+
+        Returns:
+            Tool error explaining the writable-memory boundary.
+        """
+        return ToolMessage(
+            content=_READ_ONLY_REJECTION_MESSAGE.format(path=path),
+            tool_call_id=request.tool_call["id"],
+            name=request.tool_call["name"],
+            status="error",
+        )
 
     def _guarded_path(self, request: ToolCallRequest) -> Path | None:
         """Return the resolved guarded path targeted by the call, if any.
@@ -428,6 +516,9 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
             The tool result, or an error `ToolMessage` when the managed block
                 was altered.
         """
+        read_only_path = self._read_only_path(request)
+        if read_only_path is not None:
+            return self._read_only_error(request, read_only_path)
         path = self._guarded_path(request)
         if path is None:
             return handler(request)
@@ -455,6 +546,9 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
             The tool result, or an error `ToolMessage` when the managed block
                 was altered.
         """
+        read_only_path = await asyncio.to_thread(self._read_only_path, request)
+        if read_only_path is not None:
+            return self._read_only_error(request, read_only_path)
         path = await asyncio.to_thread(self._guarded_path, request)
         if path is None:
             return await handler(request)

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
@@ -246,6 +246,12 @@ When using `ask_user`:
 - Group related questions into a single ask_user call rather than making multiple calls
 - Never ask questions you can answer yourself from the available context
 
+<memory_ownership>
+Files named `AGENTS.md` are user-authored instructions and are read-only during agent execution. Persist long-term memory only in these writable destinations:
+- User memory: `<tmp_path>/agents/agent/MEMORY.md`
+Use `write_file` to create a destination when needed and `edit_file` for later updates. Never write memory to an `AGENTS.md` source.
+</memory_ownership>
+
 <agent_memory>
 (No memory loaded)
 
@@ -263,7 +269,7 @@ When using `ask_user`:
     - Learning from your interactions with the user is a top priority. These learnings can be implicit or explicit so you can apply them in future turns.
     - To persist new knowledge, call `edit_file` to update memory promptly—usually in the same turn once you have enough context to record it accurately. Do **not** skip essential investigation when the current request requires it (for example, reading files the user asked about or reproducing failures); complete investigation, respond accurately, then save durable learnings without unnecessary delay.
     - When user says something is better/worse, capture WHY and encode it as a pattern.
-    - Each correction is a chance to improve permanently - don't just fix the immediate issue, update your instructions.
+    - Each correction is a chance to improve permanently - don't just fix the immediate issue, update your writable memory.
     - A great opportunity to update your memories is when the user interrupts a tool call and provides feedback. Update your memories promptly before revising the tool call.
     - Look for the underlying principle behind corrections, not just the specific mistake.
     - The user might not explicitly ask you to remember something, but if they provide information that is useful for future use, you should update your memories promptly.
@@ -333,7 +339,7 @@ Sources labeled "Deepagents" are specific to this agent tool; sources labeled "A
 
 - **deepagents-thread-inspector**: Inspect and explain conversations in the local Deep Agents Code SQLite session store. Use as a fallback when LangSmith trace tooling is unavailable, for offline or untraced sessions, or when asked to identify or summarize a local dcode thread, inspect checkpoint metadata, list recent local threads, or parse ~/.deepagents/.state/sessions.db and a thread UUID or prefix. (License: MIT, Compatibility: designed for deepagents-code)
   -> Read `<built_in_skills_dir>/deepagents-thread-inspector/SKILL.md` for full instructions
-- **remember**: Review the current conversation and capture valuable knowledge — best practices, coding conventions, architecture decisions, workflows, and user feedback — into persistent memory (AGENTS.md) or reusable skills. Use when the user says: (1) remember this, (2) save what we learned, (3) update memory, (4) capture learnings. (License: MIT, Compatibility: designed for deepagents-code)
+- **remember**: Review the current conversation and capture valuable knowledge — best practices, coding conventions, architecture decisions, workflows, and user feedback — into persistent memory (MEMORY.md) or reusable skills. Use when the user says: (1) remember this, (2) save what we learned, (3) update memory, (4) capture learnings. (License: MIT, Compatibility: designed for deepagents-code)
   -> Read `<built_in_skills_dir>/remember/SKILL.md` for full instructions
 - **skill-creator**: Guide for creating effective skills that extend agent capabilities with specialized knowledge, workflows, or tool integrations. Use this skill when the user asks to: (1) create a new skill, (2) make a skill, (3) build a skill, (4) set up a skill, (5) initialize a skill, (6) scaffold a skill, (7) update or modify an existing skill, (8) validate a skill, (9) learn about skill structure, (10) understand how skills work, or (11) get guidance on skill design patterns. Trigger on phrases like "create a skill", "new skill", "make a skill", "skill for X", "how do I create a skill", or "help me build a skill". (License: MIT, Compatibility: designed for deepagents-code)
   -> Read `<built_in_skills_dir>/skill-creator/SKILL.md` for full instructions

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -27,7 +27,6 @@ from deepagents_code._cli_context import CLIContext, CLIContextSchema
 from deepagents_code._repository_bounds import REPOSITORY_TOOL_CALL_LIMIT
 from deepagents_code.agent import (
     _AGENT_DIR_MARKER,
-    _MEMORY_READONLY_SYSTEM_PROMPT,
     DEFAULT_AGENT_NAME,
     AsyncApprovalHITLMiddleware,
     _add_interrupt_on,
@@ -41,6 +40,7 @@ from deepagents_code.agent import (
     _format_web_search_description,
     _format_write_file_description,
     _interrupt_predicate,
+    _memory_system_prompt,
     _reserved_agent_dir_names,
     _rubric_grader_system_prompt,
     _sanitize_agent_message_name,
@@ -2262,10 +2262,12 @@ class TestCreateCliAgentMemorySources:
         sources = captured[0]
         # User AGENTS.md is always first
         assert sources[0] == str(agent_dir / "AGENTS.md")
-        # Both project paths follow
+        # Both project paths follow, then the dedicated writable memory file.
         assert sources[1] == str(project_inner)
         assert sources[2] == str(project_root)
-        assert len(sources) == 3
+        assert sources[3] == str(agent_dir / "MEMORY.md")
+        assert sources[4] == str(tmp_path / ".deepagents" / "MEMORY.md")
+        assert len(sources) == 5
 
     def test_empty_project_paths_no_extra_sources(self, tmp_path: Path) -> None:
         """Empty project path list should not add extra memory sources."""
@@ -2326,8 +2328,12 @@ class TestCreateCliAgentMemorySources:
 
         assert len(captured) == 1
         sources = captured[0]
-        # Only user AGENTS.md, no project paths
-        assert sources == [str(agent_dir / "AGENTS.md")]
+        # User instructions remain loaded, followed by writable memory.
+        assert sources == [
+            str(agent_dir / "AGENTS.md"),
+            str(agent_dir / "MEMORY.md"),
+        ]
+        assert (agent_dir / "MEMORY.md").exists()
 
 
 class TestCreateCliAgentMemoryAutoSave:
@@ -2399,26 +2405,46 @@ class TestCreateCliAgentMemoryAutoSave:
         assert len(captured) == 1
         return captured[0]
 
-    def test_auto_save_on_uses_default_prompt(self, tmp_path: Path) -> None:
-        """Default (auto-save on) leaves the middleware's default prompt in place."""
+    def test_auto_save_on_targets_dedicated_memory(self, tmp_path: Path) -> None:
+        """Auto-save guidance names MEMORY.md and makes AGENTS.md read-only."""
         system_prompt = self._capture_system_prompt(tmp_path, memory_auto_save=True)
-        # No override passed -> MemoryMiddleware keeps its default persistence prompt.
-        assert system_prompt == "__unset__"
+        assert isinstance(system_prompt, str)
+        assert str(tmp_path / "agent" / "MEMORY.md") in system_prompt
+        assert "Files named `AGENTS.md`" in system_prompt
+        assert "only in these writable destinations" in system_prompt
+        assert "Automatic memory saving is disabled" not in system_prompt
 
     def test_auto_save_off_uses_readonly_prompt(self, tmp_path: Path) -> None:
         """Auto-save off swaps in the Code-owned read-only prompt."""
         system_prompt = self._capture_system_prompt(tmp_path, memory_auto_save=False)
-        assert system_prompt is _MEMORY_READONLY_SYSTEM_PROMPT
-
-        formatted = _MEMORY_READONLY_SYSTEM_PROMPT.format(
-            agent_memory="(No memory loaded)"
-        )
+        assert isinstance(system_prompt, str)
+        formatted = system_prompt.format(agent_memory="(No memory loaded)")
         assert "<agent_memory>" in formatted
+        assert str(tmp_path / "agent" / "MEMORY.md") in formatted
+        assert "Files named `AGENTS.md`" in formatted
         assert "**Trust and verification:**" in formatted
         assert "**Learning from feedback:**" not in formatted
         assert "**When to update memories:**" not in formatted
         assert "**Automatic memory saving is disabled:**" in formatted
         assert "Never store API keys, access tokens, passwords" in formatted
+
+    def test_prompt_builder_replaces_only_memory_path(self, tmp_path: Path) -> None:
+        """A path containing braces cannot interfere with memory formatting."""
+        prompt = _memory_system_prompt(
+            [
+                tmp_path / "agent-{one}" / "MEMORY.md",
+                tmp_path / "project-{two}" / ".deepagents" / "MEMORY.md",
+            ],
+            auto_save=True,
+        )
+
+        formatted = prompt.format(agent_memory="saved context")
+
+        assert "agent-{one}" in formatted
+        assert "project-{two}" in formatted
+        assert "User memory:" in formatted
+        assert "Project memory:" in formatted
+        assert "saved context" in formatted
 
 
 class TestCreateCliAgentProjectContext:
@@ -2580,7 +2606,12 @@ class TestCreateCliAgentProjectContext:
         assert len(captured_sources) == 1
         sources = captured_sources[0]
         assert sources[0] == str(agent_dir / "AGENTS.md")
-        assert sources[1:] == [str(deepagents_md), str(root_md)]
+        assert sources[1:] == [
+            str(deepagents_md),
+            str(root_md),
+            str(agent_dir / "MEMORY.md"),
+            str(project_root / ".deepagents" / "MEMORY.md"),
+        ]
 
     @staticmethod
     def _build_shell_agent(

--- a/libs/code/tests/unit_tests/test_memory_guard.py
+++ b/libs/code/tests/unit_tests/test_memory_guard.py
@@ -169,6 +169,75 @@ def test_unguarded_file_passes_through(tmp_path) -> None:
     assert other.read_text(encoding="utf-8") == "rewritten\n"
 
 
+@pytest.mark.parametrize("tool_name", ["write_file", "edit_file"])
+def test_read_only_instruction_write_is_rejected_before_tool(
+    tmp_path, tool_name: str
+) -> None:
+    """Agent tools cannot mutate a user-owned instruction source."""
+    instruction = tmp_path / "project" / "AGENTS.md"
+    instruction.parent.mkdir(parents=True)
+    instruction.write_text("Always run tests.\n", encoding="utf-8")
+    middleware = ManagedMemoryGuardMiddleware([], read_only_paths=[instruction])
+    called = False
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        nonlocal called
+        called = True
+        instruction.write_text("rewritten\n", encoding="utf-8")
+        return _success(tool_name)
+
+    result = middleware.wrap_tool_call(
+        _request(tool_name, str(instruction), content="rewritten\n"), handler
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert "read-only" in str(result.content)
+    assert called is False
+    assert instruction.read_text(encoding="utf-8") == "Always run tests.\n"
+
+
+def test_read_only_instruction_blocks_parent_delete(tmp_path) -> None:
+    """Deleting a directory cannot bypass an instruction-file boundary."""
+    instruction = tmp_path / "project" / "AGENTS.md"
+    instruction.parent.mkdir(parents=True)
+    instruction.write_text("Keep me.\n", encoding="utf-8")
+    middleware = ManagedMemoryGuardMiddleware([], read_only_paths=[instruction])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        pytest.fail("delete handler must not run")
+
+    result = middleware.wrap_tool_call(
+        _request("delete", str(instruction.parent)), handler
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert instruction.exists()
+
+
+def test_dedicated_memory_file_remains_writable(tmp_path) -> None:
+    """The ownership guard does not block the dedicated MEMORY.md target."""
+    instruction = tmp_path / "agent" / "AGENTS.md"
+    memory = tmp_path / "agent" / "MEMORY.md"
+    instruction.parent.mkdir(parents=True)
+    instruction.write_text("Instructions\n", encoding="utf-8")
+    memory.write_text("Old memory\n", encoding="utf-8")
+    middleware = ManagedMemoryGuardMiddleware([], read_only_paths=[instruction])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        memory.write_text("New memory\n", encoding="utf-8")
+        return _success()
+
+    result = middleware.wrap_tool_call(
+        _request("edit_file", str(memory), content="New memory\n"), handler
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "success"
+    assert memory.read_text(encoding="utf-8") == "New memory\n"
+
+
 def test_non_write_tool_passes_through(tmp_path) -> None:
     """Read-only tools targeting the guarded file are never intercepted."""
     path = tmp_path / "agent" / "AGENTS.md"


### PR DESCRIPTION
Related to #5585

Deep Agents Code now keeps user-authored instructions read-only while storing agent-authored long-term memory in dedicated user- and project-scoped `MEMORY.md` files.

---

`create_cli_agent` previously passed the user and project `AGENTS.md` files to `MemoryMiddleware` while the default auto-save guidance encouraged `edit_file` calls against those same sources. This coupled stable instructions to the agent's mutable learning lifecycle; the existing guard protected only the onboarding-name marker block.

This draft keeps every existing `AGENTS.md` source in context for compatibility, adds `~/.deepagents/<agent>/MEMORY.md` and `<project>/.deepagents/MEMORY.md` as the writable destinations, and rejects agent tool mutations of loaded instruction files before the filesystem handler runs. Existing `AGENTS.md` content is not moved or rewritten.

The `/remember` skill and configuration descriptions now reflect the ownership split. Main agents and synchronous subagents receive the same guard.

This is intentionally a draft for design feedback. In particular, the `MEMORY.md` filenames and whether an explicit user request should temporarily permit an `AGENTS.md` edit are open to maintainer direction.

<details>
<summary>Test plan</summary>

- `make lint_diff`
- `make check_imports`
- Targeted agent, memory-guard, and system-prompt tests: 256 passed
- Full unit suite: 13,139 passed and 3 skipped; seven unrelated local-context tests fail because the installed Apple Git does not support their `git init -b` fixture, and one parallel Textual timeout passed when rerun serially

</details>
