### PR TITLE
docs(code): document Python extensions

### DIFF
--- a/libs/code/ARCHITECTURE.md
+++ b/libs/code/ARCHITECTURE.md
@@ -47,6 +47,7 @@ The main extension points are:
 - **Tools and MCP servers** for external capabilities
 - **Sandboxes** for changing where tool execution happens
 - **Hooks and commands** for integrating with local workflows
+- **Python extensions** for middleware, tools, and virtual backend routes
 
 These pieces are designed to compose. A project can provide shared defaults and integrations, while each user can layer personal configuration on top.
 
@@ -67,6 +68,7 @@ The main cost is the client/server boundary. When debugging, first decide which 
 - For local setup and debugging, see [`DEVELOPMENT.md`](./DEVELOPMENT.md).
 - For command behavior, see [`COMMANDS.md`](./COMMANDS.md).
 - For lifecycle hooks (`hooks.json`), see [`HOOKS.md`](./HOOKS.md).
+- For server-side Python extensions, see [`EXTENSIONS.md`](./EXTENSIONS.md).
 - For cost estimates and local pricing overrides (`prices.json`), see
   [`PRICING.md`](./PRICING.md).
 - For security boundaries, see [`THREAT_MODEL.md`](./THREAT_MODEL.md).

--- a/libs/code/EXTENSIONS.md
+++ b/libs/code/EXTENSIONS.md
@@ -1,0 +1,110 @@
+# Python extensions
+
+Python extensions customize the agent server without modifying `dcode`. An
+extension is a Python file or package exposing one factory:
+
+```python
+from deepagents.backends import StoreBackend
+from deepagents_code.extensions import ExtensionAPI
+
+
+def extension(d: ExtensionAPI) -> None:
+    """Mount shared agent memory.
+
+    Args:
+        d: The factory-scoped extension API.
+    """
+    d.register_backend_route(
+        "/memories/",
+        StoreBackend(namespace=lambda _runtime: ("filesystem",)),
+    )
+```
+
+Place the file in `~/.deepagents/extensions/` and restart `dcode`. Filesystem
+operations under `/memories/` now use the LangGraph store, so they persist
+across threads. A custom `BackendProtocol` can use Postgres or another shared
+store while keeping the same route contract.
+
+## Supported registrations
+
+| Method | Purpose |
+| --- | --- |
+| `register_middleware(class_or_instance)` | Add LangChain `AgentMiddleware`. Classes must have a zero-argument constructor; use an instance otherwise. |
+| `register_tool(function_or_tool)` | Expose a callable or `BaseTool` to the model. |
+| `register_backend_route(prefix, backend)` | Mount a `BackendProtocol` under a virtual filesystem prefix. |
+| `on_shutdown(callback)` | Release session resources when the agent server stops. Sync and async callbacks are supported. |
+
+Registration is allowed only while `extension(d)` runs. The factory itself may
+be synchronous or asynchronous. Async initialization and shutdown run on the
+same persistent server event loop, so loop-bound clients remain valid for the
+session.
+
+The API deliberately exposes read-only session context (`d.cwd`, `d.mode`, and
+`d.path`), not mutable TUI or thread state. Custom slash commands are not part
+of this API.
+
+## Backend routes
+
+Route prefixes are lowercase absolute paths with leading and trailing slashes,
+for example `/memories/` or `/company/knowledge/`. Traversal, empty segments,
+backslashes, URL query/fragment syntax, and overlaps with dcode's internal
+routes are rejected.
+
+Routed content is available through the model's filesystem tools. Shell
+`execute` remains attached to the default local or sandbox backend, so shell
+commands cannot see virtual route contents.
+
+The first extension registration of a route prefix wins. Built-in tools,
+middleware, and internal backend routes always take precedence over extension
+units with conflicting names or paths.
+
+## Discovery and trust
+
+Sources load in this order; files within each directory load alphabetically:
+
+| Source | Trust behavior |
+| --- | --- |
+| `~/.deepagents/extensions/` | User-controlled; loaded directly. |
+| `[extensions].paths` | Explicitly configured by the user; loaded directly. |
+| `.deepagents/extensions/` | Project-controlled; never scanned before trust. |
+
+A directory scan is shallow. Direct `*.py` files are extensions. A direct
+subdirectory is a package extension when it contains `__init__.py` or
+`extension.py`; helper modules below that package are normal imports.
+
+Project extensions execute arbitrary Python with the user's process privileges.
+Interactive launches ask before loading them and can remember the canonical
+project path. Headless or CI launches can opt in for one run with
+`--trust-project-extensions`. Only trust projects you control.
+
+## Configuration
+
+```toml
+# ~/.deepagents/config.toml
+[extensions]
+enabled = true
+paths = ["~/work/dcode-extensions", "~/scratch/one-off.py"]
+trust = "ask"  # ask | always | never
+```
+
+Environment overrides:
+
+- `DEEPAGENTS_CODE_EXTENSIONS` enables or disables all extension loading.
+- `DEEPAGENTS_CODE_EXTENSIONS_PATHS` replaces `paths` using the platform path
+  separator (`:` on POSIX and `;` on Windows).
+- `DEEPAGENTS_CODE_EXTENSIONS_TRUST` overrides the project trust policy.
+
+## Failure and security behavior
+
+Each factory is transactional. If import or initialization fails, all of that
+extension's partial registrations are removed and later extensions still load.
+Failures are written to the debug log.
+
+Extension tools are appended after built-in tools and are not automatically
+added to dcode's human-approval map. An extension that performs sensitive work
+must enforce its own approval or policy through middleware. Backend routes can
+expose persistent or shared data to model filesystem operations; choose
+namespaces that maintain the tenant or user isolation your deployment needs.
+
+See `examples/extensions/` for tools, middleware, lifecycle hooks, and a shared
+memory route.

