### PR TITLE
test(code): make connection-refresh ordering test event-driven

### DIFF
--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -3,7 +3,7 @@
 import asyncio
 import inspect
 import re
-import threading
+import time
 from pathlib import Path
 from typing import get_args
 from unittest.mock import AsyncMock, MagicMock
@@ -1033,9 +1033,16 @@ async def test_connection_refresh_waits_for_initial_refresh(
 ) -> None:
     """A settled snapshot cannot be overwritten by the initial loading one."""
     screen = PluginManagerScreen(mcp_connecting=True)
-    initial_started = threading.Event()
-    release_initial = threading.Event()
-    settled_loaded = threading.Event()
+    loop = asyncio.get_running_loop()
+    # `asyncio.Event`s set via `call_soon_threadsafe` (thread-safe on every
+    # supported Python), rather than `threading.Event`s awaited via `to_thread`:
+    # the await side must not depend on the default executor, which the blocked
+    # initial load can starve on a loaded CI runner.
+    initial_started = asyncio.Event()
+    settled_applied = asyncio.Event()
+    # Read from the load thread and written once on the event loop; a one-element
+    # list acts as the cross-thread release cell (item assignment is atomic).
+    release_initial: list[bool] = []
     snapshots: list[bool] = []
     loading_state = _ManagerState((), (), (), ("loading",))
     settled_state = _ManagerState((), (), (), ("settled",))
@@ -1048,10 +1055,17 @@ async def test_connection_refresh_waits_for_initial_refresh(
     ) -> _ManagerState:
         snapshots.append(mcp_connecting)
         if mcp_connecting:
-            initial_started.set()
-            release_initial.wait(timeout=1)
+            loop.call_soon_threadsafe(initial_started.set)
+            # Block the initial load (not a fixed sleep) so the ordering under
+            # test — connection refresh queued behind it — holds no matter how
+            # long CI takes to schedule the next await.
+            while not release_initial:
+                time.sleep(0.005)
             return loading_state
