### PR TITLE
feat(code): define and discover Python extensions

### DIFF
--- a/libs/code/deepagents_code/extensions/__init__.py
+++ b/libs/code/deepagents_code/extensions/__init__.py
@@ -1,0 +1,5 @@
+"""Public contract for dcode Python extensions."""
+
+from deepagents_code.extensions.api import ExtensionAPI
+
+__all__ = ["ExtensionAPI"]

--- a/libs/code/deepagents_code/extensions/__init__.py
+++ b/libs/code/deepagents_code/extensions/__init__.py
@@ -1,5 +1,5 @@
 """Public contract for dcode Python extensions."""
 
-from deepagents_code.extensions.api import ExtensionAPI
+from deepagents_code.extensions.api import ExtensionAPI, ExtensionMode
 
-__all__ = ["ExtensionAPI"]
+__all__ = ["ExtensionAPI", "ExtensionMode"]

--- a/libs/code/deepagents_code/extensions/api.py
+++ b/libs/code/deepagents_code/extensions/api.py
@@ -1,0 +1,180 @@
+"""Public registrar passed to Python extension factories."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from deepagents_code.extensions.registry import ExtensionError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from deepagents.backends.protocol import BackendProtocol
+    from langchain.agents.middleware.types import AgentMiddleware
+    from langchain_core.tools import BaseTool
+
+    from deepagents_code.extensions.registry import ExtensionRegistry, SourceInfo
+
+_ROUTE_PREFIX = re.compile(r"^/(?:[a-z0-9][a-z0-9_-]*/)+$")
+
+
+class ExtensionAPI:
+    """Factory-scoped registrar and read-only session context.
+
+    Each extension receives a dedicated instance, which attributes every
+    registration to the extension's source without exposing mutable dcode
+    application state.
+    """
+
+    def __init__(
+        self,
+        registry: ExtensionRegistry,
+        source: SourceInfo,
+        *,
+        cwd: Path,
+        mode: str,
+    ) -> None:
+        """Bind a registrar to one extension's provenance.
+
+        Args:
+            registry: Shared registry receiving extension units.
+            source: Provenance recorded on each registration.
+            cwd: Working directory for this session.
+            mode: Runtime mode, either `interactive` or `headless`.
+        """
+        self._registry = registry
+        self._source = source
+        self._cwd = cwd
+        self._mode = mode
+        self._active = True
+
+    def _deactivate(self) -> None:
+        """Close this registrar after failed initialization or shutdown."""
+        self._active = False
+
+    def _ensure_active(self) -> None:
+        if not self._active:
+            msg = "Extension registration is closed for this session"
+            raise ExtensionError(msg)
+
+    @property
+    def cwd(self) -> Path:
+        """Working directory for this session."""
+        return self._cwd
+
+    @property
+    def mode(self) -> str:
+        """Runtime mode, either `interactive` or `headless`."""
+        return self._mode
+
+    @property
+    def has_ui(self) -> bool:
+        """Whether this session has an interactive terminal UI."""
+        return self._mode == "interactive"
+
+    @property
+    def path(self) -> Path:
+        """Entry file for this extension."""
+        return self._source.path
+
+    def register_middleware(
+        self,
+        middleware: AgentMiddleware[Any, Any] | type[AgentMiddleware[Any, Any]],
+    ) -> None:
+        """Install LangChain middleware on the agent.
+
+        A class is instantiated without arguments. Pass an instance when
+        construction requires configuration.
+
+        Args:
+            middleware: Middleware class or instance.
+
+        Raises:
+            ExtensionError: If `middleware` is invalid or cannot be constructed.
+        """
+        self._ensure_active()
+        from langchain.agents.middleware.types import AgentMiddleware
+
+        try:
+            instance = middleware() if isinstance(middleware, type) else middleware
+        except Exception as exc:
+            msg = f"Could not construct middleware {middleware!r}: {exc}"
+            raise ExtensionError(msg) from exc
+        if not isinstance(instance, AgentMiddleware):
+            kind = type(instance).__name__
+            msg = f"Registered middleware must be an AgentMiddleware, got {kind}"
+            raise ExtensionError(msg)
+        self._registry.add_middleware(instance, self._source)
+
+    def register_tool(self, tool: BaseTool | Callable[..., Any]) -> None:
+        """Expose an LLM-callable tool.
+
+        Plain callables are converted using LangChain's tool schema inference.
+
+        Args:
+            tool: Tool instance or plain callable.
+
+        Raises:
+            ExtensionError: If a callable cannot be converted into a tool.
+        """
+        self._ensure_active()
+        from langchain_core.tools import BaseTool, tool as as_tool
+
+        if isinstance(tool, BaseTool):
+            self._registry.add_tool(tool, self._source)
+            return
+        try:
+            converted = as_tool(tool)
+        except Exception as exc:
+            name = getattr(tool, "__name__", repr(tool))
+            msg = f"Could not convert {name} into a tool: {exc}"
+            raise ExtensionError(msg) from exc
+        self._registry.add_tool(converted, self._source)  # type: ignore[arg-type]  # callable overload returns BaseTool
+
+    def register_backend_route(self, prefix: str, backend: BackendProtocol) -> None:
+        """Mount a backend under a virtual filesystem path.
+
+        File operations under `prefix` are routed to `backend` by the agent's
+        `CompositeBackend`. Shell execution remains on the default backend and
+        cannot access routed virtual content.
+
+        Args:
+            prefix: Lowercase absolute path ending in `/`, such as `/memories/`.
+            backend: Backend serving file operations under the prefix.
+
+        Raises:
+            ExtensionError: If the prefix or backend is invalid.
+        """
+        self._ensure_active()
+        from deepagents.backends.protocol import BackendProtocol
+
+        if _ROUTE_PREFIX.fullmatch(prefix) is None:
+            msg = (
+                f"Invalid backend route prefix {prefix!r}: use lowercase path "
+                "segments and include leading and trailing slashes"
+            )
+            raise ExtensionError(msg)
+        if not isinstance(backend, BackendProtocol):
+            msg = (
+                f"Backend route {prefix!r} got {type(backend).__name__}, "
+                "which is not a BackendProtocol"
+            )
+            raise ExtensionError(msg)
+        self._registry.add_backend_route(prefix, backend, self._source)
+
+    def on_shutdown(self, hook: Callable[[], Any]) -> None:
+        """Register a deterministic session teardown callback.
+
+        Args:
+            hook: Sync or async zero-argument callback.
+
+        Raises:
+            ExtensionError: If `hook` is not callable.
+        """
+        self._ensure_active()
+        if not callable(hook):
+            msg = "Shutdown hook is not callable"
+            raise ExtensionError(msg)
+        self._registry.add_shutdown_hook(hook, self._source)

--- a/libs/code/deepagents_code/extensions/api.py
+++ b/libs/code/deepagents_code/extensions/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from deepagents_code.extensions.registry import ExtensionError
@@ -20,6 +21,13 @@ if TYPE_CHECKING:
 _ROUTE_PREFIX = re.compile(r"^/(?:[a-z0-9][a-z0-9_-]*/)+$")
 
 
+class ExtensionMode(StrEnum):
+    """Runtime mode exposed to extensions."""
+
+    INTERACTIVE = "interactive"
+    HEADLESS = "headless"
+
+
 class ExtensionAPI:
     """Factory-scoped registrar and read-only session context.
 
@@ -34,7 +42,7 @@ class ExtensionAPI:
         source: SourceInfo,
         *,
         cwd: Path,
