### PR TITLE
chore(evals): drop langsmith upper-bound cap

### DIFF
--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "harbor[langsmith]>=0.20.0,<0.21.0",
     "harbor-langsmith>=0.3.0,<0.4.0",
     # LangSmith for observability
-    "langsmith>=0.10.9,<0.11.0",
+    "langsmith>=0.10.9",
     # Sandbox runtimes
     "dockerfile-parse>=2.0.1",
     "modal>=1.4.3",

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -735,7 +735,7 @@ requires-dist = [
     { name = "langchain-openrouter", specifier = ">=0.2.6,<0.3.0" },
     { name = "langchain-quickjs", editable = "../partners/quickjs" },
     { name = "langchain-xai", specifier = ">=1.2.2,<1.3.0" },
-    { name = "langsmith", specifier = ">=0.10.9,<0.11.0" },
+    { name = "langsmith", specifier = ">=0.10.9" },
     { name = "matplotlib", marker = "extra == 'charts'", specifier = ">=3.11.0" },
     { name = "modal", specifier = ">=1.4.3" },
     { name = "nltk", specifier = ">=3.10.0" },
@@ -1961,7 +1961,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.10.18"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1979,9 +1979,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/08/f6575fbaf22179c52c10286df5c454fc8a7c8ce64b194a18ae0f19232503/langsmith-0.10.18.tar.gz", hash = "sha256:f78402bdbe333727459831fead2c75d0c1d1119c28e4095e5a1d65a7485e2f3a", size = 4801890, upload-time = "2026-08-11T20:27:48.731Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/62/a917e87073767db8ca335c3f5a42fb4c5336509b8d5b03e165e46da47e70/langsmith-0.11.0.tar.gz", hash = "sha256:7339f90e6fd9a1a009445b5084a7a0e56a8b6f17305ee5d7e8c5e7582217854f", size = 4805612, upload-time = "2026-08-14T12:56:55.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/07/f83cdfef58b3627175f15345105c6ee2ac152f25a0fefb930a53d4bb216c/langsmith-0.10.18-py3-none-any.whl", hash = "sha256:388236a4f031c1fe60e1517891c276ed01b102ad4405e0e9236255f2abd24cfa", size = 735339, upload-time = "2026-08-11T20:27:46.796Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/aa/18d334f04c12bb9154568747539a1143a93d0c34b894662c065454f396c8/langsmith-0.11.0-py3-none-any.whl", hash = "sha256:e87a3929915936c066b3fa3283ec3f3f0013e2ef7f98a443a7fbe3fab8e784a3", size = 737950, upload-time = "2026-08-14T12:56:53.014Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #5545

The evals package no longer caps langsmith below 0.11.0, which unblocks the automated dependency-minimums workflow that was failing to regenerate the evals lockfile after deepagents-code raised its langsmith floor to 0.11.0 (failed run: https://github.com/langchain-ai/deepagents/actions/runs/32156544008).

---

The evals package path-depends on `deepagents-code`, whose `langsmith[sandbox]>=0.11.0` floor made the evals `<0.11.0` cap unsatisfiable, so `uv lock` for `libs/evals` failed in the dependency-minimums workflow. Dropping the cap lets the lockfile resolve langsmith 0.11.0. Verified with `uv lock --directory libs/evals --python 3.12` (matching the lockfile-check invocation) and the evals unit test suite passes against langsmith 0.11.0.
