### PR TITLE
ci(ci): bound ripgrep install on ordinary PRs

### DIFF
--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -1,10 +1,16 @@
-"""Static contracts for the main CI workflow."""
+"""Contracts for the CI workflows.
+
+Mostly static assertions over workflow YAML, plus an executable check of the
+bounded ripgrep install script: `test_non_release_ripgrep_install_*` runs the
+step's real `run:` body against stubbed `sudo`/`timeout`/`dpkg`/`rg` binaries.
+"""
 
 from __future__ import annotations
 
 import json
-import os
+import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +23,17 @@ CI_WORKFLOW = WORKFLOWS / "ci.yml"
 TEST_WORKFLOW = WORKFLOWS / "_test.yml"
 RELEASE_WORKFLOW = WORKFLOWS / "release.yml"
 RIPGREP_COMMENT_WORKFLOW = WORKFLOWS / "ripgrep_timeout_comment.yml"
+FILESYSTEM_TESTS = (
+    ROOT / "libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py"
+)
+
+STRICT_STEP = "🔍 Install ripgrep (strict)"
+SOFT_STEP = "🔍 Install ripgrep (non-release PR)"
+APT_INSTALL = "apt-get update && sudo apt-get install -y ripgrep"
+# Shared by the shell producer in `_test.yml` and the JS consumer in
+# `ripgrep_timeout_comment.yml`; nothing else couples the two files.
+ARTIFACT_PREFIX = "ripgrep-timeout-"
+EXPECTED_ENV = "DEEPAGENTS_RIPGREP_EXPECTED=1"
 
 
 def _load_workflow(path: Path) -> dict[str, Any]:
