### PR TITLE
feat(code): add extension trust and inspection UX

### DIFF
--- a/libs/code/ARCHITECTURE.md
+++ b/libs/code/ARCHITECTURE.md
@@ -59,6 +59,8 @@ The main extension points are:
 - **Tools and MCP servers** for external capabilities
 - **Sandboxes** for changing where tool execution happens
 - **Hooks and commands** for integrating with local workflows
+- **Python extensions** for middleware, tools, and virtual storage routes,
+  loaded from user-authorized sources or a trusted project
 
 These pieces are designed to compose. A project can provide shared defaults and integrations, while each user can layer personal configuration on top.
 
@@ -79,6 +81,7 @@ The main cost is the client/server boundary. When debugging, first decide which 
 - For local setup and debugging, see [`DEVELOPMENT.md`](./DEVELOPMENT.md).
 - For command behavior, see [`COMMANDS.md`](./COMMANDS.md).
 - For lifecycle hooks (`hooks.json`), see [`HOOKS.md`](./HOOKS.md).
+- For server-side Python extensions, see [`EXTENSIONS.md`](./EXTENSIONS.md).
 - For cost estimates and local pricing overrides (`prices.json`), see
   [`PRICING.md`](./PRICING.md).
 - For security boundaries, see [`THREAT_MODEL.md`](./THREAT_MODEL.md).

--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -8,7 +8,7 @@ Regenerate this file with `make commands-catalog` after changing command names,
 aliases, descriptions, visibility, or hidden-command metadata.
 
 
-## Public (42)
+## Public (43)
 
 | Command | Aliases | Description |
 | --- | --- | --- |

--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -40,7 +40,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/plugins` |  | Manage plugins |
 | `/prompts` |  | Search and reuse a previous prompt |
 | `/quit` | `/q` | Exit app |
-| `/reload` |  | Reload config, plugins, and the agent server |
+| `/reload` |  | Reload environment and config |
 | `/remember` |  | Save useful context to memory or skills |
 | `/restart` |  | Restart the agent server |
 | `/rubric` | `/criteria` | Set explicit acceptance criteria for rubric grading |

--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -25,6 +25,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/docs` |  | Open the docs |
 | `/editor` |  | Open prompt in an external editor ($EDITOR) |
 | `/effort` |  | Set reasoning effort for the current model |
+| `/extensions` |  | List loaded Python extensions and their provenance |
 | `/feedback` |  | Send feedback or report an issue |
 | `/force-clear` |  | Recover a stuck session with a fresh thread |
 | `/goal` |  | Set and manage a persistent objective with acceptance criteria |
