### PR TITLE
ci(infra): warn instead of fail on unreleased-Python caps in third-party deps

### DIFF
--- a/.github/scripts/release/check_wheel_dep_freshness.py
+++ b/.github/scripts/release/check_wheel_dep_freshness.py
@@ -175,6 +175,66 @@ class DependencyCheck:
     constraint: str
     passed: bool
     message: str
+    warning: bool = False
+
+
+def _intersection_omits_only_unreleased_minors(
+    wheel_requires_python: str,
+    published_constraints: Sequence[str],
+    *,
+    current_minor: int,
+) -> bool:
+    """Whether the dependency's Python coverage gap touches no existing minor.
+
+    A minor line is installable when at least one of its probed versions
+    satisfies both the wheel's `Requires-Python` and every published file
+    constraint. The gap must then start at the first unreleased minor and
+    extend contiguously to the wheel's own ceiling, i.e. a "not tested on the
+    next minor yet" upper bound such as `<3.15`. A gap at the wheel's minimum
+    (the dependency rejects the release's install floor), in the middle of the
+    claimed range, or covering already-released minors still fails.
+
+    Args:
+        wheel_requires_python: `Requires-Python` declared by the release wheel.
+        published_constraints: `requires_python` values from the published files.
+        current_minor: Minor version of the newest released CPython line (e.g.
+            14 when 3.14 is current).
+
+    Returns:
+        `True` when only the next unreleased CPython minor and later are
+        excluded by the dependency's upper bound.
+    """
+    wheel_specifier = SpecifierSet(wheel_requires_python)
+    dep_specifiers = tuple(
+        SpecifierSet(constraint) for constraint in published_constraints if constraint
+    )
+    wheel_minors: set[tuple[int, ...]] = set()
+    dep_minors: set[tuple[int, ...]] = set()
+    for version in _supported_python_versions(
+        wheel_requires_python,
+        additional_constraints=published_constraints,
+    ):
+        minor = version.release[:2]
+        wheel_minors.add(minor)
+        if all(
+            specifier.contains(version, prereleases=True)
+            for specifier in dep_specifiers
+        ):
+            dep_minors.add(minor)
+    missing = sorted(wheel_minors - dep_minors)
+    if not missing:
+        return False
+    floor = min(
+        minor[1]
+        for minor in wheel_minors
+        if wheel_specifier.contains(Version(".".join(map(str, minor))))
+    )
+    if missing[0][1] <= floor:
+        return False
+    first_unreleased = current_minor + 1
+    return missing[0][1] == first_unreleased and [
+        minor for minor in sorted(wheel_minors) if minor[1] >= first_unreleased
+    ] == missing
 
 
 def _escape_command(value: object) -> str:
@@ -189,6 +249,10 @@ def _escape_command(value: object) -> str:
 
 def _notice(message: str) -> None:
     print(f"::notice::{_escape_command(message)}")
+
+
+def _warning(path: Path, message: str) -> None:
+    print(f"::warning file={_escape_command(path)}::{_escape_command(message)}")
 
 
 def _error(path: Path, message: str) -> None:
