### PR TITLE
feat(infra): name the package in curated release-notes check output

### DIFF
--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -1203,7 +1203,7 @@ async function checkCuratedState({
   warnUnparsableMarkedComments({ core, comments, login, id });
   if (!override) {
     core.setFailed(`Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply before merging`);
-    return { status: 'missing' };
+    return { status: 'missing', component, version };
   }
 
   const changelog = await fetchChangelog(github, owner, repo, pr.head.sha, changelogPath);
@@ -1269,12 +1269,12 @@ async function checkCuratedState({
     }
     if (generatedEntriesChanged || draftMetadataChanged) {
       core.setFailed(`Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply before merging`);
-      return { status: 'missing' };
+      return { status: 'missing', component, version };
     }
     const draftCommentUrl = override.comment.html_url
       ?? `https://github.com/${owner}/${repo}/pull/${number}#issuecomment-${override.comment.id}`;
     core.setFailed(`Review the curated release-note draft (${draftCommentUrl}), then run ${COMMAND_MENTION} apply before merging`);
-    return { status: 'unapplied', draftCommentUrl };
+    return { status: 'unapplied', draftCommentUrl, component, version };
   }
 
   const appliedMetadata = applied.metadata;
@@ -1329,11 +1329,15 @@ async function checkCuratedState({
   }
 
   if (failures.length > 0) {
-    core.setFailed(`${failures.join('; ')}. Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply.`);
-    return { status: 'failed', failures };
+    // Prefix the target so the annotation GitHub surfaces from setFailed names the
+    // package and version being gated; bare reason strings are ambiguous across the
+    // many open release PRs this check covers.
+    const target = `for ${component} ${version}`;
+    core.setFailed(`${target}: ${failures.join('; ')}. Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply.`);
+    return { status: 'failed', failures, component, version };
   }
   core.info(`Curated release notes are current for ${component} ${version}`);
-  return { status: 'passed' };
+  return { status: 'passed', component, version };
 }
 
 module.exports = {

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -708,6 +708,10 @@ test('required check passes only when applied metadata, changelog, body, and anc
   });
   assert.equal(result.status, 'passed', core.failed);
   assert.equal(core.failed, null);
+  // The refresh workflow names the validated package+version in its check output,
+  // so the result must carry them.
+  assert.equal(result.component, COMPONENT);
+  assert.equal(result.version, VERSION);
 });
 
 test('required check accepts apply after unrelated branch advancement', async () => {
@@ -848,6 +852,8 @@ test('required check warns when generated entries change after draft before appl
   const core = makeCore();
   const result = await releaseNotes.checkCuratedState({ github, context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } }, core, number: 123, ...BOT_AUTH });
   assert.equal(result.status, 'missing');
+  assert.equal(result.component, COMPONENT);
+  assert.equal(result.version, VERSION);
   assert.match(core.failed, /draft and then/);
   assert.equal(calls.createComment.length, 1);
   assert.match(calls.createComment[0].body, /New generated release entries appeared/);
@@ -1934,7 +1940,13 @@ test('required check fails when the PR body preview terminator is unparseable', 
   });
   const { github } = makeGithub({ pr, comments: [overrideComment(), appliedComment()] });
   const core = makeCore();
-  await releaseNotes.checkCuratedState({ github, context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } }, core, number: 123, ...BOT_AUTH });
+  const result = await releaseNotes.checkCuratedState({ github, context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } }, core, number: 123, ...BOT_AUTH });
+  assert.equal(result.status, 'failed');
+  assert.equal(result.component, COMPONENT);
+  assert.equal(result.version, VERSION);
+  // The annotation GitHub surfaces from setFailed must name the gated package and
+  // version — the bare reason list is ambiguous across open release PRs.
+  assert.match(core.failed, new RegExp(`^for ${COMPONENT} ${VERSION.replaceAll('.', '\\.')}: `));
   assert.match(core.failed, /exactly one release-notes preview terminator/);
 });
 

