### PR TITLE
fix(infra): retry the new-entries warning comment and grant `pull-requests: write`

### DIFF
--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -1226,13 +1226,26 @@ async function checkCuratedState({
     // (the setFailed message / failures list) reported right after this. The
     // gate still fails closed via those.
     let lastError = null;
+    let warningComments = comments;
     for (let attempt = 0; attempt <= warningCommentRetries; attempt += 1) {
       try {
-        await warnForNewEntries({ github, owner, repo, number, comments, head: pr.head.sha, fingerprint: currentFingerprint });
+        await warnForNewEntries({ github, owner, repo, number, comments: warningComments, head: pr.head.sha, fingerprint: currentFingerprint });
         return;
       } catch (error) {
         lastError = error;
-        if (attempt < warningCommentRetries) await sleep(warningCommentRetryIntervalMs);
+        if (attempt >= warningCommentRetries) break;
+        await sleep(warningCommentRetryIntervalMs);
+        // The create may have succeeded server-side while the client saw a
+        // timeout; the local snapshot then still lacks the marker and the retry
+        // would post a duplicate. Re-read comments and only retry when a fresh
+        // read still shows no marker. If the re-read itself fails, the next
+        // read could still be stale, so stop here instead of risking a
+        // duplicate courtesy comment.
+        try {
+          warningComments = await listComments(github, owner, repo, number);
+        } catch {
+          break;
+        }
       }
     }
     core.warning(`Could not post the new-entries warning comment: ${lastError instanceof Error ? lastError.message : String(lastError)}`);

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -1107,6 +1107,8 @@ async function checkCuratedState({
   expectedHead = null,
   initialDraftPollAttempts = 0,
   initialDraftPollIntervalMs = 10_000,
+  warningCommentRetries = 2,
+  warningCommentRetryIntervalMs = 2_000,
   sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
 }) {
   const { owner, repo } = context.repo;
@@ -1217,17 +1219,23 @@ async function checkCuratedState({
   // away from the curated override. Invoked at both the pre-applied miss and the
   // post-applied mismatch below.
   const maybeWarnNewEntries = async () => {
-    if (generatedEntriesChanged) {
-      // Best-effort courtesy comment: if posting it fails (rate limit, transient
-      // 5xx) it must not throw, or the raw API error would replace the specific,
-      // actionable gate reason (the setFailed message / failures list) reported
-      // right after this. The gate still fails closed via those.
+    if (!generatedEntriesChanged) return;
+    // Best-effort courtesy comment: if posting it still fails after the retries
+    // (rate limit, transient 5xx, transient permission 403) it must not throw,
+    // or the raw API error would replace the specific, actionable gate reason
+    // (the setFailed message / failures list) reported right after this. The
+    // gate still fails closed via those.
+    let lastError = null;
+    for (let attempt = 0; attempt <= warningCommentRetries; attempt += 1) {
       try {
         await warnForNewEntries({ github, owner, repo, number, comments, head: pr.head.sha, fingerprint: currentFingerprint });
+        return;
       } catch (error) {
-        core.warning(`Could not post the new-entries warning comment: ${error instanceof Error ? error.message : String(error)}`);
+        lastError = error;
+        if (attempt < warningCommentRetries) await sleep(warningCommentRetryIntervalMs);
       }
     }
+    core.warning(`Could not post the new-entries warning comment: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
   };
   if (!applied) {
     await maybeWarnNewEntries();

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -865,16 +865,59 @@ test('a failed new-entries warning comment does not mask the actionable gate rea
   });
   const files = new Map([[changedHead, changelog(newGenerated)]]);
   const { github } = makeGithub({ pr, comments: [overrideComment()], files });
-  // The courtesy warning comment fails (rate limit / transient 5xx). The gate must
-  // still fail closed with its specific, actionable reason and only log a warning
-  // about the comment, rather than surfacing the raw API error.
+  // The courtesy warning comment keeps failing across the retries (rate limit /
+  // transient 5xx / transient permission 403). The gate must still fail closed
+  // with its specific, actionable reason and only log a warning about the
+  // comment, rather than surfacing the raw API error.
   github.rest.issues.createComment = async () => { throw new Error('rate limited'); };
 
   const core = makeCore();
-  const result = await releaseNotes.checkCuratedState({ github, context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } }, core, number: 123, ...BOT_AUTH });
+  const result = await releaseNotes.checkCuratedState({
+    github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    warningCommentRetries: 1,
+    warningCommentRetryIntervalMs: 0,
+    ...BOT_AUTH,
+  });
   assert.equal(result.status, 'missing');
   assert.match(core.failed, /draft and then/);
   assert.ok(core.warnings.some(message => /Could not post the new-entries warning comment/.test(message)));
+});
+
+test('the new-entries warning comment retries a transient post failure', async () => {
+  const newGenerated = GENERATED_SECTION.replace('useful feature', 'new generated entry');
+  const changedHead = 'd'.repeat(40);
+  const pr = releasePr({
+    head: { ...releasePr().head, sha: changedHead },
+    body: `Release notes preview\n\n${newGenerated}\n_End release notes preview._\n`,
+  });
+  const files = new Map([[changedHead, changelog(newGenerated)]]);
+  const { github, calls } = makeGithub({ pr, comments: [overrideComment()], files });
+  // First post 403s (the transient permission error seen on release PRs); the
+  // retry succeeds, so the gate reports no warning about the courtesy comment.
+  let createCommentAttempts = 0;
+  github.rest.issues.createComment = async args => {
+    createCommentAttempts += 1;
+    calls.createComment.push(args);
+    if (createCommentAttempts === 1) throw new Error('Resource not accessible by integration');
+    return { data: { id: 99 } };
+  };
+
+  const core = makeCore();
+  const result = await releaseNotes.checkCuratedState({
+    github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    warningCommentRetries: 1,
+    warningCommentRetryIntervalMs: 0,
+    ...BOT_AUTH,
+  });
+  assert.equal(result.status, 'missing');
+  assert.equal(createCommentAttempts, 2);
+  assert.ok(!core.warnings.some(message => /Could not post the new-entries warning comment/.test(message)));
 });
 
 test('draft, unmanaged branch, and bypass label pass without metadata', async () => {

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -920,6 +920,41 @@ test('the new-entries warning comment retries a transient post failure', async (
   assert.ok(!core.warnings.some(message => /Could not post the new-entries warning comment/.test(message)));
 });
 
+test('the new-entries warning retry does not duplicate a comment the server already accepted', async () => {
+  const newGenerated = GENERATED_SECTION.replace('useful feature', 'new generated entry');
+  const changedHead = 'd'.repeat(40);
+  const pr = releasePr({
+    head: { ...releasePr().head, sha: changedHead },
+    body: `Release notes preview\n\n${newGenerated}\n_End release notes preview._\n`,
+  });
+  const files = new Map([[changedHead, changelog(newGenerated)]]);
+  const comments = [overrideComment()];
+  const { github, calls } = makeGithub({ pr, comments, files });
+  // The first create succeeds server-side (the marker comment lands) but the
+  // client sees a timeout instead of the response. Retrying against the stale
+  // snapshot would post the identical warning again; the retry must re-read
+  // comments, see the marker, and stop after one POST.
+  github.rest.issues.createComment = async params => {
+    comments.push({ id: 100 + comments.length, updated_at: APPLIED_UPDATED_AT, user: BOT, body: params.body });
+    calls.createComment.push(params);
+    throw new Error('request timed out');
+  };
+
+  const core = makeCore();
+  const result = await releaseNotes.checkCuratedState({
+    github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    warningCommentRetries: 2,
+    warningCommentRetryIntervalMs: 0,
+    ...BOT_AUTH,
+  });
+  assert.equal(result.status, 'missing');
+  assert.equal(calls.createComment.length, 1);
+  assert.ok(!core.warnings.some(message => /Could not post the new-entries warning comment/.test(message)));
+});
+
 test('draft, unmanaged branch, and bypass label pass without metadata', async () => {
   for (const pr of [
     releasePr({ draft: true }),

--- a/.github/scripts/tests/release/test_release_notes.py
+++ b/.github/scripts/tests/release/test_release_notes.py
@@ -61,7 +61,10 @@ def test_required_check_is_attached_to_the_validated_pr_head() -> None:
         "checks": "write",
         "contents": "read",
         "issues": "write",
-        "pull-requests": "read",
+        # The new-entries courtesy comment targets the release PR, whose branch
+        # is owned by the release-bot app installation; issues: write alone
+        # intermittently 403s there.
+        "pull-requests": "write",
     }
     job = workflow["jobs"]["curated-release-notes"]
     assert "github.event_name == 'pull_request'" in job["name"]

--- a/.github/workflows/release_notes_check.yml
+++ b/.github/workflows/release_notes_check.yml
@@ -22,7 +22,10 @@ permissions:
   checks: write
   contents: read
   issues: write
-  pull-requests: read
+  # The new-entries courtesy comment targets the release PR, whose branch is owned
+  # by the release-bot GitHub App installation; issues: write alone intermittently
+  # 403s there, so request the pull-requests write scope too.
+  pull-requests: write
 
 concurrency:
   group: release-notes-check-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}


### PR DESCRIPTION
The curated release notes check no longer logs a `Resource not accessible by integration` warning when posting its courtesy comment about newly generated changelog entries on a release PR.

---

The check posts a best-effort comment when the generated changelog drifts from the curated draft. On [this run](https://github.com/langchain-ai/deepagents/actions/runs/32293839088/job/96201984315) on #5591, that `POST /repos/langchain-ai/deepagents/issues/5591/comments` returned 403 even though the job token had `issues: write` — while an identical run 30 minutes earlier on the same PR posted comments fine. The release PR branch is owned by the `release-bot` app installation (`langchain-oss-automated-triage[bot]`), and the token posting here is `github-actions[bot]`; every other workflow in this repo that comments on PRs grants `pull-requests: write`, while this one granted only `issues: write` + `pull-requests: read`.

Two changes:

- Grant `pull-requests: write` in `release_notes_check.yml`, matching the other PR-commenting workflows.
- Retry the courtesy comment up to 2 times (2s apart) before degrading to a log warning. The comment is intentionally non-blocking — the gate still fails closed with its specific, actionable reason — but a transient 403 shouldn't surface as a confusing warning, and in `issue_comment`/`workflow_dispatch` refresh runs it would otherwise leave the refreshed required check red over a courtesy comment.

The gate failure on that run was itself real (changelog/body/applied-commit drift) and is unaffected by this change; this only fixes the courtesy-comment path.