@@ -724,13 +788,22 @@ def compare_wheel_with_pypi(
     from an unpublished sibling metadata change such as the coordinated Code/Talon
     Python-floor bump.
 
+    A third-party dependency whose newest eligible release covers every existing
+    CPython minor the wheel claims, but stops below a future minor (for example
+    `requires-python<3.15` against the wheel's `<4.0`), degrades to a warning:
+    resolvers already refuse that extra on the unreleased interpreter, so the
+    release is not blocked on another project widening its bound. Gaps at real
+    installation targets (the wheel's minimum, or any minor the dependency
+    excludes in the middle of the range) stay hard failures.
+
     Args:
         metadata: Parsed metadata from the package being released.
         pypi_payloads: Canonical dependency names mapped to PyPI project JSON.
         sibling_requires_python: Current Python constraints for repo-managed siblings.
 
     Returns:
-        One deterministic pass/fail result per distinct dependency constraint.
+        One deterministic result per distinct dependency constraint; warnings have
+        `passed=True` and `warning=True`.
 
     Raises:
         ValueError: If the release wheel has no concrete Python lower bound.
@@ -783,6 +856,7 @@ def compare_wheel_with_pypi(
             else matching_versions
         )
         passed = False
+        warning = False
         for _, files in candidates:
             python_constraints = _file_python_constraints(files)
             required_python = _applicable_python_versions(
@@ -797,15 +871,26 @@ def compare_wheel_with_pypi(
             ):
                 passed = True
                 break
+        if not passed and expected_constraint is None and matching_versions:
+            _, files = matching_versions[0]
+            published_python = _file_python_constraints(files)
+            if _intersection_omits_only_unreleased_minors(
+                metadata.requires_python,
+                published_python,
+                current_minor=sys.version_info[1],
+            ):
+                passed = True
+                warning = True
         checks.append(
             DependencyCheck(
                 dependency_name=requirement.name,
                 constraint=constraint,
                 passed=passed,
+                warning=warning,
                 message=(
                     f"{requirement.name} has a published release satisfying {constraint} "
                     f"and Python {metadata.requires_python}."
-                    if passed
+                    if passed and not warning
                     else _failure_message(
                         metadata,
                         requirement,
@@ -879,11 +964,25 @@ def validate_wheel(
         sibling_requires_python=sibling_constraints,
     )
     failures = [check for check in checks if not check.passed]
+    warnings = [check for check in checks if check.warning]
+    for check in warnings:
+        _warning(wheel_path, check.message)
     if not failures:
         _notice(
             f"All {len(checks)} dependency constraints in {wheel_path.name} have "
             "compatible published metadata."
         )
+        if warnings:
+            summary = [
+                "## Dependency metadata warnings",
+                "",
+                f"`{metadata.name}=={metadata.version}` can be released, but these "
+                "third-party dependencies do not yet publish support for every "
+                "Python minor the wheel claims:",
+                "",
+            ]
+            summary.extend(f"- {check.message}" for check in warnings)
+            _write_step_summary("\n".join(summary))
         return 0
 
     for failure in failures:

--- a/.github/scripts/release/check_wheel_dep_freshness.py
+++ b/.github/scripts/release/check_wheel_dep_freshness.py
@@ -199,6 +199,12 @@ def _intersection_omits_only_unreleased_minors(
     (the dependency rejects the release's install floor), in the middle of the
     claimed range, or covering already-released minors still fails.
 
+    Failing probes are kept at full-version granularity: a patch-level
+    exclusion on a released line (for example the wheel claims `>=3.12` but
+    the dependency requires `>=3.12.1`) must not hide behind a working later
+    patch of the same minor, so any released minor with a failed probe
+    disqualifies the warning.
+
     Args:
         wheel_requires_python: `Requires-Python` declared by the release wheel.
         published_constraints: `requires_python` values from the published files.
@@ -216,6 +222,7 @@ def _intersection_omits_only_unreleased_minors(
     )
     wheel_minors: set[tuple[int, ...]] = set()
     dep_minors: set[tuple[int, ...]] = set()
+    failed_minors: set[tuple[int, ...]] = set()
     for version in _supported_python_versions(
         wheel_requires_python,
         additional_constraints=published_constraints,
@@ -227,6 +234,11 @@ def _intersection_omits_only_unreleased_minors(
             for specifier in dep_specifiers
         ):
             dep_minors.add(minor)
+        else:
+            failed_minors.add(minor)
+    first_unreleased = current_minor + 1
+    if any(minor[1] <= current_minor for minor in failed_minors):
+        return False
     missing = sorted(wheel_minors - dep_minors)
     if not missing:
         return False
@@ -237,7 +249,6 @@ def _intersection_omits_only_unreleased_minors(
     )
     if missing[0][1] <= floor:
         return False
-    first_unreleased = current_minor + 1
     return missing[0][1] == first_unreleased and [
         minor for minor in sorted(wheel_minors) if minor[1] >= first_unreleased
     ] == missing
@@ -799,8 +810,9 @@ def compare_wheel_with_pypi(
     `requires-python<3.15` against the wheel's `<4.0`), degrades to a warning:
     resolvers already refuse that extra on the unreleased interpreter, so the
     release is not blocked on another project widening its bound. Gaps at real
-    installation targets (the wheel's minimum, or any minor the dependency
-    excludes in the middle of the range) stay hard failures.
+    installation targets (the wheel's minimum, any minor the dependency excludes
+    in the middle of the range, or a patch-level exclusion on a released line
+    such as `>=3.12.1` against the wheel's `>=3.12`) stay hard failures.
 
     Args:
         metadata: Parsed metadata from the package being released.

--- a/.github/scripts/release/check_wheel_dep_freshness.py
+++ b/.github/scripts/release/check_wheel_dep_freshness.py
@@ -38,6 +38,11 @@ if TYPE_CHECKING:
 MAX_FETCH_WORKERS = 8
 MAX_MARKER_VALUES_PER_VARIABLE = 16
 PYTHON_MINOR_PROBE_LIMIT = 100
+# Newest CPython minor with a stable release, used to tell a "not tested on
+# the next minor yet" upper bound (warning) from a cap that excludes an
+# interpreter users actually run (hard failure). Pinned to the interpreter
+# `check_dep_freshness.yml` runs this script under; bump both together.
+CURRENT_CPYTHON_MINOR = 14
 RELEASE_TITLE = re.compile(r"^release\(([^)]+)\):\s+\S+")
 MARKER_VARIABLES = (
     "implementation_name",
@@ -182,7 +187,7 @@ def _intersection_omits_only_unreleased_minors(
     wheel_requires_python: str,
     published_constraints: Sequence[str],
     *,
-    current_minor: int,
+    current_minor: int = CURRENT_CPYTHON_MINOR,
 ) -> bool:
     """Whether the dependency's Python coverage gap touches no existing minor.
 
@@ -198,7 +203,8 @@ def _intersection_omits_only_unreleased_minors(
         wheel_requires_python: `Requires-Python` declared by the release wheel.
         published_constraints: `requires_python` values from the published files.
         current_minor: Minor version of the newest released CPython line (e.g.
-            14 when 3.14 is current).
+            14 when 3.14 is current). Defaults to `CURRENT_CPYTHON_MINOR`;
+            tests override it to stay independent of the runner interpreter.
 
     Returns:
         `True` when only the next unreleased CPython minor and later are
@@ -877,7 +883,6 @@ def compare_wheel_with_pypi(
             if _intersection_omits_only_unreleased_minors(
                 metadata.requires_python,
                 published_python,
-                current_minor=sys.version_info[1],
             ):
                 passed = True
                 warning = True

--- a/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
+++ b/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
@@ -174,6 +174,57 @@ def test_compare_allows_broader_third_party_python_support() -> None:
     assert checks[0].passed
 
 
+def test_compare_warns_when_third_party_caps_only_unreleased_minors(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "check_wheel_dep_freshness.sys.version_info",
+        (3, 14, 0),
+    )
+    checks = compare_wheel_with_pypi(
+        _metadata(
+            name="deepagents-code",
+            version="0.1.58",
+            requires_python=">=3.12,<4.0",
+            requirements=("langchain-ibm>=1.1.0,<2.0.0",),
+        ),
+        {"langchain-ibm": _payload(("1.1.0", ">=3.10,<3.15"))},
+    )
+
+    assert len(checks) == 1
+    assert checks[0].passed
+    assert checks[0].warning
+    assert "langchain-ibm 1.1.0 (latest on PyPI) declares" in checks[0].message
+    assert "deepagents-code 0.1.58 requires Python >=3.12,<4.0" in checks[0].message
+
+
+def test_compare_fails_when_third_party_excludes_existing_minor() -> None:
+    checks = compare_wheel_with_pypi(
+        _metadata(
+            requires_python=">=3.12,<4.0",
+            requirements=("demo>=1",),
+        ),
+        {"demo": _payload(("1.0", ">=3.13,<3.14"))},
+    )
+
+    assert len(checks) == 1
+    assert not checks[0].passed
+    assert not checks[0].warning
+
+
+def test_compare_never_warns_for_sibling_python_metadata_lag() -> None:
+    checks = compare_wheel_with_pypi(
+        _metadata(),
+        {"deepagents-code": _payload(("0.1.57", ">=3.12,<3.15"))},
+        sibling_requires_python={"deepagents-code": ">=3.12,<4.0"},
+    )
+
+    assert len(checks) == 1
+    assert not checks[0].passed
+    assert not checks[0].warning
+    assert "Release deepagents-code first" in checks[0].message
+
+
 def test_compare_checks_full_declared_python_range() -> None:
     checks = compare_wheel_with_pypi(
         _metadata(
@@ -597,6 +648,61 @@ def test_validate_wheel_fetches_each_project_once_and_fails_with_summary(
     )
     assert calls == ["deepagents-code"]
     assert "Release deepagents-code first" in summary.read_text(encoding="utf-8")
+
+
+def test_validate_wheel_passes_with_warning_for_unreleased_minor_cap(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        "check_wheel_dep_freshness.sys.version_info",
+        (3, 14, 0),
+    )
+    wheel = tmp_path / "code.whl"
+    _write_wheel(
+        wheel,
+        name="deepagents-code",
+        version="0.1.58",
+        requires_python=">=3.12,<4.0",
+        requirements=('langchain-ibm>=1.1.0,<2.0.0; extra == "ibm"',),
+        provides_extra=("ibm",),
+    )
+    config = tmp_path / "release-please-config.json"
+    _write_release_config(
+        config,
+        {
+            "libs/code": {
+                "package-name": "deepagents-code",
+                "component": "deepagents-code",
+            }
+        },
+    )
+    manifest = tmp_path / "libs/code/pyproject.toml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        '[project]\nname = "deepagents-code"\nrequires-python = ">=3.12,<4.0"\n',
+        encoding="utf-8",
+    )
+    summary = tmp_path / "summary"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    def fetcher(_name: str) -> dict[str, object]:
+        return _payload(("1.1.0", ">=3.10,<3.15"))
+
+    assert (
+        validate_wheel(
+            wheel,
+            repo_root=tmp_path,
+            config_path=config,
+            fetcher=fetcher,
+        )
+        == 0
+    )
+    out = capsys.readouterr().out
+    assert any(line.startswith("::warning ") for line in out.splitlines())
+    assert not any(line.startswith("::error ") for line in out.splitlines())
+    assert "Dependency metadata warnings" in summary.read_text(encoding="utf-8")
 
 
 def test_validate_wheel_does_not_fetch_inactive_requirement(tmp_path: Path) -> None:

--- a/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
+++ b/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
@@ -177,10 +177,7 @@ def test_compare_allows_broader_third_party_python_support() -> None:
 def test_compare_warns_when_third_party_caps_only_unreleased_minors(
     monkeypatch,
 ) -> None:
-    monkeypatch.setattr(
-        "check_wheel_dep_freshness.sys.version_info",
-        (3, 14, 0),
-    )
+    monkeypatch.setattr("check_wheel_dep_freshness.CURRENT_CPYTHON_MINOR", 14)
     checks = compare_wheel_with_pypi(
         _metadata(
             name="deepagents-code",
@@ -655,10 +652,7 @@ def test_validate_wheel_passes_with_warning_for_unreleased_minor_cap(
     monkeypatch,
     capsys,
 ) -> None:
-    monkeypatch.setattr(
-        "check_wheel_dep_freshness.sys.version_info",
-        (3, 14, 0),
-    )
+    monkeypatch.setattr("check_wheel_dep_freshness.CURRENT_CPYTHON_MINOR", 14)
     wheel = tmp_path / "code.whl"
     _write_wheel(
         wheel,

--- a/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
+++ b/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
@@ -195,6 +195,22 @@ def test_compare_warns_when_third_party_caps_only_unreleased_minors(
     assert "deepagents-code 0.1.58 requires Python >=3.12,<4.0" in checks[0].message
 
 
+def test_compare_fails_when_patch_exclusion_hides_unreleased_cap() -> None:
+    checks = compare_wheel_with_pypi(
+        _metadata(
+            name="deepagents-code",
+            version="0.1.58",
+            requires_python=">=3.12,<4.0",
+            requirements=("demo>=1",),
+        ),
+        {"demo": _payload(("1.0", ">=3.12.1,<3.15"))},
+    )
+
+    assert len(checks) == 1
+    assert not checks[0].passed
+    assert not checks[0].warning
+
+
 def test_compare_fails_when_third_party_excludes_existing_minor() -> None:
     checks = compare_wheel_with_pypi(
         _metadata(


### PR DESCRIPTION
The release dependency gate (`check_dep_freshness.yml` → `check_wheel_dep_freshness.py`) currently hard-fails a release PR when a third-party dependency's newest published release declares a `requires-python` upper bound that excludes a CPython minor the wheel claims but that has not shipped yet. This is blocking the `deepagents-code` 0.1.58 release PR (#5591): the wheel claims `>=3.12,<4.0`, and the optional `ibm` extra's `langchain-ibm>=1.1.0,<2.0.0` only publishes `<3.15,>=3.10`. pip already refuses that extra on the unreleased interpreter and installs it fine on 3.12–3.14, so the release is blocked purely on another project widening its bound.

This change downgrades that specific case from a hard `::error::` to a `::warning::` plus a step-summary note. The warning applies only when all of these hold:

- the dependency is **third-party** — repo-managed siblings keep the strict freshest-metadata assertion that caught the coordinated Code/Talon Python-floor bump;
- a published release **satisfies the version constraint** (a missing release still fails);
- the Python coverage gap is **exactly the next unreleased CPython minor through the wheel's ceiling** (e.g. `<3.15` while 3.14 is current).

Gaps at real installation targets still fail: the wheel's minimum (dependency rejects the install floor, e.g. dep requires `>=3.13` against the wheel's `>=3.12`), any middle minor (e.g. dep ships only `>=3.13,<3.14`), and patch-level exclusions on released lines.

The gate's "latest existing minor" anchor is the interpreter running the check; `check_dep_freshness.yml` pins that job to Python 3.14, so the verdict is deterministic per workflow, and the new unit tests pin `sys.version_info` to stay runner-independent.
