### PR TITLE
ci(infra): wrap release-please PR titles in code fences

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -243,7 +243,7 @@ Do **not** add a new managed package to the manifest at `0.0.1` unless `0.0.1` h
 The [release-please workflow (`.github/workflows/release-please.yml`)](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/release-please.yml) detects merged release PRs by checking two conditions on the merge commit:
 
 1. The package's `CHANGELOG.md` was modified (e.g., `libs/cli/CHANGELOG.md` for the CLI)
-2. The commit message matches the `release(<component>): <version>` pattern
+2. The commit message matches the release(`<component>`): `<version>` pattern
 
 Both must be true. release-please always satisfies both when merging a release PR — a manual `CHANGELOG.md` edit alone will not trigger a release.
 
@@ -537,7 +537,7 @@ Pass only `--notes-file` when editing. Flags such as `--tag`, `--target`, `--pre
 
 ### Promoting a pre-release to GA
 
-After validating the final pre-release stage, merge the pending release PR (e.g., `release(deepagents-code): 0.0.35`) as normal from `main` — release-please handles the GA version, changelog, and tag. No extra steps are needed.
+After validating the final pre-release stage, merge the pending release PR (e.g., release(`deepagents-code`): `0.0.35`) as normal from `main` — release-please handles the GA version, changelog, and tag. No extra steps are needed.
 
 If no release PR exists yet (e.g., no releasable commits since the last GA, which is rare), you can force one with a package-scoped `Release-As` override. Do **not** use an empty commit on `main`: release-please assigns commits to packages by the file paths they change, not by the commit scope string. A commit titled `chore(code): ...` is not enough on its own! It must also touch a file under `libs/code` so release-please knows the override belongs to `deepagents-code` (instead of another managed package).
 
@@ -657,7 +657,7 @@ When the new line is ready to become `main`:
 
 ### Maintenance branch (patching the old line after cutover)
 
-After `main` adopts the new line, cut a `vX.Y` branch from the **last release commit** of the old line (e.g. branch `v0.6` from the `release(deepagents): 0.6.N` merge commit). Branching from the release commit means the latest `0.6` tag is its ancestor, so version math stays on the `0.6.x` line.
+After `main` adopts the new line, cut a `vX.Y` branch from the **last release commit** of the old line (e.g. branch `v0.6` from the release(`deepagents`): `0.6.N` merge commit). Branching from the release commit means the latest `0.6` tag is its ancestor, so version math stays on the `0.6.x` line.
 
 - **Backport** fixes by landing them on `main` first, then cherry-picking onto `vX.Y` with the conventional-commit message intact.
 - **Release** from the branch with [Manual Release](#manual-release) + `dangerous-nonmain-release` (its stated purpose is backports): bump the version files on the branch, then dispatch `🚀 Package Release` with that branch, package, version, and `dangerous-nonmain-release` ✓. It is usually rare to need to release old versions so these steps remain manual.
@@ -700,7 +700,7 @@ A subtler sibling of the empty-commit case. release-please scopes a commit to a 
 
 The `release_please_scope_check.yml` workflow ([`.github/scripts/release/check_lockfile_release_scope.py`](https://github.com/langchain-ai/deepagents/blob/main/.github/scripts/release/check_lockfile_release_scope.py)) catches this at PR time: when a bump-worthy PR changes only a lockfile inside a managed package, it posts a sticky comment naming the affected components and **fails the check**. Resolve it (route the lockfile churn through a `chore(deps):` commit), or — for an intentional lockfile-only release such as a leaf-package security bump — apply the `allow-lockfile-release` label to acknowledge the fan-out and let the PR pass. Applying the label posts a loud bypass warning that lists every touched component — bypassing does **not** stop release-please from opening those release PRs. For the failure to actually gate merges, add the check to the branch's required status checks (repo settings).
 
-After merge, `release_please_fanout_watch.yml` is a safety net: if an open `release(<component>):` PR's package path only changed lockfiles on `main` since the last released SHA, it sticky-comments that release PR and fails an advisory check so the fan-out is noticed within minutes. Recovery still follows [Reverting a Merged-but-Unreleased PR](#reverting-a-merged-but-unreleased-pr).
+After merge, `release_please_fanout_watch.yml` is a safety net: if an open release(`<component>`): PR's package path only changed lockfiles on `main` since the last released SHA, it sticky-comments that release PR and fails an advisory check so the fan-out is noticed within minutes. Recovery still follows [Reverting a Merged-but-Unreleased PR](#reverting-a-merged-but-unreleased-pr).
 
 ### Multi-component fan-out
 
@@ -717,7 +717,7 @@ When a `feat`/`fix` (etc.) also edits non-lockfile files under other managed pac
 
 ### Releasing a new line ahead of its dependents
 
-Local development installs sibling packages as editable path dependencies via `[tool.uv.sources]`, which hides whether published dependency ranges would resolve for real users installing from PyPI. The `📦 Check Release Dependencies` workflow closes that gap on `release(...)` PRs: it strips local sources and runs `uv pip compile --no-sources --universal --prerelease allow --all-extras` against PyPI for each changed release manifest, failing when the public install graph is unsatisfiable.
+Local development installs sibling packages as editable path dependencies via `[tool.uv.sources]`, which hides whether published dependency ranges would resolve for real users installing from PyPI. The `📦 Check Release Dependencies` workflow closes that gap on release(`...`): `...` PRs: it strips local sources and runs `uv pip compile --no-sources --universal --prerelease allow --all-extras` against PyPI for each changed release manifest, failing when the public install graph is unsatisfiable.
 
 When cutting a new major/minor line of a core package, it is normal for the release PR to be red on this check even with correct metadata: the branch already opens sibling upper bounds and floors in-tree, but **already-published** dependents on PyPI still reject the new line until they cut their own releases. In that case:
 
@@ -761,12 +761,12 @@ Notes:
 - Place the block at the bottom of the PR body, after a horizontal rule.
 - To produce multiple changelog entries from one PR, separate corrected messages by a **blank line** with each starting `type(scope):`, or wrap each in `BEGIN_NESTED_COMMIT`/`END_NESTED_COMMIT` markers — release-please's splitter requires one of these forms; a bare newline between messages is parsed as a single commit's body.
 - Only effective with **squash merges**. release-please attaches the override to the squash commit by matching it to the PR's `merge_commit_sha`; for plain-merge or rebase-merge strategies the per-branch commits have no PR association and the override is ignored.
-- Effect lands when release-please next syncs the open release PR (push to `main` or manual workflow dispatch). Verify the entry moved/disappeared in the corresponding `release(<component>): X.Y.Z` PR.
+- Effect lands when release-please next syncs the open release PR (push to `main` or manual workflow dispatch). Verify the entry moved/disappeared in the corresponding release(`<component>`): `X.Y.Z` PR.
 - Update via `gh pr edit <num> --body-file <file>` to avoid shell-escaping the multi-line body. (`gh api -f body=@<file>` does **not** work — `-f` writes the literal string `@<file>` rather than reading the file.)
 
 ### Reverting a Merged-but-Unreleased PR
 
-When a PR has merged to `main` but its `release(<component>): X.Y.Z` PR has **not** yet shipped, the bad commit is sitting in the open release PR's changelog. Pick a path based on whether the change should appear in the eventual release notes. (For commits that already shipped, see [Yanking a Release](#yanking-a-release) instead — and ship a follow-up `revert:` patch via the standard flow.)
+When a PR has merged to `main` but its release(`<component>`): `X.Y.Z` PR has **not** yet shipped, the bad commit is sitting in the open release PR's changelog. Pick a path based on whether the change should appear in the eventual release notes. (For commits that already shipped, see [Yanking a Release](#yanking-a-release) instead — and ship a follow-up `revert:` patch via the standard flow.)
 
 #### Path A — Hide and Revert (Quiet)
 
@@ -793,7 +793,7 @@ Use when the original commit is a mistake the changelog should not record (broke
 
    (This repo squash-merges, so `<merge_sha>` is a single-parent commit — no `-m` flag needed.)
 
-3. **Wait for release-please to rebase the open release PR** on the next push to `main` (or dispatch the workflow manually). Verify the entry has disappeared from the corresponding `release(<component>): X.Y.Z` PR's rendered body before merging it.
+3. **Wait for release-please to rebase the open release PR** on the next push to `main` (or dispatch the workflow manually). Verify the entry has disappeared from the corresponding release(`<component>`): `X.Y.Z` PR's rendered body before merging it.
 
 #### Path B — `revert:` with Audit Trail
 
@@ -810,7 +810,7 @@ Use when something measurable has already happened off `main` (downstream consum
 
 2. **Merge the revert PR.**
 
-3. **Wait for release-please to rebase the open release PR** on the next push to `main` (or dispatch the workflow manually). Verify the corresponding `release(<component>): X.Y.Z` PR's rendered body now contains both the original entry and a `Reverted Changes` entry before merging it.
+3. **Wait for release-please to rebase the open release PR** on the next push to `main` (or dispatch the workflow manually). Verify the corresponding release(`<component>`): `X.Y.Z` PR's rendered body now contains both the original entry and a `Reverted Changes` entry before merging it.
 
 #### Don'ts
 
@@ -850,7 +850,7 @@ If a release PR shows `autorelease: pending` after the release workflow ran, the
 
 ```bash
 # Find the PR number for the release commit (<PACKAGE> = package name from Managed Packages table)
