### PR TITLE
feat(code): gate project extension execution

### DIFF
--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -1872,6 +1872,7 @@ async def run_non_interactive(
     rubric_max_iterations: int | None = None,
     recursion_limit: int | None = None,
     trust_project_hooks: bool = False,
+    trust_project_extensions: bool = False,
 ) -> int:
     """Run a single task non-interactively and exit.
 
@@ -1953,6 +1954,10 @@ async def run_non_interactive(
 
             Defaults to `False` so untrusted repositories cannot execute hook
             commands without an explicit `--trust-project-hooks` opt-in.
+        trust_project_extensions: Allow project-authored Python extensions.
+
+            Defaults to `False`; persisted or configured trust may still grant
+            project loading inside the server.
 
     Returns:
         Exit code: 0 for success or an intentional hook stop, 1 for error, 124
@@ -2200,6 +2205,7 @@ async def run_non_interactive(
             mcp_config_path=mcp_config_path,
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
+            trust_project_extensions=trust_project_extensions,
             interactive=False,
         ) as (agent, _server_proc):
             # Collect MCP preload result (ran concurrently with server startup)

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2379,6 +2379,12 @@ def parse_args() -> argparse.Namespace:
         "(required for headless/CI runs that should load repository hooks)",
     )
     parser.add_argument(
+        "--trust-project-extensions",
+        action="store_true",
+        help="Trust project-level `.deepagents/extensions/` Python extensions "
+        "(required for headless/CI runs without persisted trust)",
+    )
+    parser.add_argument(
         "--interpreter",
         action=argparse.BooleanOptionalAction,
         default=None,
@@ -2636,6 +2642,7 @@ async def run_textual_cli_async(
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
     hook_trust: "WorkspaceTrust | None" = None,
+    trust_project_extensions: bool = False,
     enable_interpreter: bool | None = None,
     interpreter_arg: bool | None = None,
     interpreter_ptc: str | list[str] | None = None,
@@ -2697,6 +2704,8 @@ async def run_textual_cli_async(
             whole-config decision).
         hook_trust: Policy deciding which workspaces may run project-scoped hook
             commands. `None` consults only the persisted trust store.
+        trust_project_extensions: Allow project-authored Python extensions for
+            this session.
         enable_interpreter: Enable `CodeInterpreterMiddleware` (`js_eval`) on
             the main agent. `None` defers to the sandbox-aware/config default.
         interpreter_arg: The raw `--interpreter`/`--no-interpreter` tri-state,
@@ -2842,6 +2851,7 @@ async def run_textual_cli_async(
         "mcp_config_path": mcp_config_path,
         "no_mcp": no_mcp,
         "trust_project_mcp": trust_project_mcp,
+        "trust_project_extensions": trust_project_extensions,
         "interactive": True,
         "recursion_limit": recursion_limit,
     }
@@ -4224,6 +4234,102 @@ def _check_project_hooks_trust(
     return WorkspaceTrust.none()
 
 
+_PROJECT_EXTENSIONS_REMEMBER_LABEL = "Always allow extensions in this project"
+
+
+def _check_project_extensions_trust(
+    *,
+    trust_flag: bool = False,
+) -> "bool | _TrustPromptOutcome":
+    """Resolve interactive trust for project-authored Python extensions.
+
+    Args:
+        trust_flag: Whether the CLI explicitly trusted project extensions.
+
+    Returns:
+        Whether project extensions may load, `INTERRUPTED` on Ctrl+C, or
+            `CANCELLED` when startup is aborted.
+    """
+    from rich.console import Console
+
+    from deepagents_code.extensions.discovery import project_extensions_dir
+    from deepagents_code.extensions.settings import (
+        TrustPolicy,
+        load_extension_settings,
+    )
+    from deepagents_code.extensions.trust import (
+        is_project_extensions_trusted,
+        trust_project_extensions,
+    )
+    from deepagents_code.project_utils import ProjectContext
+
+    settings = load_extension_settings()
+    if not settings.enabled or settings.trust is TrustPolicy.NEVER:
+        return False
+
+    try:
+        context = ProjectContext.from_user_cwd(Path.cwd())
+        project_root = context.project_root or context.user_cwd
+        extensions_dir = project_extensions_dir(project_root)
+        if not extensions_dir.is_dir():
+            return False
+    except OSError:
+        logger.warning("Could not inspect project extensions", exc_info=True)
+        return False
+
+    if (
+        trust_flag
+        or settings.trust is TrustPolicy.ALWAYS
+        or is_project_extensions_trusted(project_root)
+    ):
+        return True
+
+    from rich.markup import escape
+
+    console = Console(stderr=True)
+    console.print()
+    console.print(
+        "[bold yellow]Project extensions run arbitrary Python in this "
+        "session.[/bold yellow]",
+        highlight=False,
+    )
+    console.print(
+        f"Extensions directory: {escape(str(extensions_dir))}", highlight=False
+    )
+    console.print(
+        "Only trust projects you control. Allow once loads these files as they "
+        f'are now; always allow trusts "{escape(str(project_root))}" for future '
+        "sessions and future edits.",
+        style="yellow",
+        highlight=False,
+    )
+    action = _select_trust_action(
+        console,
+        remember_label=_PROJECT_EXTENSIONS_REMEMBER_LABEL,
+    )
+    if action in {
+        _TrustPromptOutcome.INTERRUPTED,
+        _TrustPromptOutcome.CANCELLED,
+    }:
+        return action
+    if action is _TrustAction.ALLOW_ONCE:
+        console.print(
+            "[dim]Allowing project extensions for this session.[/dim]",
+            highlight=False,
+        )
+        return True
+    if action is _TrustAction.REMEMBER:
+        if not trust_project_extensions(project_root):
+            console.print(
+                "[yellow]Extension trust could not be remembered; allowing "
+                "this session only.[/yellow]",
+                highlight=False,
+            )
+        return True
+    console.print("[dim]Project extensions skipped.[/dim]", highlight=False)
+    return False
+
+
 def _verify_interpreter_or_exit() -> None:
     """Run the interpreter pre-flight check; print and exit on failure.
 
