### PR TITLE
fix(code): resolve message pointer shapes per cell

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
         RenderResult,
     )
     from textual.app import ComposeResult
+    from textual.css.types import PointerShape
     from textual.events import MouseMove
     from textual.timer import Timer
     from textual.widget import Widget
@@ -128,10 +129,56 @@ def _mode_color(mode: str | None, widget_or_app: object | None = None) -> str:
     return colors.primary
 
 
-def _event_targets_selectable_text(event: MouseMove) -> bool:
-    """Return whether the hovered cell contains selectable rendered text."""
-    meta = getattr(event.style, "meta", None)
-    return isinstance(meta, dict) and "offset" in meta
+def _event_targets_rendered_text(event: MouseMove) -> bool:
+    """Return whether the hovered cell was rendered from widget content.
+
+    Textual tags every content segment's style with a selection `offset`
+    (`Content.to_strip` via `Style.rich_style_with_offset`) and reads the same
+    key back in `Compositor.get_widget_and_offset_at` to map a screen cell to a
+    text position. Alignment padding and cells past the end of a line carry no
+    such meta, so the key doubles as a rendered-text hit test that agrees
+    exactly with what Textual can resolve to an offset.
+
+    `offset` and both of its producers are private Textual API. Re-verify these
+    names on every Textual bump: if the key moves, every cell reads as blank
+    and the text pointer silently stops appearing.
+
+    This tracks *rendered* text, not *selectable* text — the meta is attached
+    unconditionally, so a widget with `ALLOW_SELECT = False` still reports
+    `True` here.
+
+    Args:
+        event: The Textual mouse-move event to inspect.
+
+    Returns:
+        `True` when the hovered cell holds content-rendered text.
+    """
+    return "offset" in event.style.meta
+
+
+def _pointer_shape_for(event: MouseMove) -> PointerShape:
+    """Return the pointer shape to show for the cell under the mouse.
+
+    Textual applies a widget's pointer across its whole rectangle, so a message
+    declaring `pointer: text` in CSS shows an I-beam over the blank space beside
+    its short lines. Resolving the shape per cell instead keeps the I-beam on
+    text the reader can actually select.
+
+    The result is only accurate as of the last mouse movement: content that
+    grows or scrolls under a stationary pointer leaves the previous shape in
+    place until the mouse moves again.
+
+    Args:
+        event: The Textual mouse-move event to inspect.
+
+    Returns:
+        `'pointer'` over links, `'text'` over rendered text, else `'default'`.
+    """
+    if event_targets_link(event):
+        return "pointer"
+    if _event_targets_rendered_text(event):
+        return "text"
+    return "default"
 
 
 @dataclass(frozen=True, slots=True)
@@ -463,7 +510,6 @@ class UserMessage(Static):
         margin: 0 0 1 0;
         background: transparent;
         border-left: wide $primary;