@@ -33,6 +50,100 @@ def _find_step(workflow: dict[str, Any], *, job: str, name: str) -> dict[str, An
     return matches[0]
 
 
+def _starts_with(value: Any, prefix: str) -> bool:
+    """Mimic the GitHub Actions `startsWith`, which coerces null to ''."""
+    return str(value or "").startswith(prefix)
+
+
+# Longest first: a shorter path must not rewrite part of a longer one.
+_CONTEXT_PATHS = sorted(
+    (
+        "github.event.pull_request.title",
+        "github.event_name",
+        "github.head_ref",
+        "runner.os",
+    ),
+    key=len,
+    reverse=True,
+)
+
+
+def _eval_condition(expression: str, context: dict[str, Any]) -> bool:
+    """Evaluate the subset of GitHub Actions expression syntax used by these steps.
+
+    Supports context lookups, `startsWith`, `!`, `&&`, `||`, and parentheses —
+    enough to check that the two install steps really are mutually exclusive,
+    which substring assertions cannot do.
+    """
+    expr = " ".join(expression.split())
+    for path in _CONTEXT_PATHS:
+        expr = expr.replace(path, repr(context.get(path)))
+    expr = expr.replace("&&", " and ").replace("||", " or ")
+    # Only unary `!`; the lookahead keeps `!=` intact.
+    expr = re.sub(r"!\s*(?=startsWith|\()", " not ", expr)
+    expr = expr.replace("startsWith(", "_starts_with(")
+    return bool(eval(expr, {"__builtins__": {}}, {"_starts_with": _starts_with}))
+
+
+def _context(
+    *,
+    event_name: str,
+    head_ref: str | None = None,
+    title: str | None = None,
+    runner_os: str = "Linux",
+) -> dict[str, Any]:
+    return {
+        "github.event_name": event_name,
+        "github.head_ref": head_ref,
+        "github.event.pull_request.title": title,
+        "runner.os": runner_os,
+    }
+
+
+# (label, context, expected step) — "expected step" is the one that must run.
+SELECTION_CASES = [
+    ("push to main", _context(event_name="push"), STRICT_STEP),
+    ("merge queue", _context(event_name="merge_group"), STRICT_STEP),
+    (
+        "release-please PR",
+        _context(
+            event_name="pull_request",
+            head_ref="release-please--branches--main--components--deepagents",
+            title="chore: release main",
+        ),
+        STRICT_STEP,
+    ),
+    (
+        "manual release PR by title",
+        _context(
+            event_name="pull_request",
+            head_ref="mdrxy/release-prep",
+            title="release(deepagents): 1.2.3",
+        ),
+        STRICT_STEP,
+    ),
+    (
+        "ordinary PR",
+        _context(
+            event_name="pull_request",
+            head_ref="mdrxy/ci/soft-timeout-ripgrep",
+            title="fix(code): tighten grep bounds",
+        ),
+        SOFT_STEP,
+    ),
+    (
+        "ordinary PR on Windows",
+        _context(
+            event_name="pull_request",
+            head_ref="mdrxy/ci/soft-timeout-ripgrep",
+            title="fix(code): tighten grep bounds",
+            runner_os="Windows",
+        ),
+        None,
+    ),
+]
+
+
 def test_deepagents_code_collects_coverage_on_python_3_14() -> None:
     """Keep all supported runtimes while collecting coverage on Python 3.14."""
     workflow = _load_workflow(CI_WORKFLOW)
@@ -42,65 +153,107 @@ def test_deepagents_code_collects_coverage_on_python_3_14() -> None:
     assert config["coverage-python-version"] == "3.14"
 
 
+@pytest.mark.parametrize(
+    ("label", "context", "expected"),
+    SELECTION_CASES,
+    ids=[case[0] for case in SELECTION_CASES],
+)
+def test_exactly_one_ripgrep_install_step_runs(
+    label: str,
+    context: dict[str, Any],
+    expected: str | None,
+) -> None:
+    """The strict and soft install paths are mutually exclusive and exhaustive.
+
+    Guards the invariant that substring assertions miss: flipping the strict
+    step's `||` to `&&` makes it unsatisfiable, so release runs would install
+    no ripgrep at all while every `in step["if"]` assertion still passed.
+    """
+    workflow = _load_workflow(TEST_WORKFLOW)
+    selected = [
+        name
+        for name in (STRICT_STEP, SOFT_STEP)
+        if _eval_condition(_find_step(workflow, job="build", name=name)["if"], context)
+    ]
+
+    assert selected == ([expected] if expected else []), (
+        f"{label}: expected {expected!r} to run, got {selected!r}"
+    )
+
+
 def test_non_release_pr_ripgrep_install_has_two_minute_timeout() -> None:
     """Ordinary PRs may continue only when ripgrep installation times out."""
     workflow = _load_workflow(TEST_WORKFLOW)
-    step = _find_step(
-        workflow,
-        job="build",
-        name="🔍 Install ripgrep (non-release PR)",
-    )
+    step = _find_step(workflow, job="build", name=SOFT_STEP)
 
-    assert "github.event_name == 'pull_request'" in step["if"]
-    assert "!startsWith(github.head_ref, 'release-please--')" in step["if"]
-    assert "!startsWith(github.event.pull_request.title, 'release(')" in step["if"]
-    assert "timeout --signal=TERM --kill-after=10s 120s" in step["run"]
-    assert 'if [ "$status" -eq 124 ]' in step["run"]
+    # The upload step and the comment workflow both key off this id; a rename
+    # would resolve to an empty string and silently disable the whole warning.
+    assert step["id"] == "ripgrep-install"
+    # `timeout` must run under `sudo`, or it cannot signal the root-owned
+    # `apt-get` and the bound silently does nothing.
+    assert "sudo timeout --signal=TERM --kill-after=10s 120s" in step["run"]
     assert "continue-on-error" not in step
     assert "timeout-minutes" not in step
+
     upload = _find_step(
-        workflow,
-        job="build",
-        name="📤 Record ripgrep install timeout",
+        workflow, job="build", name="📤 Record ripgrep install timeout"
     )
     assert upload["if"] == "steps.ripgrep-install.outputs.timed-out == 'true'"
     assert upload["with"]["name"] == "${{ steps.ripgrep-install.outputs.artifact }}"
 
 
-@pytest.mark.parametrize(
-    ("timeout_status", "expected_status", "expected_timeout"),
-    [(0, 0, False), (42, 42, False), (124, 0, True)],
-)
-def test_non_release_ripgrep_install_only_softens_timeout(
-    tmp_path: Path,
-    timeout_status: int,
-    expected_status: int,
-    expected_timeout: bool,
-) -> None:
-    """The install script preserves success and errors but softens exit 124."""
+def test_only_two_ripgrep_install_steps_exist() -> None:
+    """No third install path can drift in alongside the strict/soft pair."""
     workflow = _load_workflow(TEST_WORKFLOW)
-    step = _find_step(
-        workflow,
-        job="build",
-        name="🔍 Install ripgrep (non-release PR)",
-    )
+    installs = [
+        step
+        for step in workflow["jobs"]["build"]["steps"]
+        if "apt-get install -y ripgrep" in str(step.get("run", ""))
+    ]
+
+    assert [step["name"] for step in installs] == [STRICT_STEP, SOFT_STEP]
+
+
+def _run_install_script(
+    script: str,
+    tmp_path: Path,
+    *,
+    timeout_status: int,
+    rg_available: bool = False,
+) -> tuple[subprocess.CompletedProcess[str], list[str], list[str]]:
+    """Execute the install step's `run:` body against stubbed binaries."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    timeout_stub = bin_dir / "timeout"
-    timeout_stub.write_text(f"#!/usr/bin/env bash\nexit {timeout_status}\n")
-    timeout_stub.chmod(0o755)
+
+    def stub(name: str, body: str) -> None:
+        path = bin_dir / name
+        path.write_text(f"#!/usr/bin/env bash\n{body}\n")
+        path.chmod(0o755)
+
+    # `sudo` execs its arguments so the stubbed `timeout`/`dpkg` are reached.
+    # A real `sudo` must never run here: it would hit a password prompt, or
+    # actually touch the developer's package manager.
+    stub("sudo", 'exec "$@"')
+    stub("timeout", f"exit {timeout_status}")
+    stub("dpkg", "exit 0")
+    stub("rg", "exit 0" if rg_available else "exit 127")
+
     output = tmp_path / "github-output"
     output.touch()
+    env_file = tmp_path / "github-env"
+    env_file.touch()
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
 
     result = subprocess.run(
-        ["bash", "-c", step["run"]],
+        ["bash", "-c", script],
         check=False,
         capture_output=True,
         text=True,
+        # Explicit, minimal environment: inheriting os.environ would let a
+        # developer's BASH_ENV/SHELLOPTS leak into the script under test.
         env={
-            **os.environ,
+            "GITHUB_ENV": str(env_file),
             "GITHUB_OUTPUT": str(output),
             "MATRIX_OS": "ubuntu-latest",
             "MATRIX_PYTHON": "3.14",
@@ -109,30 +262,93 @@ def test_non_release_ripgrep_install_only_softens_timeout(
             "WORKING_DIRECTORY": "libs/code",
         },
     )
+    return result, output.read_text().splitlines(), env_file.read_text().splitlines()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell script")
+@pytest.mark.parametrize(
+    ("timeout_status", "expected_status", "expected_timeout"),
+    [
+        (0, 0, False),
+        (42, 42, False),
+        (124, 0, True),
+        # `--kill-after` escalates to SIGKILL when apt defers the TERM, which
+        # coreutils reports as 137 rather than 124. Softening only 124 would
+        # hard-fail on exactly the wedged install this bound exists to absorb.
+        (137, 0, True),
+    ],
+)
+def test_non_release_ripgrep_install_only_softens_timeout(
+    tmp_path: Path,
+    timeout_status: int,
+    expected_status: int,
+    expected_timeout: bool,
+) -> None:
+    """The install script preserves success and errors but softens 124 and 137."""
+    workflow = _load_workflow(TEST_WORKFLOW)
+    step = _find_step(workflow, job="build", name=SOFT_STEP)
+    result, output_lines, env_lines = _run_install_script(
+        step["run"], tmp_path, timeout_status=timeout_status
+    )
 
     assert result.returncode == expected_status
-    output_lines = output.read_text().splitlines()
-    assert ("timed-out=true" in output_lines) is expected_timeout
+
+    # Written exactly once: a duplicated key would leave the upload step
+    # depending on undocumented last-write-wins parsing.
+    timed_out = [line for line in output_lines if line.startswith("timed-out=")]
+    assert timed_out == [f"timed-out={str(expected_timeout).lower()}"]
+
     if expected_timeout:
         assert "::warning::" in result.stdout
+        # Pins the slash-to-dash package transform and the prefix the comment
+        # workflow filters on.
+        assert f"artifact={ARTIFACT_PREFIX}libs-code-ubuntu-latest-3.14" in output_lines
         marker_lines = [line for line in output_lines if line.startswith("marker=")]
         assert len(marker_lines) == 1
         assert Path(marker_lines[0].partition("=")[2]).is_file()
+        # A runner that lost ripgrep must not also claim it is guaranteed.
+        assert EXPECTED_ENV not in env_lines
     else:
+        assert "::warning::" not in result.stdout
         assert not any(line.startswith("artifact=") for line in output_lines)
+        # Only a genuinely successful install promises ripgrep to the tests.
+        assert (EXPECTED_ENV in env_lines) is (expected_status == 0)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell script")
+def test_timeout_with_usable_ripgrep_is_not_reported(tmp_path: Path) -> None:
+    """A bound hit that still left a working `rg` must not warn.
+
+    "The bound was hit" and "ripgrep is missing" are different facts; only the
+    second one should reach the PR.
+    """
+    workflow = _load_workflow(TEST_WORKFLOW)
+    step = _find_step(workflow, job="build", name=SOFT_STEP)
+    result, output_lines, env_lines = _run_install_script(
+        step["run"], tmp_path, timeout_status=124, rg_available=True
+    )
+
+    assert result.returncode == 0
+    assert [line for line in output_lines if line.startswith("timed-out=")] == [
+        "timed-out=false"
+    ]
+    assert "::warning::" not in result.stdout
+    assert "::notice::" in result.stdout
+    assert EXPECTED_ENV in env_lines
 
 
 def test_release_and_non_pr_ripgrep_install_is_strict() -> None:
-    """Release PRs, pushes, and merge queues use the strict install path."""
+    """Release PRs, pushes, and merge queues install ripgrep with no timeout."""
     workflow = _load_workflow(TEST_WORKFLOW)
-    step = _find_step(workflow, job="build", name="🔍 Install ripgrep (strict)")
+    step = _find_step(workflow, job="build", name=STRICT_STEP)
 
-    assert "github.event_name != 'pull_request'" in step["if"]
-    assert "startsWith(github.head_ref, 'release-please--')" in step["if"]
-    assert "startsWith(github.event.pull_request.title, 'release(')" in step["if"]
-    assert step["run"] == "sudo apt-get update && sudo apt-get install -y ripgrep"
+    assert APT_INSTALL in step["run"]
+    assert "timeout" not in step["run"]
     assert "continue-on-error" not in step
     assert "timeout-minutes" not in step
+    # Promises ripgrep to the tests, turning a missing `rg` into a failure
+    # instead of a silent skip.
+    assert EXPECTED_ENV in step["run"]
 
 
 def test_release_workflow_requires_ripgrep_before_unit_tests() -> None:
@@ -143,9 +359,28 @@ def test_release_workflow_requires_ripgrep_before_unit_tests() -> None:
     tests = _find_step(workflow, job="pre-release-checks", name="Run unit tests")
 
     assert steps.index(install) < steps.index(tests)
-    assert install["run"] == "sudo apt-get update && sudo apt-get install -y ripgrep"
+    assert APT_INSTALL in install["run"]
+    assert "timeout" not in install["run"]
     assert "continue-on-error" not in install
     assert "timeout-minutes" not in install
+    assert EXPECTED_ENV in install["run"]
+
+
+def test_missing_ripgrep_fails_loudly_when_ci_promised_it() -> None:
+    """The rg-gated tests must not silently skip on a runner that installed rg.
+
+    Those tests are the only coverage of the real-binary grep contract, and one
+    of them guards symlink containment, so a silent skip would let a
+    containment regression merge green.
+    """
+    source = FILESYSTEM_TESTS.read_text()
+
+    assert "def require_ripgrep()" in source
+    assert 'os.environ.get("DEEPAGENTS_RIPGREP_EXPECTED") == "1"' in source
+    assert "pytest.fail(" in source
+    # Every rg-gated test routes through the helper rather than skipping inline.
+    assert 'pytest.skip("ripgrep not installed")' in source
+    assert source.count("require_ripgrep()") >= 6  # definition + call sites
 
 
 def test_ripgrep_timeout_comment_uses_isolated_workflow_run() -> None:
@@ -154,17 +389,45 @@ def test_ripgrep_timeout_comment_uses_isolated_workflow_run() -> None:
     assert workflow["on"]["workflow_run"]["workflows"] == ["🔧 CI"]
     assert workflow["permissions"] == {
         "actions": "read",
+        "contents": "read",
         "issues": "write",
         "pull-requests": "read",
     }
+
     job = workflow["jobs"]["manage-comment"]
-    assert job["if"] == "github.event.workflow_run.event == 'pull_request'"
-    assert all("actions/checkout" not in str(step.get("uses", "")) for step in job["steps"])
+    # Checking out PR-authored code here would hand it an `issues: write` token.
+    assert all(
+        "actions/checkout" not in str(step.get("uses", "")) for step in job["steps"]
+    )
+    assert "github.event.workflow_run.event == 'pull_request'" in job["if"]
+    # Cancelled and startup-failed runs produce no artifacts, which would be
+    # misread as "no timeout" and delete a valid warning.
+    assert "conclusion == 'success'" in job["if"]
+    assert "conclusion == 'failure'" in job["if"]
+
     script = job["steps"][0]["with"]["script"]
-    assert "listPullRequestsAssociatedWithCommit" in script
     assert "pullRequest.head.sha !== run.head_sha" in script
     assert "listWorkflowRunArtifacts" in script
-    assert "ripgrep-timeout-" in script
+    assert ARTIFACT_PREFIX in script
     assert "createComment" in script
     assert "updateComment" in script
     assert "deleteComment" in script
+    # Fork PRs carry no `workflow_run.pull_requests`; resolving by head ref is
+    # the only lookup that works for them.
+    assert "pulls.list" in script
+    assert "run.head_repository.owner.login" in script
+    # An unreportable timeout is a broken mechanism, not a no-op.
+    assert "core.setFailed" in script
+
+
+def test_ripgrep_timeout_comment_concurrency_is_keyed_on_head_sha() -> None:
+    """Runs for different commits must not cancel each other.
+
+    Keyed on the branch, a newer run could cancel an older one that was about
+    to post, and then discard itself via the stale-SHA guard.
+    """
+    workflow = _load_workflow(RIPGREP_COMMENT_WORKFLOW)
+    group = workflow["concurrency"]["group"]
+
+    assert "github.event.workflow_run.head_sha" in group
+    assert "head_branch" not in group

--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -3,19 +3,168 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from pathlib import Path
+from typing import Any
 
+import pytest
 import yaml
 
-
 ROOT = Path(__file__).resolve().parents[4]
-CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
+WORKFLOWS = ROOT / ".github" / "workflows"
+CI_WORKFLOW = WORKFLOWS / "ci.yml"
+TEST_WORKFLOW = WORKFLOWS / "_test.yml"
+RELEASE_WORKFLOW = WORKFLOWS / "release.yml"
+RIPGREP_COMMENT_WORKFLOW = WORKFLOWS / "ripgrep_timeout_comment.yml"
+
+
+def _load_workflow(path: Path) -> dict[str, Any]:
+    """Load a workflow while normalizing PyYAML's YAML 1.1 `on` key."""
+    workflow = yaml.safe_load(path.read_text())
+    workflow["on"] = workflow.pop(True, workflow.get("on"))
+    return workflow
+
+
+def _find_step(workflow: dict[str, Any], *, job: str, name: str) -> dict[str, Any]:
+    """Return one named workflow step."""
+    matches = [step for step in workflow["jobs"][job]["steps"] if step.get("name") == name]
+    assert len(matches) == 1, f"expected one {name!r} step, found {len(matches)}"
+    return matches[0]
 
 
 def test_deepagents_code_collects_coverage_on_python_3_14() -> None:
     """Keep all supported runtimes while collecting coverage on Python 3.14."""
-    workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+    workflow = _load_workflow(CI_WORKFLOW)
     config = workflow["jobs"]["test-code"]["with"]
 
     assert json.loads(config["python-versions"]) == ["3.12", "3.13", "3.14"]
     assert config["coverage-python-version"] == "3.14"
+
+
+def test_non_release_pr_ripgrep_install_has_two_minute_timeout() -> None:
+    """Ordinary PRs may continue only when ripgrep installation times out."""
+    workflow = _load_workflow(TEST_WORKFLOW)
+    step = _find_step(
+        workflow,
+        job="build",
+        name="🔍 Install ripgrep (non-release PR)",
+    )
+
+    assert "github.event_name == 'pull_request'" in step["if"]
+    assert "!startsWith(github.head_ref, 'release-please--')" in step["if"]
+    assert "!startsWith(github.event.pull_request.title, 'release(')" in step["if"]
+    assert "timeout --signal=TERM --kill-after=10s 120s" in step["run"]
+    assert 'if [ "$status" -eq 124 ]' in step["run"]
+    assert "continue-on-error" not in step
+    assert "timeout-minutes" not in step
+    upload = _find_step(
+        workflow,
+        job="build",
+        name="📤 Record ripgrep install timeout",
+    )
+    assert upload["if"] == "steps.ripgrep-install.outputs.timed-out == 'true'"
+    assert upload["with"]["name"] == "${{ steps.ripgrep-install.outputs.artifact }}"
+
+
+@pytest.mark.parametrize(
+    ("timeout_status", "expected_status", "expected_timeout"),
+    [(0, 0, False), (42, 42, False), (124, 0, True)],
+)
+def test_non_release_ripgrep_install_only_softens_timeout(
+    tmp_path: Path,
+    timeout_status: int,
+    expected_status: int,
+    expected_timeout: bool,
+) -> None:
+    """The install script preserves success and errors but softens exit 124."""
+    workflow = _load_workflow(TEST_WORKFLOW)
+    step = _find_step(
+        workflow,
+        job="build",
+        name="🔍 Install ripgrep (non-release PR)",
+    )
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    timeout_stub = bin_dir / "timeout"
+    timeout_stub.write_text(f"#!/usr/bin/env bash\nexit {timeout_status}\n")
+    timeout_stub.chmod(0o755)
+    output = tmp_path / "github-output"
+    output.touch()
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+
+    result = subprocess.run(
+        ["bash", "-c", step["run"]],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GITHUB_OUTPUT": str(output),
+            "MATRIX_OS": "ubuntu-latest",
+            "MATRIX_PYTHON": "3.14",
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "RUNNER_TEMP": str(runner_temp),
+            "WORKING_DIRECTORY": "libs/code",
+        },
+    )
+
+    assert result.returncode == expected_status
+    output_lines = output.read_text().splitlines()
+    assert ("timed-out=true" in output_lines) is expected_timeout
+    if expected_timeout:
+        assert "::warning::" in result.stdout
+        marker_lines = [line for line in output_lines if line.startswith("marker=")]
+        assert len(marker_lines) == 1
+        assert Path(marker_lines[0].partition("=")[2]).is_file()
+    else:
+        assert not any(line.startswith("artifact=") for line in output_lines)
+
+
+def test_release_and_non_pr_ripgrep_install_is_strict() -> None:
+    """Release PRs, pushes, and merge queues use the strict install path."""
+    workflow = _load_workflow(TEST_WORKFLOW)
+    step = _find_step(workflow, job="build", name="🔍 Install ripgrep (strict)")
+
+    assert "github.event_name != 'pull_request'" in step["if"]
+    assert "startsWith(github.head_ref, 'release-please--')" in step["if"]
+    assert "startsWith(github.event.pull_request.title, 'release(')" in step["if"]
+    assert step["run"] == "sudo apt-get update && sudo apt-get install -y ripgrep"
+    assert "continue-on-error" not in step
+    assert "timeout-minutes" not in step
+
+
+def test_release_workflow_requires_ripgrep_before_unit_tests() -> None:
+    """Release artifact tests install ripgrep without a soft timeout."""
+    workflow = _load_workflow(RELEASE_WORKFLOW)
+    steps = workflow["jobs"]["pre-release-checks"]["steps"]
+    install = _find_step(workflow, job="pre-release-checks", name="Install ripgrep")
+    tests = _find_step(workflow, job="pre-release-checks", name="Run unit tests")
+
+    assert steps.index(install) < steps.index(tests)
+    assert install["run"] == "sudo apt-get update && sudo apt-get install -y ripgrep"
+    assert "continue-on-error" not in install
+    assert "timeout-minutes" not in install
+
+
+def test_ripgrep_timeout_comment_uses_isolated_workflow_run() -> None:
+    """PR comments run after CI without exposing write access to tested code."""
+    workflow = _load_workflow(RIPGREP_COMMENT_WORKFLOW)
+    assert workflow["on"]["workflow_run"]["workflows"] == ["🔧 CI"]
+    assert workflow["permissions"] == {
+        "actions": "read",
+        "issues": "write",
+        "pull-requests": "read",
+    }
+    job = workflow["jobs"]["manage-comment"]
+    assert job["if"] == "github.event.workflow_run.event == 'pull_request'"
+    assert all("actions/checkout" not in str(step.get("uses", "")) for step in job["steps"])
+    script = job["steps"][0]["with"]["script"]
+    assert "listPullRequestsAssociatedWithCommit" in script
+    assert "pullRequest.head.sha !== run.head_sha" in script
+    assert "listWorkflowRunArtifacts" in script
+    assert "ripgrep-timeout-" in script
+    assert "createComment" in script
+    assert "updateComment" in script
+    assert "deleteComment" in script

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -139,8 +139,19 @@ jobs:
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
           set +e
