### PR TITLE
ci(infra): include run URL in SDK pin bump dispatch notice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1088,4 +1088,19 @@ jobs:
           # and without a repo flag `gh` shells out to `git` to discover the
           # repository, which fails with "fatal: not a git repository".
           gh workflow run bump_code_sdk_pin.yml --repo "${GITHUB_REPOSITORY}" --ref main
-          echo "::notice::Dispatched bump_code_sdk_pin.yml after publishing deepagents==${SDK_VERSION}."
+          # `gh workflow run` returns before the run exists and prints no run
+          # ID, so poll for the newest workflow_dispatch run to build its URL.
+          # Fall back to the workflow page (newest run listed at top) if the
+          # API hasn't caught up after ~30s.
+          RUN_URL=""
+          for _ in 1 2 3 4 5 6; do
+            sleep 5
+            RUN_URL="$(gh run list --repo "${GITHUB_REPOSITORY}" --workflow bump_code_sdk_pin.yml --event workflow_dispatch --limit 1 --json url --jq '.[0].url' || true)"
+            if [ -n "$RUN_URL" ]; then
+              break
+            fi
+          done
+          if [ -z "$RUN_URL" ]; then
+            RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/workflows/bump_code_sdk_pin.yml"
+          fi
+          echo "::notice::Dispatched bump_code_sdk_pin.yml after publishing deepagents==${SDK_VERSION}: ${RUN_URL}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1087,15 +1087,20 @@ jobs:
           # `-R` is required: this job skips checkout (it only needs the API),
           # and without a repo flag `gh` shells out to `git` to discover the
           # repository, which fails with "fatal: not a git repository".
+          # The dispatch time is recorded first so the poll below can ignore
+          # any earlier workflow_dispatch runs of this workflow.
+          DISPATCHED_AT="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
           gh workflow run bump_code_sdk_pin.yml --repo "${GITHUB_REPOSITORY}" --ref main
           # `gh workflow run` returns before the run exists and prints no run
           # ID, so poll for the newest workflow_dispatch run to build its URL.
-          # Fall back to the workflow page (newest run listed at top) if the
-          # API hasn't caught up after ~30s.
+          # Without the `--created >=` bound, a previous dispatch of this
+          # workflow would match immediately while the new run is still
+          # propagating. Fall back to the workflow page (newest run listed at
+          # top) if the API hasn't caught up after ~30s.
           RUN_URL=""
           for _ in 1 2 3 4 5 6; do
             sleep 5
-            RUN_URL="$(gh run list --repo "${GITHUB_REPOSITORY}" --workflow bump_code_sdk_pin.yml --event workflow_dispatch --limit 1 --json url --jq '.[0].url' || true)"
+            RUN_URL="$(gh run list --repo "${GITHUB_REPOSITORY}" --workflow bump_code_sdk_pin.yml --event workflow_dispatch --created ">=${DISPATCHED_AT}" --limit 1 --json url --jq '.[0].url // ""' || true)"
             if [ -n "$RUN_URL" ]; then
               break
             fi


### PR DESCRIPTION
When `release.yml` publishes `deepagents` to PyPI, its `bump-code-sdk-pin` job dispatches `bump_code_sdk_pin.yml` and prints a notice. The notice now includes a link to the dispatched run.

Before:

    ::notice::Dispatched bump_code_sdk_pin.yml after publishing deepagents==0.7.7.

After:

    ::notice::Dispatched bump_code_sdk_pin.yml after publishing deepagents==0.7.7: https://github.com/langchain-ai/deepagents/actions/runs/32152501551

---

`gh workflow run` prints no run ID and returns before the run exists. So there is no URL to print at dispatch time.

The step now records the time, dispatches the workflow, then polls `gh run list` for the newest `workflow_dispatch` run of `bump_code_sdk_pin.yml`. It tries six times, five seconds apart. A `--created ">=<dispatch time>"` filter makes the poll ignore older runs of the same workflow. Without the filter, the poll would match the previous run at once while the new run is still starting.

If the poll finds no run after about 30 seconds, the notice falls back to the workflow page URL (`.../actions/workflows/bump_code_sdk_pin.yml`). That page lists the newest run at the top, so the link stays useful.

The lookup uses the Org Membership App token, whose `actions: write` grant also covers reading runs. The step keeps `continue-on-error: true` and `|| true` on the list call, so a lookup failure still cannot fail the release run.
