### PR TITLE
feat(code): load Python extension factories

### DIFF
--- a/libs/code/deepagents_code/extensions/loader.py
+++ b/libs/code/deepagents_code/extensions/loader.py
@@ -1,0 +1,152 @@
+"""Import and initialize one discovered Python extension file."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.util
+import inspect
+import sys
+from typing import TYPE_CHECKING
+
+from deepagents_code.extensions.api import ExtensionAPI
+from deepagents_code.extensions.models import (
+    ExtensionError,
+    LoadedExtension,
+    UnitOrigin,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+    from typing import Any
+
+    from deepagents_code.extensions.models import ExtensionFile
+    from deepagents_code.extensions.registry import ExtensionRegistry
+
+FACTORY_NAME = "extension"
+_MODULE_PREFIX = "deepagents_code_extension_"
+
+
+def _module_name(path: Path, origin: UnitOrigin) -> str:
+    """Build a deterministic import name unique to an extension path.
+
+    Args:
+        path: Extension entry file.
+        origin: Whether the file is a package entry point.
+
+    Returns:
+        A private module name that cannot collide with the app namespace.
+    """
+    stem = path.parent.name if origin is UnitOrigin.PACKAGE else path.stem
+    sanitized = "".join(
+        char if char.isascii() and char.isalnum() else "_" for char in stem
+    )
+    digest = hashlib.sha256(str(path.resolve()).encode()).hexdigest()[:12]
+    return f"{_MODULE_PREFIX}{sanitized}_{digest}"
+
+
+def _import_factory(
+    file: ExtensionFile,
+) -> tuple[str, Callable[[ExtensionAPI], Any]]:
+    """Import an extension module and locate its factory.
+
+    Args:
+        file: Discovered extension file and provenance.
+
+    Returns:
+        Synthesized module name and callable `extension` factory.
+
+    Raises:
+        ExtensionError: If import fails or the module has no callable factory.
+        KeyboardInterrupt: If module import interrupts the process.
+        SystemExit: If module import exits the process.
+    """
+    is_package = file.source.origin is UnitOrigin.PACKAGE
+    name = _module_name(file.path, file.source.origin)
+    spec = importlib.util.spec_from_file_location(
+        name,
+        file.path,
+        submodule_search_locations=[str(file.path.parent)] if is_package else None,
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Could not build an import spec for {file.path}"
+        raise ExtensionError(msg)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except (KeyboardInterrupt, SystemExit):
+        sys.modules.pop(name, None)
+        raise
+    except Exception as exc:
+        sys.modules.pop(name, None)
+        msg = f"Failed to import {file.path}: {exc}"
+        raise ExtensionError(msg) from exc
+
+    factory = getattr(module, FACTORY_NAME, None)
+    if not callable(factory):
+        sys.modules.pop(name, None)
+        msg = f"{file.path} does not define a callable {FACTORY_NAME!r} factory"
+        raise ExtensionError(msg)
+    return name, factory
+
+
+async def load_extension(
+    file: ExtensionFile,
+    registry: ExtensionRegistry,
+    *,
+    cwd: Path,
+    mode: str,
+) -> LoadedExtension:
+    """Import and initialize one extension transactionally.
+
+    Synchronous import and factory work runs in a worker thread. Async factory
+    results are awaited on the caller's event loop so loop-bound resources can
+    remain valid for the full server lifetime.
+
+    Args:
+        file: Discovered extension file and provenance.
+        registry: Registry receiving factory registrations.
+        cwd: Working directory for the session.
+        mode: Runtime mode, either `interactive` or `headless`.
+
+    Returns:
+        Registrations produced by this extension.
+
+    Raises:
+        asyncio.CancelledError: If initialization is cancelled.
+        ExtensionError: If import or factory initialization fails.
+        KeyboardInterrupt: If extension code interrupts the process.
+        SystemExit: If extension code exits the process.
+    """
+    name, factory = await asyncio.to_thread(_import_factory, file)
+    before = registry._snapshot()
+    api = ExtensionAPI(registry, file.source, cwd=cwd, mode=mode)
+    try:
+        result = await asyncio.to_thread(factory, api)
+        if inspect.isawaitable(result):
+            await result
+    except (KeyboardInterrupt, SystemExit, asyncio.CancelledError):
+        registry._rollback(before)
+        sys.modules.pop(name, None)
+        raise
+    except Exception as exc:
+        registry._rollback(before)
+        sys.modules.pop(name, None)
+        msg = f"Extension factory in {file.path} failed: {exc}"
+        raise ExtensionError(msg) from exc
+    finally:
+        api._close()
+
+    middleware, tools, backend_routes, _shutdown_hooks = before
+    return LoadedExtension(
+        path=file.path,
+        source=file.source,
+        middleware=tuple(unit.unit for unit in registry.middleware[middleware:]),
+        tools=tuple(unit.unit for unit in registry.tools[tools:]),
+        backend_routes=tuple(
+            unit.name for unit in registry.backend_routes[backend_routes:]
+        ),
+    )

--- a/libs/code/tests/unit_tests/test_extension_loader.py
+++ b/libs/code/tests/unit_tests/test_extension_loader.py
@@ -1,0 +1,129 @@
+"""Tests for transactional extension import and initialization."""
+
+from pathlib import Path
+
+import pytest
+
+from deepagents_code.extensions import (
+    ExtensionError,
+    ExtensionFile,
+    ExtensionRegistry,
+    SourceInfo,
+    UnitOrigin,
+    UnitScope,
+)
+from deepagents_code.extensions.loader import load_extension
+
+_VALID_EXTENSION = """
+from deepagents.backends import FilesystemBackend
+
+
+def extension(d):
+    def status():
+        \"\"\"Report status.\"\"\"
+        return \"ready\"
+
+    d.register_tool(status)
+    d.register_backend_route(
+        \"/memories/\", FilesystemBackend(virtual_mode=False)
+    )
+    d.on_shutdown(lambda: None)
+"""
+
+_BROKEN_EXTENSION = """
+def extension(d):
+    def partial():
+        \"\"\"Never become visible.\"\"\"
+        return \"partial\"
+
+    d.register_tool(partial)
+    d.on_shutdown(lambda: None)
+    raise RuntimeError(\"boom\")
+"""
+
+
+def _file(path: Path, *, origin: UnitOrigin = UnitOrigin.TOP_LEVEL) -> ExtensionFile:
+    """Build a discovered extension record for a test file."""
+    return ExtensionFile(
+        path=path,
+        source=SourceInfo(path=path, scope=UnitScope.USER, origin=origin),
+    )
+
+
+async def test_loads_registered_units(tmp_path: Path) -> None:
+    """A valid factory should return the units it registered."""
+    path = tmp_path / "valid.py"
+    path.write_text(_VALID_EXTENSION, encoding="utf-8")
+    registry = ExtensionRegistry()
+
+    loaded = await load_extension(
+        _file(path), registry, cwd=tmp_path, mode="interactive"
+    )
+
+    assert [tool.name for tool in loaded.tools] == ["status"]
+    assert loaded.backend_routes == ("/memories/",)
+    assert len(registry.shutdown_hooks) == 1
+
+
+async def test_package_extension_supports_relative_imports(tmp_path: Path) -> None:
+    """Package entry points should resolve sibling helper modules."""
+    package = tmp_path / "package"
+    package.mkdir()
+    (package / "helper.py").write_text("VALUE = 'package-ready'\n", encoding="utf-8")
+    entry = package / "__init__.py"
+    entry.write_text(
+        """
+from .helper import VALUE
+
+
+def extension(d):
+    def package_status():
+        \"\"\"Report package status.\"\"\"
+        return VALUE
+
+    d.register_tool(package_status)
+""",
+        encoding="utf-8",
+    )
+
+    loaded = await load_extension(
+        _file(entry, origin=UnitOrigin.PACKAGE),
+        ExtensionRegistry(),
+        cwd=tmp_path,
+        mode="headless",
+    )
+
+    assert loaded.tools[0].invoke({}) == "package-ready"
+
+
+@pytest.mark.parametrize(
+    ("body", "message"),
+    [
+        ("VALUE = 1\n", "does not define a callable"),
+        ("raise RuntimeError('import boom')\n", "Failed to import"),
+    ],
+)
+async def test_import_failures_are_extension_errors(
+    tmp_path: Path, body: str, message: str
+) -> None:
+    """Invalid modules should fail without leaving registrations."""
+    path = tmp_path / "invalid.py"
+    path.write_text(body, encoding="utf-8")
+
+    with pytest.raises(ExtensionError, match=message):
+        await load_extension(
+            _file(path), ExtensionRegistry(), cwd=tmp_path, mode="interactive"
+        )
+
+
+async def test_failed_factory_rolls_back_partial_state(tmp_path: Path) -> None:
+    """A factory exception should remove its tools and teardown hooks."""
+    path = tmp_path / "broken.py"
+    path.write_text(_BROKEN_EXTENSION, encoding="utf-8")
+    registry = ExtensionRegistry()
+
+    with pytest.raises(ExtensionError, match="boom"):
+        await load_extension(_file(path), registry, cwd=tmp_path, mode="interactive")
+
+    assert registry.is_empty()
+    assert not registry.shutdown_hooks


### PR DESCRIPTION
Related #5556

Python extension factories load deterministically with transactional rollback when import or initialization fails.

---

This is layer 6 of 11. Synchronous work stays off the event loop, asynchronous factories stay on the caller loop, and partial tools, middleware, routes, and shutdown hooks are removed on failure.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.