-          timeout --signal=TERM --kill-after=10s 120s bash -c \
-            'sudo apt-get update && sudo apt-get install -y ripgrep'
+          timeout --signal=TERM --kill-after=10s 120s bash -c '
+            setsid bash -c "sudo apt-get update && sudo apt-get install -y ripgrep" &
+            install_pid=$!
+
+            terminate_install() {
+              kill -- -"$install_pid" 2>/dev/null || true
+              wait "$install_pid" 2>/dev/null || true
+              exit 124
+            }
+
+            trap terminate_install TERM
+            wait "$install_pid"
+          '
           status=$?
           set -e
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -177,8 +177,14 @@ jobs:
           # A killed apt can leave dpkg mid-transaction. Unwind it so later
           # steps don't trip over the lock, then check what actually landed:
           # "the bound was hit" and "ripgrep is missing" are different facts,
-          # and only the second one should warn.
-          sudo dpkg --configure -a || true
+          # and only the second one should warn. The recovery itself is
+          # bounded: `dpkg --configure -a` can wait on the same lock or
+          # maintainer script that stalled the install, and without its own
+          # timeout the supposedly bounded step can burn the rest of the job's
+          # 20 minutes. A failed recovery is tolerated here — the
+          # `rg --version` probe below is what decides the warning.
+          sudo timeout --signal=TERM --kill-after=10s 60s \
+            dpkg --configure -a || true
           if rg --version >/dev/null 2>&1; then
             echo "timed-out=false" >> "$GITHUB_OUTPUT"
             echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -116,10 +116,56 @@ jobs:
         shell: bash
         run: uv sync --group test
 
