### PR TITLE
feat(code): configure Python extension sources

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -216,6 +216,15 @@ real PyPI release.
 Any non-empty value enables the flag (including `"0"` or `"false"`).
 """
 
+EXTENSIONS = "DEEPAGENTS_CODE_EXTENSIONS"
+"""Enable loading local Python extensions."""
+
+EXTENSIONS_PATHS = "DEEPAGENTS_CODE_EXTENSIONS_PATHS"
+"""Platform-separated extension files or directories added to discovery."""
+
+EXTENSIONS_TRUST = "DEEPAGENTS_CODE_EXTENSIONS_TRUST"
+"""Default project extension trust policy: `ask`, `always`, or `never`."""
+
 DISABLED_PROJECT_MCP_SERVERS = "DEEPAGENTS_CODE_DISABLED_PROJECT_MCP_SERVERS"
 """Comma-separated project MCP server names to always reject by name.
 

--- a/libs/code/deepagents_code/extensions/__init__.py
+++ b/libs/code/deepagents_code/extensions/__init__.py
@@ -10,14 +10,22 @@ from deepagents_code.extensions.models import (
     UnitScope,
 )
 from deepagents_code.extensions.registry import ExtensionRegistry
+from deepagents_code.extensions.settings import (
+    ExtensionSettings,
+    TrustPolicy,
+    load_extension_settings,
+)
 
 __all__ = [
     "ExtensionAPI",
     "ExtensionError",
     "ExtensionFile",
     "ExtensionRegistry",
+    "ExtensionSettings",
     "LoadedExtension",
     "SourceInfo",
+    "TrustPolicy",
     "UnitOrigin",
     "UnitScope",
+    "load_extension_settings",
 ]

