### PR TITLE
fix(infra): stabilize OpenWiki updates

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "26"
 
       - name: Install OpenWiki
-        run: npm install --global openwiki@0.2.1
+        run: npm install --global openwiki@0.3.3
 
       - name: Run OpenWiki
         run: openwiki code --update --print
@@ -32,7 +32,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
           OPENWIKI_MODEL_ID: gpt-5.6-terra
-          LANGCHAIN_TRACING_V2: "false"
+          LANGSMITH_TRACING: "false"
 
       - name: Create OpenWiki update pull request
         env:

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -32,9 +32,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
           OPENWIKI_MODEL_ID: gpt-5.6-terra
-          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGCHAIN_PROJECT: openwiki
-          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_TRACING_V2: "false"
 
       - name: Create OpenWiki update pull request
         env:
@@ -47,8 +45,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          git restore -- .github/workflows/openwiki-update.yml
+
           # Stage only the paths OpenWiki is allowed to change.
-          git add -- openwiki AGENTS.md .github/workflows/openwiki-update.yml
+          git add -- openwiki AGENTS.md
 
           if git diff --cached --quiet; then
             echo "No OpenWiki changes to commit."


### PR DESCRIPTION
OpenWiki now runs on current versions without unconfigured LangSmith tracing, and generated documentation updates preserve the repository's custom workflow.

---

The workflow uses OpenWiki 0.3.3 and Node.js 26; its GitHub Actions were already at their latest releases. `LANGSMITH_TRACING` disables trace uploads, while restoring the tracked workflow keeps generated commits limited to docs and agent guidance.

Made by [Open SWE](https://openswe.vercel.app/agents/ba52484f-1462-5bca-840f-be89a83fd97d)