-      - name: "🔍 Install ripgrep"
-        if: runner.os == 'Linux'
+      - name: "🔍 Install ripgrep (strict)"
+        if: >-
+          runner.os == 'Linux' &&
+          (github.event_name != 'pull_request' ||
+          startsWith(github.head_ref, 'release-please--') ||
+          startsWith(github.event.pull_request.title, 'release('))
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: "🔍 Install ripgrep (non-release PR)"
+        id: ripgrep-install
+        if: >-
+          runner.os == 'Linux' &&
+          github.event_name == 'pull_request' &&
+          !startsWith(github.head_ref, 'release-please--') &&
+          !startsWith(github.event.pull_request.title, 'release(')
+        shell: bash
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_PYTHON: ${{ matrix.python-version }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: |
+          set +e
+          timeout --signal=TERM --kill-after=10s 120s bash -c \
+            'sudo apt-get update && sudo apt-get install -y ripgrep'
+          status=$?
+          set -e
+
+          echo "timed-out=false" >> "$GITHUB_OUTPUT"
+          if [ "$status" -eq 124 ]; then
+            echo "timed-out=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::ripgrep installation exceeded two minutes; continuing without ripgrep"
+            package="${WORKING_DIRECTORY//\//-}"
+            artifact="ripgrep-timeout-${package}-${MATRIX_OS}-${MATRIX_PYTHON}"
+            marker="$RUNNER_TEMP/$artifact/warning.txt"
+            mkdir -p "$(dirname "$marker")"
+            printf '%s\n' "$artifact" > "$marker"
+            echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
+            echo "marker=$marker" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          exit "$status"
+
+      - name: "📤 Record ripgrep install timeout"
+        if: steps.ripgrep-install.outputs.timed-out == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.ripgrep-install.outputs.artifact }}
+          path: ${{ steps.ripgrep-install.outputs.marker }}
+          retention-days: 1
 
       # Maintainer escape hatch: a PR labeled `bypass-warnings-check` runs
       # pytest with `-W default`, demoting the ini `filterwarnings` policy

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -116,6 +116,17 @@ jobs:
         shell: bash
         run: uv sync --group test
 