-        mode: str,
+        mode: ExtensionMode,
     ) -> None:
         """Bind a registrar to one extension's provenance.
 
@@ -47,7 +55,7 @@ class ExtensionAPI:
         self._registry = registry
         self._source = source
         self._cwd = cwd
-        self._mode = mode
+        self._mode = ExtensionMode(mode)
         self._active = True
 
     def _deactivate(self) -> None:
@@ -65,14 +73,14 @@ class ExtensionAPI:
         return self._cwd
 
     @property
-    def mode(self) -> str:
+    def mode(self) -> ExtensionMode:
         """Runtime mode, either `interactive` or `headless`."""
         return self._mode
 
     @property
     def has_ui(self) -> bool:
         """Whether this session has an interactive terminal UI."""
-        return self._mode == "interactive"
+        return self._mode == ExtensionMode.INTERACTIVE
 
     @property
     def path(self) -> Path:

--- a/libs/code/deepagents_code/extensions/discovery.py
+++ b/libs/code/deepagents_code/extensions/discovery.py
@@ -133,10 +133,14 @@ def _entry_point_source(entry: importlib.metadata.EntryPoint) -> SourceInfo:
 def _entry_point_sources() -> DiscoveryResult:
     sources: list[SourceInfo] = []
     errors: list[str] = []
-    entries = sorted(
-        importlib.metadata.entry_points(group=ENTRY_POINT_GROUP),
-        key=lambda entry: (entry.name, entry.value),
-    )
+    try:
+        entries = sorted(
+            importlib.metadata.entry_points(group=ENTRY_POINT_GROUP),
+            key=lambda entry: (entry.name, entry.value),
+        )
+    except (ImportError, OSError, ValueError) as exc:
+        msg = f"Could not enumerate extension entry points: {exc}"
+        return DiscoveryResult(errors=(msg,))
     for entry in entries:
         try:
             sources.append(_entry_point_source(entry))

--- a/libs/code/deepagents_code/extensions/discovery.py
+++ b/libs/code/deepagents_code/extensions/discovery.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib.metadata
 import importlib.util
-import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -18,7 +17,6 @@ if TYPE_CHECKING:
     from deepagents_code.plugins.models import PluginInstance
 
 ENTRY_POINT_GROUP = "dcode.extensions"
-logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,7 +87,6 @@ def _resolve_explicit(path: Path, scope: SourceScope) -> DiscoveryResult:
         if expanded.is_file() and expanded.suffix == ".py":
             return DiscoveryResult((_source(expanded, scope),))
     except (OSError, RuntimeError):
-        logger.debug("Could not inspect extension path %s", path, exc_info=True)
         return DiscoveryResult(errors=("Could not inspect an extension path",))
     msg = f"Extension path must be an existing Python file or directory: {path}"
     return DiscoveryResult(errors=(msg,))

--- a/libs/code/deepagents_code/extensions/discovery.py
+++ b/libs/code/deepagents_code/extensions/discovery.py
@@ -56,16 +56,26 @@ def _scan(directory: Path, scope: SourceScope) -> tuple[list[SourceInfo], list[s
         return [], [f"Could not scan extension directory {directory}: {exc}"]
 
     sources: list[SourceInfo] = []
+    errors: list[str] = []
     for entry in entries:
-        if entry.is_file() and entry.suffix == ".py":
-            sources.append(_source(entry, scope))
+        try:
+            source = _entry_source(entry, scope)
+        except (OSError, RuntimeError) as exc:
+            errors.append(f"Could not inspect extension entry {entry}: {exc}")
             continue
-        for filename in ("__init__.py", "extension.py"):
-            candidate = entry / filename
-            if candidate.is_file():
-                sources.append(_source(candidate, scope, package=True))
-                break
-    return sources, []
+        if source is not None:
+            sources.append(source)
+    return sources, errors
+
+
+def _entry_source(entry: Path, scope: SourceScope) -> SourceInfo | None:
+    if entry.is_file() and entry.suffix == ".py":
+        return _source(entry, scope)
+    for filename in ("__init__.py", "extension.py"):
+        candidate = entry / filename
+        if candidate.is_file():
+            return _source(candidate, scope, package=True)
+    return None
 
 
 def _resolve_explicit(path: Path, scope: SourceScope) -> DiscoveryResult:

--- a/libs/code/deepagents_code/extensions/discovery.py
+++ b/libs/code/deepagents_code/extensions/discovery.py
@@ -1,0 +1,208 @@
+"""Resolve authorized Python extension sources into entry files."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+from deepagents_code.extensions.registry import SourceInfo, SourceScope
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from deepagents_code.plugins.models import PluginInstance
+
+ENTRY_POINT_GROUP = "dcode.extensions"
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveryResult:
+    """Authorized sources and non-fatal resolution errors."""
+
+    sources: tuple[SourceInfo, ...] = ()
+    errors: tuple[str, ...] = ()
+
+
+def user_extensions_dir() -> Path:
+    """Return the user-wide loose-file extension directory."""
+    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
+
+    return DEFAULT_CONFIG_PATH.parent / "extensions"
+
+
+def project_extensions_dir(project_root: Path) -> Path:
+    """Return the extension directory beneath `project_root`."""
+    return project_root / ".deepagents" / "extensions"
+
+
+def _canonical(path: Path) -> Path:
+    return path.expanduser().resolve()
+
+
+def _source(path: Path, scope: SourceScope, *, package: bool = False) -> SourceInfo:
+    return SourceInfo(_canonical(path), is_package=package, scope=scope)
+
+
+def _scan(directory: Path, scope: SourceScope) -> tuple[list[SourceInfo], list[str]]:
+    try:
+        entries = sorted(directory.expanduser().iterdir())
+    except FileNotFoundError:
+        return [], []
+    except OSError as exc:
+        return [], [f"Could not scan extension directory {directory}: {exc}"]
+
+    sources: list[SourceInfo] = []
+    for entry in entries:
+        if entry.is_file() and entry.suffix == ".py":
+            sources.append(_source(entry, scope))
+            continue
+        for filename in ("__init__.py", "extension.py"):
+            candidate = entry / filename
+            if candidate.is_file():
+                sources.append(_source(candidate, scope, package=True))
+                break
+    return sources, []
+
+
+def _resolve_explicit(path: Path, scope: SourceScope) -> DiscoveryResult:
+    expanded = path.expanduser()
+    if expanded.is_dir():
+        sources, errors = _scan(expanded, scope)
+        return DiscoveryResult(tuple(sources), tuple(errors))
+    if expanded.is_file() and expanded.suffix == ".py":
+        return DiscoveryResult((_source(expanded, scope),))
+    msg = f"Extension path must be an existing Python file or directory: {path}"
+    return DiscoveryResult(errors=(msg,))
+
+
+def _resolve_paths(paths: Iterable[Path], scope: SourceScope) -> DiscoveryResult:
+    sources: list[SourceInfo] = []
+    errors: list[str] = []
+    for path in paths:
+        result = _resolve_explicit(path, scope)
+        sources.extend(result.sources)
+        errors.extend(result.errors)
+    return DiscoveryResult(tuple(sources), tuple(errors))
+
+
+def _plugin_sources(plugins: Sequence[PluginInstance]) -> list[SourceInfo]:
+    return [
+        SourceInfo(
+            _canonical(path),
+            is_package=path.name == "__init__.py",
+            plugin_id=plugin.plugin_id,
+            version=plugin.version,
+            installed_root=_canonical(plugin.root),
+        )
+        for plugin in plugins
+        if plugin.manifest is not None
+        for path in plugin.manifest.python_extensions
+    ]
+
+
+def _entry_point_source(entry: importlib.metadata.EntryPoint) -> SourceInfo:
+    module = entry.value.partition(":")[0]
+    spec = importlib.util.find_spec(module)
+    if spec is None or spec.origin is None:
+        msg = f"Entry point {entry.name!r} does not resolve to a Python module"
+        raise ValueError(msg)
+    version = entry.dist.version if entry.dist is not None else None
+    return SourceInfo(
+        _canonical(Path(spec.origin)),
+        is_package=spec.submodule_search_locations is not None,
+        plugin_id=f"{entry.name}@entry-point",
+        version=version,
+        installed_root=_canonical(Path(spec.origin).parent),
+    )
+
+
+def _entry_point_sources() -> DiscoveryResult:
+    sources: list[SourceInfo] = []
+    errors: list[str] = []
+    entries = sorted(
+        importlib.metadata.entry_points(group=ENTRY_POINT_GROUP),
+        key=lambda entry: (entry.name, entry.value),
+    )
+    for entry in entries:
+        try:
+            sources.append(_entry_point_source(entry))
+        except (ImportError, OSError, ValueError) as exc:
+            errors.append(
+                f"Could not resolve extension entry point {entry.name}: {exc}"
+            )
+    return DiscoveryResult(tuple(sources), tuple(errors))
+
+
+def _deduplicate(sources: Iterable[SourceInfo]) -> tuple[SourceInfo, ...]:
+    unique: dict[Path, SourceInfo] = {}
+    for source in sources:
+        unique.setdefault(source.path, source)
+    return tuple(unique.values())
+
+
+def discover_extensions(
+    *,
+    plugins: Sequence[PluginInstance] = (),
+    config_files: Sequence[Path] = (),
+    config_dirs: Sequence[Path] = (),
+    cli_paths: Sequence[Path] = (),
+    project_dir: Path | None = None,
+) -> DiscoveryResult:
+    """Resolve all authorized sources in deterministic load order.
+
+    Returns:
+        Canonically deduplicated sources and isolated errors.
+    """
+    if not is_env_truthy(EXPERIMENTAL):
+        return DiscoveryResult()
+    user_sources, user_errors = _scan(user_extensions_dir(), SourceScope.USER)
+    config = _resolve_paths((*config_files, *config_dirs), SourceScope.USER)
+    cli = _resolve_paths(cli_paths, SourceScope.TEMPORARY)
+    entries = _entry_point_sources()
+    project = (
+        _resolve_explicit(project_dir, SourceScope.PROJECT)
+        if project_dir is not None
+        else DiscoveryResult()
+    )
+    sources = _deduplicate(
+        (
+            *user_sources,
+            *config.sources,
+            *cli.sources,
+            *_plugin_sources(plugins),
+            *entries.sources,
+            *project.sources,
+        )
+    )
+    errors = (
+        *user_errors,
+        *config.errors,
+        *cli.errors,
+        *entries.errors,
+        *project.errors,
+    )
+    return DiscoveryResult(sources, errors)
+
+
+def discover_extension_files(
+    *,
+    plugins: Sequence[PluginInstance] = (),
+    project_dir: Path | None = None,
+) -> list[SourceInfo]:
+    """Compatibility wrapper returning discovered sources without errors.
+
+    Returns:
+        The discovered source list.
+    """
+    if not is_env_truthy(EXPERIMENTAL):
+        return []
+    project = (
+        _resolve_explicit(project_dir, SourceScope.PROJECT)
+        if project_dir is not None
+        else DiscoveryResult()
+    )
+    return list(_deduplicate((*_plugin_sources(plugins), *project.sources)))

