### PR TITLE
feat(code): host extensions on the agent server

### DIFF
--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -389,6 +389,9 @@ class ServerConfig:
     """Tri-state trust flag for project-scoped MCP servers: `True`/`False`/`None`
     (prompt user)."""
 
+    trust_project_extensions: bool = False
+    """Whether the project's Python extensions may execute for this run."""
+
     def __post_init__(self) -> None:
         """Normalize fields and validate invariants.
 
@@ -507,6 +510,7 @@ class ServerConfig:
                 if self.trust_project_mcp is not None
                 else None
             ),
+            "TRUST_PROJECT_EXTENSIONS": str(self.trust_project_extensions).lower(),
         }
 
     @classmethod
@@ -557,6 +561,7 @@ class ServerConfig:
             mcp_config_path=_read_env_str("MCP_CONFIG_PATH"),
             no_mcp=_read_env_bool("NO_MCP"),
             trust_project_mcp=_read_env_optional_bool("TRUST_PROJECT_MCP"),
+            trust_project_extensions=_read_env_bool("TRUST_PROJECT_EXTENSIONS"),
         )
 
     # ------------------------------------------------------------------
@@ -593,6 +598,7 @@ class ServerConfig:
         no_mcp: bool,
         trust_project_mcp: bool | None,
         interactive: bool,
+        trust_project_extensions: bool = False,
     ) -> ServerConfig:
         """Build a `ServerConfig` from parsed CLI arguments.
 
@@ -637,6 +643,7 @@ class ServerConfig:
             no_mcp: Disable MCP.
             trust_project_mcp: Trust project MCP servers.
             interactive: Whether the agent is interactive.
+            trust_project_extensions: Allow project extension execution.
 
         Returns:
             A fully resolved `ServerConfig`.
@@ -684,6 +691,7 @@ class ServerConfig:
             mcp_config_path=normalized_mcp,
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
+            trust_project_extensions=trust_project_extensions,
         )
 
 

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -25,7 +25,7 @@ from deepagents.middleware import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Mapping, Sequence
+    from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 
     from deepagents.backends.protocol import BackendProtocol
     from deepagents.backends.sandbox import SandboxBackendProtocol
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from langgraph.store.base import BaseStore
     from langgraph.types import Command
 
+    from deepagents_code.extensions.registry import ExtensionRegistry
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.output import OutputFormat
     from deepagents_code.plugins.adapters.skills import CodeSkillSource
@@ -2195,6 +2196,90 @@ def _apply_inherited_pythonpath(env: dict[str, str]) -> None:
         env["PYTHONPATH"] = inherited
 
 
+def _extension_backend_routes(
+    registry: ExtensionRegistry,
+    *,
+    reserved: Iterable[str],
+) -> dict[str, BackendProtocol]:
+    """Return extension routes that do not overlap internal namespaces.
+
+    Args:
+        registry: Loaded extension registry.
+        reserved: Internal route prefixes that extensions cannot intercept.
+
+    Returns:
+        Safe extension route mapping in registration order.
+    """
+    reserved_prefixes = tuple(reserved)
+    routes: dict[str, BackendProtocol] = {}
+    for route in registry.backend_routes:
+        if any(
+            route.name.startswith(prefix) or prefix.startswith(route.name)
+            for prefix in reserved_prefixes
+        ):
+            logger.warning(
+                "Ignoring extension backend route %r from %s: "
+                "prefix overlaps an internal route",
+                route.name,
+                route.source.label,
+            )
+            continue
+        routes[route.name] = route.unit
+    return routes
+
+
+def _merge_extension_tools(
+    tools: Sequence[BaseTool | Callable | dict[str, Any]],
+    registry: ExtensionRegistry,
+) -> list[BaseTool | Callable | dict[str, Any]]:
+    """Append extension tools without replacing existing names.
+
+    Returns:
+        Existing tools followed by uniquely named extension tools.
+    """
+    merged = list(tools)
+    names = {
+        name
+        for tool in merged
+        if (name := getattr(tool, "name", None) or getattr(tool, "__name__", None))
+    }
+    for registered in registry.tools:
+        if registered.name in names:
+            logger.warning(
+                "Ignoring extension tool %r from %s: name is already in use",
+                registered.name,
+                registered.source.label,
+            )
+            continue
+        merged.append(registered.unit)
+        names.add(registered.name)
+    return merged
+
+
+def _merge_extension_middleware(
+    middleware: Sequence[AgentMiddleware[Any, Any]],
+    registry: ExtensionRegistry,
+) -> list[AgentMiddleware[Any, Any]]:
+    """Append extension middleware without replacing existing names.
+
+    Returns:
+        Existing middleware followed by uniquely named extension middleware.
+    """
+    merged = list(middleware)
+    names = {getattr(item, "name", type(item).__name__) for item in merged}
+    for registered in registry.middleware:
+        if registered.name in names:
+            logger.warning(
+                "Ignoring extension middleware %r from %s: name is already in use",
+                registered.name,
+                registered.source.label,
+            )
+            continue
+        merged.append(registered.unit)
+        names.add(registered.name)
+    return merged
+
+
 def create_cli_agent(
     model: str | BaseChatModel,
     assistant_id: str,
@@ -2402,6 +2487,11 @@ def create_cli_agent(
         if cwd is not None
         else (project_context.user_cwd if project_context is not None else None)
     )
+    from deepagents_code.extensions.runtime import get_server_extensions
+
+    extension_result = get_server_extensions()
+    for message in extension_result.errors:
+        logger.warning("Extension not loaded: %s", message)
 
     # Setup agent directory for persistent memory (if enabled)
     if enable_memory or enable_skills:
@@ -2855,16 +2945,23 @@ def create_cli_agent(
                     virtual_mode=True,
                 )
             )