+      # Release-sensitive runs must exercise the real ripgrep code path rather
+      # than the Python fallback, so the install has no timeout here and a
+      # failure reds the job. `merge_group` is deliberately strict: an apt
+      # flake ejects the PR from the queue, which is recoverable, whereas a
+      # silent skip at the last gate before `main` is not.
+      #
+      # `DEEPAGENTS_RIPGREP_EXPECTED=1` is consumed by `require_ripgrep` in
+      # `libs/deepagents/tests/.../test_filesystem_backend.py`: on a runner
+      # that promised ripgrep, a missing `rg` fails the affected tests instead
+      # of skipping them. One of those tests guards symlink containment, and a
+      # silent skip would let a containment regression merge green.
       - name: "🔍 Install ripgrep (strict)"
         if: >-
           runner.os == 'Linux' &&
@@ -123,7 +134,9 @@ jobs:
           startsWith(github.head_ref, 'release-please--') ||
           startsWith(github.event.pull_request.title, 'release('))
         shell: bash
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: |
+          sudo apt-get update && sudo apt-get install -y ripgrep
+          echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
 
       - name: "🔍 Install ripgrep (non-release PR)"
         id: ripgrep-install
@@ -139,36 +152,50 @@ jobs:
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
           set +e
-          timeout --signal=TERM --kill-after=10s 120s bash -c '
-            setsid bash -c "sudo apt-get update && sudo apt-get install -y ripgrep" &
-            install_pid=$!
-
-            terminate_install() {
-              kill -- -"$install_pid" 2>/dev/null || true
-              wait "$install_pid" 2>/dev/null || true
-              exit 124
-            }
-
-            trap terminate_install TERM
-            wait "$install_pid"
-          '
+          # `sudo timeout`, not `timeout sudo`: `timeout` must run as root to
+          # signal the root-owned `apt-get`. An unprivileged `timeout` gets
+          # EPERM, leaves the install orphaned holding the dpkg lock, and the
+          # bound silently does nothing.
+          sudo timeout --signal=TERM --kill-after=10s 120s \
+            bash -c 'apt-get update && apt-get install -y ripgrep'
           status=$?
           set -e
 
