### PR TITLE
feat(code): persist project extension trust

### DIFF
--- a/libs/code/deepagents_code/extensions/__init__.py
+++ b/libs/code/deepagents_code/extensions/__init__.py
@@ -15,6 +15,10 @@ from deepagents_code.extensions.settings import (
     TrustPolicy,
     load_extension_settings,
 )
+from deepagents_code.extensions.trust import (
+    is_project_extensions_trusted,
+    trust_project_extensions,
+)
 
 __all__ = [
     "ExtensionAPI",
@@ -27,5 +31,7 @@ __all__ = [
     "TrustPolicy",
     "UnitOrigin",
     "UnitScope",
+    "is_project_extensions_trusted",
     "load_extension_settings",
+    "trust_project_extensions",
 ]

--- a/libs/code/deepagents_code/extensions/trust.py
+++ b/libs/code/deepagents_code/extensions/trust.py
@@ -1,0 +1,210 @@
+"""Persistent trust decisions for project-authored Python extensions."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from contextlib import contextmanager, suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from filelock import FileLock, Timeout
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+logger = logging.getLogger(__name__)
+
+_STORE_VERSION: Literal[1] = 1
+_LOCK_TIMEOUT_SECONDS = 5.0
+_THREAD_LOCK = threading.Lock()
+
+
+def _default_store_path() -> Path:
+    """Return the app-managed extension trust store path."""
+    from deepagents_code.model_config import DEFAULT_STATE_DIR
+
+    return DEFAULT_STATE_DIR / "extension_trust.json"
+
+
+def _project_key(project_root: Path | str) -> str:
+    """Return the canonical trust key for a project root."""
+    return str(Path(project_root).expanduser().resolve())
+
+
+@contextmanager
+def _store_lock(path: Path) -> Iterator[None]:
+    """Serialize read-merge-write trust store updates.
+
+    Args:
+        path: Trust store path.
+
+    Yields:
+        Control while both process-local and cross-process locks are held.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "nt":
+        path.parent.chmod(0o700)
+    lock = FileLock(
+        str(path.with_name(f"{path.name}.lock")),
+        timeout=_LOCK_TIMEOUT_SECONDS,
+        thread_local=False,
+    )
+    with _THREAD_LOCK, lock:
+        yield
+
+
+def _parse_projects(data: object, *, path: Path) -> dict[str, Any]:
+    """Validate the trust store structure and entries.
+
+    Args:
+        data: Parsed JSON value.
+        path: Store path for error context.
+
+    Returns:
+        Structurally valid project entries.
+
+    Raises:
+        TypeError: If the top-level value or project map has the wrong type.
+        ValueError: If the schema version is unsupported.
+    """
+    if not isinstance(data, dict):
+        msg = f"Extension trust store must be an object: {path}"
+        raise TypeError(msg)
+    if data.get("version") != _STORE_VERSION:
+        msg = f"Unsupported extension trust store version: {path}"
+        raise ValueError(msg)
+    projects = data.get("projects")
+    if not isinstance(projects, dict):
+        msg = f"Extension trust store projects must be an object: {path}"
+        raise TypeError(msg)
+    return {
+        key: value
+        for key, value in projects.items()
+        if isinstance(key, str)
+        and isinstance(value, dict)
+        and isinstance(value.get("trusted_at"), str)
+    }
+
+
+def _load_projects(path: Path, *, strict: bool = False) -> dict[str, Any]:
+    """Load and validate the persisted project map.
+
+    Args:
+        path: Trust store path.
+        strict: Raise instead of treating malformed data as untrusted.
+
+    Returns:
+        Valid project entries, or an empty mapping when reading fails safely.
+
+    Raises:
+        OSError: If strict reading fails.
+        TypeError: If strict structural validation fails.
+        UnicodeDecodeError: If strict UTF-8 decoding fails.
+        json.JSONDecodeError: If strict JSON parsing fails.
+        ValueError: If strict parsing or structural validation fails.
+    """
+    try:
+        data: object = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        if strict:
+            raise
+        logger.warning("Could not read extension trust store %s", path, exc_info=True)
+        return {}
+
+    try:
+        return _parse_projects(data, path=path)
+    except (TypeError, ValueError):
+        if strict:
+            raise
+        logger.warning("Could not read extension trust store %s", path, exc_info=True)
+        return {}
+
+
+def _write_projects(path: Path, projects: dict[str, Any]) -> None:
+    """Atomically write trust data with restrictive permissions.
+
+    Args:
+        path: Destination trust store path.
+        projects: Canonical project trust entries.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(
+                {"version": _STORE_VERSION, "projects": projects},
+                handle,
+                sort_keys=True,
+            )
+            handle.write("\n")
+        if os.name != "nt":
+            temporary.chmod(0o600)
+        temporary.replace(path)
+        if os.name != "nt":
+            path.chmod(0o600)
+    except BaseException:
+        with suppress(OSError):
+            temporary.unlink()
+        raise
+
+
+def is_project_extensions_trusted(
+    project_root: Path | str,
+    *,
+    store_path: Path | None = None,
+) -> bool:
+    """Return whether a project may execute its extension code.
+
+    Args:
+        project_root: Project root to inspect.
+        store_path: Alternate store path for tests.
+
+    Returns:
+        `True` only for a valid persisted decision on the canonical root.
+    """
+    projects = _load_projects(store_path or _default_store_path())
+    return _project_key(project_root) in projects
+
+
+def trust_project_extensions(
+    project_root: Path | str,
+    *,
+    store_path: Path | None = None,
+) -> bool:
+    """Persist permission to execute one project's extension code.
+
+    Args:
+        project_root: Project root to trust.
+        store_path: Alternate store path for tests.
+
+    Returns:
+        `True` when the decision was persisted. Failures return `False` and must
+            not be interpreted as an implicit future grant.
+    """
+    path = store_path or _default_store_path()
+    try:
+        with _store_lock(path):
+            projects = _load_projects(path, strict=True)
+            projects[_project_key(project_root)] = {
+                "trusted_at": datetime.now(UTC).isoformat()
+            }
+            _write_projects(path, projects)
+    except (
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+        Timeout,
+    ):
+        logger.exception("Could not save extension trust store %s", path)
+        return False
+    return True

--- a/libs/code/tests/unit_tests/test_extension_trust.py
+++ b/libs/code/tests/unit_tests/test_extension_trust.py
@@ -1,0 +1,68 @@
+"""Tests for project extension trust persistence."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from deepagents_code.extensions import (
+    is_project_extensions_trusted,
+    trust_project_extensions,
+)
+
+
+def test_trust_is_canonical_and_persistent(tmp_path: Path) -> None:
+    """Trust should survive aliases of the same canonical project root."""
+    project = tmp_path / "project"
+    project.mkdir()
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(project, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+    store = tmp_path / "state" / "extensions.json"
+
+    assert not is_project_extensions_trusted(project, store_path=store)
+    assert trust_project_extensions(alias, store_path=store)
+    assert is_project_extensions_trusted(project, store_path=store)
+
+    payload = json.loads(store.read_text(encoding="utf-8"))
+    assert payload["version"] == 1
+    assert str(project.resolve()) in payload["projects"]
+    if os.name != "nt":
+        assert store.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not json",
+        '{"version": 2, "projects": {}}',
+        '{"version": 1, "projects": []}',
+    ],
+)
+def test_malformed_store_fails_closed(tmp_path: Path, payload: str) -> None:
+    """Unreadable or unsupported trust data must never grant execution."""
+    store = tmp_path / "extensions.json"
+    store.write_text(payload, encoding="utf-8")
+
+    assert not is_project_extensions_trusted(tmp_path, store_path=store)
+    assert not trust_project_extensions(tmp_path, store_path=store)
+    assert store.read_text(encoding="utf-8") == payload
+
+
+def test_invalid_entry_is_not_trusted(tmp_path: Path) -> None:
+    """A project entry without trust metadata should not grant execution."""
+    store = tmp_path / "extensions.json"
+    store.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "projects": {str(tmp_path.resolve()): {"trusted_at": None}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert not is_project_extensions_trusted(tmp_path, store_path=store)


### PR DESCRIPTION
Related #5556

Users can persist trust decisions for project-local Python extensions.

---

This is layer 5 of 11. The trust store uses canonical project identities, restrictive permissions, locking, and atomic replacement. Malformed stores fail closed because project extensions execute with the dcode process privileges.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.