+        extension_routes = _extension_backend_routes(
+            extension_result.registry,
+            reserved=artifact_routes,
+        )
         composite_backend = CompositeBackend(
             default=backend,
-            routes=artifact_routes,
+            routes={**extension_routes, **artifact_routes},
             artifacts_root=artifacts_root,
         )
     else:
-        # Sandbox mode: No special routing needed
+        extension_routes = _extension_backend_routes(
+            extension_result.registry,
+            reserved=(),
+        )
         composite_backend = CompositeBackend(
             default=backend,
-            routes={},
+            routes=extension_routes,
         )
 
     compaction_middleware = _create_cli_compaction_middleware(model, composite_backend)
@@ -3080,6 +3177,10 @@ def create_cli_agent(
 
     effective_recursion_limit = (
         recursion_limit if recursion_limit is not None else resolve_recursion_limit()
+    )
+    tools = _merge_extension_tools(tools, extension_result.registry)
+    agent_middleware = _merge_extension_middleware(
+        agent_middleware, extension_result.registry
     )
     agent = create_deep_agent(
         model=model,

--- a/libs/code/deepagents_code/client/launch/server.py
+++ b/libs/code/deepagents_code/client/launch/server.py
@@ -182,6 +182,7 @@ def generate_langgraph_json(
     config: dict[str, Any] = {
         "dependencies": ["."],
         "graphs": {"agent": graph_ref},
+        "http": {"app": "deepagents_code.server_lifespan:app"},
     }
     if env_file:
         config["env"] = env_file

--- a/libs/code/deepagents_code/client/launch/server_manager.py
+++ b/libs/code/deepagents_code/client/launch/server_manager.py
@@ -318,6 +318,7 @@ async def start_server_and_get_agent(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
+    trust_project_extensions: bool = False,
     interactive: bool = True,
     host: str = "127.0.0.1",
     port: int = _EPHEMERAL_PORT,
@@ -356,6 +357,7 @@ async def start_server_and_get_agent(
         mcp_config_path: Path to MCP config.
         no_mcp: Disable MCP.
         trust_project_mcp: Trust project MCP servers.
+        trust_project_extensions: Allow project extension execution.
         interactive: Whether the agent is interactive.
         host: Server host.
         port: Server port. Defaults to `_EPHEMERAL_PORT` (0), letting the server
@@ -409,6 +411,7 @@ async def start_server_and_get_agent(
         no_mcp=no_mcp,
         trust_project_mcp=trust_project_mcp,
         interactive=interactive,
+        trust_project_extensions=trust_project_extensions,
     )
     _apply_server_config(config)
 
@@ -492,6 +495,7 @@ async def server_session(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
+    trust_project_extensions: bool = False,
     interactive: bool = True,
     host: str = "127.0.0.1",
     port: int = _EPHEMERAL_PORT,
@@ -533,6 +537,7 @@ async def server_session(
         mcp_config_path: Path to MCP config.
         no_mcp: Disable MCP.
         trust_project_mcp: Trust project MCP servers.
+        trust_project_extensions: Allow project extension execution.
         interactive: Whether the agent is interactive.
         host: Server host.
         port: Server port. Defaults to `_EPHEMERAL_PORT` (0), letting the server
@@ -570,6 +575,7 @@ async def server_session(
             mcp_config_path=mcp_config_path,
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
+            trust_project_extensions=trust_project_extensions,
             interactive=interactive,
             host=host,
             port=port,

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -15,6 +15,7 @@ import asyncio
 import atexit
 import logging
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from deepagents_code._server_config import ServerConfig
@@ -365,7 +366,41 @@ async def _make_graph() -> Any:  # noqa: ANN401
         )
         return agent
 
-    return await asyncio.to_thread(_create_cli_agent_sync)
+    from deepagents_code.extensions import load_extensions
+    from deepagents_code.extensions.runtime import (
+        HEADLESS_MODE,
+        INTERACTIVE_MODE,
+        bind_server_extensions,
+        reset_server_extensions,
+        shutdown_server_extensions,
+    )
+
+    extension_cwd = (
+        project_context.user_cwd
+        if project_context is not None
+        else Path(config.cwd)
+        if config.cwd is not None
+        else None
+    )
+    extension_project_root = (
+        project_context.project_root or project_context.user_cwd
+        if project_context is not None
+        else None
+    )
+    extension_result = await load_extensions(
+        cwd=extension_cwd,
+        mode=INTERACTIVE_MODE if config.interactive else HEADLESS_MODE,
+        project_root=extension_project_root,
+        project_trust_granted=config.trust_project_extensions,
+    )
+    token = bind_server_extensions(extension_result)
+    try:
+        return await asyncio.to_thread(_create_cli_agent_sync)
+    except BaseException:
+        await shutdown_server_extensions()
+        raise
+    finally:
+        reset_server_extensions(token)
 
 
 def _build_graph_factory(

--- a/libs/code/deepagents_code/server_lifespan.py
+++ b/libs/code/deepagents_code/server_lifespan.py
@@ -1,0 +1,26 @@
+"""LangGraph lifespan integration for server-owned extension resources."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from starlette.applications import Starlette
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+@asynccontextmanager
+async def _lifespan(_: Starlette) -> AsyncIterator[None]:
+    """Release extensions before their server event loop closes."""
+    try:
+        yield
+    finally:
+        from deepagents_code.extensions.runtime import shutdown_server_extensions
+
+        await shutdown_server_extensions()
+
+
+app = Starlette(lifespan=_lifespan)
+"""Route-free app merged into the LangGraph server for lifecycle cleanup."""

--- a/libs/code/tests/unit_tests/test_extension_hosting.py
+++ b/libs/code/tests/unit_tests/test_extension_hosting.py
@@ -1,0 +1,104 @@
+"""Tests for merging extension units into the dcode agent."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from deepagents.backends import FilesystemBackend
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.tools import tool
+
+from deepagents_code.agent import (
+    _extension_backend_routes,
+    _merge_extension_middleware,
+    _merge_extension_tools,
+)
+from deepagents_code.extensions import (
+    ExtensionRegistry,
+    SourceInfo,
+    UnitOrigin,
+    UnitScope,
+)
+
+
+def _source() -> SourceInfo:
+    """Build provenance for the hosting tests."""
+    return SourceInfo(
+        path=Path("/extensions/example.py"),
+        scope=UnitScope.USER,
+        origin=UnitOrigin.TOP_LEVEL,
+    )
+
+
+@tool("existing")
+def _existing_tool() -> str:
+    """Represent an existing dcode tool."""
+    return "existing"
+
+
+@tool("unique")
+def _unique_tool() -> str:
+    """Represent a unique extension tool."""
+    return "unique"
+
+
+class _ExistingMiddleware(AgentMiddleware):
+    """Represent middleware already installed by dcode."""
+
+    name = "existing"
+
+
+class _UniqueMiddleware(AgentMiddleware):
+    """Represent unique extension middleware."""
+
+    name = "unique"
+
+
+def test_internal_backend_namespaces_reject_overlapping_routes() -> None:
+    """Extensions must not intercept any part of an internal route tree."""
+    registry = ExtensionRegistry()
+    source = _source()
+    reserved_child = FilesystemBackend(virtual_mode=False)
+    reserved_parent = FilesystemBackend(virtual_mode=False)
+    safe = FilesystemBackend(virtual_mode=False)
+    registry.add_backend_route("/artifacts/messages/private/", reserved_child, source)
+    registry.add_backend_route("/artifacts/", reserved_parent, source)
+    registry.add_backend_route("/memories/", safe, source)
+
+    routes = _extension_backend_routes(
+        registry,
+        reserved=["/artifacts/messages/"],
+    )
+
+    assert routes == {"/memories/": safe}
+
+
+def test_builtin_tool_and_middleware_names_take_precedence() -> None:
+    """Extension units should append only when their names remain available."""
+    registry = ExtensionRegistry()
+    source = _source()
+    registry.add_tool(_existing_tool, source)
+    registry.add_tool(_unique_tool, source)
+    registry.add_middleware(_ExistingMiddleware(), source)
+    registry.add_middleware(_UniqueMiddleware(), source)
+
+    tools = _merge_extension_tools([_existing_tool], registry)
+    middleware = _merge_extension_middleware([_ExistingMiddleware()], registry)
+
+    assert tools == [_existing_tool, _unique_tool]
+    assert [item.name for item in middleware] == ["existing", "unique"]
+
+
+async def test_server_lifespan_releases_extensions() -> None:
+    """LangGraph shutdown should await server-owned extension teardown."""
+    from starlette.applications import Starlette
+
+    from deepagents_code.server_lifespan import _lifespan
+
+    shutdown = AsyncMock()
+    with patch(
+        "deepagents_code.extensions.runtime.shutdown_server_extensions", shutdown
+    ):
+        async with _lifespan(Starlette()):
+            pass
+
+    shutdown.assert_awaited_once_with()

--- a/libs/code/tests/unit_tests/test_server_config.py
+++ b/libs/code/tests/unit_tests/test_server_config.py
@@ -352,6 +352,18 @@ class TestInterpreterSuppressedBySandbox:
 
 
 class TestServerConfigEdgeCases:
+    def test_trust_project_extensions_round_trips(self) -> None:
+        """Project extension trust must reach the isolated server process."""
+        original = ServerConfig(trust_project_extensions=True)
+        env_dict = original.to_env()
+        with patch.dict(os.environ, {}, clear=True):
+            for suffix, value in env_dict.items():
+                if value is not None:
+                    os.environ[f"{SERVER_ENV_PREFIX}{suffix}"] = value
+            restored = ServerConfig.from_env()
+
+        assert restored.trust_project_extensions is True
+
     def test_trust_project_mcp_false_round_trips(self) -> None:
         """False must survive round-trip (not collapse to None)."""
         original = ServerConfig(trust_project_mcp=False)

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -13,6 +13,13 @@ import pytest
 
 from deepagents_code._env_vars import SERVER_ENV_PREFIX
 from deepagents_code._server_config import ServerConfig
+from deepagents_code.extensions.runtime import ExtensionLoadResult
+
+
+@pytest.fixture(autouse=True)
+def _disable_extensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep user extension code out of server graph unit tests."""
+    monkeypatch.setenv("DEEPAGENTS_CODE_EXTENSIONS", "0")
 
 
 def _import_fresh_server_graph() -> ModuleType:
@@ -221,6 +228,7 @@ class TestServerGraph:
 
         config = ServerConfig(
             no_mcp=False,
+            trust_project_extensions=True,
             profile_overrides={"max_input_tokens": 32000},
             # Non-default allowlist so the `fs_tools=` assertion below is
             # load-bearing: it round-trips through `to_env()`/`from_env()` and
@@ -234,6 +242,7 @@ class TestServerGraph:
             if value is not None:
                 env_overrides[f"{SERVER_ENV_PREFIX}{suffix}"] = value
 
+        load_extensions = AsyncMock(return_value=ExtensionLoadResult())
         with (
             patch.dict(os.environ, env_overrides, clear=False),
             patch.dict(
@@ -253,6 +262,10 @@ class TestServerGraph:
                 "deepagents_code.plugins.adapters.mcp.discover_plugin_mcp_configs",
                 return_value=(),
             ),
+            patch(
+                "deepagents_code.extensions.load_extensions",
+                load_extensions,
+            ),
         ):
             for suffix in (
                 "MCP_CONFIG_PATH",
@@ -269,6 +282,12 @@ class TestServerGraph:
         configure_redaction.assert_called_once_with()
         reload_from_environment.assert_called_once_with(start_path=user_cwd)
         resolve_mcp_tools.assert_awaited_once()
+        load_extensions.assert_awaited_once_with(
+            cwd=user_cwd,
+            mode="interactive",
+            project_root=project_context.project_root,
+            project_trust_granted=True,
+        )
         assert create_cli_agent_thread_ids
         assert create_cli_agent_thread_ids[0] != loop_thread_id
         # Project-context resolution and the settings bootstrap must run off the

--- a/libs/code/tests/unit_tests/test_server_manager.py
+++ b/libs/code/tests/unit_tests/test_server_manager.py
@@ -549,6 +549,7 @@ class TestStartServerAndGetAgent:
         config = json.loads((tmp_path / "langgraph.json").read_text())
         assert config["graphs"]["agent"] == "./server_graph.py:make_graph"
         assert config["checkpointer"]["path"] == "./checkpointer.py:create_checkpointer"
+        assert config["http"]["app"] == "deepagents_code.server_lifespan:app"
 
 
 class TestWritePyproject:


### PR DESCRIPTION
Related #5556

The agent server applies extension middleware and tools and mounts configurable virtual filesystem backends.

---

This is layer 8 of 11. Registered backend routes are merged into CompositeBackend while shell execution remains attached to the default backend. Built-in tools and middleware win name collisions, internal route overlaps are rejected, and extension lifecycle work runs inside the LangGraph server lifespan.

This implements the revised customer requirement for StoreBackend-backed shared memory routes without introducing custom slash commands.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.