-        settled_loaded.set()
+
+        # The connection refresh has been dequeued and rerun with the settled
+        # snapshot; signal the await side before returning the settled state.
+        loop.call_soon_threadsafe(settled_applied.set)
         return settled_state
 
     monkeypatch.setattr(
@@ -1063,12 +1077,34 @@ async def test_connection_refresh_waits_for_initial_refresh(
     )
     monkeypatch.setattr(screen, "_refresh_view", MagicMock())
 
+    async def wait_for(event: asyncio.Event, what: str) -> None:
+        """Await `event`, failing with context instead of hanging on a bug."""
+        try:
+            async with asyncio.timeout(10):
+                await event.wait()
+        except TimeoutError:
+            msg = f"timed out waiting for {what}; snapshots so far: {snapshots}"
+            raise AssertionError(msg) from None
+
     initial_refresh = asyncio.create_task(screen._refresh_state())
-    await asyncio.wait_for(asyncio.to_thread(initial_started.wait), timeout=1)
+    # The initial load has entered `load_state` and is holding the refresh lock.
+    await wait_for(initial_started, "the initial load to start")
+    # Queue the settled connection refresh behind the initial load's lock.
     screen.update_connection_state([], mcp_connecting=False)
-    release_initial.set()
+    # Release the initial load; once it finishes, the queued settled refresh runs.
+    release_initial.append(True)
     await initial_refresh
-    await asyncio.wait_for(asyncio.to_thread(settled_loaded.wait), timeout=1)
+    # Wait for the settled refresh to finish and apply its snapshot. `settled_applied`
+    # is set from the load thread, so also yield once to let the connection task run
+    # its `_state` assignment (the continuation after `await asyncio.to_thread(...)`).
+    await wait_for(settled_applied, "the settled refresh")
+    for _ in range(100):
+        if screen._state == settled_state:
+            break
+        await asyncio.sleep(0)
+    else:
+        msg = f"settled load ran but `_state` was not applied; snapshots: {snapshots}"
+        raise AssertionError(msg)
 
     assert snapshots == [True, False]
     assert screen._state == settled_state

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -1,6 +1,7 @@
 """Tests for the plugin manager modal structure."""
 
 import asyncio
+import contextlib
 import inspect
 import re
 import time
@@ -1087,24 +1088,38 @@ async def test_connection_refresh_waits_for_initial_refresh(
             raise AssertionError(msg) from None
 
     initial_refresh = asyncio.create_task(screen._refresh_state())
-    # The initial load has entered `load_state` and is holding the refresh lock.
-    await wait_for(initial_started, "the initial load to start")
-    # Queue the settled connection refresh behind the initial load's lock.
-    screen.update_connection_state([], mcp_connecting=False)
-    # Release the initial load; once it finishes, the queued settled refresh runs.
-    release_initial.append(True)
-    await initial_refresh
-    # Wait for the settled refresh to finish and apply its snapshot. `settled_applied`
-    # is set from the load thread, so also yield once to let the connection task run
-    # its `_state` assignment (the continuation after `await asyncio.to_thread(...)`).
-    await wait_for(settled_applied, "the settled refresh")
-    for _ in range(100):
-        if screen._state == settled_state:
-            break
-        await asyncio.sleep(0)
-    else:
-        msg = f"settled load ran but `_state` was not applied; snapshots: {snapshots}"
-        raise AssertionError(msg)
+    try:
+        # The initial load has entered `load_state` and is holding the refresh lock.
+        await wait_for(initial_started, "the initial load to start")
+        # Queue the settled connection refresh behind the initial load's lock.
+        screen.update_connection_state([], mcp_connecting=False)
+        # Release the initial load; once it finishes, the queued settled refresh runs.
+        release_initial.append(True)
+        await initial_refresh
+        # Wait for the settled refresh to finish and apply its snapshot.
+        # `settled_applied` is set from the load thread, so also yield once to let
+        # the connection task run its `_state` assignment (the continuation after
+        # `await asyncio.to_thread(...)`).
+        await wait_for(settled_applied, "the settled refresh")
+        for _ in range(100):
+            if screen._state == settled_state:
+                break
+            await asyncio.sleep(0)
+        else:
+            msg = (
+                f"settled load ran but `_state` was not applied; snapshots: {snapshots}"
+            )
+            raise AssertionError(msg)
+    finally:
+        # Release the load thread even when a wait above timed out: a running
+        # `to_thread` callable cannot be cancelled, and an un-released worker
+        # would spin in `load_state` forever, hanging interpreter teardown on
+        # the executor instead of surfacing the assertion.
+        release_initial.append(True)
+        if not initial_refresh.done():
+            initial_refresh.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await initial_refresh
 
     assert snapshots == [True, False]
     assert screen._state == settled_state


### PR DESCRIPTION
`test_connection_refresh_waits_for_initial_refresh` no longer flakes under CI load: its cross-thread synchronization is now event-driven with no fixed timeouts racing each other.

---

The test verifies that a settled connection refresh queued behind the initial state load cannot be overwritten by that load's stale "connecting" snapshot. It synchronized across threads with `threading.Event`s plus hardcoded 1-second timeouts:

- The stubbed state loader (running in a `to_thread` worker) blocked on `release_initial.wait(timeout=1)` — a bounded wait.
- The test body watched those events via `asyncio.wait_for(asyncio.to_thread(event.wait), timeout=1)` — using `to_thread` to wait on a threading event, competing for the same default executor the blocked initial load was occupying.

Under xdist load the executor can starve to its 1-thread minimum, collapsing the coupled 1s timeouts: the initial load timed out early and applied the `loading` state *after* the settled refresh, so `screen._state.errors` ended as `('loading',)` instead of `('settled',)`. Example failure: https://github.com/langchain-ai/deepagents/actions/runs/32194056578/job/95894437582?pr=5619

The rewrite removes both fragile mechanisms:

- `threading.Event` → `asyncio.Event`, set from the load thread via `loop.call_soon_threadsafe(...)` (`Event.set()` from a thread is only safe in 3.14+, and CI runs 3.12/3.13).
- The initial load blocks on an unbounded release flag instead of a fixed 1s wait, so the ordering under test holds no matter how slow CI scheduling is.
- The await side waits on the `asyncio.Event`s directly (no `to_thread` hop, so no executor dependency), wrapped in a generous 10s `asyncio.timeout` that raises a descriptive `AssertionError` — including the observed snapshot ordering — instead of hanging on a regression.
- After the settled load signals, the test yields to let the connection task run its `_state = ...` continuation before asserting, since the thread-side event fires one loop iteration before the assignment lands.

Behavior under test is unchanged; only the synchronization scaffolding was reworked.