-        pointer: text;
         /* The expand affordance carries `@click` meta, which Textual styles as
            a link (underline, and bold on an accent block when hovered).
            Neutralize both so the hint renders as plain inherited-colour dim
@@ -796,6 +842,14 @@ class UserMessage(Static):
         self._append_highlighted_body(parts, collapse.tail, colors=colors)
         return Content.assemble(*parts)
 
+    def on_mouse_move(self, event: MouseMove) -> None:
+        """Match the pointer shape to the cell under the mouse."""
+        self.styles.pointer = _pointer_shape_for(event)
+
+    def on_leave(self) -> None:
+        """Reset the pointer shape when the mouse leaves the message."""
+        self.styles.pointer = "default"
+
 
 class QueuedUserMessage(Static):
     """Widget displaying a queued (pending) user message in grey.
@@ -811,7 +865,6 @@ class QueuedUserMessage(Static):
         background: transparent;
         border-left: wide $panel;
         opacity: 0.6;
-        pointer: text;
     }
     """
     """Dimmed border + reduced opacity to distinguish queued messages from sent ones."""
@@ -895,6 +948,14 @@ class QueuedUserMessage(Static):
         prefix, content = self._prefix_and_body()
         content = _truncate_for_display(content)
         return Content.assemble(prefix, (content, colors.muted))
+
+    def on_mouse_move(self, event: MouseMove) -> None:
+        """Match the pointer shape to the cell under the mouse."""
+        self.styles.pointer = _pointer_shape_for(event)
+
+    def on_leave(self) -> None:
+        """Reset the pointer shape when the mouse leaves the message."""
+        self.styles.pointer = "default"
 
 
 def _strip_frontmatter(text: str) -> str:
@@ -1263,21 +1324,12 @@ class AssistantMessage(Vertical):
         self._markdown = self.query_one("#assistant-content", Markdown)
 
     def on_mouse_move(self, event: MouseMove) -> None:
-        """Match the pointer shape to links, selectable text, or blank space."""
-        if self._markdown is None:
-            return
-        if event_targets_link(event):
-            pointer = "pointer"
-        elif _event_targets_selectable_text(event):
-            pointer = "text"
-        else:
-            pointer = "default"
-        self._markdown.styles.pointer = pointer
+        """Match the pointer shape to the cell under the mouse."""
+        self.styles.pointer = _pointer_shape_for(event)
 
     def on_leave(self) -> None:
-        """Reset the markdown pointer shape when the mouse leaves the message."""
-        if self._markdown is not None:
-            self._markdown.styles.pointer = "default"
+        """Reset the pointer shape when the mouse leaves the message."""
+        self.styles.pointer = "default"
 
     async def on_markdown_link_clicked(self, event: Markdown.LinkClicked) -> None:
         """Open Markdown links with the same toast feedback as style links."""
@@ -4936,7 +4988,6 @@ class DiffMessage(Static):
         margin: 0 0 1 0;
         background: transparent;
         border-left: wide $panel;
-        pointer: text;
     }
 
     DiffMessage .diff-header {
@@ -5124,6 +5175,14 @@ class DiffMessage(Static):
             colors = theme.get_theme_colors(self)
             self.styles.border_left = ("ascii", colors.panel)
 
+    def on_mouse_move(self, event: MouseMove) -> None:
+        """Match the pointer shape to the cell under the mouse."""
+        self.styles.pointer = _pointer_shape_for(event)
+
+    def on_leave(self) -> None:
+        """Reset the pointer shape when the mouse leaves the message."""
+        self.styles.pointer = "default"
+
 
 class ErrorMessage(Static):
     """Widget displaying an error message."""
@@ -5136,7 +5195,6 @@ class ErrorMessage(Static):
         background: $error-muted;
         color: white;
         border-left: wide $error;
-        pointer: text;
     }
     """
     """Tinted background + left border to visually separate errors from output."""
@@ -5174,6 +5232,14 @@ class ErrorMessage(Static):
         """Open clicked URLs."""
         if event.style.link:
             open_style_link(event)
+
+    def on_mouse_move(self, event: MouseMove) -> None:
+        """Match the pointer shape to the cell under the mouse."""
+        self.styles.pointer = _pointer_shape_for(event)
+
+    def on_leave(self) -> None:
+        """Reset the pointer shape when the mouse leaves the message."""
+        self.styles.pointer = "default"
 
 
 class _RubricResultToggle(Static):
@@ -5504,7 +5570,6 @@ class AppMessage(Static):
         margin: 0 0 1 0;
         color: $text-muted;
         text-style: italic;
-        pointer: text;
     }
     """
 
@@ -5597,17 +5662,12 @@ class AppMessage(Static):
         open_style_link(event)
 
     def on_mouse_move(self, event: MouseMove) -> None:
-        """Show a pointer cursor over embedded links, text cursor elsewhere."""
-        self.styles.pointer = "pointer" if event_targets_link(event) else "text"
+        """Match the pointer shape to the cell under the mouse."""
+        self.styles.pointer = _pointer_shape_for(event)
 
     def on_leave(self) -> None:
-        """Restore the pointer shape when the mouse leaves the message.
-
-        `"text"` restates this widget's CSS default rather than clearing the
-        inline style, so a subclass declaring a different `pointer` would be
-        forced back to `text` on leave.
-        """
-        self.styles.pointer = "text"
+        """Reset the pointer shape when the mouse leaves the message."""
+        self.styles.pointer = "default"
 
 
 class SummarizationMessage(AppMessage):
@@ -5622,7 +5682,6 @@ class SummarizationMessage(AppMessage):
         background: $surface;
         border-left: wide $primary;
         text-style: bold;
-        pointer: text;
     }
     """
 

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -128,6 +128,12 @@ def _mode_color(mode: str | None, widget_or_app: object | None = None) -> str:
     return colors.primary
 
 
+def _event_targets_selectable_text(event: MouseMove) -> bool:
+    """Return whether the hovered cell contains selectable rendered text."""
+    meta = getattr(event.style, "meta", None)
+    return isinstance(meta, dict) and "offset" in meta
+
+
 @dataclass(frozen=True, slots=True)
 class FormattedOutput:
     """Result of formatting tool output for display."""
@@ -1198,7 +1204,6 @@ class AssistantMessage(Vertical):
     AssistantMessage Markdown {
         padding: 0;
         margin: 0;
-        pointer: text;
     }
 
     /* Markdown blocks carry a bottom margin for inter-block spacing; drop it
@@ -1258,21 +1263,21 @@ class AssistantMessage(Vertical):
         self._markdown = self.query_one("#assistant-content", Markdown)
 
     def on_mouse_move(self, event: MouseMove) -> None:
-        """Show a pointer cursor over markdown links, text cursor elsewhere.
-
-        The pointer is set on the inner `Markdown` widget because it carries a
-        non-default (`text`) pointer in CSS, so the screen resolves its shape
-        before reaching this container.
-        """
-        if self._markdown is not None:
-            self._markdown.styles.pointer = (
-                "pointer" if event_targets_link(event) else "text"
-            )
+        """Match the pointer shape to links, selectable text, or blank space."""
+        if self._markdown is None:
+            return
+        if event_targets_link(event):
+            pointer = "pointer"
+        elif _event_targets_selectable_text(event):
+            pointer = "text"
+        else:
+            pointer = "default"
+        self._markdown.styles.pointer = pointer
 
     def on_leave(self) -> None:
         """Reset the markdown pointer shape when the mouse leaves the message."""
         if self._markdown is not None:
-            self._markdown.styles.pointer = "text"
+            self._markdown.styles.pointer = "default"
 
     async def on_markdown_link_clicked(self, event: Markdown.LinkClicked) -> None:
         """Open Markdown links with the same toast feedback as style links."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -337,7 +337,7 @@ class _AssistantMessageApp(App[None]):
         yield widget
 
 
-class TestAssistantMessageLinkPointer:
+class TestAssistantMessagePointer:
     """Tests for pointer shapes over assistant-message content."""
 
     @staticmethod
@@ -347,7 +347,9 @@ class TestAssistantMessageLinkPointer:
         """Build a minimal mouse-move-like event exposing the hovered style.
 
         A namespace is enough because the handlers only read `event.style.link`
-        and `event.style.meta`; assertions use a real mounted `Markdown` widget.
+        and `event.style.meta`. It cannot validate the hitbox itself, though: it
+        hard-codes the same `offset` key the implementation reads, so the
+        `test_real_hover_*` cases below are what actually pin that behavior.
         """
         return SimpleNamespace(style=SimpleNamespace(link=link, meta=meta or {}))
 
@@ -358,8 +360,7 @@ class TestAssistantMessageLinkPointer:
 
             msg.on_mouse_move(self._move_event(meta={"@click": "link('https://x')"}))  # ty: ignore
 
-            assert msg._markdown is not None
-            assert msg._markdown.styles.pointer == "pointer"
+            assert msg.styles.pointer == "pointer"
 
     async def test_hovering_osc8_link_sets_pointer_cursor(self) -> None:
         """An OSC 8 `Style(link=...)` span also switches the pointer to pointer."""
@@ -368,8 +369,7 @@ class TestAssistantMessageLinkPointer:
 
             msg.on_mouse_move(self._move_event(link="https://example.com"))  # ty: ignore
 
-            assert msg._markdown is not None
-            assert msg._markdown.styles.pointer == "pointer"
+            assert msg.styles.pointer == "pointer"
 
     async def test_hovering_text_sets_text_pointer(self) -> None:
         """A cell carrying Textual's selection offset uses the text pointer."""
@@ -378,8 +378,7 @@ class TestAssistantMessageLinkPointer:
 
             msg.on_mouse_move(self._move_event(meta={"offset": (0, 0)}))  # ty: ignore
 
-            assert msg._markdown is not None
-            assert msg._markdown.styles.pointer == "text"
+            assert msg.styles.pointer == "text"
 
     async def test_hovering_blank_space_sets_default_pointer(self) -> None:
         """A cell without rendered text uses the default pointer."""
@@ -388,8 +387,7 @@ class TestAssistantMessageLinkPointer:
 
             msg.on_mouse_move(self._move_event())  # ty: ignore
 
-            assert msg._markdown is not None
-            assert msg._markdown.styles.pointer == "default"
+            assert msg.styles.pointer == "default"
 
     async def test_leave_resets_pointer(self) -> None:
         """Leaving the message resets the pointer after a link hover."""
@@ -399,8 +397,7 @@ class TestAssistantMessageLinkPointer:
 
             msg.on_leave()
 
-            assert msg._markdown is not None
-            assert msg._markdown.styles.pointer == "default"
+            assert msg.styles.pointer == "default"
 
     async def test_real_hover_limits_text_pointer_to_rendered_cells(self) -> None:
         """Real mouse routing distinguishes message text from trailing blank space."""
@@ -410,14 +407,68 @@ class TestAssistantMessageLinkPointer:
             await msg.write_initial_content()
             await pilot.pause()
 
-            assert msg._markdown is not None
-            assert msg._markdown.styles.pointer == "default"
+            assert msg.styles.pointer == "default"
 
             await pilot.hover("#assistant-content", offset=(0, 0))
-            assert msg._markdown.styles.pointer == "text"
+            assert msg.styles.pointer == "text"
 
-            await pilot.hover("#assistant-content", offset=(20, 0))
-            assert msg._markdown.styles.pointer == "default"
+            # The boundary itself: `hello` ends at column 4, so column 5 is the
+            # first cell an off-by-one in the hitbox would still claim as text.
+            await pilot.hover("#assistant-content", offset=(4, 0))
+            assert msg.styles.pointer == "text"
+
+            await pilot.hover("#assistant-content", offset=(5, 0))
+            assert msg.styles.pointer == "default"
+
+    async def test_real_hover_over_markdown_link_sets_pointer_cursor(self) -> None:
+        """A rendered markdown link really resolves to the hand pointer.
+
+        The fake-event cases above assert that `@click` meta means "link",
+        which is an assumption about what Textual's `Markdown` attaches rather
+        than a fact about rendered output. This drives the real span, so a
+        change in Markdown's link metadata cannot pass silently.
+        """
+        async with _AssistantMessageApp().run_test(size=(80, 24)) as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            await msg.set_content("see [docs](https://example.com) now")
+            await msg.write_initial_content()
+            await pilot.pause()
+
+            # Renders as `see docs now`, putting the link on columns 4-7.
+            await pilot.hover("#assistant-content", offset=(1, 0))
+            assert msg.styles.pointer == "text"
+
+            await pilot.hover("#assistant-content", offset=(4, 0))
+            assert msg.styles.pointer == "pointer"
+
+            # Back onto plain text without leaving the widget: `on_leave` never
+            # fires here, so only the handler's non-link branch can clear the
+            # hand cursor.
+            await pilot.hover("#assistant-content", offset=(9, 0))
+            assert msg.styles.pointer == "text"
+
+    async def test_real_hover_over_multi_block_content(self) -> None:
+        """Blank inter-block rows read as blank space; fenced code reads as text."""
+        async with _AssistantMessageApp().run_test(size=(60, 24)) as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            await msg.set_content("para one\n\n```python\nx = 1\n```\n")
+            await msg.write_initial_content()
+            await pilot.pause()
+
+            await pilot.hover("#assistant-content", offset=(0, 0))
+            assert msg.styles.pointer == "text"
+
+            # The margin row separating the paragraph from the fence.
+            await pilot.hover("#assistant-content", offset=(0, 1))
+            assert msg.styles.pointer == "default"
+
+            # Fenced code renders through `MarkdownFence` rather than the prose
+            # path, and sits two columns inside its block.
+            await pilot.hover("#assistant-content", offset=(2, 3))
+            assert msg.styles.pointer == "text"
+
+            await pilot.hover("#assistant-content", offset=(0, 3))
+            assert msg.styles.pointer == "default"
 
     async def test_markdown_open_links_is_disabled(self) -> None:
         """The app handles Markdown links so it can show URL-opened toasts."""
@@ -4871,8 +4922,8 @@ class _AppMessageApp(App[None]):
         yield AppMessage("Resumed thread: tid-1", id="app-msg")
 
 
-class TestAppMessageLinkPointer:
-    """Tests for the pointer cursor shown when hovering embedded links."""
+class TestAppMessagePointer:
+    """Tests for pointer shapes over app-message content."""
 
     @staticmethod
     def _move_event(
@@ -4890,14 +4941,23 @@ class TestAppMessageLinkPointer:
 
             assert msg.styles.pointer == "pointer"
 
-    async def test_hovering_text_keeps_text_pointer(self) -> None:
-        """Plain message text keeps the text pointer."""
+    async def test_hovering_text_sets_text_pointer(self) -> None:
+        """A cell carrying Textual's selection offset uses the text pointer."""
+        async with _AppMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#app-msg", AppMessage)
+
+            msg.on_mouse_move(self._move_event(meta={"offset": (0, 0)}))  # ty: ignore
+
+            assert msg.styles.pointer == "text"
+
+    async def test_hovering_blank_space_sets_default_pointer(self) -> None:
+        """A cell without rendered text uses the default pointer."""
         async with _AppMessageApp().run_test() as pilot:
             msg = pilot.app.query_one("#app-msg", AppMessage)
 
             msg.on_mouse_move(self._move_event())  # ty: ignore
 
-            assert msg.styles.pointer == "text"
+            assert msg.styles.pointer == "default"
 
     async def test_leave_resets_pointer(self) -> None:
         """Leaving the message resets the pointer after a link hover."""
@@ -4907,7 +4967,7 @@ class TestAppMessageLinkPointer:
 
             msg.on_leave()
 
-            assert msg.styles.pointer == "text"
+            assert msg.styles.pointer == "default"
 
     async def test_link_then_text_resets_pointer_without_leaving(self) -> None:
         """Moving off a link onto plain text resets the pointer without leaving.
@@ -4921,7 +4981,7 @@ class TestAppMessageLinkPointer:
             msg.on_mouse_move(self._move_event(link="https://example.com"))  # ty: ignore
             assert msg.styles.pointer == "pointer"
 
-            msg.on_mouse_move(self._move_event())  # ty: ignore
+            msg.on_mouse_move(self._move_event(meta={"offset": (0, 0)}))  # ty: ignore
 
             assert msg.styles.pointer == "text"
 
@@ -4972,6 +5032,76 @@ class TestAppMessagePointerEventDelivery:
 
             await pilot.hover("#app-msg", offset=(prefix_x, 0))
             assert msg.styles.pointer == "text"
+
+            # Past the end of the rendered line the widget is blank, so the
+            # I-beam must not follow the mouse across the rest of the row.
+            blank_x = len(_LinkedAppMessageApp.PREFIX) + len("tid-123") + 2
+            await pilot.hover("#app-msg", offset=(blank_x, 0))
+            assert msg.styles.pointer == "default"
+
+
+def _pointer_probe_app(widget: Static) -> App[None]:
+    """Wrap a message widget in a bare app so its hover shapes can be probed.
+
+    Args:
+        widget: The message widget to mount, which is given the id `msg`.
+
+    Returns:
+        An app mounting only that widget.
+    """
+    widget.id = "msg"
+
+    class _ProbeApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield widget
+
+    return _ProbeApp()
+
+
+class TestMessageWidgetsDropTextPointerOverBlankSpace:
+    """Every message widget resolves its pointer per cell, not per widget.
+
+    These widgets used to declare `pointer: text` in CSS, which Textual applies
+    across a widget's whole rectangle — so a short line showed an I-beam over
+    the empty remainder of its row. One real hover on either side of the text
+    covers each widget; the offsets account for the differing border and
+    padding declared in each widget's own `DEFAULT_CSS`.
+    """
+
+    @pytest.mark.parametrize(
+        ("widget", "text_offset", "blank_offset"),
+        [
+            pytest.param(UserMessage("hi"), (2, 0), (10, 0), id="user"),
+            pytest.param(QueuedUserMessage("hi"), (2, 0), (10, 0), id="queued"),
+            # `ErrorMessage` pads vertically, so its body sits on row 1.
+            pytest.param(ErrorMessage("hi"), (2, 1), (15, 1), id="error"),
+            pytest.param(
+                DiffMessage("--- a\n+++ b\n+hi\n", "f.py"),
+                (2, 0),
+                (16, 0),
+                id="diff",
+            ),
+            pytest.param(AppMessage("hi"), (1, 0), (10, 0), id="app"),
+            pytest.param(
+                SummarizationMessage("hi"), (2, 0), (10, 0), id="summarization"
+            ),
+        ],
+    )
+    async def test_text_pointer_stops_at_end_of_rendered_text(
+        self,
+        widget: Static,
+        text_offset: tuple[int, int],
+        blank_offset: tuple[int, int],
+    ) -> None:
+        """Rendered cells get the I-beam; the blank rest of the row does not."""
+        async with _pointer_probe_app(widget).run_test(size=(40, 24)) as pilot:
+            msg = pilot.app.query_one("#msg", Static)
+
+            await pilot.hover("#msg", offset=text_offset)
+            assert msg.styles.pointer == "text"
+
+            await pilot.hover("#msg", offset=blank_offset)
+            assert msg.styles.pointer == "default"
 
 
 class TestMountMessageIdSync:

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -332,13 +332,13 @@ class _AssistantMessageApp(App[None]):
     """Minimal app that mounts an AssistantMessage for runtime tests."""
 
     def compose(self) -> ComposeResult:
-        widget = AssistantMessage()
+        widget = AssistantMessage("hello")
         widget.id = "assistant"
         yield widget
 
 
 class TestAssistantMessageLinkPointer:
-    """Tests for the pointer cursor shown when hovering markdown links."""
+    """Tests for pointer shapes over assistant-message content."""
 
     @staticmethod
     def _move_event(
@@ -346,9 +346,8 @@ class TestAssistantMessageLinkPointer:
     ) -> SimpleNamespace:
         """Build a minimal mouse-move-like event exposing the hovered style.
 
-        The handlers only read `event.style.link` and `event.style.meta`, so a
-        namespace is enough; the assertions run against the real `Markdown`
-        widget mounted by `_AssistantMessageApp`.
+        A namespace is enough because the handlers only read `event.style.link`
+        and `event.style.meta`; assertions use a real mounted `Markdown` widget.
         """
         return SimpleNamespace(style=SimpleNamespace(link=link, meta=meta or {}))
 
@@ -373,17 +372,27 @@ class TestAssistantMessageLinkPointer:
             assert msg._markdown.styles.pointer == "pointer"
 
     async def test_hovering_text_sets_text_pointer(self) -> None:
-        """Plain markdown text keeps the text pointer."""
+        """A cell carrying Textual's selection offset uses the text pointer."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+
+            msg.on_mouse_move(self._move_event(meta={"offset": (0, 0)}))  # ty: ignore
+
+            assert msg._markdown is not None
+            assert msg._markdown.styles.pointer == "text"
+
+    async def test_hovering_blank_space_sets_default_pointer(self) -> None:
+        """A cell without rendered text uses the default pointer."""
         async with _AssistantMessageApp().run_test() as pilot:
             msg = pilot.app.query_one("#assistant", AssistantMessage)
 
             msg.on_mouse_move(self._move_event())  # ty: ignore
 
             assert msg._markdown is not None
-            assert msg._markdown.styles.pointer == "text"
+            assert msg._markdown.styles.pointer == "default"
 
     async def test_leave_resets_pointer(self) -> None:
-        """Leaving the message resets the pointer to text after a link hover."""
+        """Leaving the message resets the pointer after a link hover."""
         async with _AssistantMessageApp().run_test() as pilot:
             msg = pilot.app.query_one("#assistant", AssistantMessage)
             msg.on_mouse_move(self._move_event(link="https://example.com"))  # ty: ignore
@@ -391,7 +400,23 @@ class TestAssistantMessageLinkPointer:
             msg.on_leave()
 
             assert msg._markdown is not None
+            assert msg._markdown.styles.pointer == "default"
+
+    async def test_real_hover_limits_text_pointer_to_rendered_cells(self) -> None:
+        """Real mouse routing distinguishes message text from trailing blank space."""
+        async with _AssistantMessageApp().run_test(size=(80, 24)) as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            await msg.write_initial_content()
+            await pilot.pause()
+
+            assert msg._markdown is not None
+            assert msg._markdown.styles.pointer == "default"
+
+            await pilot.hover("#assistant-content", offset=(0, 0))
             assert msg._markdown.styles.pointer == "text"
+
+            await pilot.hover("#assistant-content", offset=(20, 0))
+            assert msg._markdown.styles.pointer == "default"
 
     async def test_markdown_open_links_is_disabled(self) -> None:
         """The app handles Markdown links so it can show URL-opened toasts."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -332,7 +332,7 @@ class _AssistantMessageApp(App[None]):
     """Minimal app that mounts an AssistantMessage for runtime tests."""
 
     def compose(self) -> ComposeResult:
-        widget = AssistantMessage("hello")
+        widget = AssistantMessage()
         widget.id = "assistant"
         yield widget
 
@@ -406,6 +406,7 @@ class TestAssistantMessageLinkPointer:
         """Real mouse routing distinguishes message text from trailing blank space."""
         async with _AssistantMessageApp().run_test(size=(80, 24)) as pilot:
             msg = pilot.app.query_one("#assistant", AssistantMessage)
+            await msg.set_content("hello")
             await msg.write_initial_content()
             await pilot.pause()
 


### PR DESCRIPTION
Textual applies the pointer of a widget to all of the widget area. The message widgets set `pointer: text` in CSS. Therefore a short line showed a text cursor across the empty part of its row.

Each message widget now selects the shape from the cell below the mouse:

- `pointer` on a link
- `text` on rendered text
- `default` on blank space

This changes seven widgets: `UserMessage`, `QueuedUserMessage`, `AssistantMessage`, `DiffMessage`, `ErrorMessage`, `AppMessage` and `SummarizationMessage`.

---

Made by [Open SWE](https://openswe.vercel.app/agents/7d248a88-53b8-4a78-3271-a805cbf68cdb)