-gh pr list --state merged --search "release(<PACKAGE>)" --limit 5
+gh pr list --state merged --search 'release(`<PACKAGE>`)' --limit 5
 
 # Update the label
 gh pr edit <PR_NUMBER> --remove-label "autorelease: pending" --add-label "autorelease: tagged"
@@ -966,7 +966,7 @@ This is a **GitHub UI quirk** caused by force pushes/rebasing, not actual commit
 
 **The actual PR commits** are only:
 
-- The release commit (e.g., `release(deepagents): 0.5.1` or `release(deepagents-cli): 0.0.35`)
+- The release commit (e.g., release(`deepagents`): `0.5.1` or release(`deepagents-cli`): `0.0.35`)
 - The lockfile update commit (e.g., `chore: update lockfiles`)
 
 Other commits shown are just the base that the PR branch was rebased onto. This is normal behavior and doesn't indicate unauthorized access.

--- a/.github/scripts/labeling/check_pr_scope_files.py
+++ b/.github/scripts/labeling/check_pr_scope_files.py
@@ -169,7 +169,12 @@ def parse_title_scopes(title: str) -> tuple[str, ...]:
     match = _TITLE_RE.match(title)
     if not match or not match.group(1):
         return ()
-    return tuple(scope.strip() for scope in match.group(1).split(",") if scope.strip())
+    # Strip code-fence backticks: release-please titles wrap the component
+    # (release(`deepagents-code`): `1.2.0`), and the bare component is what the
+    # scope->label map keys on.
+    return tuple(
+        scope.strip().strip("`") for scope in match.group(1).split(",") if scope.strip()
+    )
 
 
 def _package_rules(config: dict[str, Any]) -> list[dict[str, str]]:

--- a/.github/scripts/release/check_open_release_fanout.py
+++ b/.github/scripts/release/check_open_release_fanout.py
@@ -2,7 +2,7 @@
 
 Post-merge safety net for the pre-merge gates in
 `release_please_scope_check.yml`. Even when a bump-worthy multi-package PR