@@ -39,7 +40,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/plugins` |  | Manage plugins |
 | `/prompts` |  | Search and reuse a previous prompt |
 | `/quit` | `/q` | Exit app |
-| `/reload` |  | Reload environment and config |
+| `/reload` |  | Reload config, plugins, and the agent server |
 | `/remember` |  | Save useful context to memory or skills |
 | `/restart` |  | Restart the agent server |
 | `/rubric` | `/criteria` | Set explicit acceptance criteria for rubric grading |

--- a/libs/code/EXTENSIONS.md
+++ b/libs/code/EXTENSIONS.md
@@ -1,0 +1,165 @@
+# Python extensions
+
+Python extensions customize the agent server without modifying `dcode`. They
+are experimental and load only when `DEEPAGENTS_CODE_EXPERIMENTAL=1` is set
+before starting `dcode`.
+
+An installed plugin declares one or more Python entry files in its manifest:
+
+```json
+{
+  "name": "shared-memory",
+  "version": "1.0.0",
+  "extensions": {
+    "com.langchain.deepagents.code": {
+      "pythonExtensions": "./extension.py"
+    }
+  }
+}
+```
+
+The entry file exposes an `extension` setup function:
+
+```python
+from deepagents.backends import StoreBackend
+from deepagents_code.extensions import ExtensionAPI
+
+
+async def extension(d: ExtensionAPI) -> None:
+    """Add shared storage under `/memories/`.
+
+    Args:
+        d: The extension setup API.
+    """
+    d.register_backend_route(
+        "/memories/",
+        StoreBackend(namespace=lambda _runtime: ("filesystem",)),
+    )
+```
+
+Install and enable the plugin through the normal plugin commands, then run
+`/restart`. Backend composition happens while the agent graph is built, so
+backend route changes cannot be applied by `/reload`. A separately managed
+remote agent server must be restarted or redeployed by its operator.
+
+The `/memories/` route above makes shared storage available to model file
+operations. It does not automatically move dcode's built-in `AGENTS.md` memory.
+An extension that wants that content in the model's prompt must also register
+middleware that reads the shared location.
+
+## Supported registrations
+
+| Method | Purpose |
+| --- | --- |
+| `register_middleware(class_or_instance)` | Add LangChain `AgentMiddleware`. Classes must have a zero-argument constructor; use an instance otherwise. |
+| `register_tool(function_or_tool)` | Expose a callable or `BaseTool` to the model. |
+| `register_backend_route(prefix, storage)` | Make a `BackendProtocol` storage provider available under a virtual path. |
+| `on_shutdown(callback)` | Release session resources when the agent server stops. Sync and async callbacks are supported. |
+
+The factory must be declared with `async def`; dcode awaits every factory before
+building the agent. The registrar remains valid for callbacks that outlive the
+factory. Runtime tools appear on the next model request, backend routes update
+the registry but require `/restart`, and middleware also takes effect after the
+next server rebuild. `/extensions` reports when a restart is required.
+
+Do not open long-lived connections or start background tasks during module
+import. A storage provider may connect lazily on first use. If setup opens a
+session resource, register an idempotent `on_shutdown` callback to release it.
+
+The API exposes read-only session context (`d.cwd`, `d.mode`, `d.has_ui`, and
+`d.path`), not mutable TUI or thread state. Custom slash commands are not part
+of this API. Run `/extensions` to inspect registered units and their source.
+
+## Storage routes
+
+`BackendProtocol` is the SDK name for a storage implementation. Route prefixes
+are lowercase absolute paths with leading and trailing slashes, such as
+`/memories/` or `/company/knowledge/`. Traversal, empty segments, backslashes,
+URL query or fragment syntax, and overlaps with dcode's internal routes are
+rejected.
+
+Routed content is available through the model's file tools. Shell `execute`
+remains attached to the default local or sandbox storage, so shell commands
+cannot see virtual routed content.
+
+Local agents may mount `FilesystemBackend` and `LocalShellBackend`. Sandboxed
+agents reject direct instances of either class, including subclasses, because
+they would expose host storage while `execute` still runs inside the sandbox.
+Other `BackendProtocol` implementations such as `StateBackend`, `StoreBackend`,
+and `ContextHubBackend` are supported. This check is intentionally shallow:
+dcode does not recursively inspect custom or composite backend wrappers, whose
+authors own their isolation contract.
+
+The first extension registration of a route prefix or unit name wins. Extension
+tools and middleware replace same-named built-ins with a warning. A route that
+is a parent or child of dcode's artifact or conversation-history storage fails
+agent construction or runtime registration immediately; internal routes cannot
+be replaced.
+
+## Packaging, discovery, and trust
+
+For quick user-wide extensions, place Python files in
+`~/.deepagents/extensions/`. Installed plugins remain the preferred
+distribution mechanism: they provide stable identity, versions, updates, and a
+durable data directory. Dcode resolves plugin manifest entries inside the
+installed snapshot and rejects traversal, absolute paths, symlink escapes,
+missing files, and non-Python files. Entries without a plugin version are
+ignored. Installed Python distributions may also expose module entry points in
+the `dcode.extensions` group.
+
+Sources load in this order:
+
+| Source | Version and trust behavior |
+| --- | --- |
+| `~/.deepagents/extensions/` | User-owned loose files; implicitly authorized. |
+| `[extensions].extra_files` and `extra_dirs` | Explicit paths in trusted user configuration. |
+| `-e/--extension PATH` | Temporary file or directory authorized for one run. |
+| Enabled installed plugins | Identified by `name@marketplace`, loaded from the versioned plugin cache. Installing and enabling the plugin authorizes its code. |
+| `dcode.extensions` entry points | Modules from installed Python distributions. |
+| `.deepagents/extensions/` | Project-controlled and normally versioned with the project; never scanned before project trust. |
+
+The project directory is the local development escape hatch. Its scan is
+shallow: direct `*.py` files are extensions, and a direct subdirectory is a
+package extension when it contains `__init__.py` or `extension.py`.
+
+Project extensions execute arbitrary Python with the user's process privileges.
+Interactive launches ask before loading them and can remember the canonical
+project path. Headless or CI launches can opt in for one run with
+`--trust-project-extensions`. Only trust projects you control.
+
+## Configuration
+
+```toml
+# ~/.deepagents/config.toml
+[extensions]
+enabled = true
+trust = "ask"  # ask | always | never
+extra_files = ["~/src/policy.py"]
+extra_dirs = ["~/src/company-extensions"]
+```
+
+Environment overrides:
+
+- `DEEPAGENTS_CODE_EXTENSIONS` enables or disables all extension loading.
+- `DEEPAGENTS_CODE_EXTENSIONS_TRUST` overrides the project trust policy.
+
+Relative extra paths resolve from `~/.deepagents/`. Repeat `-e PATH` to add
+multiple temporary sources for one invocation.
+
+## Failure and security behavior
+
+Each setup function is transactional. If import or initialization fails, all of
+that extension's partial registrations are removed and later extensions still
+load. Failures are written to the debug log.
+
+Extension tools override same-named built-ins and are not automatically added to
+dcode's human-approval map. An extension that performs sensitive work must
+enforce its own approval or policy through middleware.
+
+Every registration retains its plugin ID, version, installed root, and source
+scope. This attribution tells dcode which extension added a storage route; it
+does not prove that an arbitrary storage implementation is safe. A provider can
+access the network or host files, so install plugins only from trusted sources
+and choose shared namespaces that preserve tenant and user isolation.
+
+See `examples/extensions/memory_store.py` for a shared storage route.

--- a/libs/code/EXTENSIONS.md
+++ b/libs/code/EXTENSIONS.md
@@ -18,31 +18,16 @@ An installed plugin declares one or more Python entry files in its manifest:
 }
 ```
 
-The entry file exposes an `extension` setup function:
-
-```python
-from deepagents.backends import StoreBackend
-from deepagents_code.extensions import ExtensionAPI
-
-
-async def extension(d: ExtensionAPI) -> None:
-    """Add shared storage under `/memories/`.
-
-    Args:
-        d: The extension setup API.
-    """
-    d.register_backend_route(
-        "/memories/",
-        StoreBackend(namespace=lambda _runtime: ("filesystem",)),
-    )
-```
+The entry file exposes an async `extension` setup function. See
+[`memory_store.py`](./examples/extensions/memory_store.py) for an example that
+registers a shared `/memories/` storage route.
 
 Install and enable the plugin through the normal plugin commands, then run
 `/restart`. Backend composition happens while the agent graph is built, so
 backend route changes cannot be applied by `/reload`. A separately managed
 remote agent server must be restarted or redeployed by its operator.
 