--- a/libs/code/deepagents_code/extensions/discovery.py
+++ b/libs/code/deepagents_code/extensions/discovery.py
@@ -186,23 +186,3 @@ def discover_extensions(
         *project.errors,
     )
     return DiscoveryResult(sources, errors)
-
-
-def discover_extension_files(
-    *,
-    plugins: Sequence[PluginInstance] = (),
-    project_dir: Path | None = None,
-) -> list[SourceInfo]:
-    """Compatibility wrapper returning discovered sources without errors.
-
-    Returns:
-        The discovered source list.
-    """
-    if not is_env_truthy(EXPERIMENTAL):
-        return []
-    project = (
-        _resolve_explicit(project_dir, SourceScope.PROJECT)
-        if project_dir is not None
-        else DiscoveryResult()
-    )
-    return list(_deduplicate((*_plugin_sources(plugins), *project.sources)))

--- a/libs/code/deepagents_code/extensions/discovery.py
+++ b/libs/code/deepagents_code/extensions/discovery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import importlib.util
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
     from deepagents_code.plugins.models import PluginInstance
 
 ENTRY_POINT_GROUP = "dcode.extensions"
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,11 +82,15 @@ def _entry_source(entry: Path, scope: SourceScope) -> SourceInfo | None:
 
 def _resolve_explicit(path: Path, scope: SourceScope) -> DiscoveryResult:
     expanded = path.expanduser()
-    if expanded.is_dir():
-        sources, errors = _scan(expanded, scope)
-        return DiscoveryResult(tuple(sources), tuple(errors))
-    if expanded.is_file() and expanded.suffix == ".py":
-        return DiscoveryResult((_source(expanded, scope),))
+    try:
+        if expanded.is_dir():
+            sources, errors = _scan(expanded, scope)
+            return DiscoveryResult(tuple(sources), tuple(errors))
+        if expanded.is_file() and expanded.suffix == ".py":
+            return DiscoveryResult((_source(expanded, scope),))
+    except (OSError, RuntimeError):
+        logger.debug("Could not inspect extension path %s", path, exc_info=True)
+        return DiscoveryResult(errors=("Could not inspect an extension path",))
     msg = f"Extension path must be an existing Python file or directory: {path}"
     return DiscoveryResult(errors=(msg,))
 

--- a/libs/code/deepagents_code/extensions/discovery.py
+++ b/libs/code/deepagents_code/extensions/discovery.py
@@ -107,7 +107,7 @@ def _plugin_sources(plugins: Sequence[PluginInstance]) -> list[SourceInfo]:
         SourceInfo(
             _canonical(path),
             is_package=path.name == "__init__.py",
-            plugin_id=plugin.plugin_id,
+            source_id=plugin.plugin_id,
             version=plugin.version,
             installed_root=_canonical(plugin.root),
         )
