### PR TITLE
fix(infra): unset `UV_PYTHON` when installing release wheels with `uv pip`

### DIFF
--- a/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
+++ b/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
@@ -792,4 +792,7 @@ def test_workflow_mirrors_release_install_flags() -> None:
     assert "DEEPAGENTS_CODE_BUILD_COMMIT:" in release
     assert 'if [ "$PKG_NAME" = "deepagents-talon" ]; then' in release
     assert 'INSTALL_ARGS=(--prerelease allow "${INSTALL_ARGS[@]}")' in release
-    assert 'VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"' in release
+    assert (
+        'env -u UV_PYTHON VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"'
+        in release
+    )

--- a/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
+++ b/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
@@ -786,7 +786,10 @@ def test_workflow_mirrors_release_install_flags() -> None:
     assert 'INSTALL_ARGS=(--index-url "https://pypi.org/simple"' in freshness
     assert 'if [ "$PACKAGE_NAME" = "deepagents-talon" ]; then' in freshness
     assert 'INSTALL_ARGS=(--prerelease allow "${INSTALL_ARGS[@]}")' in freshness
-    assert 'VIRTUAL_ENV="$VENV_PATH" uv pip install "${INSTALL_ARGS[@]}"' in freshness
+    assert (
+        'env -u UV_PYTHON VIRTUAL_ENV="$VENV_PATH" uv pip install "${INSTALL_ARGS[@]}"'
+        in freshness
+    )
 
     assert "deepagents-code|deepagents-talon)" in release
     assert "DEEPAGENTS_CODE_BUILD_COMMIT:" in release
@@ -796,3 +799,8 @@ def test_workflow_mirrors_release_install_flags() -> None:
         'env -u UV_PYTHON VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"'
         in release
     )
+ # pass if either one reverted.
+    release_install = (
+        'env -u UV_PYTHON VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"'
+    )
+    assert release.count(release_install) == 2

--- a/.github/workflows/check_dep_freshness.yml
+++ b/.github/workflows/check_dep_freshness.yml
@@ -121,7 +121,10 @@ jobs:
           if [ "$PACKAGE_NAME" = "deepagents-talon" ]; then
             INSTALL_ARGS=(--prerelease allow "${INSTALL_ARGS[@]}")
           fi
-          VIRTUAL_ENV="$VENV_PATH" uv pip install "${INSTALL_ARGS[@]}"
+          # setup-uv exports UV_PYTHON for the version it installed (3.14),
+          # which overrides VIRTUAL_ENV and makes `uv pip` demand a 3.14 venv
+          # even though the release package targets $PYTHON_VERSION.
+          env -u UV_PYTHON VIRTUAL_ENV="$VENV_PATH" uv pip install "${INSTALL_ARGS[@]}"
 
   manage-dependency-freshness-comment:
     name: "manage dependency freshness PR comment"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -705,7 +705,9 @@ jobs:
           if [ "$PKG_NAME" = "deepagents-talon" ]; then
             INSTALL_ARGS=(--prerelease allow "${INSTALL_ARGS[@]}")
           fi
-          VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"
+          # setup-uv exports UV_PYTHON, which overrides VIRTUAL_ENV for
+          # `uv pip`; unset it so the install targets the `.venv` above.
+          env -u UV_PYTHON VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"
 
           # Replace all dashes in the package name with underscores,
           # since that's how Python imports packages with dashes in the name.
@@ -735,7 +737,9 @@ jobs:
           if [ "$PKG_NAME" = "deepagents-talon" ]; then
             INSTALL_ARGS=(--prerelease allow "${INSTALL_ARGS[@]}")
           fi
-          VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"
+          # setup-uv exports UV_PYTHON, which overrides VIRTUAL_ENV for
+          # `uv pip`; unset it so the install targets the existing `.venv`.
+          env -u UV_PYTHON VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"
 
       # No timeout here: release artifacts must be validated with the real
       # ripgrep path exercised. `DEEPAGENTS_RIPGREP_EXPECTED=1` makes the


### PR DESCRIPTION
Release dependency validation and release import steps no longer fail with `No virtual environment found for Python 3.14` when the release package targets a different Python than the one setup-uv installed.

---

The `uv_setup` composite action installs Python 3.14 for running helper scripts, and `setup-uv` exports `UV_PYTHON=3.14` job-wide. `UV_PYTHON` takes precedence over `VIRTUAL_ENV` for `uv pip install`, so when the freshness gate (or release import test) created a venv from the release package's own `python_version` (e.g. 3.12) and then ran `VIRTUAL_ENV=... uv pip install`, uv refused to use it:

```
error: No virtual environment found for Python 3.14; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
```

Seen on the `deepagents-code` 0.1.58 release PR: https://github.com/langchain-ai/deepagents/actions/runs/32297131672/job/96211155972

The fix prefixes each `uv pip install` in these steps with `env -u UV_PYTHON` so the install targets the venv the step just created. This affected three call sites: the "Install wheel with dependencies from PyPI" step in `check_dep_freshness.yml`, and the "Import dist package" / "Import published package (again)" steps in `release.yml` — the latter two haven't failed only because the package Python happened to match the setup version recently. The workflow-mirror test asserting the shared install invocation is updated to match.
