### PR TITLE
feat(code): define the Python extension API

### DIFF
--- a/libs/code/deepagents_code/extensions/__init__.py
+++ b/libs/code/deepagents_code/extensions/__init__.py
@@ -1,5 +1,6 @@
-"""Public types for the dcode Python extensions API."""
+"""Public contract for dcode Python extensions."""
 
+from deepagents_code.extensions.api import ExtensionAPI
 from deepagents_code.extensions.models import (
     ExtensionError,
     ExtensionFile,
@@ -11,6 +12,7 @@ from deepagents_code.extensions.models import (
 from deepagents_code.extensions.registry import ExtensionRegistry
 
 __all__ = [
+    "ExtensionAPI",
     "ExtensionError",
     "ExtensionFile",
     "ExtensionRegistry",

--- a/libs/code/deepagents_code/extensions/api.py
+++ b/libs/code/deepagents_code/extensions/api.py
@@ -1,0 +1,182 @@
+"""Public registrar passed to Python extension factories."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from deepagents_code.extensions.models import ExtensionError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from deepagents.backends.protocol import BackendProtocol
+    from langchain.agents.middleware.types import AgentMiddleware
+    from langchain_core.tools import BaseTool
+
+    from deepagents_code.extensions.models import SourceInfo
+    from deepagents_code.extensions.registry import ExtensionRegistry
+
+_ROUTE_PREFIX = re.compile(r"^/(?:[a-z0-9][a-z0-9_-]*/)+$")
+"""Accepted absolute, slash-terminated virtual route prefixes."""
+
+
+class ExtensionAPI:
+    """Factory-scoped registrar and read-only session context.
+
+    Each extension receives a dedicated instance, which attributes every
+    registration to the extension's source without exposing mutable dcode
+    application state.
+    """
+
+    def __init__(
+        self,
+        registry: ExtensionRegistry,
+        source: SourceInfo,
+        *,
+        cwd: Path,
+        mode: str,
+    ) -> None:
+        """Bind a registrar to one extension's provenance.
+
+        Args:
+            registry: Shared registry receiving extension units.
+            source: Provenance recorded on each registration.
+            cwd: Working directory for this session.
+            mode: Runtime mode, either `interactive` or `headless`.
+        """
+        self._registry = registry
+        self._source = source
+        self._cwd = cwd
+        self._mode = mode
+        self._closed = False
+
+    def _close(self) -> None:
+        """Close the factory-scoped registration window."""
+        self._closed = True
+
+    def _ensure_open(self) -> None:
+        """Reject registration after factory initialization.
+
+        Raises:
+            ExtensionError: If the extension factory has returned.
+        """
+        if self._closed:
+            msg = "Extensions may register units only while their factory is running"
+            raise ExtensionError(msg)
+
+    @property
+    def cwd(self) -> Path:
+        """Working directory for this session."""
+        return self._cwd
+
+    @property
+    def mode(self) -> str:
+        """Runtime mode, either `interactive` or `headless`."""
+        return self._mode
+
+    @property
+    def path(self) -> Path:
+        """Entry file for this extension."""
+        return self._source.path
+
+    def register_middleware(
+        self,
+        middleware: AgentMiddleware[Any, Any] | type[AgentMiddleware[Any, Any]],
+    ) -> None:
+        """Install LangChain middleware on the agent.
+
+        A class is instantiated without arguments. Pass an instance when
+        construction requires configuration.
+
+        Args:
+            middleware: Middleware class or instance.
+
+        Raises:
+            ExtensionError: If `middleware` is invalid or cannot be constructed.
+        """
+        self._ensure_open()
+        from langchain.agents.middleware.types import AgentMiddleware
+
+        try:
+            instance = middleware() if isinstance(middleware, type) else middleware
+        except Exception as exc:
+            msg = f"Could not construct middleware {middleware!r}: {exc}"
+            raise ExtensionError(msg) from exc
+        if not isinstance(instance, AgentMiddleware):
+            kind = type(instance).__name__
+            msg = f"Registered middleware must be an AgentMiddleware, got {kind}"
+            raise ExtensionError(msg)
+        self._registry.add_middleware(instance, self._source)
+
+    def register_tool(self, tool: BaseTool | Callable[..., Any]) -> None:
+        """Expose an LLM-callable tool.
+
+        Plain callables are converted using LangChain's tool schema inference.
+
+        Args:
+            tool: Tool instance or plain callable.
+
+        Raises:
+            ExtensionError: If a callable cannot be converted into a tool.
+        """
+        self._ensure_open()
+        from langchain_core.tools import BaseTool, tool as as_tool
+
+        if isinstance(tool, BaseTool):
+            self._registry.add_tool(tool, self._source)
+            return
+        try:
+            converted = as_tool(tool)
+        except Exception as exc:
+            name = getattr(tool, "__name__", repr(tool))
+            msg = f"Could not convert {name} into a tool: {exc}"
+            raise ExtensionError(msg) from exc
+        self._registry.add_tool(converted, self._source)  # type: ignore[arg-type]  # callable overload returns BaseTool
+
+    def register_backend_route(self, prefix: str, backend: BackendProtocol) -> None:
+        """Mount a backend under a virtual filesystem path.
+
+        File operations under `prefix` are routed to `backend` by the agent's
+        `CompositeBackend`. Shell execution remains on the default backend and
+        cannot access routed virtual content.
+
+        Args:
+            prefix: Lowercase absolute path ending in `/`, such as `/memories/`.
+            backend: Backend serving file operations under the prefix.
+
+        Raises:
+            ExtensionError: If the prefix or backend is invalid.
+        """
+        self._ensure_open()
+        from deepagents.backends.protocol import BackendProtocol
+
+        if _ROUTE_PREFIX.fullmatch(prefix) is None:
+            msg = (
+                f"Invalid backend route prefix {prefix!r}: use lowercase path "
+                "segments and include leading and trailing slashes"
+            )
+            raise ExtensionError(msg)
+        if not isinstance(backend, BackendProtocol):
+            msg = (
+                f"Backend route {prefix!r} got {type(backend).__name__}, "
+                "which is not a BackendProtocol"
+            )
+            raise ExtensionError(msg)
+        self._registry.add_backend_route(prefix, backend, self._source)
+
+    def on_shutdown(self, hook: Callable[[], Any]) -> None:
+        """Register a deterministic session teardown callback.
+
+        Args:
+            hook: Sync or async zero-argument callback.
+
+        Raises:
+            ExtensionError: If `hook` is not callable.
+        """
+        self._ensure_open()
+        if not callable(hook):
+            msg = "Shutdown hook is not callable"
+            raise ExtensionError(msg)
+        self._registry.add_shutdown_hook(hook, self._source)

--- a/libs/code/tests/unit_tests/test_extension_api.py
+++ b/libs/code/tests/unit_tests/test_extension_api.py
@@ -1,0 +1,106 @@
+"""Tests for the public extension registrar."""
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from deepagents.backends import FilesystemBackend
+from langchain.agents.middleware.types import AgentMiddleware
+
+from deepagents_code.extensions import (
+    ExtensionAPI,
+    ExtensionError,
+    ExtensionRegistry,
+    SourceInfo,
+    UnitOrigin,
+    UnitScope,
+)
+
+
+class _Middleware(AgentMiddleware):
+    """Minimal valid middleware registration."""
+
+
+class _ConfiguredMiddleware(AgentMiddleware):
+    """Middleware that must be registered as an instance."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+@pytest.fixture
+def api() -> ExtensionAPI:
+    """Create a registrar with user-extension provenance."""
+    source = SourceInfo(
+        path=Path("/extensions/example.py"),
+        scope=UnitScope.USER,
+        origin=UnitOrigin.TOP_LEVEL,
+    )
+    return ExtensionAPI(
+        ExtensionRegistry(), source, cwd=Path("/workspace"), mode="interactive"
+    )
+
+
+def test_registers_supported_extension_units(api: ExtensionAPI) -> None:
+    """The P0 API should register middleware, tools, routes, and teardown."""
+    backend = FilesystemBackend(virtual_mode=False)
+
+    def status() -> str:
+        """Report extension status."""
+        return "ready"
+
+    api.register_middleware(_Middleware)
+    api.register_tool(status)
+    api.register_backend_route("/memories/", backend)
+    api.on_shutdown(lambda: None)
+
+    registry = api._registry
+    assert registry.middleware[0].unit.name == "_Middleware"
+    assert registry.tools[0].name == "status"
+    assert registry.backend_routes[0].unit is backend
+    assert len(registry.shutdown_hooks) == 1
+    assert api.cwd == Path("/workspace")
+    assert api.mode == "interactive"
+    assert api.path == Path("/extensions/example.py")
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "memories/",
+        "/memories",
+        "/../memories/",
+        "/./memories/",
+        "/memory//notes/",
+        "/Memories/",
+        "/memory.notes/",
+        "/memories\\notes/",
+        "/memories/?user=1",
+        "/memories/#fragment",
+    ],
+)
+def test_rejects_unsafe_backend_route_prefixes(api: ExtensionAPI, prefix: str) -> None:
+    """Routes must be canonical virtual paths without traversal syntax."""
+    with pytest.raises(ExtensionError, match="Invalid backend route prefix"):
+        api.register_backend_route(prefix, FilesystemBackend(virtual_mode=False))
+
+
+def test_rejects_invalid_registration_values(api: ExtensionAPI) -> None:
+    """Invalid unit types should fail at the extension boundary."""
+    with pytest.raises(ExtensionError, match="Could not construct middleware"):
+        api.register_middleware(_ConfiguredMiddleware)
+    with pytest.raises(ExtensionError, match="must be an AgentMiddleware"):
+        # Wrong runtime types are intentional in these boundary checks.
+        api.register_middleware(cast("Any", object()))
+    with pytest.raises(ExtensionError, match="not a BackendProtocol"):
+        api.register_backend_route("/memories/", cast("Any", object()))
+    with pytest.raises(ExtensionError, match="not callable"):
+        api.on_shutdown(cast("Any", None))
+
+
+def test_registration_closes_with_factory_scope(api: ExtensionAPI) -> None:
+    """Retaining the registrar must not allow post-compilation mutation."""
+    api._close()
+
+    with pytest.raises(ExtensionError, match="only while their factory is running"):
+        api.register_middleware(_Middleware())


### PR DESCRIPTION
Related #5556

Python extension factories can register middleware, tools, shutdown callbacks, and configurable backend routes through a narrow API.

---

This is layer 2 of 11. The API exposes only read-only session context and validates route prefixes before recording registrations. It deliberately does not expose mutable dcode state or custom slash-command registration.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.