### PR TITLE
feat(code): add extension registry foundation

### DIFF
--- a/libs/code/deepagents_code/extensions/__init__.py
+++ b/libs/code/deepagents_code/extensions/__init__.py
@@ -1,0 +1,21 @@
+"""Public types for the dcode Python extensions API."""
+
+from deepagents_code.extensions.models import (
+    ExtensionError,
+    ExtensionFile,
+    LoadedExtension,
+    SourceInfo,
+    UnitOrigin,
+    UnitScope,
+)
+from deepagents_code.extensions.registry import ExtensionRegistry
+
+__all__ = [
+    "ExtensionError",
+    "ExtensionFile",
+    "ExtensionRegistry",
+    "LoadedExtension",
+    "SourceInfo",
+    "UnitOrigin",
+    "UnitScope",
+]

--- a/libs/code/deepagents_code/extensions/models.py
+++ b/libs/code/deepagents_code/extensions/models.py
@@ -1,0 +1,80 @@
+"""Shared data types for Python extension discovery and registration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from langchain.agents.middleware.types import AgentMiddleware
+    from langchain_core.tools import BaseTool
+
+
+class UnitScope(StrEnum):
+    """Configuration scope where an extension was discovered."""
+
+    USER = "user"
+    PROJECT = "project"
+
+
+class UnitOrigin(StrEnum):
+    """Shape of an extension on disk."""
+
+    PACKAGE = "package"
+    TOP_LEVEL = "top-level"
+
+
+@dataclass(frozen=True, slots=True)
+class SourceInfo:
+    """Provenance attached to every extension registration."""
+
+    path: Path
+    """Entry file that registered the unit."""
+
+    scope: UnitScope
+    """Configuration scope that supplied the extension."""
+
+    origin: UnitOrigin
+    """Whether the extension is a package or top-level file."""
+
+    @property
+    def label(self) -> str:
+        """Short human-readable extension label."""
+        if self.origin is UnitOrigin.PACKAGE:
+            return self.path.parent.name
+        return self.path.stem
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionFile:
+    """Discovered extension entry file and its provenance."""
+
+    path: Path
+    source: SourceInfo
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredUnit[T]:
+    """Registered extension unit paired with its provenance."""
+
+    name: str
+    unit: T
+    source: SourceInfo
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedExtension:
+    """Registrations produced by one successfully loaded extension."""
+
+    path: Path
+    source: SourceInfo
+    middleware: tuple[AgentMiddleware[Any, Any], ...] = ()
+    tools: tuple[BaseTool, ...] = ()
+    backend_routes: tuple[str, ...] = ()
+
+
+class ExtensionError(Exception):
+    """Raised when an extension cannot be imported or initialized."""

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -1,0 +1,168 @@
+"""In-memory registry for units contributed by Python extensions."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from deepagents_code.extensions.models import RegisteredUnit
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from deepagents.backends.protocol import BackendProtocol
+    from langchain.agents.middleware.types import AgentMiddleware
+    from langchain_core.tools import BaseTool
+
+    from deepagents_code.extensions.models import SourceInfo
+
+logger = logging.getLogger(__name__)
+
+RegistrySnapshot = tuple[int, int, int, int]
+"""Registration counts captured before an extension factory runs."""
+
+
+class ExtensionRegistry:
+    """Hold extension registrations in deterministic load order."""
+
+    def __init__(self) -> None:
+        """Create an empty extension registry."""
+        self._middleware: list[RegisteredUnit[AgentMiddleware[Any, Any]]] = []
+        self._tools: list[RegisteredUnit[BaseTool]] = []
+        self._backend_routes: list[RegisteredUnit[BackendProtocol]] = []
+        self._shutdown_hooks: list[RegisteredUnit[Callable[[], Any]]] = []
+
+    def _snapshot(self) -> RegistrySnapshot:
+        """Capture registration counts for factory-failure rollback.
+
+        Returns:
+            Per-kind registration counts for the current registry state.
+        """
+        return (
+            len(self._middleware),
+            len(self._tools),
+            len(self._backend_routes),
+            len(self._shutdown_hooks),
+        )
+
+    def _rollback(self, snapshot: RegistrySnapshot) -> None:
+        """Remove registrations made after `snapshot`.
+
+        Args:
+            snapshot: Counts returned by `_snapshot` before factory execution.
+        """
+        middleware, tools, backend_routes, shutdown_hooks = snapshot
+        del self._middleware[middleware:]
+        del self._tools[tools:]
+        del self._backend_routes[backend_routes:]
+        del self._shutdown_hooks[shutdown_hooks:]
+
+    @property
+    def middleware(self) -> list[RegisteredUnit[AgentMiddleware[Any, Any]]]:
+        """Registered middleware in load order."""
+        return list(self._middleware)
+
+    @property
+    def tools(self) -> list[RegisteredUnit[BaseTool]]:
+        """Registered tools in load order."""
+        return list(self._tools)
+
+    @property
+    def backend_routes(self) -> list[RegisteredUnit[BackendProtocol]]:
+        """Registered backend routes in load order."""
+        return list(self._backend_routes)
+
+    @property
+    def shutdown_hooks(self) -> list[RegisteredUnit[Callable[[], Any]]]:
+        """Registered teardown callbacks in load order."""
+        return list(self._shutdown_hooks)
+
+    def add_middleware(
+        self,
+        middleware: AgentMiddleware[Any, Any],
+        source: SourceInfo,
+    ) -> None:
+        """Record uniquely named middleware.
+
+        Args:
+            middleware: Middleware instance to install on the agent.
+            source: Extension provenance.
+        """
+        name = getattr(middleware, "name", type(middleware).__name__)
+        if any(existing.name == name for existing in self._middleware):
+            logger.warning(
+                "Ignoring duplicate middleware %r from %s", name, source.label
+            )
+            return
+        self._middleware.append(
+            RegisteredUnit(name=name, unit=middleware, source=source)
+        )
+
+    def add_tool(self, tool: BaseTool, source: SourceInfo) -> None:
+        """Record a tool, keeping the first registration of a name.
+
+        Args:
+            tool: Tool to expose to the model.
+            source: Extension provenance.
+        """
+        existing = next((unit for unit in self._tools if unit.name == tool.name), None)
+        if existing is not None:
+            logger.warning(
+                "Ignoring tool %r from %s: already registered by %s",
+                tool.name,
+                source.label,
+                existing.source.label,
+            )
+            return
+        self._tools.append(RegisteredUnit(name=tool.name, unit=tool, source=source))
+
+    def add_backend_route(
+        self,
+        prefix: str,
+        backend: BackendProtocol,
+        source: SourceInfo,
+    ) -> None:
+        """Record a backend route, keeping the first registration of a prefix.
+
+        Args:
+            prefix: Virtual path prefix mounted by the backend.
+            backend: Backend serving matching paths.
+            source: Extension provenance.
+        """
+        existing = next(
+            (unit for unit in self._backend_routes if unit.name == prefix), None
+        )
+        if existing is not None:
+            logger.warning(
+                "Ignoring backend route %r from %s: already registered by %s",
+                prefix,
+                source.label,
+                existing.source.label,
+            )
+            return
+        self._backend_routes.append(
+            RegisteredUnit(name=prefix, unit=backend, source=source)
+        )
+
+    def add_shutdown_hook(
+        self,
+        hook: Callable[[], Any],
+        source: SourceInfo,
+    ) -> None:
+        """Record a deterministic session teardown callback.
+
+        Args:
+            hook: Sync or async callback invoked during shutdown.
+            source: Extension provenance.
+        """
+        self._shutdown_hooks.append(
+            RegisteredUnit(name=source.label, unit=hook, source=source)
+        )
+
+    def is_empty(self) -> bool:
+        """Return whether the registry contains no extension units."""
+        return not (self._middleware or self._tools or self._backend_routes)
+
+    def units(self) -> list[RegisteredUnit[Any]]:
+        """Return all model-visible registrations in display order."""
+        return [*self._middleware, *self._tools, *self._backend_routes]

