### PR TITLE
fix(infra): fall back to head commit subject when release-please run `display_title` is the workflow name

### DIFF
--- a/.github/workflows/release_comment_update.yml
+++ b/.github/workflows/release_comment_update.yml
@@ -43,6 +43,13 @@
 #   started. It diverges from `find_run_url` in one deliberate way: that
 #   helper takes only the most recent match, while this keeps every match.
 #
+#   The run's `display_title` normally carries the head commit's subject, but
+#   GitHub intermittently serves the workflow name instead (observed on the
+#   merged release PR run for `release(deepagents): 0.7.7`, whose title came
+#   back as `⚠️ (Automated) Release Please`). When the display title fails
+#   the release-title pattern and equals the workflow name exactly, the gate
+#   below retries the match against the head commit's subject line instead.
+#
 #   Runs are NOT matched on head SHA: `trigger-releases` dispatches with
 #   `gh workflow run --ref main`, so a dispatched run's head SHA is whatever
 #   main resolves to at dispatch time, which can drift from the merge commit
@@ -172,6 +179,18 @@ jobs:
           # syntax error written inline, and quoting it inline would match it
           # verbatim instead of as a regex.
           title_re='^(release\([^)]+\): .+) \(#[0-9]+\)$'
+          if ! [[ "$run_display" =~ $title_re ]] && [ "$run_display" = "⚠️ (Automated) Release Please" ]; then
+            # GitHub intermittently serves the workflow name as
+            # `display_title` instead of the head commit's subject (see the
+            # header's "Matching" note). Fall back to the commit message,
+            # which is what `display_title` was supposed to render.
+            echo "::notice::display_title is the workflow name; falling back to the head commit subject for $run_sha."
+            run_display=$(
+              gh api "repos/${GITHUB_REPOSITORY}/commits/${run_sha}" \
+                --jq '.commit.message' | head -n 1
+            )
+            echo "Resolved title from commit: $run_display"
+          fi
           if ! [[ "$run_display" =~ $title_re ]]; then
             echo "::notice::Run title '$run_display' is not a merged release PR run; nothing to comment on."
             echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
When a release finishes, an automated workflow posts a comment on the release pull request with the result. That comment did not post for a recent release. This change fixes the cause.

---

**Background**

Each release runs in two steps:

1. The release-please workflow merges the release pull request and starts the publish jobs.
2. The release-comment workflow then posts the publish result as a comment on the merged pull request.

The second workflow must find the release pull request that caused the run. To do this, it reads the run's title. A release run has a title like `release(deepagents): 0.7.7 (#5498)`. Runs that are not releases have different titles and are skipped.

**Problem**

GitHub sometimes returns the workflow's name (`⚠️ (Automated) Release Please`) as the run title instead of the title shown above. This happened for the `deepagents 0.7.7` release ([run 32152816232](https://github.com/langchain-ai/deepagents/actions/runs/32152816232)). The title check did not match, so the workflow stopped and no result comment was posted.

**Fix**

The run title normally comes from the message of the commit that started the run. When the title check fails and the returned title is exactly the workflow's name, the workflow now reads that commit message and checks it instead. Non-release runs are still skipped, because their commit messages do not have the release format.

The fix also applies to manually started runs, which read the same title field.

<details>
<summary>Test plan</summary>

- Checked that the workflow file parses and the shell script has valid syntax.
- Tested the title check with four cases: a normal release run (matched), a non-release run (skipped), the broken title with a release commit message (matched through the fallback), and the broken title with a non-release commit message (still skipped).

</details>