--- a/libs/code/deepagents_code/extensions/settings.py
+++ b/libs/code/deepagents_code/extensions/settings.py
@@ -1,0 +1,135 @@
+"""Resolve extension configuration from user config and environment."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+from deepagents_code._env_vars import (
+    EXTENSIONS,
+    EXTENSIONS_PATHS,
+    EXTENSIONS_TRUST,
+    classify_env_bool,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TrustPolicy(StrEnum):
+    """Default decision for project-authored extension code."""
+
+    ASK = "ask"
+    ALWAYS = "always"
+    NEVER = "never"
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionSettings:
+    """Effective extension configuration for one process."""
+
+    enabled: bool = True
+    """Whether extension discovery is enabled."""
+
+    paths: tuple[Path, ...] = field(default_factory=tuple)
+    """Additional user-authorized extension files or directories."""
+
+    trust: TrustPolicy = TrustPolicy.ASK
+    """Fallback policy for project extension code."""
+
+
+def _read_config_section() -> dict[str, object]:
+    """Read `[extensions]` from the user configuration.
+
+    Returns:
+        Section contents, or an empty mapping when absent or unreadable.
+    """
+    import tomllib
+
+    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
+
+    try:
+        with DEFAULT_CONFIG_PATH.open("rb") as handle:
+            data = tomllib.load(handle)
+    except FileNotFoundError:
+        return {}
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.warning(
+            "Could not read extensions config from %s",
+            DEFAULT_CONFIG_PATH,
+            exc_info=True,
+        )
+        return {}
+    section = data.get("extensions")
+    return section if isinstance(section, dict) else {}
+
+
+def parse_trust_policy(raw: object) -> TrustPolicy | None:
+    """Parse a project extension trust policy.
+
+    Args:
+        raw: Value from configuration or the environment.
+
+    Returns:
+        Parsed policy, or `None` when the value is invalid.
+    """
+    if not isinstance(raw, str):
+        return None
+    try:
+        return TrustPolicy(raw.strip().lower())
+    except ValueError:
+        return None
+
+
+def load_extension_settings() -> ExtensionSettings:
+    """Resolve extension settings with environment overrides.
+
+    Invalid environment values fall through to user configuration rather than
+    silently changing the runtime behavior reported by `dcode config`.
+
+    Returns:
+        Effective settings with safe defaults for malformed values.
+    """
+    section = _read_config_section()
+
+    configured_enabled = section.get("enabled")
+    enabled = configured_enabled if isinstance(configured_enabled, bool) else True
+    env_enabled = os.environ.get(EXTENSIONS)
+    if env_enabled is not None and env_enabled.strip():
+        parsed_enabled = classify_env_bool(env_enabled)
+        if parsed_enabled is None:
+            logger.warning("Ignoring %s=%r (expected bool)", EXTENSIONS, env_enabled)
+        else:
+            enabled = parsed_enabled
+
+    configured_paths = section.get("paths")
+    paths = (
+        [item for item in configured_paths if isinstance(item, str)]
+        if isinstance(configured_paths, list)
+        else []
+    )
+    env_paths = os.environ.get(EXTENSIONS_PATHS)
+    if env_paths is not None and env_paths.strip():
+        paths = [item for item in env_paths.split(os.pathsep) if item.strip()]
+
+    configured_trust = parse_trust_policy(section.get("trust")) or TrustPolicy.ASK
+    trust = configured_trust
+    env_trust = os.environ.get(EXTENSIONS_TRUST)
+    if env_trust is not None and env_trust.strip():
+        parsed_trust = parse_trust_policy(env_trust)
+        if parsed_trust is None:
+            logger.warning(
+                "Ignoring %s=%r (expected ask, always, or never)",
+                EXTENSIONS_TRUST,
+                env_trust,
+            )
+        else:
+            trust = parsed_trust
+
+    return ExtensionSettings(
+        enabled=enabled,
+        paths=tuple(Path(item).expanduser() for item in paths),
+        trust=trust,
+    )

--- a/libs/code/tests/unit_tests/test_extension_settings.py
+++ b/libs/code/tests/unit_tests/test_extension_settings.py
@@ -1,0 +1,90 @@
+"""Tests for extension configuration resolution."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from deepagents_code._env_vars import (
+    EXTENSIONS,
+    EXTENSIONS_PATHS,
+    EXTENSIONS_TRUST,
+)
+from deepagents_code.extensions import TrustPolicy, load_extension_settings
+
+
+@pytest.fixture
+def config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point extension settings at an isolated user config file."""
+    path = tmp_path / "config.toml"
+    monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", path)
+    return path
+
+
+def test_loads_extension_config(config_path: Path) -> None:
+    """Typed TOML values should populate extension settings."""
+    config_path.write_text(
+        """
+[extensions]
+enabled = false
+paths = ["~/one.py", "/tmp/two"]
+trust = "always"
+""",
+        encoding="utf-8",
+    )
+
+    settings = load_extension_settings()
+
+    assert settings.enabled is False
+    assert settings.paths == (Path("~/one.py").expanduser(), Path("/tmp/two"))
+    assert settings.trust is TrustPolicy.ALWAYS
+
+
+def test_environment_overrides_config(
+    config_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Valid environment values should take precedence over TOML."""
+    config_path.write_text(
+        '[extensions]\nenabled = false\npaths = ["old.py"]\ntrust = "never"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(EXTENSIONS, "yes")
+    monkeypatch.setenv(EXTENSIONS_PATHS, f"one.py{os.pathsep}two.py")
+    monkeypatch.setenv(EXTENSIONS_TRUST, "ask")
+
+    settings = load_extension_settings()
+
+    assert settings.enabled is True
+    assert settings.paths == (Path("one.py"), Path("two.py"))
+    assert settings.trust is TrustPolicy.ASK
+
+
+def test_invalid_environment_falls_through_to_config(
+    config_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Malformed overrides must not disagree with effective TOML behavior."""
+    config_path.write_text(
+        '[extensions]\nenabled = false\ntrust = "never"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(EXTENSIONS, "maybe")
+    monkeypatch.setenv(EXTENSIONS_TRUST, "sometimes")
+
+    settings = load_extension_settings()
+
+    assert settings.enabled is False
+    assert settings.trust is TrustPolicy.NEVER
+
+
+def test_malformed_config_uses_safe_defaults(config_path: Path) -> None:
+    """Wrong TOML types and invalid policy strings should use defaults."""
+    config_path.write_text(
+        '[extensions]\nenabled = "false"\npaths = "one.py"\ntrust = "bogus"\n',
+        encoding="utf-8",
+    )
+
+    settings = load_extension_settings()
+
+    assert settings.enabled is True
+    assert not settings.paths
+    assert settings.trust is TrustPolicy.ASK


### PR DESCRIPTION
Related #5556

Users can enable extensions, add source paths, and choose a project-extension trust policy through TOML or environment settings.

---

This is layer 4 of 11. Configuration precedence and invalid-value fallthrough are consistent across file and environment inputs, with no new dependencies or startup-heavy imports.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.