@@ -127,7 +127,7 @@ def _entry_point_source(entry: importlib.metadata.EntryPoint) -> SourceInfo:
     return SourceInfo(
         _canonical(Path(spec.origin)),
         is_package=spec.submodule_search_locations is not None,
-        plugin_id=f"{entry.name}@entry-point",
+        source_id=f"{entry.name}@entry-point",
         version=version,
         installed_root=_canonical(Path(spec.origin).parent),
     )

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -1,0 +1,260 @@
+"""In-memory registrations contributed by Python extensions."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from deepagents.backends.protocol import BackendProtocol
+    from langchain.agents.middleware.types import AgentMiddleware
+    from langchain_core.tools import BaseTool
+
+    from deepagents_code.extensions.api import ExtensionAPI
+
+logger = logging.getLogger(__name__)
+
+
+class SourceScope(StrEnum):
+    """Authority scope that supplied an extension."""
+
+    USER = "user"
+    PROJECT = "project"
+    TEMPORARY = "temporary"
+
+
+class SourceOrigin(StrEnum):
+    """Packaging shape of an extension entry file."""
+
+    TOP_LEVEL = "top-level"
+    PACKAGE = "package"
+
+
+class SourceType(StrEnum):
+    """Producer category used by provenance displays and filtering."""
+
+    BUILTIN = "builtin"
+    EXTENSION = "extension"
+    SDK = "sdk"
+
+
+@dataclass(frozen=True, slots=True)
+class RegistrySnapshot:
+    """Registration counts used to restore registry state."""
+
+    middleware: int
+    tools: int
+    backend_routes: int
+    shutdown_hooks: int
+    apis: int
+
+
+@dataclass(frozen=True, slots=True)
+class SourceInfo:
+    """An extension entry file, ownership, and import shape."""
+
+    path: Path
+    is_package: bool = False
+    plugin_id: str | None = None
+    source: SourceType = SourceType.EXTENSION
+    scope: SourceScope = SourceScope.USER
+    origin: SourceOrigin | None = None
+    version: str | None = None
+    installed_root: Path | None = None
+
+    def __post_init__(self) -> None:
+        """Derive package provenance when callers use the compatibility flag."""
+        if self.origin is None:
+            origin = SourceOrigin.PACKAGE if self.is_package else SourceOrigin.TOP_LEVEL
+            object.__setattr__(self, "origin", origin)
+
+    @property
+    def label(self) -> str:
+        """Short extension label."""
+        if self.plugin_id is not None:
+            return self.plugin_id
+        return self.path.parent.name if self.is_package else self.path.stem
+
+    def as_dict(self) -> dict[str, str | bool | None]:
+        """Return JSON-safe provenance without reading extension contents."""
+        return {
+            "path": str(self.path),
+            "source": self.source.value,
+            "scope": self.scope.value,
+            "origin": self.origin.value if self.origin is not None else None,
+            "is_package": self.is_package,
+            "plugin_id": self.plugin_id,
+            "version": self.version,
+            "installed_root": (
+                str(self.installed_root) if self.installed_root is not None else None
+            ),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredUnit[T]:
+    """A registered unit paired with its source."""
+
+    name: str
+    unit: T
+    source: SourceInfo
+
+
+class ExtensionError(Exception):
+    """Raised when an extension cannot be loaded."""
+
+
+class ExtensionRegistry:
+    """Hold extension registrations in load order."""
+
+    def __init__(self) -> None:
+        """Create an empty registry."""
+        self.middleware: list[RegisteredUnit[AgentMiddleware[Any, Any]]] = []
+        self.tools: list[RegisteredUnit[BaseTool]] = []
+        self.backend_routes: list[RegisteredUnit[BackendProtocol]] = []
+        self.shutdown_hooks: list[RegisteredUnit[Callable[[], Any]]] = []
+        self._lock = threading.RLock()
+        self._listeners: list[Callable[[str, RegisteredUnit[Any]], None]] = []
+        self._apis: list[ExtensionAPI] = []
+        self._restart_required = False
+
+    @property
+    def restart_required(self) -> bool:
+        """Whether a late registration needs a new agent graph."""
+        with self._lock:
+            return self._restart_required
+
+    def require_restart(self) -> None:
+        """Record that registrations have changed graph construction inputs."""
+        with self._lock:
+            self._restart_required = True
+
+    def _snapshot(self) -> RegistrySnapshot:
+        with self._lock:
+            return RegistrySnapshot(
+                middleware=len(self.middleware),
+                tools=len(self.tools),
+                backend_routes=len(self.backend_routes),
+                shutdown_hooks=len(self.shutdown_hooks),
+                apis=len(self._apis),
+            )
+
+    def _rollback(self, snapshot: RegistrySnapshot) -> None:
+        with self._lock:
+            del self.middleware[snapshot.middleware :]
+            del self.tools[snapshot.tools :]
+            del self.backend_routes[snapshot.backend_routes :]
+            del self.shutdown_hooks[snapshot.shutdown_hooks :]
+            del self._apis[snapshot.apis :]
+
+    def retain_api(self, api: ExtensionAPI) -> None:
+        """Keep a successful factory registrar active for this session."""
+        with self._lock:
+            self._apis.append(api)
+
+    def deactivate_apis(self) -> None:
+        """Close every registrar after session teardown."""
+        with self._lock:
+            apis, self._apis = self._apis, []
+        for api in apis:
+            api._deactivate()
+
+    def subscribe(self, listener: Callable[[str, RegisteredUnit[Any]], None]) -> None:
+        """Observe successful registrations made after host construction."""
+        with self._lock:
+            self._listeners.append(listener)
+
+    def find_tool(self, name: str) -> RegisteredUnit[BaseTool] | None:
+        """Return the current extension tool named `name`."""
+        with self._lock:
+            return next((item for item in self.tools if item.name == name), None)
+
+    def tool_units(self) -> tuple[RegisteredUnit[BaseTool], ...]:
+        """Return a stable snapshot for one model request."""
+        with self._lock:
+            return tuple(self.tools)
+
+    def registrations(self) -> tuple[tuple[str, RegisteredUnit[Any]], ...]:
+        """Return every registration in display order."""
+        with self._lock:
+            return tuple(
+                (kind, item)
+                for kind, items in (
+                    ("middleware", self.middleware),
+                    ("tool", self.tools),
+                    ("backend_route", self.backend_routes),
+                    ("shutdown", self.shutdown_hooks),
+                )
+                for item in items
+            )
+
+    def _add[T](
+        self,
+        items: list[RegisteredUnit[T]],
+        kind: str,
+        name: str,
+        unit: T,
+        source: SourceInfo,
+    ) -> None:
+        with self._lock:
+            existing = next((item for item in items if item.name == name), None)
+            if existing is not None:
+                logger.warning(
+                    "Ignoring %r from %s: already registered by %s",
+                    name,
+                    source.label,
+                    existing.source.label,
+                )
+                return
+            registered = RegisteredUnit(name, unit, source)
+            items.append(registered)
+            listeners = tuple(self._listeners)
+        try:
+            for listener in listeners:
+                listener(kind, registered)
+        except Exception:
+            with self._lock:
+                items.remove(registered)
+            raise
+
+    def add_middleware(
+        self, middleware: AgentMiddleware[Any, Any], source: SourceInfo
+    ) -> None:
+        """Register uniquely named middleware."""
+        self._add(
+            self.middleware,
+            "middleware",
+            getattr(middleware, "name", type(middleware).__name__),
+            middleware,
+            source,
+        )
+
+    def add_tool(self, tool: BaseTool, source: SourceInfo) -> None:
+        """Register a uniquely named tool."""
+        self._add(self.tools, "tool", tool.name, tool, source)
+
+    def add_backend_route(
+        self, prefix: str, backend: BackendProtocol, source: SourceInfo
+    ) -> None:
+        """Register a unique virtual filesystem route."""
+        self._add(self.backend_routes, "backend_route", prefix, backend, source)
+
+    def add_shutdown_hook(self, hook: Callable[[], Any], source: SourceInfo) -> None:
+        """Register a teardown callback."""
+        registered = RegisteredUnit(source.label, hook, source)
+        with self._lock:
+            self.shutdown_hooks.append(registered)
+            listeners = tuple(self._listeners)
+        try:
+            for listener in listeners:
+                listener("shutdown", registered)
+        except Exception:
+            with self._lock:
+                self.shutdown_hooks.remove(registered)
+            raise

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -94,7 +94,9 @@ class ExtensionRegistry:
         self.backend_routes: list[RegisteredUnit[BackendProtocol]] = []
         self.shutdown_hooks: list[RegisteredUnit[Callable[[], Any]]] = []
         self._lock = threading.RLock()
-        self._listeners: list[Callable[[str, RegisteredUnit[Any]], None]] = []
+        self._registration_listeners: list[
+            Callable[[str, RegisteredUnit[Any]], None]
+        ] = []
         self._restart_required = False
 
     @property
@@ -124,10 +126,17 @@ class ExtensionRegistry:
             del self.backend_routes[snapshot.backend_routes :]
             del self.shutdown_hooks[snapshot.shutdown_hooks :]
 
-    def subscribe(self, listener: Callable[[str, RegisteredUnit[Any]], None]) -> None:
-        """Observe successful registrations made after host construction."""
+    def subscribe_to_registrations(
+        self, listener: Callable[[str, RegisteredUnit[Any]], None]
+    ) -> None:
+        """Observe registrations and allow the callback to reject them.
+
+        Args:
+            listener: Called with the registration kind and registered unit. Raising
+                rolls back that registration.
+        """
         with self._lock:
-            self._listeners.append(listener)
+            self._registration_listeners.append(listener)
 
     def find_tool(self, name: str) -> RegisteredUnit[BaseTool] | None:
         """Return the current extension tool named `name`."""
@@ -173,7 +182,7 @@ class ExtensionRegistry:
                 return
             registered = RegisteredUnit(name, unit, source)
             items.append(registered)
-            listeners = tuple(self._listeners)
+            listeners = tuple(self._registration_listeners)
         try:
             for listener in listeners:
                 listener(kind, registered)
@@ -209,7 +218,7 @@ class ExtensionRegistry:
         registered = RegisteredUnit(source.label, hook, source)
         with self._lock:
             self.shutdown_hooks.append(registered)
-            listeners = tuple(self._listeners)
+            listeners = tuple(self._registration_listeners)
         try:
             for listener in listeners:
                 listener("shutdown", registered)

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -21,6 +21,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class RegistrySnapshot:
+    """Registration counts used to restore registry state."""
+
+    middleware: int
+    tools: int
+    backend_routes: int
+    shutdown_hooks: int
+
+
 class SourceScope(StrEnum):
     """Authority scope that supplied an extension; temporary means one invocation."""
 
@@ -101,22 +111,21 @@ class ExtensionRegistry:
         with self._lock:
             self._restart_required = True
 
-    def _snapshot(self) -> tuple[int, int, int, int]:
+    def _snapshot(self) -> RegistrySnapshot:
         with self._lock:
-            return (
-                len(self.middleware),
-                len(self.tools),
-                len(self.backend_routes),
-                len(self.shutdown_hooks),
+            return RegistrySnapshot(
+                middleware=len(self.middleware),
+                tools=len(self.tools),
+                backend_routes=len(self.backend_routes),
+                shutdown_hooks=len(self.shutdown_hooks),
             )
 
-    def _rollback(self, snapshot: tuple[int, int, int, int]) -> None:
+    def _rollback(self, snapshot: RegistrySnapshot) -> None:
         with self._lock:
-            middleware, tools, backend_routes, shutdown_hooks = snapshot
-            del self.middleware[middleware:]
-            del self.tools[tools:]
-            del self.backend_routes[backend_routes:]
-            del self.shutdown_hooks[shutdown_hooks:]
+            del self.middleware[snapshot.middleware :]
+            del self.tools[snapshot.tools :]
+            del self.backend_routes[snapshot.backend_routes :]
+            del self.shutdown_hooks[snapshot.shutdown_hooks :]
 
     def retain_api(self, api: ExtensionAPI) -> None:
         """Keep a successful factory registrar active for this session."""

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class SourceScope(StrEnum):
-    """Authority scope that supplied an extension."""
+    """Authority scope that supplied an extension; temporary means one invocation."""
 
     USER = "user"
     PROJECT = "project"
@@ -35,7 +35,7 @@ class SourceInfo:
 
     path: Path
     is_package: bool = False
-    plugin_id: str | None = None
+    source_id: str | None = None
     scope: SourceScope = SourceScope.USER
     version: str | None = None
     installed_root: Path | None = None
@@ -43,8 +43,8 @@ class SourceInfo:
     @property
     def label(self) -> str:
         """Short extension label."""
-        if self.plugin_id is not None:
-            return self.plugin_id
+        if self.source_id is not None:
+            return self.source_id
         return self.path.parent.name if self.is_package else self.path.stem
 
     def as_dict(self) -> dict[str, str | bool | None]:
@@ -55,7 +55,7 @@ class SourceInfo:
             "scope": self.scope.value,
             "origin": "package" if self.is_package else "top-level",
             "is_package": self.is_package,
-            "plugin_id": self.plugin_id,
+            "source_id": self.source_id,
             "version": self.version,
             "installed_root": (
                 str(self.installed_root) if self.installed_root is not None else None

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -29,21 +29,6 @@ class SourceScope(StrEnum):
     TEMPORARY = "temporary"
 
 
-class SourceOrigin(StrEnum):
-    """Packaging shape of an extension entry file."""
-
-    TOP_LEVEL = "top-level"
-    PACKAGE = "package"
-
-
-class SourceType(StrEnum):
-    """Producer category used by provenance displays and filtering."""
-
-    BUILTIN = "builtin"
-    EXTENSION = "extension"
-    SDK = "sdk"
-
-
 @dataclass(frozen=True, slots=True)
 class RegistrySnapshot:
     """Registration counts used to restore registry state."""
@@ -52,7 +37,6 @@ class RegistrySnapshot:
     tools: int
     backend_routes: int
     shutdown_hooks: int
-    apis: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,17 +46,9 @@ class SourceInfo:
     path: Path
     is_package: bool = False
     plugin_id: str | None = None
-    source: SourceType = SourceType.EXTENSION
     scope: SourceScope = SourceScope.USER
-    origin: SourceOrigin | None = None
     version: str | None = None
     installed_root: Path | None = None
-
-    def __post_init__(self) -> None:
-        """Derive package provenance when callers use the compatibility flag."""
-        if self.origin is None:
-            origin = SourceOrigin.PACKAGE if self.is_package else SourceOrigin.TOP_LEVEL
-            object.__setattr__(self, "origin", origin)
 
     @property
     def label(self) -> str:
@@ -85,9 +61,9 @@ class SourceInfo:
         """Return JSON-safe provenance without reading extension contents."""
         return {
             "path": str(self.path),
-            "source": self.source.value,
+            "source": "extension",
             "scope": self.scope.value,
-            "origin": self.origin.value if self.origin is not None else None,
+            "origin": "package" if self.is_package else "top-level",
             "is_package": self.is_package,
             "plugin_id": self.plugin_id,
             "version": self.version,
@@ -142,7 +118,6 @@ class ExtensionRegistry:
                 tools=len(self.tools),
                 backend_routes=len(self.backend_routes),
                 shutdown_hooks=len(self.shutdown_hooks),
-                apis=len(self._apis),
             )
 
     def _rollback(self, snapshot: RegistrySnapshot) -> None:
@@ -151,7 +126,6 @@ class ExtensionRegistry:
             del self.tools[snapshot.tools :]
             del self.backend_routes[snapshot.backend_routes :]
             del self.shutdown_hooks[snapshot.shutdown_hooks :]
-            del self._apis[snapshot.apis :]
 
     def retain_api(self, api: ExtensionAPI) -> None:
         """Keep a successful factory registrar active for this session."""

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
     from langchain.agents.middleware.types import AgentMiddleware
     from langchain_core.tools import BaseTool
 
-    from deepagents_code.extensions.api import ExtensionAPI
-
 logger = logging.getLogger(__name__)
 
 
@@ -97,7 +95,6 @@ class ExtensionRegistry:
         self.shutdown_hooks: list[RegisteredUnit[Callable[[], Any]]] = []
         self._lock = threading.RLock()
         self._listeners: list[Callable[[str, RegisteredUnit[Any]], None]] = []
-        self._apis: list[ExtensionAPI] = []
         self._restart_required = False
 
     @property
@@ -126,18 +123,6 @@ class ExtensionRegistry:
             del self.tools[snapshot.tools :]
             del self.backend_routes[snapshot.backend_routes :]
             del self.shutdown_hooks[snapshot.shutdown_hooks :]
-
-    def retain_api(self, api: ExtensionAPI) -> None:
-        """Keep a successful factory registrar active for this session."""
-        with self._lock:
-            self._apis.append(api)
-
-    def deactivate_apis(self) -> None:
-        """Close every registrar after session teardown."""
-        with self._lock:
-            apis, self._apis = self._apis, []
-        for api in apis:
-            api._deactivate()
 
     def subscribe(self, listener: Callable[[str, RegisteredUnit[Any]], None]) -> None:
         """Observe successful registrations made after host construction."""

--- a/libs/code/deepagents_code/extensions/registry.py
+++ b/libs/code/deepagents_code/extensions/registry.py
@@ -30,16 +30,6 @@ class SourceScope(StrEnum):
 
 
 @dataclass(frozen=True, slots=True)
-class RegistrySnapshot:
-    """Registration counts used to restore registry state."""
-
-    middleware: int
-    tools: int
-    backend_routes: int
-    shutdown_hooks: int
-
-
-@dataclass(frozen=True, slots=True)
 class SourceInfo:
     """An extension entry file, ownership, and import shape."""
 
@@ -111,21 +101,22 @@ class ExtensionRegistry:
         with self._lock:
             self._restart_required = True
 
-    def _snapshot(self) -> RegistrySnapshot:
+    def _snapshot(self) -> tuple[int, int, int, int]:
         with self._lock:
-            return RegistrySnapshot(
-                middleware=len(self.middleware),
-                tools=len(self.tools),
-                backend_routes=len(self.backend_routes),
-                shutdown_hooks=len(self.shutdown_hooks),
+            return (
+                len(self.middleware),
+                len(self.tools),
+                len(self.backend_routes),
+                len(self.shutdown_hooks),
             )
 
-    def _rollback(self, snapshot: RegistrySnapshot) -> None:
+    def _rollback(self, snapshot: tuple[int, int, int, int]) -> None:
         with self._lock:
-            del self.middleware[snapshot.middleware :]
-            del self.tools[snapshot.tools :]
-            del self.backend_routes[snapshot.backend_routes :]
-            del self.shutdown_hooks[snapshot.shutdown_hooks :]
+            middleware, tools, backend_routes, shutdown_hooks = snapshot
+            del self.middleware[middleware:]
+            del self.tools[tools:]
+            del self.backend_routes[backend_routes:]
+            del self.shutdown_hooks[shutdown_hooks:]
 
     def retain_api(self, api: ExtensionAPI) -> None:
         """Keep a successful factory registrar active for this session."""

--- a/libs/code/deepagents_code/plugins/manifest.py
+++ b/libs/code/deepagents_code/plugins/manifest.py
@@ -270,15 +270,13 @@ def load_manifest(
             component_paths[field_name] = paths
 
     version_value = raw.get("version")
-    version = (
-        version_value if isinstance(version_value, str) and version_value else None
-    )
+    version = version_value if isinstance(version_value, str) else None
     display_name_value = raw.get("displayName")
     extension_settings = raw.get("extensions")
     if isinstance(extension_settings, dict):
         extension_settings = extension_settings.get("com.langchain.deepagents.code")
     python_extensions = _python_extensions(extension_settings, root, warnings)
-    if python_extensions and version is None:
+    if python_extensions and not version:
         warnings.append(
             f"ignoring {_PYTHON_EXTENSIONS_FIELD}: "
             "Python extensions require a non-empty plugin version"

--- a/libs/code/deepagents_code/plugins/manifest.py
+++ b/libs/code/deepagents_code/plugins/manifest.py
@@ -23,6 +23,7 @@ _MANIFEST_RELATIVE_PATHS = (
     Path(".codex-plugin") / "plugin.json",
 )
 _PATH_COMPONENT_FIELDS = {"skills", "mcpServers", "hooks"}
+_PYTHON_EXTENSIONS_FIELD = "pythonExtensions"
 _UNSUPPORTED_COMPONENT_DIRS: tuple[UnsupportedComponent, ...] = (
     "agents",
     "commands",
@@ -109,7 +110,7 @@ def _resolve_component_path(
     try:
         root_resolved = plugin_root.resolve()
         resolved = (plugin_root / path).resolve()
-    except OSError as exc:
+    except (OSError, RuntimeError) as exc:
         warnings.append(
             f"ignoring {field_name}: could not resolve {declaration!r}: {exc}"
         )
@@ -186,6 +187,44 @@ def _inline_hooks(value: object) -> JsonObject:
     return {"hooks": normalized}
 
 
+def _python_extensions(
+    settings: object,
+    plugin_root: Path,
+    warnings: list[str],
+) -> tuple[Path, ...]:
+    """Resolve dcode Python entry files contained by a plugin install.
+
+    Args:
+        settings: Dcode-specific plugin manifest settings.
+        plugin_root: Root of the installed plugin snapshot.
+        warnings: Destination for invalid declaration diagnostics.
+
+    Returns:
+        Existing Python files contained by `plugin_root`.
+    """
+    if not isinstance(settings, dict):
+        return ()
+    declaration = settings.get(_PYTHON_EXTENSIONS_FIELD)
+    if declaration is None:
+        return ()
+    paths = _resolve_component_paths(
+        declaration,
+        plugin_root,
+        _PYTHON_EXTENSIONS_FIELD,
+        warnings,
+    )
+    entries: list[Path] = []
+    for path in paths:
+        if path.suffix != ".py" or not path.is_file():
+            warnings.append(
+                f"ignoring {_PYTHON_EXTENSIONS_FIELD}: "
+                f"{path} must be an existing Python file"
+            )
+            continue
+        entries.append(path)
+    return tuple(entries)
+
+
 def load_manifest(
     root: Path, *, fallback_name: str | None = None
 ) -> tuple[PluginManifest | None, Path | None, tuple[str, ...]]:
@@ -231,23 +270,33 @@ def load_manifest(
             component_paths[field_name] = paths
 
     version_value = raw.get("version")
-    version = version_value if isinstance(version_value, str) else None
+    version = (
+        version_value if isinstance(version_value, str) and version_value else None
+    )
     display_name_value = raw.get("displayName")
-    auto_update_settings = raw.get("extensions")
-    if isinstance(auto_update_settings, dict):
-        auto_update_settings = auto_update_settings.get("com.langchain.deepagents.code")
+    extension_settings = raw.get("extensions")
+    if isinstance(extension_settings, dict):
+        extension_settings = extension_settings.get("com.langchain.deepagents.code")
+    python_extensions = _python_extensions(extension_settings, root, warnings)
+    if python_extensions and version is None:
+        warnings.append(
+            f"ignoring {_PYTHON_EXTENSIONS_FIELD}: "
+            "Python extensions require a non-empty plugin version"
+        )
+        python_extensions = ()
     manifest = PluginManifest(
         name=name,
         version=version,
         component_paths=component_paths,
         inline_mcp=_inline_mcp(raw.get("mcpServers")),
         inline_hooks=_inline_hooks(raw.get("hooks")),
+        python_extensions=python_extensions,
         display_name=(
             display_name_value if isinstance(display_name_value, str) else None
         ),
         auto_update=(
-            isinstance(auto_update_settings, dict)
-            and auto_update_settings.get("autoUpdate") is True
+            isinstance(extension_settings, dict)
+            and extension_settings.get("autoUpdate") is True
         ),
     )
     return manifest, manifest_path, tuple(warnings)

--- a/libs/code/deepagents_code/plugins/manifest.py
+++ b/libs/code/deepagents_code/plugins/manifest.py
@@ -7,6 +7,7 @@ import logging
 import re
 from pathlib import Path, PureWindowsPath
 
+from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
 from deepagents_code.plugins._json import json_object
 from deepagents_code.plugins.models import (
     ComponentInventory,
@@ -192,6 +193,8 @@ def _python_extensions(
     plugin_root: Path,
     warnings: list[str],
 ) -> tuple[Path, ...]:
+    if not is_env_truthy(EXPERIMENTAL):
+        return ()
     if not isinstance(settings, dict):
         return ()
     declaration = settings.get(_PYTHON_EXTENSIONS_FIELD)

--- a/libs/code/deepagents_code/plugins/manifest.py
+++ b/libs/code/deepagents_code/plugins/manifest.py
@@ -205,7 +205,17 @@ def _python_extensions(
     )
     entries: list[Path] = []
     for path in paths:
-        if path.suffix != ".py" or not path.is_file():
+        try:
+            is_file = path.is_file()
+        except (OSError, RuntimeError):
+            logger.debug(
+                "Could not inspect Python extension path %s", path, exc_info=True
+            )
+            warnings.append(
+                f"ignoring {_PYTHON_EXTENSIONS_FIELD}: could not inspect declared path"
+            )
+            continue
+        if path.suffix != ".py" or not is_file:
             warnings.append(
                 f"ignoring {_PYTHON_EXTENSIONS_FIELD}: "
                 f"{path} must be an existing Python file"

--- a/libs/code/deepagents_code/plugins/manifest.py
+++ b/libs/code/deepagents_code/plugins/manifest.py
@@ -192,16 +192,6 @@ def _python_extensions(
     plugin_root: Path,
     warnings: list[str],
 ) -> tuple[Path, ...]:
-    """Resolve dcode Python entry files contained by a plugin install.
-
-    Args:
-        settings: Dcode-specific plugin manifest settings.
-        plugin_root: Root of the installed plugin snapshot.
-        warnings: Destination for invalid declaration diagnostics.
-
-    Returns:
-        Existing Python files contained by `plugin_root`.
-    """
     if not isinstance(settings, dict):
         return ()
     declaration = settings.get(_PYTHON_EXTENSIONS_FIELD)

--- a/libs/code/deepagents_code/plugins/models.py
+++ b/libs/code/deepagents_code/plugins/models.py
@@ -63,6 +63,8 @@ class PluginManifest:
         inline_mcp: Inline MCP servers declared in the manifest.
         inline_hooks: Inline hook configuration declared in the manifest, in
             `hooks.json` document form.
+        python_extensions: Python extension entry files declared in dcode's
+            namespaced manifest settings.
         auto_update: Whether this plugin permits automatic updates.
     """
 