--- a/libs/code/tests/unit_tests/test_extension_registry.py
+++ b/libs/code/tests/unit_tests/test_extension_registry.py
@@ -1,0 +1,92 @@
+"""Tests for extension provenance and registration behavior."""
+
+from pathlib import Path
+
+from deepagents.backends import FilesystemBackend
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.tools import tool
+
+from deepagents_code.extensions import (
+    ExtensionRegistry,
+    SourceInfo,
+    UnitOrigin,
+    UnitScope,
+)
+
+
+def _source(name: str) -> SourceInfo:
+    """Build extension provenance for a top-level user file."""
+    return SourceInfo(
+        path=Path(f"/extensions/{name}.py"),
+        scope=UnitScope.USER,
+        origin=UnitOrigin.TOP_LEVEL,
+    )
+
+
+class _Middleware(AgentMiddleware):
+    """Minimal middleware used to exercise registry naming."""
+
+    name = "extension-test"
+
+
+@tool("extension_test")
+def _first_tool() -> str:
+    """Return the first result."""
+    return "first"
+
+
+@tool("extension_test")
+def _second_tool() -> str:
+    """Return the second result."""
+    return "second"
+
+
+def test_source_label_uses_package_directory() -> None:
+    """Package provenance should identify the extension directory."""
+    source = SourceInfo(
+        path=Path("/extensions/example/__init__.py"),
+        scope=UnitScope.PROJECT,
+        origin=UnitOrigin.PACKAGE,
+    )
+
+    assert source.label == "example"
+
+
+def test_duplicate_registrations_keep_first_unit() -> None:
+    """Duplicate names and route prefixes must not replace earlier units."""
+    registry = ExtensionRegistry()
+    first = _source("first")
+    second = _source("second")
+    first_backend = FilesystemBackend(virtual_mode=False)
+
+    registry.add_middleware(_Middleware(), first)
+    registry.add_middleware(_Middleware(), second)
+    registry.add_tool(_first_tool, first)
+    registry.add_tool(_second_tool, second)
+    registry.add_backend_route("/memories/", first_backend, first)
+    registry.add_backend_route(
+        "/memories/", FilesystemBackend(virtual_mode=False), second
+    )
+
+    assert [unit.source for unit in registry.middleware] == [first]
+    assert [unit.source for unit in registry.tools] == [first]
+    assert [unit.source for unit in registry.backend_routes] == [first]
+    assert registry.backend_routes[0].unit is first_backend
+
+
+def test_rollback_removes_partial_factory_state() -> None:
+    """Factory rollback should remove every registration kind and hook."""
+    registry = ExtensionRegistry()
+    source = _source("broken")
+    snapshot = registry._snapshot()
+
+    registry.add_middleware(_Middleware(), source)
+    registry.add_tool(_first_tool, source)
+    registry.add_backend_route(
+        "/memories/", FilesystemBackend(virtual_mode=False), source
+    )
+    registry.add_shutdown_hook(lambda: None, source)
+    registry._rollback(snapshot)
+
+    assert registry.is_empty()
+    assert not registry.shutdown_hooks


### PR DESCRIPTION
Related #5556

Establishes the transactional registry and provenance model used by Python extensions.

---

This is layer 1 of 11 in the replacement extension stack. It defines immutable registration records, deterministic collision handling, and rollback primitives without loading or executing extension code.

The stack follows the revised scope: middleware, tools, shutdown hooks, and configurable backend routes are included; custom slash commands are deferred. PR #5556 is left unchanged.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.