--- a/.github/scripts/tests/release/test_release_notes.py
+++ b/.github/scripts/tests/release/test_release_notes.py
@@ -77,6 +77,10 @@ def test_required_check_is_attached_to_the_validated_pr_head() -> None:
     check_workflow = CHECK_WORKFLOW.read_text()
     assert "expectedHead: pr.head.sha" in check_workflow
     assert "initialDraftPollAttempts: context.eventName === 'issue_comment' ? 0 : 72" in check_workflow
+    # Refresh runs share one package-agnostic job name across every release PR, so the
+    # refreshed check's title/summary must name the validated package and version.
+    assert "Curated release notes are valid for ${target}" in check_workflow
+    assert "Validation result for ${target}: ${result.status}." in check_workflow
     # A cancelled/timed-out poll must not leave the refresh check spinning forever:
     # an always() finalizer closes an interrupted in_progress check.
     assert "if: always() && steps.validate.outputs.refresh_check_id != ''" in check_workflow

--- a/.github/workflows/release_notes_check.yml
+++ b/.github/workflows/release_notes_check.yml
@@ -102,7 +102,13 @@ jobs:
                 id: process.env.BOT_ID,
                 initialDraftPollAttempts: context.eventName === 'issue_comment' ? 0 : 72,
               });
-              core.info(`Curated release-note state: ${result.status}.`);
+              // Name the package and version being validated so refresh runs (whose
+              // job and check names are package-agnostic) identify their target in
+              // the log and in the refreshed check's output.
+              const target = result.component
+                ? `the ${result.component} ${result.version} release PR`
+                : `PR #${number}`;
+              core.info(`Curated release-note state for ${target}: ${result.status}.`);
               if (refreshCheck !== null) {
                 // 'not-applicable' means the PR is no longer the release branch, so
                 // the gate isn't required — treat it as passing, matching the
@@ -116,10 +122,10 @@ jobs:
                   conclusion: passing.has(result.status) ? 'success' : 'failure',
                   output: {
                     title: passing.has(result.status)
-                      ? 'Curated release notes are valid'
+                      ? `Curated release notes are valid for ${target}`
                       : result.status === 'unapplied'
-                        ? 'Curated release notes are ready for review'
-                        : 'Curated release notes need attention',
+                        ? `Curated release notes are ready for review for ${target}`
+                        : `Curated release notes need attention for ${target}`,
                     summary: result.status === 'unapplied'
                       ? [
                           result.draftCommentUrl
@@ -130,7 +136,7 @@ jobs:
                           '@release-bot apply',
                           '```',
                         ].join('\n')
-                      : `Validation result: ${result.status}.`,
+                      : `Validation result for ${target}: ${result.status}.`,
                   },
                 });
               }


### PR DESCRIPTION
The curated release-notes refresh runs share one package-agnostic job name ("Refresh curated release notes check") across every open release PR, and neither the job output nor the refreshed check named the package or version being validated. A failure run surfaced only a bare list of stale-state reasons ("applied metadata references an older override comment; …"), leaving no indication of which component was gated or whether the failure was a real verdict versus a validator error.

`checkCuratedState` now returns the resolved `component` and `version` on every status it reaches after resolving them, and the workflow threads them through the output:

- The job log line reads `Curated release-note state for the <component> <version> release PR: <status>.`
- The refreshed check's title and summary name the target, e.g. `Curated release notes are valid for the deepagents-code 0.1.58 release PR`.
- The `setFailed` annotation behind a `failed` result is prefixed with `for <component> <version>:` so the annotation GitHub surfaces on the run identifies the package on its own.

The failure conclusion itself is unchanged and is by design: dispatch runs execute from `main`, so the run's native job conclusion is how the gate reports the release PR's state — `setFailed` marks the run failed whenever the curated notes are stale, which is distinct from a validator error (that path gets its own "hit an error talking to GitHub" check summary).