--- a/libs/code/THREAT_MODEL.md
+++ b/libs/code/THREAT_MODEL.md
@@ -28,6 +28,7 @@
 - Custom subagent loader (`subagents.py`, `agent.py:load_async_subagents`)
 - Conversation offload (`offload.py`)
 - Skill management (`skills/commands.py`)
+- Python extension loading (`extensions/`)
 
 ### Out of Scope
 
@@ -50,6 +51,7 @@
 6. The LangGraph dev server subprocess binds to `127.0.0.1` by default (`client/launch/server.py:_DEFAULT_HOST`) and is ephemeral — started and stopped per CLI session.
 7. `DA_SERVER_*` environment variables are readable only by the CLI process and its child server subprocess (OS process isolation assumption).
 8. Users who set `class_path` in `config.toml` accept the same trust model as `pyproject.toml` build scripts — they control their own machine.
+9. User extension paths are trusted as user configuration. Project extensions execute only after explicit, configured, or persisted trust.
 
 ---
 

--- a/libs/code/examples/extensions/memory_store.py
+++ b/libs/code/examples/extensions/memory_store.py
@@ -1,0 +1,22 @@
+"""Reference extension: persistent memory through a virtual backend route."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deepagents.backends import StoreBackend
+
+if TYPE_CHECKING:
+    from deepagents_code.extensions import ExtensionAPI
+
+
+def extension(d: ExtensionAPI) -> None:
+    """Mount LangGraph store data under `/memories/`.
+
+    Args:
+        d: The dcode extension API.
+    """
+    d.register_backend_route(
+        "/memories/",
+        StoreBackend(namespace=lambda _runtime: ("filesystem",)),
+    )

--- a/libs/code/examples/extensions/scratchpad.py
+++ b/libs/code/examples/extensions/scratchpad.py
@@ -1,0 +1,37 @@
+"""Reference extension: session-scoped tools with deterministic teardown."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deepagents_code.extensions import ExtensionAPI
+
+
+def extension(d: ExtensionAPI) -> None:
+    """Register an in-memory scratchpad.
+
+    Args:
+        d: The dcode extension API.
+    """
+    notes: list[str] = []
+
+    def remember_note(note: str) -> str:
+        """Save a note for this server session.
+
+        Args:
+            note: Text to remember.
+
+        Returns:
+            Confirmation with the updated note count.
+        """
+        notes.append(note)
+        return f"Saved {len(notes)} note(s)."
+
+    def read_notes() -> str:
+        """Return the session scratchpad."""
+        return "\n".join(notes) if notes else "The scratchpad is empty."
+
+    d.register_tool(remember_note)
+    d.register_tool(read_notes)
+    d.on_shutdown(notes.clear)

--- a/libs/code/examples/extensions/tool_counter.py
+++ b/libs/code/examples/extensions/tool_counter.py
@@ -1,0 +1,52 @@
+"""Reference extension: middleware around agent tool calls."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import AgentMiddleware
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from langchain.agents.middleware.types import ToolCallRequest
+    from langchain_core.messages import ToolMessage
+    from langgraph.types import Command
+
+    from deepagents_code.extensions import ExtensionAPI
+
+
+class ToolCounter(AgentMiddleware):
+    """Count tool calls without changing their results."""
+
+    name = "ToolCounter"
+
+    def __init__(self) -> None:
+        """Initialize the tool-call count."""
+        self.count = 0
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Count and forward one tool call.
+
+        Args:
+            request: Pending tool call.
+            handler: Remaining middleware chain.
+
+        Returns:
+            Unchanged downstream tool result.
+        """
+        self.count += 1
+        return handler(request)
+
+
+def extension(d: ExtensionAPI) -> None:
+    """Register tool-counting middleware.
+
+    Args:
+        d: The dcode extension API.
+    """
+    d.register_middleware(ToolCounter)


### PR DESCRIPTION
Related #5556

Documents Python extension setup, trust behavior, lifecycle semantics, and configurable backend routes with runnable examples.

---

This is layer 11 of 11. The guide includes StoreBackend memory routing, session tools, middleware, shutdown callbacks, configuration precedence, and security constraints. It also states that custom slash commands are outside this API.
## Stack

1. [#5620 — registry foundation](https://github.com/langchain-ai/deepagents/pull/5620)
2. [#5621 — extension API](https://github.com/langchain-ai/deepagents/pull/5621)
3. [#5622 — discovery](https://github.com/langchain-ai/deepagents/pull/5622)
4. [#5623 — settings](https://github.com/langchain-ai/deepagents/pull/5623)
5. [#5624 — project trust store](https://github.com/langchain-ai/deepagents/pull/5624)
6. [#5625 — factory loader](https://github.com/langchain-ai/deepagents/pull/5625)
7. [#5626 — lifecycle runtime](https://github.com/langchain-ai/deepagents/pull/5626)
8. [#5627 — agent-server hosting and backend routes](https://github.com/langchain-ai/deepagents/pull/5627)
9. [#5628 — CLI trust flow](https://github.com/langchain-ai/deepagents/pull/5628)
10. [#5629 — configuration catalog](https://github.com/langchain-ai/deepagents/pull/5629)
11. [#5630 — documentation and examples](https://github.com/langchain-ai/deepagents/pull/5630)

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link). This stack applies the revised backend-route scope discussed after those documents.