@@ -5173,6 +5279,9 @@ def cli_main() -> None:
                             trust_project_hooks=getattr(
                                 args, "trust_project_hooks", False
                             ),
+                            trust_project_extensions=getattr(
+                                args, "trust_project_extensions", False
+                            ),
                             enable_interpreter=enable_interpreter,
                             interpreter_ptc=interpreter_ptc,
                             allow_fs_tools=allow_fs_tools,
@@ -5287,6 +5396,20 @@ def cli_main() -> None:
                 )
                 return
 
+            extensions_trust = _check_project_extensions_trust(
+                trust_flag=getattr(args, "trust_project_extensions", False),
+            )
+            if extensions_trust is _TrustPromptOutcome.INTERRUPTED:
+                sys.exit(130)
+            if extensions_trust is _TrustPromptOutcome.CANCELLED:
+                from rich.console import Console as _Console
+
+                _Console(stderr=True).print(
+                    "[dim]Aborted; project extensions not loaded.[/dim]",
+                    highlight=False,
+                )
+                return
+
             # Run Textual TUI
             return_code = 0
             request_count = 0
@@ -5341,6 +5464,7 @@ def cli_main() -> None:
                         no_mcp=getattr(args, "no_mcp", False),
                         trust_project_mcp=mcp_trust_decision,
                         hook_trust=hook_trust,
+                        trust_project_extensions=bool(extensions_trust),
                         enable_interpreter=enable_interpreter,
                         interpreter_arg=args.interpreter,
                         interpreter_ptc=interpreter_ptc,

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -186,6 +186,9 @@ def show_help() -> None:
         "  --trust-project-hooks      Trust project hooks.json command handlers"
     )
     console.print(
+        "  --trust-project-extensions Trust project .deepagents/extensions Python"
+    )
+    console.print(
         "  --interpreter, --no-interpreter"
         "  Enable or disable JS interpreter (`js_eval`) middleware"
     )

