### PR TITLE
chore(code): set package author and homepage metadata

### DIFF
--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -155,7 +155,7 @@ dcode = "deepagents_code:cli_main"
 
 [project.urls]
 Homepage = "https://www.langchain.com/dcode"
-Documentation = "https://reference.langchain.com/python/deepagents/"
+Documentation = "https://docs.langchain.com/oss/deepagents/code/overview"
 Repository = "https://github.com/langchain-ai/deepagents"
 Issues = "https://github.com/langchain-ai/deepagents/issues"
 Changelog = "https://github.com/langchain-ai/deepagents/blob/main/libs/code/CHANGELOG.md"

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -154,7 +154,7 @@ deepagents-code = "deepagents_code:cli_main"
 dcode = "deepagents_code:cli_main"
 
 [project.urls]
-Homepage = "https://docs.langchain.com/oss/deepagents/code/overview"
+Homepage = "https://www.langchain.com/dcode"
 Documentation = "https://reference.langchain.com/python/deepagents/"
 Repository = "https://github.com/langchain-ai/deepagents"
 Issues = "https://github.com/langchain-ai/deepagents/issues"

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -8,6 +8,8 @@ version = "0.1.57"
 description = "Terminal coding agent built on the Deep Agents SDK - works with any model, with persistent memory, customizable skills, subagents, and approval controls."
 readme = "README.md"
 license = { text = "MIT" }
+authors = [{ name = "LangChain" }]
+maintainers = [{ name = "LangChain" }]
 requires-python = ">=3.11,<4.0"
 keywords = ["agents", "ai", "cli", "terminal", "llm", "langgraph", "langchain", "deep-agent"]
 classifiers = [
@@ -152,7 +154,7 @@ deepagents-code = "deepagents_code:cli_main"
 dcode = "deepagents_code:cli_main"
 
 [project.urls]
-Homepage = "https://docs.langchain.com/oss/python/deepagents/overview"
+Homepage = "https://docs.langchain.com/oss/deepagents/code/overview"
 Documentation = "https://reference.langchain.com/python/deepagents/"
 Repository = "https://github.com/langchain-ai/deepagents"
 Issues = "https://github.com/langchain-ai/deepagents/issues"


### PR DESCRIPTION
`deepagents-code` published to PyPI without an author and pointed its Homepage at the generic Deep Agents overview. This sets `authors`/`maintainers` to LangChain and points Homepage at the Deep Agents Code overview docs so the PyPI page carries the right metadata.

Made by [Open SWE](https://openswe.vercel.app/agents/5f028685-c859-5cd1-b32a-847e65f8b8aa)