### PR TITLE
feat(quickjs): add hmac check to snapshot bytes

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_snapshot.py
+++ b/libs/partners/quickjs/langchain_quickjs/_snapshot.py
@@ -24,7 +24,9 @@ custom/unregistered type:
 
 from __future__ import annotations
 
+import hmac
 import logging
+from hashlib import sha256
 from typing import TYPE_CHECKING
 
 import bsdiff4
@@ -39,6 +41,64 @@ PATCH = "patch"
 CLEAR = "clear"
 
 SnapshotRecord = tuple[str, bytes]
+
+# Domain-separation prefix folded into every signed message so a snapshot HMAC
+# can never be confused with an HMAC computed over some other blob using the
+# same key. Bump the version suffix if the signed-message layout ever changes.
+_HMAC_DOMAIN = b"langchain-quickjs/snapshot-hmac/v1"
+
+
+def normalize_signing_key(key: str | bytes) -> bytes:
+    """Coerce a user-supplied signing key into raw ``bytes``.
+
+    ``str`` keys are UTF-8 encoded; ``bytes`` are used verbatim. Empty keys are
+    rejected because an empty HMAC key provides no integrity guarantee.
+    """
+    material = key.encode("utf-8") if isinstance(key, str) else bytes(key)
+    if not material:
+        msg = "`snapshot_signing_key` must be a non-empty str or bytes."
+        raise ValueError(msg)
+    return material
+
+
+def sign_snapshot(key: bytes, payload: bytes, thread_id: str) -> bytes:
+    """Return the HMAC-SHA256 tag over a fully materialized snapshot.
+
+    The tag is computed over the *completed materialized* snapshot bytes (the
+    full heap serialization) bound to ``thread_id``, so a valid snapshot for one
+    thread cannot be replayed into another by a state-store adversary. This is
+    signed before the payload is delta-encoded (``encode_snapshot``) and flushed
+    onto the ``bsdiff`` patch chain; verification recomputes the tag over the
+    materialized bytes the chain replays back to.
+    """
+    return hmac.new(key, _signed_message(payload, thread_id), sha256).digest()
+
+
+def verify_snapshot(
+    key: bytes, payload: bytes, thread_id: str, tag: bytes | None
+) -> bool:
+    """Constant-time check that ``tag`` authenticates ``payload`` for ``thread_id``.
+
+    Returns ``False`` for a missing/short tag or any mismatch. The comparison uses
+    :func:`hmac.compare_digest` to avoid leaking timing information about how much
+    of the tag matched.
+    """
+    if not tag:
+        return False
+    expected = sign_snapshot(key, payload, thread_id)
+    return hmac.compare_digest(expected, bytes(tag))
+
+
+def _signed_message(payload: bytes, thread_id: str) -> bytes:
+    """Build the length-prefixed message HMAC is computed over.
+
+    Framing (domain, then a length-prefixed ``thread_id``, then the payload)
+    makes no two distinct ``(thread_id, payload)`` pairs can serialize to the
+    same byte string, so an attacker cannot shift bytes across the boundary
+    to forge a collision.
+    """
+    tid = thread_id.encode("utf-8")
+    return b"".join((_HMAC_DOMAIN, len(tid).to_bytes(8, "big"), tid, bytes(payload)))
 
 
 def coerce_record(write: object) -> tuple[str, bytes] | None:

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -41,7 +41,13 @@ from langchain_quickjs._ptc import (
     render_ptc_prompt,
 )
 from langchain_quickjs._repl import _Registry
-from langchain_quickjs._snapshot import encode_snapshot, replay_snapshot_chain
+from langchain_quickjs._snapshot import (
+    encode_snapshot,
+    normalize_signing_key,
+    replay_snapshot_chain,
+    sign_snapshot,
+    verify_snapshot,
+)
 from langchain_quickjs._subagent import find_subagent_task_tool
 
 logger = logging.getLogger(__name__)
@@ -65,6 +71,7 @@ class REPLState(AgentState):
             PrivateStateAttr,
         ]
     ]
+    _quickjs_snapshot_hmac: NotRequired[Annotated[bytes, PrivateStateAttr]]
 
 
 class EvalSchema(BaseModel):