--- a/libs/code/tests/unit_tests/test_extension_cli_trust.py
+++ b/libs/code/tests/unit_tests/test_extension_cli_trust.py
@@ -1,0 +1,100 @@
+"""Tests for interactive project extension trust decisions."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from deepagents_code.extensions import ExtensionSettings, TrustPolicy
+from deepagents_code.main import (
+    _check_project_extensions_trust,
+    _TrustAction,
+    _TrustPromptOutcome,
+)
+
+
+def _project(tmp_path: Path) -> SimpleNamespace:
+    """Create a project context containing an extensions directory."""
+    (tmp_path / ".deepagents" / "extensions").mkdir(parents=True)
+    return SimpleNamespace(project_root=tmp_path, user_cwd=tmp_path)
+
+
+def test_never_policy_overrides_explicit_flag(tmp_path: Path) -> None:
+    """A user-level never policy should remain a hard stop."""
+    context = _project(tmp_path)
+    with (
+        patch(
+            "deepagents_code.extensions.settings.load_extension_settings",
+            return_value=ExtensionSettings(trust=TrustPolicy.NEVER),
+        ),
+        patch(
+            "deepagents_code.project_utils.ProjectContext.from_user_cwd",
+            return_value=context,
+        ),
+    ):
+        assert not _check_project_extensions_trust(trust_flag=True)
+
+
+def test_allow_once_grants_current_session(tmp_path: Path) -> None:
+    """An allow-once response should grant without persisting."""
+    context = _project(tmp_path)
+    with (
+        patch(
+            "deepagents_code.project_utils.ProjectContext.from_user_cwd",
+            return_value=context,
+        ),
+        patch(
+            "deepagents_code.extensions.trust.is_project_extensions_trusted",
+            return_value=False,
+        ),
+        patch(
+            "deepagents_code.main._select_trust_action",
+            return_value=_TrustAction.ALLOW_ONCE,
+        ),
+    ):
+        assert _check_project_extensions_trust() is True
+
+
+def test_remember_persists_project_trust(tmp_path: Path) -> None:
+    """The remember response should write the canonical project decision."""
+    context = _project(tmp_path)
+    with (
+        patch(
+            "deepagents_code.project_utils.ProjectContext.from_user_cwd",
+            return_value=context,
+        ),
+        patch(
+            "deepagents_code.extensions.trust.is_project_extensions_trusted",
+            return_value=False,
+        ),
+        patch(
+            "deepagents_code.extensions.trust.trust_project_extensions",
+            return_value=True,
+        ) as trust,
+        patch(
+            "deepagents_code.main._select_trust_action",
+            return_value=_TrustAction.REMEMBER,
+        ),
+    ):
+        assert _check_project_extensions_trust() is True
+
+    trust.assert_called_once_with(tmp_path)
+
+
+def test_cancel_propagates_to_startup(tmp_path: Path) -> None:
+    """Cancelling the selector should abort rather than silently deny."""
+    context = _project(tmp_path)
+    with (
+        patch(
+            "deepagents_code.project_utils.ProjectContext.from_user_cwd",
+            return_value=context,
+        ),
+        patch(
+            "deepagents_code.extensions.trust.is_project_extensions_trusted",
+            return_value=False,
+        ),
+        patch(
+            "deepagents_code.main._select_trust_action",
+            return_value=_TrustPromptOutcome.CANCELLED,
+        ),
+    ):
+        assert _check_project_extensions_trust() is _TrustPromptOutcome.CANCELLED


### PR DESCRIPTION
Related #5556

Interactive launches ask before executing project extensions, while headless launches require explicit trust.

---

This is layer 9 of 11. The CLI supports one-run trust, remembered trust, and configured always or never policies, and forwards the resolved decision to the server process.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.