-          echo "timed-out=false" >> "$GITHUB_OUTPUT"
-          if [ "$status" -eq 124 ]; then
-            echo "timed-out=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::ripgrep installation exceeded two minutes; continuing without ripgrep"
-            package="${WORKING_DIRECTORY//\//-}"
-            artifact="ripgrep-timeout-${package}-${MATRIX_OS}-${MATRIX_PYTHON}"
-            marker="$RUNNER_TEMP/$artifact/warning.txt"
-            mkdir -p "$(dirname "$marker")"
-            printf '%s\n' "$artifact" > "$marker"
-            echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
-            echo "marker=$marker" >> "$GITHUB_OUTPUT"
+          # coreutils `timeout` reports 124 when the command dies from the
+          # initial TERM and 137 (128+9) when `--kill-after` escalates to
+          # KILL. apt defers TERM mid-transaction, so 137 is the likely status
+          # for a genuinely wedged install. Both mean "hit the bound"; every
+          # other non-zero status is a real apt failure that must fail the job.
+          if [ "$status" -ne 124 ] && [ "$status" -ne 137 ]; then
+            echo "timed-out=false" >> "$GITHUB_OUTPUT"
+            if [ "$status" -eq 0 ]; then
+              echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
+            fi
+            exit "$status"
+          fi
+
+          # A killed apt can leave dpkg mid-transaction. Unwind it so later
+          # steps don't trip over the lock, then check what actually landed:
+          # "the bound was hit" and "ripgrep is missing" are different facts,
+          # and only the second one should warn.
+          sudo dpkg --configure -a || true
+          if rg --version >/dev/null 2>&1; then
+            echo "timed-out=false" >> "$GITHUB_OUTPUT"
+            echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
+            echo "::notice::ripgrep install hit the two-minute bound but a usable rg is present; continuing with ripgrep"
             exit 0
           fi
