### PR TITLE
feat(code): catalog extension configuration

### DIFF
--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -141,7 +141,7 @@ class OptionKind(Enum):
     All kinds flow through `resolve_scalar`. The scalar kinds (`BOOL`,
     `BOOL_MODE_DEFAULT`, `BOOL_PRESENCE`, `INT`, `NON_NEGATIVE_INT`, `FLOAT`,
     `STR`, and `NON_EMPTY_STR`) are coerced inline by `_coerce_env`/`_coerce_toml`.
-    `LOG_LEVEL_DELEGATE`, `SHELL_LIST_DELEGATE`,
+    `LOG_LEVEL_DELEGATE`, `SHELL_LIST_DELEGATE`, `EXTENSION_TRUST_DELEGATE`,
     `SKILLS_DIRS_DELEGATE`, `PTC_DELEGATE`, and `STARTUP_MODE_DELEGATE` defer to
     bespoke parsers (their semantics — dynamic debug fallback, colon-split Path
     resolution, comma + `recommended`/`all` sentinels, and the PTC/startup-mode
@@ -174,6 +174,9 @@ class OptionKind(Enum):
 
     NON_EMPTY_STR = "non_empty_str"
     """A string stripped of surrounding whitespace; blank values are unset."""
+
+    EXTENSION_TRUST_DELEGATE = "extension_trust"
+    """Validates the `ask`, `always`, and `never` extension trust policies."""
 
     LOG_LEVEL_DELEGATE = "log_level"
     """Validates log levels and resolves the default from debug mode."""
@@ -209,6 +212,7 @@ _KIND_TYPE_LABEL: dict[OptionKind, str] = {
     OptionKind.FLOAT: "float",
     OptionKind.STR: "str",
     OptionKind.NON_EMPTY_STR: "non-empty str",
+    OptionKind.EXTENSION_TRUST_DELEGATE: "str",
     OptionKind.LOG_LEVEL_DELEGATE: "str",
     OptionKind.SHELL_LIST_DELEGATE: "list[str]",
     OptionKind.SKILLS_DIRS_DELEGATE: "list[path]",
@@ -543,6 +547,14 @@ def _coerce_env(option: ConfigOption, raw: str, name: str) -> object:
             return value
         logger.warning("Ignoring %s=%r (expected non-empty string)", name, raw)
         return _INVALID
+    if kind is OptionKind.EXTENSION_TRUST_DELEGATE:
+        from deepagents_code.extensions.settings import parse_trust_policy
+
+        policy = parse_trust_policy(raw)
+        if policy is not None:
+            return policy.value
+        logger.warning("Ignoring %s=%r (expected ask, always, or never)", name, raw)
+        return _INVALID
     if kind is OptionKind.LOG_LEVEL_DELEGATE:
         from deepagents_code._debug import LOG_LEVELS
 
@@ -659,6 +671,12 @@ def _coerce_toml(option: ConfigOption, raw: object) -> object:
     elif kind is OptionKind.NON_EMPTY_STR:
         if isinstance(raw, str) and (value := raw.strip()):
             return value
+    elif kind is OptionKind.EXTENSION_TRUST_DELEGATE:
+        from deepagents_code.extensions.settings import parse_trust_policy
+
+        policy = parse_trust_policy(raw)
+        if policy is not None:
+            return policy.value
     elif kind is OptionKind.SKILLS_DIRS_DELEGATE:
         if isinstance(raw, list):
             from deepagents_code.config import _parse_extra_skills_dirs
@@ -1769,6 +1787,35 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         kind=OptionKind.STR,
         env_var=_env_vars.EXTERNAL_EVENT_SOCKET_PATH,
     ),
+    # --- Extensions -----------------------------------------------------
+    ConfigOption(
+        key="extensions.enabled",
+        group="Extensions",
+        summary="Enable loading local Python extensions.",
+        kind=OptionKind.BOOL,
+        default=True,
+        env_var=_env_vars.EXTENSIONS,
+        toml_keys=("extensions", "enabled"),
+    ),
+    ConfigOption(
+        key="extensions.paths",
+        group="Extensions",
+        summary=(
+            "Additional extension files or directories; the environment "
+            "override uses the platform path separator."
+        ),
+        kind=OptionKind.STRUCTURED,
+        toml_keys=("extensions", "paths"),
+    ),
+    ConfigOption(
+        key="extensions.trust",
+        group="Extensions",
+        summary="Default project extension trust policy.",
+        kind=OptionKind.EXTENSION_TRUST_DELEGATE,
+        default="ask",
+        env_var=_env_vars.EXTENSIONS_TRUST,
+        toml_keys=("extensions", "trust"),
+    ),
     # --- Goals ----------------------------------------------------------
     ConfigOption(
         key="goals.auto_accept_criteria",
@@ -2174,6 +2221,8 @@ NON_OPTION_ENV_VARS: frozenset[str] = frozenset(
         # Set then popped during the self-update restart handshake (main.py);
         # never user-configured.
         _env_vars.RESTARTED_AFTER_UPDATE,
+        # Platform-separated list parsed by the extension settings loader.
+        _env_vars.EXTENSIONS_PATHS,
         # Env equivalents of the STRUCTURED `[mcp]` lists. They are read by the
         # dedicated `model_config.load_mcp_server_trust_lists` loader (which the
         # `mcp.*` STRUCTURED options describe for discovery), not by the scalar

--- a/libs/code/tests/unit_tests/test_extension_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_extension_config_manifest.py
@@ -1,0 +1,43 @@
+"""Tests for extension entries in the configuration catalog."""
+
+from unittest.mock import patch
+
+from deepagents_code._env_vars import EXTENSIONS, EXTENSIONS_PATHS, EXTENSIONS_TRUST
+from deepagents_code.config_manifest import (
+    NON_OPTION_ENV_VARS,
+    OptionKind,
+    get_option,
+    resolve_scalar,
+)
+
+
+def test_extension_options_are_cataloged() -> None:
+    """The config CLI should describe every user-facing extension setting."""
+    enabled = get_option("extensions.enabled")
+    paths = get_option("extensions.paths")
+    trust = get_option("extensions.trust")
+
+    assert enabled is not None
+    assert enabled.kind is OptionKind.BOOL
+    assert paths is not None
+    assert paths.kind is OptionKind.STRUCTURED
+    assert trust is not None
+    assert trust.kind is OptionKind.EXTENSION_TRUST_DELEGATE
+    assert EXTENSIONS_PATHS in NON_OPTION_ENV_VARS
+
+
+def test_invalid_env_values_match_runtime_fallback() -> None:
+    """Malformed overrides should fall through to typed TOML values."""
+    enabled = get_option("extensions.enabled")
+    trust = get_option("extensions.trust")
+    assert enabled is not None
+    assert trust is not None
+    toml = {"extensions": {"enabled": False, "trust": "never"}}
+
+    with patch.dict(
+        "os.environ",
+        {EXTENSIONS: "maybe", EXTENSIONS_TRUST: "sometimes"},
+        clear=False,
+    ):
+        assert resolve_scalar(enabled, toml_data=toml) == (False, "config.toml")
+        assert resolve_scalar(trust, toml_data=toml) == ("never", "config.toml")


### PR DESCRIPTION
Related #5556

Extension enablement, source paths, and trust policy appear in dcode configuration discovery and validation.

---

This is layer 10 of 11. The catalog delegates trust-policy validation to the extension settings parser so CLI and runtime configuration accept the same values.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.