### PR TITLE
fix(code): drain hook pipes after timeout

### DIFF
--- a/libs/code/deepagents_code/hooks/runner.py
+++ b/libs/code/deepagents_code/hooks/runner.py
@@ -105,13 +105,17 @@ async def run_command_handler(
         return _failure(handler.id, "launch_failed", f"Could not launch hook: {exc}")
 
     timeout = handler.timeout if handler.timeout is not None else default_timeout
+    communication = asyncio.create_task(
+        _communicate_bounded(process, payload, max_output_bytes)
+    )
     try:
         stdout, stderr, stdout_truncated, stderr_truncated = await asyncio.wait_for(
-            _communicate_bounded(process, payload, max_output_bytes),
+            asyncio.shield(communication),
             timeout=timeout,
         )
     except TimeoutError:
         await _terminate(process)
+        await _finish_communication(communication)
         return _failure(
             handler.id,
             "timeout",
@@ -119,9 +123,11 @@ async def run_command_handler(
         )
     except asyncio.CancelledError:
         await _terminate(process)
+        await _finish_communication(communication)
         raise
     except (BrokenPipeError, ConnectionResetError) as exc:
         await _terminate(process)
+        await _finish_communication(communication)
         return _failure(handler.id, "io_failed", f"Hook communication failed: {exc}")
 
     diagnostics: list[HookDiagnostic] = []
@@ -189,6 +195,20 @@ async def run_command_handler(
         output=output,
         diagnostics=tuple(diagnostics),
     )
+
+
+async def _finish_communication(
+    task: asyncio.Task[tuple[bytes, bytes, bool, bool]],
+) -> None:
+    completion = asyncio.gather(task, return_exceptions=True)
+    try:
+        await asyncio.wait_for(
+            asyncio.shield(completion),
+            timeout=_TERMINATE_WAIT_TIMEOUT,
+        )
+    except TimeoutError:
+        task.cancel()
+        await completion
 
 
 async def _communicate_bounded(

--- a/libs/code/tests/unit_tests/hooks/test_execution.py
+++ b/libs/code/tests/unit_tests/hooks/test_execution.py
@@ -335,6 +335,47 @@ async def test_windows_tree_termination_bounds_taskkill(
     process.kill.assert_called_once_with()
 
 
+async def test_runner_finishes_communication_after_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = MagicMock()
+    launch = AsyncMock(return_value=process)
+    released = asyncio.Event()
+    communication_cancelled = False
+
+    async def communicate(
+        _process: object,
+        _payload: bytes,
+        _limit: int,
+    ) -> tuple[bytes, bytes, bool, bool]:
+        nonlocal communication_cancelled
+        try:
+            await released.wait()
+        except asyncio.CancelledError:
+            communication_cancelled = True
+            raise
+        return b"", b"", False, False
+
+    def terminate(_process: object) -> None:
+        released.set()
+
+    cleanup = AsyncMock(side_effect=terminate)
+    monkeypatch.setattr(runner.asyncio, "create_subprocess_shell", launch)
+    monkeypatch.setattr(runner, "_communicate_bounded", communicate)
+    monkeypatch.setattr(runner, "_terminate", cleanup)
+
+    result = await run_command_handler(
+        _handler("hook", timeout=0.01),
+        b"{}",
+        cwd=tmp_path,
+    )
+
+    assert [item.code for item in result.diagnostics] == ["timeout"]
+    assert communication_cancelled is False
+    cleanup.assert_awaited_once_with(process)
+
+
 @pytest.mark.skipif(os.name != "posix", reason="process groups are POSIX-specific")
 async def test_runner_kills_process_group_on_timeout(tmp_path: Path) -> None:
     script = tmp_path / "hook.sh"


### PR DESCRIPTION
Hook subprocess timeouts now fully drain their pipe transports instead of leaking file descriptors on Python 3.14.

---

Timeout handling previously cancelled bounded communication before killing the child, abandoning stdout and stderr readers. The runner now shields communication during deadline enforcement, terminates and reaps the child, and waits for bounded pipe cleanup. A regression test verifies timeout cleanup completes without cancelling communication.

Made by [Open SWE](https://openswe.vercel.app/agents/ed465228-7617-573a-a869-f2bf3097ad05)