### PR TITLE
fix(infra): use `OPENAI_API_KEY` for OpenWiki

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -29,7 +29,7 @@ jobs:
         run: openwiki code --update --print
         env:
           OPENWIKI_PROVIDER: openai
-          OPENAI_API_KEY: ${{ secrets.LS_GATEWAY_OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
           OPENWIKI_MODEL_ID: gpt-5.6-terra
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}


### PR DESCRIPTION
OpenWiki now reads the gateway credential from the environment-scoped `OPENAI_API_KEY` secret.

---

The workflow referenced `LS_GATEWAY_OPENAI_API_KEY`, so GitHub injected an empty value despite the `openwiki` environment being selected.

Made by [Open SWE](https://openswe.vercel.app/agents/ba52484f-1462-5bca-840f-be89a83fd97d)