@@ -71,6 +73,7 @@ class PluginManifest:
     component_paths: dict[str, tuple[Path, ...]]
     inline_mcp: JsonObject
     inline_hooks: JsonObject = field(default_factory=dict)
+    python_extensions: tuple[Path, ...] = ()
     display_name: str | None = None
     auto_update: bool = False
 

--- a/libs/code/tests/unit_tests/test_extension_api.py
+++ b/libs/code/tests/unit_tests/test_extension_api.py
@@ -133,7 +133,7 @@ def test_plugin_extension_discovery_requires_experimental_mode(
     monkeypatch.setenv(EXPERIMENTAL, "1")
     sources = discover_extensions(plugins=(plugin,)).sources
     assert [source.path for source in sources] == [path.resolve()]
-    assert sources[0].plugin_id == "example@test"
+    assert sources[0].source_id == "example@test"
 
 
 def test_plugin_manifest_does_not_resolve_extensions_when_disabled(

--- a/libs/code/tests/unit_tests/test_extension_api.py
+++ b/libs/code/tests/unit_tests/test_extension_api.py
@@ -91,9 +91,8 @@ def test_rejects_invalid_registrations(api: ExtensionAPI) -> None:
 
 
 def test_registrar_closes_after_session(api: ExtensionAPI) -> None:
-    """A retained registrar cannot mutate a registry after teardown."""
-    api._registry.retain_api(api)
-    api._registry.deactivate_apis()
+    """A deactivated registrar cannot mutate a registry after teardown."""
+    api._deactivate()
 
     with pytest.raises(ExtensionError, match="closed for this session"):
         api.register_middleware(_Middleware())

--- a/libs/code/tests/unit_tests/test_extension_api.py
+++ b/libs/code/tests/unit_tests/test_extension_api.py
@@ -103,6 +103,7 @@ def test_plugin_extension_discovery_requires_experimental_mode(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Installed plugin entries remain invisible until explicitly enabled."""
+    monkeypatch.setenv(EXPERIMENTAL, "1")
     path = tmp_path / "example.py"
     path.touch()
     _write_manifest(tmp_path, path="./example.py", version="1.2.3")
@@ -135,8 +136,33 @@ def test_plugin_extension_discovery_requires_experimental_mode(
     assert sources[0].plugin_id == "example@test"
 
 
-def test_plugin_python_extension_requires_version(tmp_path: Path) -> None:
+def test_plugin_manifest_does_not_resolve_extensions_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Normal plugin discovery does not inspect experimental entry paths."""
+    monkeypatch.delenv(EXPERIMENTAL, raising=False)
+    _write_manifest(tmp_path)
+
+    def fail(*_: object, **__: object) -> None:
+        msg = "plugin manifest crossed the experimental gate"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(
+        "deepagents_code.plugins.manifest._resolve_component_paths", fail
+    )
+
+    manifest, _, warnings = load_manifest(tmp_path)
+
+    assert manifest is not None
+    assert not manifest.python_extensions
+    assert not warnings
+
+
+def test_plugin_python_extension_requires_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """User-wide executable extensions must have a plugin version."""
+    monkeypatch.setenv(EXPERIMENTAL, "1")
     path = tmp_path / "extension.py"
     path.touch()
     _write_manifest(tmp_path)
@@ -152,6 +178,7 @@ def test_unreadable_plugin_extension_path_is_isolated(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """An unreadable Python extension declaration does not abort plugin loading."""
+    monkeypatch.setenv(EXPERIMENTAL, "1")
     path = tmp_path / "extension.py"
     path.touch()
     _write_manifest(tmp_path, version="1.2.3")

--- a/libs/code/tests/unit_tests/test_extension_api.py
+++ b/libs/code/tests/unit_tests/test_extension_api.py
@@ -1,0 +1,142 @@
+"""Tests for the public extension factory API."""
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from deepagents.backends import FilesystemBackend
+from langchain.agents.middleware.types import AgentMiddleware
+
+from deepagents_code._env_vars import EXPERIMENTAL
+from deepagents_code.extensions import ExtensionAPI
+from deepagents_code.extensions.discovery import discover_extension_files
+from deepagents_code.extensions.registry import (
+    ExtensionError,
+    ExtensionRegistry,
+    SourceInfo,
+)
+from deepagents_code.plugins.manifest import load_manifest
+from deepagents_code.plugins.models import ComponentInventory, PluginInstance
+
+
+class _Middleware(AgentMiddleware):
+    """Minimal extension middleware."""
+
+
+def _write_manifest(
+    root: Path, *, path: str = "./extension.py", version: str | None = None
+) -> None:
+    manifest: dict[str, Any] = {
+        "name": "example",
+        "extensions": {"com.langchain.deepagents.code": {"pythonExtensions": path}},
+    }
+    if version is not None:
+        manifest["version"] = version
+    (root / "plugin.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+@pytest.fixture
+def api() -> ExtensionAPI:
+    """Return a factory-scoped registrar."""
+    return ExtensionAPI(
+        ExtensionRegistry(),
+        SourceInfo(Path("/extensions/example.py")),
+        cwd=Path("/workspace"),
+        mode="interactive",
+    )
+
+
+def test_registers_supported_units_and_context(api: ExtensionAPI) -> None:
+    """Factories can register every supported unit and read session context."""
+    backend = FilesystemBackend(virtual_mode=False)
+
+    def status() -> str:
+        """Report status."""
+        return "ready"
+
+    api.register_middleware(_Middleware)
+    api.register_tool(status)
+    api.register_backend_route("/memories/", backend)
+    api.on_shutdown(lambda: None)
+
+    registry = api._registry
+    assert [item.name for item in registry.middleware] == ["_Middleware"]
+    assert [item.name for item in registry.tools] == ["status"]
+    assert registry.backend_routes[0].unit is backend
+    assert len(registry.shutdown_hooks) == 1
+    assert (api.cwd, api.mode, api.path) == (
+        Path("/workspace"),
+        "interactive",
+        Path("/extensions/example.py"),
+    )
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    ["memories/", "/memories", "/../memories/", "/memory//notes/", "/UPPER/"],
+)
+def test_rejects_unsafe_routes(api: ExtensionAPI, prefix: str) -> None:
+    """Backend prefixes must be canonical virtual paths."""
+    with pytest.raises(ExtensionError, match="Invalid backend route prefix"):
+        api.register_backend_route(prefix, FilesystemBackend(virtual_mode=False))
+
+
+def test_rejects_invalid_and_allows_runtime_registrations(api: ExtensionAPI) -> None:
+    """Invalid types fail while valid runtime registrations remain supported."""
+    with pytest.raises(ExtensionError, match="AgentMiddleware"):
+        api.register_middleware(cast("Any", object()))
+    with pytest.raises(ExtensionError, match="BackendProtocol"):
+        api.register_backend_route("/memories/", cast("Any", object()))
+    api.register_middleware(_Middleware())
+    assert api._registry.middleware[0].name == "_Middleware"
+
+
+def test_registrar_closes_after_session(api: ExtensionAPI) -> None:
+    """A retained registrar cannot mutate a registry after teardown."""
+    api._registry.retain_api(api)
+    api._registry.deactivate_apis()
+
+    with pytest.raises(ExtensionError, match="closed for this session"):
+        api.register_middleware(_Middleware())
+
+
+def test_plugin_extension_discovery_requires_experimental_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Installed plugin entries remain invisible until explicitly enabled."""
+    path = tmp_path / "example.py"
+    path.touch()
+    _write_manifest(tmp_path, path="./example.py", version="1.2.3")
+    manifest, _, warnings = load_manifest(tmp_path)
+    assert manifest is not None
+    assert not warnings
+    plugin = PluginInstance(
+        plugin_id="example@test",
+        name="example",
+        marketplace="test",
+        version=manifest.version,
+        root=tmp_path,
+        data_dir=tmp_path / "data",
+        manifest=manifest,
+        inventory=ComponentInventory(),
+    )
+    monkeypatch.delenv(EXPERIMENTAL, raising=False)
+    assert not discover_extension_files(plugins=(plugin,))
+    monkeypatch.setenv(EXPERIMENTAL, "1")
+    sources = discover_extension_files(plugins=(plugin,))
+    assert [source.path for source in sources] == [path.resolve()]
+    assert sources[0].plugin_id == "example@test"
+
+
+def test_plugin_python_extension_requires_version(tmp_path: Path) -> None:
+    """User-wide executable extensions must have a plugin version."""
+    path = tmp_path / "extension.py"
+    path.touch()
+    _write_manifest(tmp_path)
+
+    manifest, _, warnings = load_manifest(tmp_path)
+
+    assert manifest is not None
+    assert not manifest.python_extensions
+    assert any("require a non-empty plugin version" in warning for warning in warnings)

--- a/libs/code/tests/unit_tests/test_extension_api.py
+++ b/libs/code/tests/unit_tests/test_extension_api.py
@@ -9,7 +9,7 @@ from deepagents.backends import FilesystemBackend
 from langchain.agents.middleware.types import AgentMiddleware
 
 from deepagents_code._env_vars import EXPERIMENTAL
-from deepagents_code.extensions import ExtensionAPI
+from deepagents_code.extensions import ExtensionAPI, ExtensionMode
 from deepagents_code.extensions.discovery import discover_extensions
 from deepagents_code.extensions.registry import (
     ExtensionError,
@@ -43,7 +43,7 @@ def api() -> ExtensionAPI:
         ExtensionRegistry(),
         SourceInfo(Path("/extensions/example.py")),
         cwd=Path("/workspace"),
-        mode="interactive",
+        mode=ExtensionMode.INTERACTIVE,
     )
 
 
@@ -67,7 +67,7 @@ def test_registers_supported_units_and_context(api: ExtensionAPI) -> None:
     assert len(registry.shutdown_hooks) == 1
     assert (api.cwd, api.mode, api.path) == (
         Path("/workspace"),
-        "interactive",
+        ExtensionMode.INTERACTIVE,
         Path("/extensions/example.py"),
     )
 

--- a/libs/code/tests/unit_tests/test_extension_api.py
+++ b/libs/code/tests/unit_tests/test_extension_api.py
@@ -146,3 +146,27 @@ def test_plugin_python_extension_requires_version(tmp_path: Path) -> None:
     assert manifest is not None
     assert not manifest.python_extensions
     assert any("require a non-empty plugin version" in warning for warning in warnings)
+
+
+def test_unreadable_plugin_extension_path_is_isolated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable Python extension declaration does not abort plugin loading."""
+    path = tmp_path / "extension.py"
+    path.touch()
+    _write_manifest(tmp_path, version="1.2.3")
+    is_file = Path.is_file
+
+    def guarded(self: Path) -> bool:
+        if self == path:
+            msg = "unreadable"
+            raise OSError(msg)
+        return is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", guarded)
+
+    manifest, _, warnings = load_manifest(tmp_path)
+
+    assert manifest is not None
+    assert not manifest.python_extensions
+    assert any("could not inspect declared path" in warning for warning in warnings)

--- a/libs/code/tests/unit_tests/test_extension_api.py
+++ b/libs/code/tests/unit_tests/test_extension_api.py
@@ -10,7 +10,7 @@ from langchain.agents.middleware.types import AgentMiddleware
 
 from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.extensions import ExtensionAPI
-from deepagents_code.extensions.discovery import discover_extension_files
+from deepagents_code.extensions.discovery import discover_extensions
 from deepagents_code.extensions.registry import (
     ExtensionError,
     ExtensionRegistry,
@@ -82,14 +82,12 @@ def test_rejects_unsafe_routes(api: ExtensionAPI, prefix: str) -> None:
         api.register_backend_route(prefix, FilesystemBackend(virtual_mode=False))
 
 
-def test_rejects_invalid_and_allows_runtime_registrations(api: ExtensionAPI) -> None:
-    """Invalid types fail while valid runtime registrations remain supported."""
+def test_rejects_invalid_registrations(api: ExtensionAPI) -> None:
+    """Invalid unit types fail at the API boundary."""
     with pytest.raises(ExtensionError, match="AgentMiddleware"):
         api.register_middleware(cast("Any", object()))
     with pytest.raises(ExtensionError, match="BackendProtocol"):
         api.register_backend_route("/memories/", cast("Any", object()))
-    api.register_middleware(_Middleware())
-    assert api._registry.middleware[0].name == "_Middleware"
 
 
 def test_registrar_closes_after_session(api: ExtensionAPI) -> None:
@@ -121,10 +119,18 @@ def test_plugin_extension_discovery_requires_experimental_mode(
         manifest=manifest,
         inventory=ComponentInventory(),
     )
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.user_extensions_dir",
+        lambda: tmp_path / "missing",
+    )
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.importlib.metadata.entry_points",
+        lambda **_: (),
+    )
     monkeypatch.delenv(EXPERIMENTAL, raising=False)
-    assert not discover_extension_files(plugins=(plugin,))
+    assert not discover_extensions(plugins=(plugin,)).sources
     monkeypatch.setenv(EXPERIMENTAL, "1")
-    sources = discover_extension_files(plugins=(plugin,))
+    sources = discover_extensions(plugins=(plugin,)).sources
     assert [source.path for source in sources] == [path.resolve()]
     assert sources[0].plugin_id == "example@test"
 

--- a/libs/code/tests/unit_tests/test_extension_discovery.py
+++ b/libs/code/tests/unit_tests/test_extension_discovery.py
@@ -99,3 +99,28 @@ def test_unreadable_directory_entry_is_isolated(
     assert [source.path for source in result.sources] == [valid.resolve()]
     assert len(result.errors) == 1
     assert "broken.py" in result.errors[0]
+
+
+def test_broken_entry_point_metadata_is_isolated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unreadable distribution metadata reports an error without aborting."""
+    valid = _extension(tmp_path / "user", "valid.py")
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.user_extensions_dir",
+        lambda: valid.parent,
+    )
+
+    def broken(**_: object) -> tuple[()]:
+        msg = "malformed entry_points.txt"
+        raise ValueError(msg)
+
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.importlib.metadata.entry_points", broken
+    )
+
+    result = discover_extensions()
+
+    assert [source.path for source in result.sources] == [valid.resolve()]
+    assert len(result.errors) == 1
+    assert "malformed entry_points.txt" in result.errors[0]

--- a/libs/code/tests/unit_tests/test_extension_discovery.py
+++ b/libs/code/tests/unit_tests/test_extension_discovery.py
@@ -74,6 +74,32 @@ def test_invalid_explicit_path_is_isolated(
     assert "missing.py" in result.errors[0]
 
 
+def test_unreadable_explicit_path_is_isolated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A filesystem error inspecting one explicit path remains non-fatal."""
+    valid = _extension(tmp_path / "user", "valid.py")
+    unreadable = tmp_path / "unreadable.py"
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.user_extensions_dir",
+        lambda: valid.parent,
+    )
+    is_dir = Path.is_dir
+
+    def guarded(self: Path) -> bool:
+        if self == unreadable:
+            msg = "unreadable"
+            raise OSError(msg)
+        return is_dir(self)
+
+    monkeypatch.setattr(Path, "is_dir", guarded)
+
+    result = discover_extensions(cli_paths=(unreadable,))
+
+    assert [source.path for source in result.sources] == [valid.resolve()]
+    assert result.errors == ("Could not inspect an extension path",)
+
+
 def test_unreadable_directory_entry_is_isolated(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/libs/code/tests/unit_tests/test_extension_discovery.py
+++ b/libs/code/tests/unit_tests/test_extension_discovery.py
@@ -1,0 +1,74 @@
+"""Tests for extension source resolution and provenance."""
+
+from pathlib import Path
+
+import pytest
+
+from deepagents_code.extensions.discovery import discover_extensions
+from deepagents_code.extensions.registry import SourceScope
+
+
+@pytest.fixture(autouse=True)
+def _experimental(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEEPAGENTS_CODE_EXPERIMENTAL", "1")
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.importlib.metadata.entry_points",
+        lambda **_: (),
+    )
+
+
+def _extension(directory: Path, name: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text("async def extension(d):\n    pass\n", encoding="utf-8")
+    return path
+
+
+def test_sources_resolve_in_authority_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """User, config, CLI, and trusted project sources retain stable order."""
+    user = _extension(tmp_path / "user", "a.py")
+    configured = _extension(tmp_path / "configured", "b.py")
+    temporary = _extension(tmp_path / "temporary", "c.py")
+    project = _extension(tmp_path / "project", "d.py")
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.user_extensions_dir",
+        lambda: user.parent,
+    )
+
+    result = discover_extensions(
+        config_files=(configured, user),
+        cli_paths=(temporary,),
+        project_dir=project.parent,
+    )
+
+    assert [source.path for source in result.sources] == [
+        user.resolve(),
+        configured.resolve(),
+        temporary.resolve(),
+        project.resolve(),
+    ]
+    assert [source.scope for source in result.sources] == [
+        SourceScope.USER,
+        SourceScope.USER,
+        SourceScope.TEMPORARY,
+        SourceScope.PROJECT,
+    ]
+
+
+def test_invalid_explicit_path_is_isolated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing CLI source reports an error without blocking valid files."""
+    valid = _extension(tmp_path, "valid.py")
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.user_extensions_dir",
+        lambda: tmp_path / "absent-user-dir",
+    )
+
+    result = discover_extensions(cli_paths=(tmp_path / "missing.py", valid))
+
+    assert [source.path for source in result.sources] == [valid.resolve()]
+    assert len(result.errors) == 1
+    assert "missing.py" in result.errors[0]

--- a/libs/code/tests/unit_tests/test_extension_discovery.py
+++ b/libs/code/tests/unit_tests/test_extension_discovery.py
@@ -72,3 +72,30 @@ def test_invalid_explicit_path_is_isolated(
     assert [source.path for source in result.sources] == [valid.resolve()]
     assert len(result.errors) == 1
     assert "missing.py" in result.errors[0]
+
+
+def test_unreadable_directory_entry_is_isolated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An entry that fails inspection is reported without aborting the scan."""
+    user = tmp_path / "user"
+    _extension(user, "broken.py")
+    valid = _extension(user, "valid.py")
+    monkeypatch.setattr(
+        "deepagents_code.extensions.discovery.user_extensions_dir", lambda: user
+    )
+    is_file = Path.is_file
+
+    def guarded(self: Path) -> bool:
+        if self.name == "broken.py":
+            msg = "unreadable"
+            raise OSError(msg)
+        return is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", guarded)
+
+    result = discover_extensions()
+
+    assert [source.path for source in result.sources] == [valid.resolve()]
+    assert len(result.errors) == 1
+    assert "broken.py" in result.errors[0]

--- a/libs/code/tests/unit_tests/test_extension_discovery.py
+++ b/libs/code/tests/unit_tests/test_extension_discovery.py
@@ -24,6 +24,34 @@ def _extension(directory: Path, name: str) -> Path:
     return path
 
 
+def test_experimental_mode_gates_all_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disabled experiment performs no extension source inspection."""
+    monkeypatch.delenv("DEEPAGENTS_CODE_EXPERIMENTAL")
+
+    def fail(*_: object, **__: object) -> None:
+        msg = "extension discovery crossed the experimental gate"
+        raise AssertionError(msg)
+
+    for name in (
+        "user_extensions_dir",
+        "_resolve_paths",
+        "_entry_point_sources",
+        "_plugin_sources",
+    ):
+        monkeypatch.setattr(f"deepagents_code.extensions.discovery.{name}", fail)
+
+    result = discover_extensions(
+        config_files=(Path("configured.py"),),
+        cli_paths=(Path("temporary.py"),),
+        project_dir=Path("project"),
+    )
+
+    assert not result.sources
+    assert not result.errors
+
+
 def test_sources_resolve_in_authority_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Related #5556

Defines the narrow Python extension API, registry, provenance model, and deterministic source discovery. Extension discovery remains disabled unless `DEEPAGENTS_CODE_EXPERIMENTAL` is truthy.

---

Layer 1 of 4. This layer owns registration validation and collision handling, transactional rollback primitives, plugin manifest declarations, and discovery from user, configured, temporary CLI, plugin, entry-point, and trusted project sources. Configuration, loading, graph hosting, and user-facing trust controls are deliberately excluded.

## Stack

1. [#5631 — API, registry, and discovery](https://github.com/langchain-ai/deepagents/pull/5631)
2. [#5632 — configuration, trust, and loading](https://github.com/langchain-ai/deepagents/pull/5632)
3. [#5633 — agent hosting and lifecycle](https://github.com/langchain-ai/deepagents/pull/5633)
4. [#5634 — trust and inspection UX](https://github.com/langchain-ai/deepagents/pull/5634)