@@ -193,6 +200,20 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
             in middleware state. If a snapshot exceeds this size, it is
             dropped (`_quickjs_snapshot_payload=None`). Defaults to
             `memory_limit`.
+        snapshot_signing_key: Secret key (`str` or `bytes`) used to
+            HMAC-sign persisted REPL snapshots. When set (and `mode="thread"`),
+            each materialized snapshot is signed before it is written to the
+            checkpointer and its signature is verified before restore. A
+            snapshot whose signature is missing or does not match is rejected
+            and discarded instead of executed.
+
+            !!! warning
+
+                When left unset, persisted snapshots are **not** integrity-checked.
+                Set `snapshot_signing_key` to a high-entropy secret in any deployment
+                where the checkpointer is not fully trusted. Use the same key across
+                all processes that share a thread, and rotate it by starting fresh
+                threads.
 
     Example:
         ```python
@@ -221,6 +242,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         ptc: PTCOption | None = None,
         mode: PersistenceMode | None = None,
         max_snapshot_bytes: int | None = None,
+        snapshot_signing_key: str | bytes | None = None,
     ) -> None:
         """Initialize REPL middleware state and build the exposed eval tool."""
         super().__init__()
@@ -241,6 +263,11 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         self._mode = _resolve_mode(mode=mode)
         self._max_snapshot_bytes = (
             memory_limit if max_snapshot_bytes is None else max_snapshot_bytes
+        )
+        self._snapshot_signing_key = (
+            normalize_signing_key(snapshot_signing_key)
+            if snapshot_signing_key is not None
+            else None
         )
         self._registry = _Registry(
             memory_limit=memory_limit,
@@ -340,6 +367,33 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
             repl.install_tools(list(self._ptc_tools_by_thread.get(thread_id, ())))
         return repl
 
+    def _snapshot_authenticated(self, payload: bytes, state: REPLState) -> bool:
+        """Whether ``payload`` may be restored under the current signing policy.
+
+        With a signing key configured, the materialized ``payload`` must carry a
+        matching ``_quickjs_snapshot_hmac`` tag: a missing or
+        mismatched tag means the snapshot was not produced by us, or was tampered
+        with in the store, so it is rejected. With no key configured we cannot
+        verify anything and fall back to the (unauthenticated) legacy behavior.
+        """
+        if self._snapshot_signing_key is None:
+            return True
+        thread_id = _resolve_thread_id(self._fallback_thread_id)
+        # `_quickjs_snapshot_hmac` is `NotRequired`: an unsigned or legacy
+        # snapshot has no tag, and a store adversary can strip it. Default to
+        # `None` so a missing tag flows into `verify_snapshot` as a rejection
+        # rather than raising `KeyError`.
+        tag = state.get("_quickjs_snapshot_hmac", None)
+        if verify_snapshot(self._snapshot_signing_key, payload, thread_id, tag):
+            return True
+        logger.warning(
+            "Rejecting QuickJS snapshot for thread_id=%s: HMAC verification "
+            "failed (missing or tampered signature). Snapshot will not be "
+            "restored.",
+            thread_id,
+        )
+        return False
+
     def before_agent(
         self,
         state: REPLState,
@@ -351,6 +405,8 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         payload = state.get("_quickjs_snapshot_payload")
         if not payload:
             return None
+        if not self._snapshot_authenticated(payload, state):
+            return {"_quickjs_snapshot_payload": None, "_quickjs_snapshot_hmac": None}
         thread_id = _resolve_thread_id(self._fallback_thread_id)
         repl = self._registry.get(thread_id)
         try:
@@ -361,7 +417,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
                 thread_id,
                 exc_info=True,
             )
-            return {"_quickjs_snapshot_payload": None}
+            return {"_quickjs_snapshot_payload": None, "_quickjs_snapshot_hmac": None}
         return None
 
     async def abefore_agent(
@@ -375,6 +431,8 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         payload = state.get("_quickjs_snapshot_payload")
         if not payload:
             return None
+        if not self._snapshot_authenticated(payload, state):
+            return {"_quickjs_snapshot_payload": None, "_quickjs_snapshot_hmac": None}
         thread_id = _resolve_thread_id(self._fallback_thread_id)
         repl = self._registry.get(thread_id)
         try:
@@ -385,7 +443,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
                 thread_id,
                 exc_info=True,
             )
-            return {"_quickjs_snapshot_payload": None}
+            return {"_quickjs_snapshot_payload": None, "_quickjs_snapshot_hmac": None}
         return None
 
     def wrap_model_call(
@@ -495,8 +553,21 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
                 size,
                 self._max_snapshot_bytes,
             )
-            return {"_quickjs_snapshot_payload": None}
-        return {"_quickjs_snapshot_payload": encode_snapshot(payload, prior)}
+            # Clear the stale signature too, so a dropped snapshot cannot leave a
+            # tag that would later authenticate a mismatched payload.
+            return {"_quickjs_snapshot_payload": None, "_quickjs_snapshot_hmac": None}
+        # Sign the full payload *before* `encode_snapshot` folds it into a
+        # `bsdiff` patch record. Restore recomputes the tag over the bytes the
+        # patch chain replays back to, so the signature authenticates the
+        # reconstructed snapshot rather than any single delta.
+        update: dict[str, Any] = {
+            "_quickjs_snapshot_payload": encode_snapshot(payload, prior)
+        }
+        if self._snapshot_signing_key is not None:
+            update["_quickjs_snapshot_hmac"] = sign_snapshot(
+                self._snapshot_signing_key, payload, thread_id
+            )
+        return update
 
     def after_agent(
         self,
@@ -527,7 +598,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
                 thread_id,
                 exc_info=True,
             )
-            update = {"_quickjs_snapshot_payload": None}
+            update = {"_quickjs_snapshot_payload": None, "_quickjs_snapshot_hmac": None}
         finally:
             self._registry.evict(thread_id)
         return update
@@ -561,7 +632,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
                 thread_id,
                 exc_info=True,
             )
-            update = {"_quickjs_snapshot_payload": None}
+            update = {"_quickjs_snapshot_payload": None, "_quickjs_snapshot_hmac": None}
         finally:
             await self._registry.aevict(thread_id)
         return update

--- a/libs/partners/quickjs/tests/unit_tests/test_snapshot.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_snapshot.py
@@ -6,6 +6,14 @@ and the ``CodeInterpreterMiddleware`` policy around them: ``_snapshot_update``
 encoding decisions, ``before_agent``/``after_agent`` snapshot roundtrips and
 failure handling, and the ``DeltaChannel`` checkpoint-storage behavior through
 a real compiled graph.
+
+Also covers HMAC signing of persisted snapshots (advisory AT-5b): the pure
+helpers (``normalize_signing_key``, ``sign_snapshot``, ``verify_snapshot``) and
+the middleware policy that signs the completed materialized snapshot in
+``after_agent`` before it is delta-encoded onto the ``bsdiff`` patch chain, then
+verifies it in ``before_agent`` before restore. A snapshot whose signature is
+missing, wrong, tampered, or bound to a different thread must be rejected
+instead of executed.
 """
 
 from __future__ import annotations
@@ -14,13 +22,20 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import bsdiff4
+import pytest
 from langchain.agents import create_agent
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage
 from pydantic import Field
 
 from langchain_quickjs import CodeInterpreterMiddleware
-from langchain_quickjs._snapshot import coerce_record, replay_snapshot_chain
+from langchain_quickjs._snapshot import (
+    coerce_record,
+    normalize_signing_key,
+    replay_snapshot_chain,
+    sign_snapshot,
+    verify_snapshot,
+)
 
 if TYPE_CHECKING:
     from langchain_core.messages import BaseMessage
@@ -83,7 +98,11 @@ def test_before_agent_clears_payload_on_restore_failure() -> None:
             state={"_quickjs_snapshot_payload": b"not-a-snapshot"},
             runtime=MagicMock(),
         )
-        assert update == {"_quickjs_snapshot_payload": None}
+
+        assert update == {
+            "_quickjs_snapshot_payload": None,
+            "_quickjs_snapshot_hmac": None,
+        }
     finally:
         mw._registry.close()
 
@@ -125,7 +144,10 @@ def test_after_agent_clears_payload_on_snapshot_failure() -> None:
         repl = mw._registry.get(mw._fallback_thread_id)
         with patch.object(repl, "create_snapshot", side_effect=RuntimeError("boom")):
             update = mw.after_agent(state={}, runtime=MagicMock())
-        assert update == {"_quickjs_snapshot_payload": None}
+        assert update == {
+            "_quickjs_snapshot_payload": None,
+            "_quickjs_snapshot_hmac": None,
+        }
         assert mw._fallback_thread_id not in mw._registry._slots
     finally:
         mw._registry.close()
@@ -137,7 +159,10 @@ def test_after_agent_drops_payload_above_snapshot_size_cap() -> None:
         repl = mw._registry.get(mw._fallback_thread_id)
         with patch.object(repl, "create_snapshot", return_value=b"12345"):
             update = mw.after_agent(state={}, runtime=MagicMock())
-        assert update == {"_quickjs_snapshot_payload": None}
+        assert update == {
+            "_quickjs_snapshot_payload": None,
+            "_quickjs_snapshot_hmac": None,
+        }
         assert mw._fallback_thread_id not in mw._registry._slots
     finally:
         mw._registry.close()
@@ -153,7 +178,10 @@ async def test_aafter_agent_drops_payload_above_snapshot_size_cap() -> None:
             new=AsyncMock(return_value=b"12345"),
         ):
             update = await mw.aafter_agent(state={}, runtime=MagicMock())
-        assert update == {"_quickjs_snapshot_payload": None}
+        assert update == {
+            "_quickjs_snapshot_payload": None,
+            "_quickjs_snapshot_hmac": None,
+        }
         assert mw._fallback_thread_id not in mw._registry._slots
     finally:
         mw._registry.close()
@@ -510,5 +538,310 @@ def test_mode_call_ignores_snapshot_payload() -> None:
         )
         assert before_update is None
         assert mw._registry.get_if_exists(mw._fallback_thread_id) is None
+    finally:
+        mw._registry.close()
+
+
+# Signing keys used by the HMAC tests below. `_SIGNING_KEY` is the "real"
+# deployment secret; `_WRONG_SIGNING_KEY` stands in for a key an adversary
+# would use to forge a signature (or a key-rotation mismatch).
+_SIGNING_KEY = "correct horse battery staple"
+_WRONG_SIGNING_KEY = b"a-different-secret"
+
+
+def _signing_thread_id(mw: CodeInterpreterMiddleware) -> str:
+    """The thread id the middleware signs/verifies snapshots under.
+
+    Bound into every HMAC tag, so signing and verifying test helpers must agree
+    on it. Mirrors the middleware's own `_resolve_thread_id` fallback.
+    """
+    return mw._fallback_thread_id
+
+
+
+def test_normalize_signing_key_encodes_str_and_passes_bytes() -> None:
+    assert normalize_signing_key("abc") == b"abc"
+    assert normalize_signing_key(b"abc") == b"abc"
+    assert normalize_signing_key(bytearray(b"abc")) == b"abc"
+
+
+def test_normalize_signing_key_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        normalize_signing_key("")
+    with pytest.raises(ValueError, match="non-empty"):
+        normalize_signing_key(b"")
+
+
+def test_sign_verify_roundtrip() -> None:
+    key = normalize_signing_key(_SIGNING_KEY)
+    tag = sign_snapshot(key, b"payload", "thread-1")
+    assert verify_snapshot(key, b"payload", "thread-1", tag) is True
+
+
+def test_verify_rejects_missing_tag() -> None:
+    key = normalize_signing_key(_SIGNING_KEY)
+    assert verify_snapshot(key, b"payload", "thread-1", None) is False
+    assert verify_snapshot(key, b"payload", "thread-1", b"") is False
+
+
+def test_verify_rejects_tampered_payload() -> None:
+    key = normalize_signing_key(_SIGNING_KEY)
+    tag = sign_snapshot(key, b"payload", "thread-1")
+    assert verify_snapshot(key, b"payload-EVIL", "thread-1", tag) is False
+
+
+def test_verify_rejects_wrong_key() -> None:
+    good = normalize_signing_key(_SIGNING_KEY)
+    bad = normalize_signing_key(_WRONG_SIGNING_KEY)
+    tag = sign_snapshot(good, b"payload", "thread-1")
+    assert verify_snapshot(bad, b"payload", "thread-1", tag) is False
+
+
+def test_verify_rejects_cross_thread_replay() -> None:
+    """A tag signed for one thread must not authenticate another thread.
+
+    This is the state-store adversary who copies a legitimately-signed snapshot
+    from thread A into thread B's slot in the checkpointer.
+    """
+    key = normalize_signing_key(_SIGNING_KEY)
+    tag = sign_snapshot(key, b"payload", "thread-A")
+    assert verify_snapshot(key, b"payload", "thread-B", tag) is False
+
+
+def test_thread_id_framing_is_unambiguous() -> None:
+    """Length-prefixed framing prevents boundary-shift collisions.
+
+    Without length-prefixing, ``("ab", "cX")`` and ``("abc", "X")`` could
+    serialize to the same bytes. The tags must differ.
+    """
+    key = normalize_signing_key(_SIGNING_KEY)
+    tag1 = sign_snapshot(key, b"cX-payload", "ab")
+    tag2 = sign_snapshot(key, b"X-payload", "abc")
+    assert tag1 != tag2
+
+
+def test_empty_key_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        CodeInterpreterMiddleware(snapshot_signing_key="")
+
+
+
+def test_after_agent_emits_hmac_when_key_set() -> None:
+    mw = CodeInterpreterMiddleware(snapshot_signing_key=_SIGNING_KEY)
+    try:
+        repl = mw._registry.get(_signing_thread_id(mw))
+        repl.eval_sync("const answer = 42")
+        update = mw.after_agent(state={}, runtime=MagicMock())
+        assert isinstance(update, dict)
+        tag = update["_quickjs_snapshot_hmac"]
+        assert isinstance(tag, bytes)
+        assert len(tag) == 32  # SHA-256 digest
+
+        # The tag authenticates the *materialized* snapshot the chain replays to.
+        materialized = replay_snapshot_chain(b"", [update["_quickjs_snapshot_payload"]])
+        assert verify_snapshot(
+            mw._snapshot_signing_key, materialized, _signing_thread_id(mw), tag
+        )
+    finally:
+        mw._registry.close()
+
+
+def test_after_agent_no_hmac_when_key_unset() -> None:
+    mw = CodeInterpreterMiddleware()  # thread mode, no key -> no signing
+    try:
+        repl = mw._registry.get(_signing_thread_id(mw))
+        repl.eval_sync("const answer = 42")
+        update = mw.after_agent(state={}, runtime=MagicMock())
+        assert isinstance(update, dict)
+        assert "_quickjs_snapshot_hmac" not in update
+    finally:
+        mw._registry.close()
+
+
+def test_signed_snapshot_roundtrip_restores() -> None:
+    """A snapshot signed in after_agent restores cleanly in before_agent."""
+    mw = CodeInterpreterMiddleware(snapshot_signing_key=_SIGNING_KEY)
+    try:
+        repl = mw._registry.get(_signing_thread_id(mw))
+        repl.eval_sync("const answer = 42")
+        update = mw.after_agent(state={}, runtime=MagicMock())
+        materialized = replay_snapshot_chain(b"", [update["_quickjs_snapshot_payload"]])
+
+        before_update = mw.before_agent(
+            state={
+                "_quickjs_snapshot_payload": materialized,
+                "_quickjs_snapshot_hmac": update["_quickjs_snapshot_hmac"],
+            },
+            runtime=MagicMock(),
+        )
+        assert before_update is None  # accepted, restored in place
+        restored = mw._registry.get(_signing_thread_id(mw))
+        assert restored.eval_sync("answer").result == "42"
+    finally:
+        mw._registry.close()
+
+
+def test_before_agent_rejects_missing_hmac() -> None:
+    """Key configured but snapshot carries no tag -> rejected, not restored."""
+    mw = CodeInterpreterMiddleware(snapshot_signing_key=_SIGNING_KEY)
+    try:
+        repl = mw._registry.get(_signing_thread_id(mw))
+        repl.eval_sync("const answer = 42")
+        update = mw.after_agent(state={}, runtime=MagicMock())
+        materialized = replay_snapshot_chain(b"", [update["_quickjs_snapshot_payload"]])
+
+        repl = mw._registry.get(_signing_thread_id(mw))
+        with patch.object(repl, "restore_snapshot") as restore:
+            before_update = mw.before_agent(
+                state={"_quickjs_snapshot_payload": materialized},  # no hmac
+                runtime=MagicMock(),
+            )
+            restore.assert_not_called()
+        assert before_update == {
+            "_quickjs_snapshot_payload": None,
+            "_quickjs_snapshot_hmac": None,
+        }
+    finally:
+        mw._registry.close()
+
+
+def test_before_agent_rejects_tampered_payload() -> None:
+    """Attacker mutates the stored snapshot bytes; the tag no longer matches."""
+    mw = CodeInterpreterMiddleware(snapshot_signing_key=_SIGNING_KEY)
+    try:
+        repl = mw._registry.get(_signing_thread_id(mw))
+        repl.eval_sync("const answer = 42")
+        update = mw.after_agent(state={}, runtime=MagicMock())
+        materialized = bytearray(
+            replay_snapshot_chain(b"", [update["_quickjs_snapshot_payload"]])
+        )
+        materialized[-1] ^= 0xFF  # flip a byte
+
+        before_update = mw.before_agent(
+            state={
+                "_quickjs_snapshot_payload": bytes(materialized),
+                "_quickjs_snapshot_hmac": update["_quickjs_snapshot_hmac"],
+            },
+            runtime=MagicMock(),
+        )
+        assert before_update == {
+            "_quickjs_snapshot_payload": None,
+            "_quickjs_snapshot_hmac": None,
+        }
+    finally:
+        mw._registry.close()
+
+
+def test_before_agent_rejects_wrong_key_signature() -> None:
+    """Snapshot signed under a different key (forged by an adversary)."""
+    signer = CodeInterpreterMiddleware(snapshot_signing_key=_WRONG_SIGNING_KEY)
+    verifier = CodeInterpreterMiddleware(snapshot_signing_key=_SIGNING_KEY)
+    try:
+        repl = signer._registry.get(_signing_thread_id(signer))
+        repl.eval_sync("const answer = 42")
+        update = signer.after_agent(state={}, runtime=MagicMock())
+        materialized = replay_snapshot_chain(b"", [update["_quickjs_snapshot_payload"]])
+
+        before_update = verifier.before_agent(
+            state={
+                "_quickjs_snapshot_payload": materialized,
+                "_quickjs_snapshot_hmac": update["_quickjs_snapshot_hmac"],
+            },
+            runtime=MagicMock(),
+        )
+        assert before_update == {
+            "_quickjs_snapshot_payload": None,
+            "_quickjs_snapshot_hmac": None,
+        }
+    finally:
+        signer._registry.close()
+        verifier._registry.close()
+
+
+async def test_abefore_agent_rejects_tampered_payload() -> None:
+    """Async restore path enforces the same rejection."""
+    mw = CodeInterpreterMiddleware(snapshot_signing_key=_SIGNING_KEY)
+    try:
+        repl = mw._registry.get(_signing_thread_id(mw))
+        await repl.eval_async("const answer = 42")
+        update = await mw.aafter_agent(state={}, runtime=MagicMock())
+        materialized = bytearray(
+            replay_snapshot_chain(b"", [update["_quickjs_snapshot_payload"]])
+        )
+        materialized[0] ^= 0xFF
+
+        before_update = await mw.abefore_agent(
+            state={
+                "_quickjs_snapshot_payload": bytes(materialized),
+                "_quickjs_snapshot_hmac": update["_quickjs_snapshot_hmac"],
+            },
+            runtime=MagicMock(),
+        )
+        assert before_update == {
+            "_quickjs_snapshot_payload": None,
+            "_quickjs_snapshot_hmac": None,
+        }
+    finally:
+        mw._registry.close()
+
+
+async def test_asigned_snapshot_roundtrip_restores() -> None:
+    mw = CodeInterpreterMiddleware(snapshot_signing_key=_SIGNING_KEY)
+    try:
+        repl = mw._registry.get(_signing_thread_id(mw))
+        await repl.eval_async("const answer = 42")
+        update = await mw.aafter_agent(state={}, runtime=MagicMock())
+        materialized = replay_snapshot_chain(b"", [update["_quickjs_snapshot_payload"]])
+
+        before_update = await mw.abefore_agent(
+            state={
+                "_quickjs_snapshot_payload": materialized,
+                "_quickjs_snapshot_hmac": update["_quickjs_snapshot_hmac"],
+            },
+            runtime=MagicMock(),
+        )
+        assert before_update is None
+        restored = mw._registry.get(_signing_thread_id(mw))
+        assert restored.eval_sync("answer").result == "42"
+    finally:
+        mw._registry.close()
+
+
+def test_no_key_restores_without_verification() -> None:
+    """Legacy behavior: with no key, an unsigned snapshot still restores.
+
+    This preserves backward compatibility for trusted-store deployments, where
+    the caller opts out of integrity verification by not configuring a key.
+    """
+    mw = CodeInterpreterMiddleware()  # no key
+    try:
+        repl = mw._registry.get(_signing_thread_id(mw))
+        repl.eval_sync("const answer = 42")
+        update = mw.after_agent(state={}, runtime=MagicMock())
+        materialized = replay_snapshot_chain(b"", [update["_quickjs_snapshot_payload"]])
+        before_update = mw.before_agent(
+            state={"_quickjs_snapshot_payload": materialized},  # no hmac
+            runtime=MagicMock(),
+        )
+        assert before_update is None
+        restored = mw._registry.get(_signing_thread_id(mw))
+        assert restored.eval_sync("answer").result == "42"
+    finally:
+        mw._registry.close()
+
+
+def test_snapshot_size_cap_clears_hmac() -> None:
+    """A dropped oversized snapshot must also clear any stale signature."""
+    mw = CodeInterpreterMiddleware(
+        snapshot_signing_key=_SIGNING_KEY, max_snapshot_bytes=4
+    )
+    try:
+        repl = mw._registry.get(_signing_thread_id(mw))
+        with patch.object(repl, "create_snapshot", return_value=b"12345"):
+            update = mw.after_agent(state={}, runtime=MagicMock())
+        assert update == {
+            "_quickjs_snapshot_payload": None,
+            "_quickjs_snapshot_hmac": None,
+        }
     finally:
         mw._registry.close()

--- a/libs/partners/quickjs/tests/unit_tests/test_snapshot.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_snapshot.py
@@ -558,7 +558,6 @@ def _signing_thread_id(mw: CodeInterpreterMiddleware) -> str:
     return mw._fallback_thread_id
 
 
-
 def test_normalize_signing_key_encodes_str_and_passes_bytes() -> None:
     assert normalize_signing_key("abc") == b"abc"
     assert normalize_signing_key(b"abc") == b"abc"
@@ -623,7 +622,6 @@ def test_thread_id_framing_is_unambiguous() -> None:
 def test_empty_key_rejected_at_construction() -> None:
     with pytest.raises(ValueError, match="non-empty"):
         CodeInterpreterMiddleware(snapshot_signing_key="")
-
 
 
 def test_after_agent_emits_hmac_when_key_set() -> None:


### PR DESCRIPTION
* adds a `snapshot_signing_key` value to `CodeInterpreterMiddleware` kwargs that validates snapshots aren't mutated.
  * does this by adding an additional hmac signature state key that's updated in `after_agent` when we have the fully materialized snapshot bytes (before we flush to the reducer which uses `bsdiff`), and checks in `before_agent` when the state key has been reconstructed by delta channels
  * this is only used by `mode="thread"` since this is when snapshots get triggered

Co-authored-by: Ron F. del Rosario <2307524+guerilla7@users.noreply.github.com>
