### PR TITLE
feat(code): orchestrate extension lifecycle

### DIFF
--- a/libs/code/deepagents_code/extensions/__init__.py
+++ b/libs/code/deepagents_code/extensions/__init__.py
@@ -10,6 +10,12 @@ from deepagents_code.extensions.models import (
     UnitScope,
 )
 from deepagents_code.extensions.registry import ExtensionRegistry
+from deepagents_code.extensions.runtime import (
+    ExtensionLoadResult,
+    load_extensions,
+    project_extensions_trusted,
+    shutdown_extensions,
+)
 from deepagents_code.extensions.settings import (
     ExtensionSettings,
     TrustPolicy,
@@ -24,6 +30,7 @@ __all__ = [
     "ExtensionAPI",
     "ExtensionError",
     "ExtensionFile",
+    "ExtensionLoadResult",
     "ExtensionRegistry",
     "ExtensionSettings",
     "LoadedExtension",
@@ -33,5 +40,8 @@ __all__ = [
     "UnitScope",
     "is_project_extensions_trusted",
     "load_extension_settings",
+    "load_extensions",
+    "project_extensions_trusted",
+    "shutdown_extensions",
     "trust_project_extensions",
 ]

--- a/libs/code/deepagents_code/extensions/runtime.py
+++ b/libs/code/deepagents_code/extensions/runtime.py
@@ -1,0 +1,222 @@
+"""Orchestrate extension discovery, trust, loading, and teardown."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from deepagents_code.extensions.discovery import (
+    discover_extension_files,
+    project_extensions_dir,
+)
+from deepagents_code.extensions.loader import load_extension
+from deepagents_code.extensions.models import ExtensionError
+from deepagents_code.extensions.registry import ExtensionRegistry
+from deepagents_code.extensions.settings import (
+    ExtensionSettings,
+    TrustPolicy,
+    load_extension_settings,
+)
+from deepagents_code.extensions.trust import is_project_extensions_trusted
+
+if TYPE_CHECKING:
+    from deepagents_code.extensions.models import ExtensionFile, LoadedExtension
+
+logger = logging.getLogger(__name__)
+
+INTERACTIVE_MODE = "interactive"
+HEADLESS_MODE = "headless"
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionLoadResult:
+    """Outcome of one extension discovery and loading pass."""
+
+    registry: ExtensionRegistry = field(default_factory=ExtensionRegistry)
+    loaded: tuple[LoadedExtension, ...] = ()
+    errors: tuple[str, ...] = ()
+
+
+_server_result: ContextVar[ExtensionLoadResult | None] = ContextVar(
+    "server_extension_result", default=None
+)
+_server_shutdown_registry: ExtensionRegistry | None = None
+
+
+def project_extensions_trusted(
+    project_root: Path | str,
+    *,
+    policy: TrustPolicy,
+    granted: bool = False,
+    store_path: Path | None = None,
+) -> bool:
+    """Resolve whether a project's extension directory may be scanned.
+
+    Args:
+        project_root: Project root under consideration.
+        policy: Default policy when no decision is persisted.
+        granted: Explicit one-run trust decision.
+        store_path: Alternate persisted trust store for tests.
+
+    Returns:
+        `True` only when project extension execution is authorized.
+    """
+    if policy is TrustPolicy.NEVER:
+        return False
+    if granted or policy is TrustPolicy.ALWAYS:
+        return True
+    return is_project_extensions_trusted(project_root, store_path=store_path)
+
+
+def _prepare_extension_load(
+    *,
+    cwd: Path | None,
+    project_root: Path | None,
+    project_trust_granted: bool,
+    settings: ExtensionSettings | None,
+    trust_store_path: Path | None,
+) -> tuple[list[ExtensionFile], Path] | None:
+    """Resolve settings, trust, sources, and cwd without executing code.
+
+    Returns:
+        Files and session cwd, or `None` when loading is disabled or empty.
+    """
+    resolved = load_extension_settings() if settings is None else settings
+    if not resolved.enabled:
+        return None
+
+    trusted_project_dir: Path | None = None
+    if project_root is not None and project_extensions_trusted(
+        project_root,
+        policy=resolved.trust,
+        granted=project_trust_granted,
+        store_path=trust_store_path,
+    ):
+        trusted_project_dir = project_extensions_dir(project_root)
+
+    files = discover_extension_files(
+        extra_paths=resolved.paths,
+        project_dir=trusted_project_dir,
+    )
+    if not files:
+        return None
+    return files, Path.cwd() if cwd is None else Path(cwd)
+
+
+async def load_extensions(
+    *,
+    cwd: Path | None = None,
+    mode: str = INTERACTIVE_MODE,
+    project_root: Path | None = None,
+    project_trust_granted: bool = False,
+    settings: ExtensionSettings | None = None,
+    trust_store_path: Path | None = None,
+) -> ExtensionLoadResult:
+    """Discover and load every authorized extension.
+
+    Args:
+        cwd: Working directory for extension context.
+        mode: Runtime mode, either `interactive` or `headless`.
+        project_root: Project whose extension directory may be considered.
+        project_trust_granted: Explicit one-run project trust decision.
+        settings: Pre-resolved settings; loaded automatically when omitted.
+        trust_store_path: Alternate persisted trust store for tests.
+
+    Returns:
+        Registry plus successful extensions and isolated error messages.
+    """
+    prepared = await asyncio.to_thread(
+        _prepare_extension_load,
+        cwd=cwd,
+        project_root=project_root,
+        project_trust_granted=project_trust_granted,
+        settings=settings,
+        trust_store_path=trust_store_path,
+    )
+    if prepared is None:
+        return ExtensionLoadResult()
+
+    files, session_cwd = prepared
+    registry = ExtensionRegistry()
+    loaded: list[LoadedExtension] = []
+    errors: list[str] = []
+    for file in files:
+        try:
+            loaded.append(
+                await load_extension(file, registry, cwd=session_cwd, mode=mode)
+            )
+        except ExtensionError as exc:
+            logger.warning("Skipping extension %s", file.path, exc_info=True)
+            errors.append(str(exc))
+        except Exception as exc:
+            logger.exception("Unexpected failure loading extension %s", file.path)
+            errors.append(f"{file.path}: {type(exc).__name__}: {exc}")
+
+    return ExtensionLoadResult(
+        registry=registry,
+        loaded=tuple(loaded),
+        errors=tuple(errors),
+    )
+
+
+def bind_server_extensions(
+    result: ExtensionLoadResult,
+) -> Token[ExtensionLoadResult | None]:
+    """Expose a server-loop registry to threaded graph construction.
+
+    Args:
+        result: Extensions initialized on the persistent server loop.
+
+    Returns:
+        Context token used to restore the caller after graph construction.
+    """
+    global _server_shutdown_registry  # noqa: PLW0603
+    _server_shutdown_registry = (
+        result.registry if result.registry.shutdown_hooks else None
+    )
+    return _server_result.set(result)
+
+
+def get_server_extensions() -> ExtensionLoadResult:
+    """Return the bound server extensions or an empty result."""
+    return _server_result.get() or ExtensionLoadResult()
+
+
+def reset_server_extensions(token: Token[ExtensionLoadResult | None]) -> None:
+    """Restore server extension context after graph construction.
+
+    Args:
+        token: Token returned by `bind_server_extensions`.
+    """
+    _server_result.reset(token)
+
+
+async def shutdown_extensions(registry: ExtensionRegistry) -> None:
+    """Run every teardown hook while isolating individual failures.
+
+    Args:
+        registry: Registry whose session resources are ending.
+    """
+    for hook in registry.shutdown_hooks:
+        try:
+            result = hook.unit()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.warning(
+                "Shutdown hook from %s failed", hook.source.label, exc_info=True
+            )
+
+
+async def shutdown_server_extensions() -> None:
+    """Release server-owned extensions on their persistent event loop."""
+    global _server_shutdown_registry  # noqa: PLW0603
+    registry = _server_shutdown_registry
+    _server_shutdown_registry = None
+    if registry is not None:
+        await shutdown_extensions(registry)

--- a/libs/code/tests/unit_tests/test_extension_runtime.py
+++ b/libs/code/tests/unit_tests/test_extension_runtime.py
@@ -1,0 +1,185 @@
+"""Tests for extension loading orchestration and lifecycle."""
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from deepagents_code.extensions import (
+    ExtensionSettings,
+    TrustPolicy,
+    load_extensions,
+    project_extensions_trusted,
+    shutdown_extensions,
+)
+from deepagents_code.extensions.runtime import (
+    bind_server_extensions,
+    get_server_extensions,
+    reset_server_extensions,
+    shutdown_server_extensions,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_user_extensions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep real user extensions out of runtime tests."""
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.user_extensions_dir",
+        lambda: tmp_path / "isolated-user-extensions",
+    )
+
+
+def _write(directory: Path, name: str, body: str) -> Path:
+    """Write one test extension source file."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+async def test_loads_user_and_explicitly_trusted_project_extensions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Project code should join user sources only after explicit trust."""
+    user_dir = tmp_path / "user"
+    project_root = tmp_path / "project"
+    project_dir = project_root / ".deepagents" / "extensions"
+    body = """
+def extension(d):
+    def status():
+        \"\"\"Report extension status.\"\"\"
+        return d.path.stem
+    d.register_tool(status)
+"""
+    _write(user_dir, "user.py", body)
+    _write(project_dir, "project.py", body.replace("status", "project_status"))
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.user_extensions_dir", lambda: user_dir
+    )
+
+    result = await load_extensions(
+        cwd=tmp_path,
+        project_root=project_root,
+        project_trust_granted=True,
+        settings=ExtensionSettings(),
+    )
+
+    assert [unit.name for unit in result.registry.tools] == [
+        "status",
+        "project_status",
+    ]
+    assert not result.errors
+
+
+async def test_untrusted_project_directory_is_not_discovered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The project path must remain absent from discovery until authorized."""
+    from deepagents_code.extensions import runtime
+
+    observed: list[Path | None] = []
+
+    def record_discovery(**kwargs: object) -> list[object]:
+        observed.append(cast("Path | None", kwargs.get("project_dir")))
+        return []
+
+    monkeypatch.setattr(runtime, "discover_extension_files", record_discovery)
+
+    await load_extensions(
+        project_root=tmp_path,
+        settings=ExtensionSettings(trust=TrustPolicy.ASK),
+    )
+
+    assert observed == [None]
+
+
+async def test_bad_extension_does_not_block_later_files(tmp_path: Path) -> None:
+    """Factory failures should be reported without aborting the load pass."""
+    directory = tmp_path / "extensions"
+    _write(directory, "a_broken.py", "raise RuntimeError('boom')\n")
+    _write(
+        directory,
+        "b_valid.py",
+        """
+def extension(d):
+    def status():
+        \"\"\"Report status.\"\"\"
+        return \"ready\"
+    d.register_tool(status)
+""",
+    )
+
+    result = await load_extensions(
+        settings=ExtensionSettings(paths=(directory,)),
+    )
+
+    assert [unit.name for unit in result.registry.tools] == ["status"]
+    assert len(result.errors) == 1
+    assert "boom" in result.errors[0]
+
+
+def test_project_trust_policy_is_fail_closed(tmp_path: Path) -> None:
+    """Never must override grants and ask must require a stored decision."""
+    store = tmp_path / "missing.json"
+
+    assert not project_extensions_trusted(
+        tmp_path, policy=TrustPolicy.NEVER, granted=True, store_path=store
+    )
+    assert project_extensions_trusted(
+        tmp_path, policy=TrustPolicy.ALWAYS, store_path=store
+    )
+    assert not project_extensions_trusted(
+        tmp_path, policy=TrustPolicy.ASK, store_path=store
+    )
+
+
+async def test_shutdown_uses_factory_loop_and_isolates_failures(tmp_path: Path) -> None:
+    """Async resources should initialize and close on the same event loop."""
+    directory = tmp_path / "extensions"
+    _write(
+        directory,
+        "lifecycle.py",
+        """
+import asyncio
+
+
+async def extension(d):
+    loop = asyncio.get_running_loop()
+    d.on_shutdown(lambda: (_ for _ in ()).throw(RuntimeError("ignored")))
+
+    async def shutdown():
+        assert asyncio.get_running_loop() is loop
+    d.on_shutdown(shutdown)
+""",
+    )
+    result = await load_extensions(
+        settings=ExtensionSettings(paths=(directory,)),
+    )
+
+    await shutdown_extensions(result.registry)
+
+
+async def test_server_binding_exposes_and_releases_registry(tmp_path: Path) -> None:
+    """Thread context binding should retain hooks for lifespan teardown."""
+    directory = tmp_path / "extensions"
+    marker = tmp_path / "closed"
+    _write(
+        directory,
+        "lifecycle.py",
+        f"""
+def extension(d):
+    d.on_shutdown(lambda: open({str(marker)!r}, "w").close())
+""",
+    )
+    result = await load_extensions(
+        settings=ExtensionSettings(paths=(directory,)),
+    )
+
+    token = bind_server_extensions(result)
+    try:
+        assert get_server_extensions() is result
+    finally:
+        reset_server_extensions(token)
+    await shutdown_server_extensions()
+
+    assert marker.exists()


### PR DESCRIPTION
Related #5556

The extension runtime isolates factory failures and preserves loop-bound resources through server shutdown.

---

This is layer 7 of 11. Project discovery occurs only after trust resolution, each extension loads independently, and successful shutdown callbacks run on the same persistent event loop used for initialization.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.