### PR TITLE
chore(code): render stale-PATH hint as next step, not warning

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -3212,17 +3212,27 @@ if [ "$VERIFY_OK" = true ] && [ "$DCODE_ON_PATH" = false ] && [ -n "$DCODE_BIN" 
   ensure_path_setup "$DCODE_NAME" "$DCODE_BIN" || path_setup_rc=$?
   if [ "$path_setup_rc" -ne 0 ] && [ "$path_setup_rc" -ne 3 ] && \
     [ "$path_setup_rc" -ne 4 ]; then
-    # rc=1: ensure_path_setup printed a specific warning; add the fallback.
+    # rc=1: ensure_path_setup already printed a specific warning; keep the
+    #   fallback in warning styling since profile setup genuinely failed.
     # rc=2: startup files were written, or no change was needed — either way
-    #   the *running* shell still lacks ~/.local/bin on PATH, so emit the
-    #   reload/source hint.
+    #   the *running* shell still lacks ~/.local/bin on PATH. Render the hint
+    #   as a friendly next step (new terminals already work), not a warning.
     # rc=0/3/4 are silent here: PATH is already fixed, MDM owns it, or the user
     #   declined and was already given the one line that would help.
-    log_warn "  Restart your shell, or run:"
-    if [ -f "${HOME}/.local/bin/env" ]; then
-      log_warn "  source ~/.local/bin/env"
+    if [ "$path_setup_rc" -eq 2 ]; then
+      log_info "To use ${DCODE_NAME} in this shell, run:"
+      if [ -f "${HOME}/.local/bin/env" ]; then
+        printf "  ${CYAN}>${NC} source ~/.local/bin/env\n"
+      else
+        printf "  ${CYAN}>${NC} export PATH=\"\$HOME/.local/bin:\$PATH\"\n"
+      fi
     else
-      log_warn "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+      log_warn "  Restart your shell, or run:"
+      if [ -f "${HOME}/.local/bin/env" ]; then
+        log_warn "  source ~/.local/bin/env"
+      else
+        log_warn "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+      fi
     fi
   fi
 fi

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -5467,7 +5467,11 @@ def test_install_script_emits_reload_hint_after_writing_a_profile(
     assert proc.returncode == 0, proc.stderr
     combined = proc.stdout + proc.stderr
     assert "Added ~/.local/bin to PATH" in combined
-    assert "Restart your shell, or run:" in combined
+    # The profile write succeeded, so the hint is a next step, not a warning:
+    # the running shell is stale but new terminals already work.
+    assert "To use dcode in this shell, run:" in combined
+    assert "Restart your shell, or run:" not in combined
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in combined
 
 
 def test_install_script_tilde_display_has_no_literal_backslash(
@@ -6129,9 +6133,10 @@ def test_install_script_stale_shell_with_profile_already_set_shows_reload_hint(
     combined = proc.stdout + proc.stderr
     # No duplicate PATH export was appended.
     assert combined.count('export PATH="$HOME/.local/bin:$PATH"') == 1
-    # But the reload hint is shown because the current shell is stale.
-    assert "Restart your shell, or run:" in combined
-    assert 'export PATH="$HOME/.local/bin:$PATH"' in combined
+    # But the reload hint is shown because the current shell is stale — styled
+    # as a next step, not a warning, since no setup step failed.
+    assert "To use dcode in this shell, run:" in combined
+    assert "Restart your shell, or run:" not in combined
 
 
 def test_install_script_rewrites_existing_managed_path_block(tmp_path: Path) -> None:


### PR DESCRIPTION
When the installer successfully updates the shell profile, the running shell still lacks `~/.local/bin` on PATH until it's reloaded. That case was rendered with the same yellow warning styling as a genuine profile setup failure, even though the install succeeded and new terminals work immediately. Now it prints a cyan info line with a paste-ready command instead:

    ▸ To use dcode in this shell, run:
      > source ~/.local/bin/env

---

`ensure_path_setup` returns distinct codes for "profile setup failed" (rc=1, already accompanied by a specific warning) and "profile written, running shell just stale" (rc=2). The footer previously lumped both under one `log_warn "Restart your shell, or run:"` block, so a fully successful install could end on a warning. The rc=2 path now renders as a `log_info` next-step hint styled like a prompt (`> command`), matching how other installers (e.g. fx) present the same affordance. The rc=1 path keeps the warning styling since something genuinely went wrong.

Adapted from the fx install script (https://releases.fx.sh).