-          exit "$status"
+
+          echo "timed-out=true" >> "$GITHUB_OUTPUT"
+          echo "::warning::ripgrep installation exceeded two minutes; continuing without ripgrep"
+          package="${WORKING_DIRECTORY//\//-}"
+          artifact="ripgrep-timeout-${package}-${MATRIX_OS}-${MATRIX_PYTHON}"
+          marker="$RUNNER_TEMP/$artifact/warning.txt"
+          mkdir -p "$(dirname "$marker")"
+          printf '%s\n' "$artifact" > "$marker"
+          echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
+          echo "marker=$marker" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: "📤 Record ripgrep install timeout"
         if: steps.ripgrep-install.outputs.timed-out == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -737,6 +737,9 @@ jobs:
           fi
           VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Run unit tests
         run: make test COV_ARGS= PYTEST_EXTRA="-v"
         working-directory: ${{ env.WORKING_DIR }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -737,8 +737,13 @@ jobs:
           fi
           VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"
 
+      # No timeout here: release artifacts must be validated with the real
+      # ripgrep path exercised. `DEEPAGENTS_RIPGREP_EXPECTED=1` makes the
+      # rg-gated tests fail rather than skip if `rg` goes missing anyway.
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: |
+          sudo apt-get update && sudo apt-get install -y ripgrep
+          echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
 
       - name: Run unit tests
         run: make test COV_ARGS= PYTEST_EXTRA="-v"

--- a/.github/workflows/ripgrep_timeout_comment.yml
+++ b/.github/workflows/ripgrep_timeout_comment.yml
@@ -1,0 +1,114 @@
+name: Ripgrep timeout warning
+
+on:
+  workflow_run:
+    workflows: ["🔧 CI"]
+    types: [completed]
+
+permissions:
+  actions: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: >-
+    ripgrep-timeout-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  manage-comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Manage PR warning comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- ripgrep-install-timeout -->';
+            const { owner, repo } = context.repo;
+            const run = context.payload.workflow_run;
+            let prNumber = run.pull_requests?.[0]?.number;
+            if (!prNumber) {
+              const associated = await github.paginate(
+                github.rest.repos.listPullRequestsAssociatedWithCommit,
+                { owner, repo, commit_sha: run.head_sha, per_page: 100 },
+              );
+              const pullRequest = associated.find(
+                candidate => candidate.head.sha === run.head_sha &&
+                  candidate.base.repo.full_name === `${owner}/${repo}`,
+              );
+              prNumber = pullRequest?.number;
+            }
+            if (!prNumber) {
+              core.warning(`CI run ${run.id} has no associated pull request; cannot manage the ripgrep timeout comment.`);
+              return;
+            }
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+            if (pullRequest.head.sha !== run.head_sha) {
+              core.info(`Ignoring stale CI run ${run.id}; PR #${prNumber} now points at ${pullRequest.head.sha}.`);
+              return;
+            }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              { owner, repo, run_id: run.id, per_page: 100 },
+            );
+            const timeoutArtifacts = artifacts.filter(
+              artifact => !artifact.expired && artifact.name.startsWith('ripgrep-timeout-'),
+            );
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber, per_page: 100 },
+            );
+            const existing = comments.find(
+              comment => comment.user?.login === 'github-actions[bot]' &&
+                (comment.body ?? '').startsWith(marker),
+            );
+
+            if (timeoutArtifacts.length === 0) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                });
+                core.info('Removed the obsolete ripgrep timeout warning comment.');
+              }
+              return;
+            }
+
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${run.id}`;
+            const body = [
+              marker,
+              '**Warning: ripgrep installation timed out in CI.**',
+              '',
+              'Installation exceeded two minutes on one or more non-release PR test runners. Those runners continued without ripgrep, so ripgrep-specific tests may have been skipped and filesystem searches used the slower Python fallback.',
+              '',
+              'Release PRs and release-workflow tests still require ripgrep installation to succeed without this timeout.',
+              '',
+              `[View the CI run](${runUrl})`,
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info('Updated the ripgrep timeout warning comment.');
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info('Created the ripgrep timeout warning comment.');
+            }

--- a/.github/workflows/ripgrep_timeout_comment.yml
+++ b/.github/workflows/ripgrep_timeout_comment.yml
@@ -1,23 +1,50 @@
-name: Ripgrep timeout warning
+# Posts a sticky PR comment when the bounded ripgrep install in `_test.yml`
+# gave up, so a reviewer can see that the affected legs ran without ripgrep.
+#
+# Trigger — `workflow_run` of ci.yml, completed, rather than `pull_request`:
+# a `pull_request` run from a fork gets a read-only token and cannot comment.
+# This workflow runs in the base repository's context, so it holds the
+# `issues: write` needed to post. That token must never be handed to
+# PR-authored code:
+#
+#   DO NOT add `actions/checkout` (or any step that runs code from the PR)
+#   to this workflow. It reads artifact *names* through the API only, never
+#   artifact contents, and the comment body is fully static.
+#
+# Not a merge gate. This posts a comment; it never blocks anything.
+
+name: "🔍 Ripgrep timeout warning"
 
 on:
   workflow_run:
     workflows: ["🔧 CI"]
     types: [completed]
 
+# `issues: write` covers createComment/updateComment/deleteComment — PR
+# conversation comments are the issues API. `pull-requests: read` covers
+# `pulls.get` and `pulls.list` for resolving the PR number.
 permissions:
   actions: read
+  contents: read
   issues: write
   pull-requests: read
 
 concurrency:
-  group: >-
-    ripgrep-timeout-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  # Keyed on the head SHA, not the branch: two CI runs for different commits
+  # must not cancel each other, or the surviving run can be discarded by the
+  # stale-SHA guard below and no comment is ever managed.
+  group: ripgrep-timeout-comment-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
   manage-comment:
-    if: github.event.workflow_run.event == 'pull_request'
+    # A cancelled or startup-failed run produces no artifacts, which is
+    # indistinguishable from "no timeout" and would wrongly delete a valid
+    # warning. Only act on runs that actually reached a conclusion.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -28,23 +55,49 @@ jobs:
             const marker = '<!-- ripgrep-install-timeout -->';
             const { owner, repo } = context.repo;
             const run = context.payload.workflow_run;
+
+            // `workflow_run.pull_requests` is empty for fork PRs, and
+            // `listPullRequestsAssociatedWithCommit` often fails to resolve a
+            // commit that lives in the fork. Resolving by head ref works for
+            // both same-repo and fork PRs, so it is the primary lookup.
             let prNumber = run.pull_requests?.[0]?.number;
             if (!prNumber) {
-              const associated = await github.paginate(
-                github.rest.repos.listPullRequestsAssociatedWithCommit,
-                { owner, repo, commit_sha: run.head_sha, per_page: 100 },
+              const candidates = await github.paginate(
+                github.rest.pulls.list,
+                {
+                  owner,
+                  repo,
+                  state: 'open',
+                  head: `${run.head_repository.owner.login}:${run.head_branch}`,
+                  per_page: 100,
+                },
               );
-              const pullRequest = associated.find(
-                candidate => candidate.head.sha === run.head_sha &&
-                  candidate.base.repo.full_name === `${owner}/${repo}`,
-              );
-              prNumber = pullRequest?.number;
+              prNumber = candidates.find(c => c.head.sha === run.head_sha)?.number;
             }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              { owner, repo, run_id: run.id, per_page: 100 },
+            );
+            const timeoutArtifacts = artifacts.filter(
+              artifact => !artifact.expired && artifact.name.startsWith('ripgrep-timeout-'),
+            );
+
             if (!prNumber) {
-              core.warning(`CI run ${run.id} has no associated pull request; cannot manage the ripgrep timeout comment.`);
+              // Failing to notify about a real timeout is a broken mechanism,
+              // not a no-op: say so loudly instead of logging into a run page
+              // nobody opens.
+              const message = `CI run ${run.id} has no resolvable pull request.`;
+              if (timeoutArtifacts.length > 0) {
+                core.setFailed(`${message} A ripgrep timeout went unreported.`);
+              } else {
+                core.info(`${message} No timeout to report.`);
+              }
               return;
             }
 
+            // Guards against a re-run of an old CI run posting a warning for a
+            // commit the PR has already moved past.
             const { data: pullRequest } = await github.rest.pulls.get({
               owner,
               repo,
@@ -55,44 +108,53 @@ jobs:
               return;
             }
 
-            const artifacts = await github.paginate(
-              github.rest.actions.listWorkflowRunArtifacts,
-              { owner, repo, run_id: run.id, per_page: 100 },
-            );
-            const timeoutArtifacts = artifacts.filter(
-              artifact => !artifact.expired && artifact.name.startsWith('ripgrep-timeout-'),
-            );
             const comments = await github.paginate(
               github.rest.issues.listComments,
               { owner, repo, issue_number: prNumber, per_page: 100 },
             );
+            // Matched on the marker alone, not the bot login: if the posting
+            // identity ever changes, an identity check would silently stop
+            // finding the comment and append a new one on every CI run.
             const existing = comments.find(
-              comment => comment.user?.login === 'github-actions[bot]' &&
-                (comment.body ?? '').startsWith(marker),
+              comment => (comment.body ?? '').startsWith(marker),
             );
 
             if (timeoutArtifacts.length === 0) {
               if (existing) {
-                await github.rest.issues.deleteComment({
-                  owner,
-                  repo,
-                  comment_id: existing.id,
-                });
-                core.info('Removed the obsolete ripgrep timeout warning comment.');
+                try {
+                  await github.rest.issues.deleteComment({
+                    owner,
+                    repo,
+                    comment_id: existing.id,
+                  });
+                  core.info('Removed the obsolete ripgrep timeout warning comment.');
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                  core.info('Comment was already removed.');
+                }
               }
               return;
             }
 
+            // Artifact names carry the package, OS, and Python version, so the
+            // comment can name the affected legs instead of hedging.
+            const legs = timeoutArtifacts
+              .map(artifact => artifact.name.replace(/^ripgrep-timeout-/, ''))
+              .sort();
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${run.id}`;
             const body = [
               marker,
-              '**Warning: ripgrep installation timed out in CI.**',
+              '**Warning: ripgrep did not install in time.**',
               '',
-              'Installation exceeded two minutes on one or more non-release PR test runners. Those runners continued without ripgrep, so ripgrep-specific tests may have been skipped and filesystem searches used the slower Python fallback.',
+              'Installation took more than two minutes on these test runners:',
               '',
-              'Release PRs and release-workflow tests still require ripgrep installation to succeed without this timeout.',
+              ...legs.map(leg => `- \`${leg}\``),
               '',
-              `[View the CI run](${runUrl})`,
+              'Those runners ran without ripgrep. The real-binary grep tests were skipped there, including the symlink containment check. `grep` on the filesystem backend used the Python fallback, which is slower and does not skip `.gitignore`d or hidden files, so some results differ.',
+              '',
+              'Release PRs, merge-queue runs, and the release workflow do not use this timeout. They fail if ripgrep does not install.',
+              '',
+              `No action is needed to merge. Re-run CI to get ripgrep coverage. [View the CI run](${runUrl})`,
             ].join('\n');
 
             if (existing) {

--- a/.github/workflows/ripgrep_timeout_comment.yml
+++ b/.github/workflows/ripgrep_timeout_comment.yml
@@ -112,11 +112,16 @@ jobs:
               github.rest.issues.listComments,
               { owner, repo, issue_number: prNumber, per_page: 100 },
             );
