### PR TITLE
feat(code): discover Python extension sources

### DIFF
--- a/libs/code/deepagents_code/extensions/discovery.py
+++ b/libs/code/deepagents_code/extensions/discovery.py
@@ -1,0 +1,160 @@
+"""Resolve configured extension sources into an ordered file list."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from deepagents_code.extensions.models import (
+    ExtensionFile,
+    SourceInfo,
+    UnitOrigin,
+    UnitScope,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+_ENTRY_FILENAMES = ("__init__.py", "extension.py")
+EXTENSIONS_DIRNAME = "extensions"
+
+
+def user_extensions_dir() -> Path:
+    """Return the global user extensions directory."""
+    return Path.home() / ".deepagents" / EXTENSIONS_DIRNAME
+
+
+def project_extensions_dir(project_root: Path) -> Path:
+    """Return a project's extensions directory.
+
+    Args:
+        project_root: Root of the project being worked in.
+
+    Returns:
+        `<project_root>/.deepagents/extensions/`.
+    """
+    return project_root / ".deepagents" / EXTENSIONS_DIRNAME
+
+
+def scan_extension_dir(directory: Path) -> list[tuple[Path, UnitOrigin]]:
+    """Resolve one directory into extension entry files.
+
+    Discovery is deliberately shallow: direct Python files are extensions, and
+    a direct subdirectory is a package extension when it contains
+    `__init__.py` or `extension.py`.
+
+    Args:
+        directory: Directory to scan.
+
+    Returns:
+        Entry files and origins sorted by path.
+    """
+    try:
+        entries = sorted(directory.iterdir())
+    except OSError:
+        logger.debug("Could not scan extensions directory %s", directory, exc_info=True)
+        return []
+
+    resolved: list[tuple[Path, UnitOrigin]] = []
+    for entry in entries:
+        try:
+            if entry.is_file() and entry.suffix == ".py":
+                resolved.append((entry, UnitOrigin.TOP_LEVEL))
+                continue
+            if not entry.is_dir():
+                continue
+            for filename in _ENTRY_FILENAMES:
+                candidate = entry / filename
+                if candidate.is_file():
+                    resolved.append((candidate, UnitOrigin.PACKAGE))
+                    break
+        except OSError:
+            logger.debug("Skipping unreadable extension entry %s", entry, exc_info=True)
+    return resolved
+
+
+def _files_for_source(
+    paths: Iterable[Path],
+    scope: UnitScope,
+) -> list[ExtensionFile]:
+    """Resolve files directly and directories through the scan recipe.
+
+    Args:
+        paths: Configured extension files or directories.
+        scope: Provenance scope for resolved entries.
+
+    Returns:
+        Discovered extension files in source order.
+    """
+    discovered: list[ExtensionFile] = []
+    for path in paths:
+        expanded = path.expanduser()
+        try:
+            is_file = expanded.is_file()
+            is_dir = expanded.is_dir()
+        except OSError:
+            logger.debug("Could not stat extension path %s", expanded, exc_info=True)
+            continue
+        if is_file:
+            discovered.append(
+                ExtensionFile(
+                    path=expanded,
+                    source=SourceInfo(
+                        path=expanded,
+                        scope=scope,
+                        origin=UnitOrigin.TOP_LEVEL,
+                    ),
+                )
+            )
+        elif is_dir:
+            discovered.extend(
+                ExtensionFile(
+                    path=entry,
+                    source=SourceInfo(path=entry, scope=scope, origin=origin),
+                )
+                for entry, origin in scan_extension_dir(expanded)
+            )
+    return discovered
+
+
+def discover_extension_files(
+    *,
+    user_dir: Path | None = None,
+    extra_paths: Sequence[Path] = (),
+    project_dir: Path | None = None,
+) -> list[ExtensionFile]:
+    """Resolve every enabled source into one ordered file list.
+
+    Callers must leave `project_dir` unset until project trust is resolved; this
+    module intentionally performs no trust checks or implicit project lookup.
+
+    Args:
+        user_dir: Global directory; defaults to `~/.deepagents/extensions/`.
+        extra_paths: Explicit user-configured files and directories.
+        project_dir: Trusted project extension directory, when allowed.
+
+    Returns:
+        Files in load order, deduplicated by canonical path.
+    """
+    resolved_user_dir = user_extensions_dir() if user_dir is None else user_dir
+    discovered = [
+        *_files_for_source([resolved_user_dir], UnitScope.USER),
+        *_files_for_source(extra_paths, UnitScope.USER),
+    ]
+    if project_dir is not None:
+        discovered.extend(_files_for_source([project_dir], UnitScope.PROJECT))
+
+    unique: list[ExtensionFile] = []
+    seen: set[Path] = set()
+    for candidate in discovered:
+        try:
+            key = candidate.path.resolve()
+        except OSError:
+            key = candidate.path
+        if key not in seen:
+            seen.add(key)
+            unique.append(candidate)
+    return unique

--- a/libs/code/tests/unit_tests/test_extension_discovery.py
+++ b/libs/code/tests/unit_tests/test_extension_discovery.py
@@ -1,0 +1,87 @@
+"""Tests for deterministic extension source discovery."""
+
+from pathlib import Path
+
+from deepagents_code.extensions.discovery import (
+    discover_extension_files,
+    scan_extension_dir,
+)
+from deepagents_code.extensions.models import UnitOrigin, UnitScope
+
+
+def _write(path: Path, body: str = "") -> Path:
+    """Create a test extension file and return its path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_scan_is_shallow_sorted_and_package_aware(tmp_path: Path) -> None:
+    """A directory scan should recognize only direct files and packages."""
+    _write(tmp_path / "zeta.py")
+    _write(tmp_path / "alpha.py")
+    _write(tmp_path / "package" / "extension.py")
+    _write(tmp_path / "preferred" / "__init__.py")
+    _write(tmp_path / "preferred" / "extension.py")
+    _write(tmp_path / "ignored" / "nested" / "extension.py")
+    _write(tmp_path / "notes.txt")
+
+    entries = scan_extension_dir(tmp_path)
+
+    assert entries == [
+        (tmp_path / "alpha.py", UnitOrigin.TOP_LEVEL),
+        (tmp_path / "package" / "extension.py", UnitOrigin.PACKAGE),
+        (tmp_path / "preferred" / "__init__.py", UnitOrigin.PACKAGE),
+        (tmp_path / "zeta.py", UnitOrigin.TOP_LEVEL),
+    ]
+
+
+def test_sources_follow_precedence_and_project_scope(tmp_path: Path) -> None:
+    """User, explicit, and trusted project sources should retain precedence."""
+    user = tmp_path / "user"
+    extra = tmp_path / "extra"
+    project = tmp_path / "project"
+    user_file = _write(user / "user.py")
+    extra_file = _write(extra / "extra.py")
+    project_file = _write(project / "project.py")
+
+    discovered = discover_extension_files(
+        user_dir=user,
+        extra_paths=[extra],
+        project_dir=project,
+    )
+
+    assert [entry.path for entry in discovered] == [
+        user_file,
+        extra_file,
+        project_file,
+    ]
+    assert [entry.source.scope for entry in discovered] == [
+        UnitScope.USER,
+        UnitScope.USER,
+        UnitScope.PROJECT,
+    ]
+
+
+def test_explicit_duplicate_path_loads_once(tmp_path: Path) -> None:
+    """The same canonical file from two configured sources should deduplicate."""
+    extension = _write(tmp_path / "extension.py")
+
+    discovered = discover_extension_files(
+        user_dir=tmp_path / "missing",
+        extra_paths=[extension, tmp_path],
+    )
+
+    assert [entry.path for entry in discovered] == [extension]
+
+
+def test_missing_or_unreadable_sources_are_skipped(tmp_path: Path) -> None:
+    """A missing source should not abort discovery of later sources."""
+    extension = _write(tmp_path / "valid" / "extension.py")
+
+    discovered = discover_extension_files(
+        user_dir=tmp_path / "missing",
+        extra_paths=[tmp_path / "also-missing", extension],
+    )
+
+    assert [entry.path for entry in discovered] == [extension]


### PR DESCRIPTION
Related #5556

Python extension files and packages are discovered deterministically from supported extension paths.

---

This is layer 3 of 11. Discovery is shallow, ordered, and canonically deduplicated so repeated paths cannot load the same extension twice. Project-controlled sources remain separable for later trust gating.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.