-slips through, this report surfaces open `release(<component>):` PRs whose
+slips through, this report surfaces open release(`<component>`): PRs whose
 component path — relative to the last *released package version* in
 `.release-please-manifest.json` — only changed lockfiles on `main`.
 

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -148,7 +148,7 @@ function componentFromBranch(ref) {
 }
 
 function parseReleaseTitle(title) {
-  const match = /^release\(([^()\s]+)\): ([0-9A-Za-z][0-9A-Za-z.+-]*)$/.exec(title ?? '');
+  const match = /^release\(`([^()\s]+)`\): `([0-9A-Za-z][0-9A-Za-z.+-]*)`$/.exec(title ?? '');
   return match ? { component: match[1], version: match[2] } : null;
 }
 
@@ -183,7 +183,7 @@ function isReleaseBranchPr(pr, registry = componentRegistry()) {
 
 // Resolve which package a release PR is for, or null if it is not one. The
 // component comes from the head ref and must both exist in the registry and match
-// the `release(<component>): <version>` title, so the branch and title have to
+// the release(`<component>`): `<version>` title, so the branch and title have to
 // agree before any changelog path or branch ref is derived from them.
 function releaseTarget(pr, registry = componentRegistry()) {
   if (!isReleaseBranchPr(pr, registry)) return null;
@@ -1122,7 +1122,7 @@ async function checkCuratedState({
   const component = componentFromBranch(pr.head.ref);
   const version = releaseVersion(pr.title, component);
   if (version === null) {
-    core.setFailed(`The ${component} release PR title does not match the required \`release(${component}): <version>\` title`);
+    core.setFailed(`The ${component} release PR title does not match the required release(\`${component}\`): \`<version>\` title`);
     return { status: 'invalid-title' };
   }
   const { changelogPath } = targetForComponent(component);

--- a/.github/scripts/tests/labeling/test_check_pr_scope_files.py
+++ b/.github/scripts/tests/labeling/test_check_pr_scope_files.py
@@ -152,10 +152,10 @@ def test_release_title_with_release_files_bypasses_scope_file_check() -> None:
     therefore only pass via the release bypass, not ordinary scope coverage —
     deleting the early-return in `find_offenders` makes this test fail.
     """
-    assert is_release_title("release(deepagents-code): 0.1.22")
+    assert is_release_title("release(`deepagents-code`): `0.1.22`")
     assert (
         find_offenders(
-            "release(deepagents-code): 0.1.22",
+            "release(`deepagents-code`): `0.1.22`",
             [
                 "libs/code/deepagents_code/_version.py",
                 "libs/cli/deepagents_cli/_version.py",
@@ -213,8 +213,8 @@ def test_unmanaged_package_artifacts_do_not_trigger_release_bypass() -> None:
 
     assert not is_release_file("libs/evals/pyproject.toml")
     assert not is_release_file("libs/evals/deepagents_evals/_version.py")
-    assert not is_release_pr_change("release(deepagents-code): 0.1.22", changed)
-    assert find_offenders("release(deepagents-code): 0.1.22", changed, config) == [
+    assert not is_release_pr_change("release(`deepagents-code`): `0.1.22`", changed)
+    assert find_offenders("release(`deepagents-code`): `0.1.22`", changed, config) == [
         {"package": "evals", "dirs": ["libs/evals/"]}
     ]
 
@@ -244,7 +244,7 @@ def test_release_pr_change_fails_closed_on_malformed_release_config(tmp_path) ->
     bad.write_text(json.dumps({"packages": {}}), encoding="utf-8")
     with pytest.raises(ValueError, match="no non-empty 'packages' map"):
         is_release_pr_change(
-            "release(deepagents-code): 0.1.22",
+            "release(`deepagents-code`): `0.1.22`",
             ["libs/code/deepagents_code/_version.py"],
             release_config_path=bad,
         )
@@ -261,7 +261,7 @@ def test_release_uv_lock_only_still_validates_release_config(tmp_path) -> None:
     bad.write_text("{not json", encoding="utf-8")
     with pytest.raises(ValueError, match="could not read release-please config"):
         is_release_pr_change(
-            "release(deepagents-code): 0.1.22",
+            "release(`deepagents-code`): `0.1.22`",
             ["libs/code/uv.lock", "libs/cli/uv.lock"],
             release_config_path=bad,
         )
@@ -277,7 +277,7 @@ def test_main_malformed_release_config_fails_closed_and_attributes_correctly(
     release.write_text(json.dumps({"packages": {}}), encoding="utf-8")
 
     rc = main(
-        "release(deepagents-code): 0.1.22",
+        "release(`deepagents-code`): `0.1.22`",
         ["libs/code/deepagents_code/_version.py"],
         config_path=labeler,
         release_config_path=release,
@@ -298,7 +298,7 @@ def test_main_uv_lock_only_fails_closed_on_bad_release_config(capsys, tmp_path) 
     release.write_text("{not json", encoding="utf-8")
 
     rc = main(
-        "release(deepagents-code): 0.1.22",
+        "release(`deepagents-code`): `0.1.22`",
         ["libs/code/uv.lock", "libs/cli/uv.lock"],
         config_path=labeler,
         release_config_path=release,
@@ -321,7 +321,7 @@ def test_release_pr_change_covers_repo_wide_lockfiles() -> None:
     assert is_release_file("examples/async-subagent-server/uv.lock")
     assert is_release_file("examples/llm-wiki/uv.lock")
     assert is_release_pr_change(
-        "release(langchain-quickjs): 0.3.1",
+        "release(`langchain-quickjs`): `0.3.1`",
         [
             ".release-please-manifest.json",
             "examples/async-subagent-server/uv.lock",
@@ -349,8 +349,8 @@ def test_release_title_ignores_lockfile_churn_for_other_package_dirs() -> None:
     ]
     config = json.loads(DEFAULT_CONFIG.read_text(encoding="utf-8"))
 
-    assert not is_release_pr_change("release(deepagents-code): 0.1.23", changed)
-    assert find_offenders("release(deepagents-code): 0.1.23", changed, config) == []
+    assert not is_release_pr_change("release(`deepagents-code`): `0.1.23`", changed)
+    assert find_offenders("release(`deepagents-code`): `0.1.23`", changed, config) == []
 
 
 def test_release_title_with_mixed_files_does_not_bypass() -> None:
@@ -378,12 +378,12 @@ def test_release_bypass_does_not_validate_component() -> None:
 
 
 def test_is_release_title_boundaries() -> None:
-    """Only `release(<scope>):` shapes trigger the bypass title gate."""
-    assert is_release_title("release(cli): 1.0.0")
+    """Only release(`<scope>`): shapes trigger the bypass title gate."""
+    assert is_release_title("release(`cli`): `1.0.0`")
     assert is_release_title("release(): 1.0.0")  # empty scope still matches
     assert not is_release_title("release: 1.0.0")  # scope required
     assert not is_release_title("release(scope)!: 1.0.0")  # breaking marker excluded
-    assert not is_release_title("  release(cli): 1.0.0")  # anchored; no leading ws
+    assert not is_release_title("  release(`cli`): `1.0.0`")  # anchored; no leading ws
     assert not is_release_title("Release(cli): 1.0.0")  # case-sensitive
 
 
@@ -454,7 +454,7 @@ def test_main_release_bypass_validates_labeler_config(capsys, tmp_path) -> None:
         encoding="utf-8",
     )
     rc = main(
-        "release(deepagents-code): 0.1.22",
+        "release(`deepagents-code`): `0.1.22`",
         ["libs/code/uv.lock"],
         config_path=config_path,
     )
@@ -516,7 +516,7 @@ def test_main_release_bypass_emits_notice(capsys, tmp_path) -> None:
     config_path.write_text(json.dumps(CONFIG), encoding="utf-8")
 
     rc = main(
-        "release(deepagents-code): 0.1.22",
+        "release(`deepagents-code`): `0.1.22`",
         ["libs/code/uv.lock", "libs/evals/uv.lock"],
         config_path=config_path,
     )

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -30,7 +30,7 @@ function changelog(section = GENERATED_SECTION) {
 function releasePr(overrides = {}) {
   return {
     number: 123,
-    title: `release(deepagents-code): ${VERSION}`,
+    title: `release(\`deepagents-code\`): \`${VERSION}\``,
     state: 'open',
     draft: false,
     body: `Release notes preview\n\n${GENERATED_SECTION}\n_End release notes preview._\n`,
@@ -223,8 +223,8 @@ function tempWorkspace(section = GENERATED_SECTION) {
 }
 
 test('identifies only an exact release title and branch pair', () => {
-  assert.equal(releaseNotes.releaseVersion(`release(deepagents-code): ${VERSION}`, COMPONENT), VERSION);
-  assert.equal(releaseNotes.releaseVersion(`release(deepagents): ${VERSION}`, COMPONENT), null);
+  assert.equal(releaseNotes.releaseVersion(`release(\`deepagents-code\`): \`${VERSION}\``, COMPONENT), VERSION);
+  assert.equal(releaseNotes.releaseVersion(`release(\`deepagents\`): \`${VERSION}\``, COMPONENT), null);
   assert.equal(releaseNotes.isReleasePr(releasePr()), true);
   assert.equal(releaseNotes.isReleasePr(releasePr({ head: { ...releasePr().head, ref: `${RELEASE_BRANCH}-extra` } })), false);
   assert.equal(releaseNotes.isReleasePr(releasePr({ base: { ref: 'v0.1', repo: { full_name: 'langchain-ai/deepagents' } } })), false);
@@ -241,8 +241,8 @@ test('extracts and replaces exactly one version section', () => {
 });
 
 test('release version and section extraction accept prerelease and build metadata', () => {
-  assert.equal(releaseNotes.releaseVersion('release(deepagents-code): 0.2.0-rc.1', COMPONENT), '0.2.0-rc.1');
-  assert.equal(releaseNotes.releaseVersion('release(deepagents-code): 1.0.0+build.5', COMPONENT), '1.0.0+build.5');
+  assert.equal(releaseNotes.releaseVersion('release(`deepagents-code`): `0.2.0-rc.1`', COMPONENT), '0.2.0-rc.1');
+  assert.equal(releaseNotes.releaseVersion('release(`deepagents-code`): `1.0.0+build.5`', COMPONENT), '1.0.0+build.5');
   const version = '0.2.0-rc.1';
   const heading = `## [${version}](https://example.test) (2026-07-09)`;
   const doc = `# Changelog\n\n${heading}\n\n* Prerelease note\n\n## [0.1.34](https://example.test) (2026-07-01)\n\n* Older\n`;
@@ -760,7 +760,7 @@ test('required check binds to the expected head and rejects malformed target tit
   await releaseNotes.checkCuratedState({ github: staleHead.github, context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } }, core: staleCore, number: 123, ...BOT_AUTH, expectedHead: APPLIED_HEAD });
   assert.match(staleCore.failed, /head changed before/);
 
-  const malformed = makeGithub({ pr: releasePr({ title: `release(deepagents): ${VERSION}` }) });
+  const malformed = makeGithub({ pr: releasePr({ title: `release(\`deepagents\`): \`${VERSION}\`` }) });
   const malformedCore = makeCore();
   await releaseNotes.checkCuratedState({ github: malformed.github, context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } }, core: malformedCore, number: 123, ...BOT_AUTH });
   assert.match(malformedCore.failed, /title does not match/);
@@ -883,7 +883,7 @@ test('draft, unmanaged branch, and bypass label pass without metadata', async ()
     // Not a component release-please manages, so the gate does not apply. Every
     // managed component IS gated — see the companion test below.
     releasePr({
-      title: `release(not-a-package): ${VERSION}`,
+      title: `release(\`not-a-package\`): \`${VERSION}\``,
       head: { ...releasePr().head, ref: 'release-please--branches--main--components--not-a-package' },
     }),
     releasePr({ labels: [{ name: releaseNotes.BYPASS_LABEL }] }),
@@ -1976,7 +1976,7 @@ const OTHER_BRANCH = `${releaseNotes.RELEASE_BRANCH_PREFIX}${OTHER_COMPONENT}`;
 function prForComponent(component, overrides = {}) {
   const base = releasePr();
   return releasePr({
-    title: `release(${component}): ${VERSION}`,
+    title: `release(\`${component}\`): \`${VERSION}\``,
     head: { ...base.head, ref: `${releaseNotes.RELEASE_BRANCH_PREFIX}${component}` },
     ...overrides,
   });
@@ -2042,15 +2042,15 @@ test('rejects a head ref that is not a managed component', () => {
 
 test('rejects a release PR whose title and branch name different components', () => {
   const mismatched = prForComponent(COMPONENT, {
-    title: `release(${OTHER_COMPONENT}): ${VERSION}`,
+    title: `release(\`${OTHER_COMPONENT}\`): \`${VERSION}\``,
   });
   // The branch is a real managed component, so the branch check alone passes...
   assert.equal(releaseNotes.isReleaseBranchPr(mismatched), true);
   // ...but the title must name that same component before a target is derived.
   assert.equal(releaseNotes.releaseTarget(mismatched), null);
   assert.equal(releaseNotes.isReleasePr(mismatched), false);
-  assert.equal(releaseNotes.releaseVersion(`release(${OTHER_COMPONENT}): ${VERSION}`, COMPONENT), null);
-  assert.equal(releaseNotes.releaseVersion(`release(${OTHER_COMPONENT}): ${VERSION}`, OTHER_COMPONENT), VERSION);
+  assert.equal(releaseNotes.releaseVersion(`release(\`${OTHER_COMPONENT}\`): \`${VERSION}\``, COMPONENT), null);
+  assert.equal(releaseNotes.releaseVersion(`release(\`${OTHER_COMPONENT}\`): \`${VERSION}\``, OTHER_COMPONENT), VERSION);
 });
 
 test('a curated draft for one component does not satisfy another component', async () => {

--- a/.github/scripts/tests/release/test_release_please_workflow.py
+++ b/.github/scripts/tests/release/test_release_please_workflow.py
@@ -405,8 +405,8 @@ def test_every_component_is_wired_for_detection_and_dispatch() -> None:
 
     for path, meta in packages.items():
         component = meta["component"]
-        assert f"release\\({component}\\)" in detect, (
-            f"detect-release-commit does not match release({component})"
+        assert f"release\\(`{component}`\\)" in detect, (
+            f"detect-release-commit does not match release(`{component}`)"
         )
         changelog = f"^{path}/{meta['changelog-path']}$"
         assert changelog in detect, (

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -38,8 +38,10 @@
 #   1. The 'Type' must start with a lowercase letter.
 #   2. Breaking changes: append "!" after type/scope (e.g., feat(sdk)!: drop x support)
 #   3. When releasing (updating the pyproject.toml and uv.lock), the commit message
-#      should be: `release(scope): x.y.z` (e.g., `release(deepagents): 1.2.0` with no
-#      body, footer, or preceding/following text).
+#      should be: release(`scope`): `x.y.z` (e.g., release(`deepagents`): `1.2.0`
+#      with no body, footer, or preceding/following text). The auto-generated
+#      release-please title wraps the component and version in code fences, so it
+#      is exempt from the scope allowlist below (see the step's `if:`).
 #
 # Enforces Conventional Commits format for pull request titles to maintain a clear and
 # machine-readable change history.
@@ -89,6 +91,11 @@ jobs:
           fi
       - name: "✅ Validate Conventional Commits Format"
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        # release-please titles wrap the component in backticks
+        # (release(`deepagents-code`): `0.5.0`), which is not one of the
+        # allowlisted scopes below; the release pipeline validates those titles
+        # itself, so skip the scope check for them.
+        if: "!startsWith(github.event.pull_request.title, 'release(`')"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -161,11 +161,11 @@ jobs:
             echo "::warning::Commit message is empty — no release will be triggered."
           fi
 
-          # Extract version from release commit message: "release(component): X.Y.Z"
+          # Extract version from release commit message: "release(`component`): `X.Y.Z`"
           # [^ ]+ stops at the first space to avoid capturing trailing PR refs like "(#1234)"
           # NOTE: separate-pull-requests=true ensures one release commit per workflow run,
           # so a single version output is correct — each package triggers its own run.
-          RELEASE_VERSION=$(echo "$COMMIT_MSG" | sed -nE 's/^release\([^)]+\): +([^ ]+).*/\1/p')
+          RELEASE_VERSION=$(echo "$COMMIT_MSG" | sed -nE 's/^release\(`?[^)`]+`?\): +`?([^ `]+)`?.*/\1/p')
           echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
 
           if [ -n "$RELEASE_VERSION" ]; then
@@ -189,7 +189,7 @@ jobs:
           # check after the last package below).
           ANY_PACKAGE=false
 
-          if echo "$CHANGED" | grep -q "^libs/cli/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-cli\):"; then
+          if echo "$CHANGED" | grep -q "^libs/cli/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(`deepagents-cli`\):"; then
             echo "cli-release=true" >> "$GITHUB_OUTPUT"
             ANY_PACKAGE=true
             echo "CLI release detected: $COMMIT_MSG"
@@ -197,7 +197,7 @@ jobs:
             echo "cli-release=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED" | grep -q "^libs/deepagents/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents\):"; then
+          if echo "$CHANGED" | grep -q "^libs/deepagents/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(`deepagents`\):"; then
             echo "sdk-release=true" >> "$GITHUB_OUTPUT"
             ANY_PACKAGE=true
             echo "SDK release detected: $COMMIT_MSG"
@@ -205,7 +205,7 @@ jobs:
             echo "sdk-release=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED" | grep -q "^libs/acp/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-acp\):"; then
+          if echo "$CHANGED" | grep -q "^libs/acp/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(`deepagents-acp`\):"; then
             echo "acp-release=true" >> "$GITHUB_OUTPUT"
             ANY_PACKAGE=true
             echo "ACP release detected: $COMMIT_MSG"
@@ -213,7 +213,7 @@ jobs:
             echo "acp-release=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED" | grep -q "^libs/code/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-code\):"; then
+          if echo "$CHANGED" | grep -q "^libs/code/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(`deepagents-code`\):"; then
             echo "code-release=true" >> "$GITHUB_OUTPUT"
             ANY_PACKAGE=true
             echo "Deep Agents Code release detected: $COMMIT_MSG"
@@ -221,7 +221,7 @@ jobs:
             echo "code-release=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED" | grep -q "^libs/talon/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-talon\):"; then
+          if echo "$CHANGED" | grep -q "^libs/talon/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(`deepagents-talon`\):"; then
             echo "talon-release=true" >> "$GITHUB_OUTPUT"
             ANY_PACKAGE=true
             echo "Deep Agents Talon release detected: $COMMIT_MSG"
@@ -229,7 +229,7 @@ jobs:
             echo "talon-release=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED" | grep -q "^libs/partners/daytona/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-daytona\):"; then
+          if echo "$CHANGED" | grep -q "^libs/partners/daytona/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(`langchain-daytona`\):"; then
             echo "daytona-release=true" >> "$GITHUB_OUTPUT"
             ANY_PACKAGE=true
             echo "Daytona release detected: $COMMIT_MSG"
@@ -237,7 +237,7 @@ jobs:
             echo "daytona-release=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED" | grep -q "^libs/partners/modal/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-modal\):"; then
+          if echo "$CHANGED" | grep -q "^libs/partners/modal/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(`langchain-modal`\):"; then
             echo "modal-release=true" >> "$GITHUB_OUTPUT"
             ANY_PACKAGE=true
             echo "Modal release detected: $COMMIT_MSG"
@@ -245,7 +245,7 @@ jobs:
             echo "modal-release=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED" | grep -q "^libs/partners/runloop/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-runloop\):"; then
+          if echo "$CHANGED" | grep -q "^libs/partners/runloop/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(`langchain-runloop`\):"; then
             echo "runloop-release=true" >> "$GITHUB_OUTPUT"
             ANY_PACKAGE=true
             echo "Runloop release detected: $COMMIT_MSG"
@@ -253,7 +253,7 @@ jobs:
             echo "runloop-release=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED" | grep -q "^libs/partners/vercel/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-vercel-sandbox\):"; then
+          if echo "$CHANGED" | grep -q "^libs/partners/vercel/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(`langchain-vercel-sandbox`\):"; then
             echo "vercel-release=true" >> "$GITHUB_OUTPUT"
             ANY_PACKAGE=true
             echo "Vercel release detected: $COMMIT_MSG"
@@ -261,7 +261,7 @@ jobs:
             echo "vercel-release=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED" | grep -q "^libs/partners/quickjs/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-quickjs\):"; then
+          if echo "$CHANGED" | grep -q "^libs/partners/quickjs/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(`langchain-quickjs`\):"; then
             echo "quickjs-release=true" >> "$GITHUB_OUTPUT"
             ANY_PACKAGE=true
             echo "QuickJS release detected: $COMMIT_MSG"
@@ -443,8 +443,8 @@ jobs:
           # Matching is `release.yml` run displayTitle == release PR title. That
           # holds only because two independently-maintained templates render
           # byte-identically: release-please-config.json's
-          # `pull-request-title-pattern` ("release(${component}): ${version}") and
-          # release.yml's `run-name` ("release(<package>): <version>"), with
+          # `pull-request-title-pattern` ("release(`${component}`): `${version}`") and
+          # release.yml's `run-name` ("release(`<package>`): `<version>`"), with
           # component == the dispatched package. This is the same run-name
           # coupling that `find_run_url` (in the trigger-releases job) reconstructs
           # from parts and warns about — see its lock-step comment. If either
@@ -937,8 +937,8 @@ jobs:
               | . as $pr
               | ($pr.headBranchName | ltrimstr($prefix)) as $component
               | select($component != "")
-              | select($pr.title | startswith("release(" + $component + "): "))
-              | select($pr.title | test("^release\\([^()]+\\): [0-9A-Za-z][0-9A-Za-z.+-]*$"))
+              | select($pr.title | startswith("release(`" + $component + "`): `"))
+              | select($pr.title | test("^release\\(`[^()]+`\\): `[0-9A-Za-z][0-9A-Za-z.+-]*`$"))
               | $pr.number' <<< "$RELEASE_PRS"); then
             echo "::error::Failed to parse release-please prs output for curated-notes dispatch."
             exit 1
@@ -1070,7 +1070,7 @@ jobs:
 
           # Recover the URL of a dispatched run. The workflow_dispatch API does
           # not return the created run's id, so we correlate on release.yml's
-          # `run-name`, which renders as "release(<package>): <version>". This
+          # `run-name`, which renders as "release(`<package>`): `<version>`". This
           # string MUST stay in lock-step with release.yml's `run-name`: if that
           # template changes, the jq $title below stops matching and correlation
           # silently always-misses (the best-effort warning fires, nothing else
@@ -1089,7 +1089,7 @@ jobs:
               --created ">=$started" \
               --limit 50 \
               --json displayTitle,url,createdAt 2>/dev/null \
-            | jq -r --arg title "release(${package}): ${VERSION}" \
+            | jq -r --arg title "release(\`${package}\`): \`${VERSION}\`" \
                 'map(select(.displayTitle == $title)) | sort_by(.createdAt) | last | .url // empty' \
               2>/dev/null || true
           }
@@ -1206,7 +1206,7 @@ jobs:
               if [ -z "$url" ]; then
                 continue
               fi
-              links+=$'\n\n'"- [\`release(${package}): ${VERSION}\`](${url})"
+              links+=$'\n\n'"- [release(\`${package}\`): \`${VERSION}\`](${url})"
               linked=$((linked + 1))
             done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@
 # Flow: build -> pre-release-checks -> test-pypi -> publish -> release
 
 name: "🚀 Package Release"
-run-name: "release(${{ inputs.package-override || inputs.package }}):${{
-  inputs.version && format(' {0}', inputs.version) || '' }}"
+run-name: "release(`${{ inputs.package-override || inputs.package }}`):${{
+  inputs.version && format(' `{0}`', inputs.version) || '' }}"
 on:
   workflow_dispatch:
     inputs:
@@ -239,7 +239,7 @@ jobs:
 
           if [ -z "$INPUT_SHA" ]; then
             if [ "$IS_DANGEROUS" = "true" ]; then
-              # Alpha/hotfix branches don't have a "release(pkg): X.Y.Z" commit; fall
+              # Alpha/hotfix branches don't have a "release(`pkg`): `X.Y.Z`" commit; fall
               # back to the dispatched HEAD. See RELEASING.md > Alpha / Beta / Pre-release.
               SHA="$GITHUB_SHA_FALLBACK"
               echo "release-sha unset; dangerous-nonmain-release=true -> using github.sha=$SHA"
@@ -1003,7 +1003,7 @@ jobs:
               --state merged \
               --label "autorelease: pending" \
               --label "release" \
-              --search "\"release($PKG_NAME)\" in:title" \
+              --search "\"release(\`$PKG_NAME\`)\" in:title" \
               --json number --jq '.[0].number // empty' 2>&1); then
               echo "::error::gh pr list failed: $LIST_OUT"
               fail_summary ""
@@ -1024,7 +1024,7 @@ jobs:
                 --state merged \
                 --label "autorelease: tagged" \
                 --label "release" \
-                --search "\"release($PKG_NAME): $VERSION\" in:title" \
+                --search "\"release(\`$PKG_NAME\`): \`$VERSION\`\" in:title" \
                 --json number --jq '.[0].number // empty' 2>&1); then
                 echo "::error::gh pr list failed while checking already-tagged releases: $TAGGED_PR"
                 fail_summary ""

--- a/.github/workflows/release_comment_update.yml
+++ b/.github/workflows/release_comment_update.yml
@@ -37,7 +37,7 @@
 #   main). To name the published artifacts, the release.yml runs dispatched by
 #   the pipeline are re-discovered on the same correlation key
 #   `trigger-releases` uses for the original comment: release.yml's
-#   `run-name`, which renders exactly `release(<package>): <version>` (parsed
+#   `run-name`, which renders exactly release(`<package>`): `<version>` (parsed
 #   here from the release-please run's own title), restricted to
 #   `workflow_dispatch` runs created at or after the release-please run
 #   started. It diverges from `find_run_url` in one deliberate way: that
@@ -164,7 +164,7 @@ jobs:
 
           # Only runs that processed a merged release PR could have produced a
           # dispatch comment to follow up on. The display title for those is
-          # "release(<component>): <version> (#<pr>)"; maintenance runs that
+          # "release(`<component>`): `<version>` (#<pr>)"; maintenance runs that
           # merely opened/updated release PRs carry their triggering commit's
           # subject, which does not match.
           # The pattern lives in a variable because `[[ =~ ]]` word-splits an
@@ -177,7 +177,7 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # e.g. "release(deepagents-code): 0.5.0" — the exact title
+          # e.g. "release(`deepagents-code`): `0.5.0`" — the exact title
           # release.yml's run-name renders for each dispatched run.
           release_title="${BASH_REMATCH[1]}"
 
@@ -214,7 +214,7 @@ jobs:
           # already finished.
           created=$(date -u -d "$CREATED_AT" +%Y-%m-%dT%H:%M:%SZ)
 
-          # Match on the exact run title ("release(<package>): <version>", the
+          # Match on the exact run title ("release(`<package>`): `<version>`", the
           # release.yml run-name), the same correlation key find_run_url uses,
           # and on `event=workflow_dispatch` for the same reason it does: to
           # keep an unrelated run that happens to share a title from being
@@ -294,9 +294,9 @@ jobs:
           set -euo pipefail
 
           # Build one line per dispatched run, e.g.
-          #   - ✅ `release(deepagents-acp): 0.0.10` — published to PyPI (<url>)
-          #   - ⏹️ `release(deepagents): 0.5.0` — cancelled before publish (<url>)
-          #   - ❌ `release(deepagents-code): 0.5.0` — failed (conclusion: `failure`) (<url>)
+          #   - ✅ ``release(`deepagents-acp`): `0.0.10` `` — published to PyPI (<url>)
+          #   - ⏹️ ``release(`deepagents`): `0.5.0` `` — cancelled before publish (<url>)
+          #   - ❌ ``release(`deepagents-code`): `0.5.0` `` — failed (conclusion: `failure`) (<url>)
           #
           # RUNS rows are TSV: name <tab> conclusion <tab> url. The
           # re-discovery step polls until every run concludes, so the
@@ -319,12 +319,15 @@ jobs:
           for name, conclusion, url in rows:
               if not conclusion:
                   sys.exit(f"::error::run {url} has no conclusion; the poll loop exited early")
+              # The run name carries literal backticks from release.yml's
+              # run-name (release(`<pkg>`): `<version>`); double backticks keep
+              # the title a single Markdown code span.
               if conclusion == "success":
-                  out.append(f"- ✅ `{name}` — published to PyPI (<{url}>)")
+                  out.append(f"- ✅ ``{name}`` — published to PyPI (<{url}>)")
               elif conclusion == "cancelled":
-                  out.append(f"- ⏹️ `{name}` — cancelled before publish (<{url}>)")
+                  out.append(f"- ⏹️ ``{name}`` — cancelled before publish (<{url}>)")
               else:
-                  out.append(f"- ❌ `{name}` — failed (conclusion: `{conclusion}`) (<{url}>)")
+                  out.append(f"- ❌ ``{name}`` — failed (conclusion: `{conclusion}`) (<{url}>)")
           print("\n".join(out))
           ')
 

--- a/.github/workflows/release_please_fanout_watch.yml
+++ b/.github/workflows/release_please_fanout_watch.yml
@@ -3,7 +3,7 @@
 # Why this exists:
 #   Pre-merge gates (`release_please_scope_check.yml`, etc.) should catch most
 #   multi-component / lockfile-only fan-outs, but bypass labels and race windows
-#   still happen. When release-please opens a `release(<component>):` PR for a
+#   still happen. When release-please opens a release(`<component>`): PR for a
 #   package whose only unreleased path changes on main are lockfiles, this job
 #   sticky-comments that release PR within minutes and fails the advisory check
 #   so someone notices before release time.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -50,7 +50,7 @@
       "hidden": true
     }
   ],
-  "pull-request-title-pattern": "release(${component}): ${version}",
+  "pull-request-title-pattern": "release(`${component}`): `${version}`",
   "component-no-space": true,
   "pull-request-header": "> [!CAUTION]\n> Merging this PR will automatically publish to **PyPI** and create a **GitHub release**.\n\nFor the full release process, see [`.github/RELEASING.md`](https://github.com/langchain-ai/deepagents/blob/main/.github/RELEASING.md).\n\n---\n\n_Release notes preview: keep this section in sync with the package `CHANGELOG.md`. Publish reads the merged CHANGELOG via `release.yml`, not this PR description — keep them aligned anyway so the PR stays an accurate historical record for reviewers and anyone returning later._\n",
   "pull-request-footer": "\n_End release notes preview._\n\n---\n\n> [!NOTE]\n> A **community contributors** list and a **Special thanks** section (crediting the users who filed the issues this release's PRs closed) are appended to the GitHub release notes automatically at publish time (see [Release Pipeline](https://github.com/langchain-ai/deepagents/blob/main/.github/RELEASING.md#release-pipeline), step 3).",


### PR DESCRIPTION
Release-please PR titles now wrap the component and version in code fences, so they render as `` release(`deepagents-code`): `0.5.0` `` instead of `release(deepagents-code): 0.5.0`.

---

## Before / after

| | |
|---|---|
| Before | `release(deepagents-code): 0.5.0` |
| After | `` release(`deepagents-code`): `0.5.0` `` |

On GitHub, backticks in a PR title render as inline code, so the package and version now show in monospace.

## Why the title is load-bearing here

A release-please title is not just a label in this repo — it is a machine-readable contract, and the exact byte format is matched across the release pipeline. This PR changes the producer and every exact-match consumer in one commit so none of the correlations silently always-miss (most of these guards are deliberately fail-open, so a drift would not error — it would just stop catching failures):

- **Producer** — `release-please-config.json`'s `pull-request-title-pattern`.
- **Run-title correlation** — `release.yml`'s `run-name`, `release-please.yml`'s `find_run_url` and the pending-release guard's `displayTitle == title` equality, and `release_comment_update.yml`'s run re-discovery all key on the same rendered string; all four are updated together.
- **Version extraction** — `release-please.yml` pulls the version out of the squash-merge commit subject with a `sed` capture. That capture now strips the surrounding backticks, so the *bare* version (`0.5.0`) still flows to `release.yml` for the pyproject version check and the git tag. This was the highest-risk capture-shift: without the change, the tag and version check would have picked up a leading backtick.
- **Per-package dispatch** — all ten commit matchers in `release-please.yml`.
- **PR lookup** — both `in:title` searches in `release.yml`.
- **Curated notes** — `release-notes.js`'s `parseReleaseTitle` expects the new form.

## Lint and scope-gate interplay

Two checks treat the title as input rather than a fixed string:

- `pr_lint.yml` validates titles against a scope allowlist, and a backticked component (`` `deepagents-code` ``) is not in that list, so release titles are now exempted from the scope check — the release pipeline validates them itself.
- `check_pr_scope_files.py` gates the scope-file bypass on a `release(...)` title. That gate intentionally still matches *both* title forms: an author-typed `release(cli): anything` must keep failing the scope check, so the gate cannot become a bypass vector. `parse_title_scopes` now strips the backticks so the real release title maps to the correct package label.

The outcome comment on the release PR wraps the title in double backticks so the embedded code fences render as a single code span.

## Verification

- All 54 workflow files parse as valid YAML.
- The helper-script suite (`python -m pytest .github/scripts/tests`, which also runs the `node --test` release-notes tests) passes: 1046 passed.

<details>
<summary>Test plan</summary>

- `python -m pytest .github/scripts/tests -q` — 1046 passed.
- YAML parse check across all of `.github/workflows/*.yml`.
- The `sed` extraction was exercised against both `` release(`deepagents-code`): `0.5.0` (#1234) `` and the legacy `release(deepagents): 0.5.0` form and returns the bare version for each.

</details>