-            // Matched on the marker alone, not the bot login: if the posting
-            // identity ever changes, an identity check would silently stop
-            // finding the comment and append a new one on every CI run.
+            // Matched on the marker AND the bot login: matching the marker
+            // alone lets a PR author pre-post the marker and capture the
+            // sticky-comment slot — the update/delete call then fails (or
+            // the warning stays user-owned and editable), so the genuine
+            // timeout warning is never managed. If the posting identity ever
+            // changes, update this login; a missed match only means one extra
+            // comment, while a hijacked slot means no warning at all.
             const existing = comments.find(
-              comment => (comment.body ?? '').startsWith(marker),
+              comment => comment.user?.login === 'github-actions[bot]' &&
+                (comment.body ?? '').startsWith(marker),
             );
 
             if (timeoutArtifacts.length === 0) {

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -2,6 +2,7 @@ import base64
 import io
 import json
 import logging
+import os
 import shutil
 import subprocess
 import sys
@@ -19,6 +20,28 @@ from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import DeleteResult, EditResult, GrepMatch, ReadResult, WriteResult
 from deepagents.backends.utils import format_grep_matches
 from deepagents.middleware.filesystem import GLOB_TIMEOUT, FilesystemMiddleware
+
+
+def require_ripgrep() -> None:
+    """Skip when ripgrep is absent, or fail when the runner promised it.
+
+    CI installs ripgrep and exports `DEEPAGENTS_RIPGREP_EXPECTED=1` on every
+    runner where the install is required to have succeeded. On those runners a
+    missing `rg` means the install silently regressed, so the tests below must
+    fail rather than skip: they are the only coverage of the *real binary*
+    contract (the rest of the ripgrep tests patch `subprocess.Popen`), and one
+    of them guards symlink containment. A skip would let a containment
+    regression merge with a green build.
+
+    Locally, and on runners where the install was allowed to time out, a
+    missing `rg` is expected and still skips.
+    """
+    if shutil.which("rg") is not None:
+        return
+    if os.environ.get("DEEPAGENTS_RIPGREP_EXPECTED") == "1":
+        msg = "CI installed ripgrep on this runner but `rg` is not on PATH"
+        pytest.fail(msg)
+    pytest.skip("ripgrep not installed")
 
 
 def write_file(p: Path, content: str):
@@ -774,8 +797,7 @@ def test_grep_ripgrep_glob_with_directory_component(tmp_path: Path, monkeypatch:
     ripgrep `--glob` patterns with a directory component (e.g. `docs/*.md`)
     must still match when the process cwd differs from the search root.
     """
-    if shutil.which("rg") is None:
-        pytest.skip("ripgrep not installed")
+    require_ripgrep()
 
     root = tmp_path / "project"
     (root / "docs").mkdir(parents=True)
@@ -801,8 +823,7 @@ def test_grep_ripgrep_glob_virtual_mode(tmp_path: Path, monkeypatch: pytest.Monk
     Exercises the relative-path re-anchoring through `_to_virtual_path` so a
     regression in path handling can't silently drop results.
     """
-    if shutil.which("rg") is None:
-        pytest.skip("ripgrep not installed")
+    require_ripgrep()
 
     root = tmp_path / "project"
     (root / "docs").mkdir(parents=True)
@@ -828,8 +849,7 @@ def test_grep_on_single_file_path(tmp_path: Path) -> None:
     Before #2732's fix, ripgrep was given the file path directly. Naively
     threading `cwd=base_full` would raise NotADirectoryError for file paths.
     """
-    if shutil.which("rg") is None:
-        pytest.skip("ripgrep not installed")
+    require_ripgrep()
 
     target = tmp_path / "single.txt"
     target.write_text("hello single\n")
@@ -849,8 +869,7 @@ def test_grep_preserves_symlink_path_in_results(tmp_path: Path, monkeypatch: pyt
     `.resolve()` was applied — so users saw the symlinked path they searched
     under. The fix must preserve that behavior.
     """
-    if shutil.which("rg") is None:
-        pytest.skip("ripgrep not installed")
+    require_ripgrep()
 
     real = tmp_path / "real"
     real.mkdir()
@@ -884,8 +903,7 @@ def test_grep_containment_check_blocks_escaping_symlink(tmp_path: Path, monkeypa
     access to files beyond the intended search boundary. The containment check
     must drop those results so they never surface to callers.
     """
-    if shutil.which("rg") is None:
-        pytest.skip("ripgrep not installed")
+    require_ripgrep()
 
     outside = tmp_path / "outside"
     outside.mkdir()


### PR DESCRIPTION
Slow apt metadata refreshes should not block ordinary pull-request validation, so non-release PR jobs now continue after a two-minute ripgrep install timeout and publish a sticky warning after CI. Release PRs, merge-queue/main runs, and release artifact tests keep the strict install path.

<details>
<summary>Test plan</summary>

- 90 workflow contract tests pass; changed workflows also parse as valid YAML.

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/1a61b60c-cf77-5b18-83d9-3a2028f55fb6)