-The `/memories/` route above makes shared storage available to model file
+The `/memories/` route makes shared storage available to model file
 operations. It does not automatically move dcode's built-in `AGENTS.md` memory.
 An extension that wants that content in the model's prompt must also register
 middleware that reads the shared location.
@@ -91,10 +76,10 @@ dcode does not recursively inspect custom or composite backend wrappers, whose
 authors own their isolation contract.
 
 The first extension registration of a route prefix or unit name wins. Extension
-tools and middleware replace same-named built-ins with a warning. A route that
-is a parent or child of dcode's artifact or conversation-history storage fails
-agent construction or runtime registration immediately; internal routes cannot
-be replaced.
+tools and middleware replace same-named built-ins. A route that is a parent or
+child of dcode's artifact or conversation-history storage fails agent
+construction or runtime registration immediately; internal routes cannot be
+replaced.
 
 ## Packaging, discovery, and trust
 
@@ -161,5 +146,3 @@ scope. This attribution tells dcode which extension added a storage route; it
 does not prove that an arbitrary storage implementation is safe. A provider can
 access the network or host files, so install plugins only from trusted sources
 and choose shared namespaces that preserve tenant and user isolation.
-
-See `examples/extensions/memory_store.py` for a shared storage route.

--- a/libs/code/THREAT_MODEL.md
+++ b/libs/code/THREAT_MODEL.md
@@ -28,6 +28,7 @@
 - Custom subagent loader (`subagents.py`, `agent.py:load_async_subagents`)
 - Conversation offload (`offload.py`)
 - Skill management (`skills/commands.py`)
+- Python extension loading (`extensions/`)
 - Persisted goal/rubric state notices (`goal_state_notice.py`, `goal_tools.py`,
   `goal_state_limits.py`)
 
@@ -55,6 +56,8 @@
 7. `DA_SERVER_*` environment variables are readable only by the CLI process and its child server subprocess (OS process isolation assumption).
 8. Users who set `class_path` in `config.toml` accept the same trust model as `pyproject.toml` build scripts — they control their own machine.
 9. Administrators deploy and protect the fixed `managed_config.toml` path with operating-system controls; the CLI does not validate its owner or mode and never writes it.
+10. User-directory, user-config, CLI, installed-plugin, and Python entry-point extensions are authorized by the user action that supplied them. Project extensions execute only after explicit, configured, or persisted trust.
+11. Extension backend routes cannot overlap dcode's local artifact or conversation-history storage. A sandboxed agent rejects direct `FilesystemBackend` and `LocalShellBackend` mounts, including subclasses; wrapper implementations are responsible for their own isolation because dcode does not recursively inspect arbitrary backend object graphs.
 
 ---
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12850,7 +12850,6 @@ class DeepAgentsApp(App):
         )
 
     async def _handle_extensions_command(self, command: str) -> None:
-        """List live extension registrations from the owned local server."""
         await self._mount_message(UserMessage(command))
         if self._server_proc is None:
             await self._mount_message(

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12851,6 +12851,16 @@ class DeepAgentsApp(App):
 
     async def _handle_extensions_command(self, command: str) -> None:
         await self._mount_message(UserMessage(command))
+        from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+
+        if not is_env_truthy(EXPERIMENTAL):
+            await self._mount_message(
+                AppMessage(
+                    "Python extensions require `DEEPAGENTS_CODE_EXPERIMENTAL=1` "
+                    "before starting dcode."
+                )
+            )
+            return
         if self._server_proc is None:
             await self._mount_message(
                 AppMessage("Extension provenance is unavailable for this agent.")

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12849,6 +12849,70 @@ class DeepAgentsApp(App):
             AppMessage(render_context_doctor_report(report), markdown=False)
         )
 
+    async def _handle_extensions_command(self, command: str) -> None:
+        """List live extension registrations from the owned local server."""
+        await self._mount_message(UserMessage(command))
+        if self._server_proc is None:
+            await self._mount_message(
+                AppMessage("Extension provenance is unavailable for this agent.")
+            )
+            return
+        try:
+            import httpx
+
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                response = await client.get(f"{self._server_proc.url}/extensions")
+                response.raise_for_status()
+                payload = response.json()
+        except Exception:
+            logger.exception("Failed to query extension provenance")
+            await self._mount_message(
+                AppMessage("Could not retrieve extension provenance from the server.")
+            )
+            return
+        await self._mount_message(
+            AppMessage(self._render_extensions(payload), markdown=True)
+        )
+
+    @staticmethod
+    def _render_extensions(payload: object) -> str:
+        """Render untrusted endpoint data as escaped markdown.
+
+        Returns:
+            A markdown provenance table or validation error.
+        """
+        if not isinstance(payload, dict):
+            return "The server returned invalid extension metadata."
+        raw = payload.get("registrations")
+        rows: list[list[str]] = []
+        if isinstance(raw, list):
+            for item in raw:
+                if not isinstance(item, dict):
+                    continue
+                source = item.get("source")
+                if not isinstance(source, dict):
+                    continue
+                rows.append(
+                    [
+                        str(item.get("kind", "")),
+                        str(item.get("name", "")),
+                        str(source.get("scope", "")),
+                        str(source.get("path", "")),
+                    ]
+                )
+        body = (
+            _markdown_table(("Kind", "Name", "Scope", "Source"), rows)
+            if rows
+            else "No extensions are loaded."
+        )
+        errors = payload.get("errors")
+        if isinstance(errors, list) and errors:
+            details = "\n".join(f"- {_escape_markdown(str(error))}" for error in errors)
+            body = f"{body}\n\nLoad failures:\n{details}"
+        if payload.get("restart_required") is True:
+            body = f"{body}\n\nRun `/restart` to apply graph-bound extension changes."
+        return body
+
     def _mcp_server_info_for_tools(self) -> list[MCPServerInfo]:
         """Return MCP metadata matching the tools bound to the running agent.
 
@@ -15979,6 +16043,8 @@ class DeepAgentsApp(App):
             await self._mount_message(AppMessage(self._format_cost_summary()))
         elif cmd == "/tools":
             await self._handle_tools_command(command)
+        elif cmd == "/extensions":
+            await self._handle_extensions_command(command)
         elif cmd == "/remember" or cmd.startswith("/remember "):
             # Convenience alias for /skill:remember — shorter and discoverable
             # before skill loading completes.

--- a/libs/code/deepagents_code/client/launch/server_manager.py
+++ b/libs/code/deepagents_code/client/launch/server_manager.py
@@ -319,6 +319,8 @@ async def start_server_and_get_agent(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
+    trust_project_extensions: bool = False,
+    extension_paths: tuple[str, ...] = (),
     interactive: bool = True,
     host: str = "127.0.0.1",
     port: int = _EPHEMERAL_PORT,
@@ -358,6 +360,8 @@ async def start_server_and_get_agent(
         mcp_config_path: Path to MCP config.
         no_mcp: Disable MCP.
         trust_project_mcp: Trust project MCP servers.
+        trust_project_extensions: Allow project extension execution.
+        extension_paths: Explicit one-run extension files or directories.
         interactive: Whether the agent is interactive.
         host: Server host.
         port: Server port. Defaults to `_EPHEMERAL_PORT` (0), letting the server
@@ -412,6 +416,8 @@ async def start_server_and_get_agent(
         no_mcp=no_mcp,
         trust_project_mcp=trust_project_mcp,
         interactive=interactive,
+        trust_project_extensions=trust_project_extensions,
+        extension_paths=extension_paths,
     )
     _apply_server_config(config)
 
@@ -496,6 +502,8 @@ async def server_session(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
+    trust_project_extensions: bool = False,
+    extension_paths: tuple[str, ...] = (),
     interactive: bool = True,
     host: str = "127.0.0.1",
     port: int = _EPHEMERAL_PORT,
@@ -538,6 +546,8 @@ async def server_session(
         mcp_config_path: Path to MCP config.
         no_mcp: Disable MCP.
         trust_project_mcp: Trust project MCP servers.
+        trust_project_extensions: Allow project extension execution.
+        extension_paths: Explicit one-run extension files or directories.
         interactive: Whether the agent is interactive.
         host: Server host.
         port: Server port. Defaults to `_EPHEMERAL_PORT` (0), letting the server
@@ -576,6 +586,8 @@ async def server_session(
             mcp_config_path=mcp_config_path,
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
+            trust_project_extensions=trust_project_extensions,
+            extension_paths=extension_paths,
             interactive=interactive,
             host=host,
             port=port,

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -1933,6 +1933,8 @@ async def run_non_interactive(
     rubric_max_iterations: int | None = None,
     recursion_limit: int | None = None,
     trust_project_hooks: bool = False,
+    trust_project_extensions: bool = False,
+    extension_paths: tuple[str, ...] = (),
 ) -> int:
     """Run a single task non-interactively and exit.
 
@@ -2014,6 +2016,11 @@ async def run_non_interactive(
 
             Defaults to `False` so untrusted repositories cannot execute hook
             commands without an explicit `--trust-project-hooks` opt-in.
+        trust_project_extensions: Allow project-authored Python extensions.
+
+            Defaults to `False`; persisted or configured trust may still grant
+            project loading inside the server.
+        extension_paths: Explicit one-run extension files or directories.
 
     Returns:
         Exit code: 0 for success or an intentional hook stop, 1 for error, 124
@@ -2261,6 +2268,8 @@ async def run_non_interactive(
             mcp_config_path=mcp_config_path,
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
+            trust_project_extensions=trust_project_extensions,
+            extension_paths=extension_paths,
             interactive=False,
         ) as (agent, _server_proc):
             # Collect MCP preload result (ran concurrently with server startup)

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -220,7 +220,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     # `re` → `/remember`, `rel` → `/reload`.
     SlashCommand(
         name="/reload",
-        description="Reload config, plugins, and the agent server",
+        description="Reload environment and config",
         bypass_tier=BypassTier.QUEUED,
         hidden_keywords="refresh plugin plugins marketplace",
     ),
@@ -252,7 +252,6 @@ COMMANDS: tuple[SlashCommand, ...] = (
         name="/extensions",
         description="List loaded Python extensions and their provenance",
         bypass_tier=BypassTier.QUEUED,
-        hidden_keywords="plugins middleware backend provenance",
     ),
     SlashCommand(
         name="/tools",

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -220,7 +220,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     # `re` → `/remember`, `rel` → `/reload`.
     SlashCommand(
         name="/reload",
-        description="Reload environment and config",
+        description="Reload config, plugins, and the agent server",
         bypass_tier=BypassTier.QUEUED,
         hidden_keywords="refresh plugin plugins marketplace",
     ),
@@ -247,6 +247,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
         description="Show token usage",
         bypass_tier=BypassTier.QUEUED,
         hidden_keywords="cost",
+    ),
+    SlashCommand(
+        name="/extensions",
+        description="List loaded Python extensions and their provenance",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="plugins middleware backend provenance",
     ),
     SlashCommand(
         name="/tools",

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -56,6 +56,9 @@ class SlashCommand:
     aliases: tuple[str, ...] = ()
     """Alternative names (e.g. `("/q",)` for `/quit`)."""
 
+    experimental: bool = False
+    """Whether autocomplete requires experimental mode."""
+
     def to_entry(self) -> CommandEntry:
         """Project this command into a `CommandEntry` for autocomplete.
 
@@ -252,6 +255,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
         name="/extensions",
         description="List loaded Python extensions and their provenance",
         bypass_tier=BypassTier.QUEUED,
+        experimental=True,
     ),
     SlashCommand(
         name="/tools",
@@ -484,7 +488,14 @@ def get_slash_commands() -> list[CommandEntry]:
     Returns:
         Autocomplete entries derived from `COMMANDS`.
     """
-    return [command.to_entry() for command in COMMANDS]
+    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+
+    experimental = is_env_truthy(EXPERIMENTAL)
+    return [
+        command.to_entry()
+        for command in COMMANDS
+        if experimental or not command.experimental
+    ]
 
 
 def parse_skill_command(command: str) -> tuple[str, str]:

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2746,6 +2746,20 @@ def parse_args() -> argparse.Namespace:
         "(required for headless/CI runs that should load repository hooks)",
     )
     parser.add_argument(
+        "--trust-project-extensions",
+        action="store_true",
+        help="Trust project-level `.deepagents/extensions/` Python extensions "
+        "(required for headless/CI runs without persisted trust)",
+    )
+    parser.add_argument(
+        "-e",
+        "--extension",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Load an extension file or directory for this run (repeatable)",
+    )
+    parser.add_argument(
         "--interpreter",
         action=argparse.BooleanOptionalAction,
         default=None,
@@ -3047,6 +3061,8 @@ async def run_textual_cli_async(
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
     hook_trust: "WorkspaceTrust | None" = None,
+    trust_project_extensions: bool = False,
+    extension_paths: tuple[str, ...] = (),
     enable_interpreter: bool | None = None,
     interpreter_arg: bool | None = None,
     interpreter_ptc: str | list[str] | None = None,
@@ -3109,6 +3125,9 @@ async def run_textual_cli_async(
             whole-config decision).
         hook_trust: Policy deciding which workspaces may run project-scoped hook
             commands. `None` consults only the persisted trust store.
+        trust_project_extensions: Allow project-authored Python extensions for
+            this session.
+        extension_paths: Explicit one-run extension files or directories.
         enable_interpreter: Enable `CodeInterpreterMiddleware` (`js_eval`) on
             the main agent. `None` defers to the sandbox-aware/config default.
         interpreter_arg: The raw `--interpreter`/`--no-interpreter` tri-state,
@@ -3258,6 +3277,8 @@ async def run_textual_cli_async(
         "mcp_config_path": mcp_config_path,
         "no_mcp": no_mcp,
         "trust_project_mcp": trust_project_mcp,
+        "trust_project_extensions": trust_project_extensions,
+        "extension_paths": extension_paths,
         "interactive": True,
         "recursion_limit": recursion_limit,
     }
@@ -4691,6 +4712,106 @@ def _check_project_hooks_trust(
     return WorkspaceTrust.none()
 
 
+_PROJECT_EXTENSIONS_REMEMBER_LABEL = "Always allow extensions in this project"
+
+
+def _check_project_extensions_trust(
+    *,
+    trust_flag: bool = False,
+) -> "bool | _TrustPromptOutcome":
+    """Resolve interactive trust for project-authored Python extensions.
+
+    Args:
+        trust_flag: Whether the CLI explicitly trusted project extensions.
+
+    Returns:
+        Whether project extensions may load, `INTERRUPTED` on Ctrl+C, or
+            `CANCELLED` when startup is aborted.
+    """
+    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+
+    if not is_env_truthy(EXPERIMENTAL):
+        return False
+    from rich.console import Console
+
+    from deepagents_code.extensions.discovery import project_extensions_dir
+    from deepagents_code.extensions.settings import (
+        TrustPolicy,
+        load_extension_settings,
+    )
+    from deepagents_code.extensions.trust import (
+        is_project_extensions_trusted,
+        trust_project_extensions,
+    )
+    from deepagents_code.project_utils import ProjectContext
+
+    settings = load_extension_settings()
+    if not settings.enabled or settings.trust is TrustPolicy.NEVER:
+        return False
+
+    try:
+        context = ProjectContext.from_user_cwd(Path.cwd())
+        project_root = context.project_root or context.user_cwd
+        extensions_dir = project_extensions_dir(project_root)
+        if not extensions_dir.is_dir():
+            return False
+    except OSError:
+        logger.warning("Could not inspect project extensions", exc_info=True)
+        return False
+
+    if (
+        trust_flag
+        or settings.trust is TrustPolicy.ALWAYS
+        or is_project_extensions_trusted(project_root)
+    ):
+        return True
+
+    from rich.markup import escape
+
+    console = Console(stderr=True)
+    console.print()
+    console.print(
+        "[bold yellow]Project extensions run arbitrary Python in this "
+        "session.[/bold yellow]",
+        highlight=False,
+    )
+    console.print(
+        f"Extensions directory: {escape(str(extensions_dir))}", highlight=False
+    )
+    console.print(
+        "Only trust projects you control. Allow once loads these files as they "
+        f'are now; always allow trusts "{escape(str(project_root))}" for future '
+        "sessions and future edits.",
+        style="yellow",
+        highlight=False,
+    )
+    action = _select_trust_action(
+        console,
+        remember_label=_PROJECT_EXTENSIONS_REMEMBER_LABEL,
+    )
+    if action in {
+        _TrustPromptOutcome.INTERRUPTED,
+        _TrustPromptOutcome.CANCELLED,
+    }:
+        return action
+    if action is _TrustAction.ALLOW_ONCE:
+        console.print(
+            "[dim]Allowing project extensions for this session.[/dim]",
+            highlight=False,
+        )
+        return True
+    if action is _TrustAction.REMEMBER:
+        if not trust_project_extensions(project_root):
+            console.print(
+                "[yellow]Extension trust could not be remembered; allowing "
+                "this session only.[/yellow]",
+                highlight=False,
+            )
+        return True
+    console.print("[dim]Project extensions skipped.[/dim]", highlight=False)
+    return False
+
+
 def _verify_interpreter_or_exit() -> None:
     """Run the interpreter pre-flight check; print and exit on failure.
 
@@ -6009,6 +6130,10 @@ def cli_main() -> None:
                             trust_project_hooks=getattr(
                                 args, "trust_project_hooks", False
                             ),
+                            trust_project_extensions=getattr(
+                                args, "trust_project_extensions", False
+                            ),
+                            extension_paths=tuple(getattr(args, "extension", ())),
                             enable_interpreter=enable_interpreter,
                             interpreter_ptc=interpreter_ptc,
                             allow_fs_tools=allow_fs_tools,
@@ -6124,6 +6249,20 @@ def cli_main() -> None:
                 )
                 return
 
+            extensions_trust = _check_project_extensions_trust(
+                trust_flag=getattr(args, "trust_project_extensions", False),
+            )
+            if extensions_trust is _TrustPromptOutcome.INTERRUPTED:
+                sys.exit(130)
+            if extensions_trust is _TrustPromptOutcome.CANCELLED:
+                from rich.console import Console as _Console
+
+                _Console(stderr=True).print(
+                    "[dim]Aborted; project extensions not loaded.[/dim]",
+                    highlight=False,
+                )
+                return
+
             # Run Textual TUI
             return_code = 0
             request_count = 0
@@ -6179,6 +6318,8 @@ def cli_main() -> None:
                         no_mcp=getattr(args, "no_mcp", False),
                         trust_project_mcp=mcp_trust_decision,
                         hook_trust=hook_trust,
+                        trust_project_extensions=bool(extensions_trust),
+                        extension_paths=tuple(getattr(args, "extension", ())),
                         enable_interpreter=enable_interpreter,
                         interpreter_arg=args.interpreter,
                         interpreter_ptc=interpreter_ptc,

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2749,7 +2749,7 @@ def parse_args() -> argparse.Namespace:
         "--trust-project-extensions",
         action="store_true",
         help="Trust project-level `.deepagents/extensions/` Python extensions "
-        "(required for headless/CI runs without persisted trust)",
+        "(requires DEEPAGENTS_CODE_EXPERIMENTAL=1)",
     )
     parser.add_argument(
         "-e",
@@ -2757,7 +2757,8 @@ def parse_args() -> argparse.Namespace:
         action="append",
         default=[],
         metavar="PATH",
-        help="Load an extension file or directory for this run (repeatable)",
+        help="Load an extension file or directory for this run; requires "
+        "DEEPAGENTS_CODE_EXPERIMENTAL=1 (repeatable)",
     )
     parser.add_argument(
         "--interpreter",
@@ -2851,6 +2852,16 @@ def parse_args() -> argparse.Namespace:
     )
 
     args = parser.parse_args()
+    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+
+    if (
+        getattr(args, "trust_project_extensions", False)
+        or getattr(args, "extension", ())
+    ) and not is_env_truthy(EXPERIMENTAL):
+        parser.error(
+            "--extension and --trust-project-extensions require "
+            "DEEPAGENTS_CODE_EXPERIMENTAL=1"
+        )
     # `--auto-classifier-model ""` yields the empty string, not `None`. Keep it
     # distinct from an absent flag (just trimmed): an explicit blank is the
     # "inherit the main agent model" instruction and must override a classifier

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -4712,9 +4712,6 @@ def _check_project_hooks_trust(
     return WorkspaceTrust.none()
 
 
-_PROJECT_EXTENSIONS_REMEMBER_LABEL = "Always allow extensions in this project"
-
-
 def _check_project_extensions_trust(
     *,
     trust_flag: bool = False,
@@ -4787,7 +4784,7 @@ def _check_project_extensions_trust(
     )
     action = _select_trust_action(
         console,
-        remember_label=_PROJECT_EXTENSIONS_REMEMBER_LABEL,
+        remember_label="Always allow extensions in this project",
     )
     if action in {
         _TrustPromptOutcome.INTERRUPTED,

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -216,6 +216,12 @@ def show_help() -> None:
         "  --trust-project-hooks      Trust project hooks.json command handlers"
     )
     console.print(
+        "  --trust-project-extensions Trust project .deepagents/extensions Python"
+    )
+    console.print(
+        "  -e, --extension PATH       Load extension file or directory (repeatable)"
+    )
+    console.print(
         "  --interpreter, --no-interpreter"
         "  Enable or disable JS interpreter (`js_eval`) middleware"
     )

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -216,10 +216,12 @@ def show_help() -> None:
         "  --trust-project-hooks      Trust project hooks.json command handlers"
     )
     console.print(
-        "  --trust-project-extensions Trust project .deepagents/extensions Python"
+        "  --trust-project-extensions Trust project .deepagents/extensions Python "
+        "(experimental)"
     )
     console.print(
-        "  -e, --extension PATH       Load extension file or directory (repeatable)"
+        "  -e, --extension PATH       Load extension file or directory "
+        "(experimental, repeatable)"
     )
     console.print(
         "  --interpreter, --no-interpreter"

--- a/libs/code/examples/extensions/memory_store.py
+++ b/libs/code/examples/extensions/memory_store.py
@@ -1,0 +1,22 @@
+"""Reference extension: shared data through a virtual storage route."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deepagents.backends import StoreBackend
+
+if TYPE_CHECKING:
+    from deepagents_code.extensions import ExtensionAPI
+
+
+async def extension(d: ExtensionAPI) -> None:  # noqa: RUF029  # Public extension factories are async by contract.
+    """Make LangGraph store data available under `/memories/`.
+
+    Args:
+        d: The dcode extension API.
+    """
+    d.register_backend_route(
+        "/memories/",
+        StoreBackend(namespace=lambda _runtime: ("filesystem",)),
+    )

--- a/libs/code/examples/extensions/memory_store.py
+++ b/libs/code/examples/extensions/memory_store.py
@@ -1,13 +1,8 @@
 """Reference extension: shared data through a virtual storage route."""
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 from deepagents.backends import StoreBackend
 
-if TYPE_CHECKING:
-    from deepagents_code.extensions import ExtensionAPI
+from deepagents_code.extensions import ExtensionAPI
 
 
 async def extension(d: ExtensionAPI) -> None:  # noqa: RUF029  # Public extension factories are async by contract.

--- a/libs/code/tests/unit_tests/test_extension_cli_trust.py
+++ b/libs/code/tests/unit_tests/test_extension_cli_trust.py
@@ -1,0 +1,80 @@
+"""Tests for interactive project-extension trust."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from deepagents_code._env_vars import EXPERIMENTAL
+from deepagents_code.extensions.settings import ExtensionSettings, TrustPolicy
+from deepagents_code.main import (
+    _check_project_extensions_trust,
+    _TrustAction,
+    _TrustPromptOutcome,
+)
+
+
+@pytest.fixture(autouse=True)
+def _enable_extensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(EXPERIMENTAL, "1")
+
+
+def _project(tmp_path: Path) -> SimpleNamespace:
+    (tmp_path / ".deepagents" / "extensions").mkdir(parents=True)
+    return SimpleNamespace(project_root=tmp_path, user_cwd=tmp_path)
+
+
+def test_experimental_mode_is_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disabled extensions do not inspect projects or prompt for trust."""
+    monkeypatch.delenv(EXPERIMENTAL)
+    assert not _check_project_extensions_trust(trust_flag=True)
+
+
+def test_never_policy_overrides_explicit_flag(tmp_path: Path) -> None:
+    """A configured hard stop wins over the CLI flag."""
+    with (
+        patch(
+            "deepagents_code.extensions.settings.load_extension_settings",
+            return_value=ExtensionSettings(trust=TrustPolicy.NEVER),
+        ),
+        patch(
+            "deepagents_code.project_utils.ProjectContext.from_user_cwd",
+            return_value=_project(tmp_path),
+        ),
+    ):
+        assert not _check_project_extensions_trust(trust_flag=True)
+
+
+@pytest.mark.parametrize(
+    ("action", "expected", "persist"),
+    [
+        (_TrustAction.ALLOW_ONCE, True, False),
+        (_TrustAction.REMEMBER, True, True),
+        (_TrustPromptOutcome.CANCELLED, _TrustPromptOutcome.CANCELLED, False),
+    ],
+)
+def test_prompt_decisions(
+    tmp_path: Path,
+    action: _TrustAction | _TrustPromptOutcome,
+    expected: bool | _TrustPromptOutcome,
+    persist: bool,
+) -> None:
+    """Prompt outcomes grant, persist, or cancel as selected."""
+    with (
+        patch(
+            "deepagents_code.project_utils.ProjectContext.from_user_cwd",
+            return_value=_project(tmp_path),
+        ),
+        patch(
+            "deepagents_code.extensions.trust.is_project_extensions_trusted",
+            return_value=False,
+        ),
+        patch(
+            "deepagents_code.extensions.trust.trust_project_extensions",
+            return_value=True,
+        ) as trust,
+        patch("deepagents_code.main._select_trust_action", return_value=action),
+    ):
+        assert _check_project_extensions_trust() is expected
+    assert trust.call_count == int(persist)

--- a/libs/code/tests/unit_tests/test_extension_cli_trust.py
+++ b/libs/code/tests/unit_tests/test_extension_cli_trust.py
@@ -12,6 +12,7 @@ from deepagents_code.main import (
     _check_project_extensions_trust,
     _TrustAction,
     _TrustPromptOutcome,
+    parse_args,
 )
 
 
@@ -24,6 +25,24 @@ def test_experimental_mode_is_required(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disabled extensions do not inspect projects or prompt for trust."""
     monkeypatch.delenv(EXPERIMENTAL)
     assert not _check_project_extensions_trust(trust_flag=True)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["dcode", "--extension", "extension.py"],
+        ["dcode", "--trust-project-extensions"],
+    ],
+)
+def test_extension_flags_require_experimental_mode(
+    argv: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit extension flags fail instead of being silently ignored."""
+    monkeypatch.delenv(EXPERIMENTAL, raising=False)
+    monkeypatch.setattr("sys.argv", argv)
+
+    with pytest.raises(SystemExit, match="2"):
+        parse_args()
 
 
 def test_never_policy_overrides_explicit_flag() -> None:

--- a/libs/code/tests/unit_tests/test_extension_cli_trust.py
+++ b/libs/code/tests/unit_tests/test_extension_cli_trust.py
@@ -20,28 +20,17 @@ def _enable_extensions(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(EXPERIMENTAL, "1")
 
 
-def _project(tmp_path: Path) -> SimpleNamespace:
-    (tmp_path / ".deepagents" / "extensions").mkdir(parents=True)
-    return SimpleNamespace(project_root=tmp_path, user_cwd=tmp_path)
-
-
 def test_experimental_mode_is_required(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disabled extensions do not inspect projects or prompt for trust."""
     monkeypatch.delenv(EXPERIMENTAL)
     assert not _check_project_extensions_trust(trust_flag=True)
 
 
-def test_never_policy_overrides_explicit_flag(tmp_path: Path) -> None:
+def test_never_policy_overrides_explicit_flag() -> None:
     """A configured hard stop wins over the CLI flag."""
-    with (
-        patch(
-            "deepagents_code.extensions.settings.load_extension_settings",
-            return_value=ExtensionSettings(trust=TrustPolicy.NEVER),
-        ),
-        patch(
-            "deepagents_code.project_utils.ProjectContext.from_user_cwd",
-            return_value=_project(tmp_path),
-        ),
+    with patch(
+        "deepagents_code.extensions.settings.load_extension_settings",
+        return_value=ExtensionSettings(trust=TrustPolicy.NEVER),
     ):
         assert not _check_project_extensions_trust(trust_flag=True)
 
@@ -61,10 +50,11 @@ def test_prompt_decisions(
     persist: bool,
 ) -> None:
     """Prompt outcomes grant, persist, or cancel as selected."""
+    (tmp_path / ".deepagents" / "extensions").mkdir(parents=True)
     with (
         patch(
             "deepagents_code.project_utils.ProjectContext.from_user_cwd",
-            return_value=_project(tmp_path),
+            return_value=SimpleNamespace(project_root=tmp_path, user_cwd=tmp_path),
         ),
         patch(
             "deepagents_code.extensions.trust.is_project_extensions_trusted",

--- a/libs/code/tests/unit_tests/test_extension_display.py
+++ b/libs/code/tests/unit_tests/test_extension_display.py
@@ -11,10 +11,7 @@ def test_extension_display_escapes_endpoint_metadata() -> None:
                 {
                     "kind": "tool",
                     "name": "name|forged",
-                    "source": {
-                        "scope": "project",
-                        "path": "<b>/tmp/[extension]</b>",
-                    },
+                    "source": {"scope": "project", "path": "<b>/tmp/[extension]</b>"},
                 }
             ],
             "errors": ["bad\n# injected"],

--- a/libs/code/tests/unit_tests/test_extension_display.py
+++ b/libs/code/tests/unit_tests/test_extension_display.py
@@ -1,0 +1,28 @@
+"""Tests for the built-in extension provenance display."""
+
+from deepagents_code.app import DeepAgentsApp
+
+
+def test_extension_display_escapes_endpoint_metadata() -> None:
+    """Paths and errors cannot inject markdown structure into the transcript."""
+    rendered = DeepAgentsApp._render_extensions(
+        {
+            "registrations": [
+                {
+                    "kind": "tool",
+                    "name": "name|forged",
+                    "source": {
+                        "scope": "project",
+                        "path": "<b>/tmp/[extension]</b>",
+                    },
+                }
+            ],
+            "errors": ["bad\n# injected"],
+            "restart_required": True,
+        }
+    )
+
+    assert "name\\|forged" in rendered
+    assert "\\<b\\>" in rendered
+    assert "bad # injected" in rendered
+    assert "Run `/restart`" in rendered

--- a/libs/code/tests/unit_tests/test_extension_display.py
+++ b/libs/code/tests/unit_tests/test_extension_display.py
@@ -1,6 +1,39 @@
 """Tests for the built-in extension provenance display."""
 
+from unittest.mock import AsyncMock
+
+import pytest
+
+from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.app import DeepAgentsApp
+from deepagents_code.command_registry import get_slash_commands
+
+
+def test_extension_command_autocomplete_requires_experimental_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The disabled experiment is absent from user-facing autocomplete."""
+    monkeypatch.delenv(EXPERIMENTAL, raising=False)
+    assert "/extensions" not in {item.name for item in get_slash_commands()}
+
+    monkeypatch.setenv(EXPERIMENTAL, "1")
+    assert "/extensions" in {item.name for item in get_slash_commands()}
+
+
+async def test_extension_command_rejects_when_experimental_mode_is_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Typing the hidden command directly cannot reach the server endpoint."""
+    monkeypatch.delenv(EXPERIMENTAL, raising=False)
+    app = object.__new__(DeepAgentsApp)
+    mount_message = AsyncMock()
+    monkeypatch.setattr(app, "_mount_message", mount_message)
+
+    await app._handle_extensions_command("/extensions")
+
+    assert "DEEPAGENTS_CODE_EXPERIMENTAL=1" in str(
+        mount_message.await_args_list[-1].args[0]._content
+    )
 
 
 def test_extension_display_escapes_endpoint_metadata() -> None:


### PR DESCRIPTION
Related #5556

Adds interactive and headless project-extension trust controls, explicit one-run extension paths, live provenance inspection, and extension documentation.

---

Layer 4 of 4. The CLI supports `--extension` and `--trust-project-extensions`, prompts before executing untrusted project code in interactive mode, forwards explicit policy in headless mode, and exposes loaded registrations through `/extensions`. The guide and example document the complete extension lifecycle and a StoreBackend memory route.

References: [original PRD](https://app.notion.com/p/Extensions-PRD-3b4808527b17809c9534cbdd8c14d642?source=copy_link) and [tech spec](https://app.notion.com/p/Extensions-Tech-Spec-3bb808527b1780ce8a75f392ac13aa02?source=copy_link).

## Stack

1. [#5631 — API, registry, and discovery](https://github.com/langchain-ai/deepagents/pull/5631)
2. [#5632 — configuration, trust, and loading](https://github.com/langchain-ai/deepagents/pull/5632)
3. [#5633 — agent hosting and lifecycle](https://github.com/langchain-ai/deepagents/pull/5633)
4. [#5634 — trust and inspection UX](https://github.com/langchain-ai/deepagents/pull/5634)