### PR TITLE
feat(infra): `bypass-ripgrep-check` label for release PR strict install

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1007,14 +1007,14 @@ If the older pin is intentional, add the `release: skip sdk pin check` label to 
 
 ### Release Failed: Ripgrep Install
 
-The strict ripgrep install in CI (and the `Install ripgrep` step in `release.yml`) runs with no timeout on release-sensitive paths, because the rg-gated tests — including the symlink containment check — must exercise the real binary rather than the Python fallback. A transient apt or mirror failure therefore fails the job even though nothing is wrong with the code.
+On release-sensitive paths, the ripgrep install itself runs with no timeout. This applies to the strict step in CI and to the `Install ripgrep` step in `release.yml`. The rg-gated tests must exercise the real binary, not the Python fallback; one of them checks symlink containment. An apt or mirror failure therefore fails the job even though the code is fine.
 
-If the failure is genuinely transient infrastructure flake, add the `bypass-ripgrep-check` label to the release PR and re-run CI. With the label present:
+If the apt log shows a mirror or network error, add the `bypass-ripgrep-check` label to the release PR and re-run CI. With the label present:
 
-- **In CI** (`_test.yml`): the strict install still runs, but a failure becomes a tolerated continue. `DEEPAGENTS_RIPGREP_EXPECTED` is left unset, so `require_ripgrep()` skips the gated tests on that leg instead of failing them. The run posts a sticky comment on the PR recording which legs ran without ripgrep.
-- **At dispatch** (`release-please.yml`): the automatic release dispatch passes `dangerous-skip-ripgrep-check=true` to `release.yml`, so the publish run's `Install ripgrep` step tolerates the same apt failure and its rg-gated artifact tests skip rather than re-failing on the flake.
+- **In CI** (`_test.yml`): the strict install still runs, but a failure becomes a tolerated continue. The step then unwinds `dpkg` and probes for a usable `rg`. If one is present, the leg keeps full coverage. If not, `DEEPAGENTS_RIPGREP_EXPECTED` is left unset, so `require_ripgrep()` skips the gated tests on that leg instead of failing them. The run posts a sticky comment on the PR that records which legs ran without ripgrep.
+- **At dispatch** (`release-please.yml`): the automatic release dispatch passes `dangerous-skip-ripgrep-check=true` to `release.yml`. The publish run's `Install ripgrep` step then tolerates the same apt failure. It applies the same `rg` probe, and when the binary really is missing it writes a "Published without ripgrep coverage" block to the run summary.
 
-The label is honored only on release PRs (`pull_request` with a `release-please--` branch or `release(` title). `push`-to-`main` and merge-queue runs have no PR label to read, so they always enforce the strict install. Remove the label and re-run CI to restore full ripgrep coverage before relying on the result.
+The label is honored only on release PRs — a `pull_request` with a `release-please--` branch or a `release(` title. `push`-to-`main` and merge-queue runs have no PR label to read, so they always enforce the strict install. The dispatch reads the label at merge time: remove it before merging and the publish run enforces the strict install again. Remove the label and re-run CI to restore full ripgrep coverage before you rely on the result.
 
 ### "Untagged, merged release PRs outstanding" Error
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1005,6 +1005,17 @@ If the older pin is intentional, add the `release: skip sdk pin check` label to 
 
 3. **Verify the `autorelease: pending` label was swapped.** The `mark-release` job will attempt to find the release PR by label and update it automatically, even on manual dispatch. If the label wasn't swapped (e.g., the job failed), fix it manually — see [Release PR Stuck with "autorelease: pending" Label](#release-pr-stuck-with-autorelease-pending-label). **If you skip this step, release-please will not create new release PRs.**
 
+### Release Failed: Ripgrep Install
+
+The strict ripgrep install in CI (and the `Install ripgrep` step in `release.yml`) runs with no timeout on release-sensitive paths, because the rg-gated tests — including the symlink containment check — must exercise the real binary rather than the Python fallback. A transient apt or mirror failure therefore fails the job even though nothing is wrong with the code.
+
+If the failure is genuinely transient infrastructure flake, add the `bypass-ripgrep-check` label to the release PR and re-run CI. With the label present:
+
+- **In CI** (`_test.yml`): the strict install still runs, but a failure becomes a tolerated continue. `DEEPAGENTS_RIPGREP_EXPECTED` is left unset, so `require_ripgrep()` skips the gated tests on that leg instead of failing them. The run posts a sticky comment on the PR recording which legs ran without ripgrep.
+- **At dispatch** (`release-please.yml`): the automatic release dispatch passes `dangerous-skip-ripgrep-check=true` to `release.yml`, so the publish run's `Install ripgrep` step tolerates the same apt failure and its rg-gated artifact tests skip rather than re-failing on the flake.
+
+The label is honored only on release PRs (`pull_request` with a `release-please--` branch or `release(` title). `push`-to-`main` and merge-queue runs have no PR label to read, so they always enforce the strict install. Remove the label and re-run CI to restore full ripgrep coverage before relying on the result.
+
 ### "Untagged, merged release PRs outstanding" Error
 
 If release-please logs show:

--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -1,8 +1,12 @@
 """Contracts for the CI workflows.
 
-Mostly static assertions over workflow YAML, plus an executable check of the
-bounded ripgrep install script: `test_non_release_ripgrep_install_*` runs the
-step's real `run:` body against stubbed `sudo`/`timeout`/`dpkg`/`rg` binaries.
+Mostly static assertions over workflow YAML. The parts that can silently
+disable a gate are executed instead of grepped: every ripgrep install step
+(`_test.yml`'s soft and strict steps, and `release.yml`'s) has its real `run:`
+body driven through `_run_install_script` against stubbed
+`sudo`/`timeout`/`dpkg`/`rg`/`apt-get` binaries, and the label step that arms
+the strict step's bypass runs against a stubbed `gh` in
+`test_ripgrep_bypass_step_behaviour`.
 """
 
 from __future__ import annotations
@@ -29,6 +33,12 @@ FILESYSTEM_TESTS = (
 
 STRICT_STEP = "🔍 Install ripgrep (strict)"
 SOFT_STEP = "🔍 Install ripgrep (non-release PR)"
+RESOLVE_STEP = "🏷️ Resolve ripgrep bypass"
+# What makes a PR release-sensitive. Spelled once here and asserted against
+# every place that re-implements it: two `if:` conditions in `_test.yml` and
+# the JS predicate in `ripgrep_timeout_comment.yml`, which decides whether the
+# posted comment describes a timeout or a bypass.
+RELEASE_PR_PREDICATES = ("release-please--", "release(")
 APT_INSTALL = "apt-get update && sudo apt-get install -y ripgrep"
 # Shared by the shell producer in `_test.yml` and the JS consumer in
 # `ripgrep_timeout_comment.yml`; nothing else couples the two files.
@@ -50,6 +60,21 @@ def _find_step(workflow: dict[str, Any], *, job: str, name: str) -> dict[str, An
     ]
     assert len(matches) == 1, f"expected one {name!r} step, found {len(matches)}"
     return matches[0]
+
+
+def _assert_install_is_unbounded(run: str) -> None:
+    """No `timeout` may wrap the apt install itself.
+
+    Both strict steps legitimately contain a `timeout` — the bounded
+    `dpkg --configure -a` unwind on the failure path — so the absence of any
+    one literal spelling proves nothing. Everything before `status=$?` is the
+    install; that region must have no `timeout` at all, whatever the duration.
+    """
+    install, separator, _ = run.partition("status=$?")
+    assert separator, "expected the install to capture its status in `status=$?`"
+    assert "timeout" not in install, (
+        f"the apt install is bounded by a timeout:\n{install}"
+    )
 
 
 def _starts_with(value: Any, prefix: str) -> bool:
@@ -184,7 +209,11 @@ def test_exactly_one_ripgrep_install_step_runs(
 
 
 def test_non_release_pr_ripgrep_install_has_two_minute_timeout() -> None:
-    """Ordinary PRs may continue only when ripgrep installation times out."""
+    """Ordinary PRs may continue only when ripgrep installation times out.
+
+    Also pins the shared upload step, which is wired to *both* install steps:
+    the assertions about `ripgrep-strict` below are load-bearing, not leftovers.
+    """
     workflow = _load_workflow(TEST_WORKFLOW)
     step = _find_step(workflow, job="build", name=SOFT_STEP)
 
@@ -220,6 +249,11 @@ def test_only_two_ripgrep_install_steps_exist() -> None:
     assert [step["name"] for step in installs] == [STRICT_STEP, SOFT_STEP]
 
 
+def _summary_path(tmp_path: Path) -> Path:
+    """Where `_run_install_script` points `GITHUB_STEP_SUMMARY`."""
+    return tmp_path / "github-step-summary"
+
+
 def _run_install_script(
     script: str,
     tmp_path: Path,
@@ -228,6 +262,7 @@ def _run_install_script(
     rg_available: bool = False,
     apt_status: int | None = None,
     bypass: str = "",
+    skip_ripgrep_check: str = "",
 ) -> tuple[subprocess.CompletedProcess[str], list[str], list[str]]:
     """Execute the install step's `run:` body against stubbed binaries.
 
@@ -235,6 +270,8 @@ def _run_install_script(
     so `timeout_status` drives its outcome. The strict step calls
     `sudo apt-get ...` directly, so `apt_status` (when set) stubs `apt-get`
     itself; `bypass` feeds the step's `BYPASS` env (the resolved PR label).
+    `release.yml`'s step is the same shape, driven by `SKIP_RIPGREP_CHECK`
+    instead; its step-summary writes land in `summary_path`.
     """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -260,6 +297,8 @@ def _run_install_script(
     env_file.touch()
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
+    summary = _summary_path(tmp_path)
+    summary.touch()
 
     result = subprocess.run(
         ["bash", "-c", script],
@@ -272,10 +311,12 @@ def _run_install_script(
             "BYPASS": bypass,
             "GITHUB_ENV": str(env_file),
             "GITHUB_OUTPUT": str(output),
+            "GITHUB_STEP_SUMMARY": str(summary),
             "MATRIX_OS": "ubuntu-latest",
             "MATRIX_PYTHON": "3.14",
             "PATH": f"{bin_dir}:/usr/bin:/bin",
             "RUNNER_TEMP": str(runner_temp),
+            "SKIP_RIPGREP_CHECK": skip_ripgrep_check,
             "WORKING_DIRECTORY": "libs/code",
         },
     )
@@ -356,20 +397,43 @@ def test_timeout_with_usable_ripgrep_is_not_reported(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell script")
 @pytest.mark.parametrize(
-    ("bypass", "apt_status", "rg_available", "expected_status", "expect_env"),
+    (
+        "bypass",
+        "apt_status",
+        "rg_available",
+        "expected_status",
+        "expect_env",
+        "expect_artifact",
+        "expect_annotation",
+    ),
     [
+        # The overwhelmingly common case, and the one that arms the rg-gated
+        # tests for every release and merge-queue run: apt succeeds, the tests
+        # are promised ripgrep, and nothing is reported.
+        ("", 0, False, 0, True, False, None),
+        ("true", 0, False, 0, True, False, None),
         # Unlabeled: any apt failure fails the job, ripgrep never promised.
-        ("", 1, False, 1, False),
-        ("", 100, False, 100, False),
+        ("", 1, False, 1, False, False, "::error::"),
+        ("", 100, False, 100, False, False, "::error::"),
+        # An empty `BYPASS` is what `push`/`merge_group` see, because the label
+        # step is skipped there and a skipped step's output is the empty string.
+        # Anything other than an exact "true" must enforce.
+        ("false", 1, False, 1, False, False, "::error::"),
+        ("True", 1, False, 1, False, False, "::error::"),
         # Labeled: a failed install is tolerated; without a usable `rg` the leg
         # reports the timeout artifact and does not promise ripgrep to the tests.
-        ("true", 1, False, 0, False),
-        # Labeled but `rg` is actually present anyway: promise ripgrep, no warning.
-        ("true", 1, True, 0, True),
+        ("true", 1, False, 0, False, True, "::warning::"),
+        # Labeled but `rg` is actually present anyway: promise ripgrep, keep the
+        # leg's coverage, and report nothing to the comment workflow.
+        ("true", 1, True, 0, True, False, "::notice::"),
     ],
     ids=[
+        "unlabeled-succeeds",
+        "labeled-succeeds",
         "unlabeled-fails",
         "unlabeled-fails-100",
+        "bypass-literal-false",
+        "bypass-wrong-case",
         "labeled-bypasses",
         "labeled-rg-present",
     ],
@@ -381,8 +445,15 @@ def test_strict_ripgrep_install_bypass(
     rg_available: bool,
     expected_status: int,
     expect_env: bool,
+    expect_artifact: bool,
+    expect_annotation: str | None,
 ) -> None:
-    """The strict step fails on apt errors unless the PR carries the bypass label."""
+    """The strict step fails on apt errors unless the PR carries the bypass label.
+
+    Every row asserts the full outcome — exit status, whether ripgrep is
+    promised to the tests, whether the leg is reported to the comment workflow,
+    and which annotation is emitted — so no case can pass by falling through.
+    """
     workflow = _load_workflow(TEST_WORKFLOW)
     step = _find_step(workflow, job="build", name=STRICT_STEP)
     result, output_lines, env_lines = _run_install_script(
@@ -398,15 +469,115 @@ def test_strict_ripgrep_install_bypass(
     assert (EXPECTED_ENV in env_lines) is expect_env
 
     timed_out = [line for line in output_lines if line.startswith("timed-out=")]
-    if expected_status == 0 and not expect_env:
-        # A bypassed failure with no usable rg reports the artifact for the
-        # comment workflow to pick up.
+    artifact = f"artifact={ARTIFACT_PREFIX}libs-code-ubuntu-latest-3.14"
+    if expect_artifact:
+        # Only a bypassed failure with no usable rg reports a leg; reporting a
+        # leg that kept its coverage would put a false warning on the PR.
         assert timed_out == ["timed-out=true"]
-        assert "::warning::" in result.stdout
-        assert f"artifact={ARTIFACT_PREFIX}libs-code-ubuntu-latest-3.14" in output_lines
-    elif expected_status != 0:
+        assert artifact in output_lines
+    else:
         assert timed_out == []
-        assert "::error::" in result.stdout
+        assert artifact not in output_lines
+
+    for annotation in ("::error::", "::warning::", "::notice::"):
+        assert (annotation in result.stdout) is (annotation == expect_annotation), (
+            f"unexpected {annotation} handling in: {result.stdout}"
+        )
+
+
+def test_ripgrep_bypass_step_runs_only_where_the_strict_step_does() -> None:
+    """The label step must not annotate legs that have no strict install.
+
+    Its `if:` is the intersection of `pull_request` and the strict step's own
+    condition. Widen it and every ordinary PR collects a per-leg `::error::`
+    about a check that is not enforced there; narrow it and a release PR
+    silently loses the bypass.
+    """
+    workflow = _load_workflow(TEST_WORKFLOW)
+    resolve = _find_step(workflow, job="build", name=RESOLVE_STEP)
+    strict = _find_step(workflow, job="build", name=STRICT_STEP)
+
+    condition = " ".join(resolve["if"].split())
+    assert condition == (
+        "runner.os == 'Linux' && github.event_name == 'pull_request' && "
+        "(startsWith(github.head_ref, 'release-please--') || "
+        "startsWith(github.event.pull_request.title, 'release('))"
+    )
+    # Whatever the release predicate is, both steps must spell it the same way.
+    for predicate in RELEASE_PR_PREDICATES:
+        assert predicate in " ".join(resolve["if"].split())
+        assert predicate in " ".join(strict["if"].split())
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell script")
+@pytest.mark.parametrize(
+    ("labels", "gh_exit", "expected_bypass", "expect_error"),
+    [
+        ("bypass-ripgrep-check", 0, "true", False),
+        ("dependencies\nlgtm", 0, "false", False),
+        ("", 0, "false", False),
+        # Neither a superstring nor a prefixed variant may arm the bypass.
+        ("bypass-ripgrep-check-v2", 0, "false", False),
+        ("no-bypass-ripgrep-check", 0, "false", False),
+        # Fail closed and say so. Stdout carrying the label is deliberately
+        # ignored when the call itself failed: a partial read must never arm a
+        # bypass, and a silent enforce is indistinguishable from "label absent".
+        ("bypass-ripgrep-check", 1, "false", True),
+    ],
+    ids=[
+        "label-present",
+        "label-absent",
+        "no-labels",
+        "label-superstring",
+        "label-prefixed",
+        "api-failure-fails-closed",
+    ],
+)
+def test_ripgrep_bypass_step_behaviour(
+    tmp_path: Path,
+    labels: str,
+    gh_exit: int,
+    expected_bypass: str,
+    expect_error: bool,
+) -> None:
+    """Run the label step's real shell against a stubbed `gh`.
+
+    This step is the single switch that can disarm the strict install on a
+    release PR, so its polarity is executed rather than grepped.
+    """
+    workflow = _load_workflow(TEST_WORKFLOW)
+    step = _find_step(workflow, job="build", name=RESOLVE_STEP)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh_stub = bin_dir / "gh"
+    gh_stub.write_text(
+        f'#!/usr/bin/env bash\nprintf "%s\\n" "{labels}"\nexit {gh_exit}\n'
+    )
+    gh_stub.chmod(0o755)
+
+    github_output = tmp_path / "github-output"
+    github_output.touch()
+
+    result = subprocess.run(
+        ["bash", "-c", step["run"]],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "GH_TOKEN": "stub-token",
+            "GITHUB_OUTPUT": str(github_output),
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "PR": "1234",
+            "REPO": "langchain-ai/deepagents",
+        },
+    )
+
+    # A non-zero exit would fail the job outright, which is a different (and
+    # much louder) outcome than resolving the bypass to false.
+    assert result.returncode == 0, result.stderr
+    assert github_output.read_text().splitlines() == [f"bypass={expected_bypass}"]
+    assert ("::error::" in result.stdout) is expect_error
 
 
 def test_release_and_non_pr_ripgrep_install_is_strict() -> None:
@@ -414,8 +585,8 @@ def test_release_and_non_pr_ripgrep_install_is_strict() -> None:
 
     The install itself is unbounded — the only `timeout` in the step is the
     dpkg unwind that runs *after* a bypassed failure, never around the install.
-    The bypass is read from the live PR label, and the tests are only promised
-    ripgrep when the install actually succeeded.
+    The bypass is read from the live PR label, and the tests are promised
+    ripgrep only when a usable `rg` is present, whether or not apt said so.
     """
     workflow = _load_workflow(TEST_WORKFLOW)
     step = _find_step(workflow, job="build", name=STRICT_STEP)
@@ -423,14 +594,16 @@ def test_release_and_non_pr_ripgrep_install_is_strict() -> None:
     assert APT_INSTALL in step["run"]
     assert "continue-on-error" not in step
     assert "timeout-minutes" not in step
-    # No `timeout` wrapping the apt install itself; only the post-failure dpkg
-    # unwind is bounded.
-    assert "timeout --signal=TERM --kill-after=10s 120s" not in step["run"]
+    _assert_install_is_unbounded(step["run"])
     # Bypass comes from the resolved PR label, not the event payload.
     assert step["env"]["BYPASS"] == "${{ steps.ripgrep-bypass.outputs.bypass }}"
     # Promises ripgrep to the tests, turning a missing `rg` into a failure
-    # instead of a silent skip.
-    assert EXPECTED_ENV in step["run"]
+    # instead of a silent skip. Asserted on the *success* branch specifically:
+    # the step sets it twice, so a bare `in step["run"]` is satisfied by the
+    # bypass branch alone and would not notice the success branch losing it.
+    success_branch, separator, _ = step["run"].partition("# apt failed.")
+    assert separator, "expected the success branch to precede the apt-failure comment"
+    assert EXPECTED_ENV in success_branch
 
 
 def test_release_workflow_requires_ripgrep_before_unit_tests() -> None:
@@ -442,10 +615,95 @@ def test_release_workflow_requires_ripgrep_before_unit_tests() -> None:
 
     assert steps.index(install) < steps.index(tests)
     assert APT_INSTALL in install["run"]
-    assert "timeout" not in install["run"]
+    _assert_install_is_unbounded(install["run"])
     assert "continue-on-error" not in install
     assert "timeout-minutes" not in install
-    assert EXPECTED_ENV in install["run"]
+    # The dangerous bypass must come from the dispatch input, never a default.
+    assert (
+        install["env"]["SKIP_RIPGREP_CHECK"]
+        == "${{ inputs.dangerous-skip-ripgrep-check }}"
+    )
+    success_branch, separator, _ = install["run"].partition("SKIP_RIPGREP_CHECK")
+    assert separator
+    assert EXPECTED_ENV in success_branch
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell script")
+@pytest.mark.parametrize(
+    (
+        "skip",
+        "apt_status",
+        "rg_available",
+        "expected_status",
+        "expect_env",
+        "expect_summary",
+        "expect_annotation",
+    ),
+    [
+        # apt succeeds: the artifact tests are held to the real binary.
+        ("false", 0, False, 0, True, False, None),
+        ("true", 0, False, 0, True, False, None),
+        # No dispatch flag: an apt failure fails the publish run, exit code kept.
+        ("false", 1, False, 1, False, False, "::error::"),
+        ("false", 100, True, 100, False, False, "::error::"),
+        # The input arrives as a string; only an exact "true" may soften.
+        ("", 1, False, 1, False, False, "::error::"),
+        ("True", 1, False, 1, False, False, "::error::"),
+        # Flagged and `rg` really is missing: continue, and record the dropped
+        # coverage in the run summary rather than in a step log alone.
+        ("true", 1, False, 0, False, True, "::warning::"),
+        # Flagged but a usable `rg` is present: keep full coverage instead of
+        # discarding it, and publish nothing about missing coverage.
+        ("true", 1, True, 0, True, False, "::notice::"),
+    ],
+    ids=[
+        "unflagged-succeeds",
+        "flagged-succeeds",
+        "unflagged-fails",
+        "unflagged-fails-100",
+        "flag-empty",
+        "flag-wrong-case",
+        "flagged-bypasses",
+        "flagged-rg-present",
+    ],
+)
+def test_release_workflow_ripgrep_bypass(
+    tmp_path: Path,
+    skip: str,
+    apt_status: int,
+    rg_available: bool,
+    expected_status: int,
+    expect_env: bool,
+    expect_summary: bool,
+    expect_annotation: str | None,
+) -> None:
+    """`release.yml`'s install tolerates apt only under the dispatch flag.
+
+    This step publishes to PyPI, so it is executed rather than grepped: a
+    static check cannot tell `if [ "$SKIP_RIPGREP_CHECK" = "true" ]` from
+    `if true`.
+    """
+    workflow = _load_workflow(RELEASE_WORKFLOW)
+    install = _find_step(workflow, job="pre-release-checks", name="Install ripgrep")
+    result, _, env_lines = _run_install_script(
+        install["run"],
+        tmp_path,
+        timeout_status=0,
+        apt_status=apt_status,
+        rg_available=rg_available,
+        skip_ripgrep_check=skip,
+    )
+
+    assert result.returncode == expected_status
+    assert (EXPECTED_ENV in env_lines) is expect_env
+
+    summary = _summary_path(tmp_path).read_text()
+    assert ("Published without ripgrep coverage" in summary) is expect_summary
+
+    for annotation in ("::error::", "::warning::", "::notice::"):
+        assert (annotation in result.stdout) is (annotation == expect_annotation), (
+            f"unexpected {annotation} handling in: {result.stdout}"
+        )
 
 
 def test_missing_ripgrep_fails_loudly_when_ci_promised_it() -> None:
@@ -491,8 +749,6 @@ def test_ripgrep_timeout_comment_uses_isolated_workflow_run() -> None:
     assert "pullRequest.head.sha !== run.head_sha" in script
     assert "listWorkflowRunArtifacts" in script
     assert ARTIFACT_PREFIX in script
-    # A labeled release PR's bypassed legs must be reported as such, not lumped
-    # in with the soft-timeout wording.
     assert "listLabelsOnIssue" in script
     assert "bypass-ripgrep-check" in script
     assert "createComment" in script
@@ -504,8 +760,47 @@ def test_ripgrep_timeout_comment_uses_isolated_workflow_run() -> None:
     assert "run.head_repository.owner.login" in script
     # An unreportable timeout is a broken mechanism, not a no-op.
     assert "core.setFailed" in script
-    # The comment workflow needs the label to branch its bypass wording.
-    assert workflow["permissions"]["issues"] == "write"
+
+
+def test_ripgrep_comment_wording_is_keyed_on_pr_kind_not_the_label() -> None:
+    """Which failure the comment describes must not depend on a label read.
+
+    On a release PR the only producer of these artifacts is the strict step's
+    bypass path, which has no timeout — so the soft-timeout wording ("took more
+    than two minutes") is false there. Keying the branch on the label instead
+    reintroduces that: a failed `listLabelsOnIssue`, or a label removed between
+    CI finishing and this workflow running, would post the wrong explanation
+    plus "No action is needed to merge."
+    """
+    workflow = _load_workflow(RIPGREP_COMMENT_WORKFLOW)
+    script = workflow["jobs"]["manage-comment"]["steps"][0]["with"]["script"]
+
+    assert "const body = isReleasePullRequest\n" in script
+    assert "isReleasePullRequest && hasBypassLabel" not in script
+    # The label may still colour one sentence, and must fail closed to
+    # "unconfirmed" rather than asserting either outcome.
+    assert "let hasBypassLabel = false;" in script
+    assert "hasBypassLabel = true" not in script
+
+
+def test_release_pr_predicate_matches_between_ci_and_comment_workflow() -> None:
+    """`_test.yml` produces the artifacts; the comment workflow explains them.
+
+    Each spells the release-PR test in its own language against its own data
+    source. If they drift, a PR gets artifacts from one failure mode described
+    as the other, and nothing else in CI notices.
+    """
+    test_workflow = _load_workflow(TEST_WORKFLOW)
+    strict = _find_step(test_workflow, job="build", name=STRICT_STEP)
+    soft = _find_step(test_workflow, job="build", name=SOFT_STEP)
+    script = _load_workflow(RIPGREP_COMMENT_WORKFLOW)["jobs"]["manage-comment"][
+        "steps"
+    ][0]["with"]["script"]
+
+    for predicate in RELEASE_PR_PREDICATES:
+        assert predicate in strict["if"]
+        assert predicate in soft["if"]
+        assert f"'{predicate}'" in script
 
 
 def test_ripgrep_timeout_comment_concurrency_is_keyed_on_head_sha() -> None:

--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -45,7 +45,9 @@ def _load_workflow(path: Path) -> dict[str, Any]:
 
 def _find_step(workflow: dict[str, Any], *, job: str, name: str) -> dict[str, Any]:
     """Return one named workflow step."""
-    matches = [step for step in workflow["jobs"][job]["steps"] if step.get("name") == name]
+    matches = [
+        step for step in workflow["jobs"][job]["steps"] if step.get("name") == name
+    ]
     assert len(matches) == 1, f"expected one {name!r} step, found {len(matches)}"
     return matches[0]
 
@@ -195,11 +197,15 @@ def test_non_release_pr_ripgrep_install_has_two_minute_timeout() -> None:
     assert "continue-on-error" not in step
     assert "timeout-minutes" not in step
 
-    upload = _find_step(
-        workflow, job="build", name="📤 Record ripgrep install timeout"
+    upload = _find_step(workflow, job="build", name="📤 Record ripgrep install timeout")
+    # Both the soft step (genuine timeout) and the strict step (bypassed
+    # release-PR failure) feed the same marker artifact to the comment workflow.
+    assert "steps.ripgrep-install.outputs.timed-out == 'true'" in upload["if"]
+    assert "steps.ripgrep-strict.outputs.timed-out == 'true'" in upload["if"]
+    assert (
+        upload["with"]["name"]
+        == "${{ steps.ripgrep-install.outputs.artifact || steps.ripgrep-strict.outputs.artifact }}"
     )
-    assert upload["if"] == "steps.ripgrep-install.outputs.timed-out == 'true'"
-    assert upload["with"]["name"] == "${{ steps.ripgrep-install.outputs.artifact }}"
 
 
 def test_only_two_ripgrep_install_steps_exist() -> None:
@@ -220,8 +226,16 @@ def _run_install_script(
     *,
     timeout_status: int,
     rg_available: bool = False,
+    apt_status: int | None = None,
+    bypass: str = "",
 ) -> tuple[subprocess.CompletedProcess[str], list[str], list[str]]:
-    """Execute the install step's `run:` body against stubbed binaries."""
+    """Execute the install step's `run:` body against stubbed binaries.
+
+    The soft step routes apt through `sudo timeout ... bash -c '...apt-get...'`,
+    so `timeout_status` drives its outcome. The strict step calls
+    `sudo apt-get ...` directly, so `apt_status` (when set) stubs `apt-get`
+    itself; `bypass` feeds the step's `BYPASS` env (the resolved PR label).
+    """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
 
@@ -237,6 +251,8 @@ def _run_install_script(
     stub("timeout", f"exit {timeout_status}")
     stub("dpkg", "exit 0")
     stub("rg", "exit 0" if rg_available else "exit 127")
+    if apt_status is not None:
+        stub("apt-get", f"exit {apt_status}")
 
     output = tmp_path / "github-output"
     output.touch()
@@ -253,6 +269,7 @@ def _run_install_script(
         # Explicit, minimal environment: inheriting os.environ would let a
         # developer's BASH_ENV/SHELLOPTS leak into the script under test.
         env={
+            "BYPASS": bypass,
             "GITHUB_ENV": str(env_file),
             "GITHUB_OUTPUT": str(output),
             "MATRIX_OS": "ubuntu-latest",
@@ -337,15 +354,80 @@ def test_timeout_with_usable_ripgrep_is_not_reported(tmp_path: Path) -> None:
     assert EXPECTED_ENV in env_lines
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell script")
+@pytest.mark.parametrize(
+    ("bypass", "apt_status", "rg_available", "expected_status", "expect_env"),
+    [
+        # Unlabeled: any apt failure fails the job, ripgrep never promised.
+        ("", 1, False, 1, False),
+        ("", 100, False, 100, False),
+        # Labeled: a failed install is tolerated; without a usable `rg` the leg
+        # reports the timeout artifact and does not promise ripgrep to the tests.
+        ("true", 1, False, 0, False),
+        # Labeled but `rg` is actually present anyway: promise ripgrep, no warning.
+        ("true", 1, True, 0, True),
+    ],
+    ids=[
+        "unlabeled-fails",
+        "unlabeled-fails-100",
+        "labeled-bypasses",
+        "labeled-rg-present",
+    ],
+)
+def test_strict_ripgrep_install_bypass(
+    tmp_path: Path,
+    bypass: str,
+    apt_status: int,
+    rg_available: bool,
+    expected_status: int,
+    expect_env: bool,
+) -> None:
+    """The strict step fails on apt errors unless the PR carries the bypass label."""
+    workflow = _load_workflow(TEST_WORKFLOW)
+    step = _find_step(workflow, job="build", name=STRICT_STEP)
+    result, output_lines, env_lines = _run_install_script(
+        step["run"],
+        tmp_path,
+        timeout_status=0,
+        apt_status=apt_status,
+        rg_available=rg_available,
+        bypass=bypass,
+    )
+
+    assert result.returncode == expected_status
+    assert (EXPECTED_ENV in env_lines) is expect_env
+
+    timed_out = [line for line in output_lines if line.startswith("timed-out=")]
+    if expected_status == 0 and not expect_env:
+        # A bypassed failure with no usable rg reports the artifact for the
+        # comment workflow to pick up.
+        assert timed_out == ["timed-out=true"]
+        assert "::warning::" in result.stdout
+        assert f"artifact={ARTIFACT_PREFIX}libs-code-ubuntu-latest-3.14" in output_lines
+    elif expected_status != 0:
+        assert timed_out == []
+        assert "::error::" in result.stdout
+
+
 def test_release_and_non_pr_ripgrep_install_is_strict() -> None:
-    """Release PRs, pushes, and merge queues install ripgrep with no timeout."""
+    """Release runs install ripgrep with no soft timeout, and only bypass on a label.
+
+    The install itself is unbounded — the only `timeout` in the step is the
+    dpkg unwind that runs *after* a bypassed failure, never around the install.
+    The bypass is read from the live PR label, and the tests are only promised
+    ripgrep when the install actually succeeded.
+    """
     workflow = _load_workflow(TEST_WORKFLOW)
     step = _find_step(workflow, job="build", name=STRICT_STEP)
 
     assert APT_INSTALL in step["run"]
-    assert "timeout" not in step["run"]
     assert "continue-on-error" not in step
     assert "timeout-minutes" not in step
+    # No `timeout` wrapping the apt install itself; only the post-failure dpkg
+    # unwind is bounded.
+    assert "timeout --signal=TERM --kill-after=10s 120s" not in step["run"]
+    # Bypass comes from the resolved PR label, not the event payload.
+    assert step["env"]["BYPASS"] == "${{ steps.ripgrep-bypass.outputs.bypass }}"
     # Promises ripgrep to the tests, turning a missing `rg` into a failure
     # instead of a silent skip.
     assert EXPECTED_ENV in step["run"]
@@ -409,6 +491,10 @@ def test_ripgrep_timeout_comment_uses_isolated_workflow_run() -> None:
     assert "pullRequest.head.sha !== run.head_sha" in script
     assert "listWorkflowRunArtifacts" in script
     assert ARTIFACT_PREFIX in script
+    # A labeled release PR's bypassed legs must be reported as such, not lumped
+    # in with the soft-timeout wording.
+    assert "listLabelsOnIssue" in script
+    assert "bypass-ripgrep-check" in script
     assert "createComment" in script
     assert "updateComment" in script
     assert "deleteComment" in script
@@ -418,6 +504,8 @@ def test_ripgrep_timeout_comment_uses_isolated_workflow_run() -> None:
     assert "run.head_repository.owner.login" in script
     # An unreportable timeout is a broken mechanism, not a no-op.
     assert "core.setFailed" in script
+    # The comment workflow needs the label to branch its bypass wording.
+    assert workflow["permissions"]["issues"] == "write"
 
 
 def test_ripgrep_timeout_comment_concurrency_is_keyed_on_head_sha() -> None:

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -116,11 +116,53 @@ jobs:
         shell: bash
         run: uv sync --group test
 
+      # Maintainer escape hatch: a release PR labeled `bypass-ripgrep-check`
+      # turns a strict ripgrep-install failure into a tolerated continue. The
+      # label is read from the live GitHub API rather than
+      # `github.event.pull_request.labels` because re-running a job replays the
+      # original event payload, which would miss a label added after the fact.
+      # Non-PR events (`push`, `merge_group`) carry no PR label context, so this
+      # step is skipped there and the strict install below always fails loudly.
+      - name: "🏷️ Resolve ripgrep bypass"
+        id: ripgrep-bypass
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+          # `per_page=100` rather than `--paginate`: an issue caps at 100 labels,
+          # and `--paginate` streams each page as it arrives, so a failure on a
+          # later page would leave earlier pages in $LABELS while the nonzero exit
+          # is discarded -- i.e. it could bypass on the strength of a failed call.
+          # A single request makes the exit status an honest all-or-nothing signal.
+          rc=0
+          LABELS="$(gh api "repos/$REPO/issues/$PR/labels?per_page=100" --jq '.[].name')" || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            # Fail closed, but loudly: a silent fall-through here is
+            # indistinguishable from "label absent", so a maintainer would apply
+            # the label, re-run, and watch it fail again with no explanation.
+            echo "::error::Could not read labels for PR #$PR (gh api exit $rc); the strict ripgrep install will be ENFORCED. The bypass label cannot take effect until this is resolved."
+            echo "bypass=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s\n' "$LABELS" | grep -Fxq "bypass-ripgrep-check"; then
+            echo "bypass=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::'bypass-ripgrep-check' label present — a failed strict ripgrep install will be tolerated and the rg-gated tests will skip"
+          else
+            echo "bypass=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Release-sensitive runs must exercise the real ripgrep code path rather
       # than the Python fallback, so the install has no timeout here and a
-      # failure reds the job. `merge_group` is deliberately strict: an apt
-      # flake ejects the PR from the queue, which is recoverable, whereas a
-      # silent skip at the last gate before `main` is not.
+      # failure reds the job — unless the PR carries `bypass-ripgrep-check`,
+      # which turns an apt failure into a tolerated continue (see
+      # RELEASING.md > "Release Failed: Ripgrep Install"). `merge_group` and
+      # `push` stay strict even then: they have no PR label context to read,
+      # so an apt flake there still fails (for the merge queue, ejection is
+      # recoverable, whereas a silent skip at the last gate is not).
       #
       # `DEEPAGENTS_RIPGREP_EXPECTED=1` is consumed by `require_ripgrep` in
       # `libs/deepagents/tests/.../test_filesystem_backend.py`: on a runner
@@ -128,15 +170,57 @@ jobs:
       # of skipping them. One of those tests guards symlink containment, and a
       # silent skip would let a containment regression merge green.
       - name: "🔍 Install ripgrep (strict)"
+        id: ripgrep-strict
         if: >-
           runner.os == 'Linux' &&
           (github.event_name != 'pull_request' ||
           startsWith(github.head_ref, 'release-please--') ||
           startsWith(github.event.pull_request.title, 'release('))
         shell: bash
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_PYTHON: ${{ matrix.python-version }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          BYPASS: ${{ steps.ripgrep-bypass.outputs.bypass }}
         run: |
+          set +e
           sudo apt-get update && sudo apt-get install -y ripgrep
-          echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          # apt failed. Tolerate it only when the PR is labeled; otherwise
+          # fail as before. The label only exists on a `pull_request`, so
+          # `push`/`merge_group` always take the strict path.
+          if [ "$BYPASS" != "true" ]; then
+            echo "::error::ripgrep install failed on a release-sensitive run and no 'bypass-ripgrep-check' label is present."
+            exit "$status"
+          fi
+          # Bypassed: run the same dpkg unwind and `rg` probe as the
+          # non-release path, then record the same artifact so the timeout
+          # comment workflow reports these legs too. `DEEPAGENTS_RIPGREP_EXPECTED`
+          # is only set when `rg` is actually usable, so a genuinely missing
+          # binary lets `require_ripgrep` skip the gated tests rather than
+          # fail them.
+          sudo timeout --signal=TERM --kill-after=10s 60s \
+            dpkg --configure -a || true
+          if rg --version >/dev/null 2>&1; then
+            echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
+            echo "::notice::ripgrep install reported failure but a usable rg is present; continuing with ripgrep"
+            exit 0
+          fi
+          echo "timed-out=true" >> "$GITHUB_OUTPUT"
+          echo "::warning::ripgrep install failed on release PR; 'bypass-ripgrep-check' present — continuing without ripgrep (rg-gated tests will skip)"
+          package="${WORKING_DIRECTORY//\//-}"
+          artifact="ripgrep-timeout-${package}-${MATRIX_OS}-${MATRIX_PYTHON}"
+          marker="$RUNNER_TEMP/$artifact/warning.txt"
+          mkdir -p "$(dirname "$marker")"
+          printf '%s\n' "$artifact" > "$marker"
+          echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
+          echo "marker=$marker" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: "🔍 Install ripgrep (non-release PR)"
         id: ripgrep-install
@@ -204,11 +288,17 @@ jobs:
           exit 0
 
       - name: "📤 Record ripgrep install timeout"
-        if: steps.ripgrep-install.outputs.timed-out == 'true'
+        # The soft step reports a genuine timeout; the strict step reports a
+        # bypassed release-PR failure. Both produce the same marker artifact.
+        if: >-
+          steps.ripgrep-install.outputs.timed-out == 'true' ||
+          steps.ripgrep-strict.outputs.timed-out == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ steps.ripgrep-install.outputs.artifact }}
-          path: ${{ steps.ripgrep-install.outputs.marker }}
+          # Whichever install step reported `timed-out` is the one that set
+          # `artifact`/`marker`; the other's outputs are empty here.
+          name: ${{ steps.ripgrep-install.outputs.artifact || steps.ripgrep-strict.outputs.artifact }}
+          path: ${{ steps.ripgrep-install.outputs.marker || steps.ripgrep-strict.outputs.marker }}
           retention-days: 1
 
       # Maintainer escape hatch: a PR labeled `bypass-warnings-check` runs

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -121,11 +121,20 @@ jobs:
       # label is read from the live GitHub API rather than
       # `github.event.pull_request.labels` because re-running a job replays the
       # original event payload, which would miss a label added after the fact.
-      # Non-PR events (`push`, `merge_group`) carry no PR label context, so this
-      # step is skipped there and the strict install below always fails loudly.
+      #
+      # The condition is the intersection of "this is a `pull_request`" and the
+      # strict step's own `if:` below. Running anywhere else would annotate legs
+      # that have no strict install to bypass -- an `::error::` about a check
+      # that is not enforced there, once per matrix leg. `push` and
+      # `merge_group` carry no PR label context at all, so they skip this step
+      # and the strict install always fails loudly for them.
       - name: "🏷️ Resolve ripgrep bypass"
         id: ripgrep-bypass
-        if: github.event_name == 'pull_request'
+        if: >-
+          runner.os == 'Linux' &&
+          github.event_name == 'pull_request' &&
+          (startsWith(github.head_ref, 'release-please--') ||
+          startsWith(github.event.pull_request.title, 'release('))
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -195,7 +204,7 @@ jobs:
           # fail as before. The label only exists on a `pull_request`, so
           # `push`/`merge_group` always take the strict path.
           if [ "$BYPASS" != "true" ]; then
-            echo "::error::ripgrep install failed on a release-sensitive run and no 'bypass-ripgrep-check' label is present."
+            echo "::error::ripgrep install failed (apt exit $status) on a release-sensitive run and no 'bypass-ripgrep-check' label is present."
             exit "$status"
           fi
           # Bypassed: run the same dpkg unwind and `rg` probe as the
@@ -212,7 +221,10 @@ jobs:
             exit 0
           fi
           echo "timed-out=true" >> "$GITHUB_OUTPUT"
-          echo "::warning::ripgrep install failed on release PR; 'bypass-ripgrep-check' present — continuing without ripgrep (rg-gated tests will skip)"
+          # Log the apt status: the bypass tolerates every non-zero status, so
+          # the status is the only thing that separates a mirror flake from a
+          # permanently broken install that will be bypassed on every re-run.
+          echo "::warning::ripgrep install failed (apt exit $status) on release PR; 'bypass-ripgrep-check' present — continuing without ripgrep (rg-gated tests will skip)"
           package="${WORKING_DIRECTORY//\//-}"
           artifact="ripgrep-timeout-${package}-${MATRIX_OS}-${MATRIX_PYTHON}"
           marker="$RUNNER_TEMP/$artifact/warning.txt"
@@ -296,7 +308,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           # Whichever install step reported `timed-out` is the one that set
-          # `artifact`/`marker`; the other's outputs are empty here.
+          # `artifact`/`marker`; the other's outputs are empty here, because the
+          # two steps' `if:` conditions are exact complements and a skipped
+          # step's outputs are the empty string. Relax either condition and
+          # this fallback stops being unambiguous.
           name: ${{ steps.ripgrep-install.outputs.artifact || steps.ripgrep-strict.outputs.artifact }}
           path: ${{ steps.ripgrep-install.outputs.marker || steps.ripgrep-strict.outputs.marker }}
           retention-days: 1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1113,14 +1113,18 @@ jobs:
             RELEASE_PR_NUMBER="$pr_number"
           }
 
-          # Fail-closed: a non-zero return means "do NOT skip the SDK pin check".
+          # Fail-closed: a non-zero return means "do NOT skip the caller's check".
           # Every error path (PR unresolved, label-read API failure) returns
           # non-zero, so a transient API blip can never flip the dangerous bypass
           # on — it only ever turns on for a positively-matched label.
+          #
+          # `$2` names the check that stays enforced. The helper serves more than
+          # one bypass label now, so a hardcoded subject would point an operator
+          # debugging a ripgrep-label failure at the SDK pin check instead.
           release_pr_has_label() {
-            local label="$1" labels="" rc=0
+            local label="$1" subject="$2" labels="" rc=0
             if ! resolve_release_pr_number; then
-              echo "::warning::Could not resolve release PR for $RELEASE_SHA; SDK pin check will be ENFORCED for deepagents-code (bypass label '$label' not read)."
+              echo "::warning::Could not resolve release PR for $RELEASE_SHA; $subject will be ENFORCED (bypass label '$label' not read)."
               return 1
             fi
             # Capture the label read separately so an API failure is distinguishable
@@ -1129,7 +1133,7 @@ jobs:
             labels=$(gh api "/repos/${GITHUB_REPOSITORY}/issues/${RELEASE_PR_NUMBER}/labels" \
               --jq '.[].name' 2>/dev/null) || rc=$?
             if [ "$rc" -ne 0 ]; then
-              echo "::warning::Could not read labels for PR #$RELEASE_PR_NUMBER (gh api exit $rc); SDK pin check will be ENFORCED for deepagents-code (bypass label '$label' treated as absent)."
+              echo "::warning::Could not read labels for PR #$RELEASE_PR_NUMBER (gh api exit $rc); $subject will be ENFORCED (bypass label '$label' treated as absent)."
               return 1
             fi
             printf '%s\n' "$labels" | grep -Fxq "$label"
@@ -1143,8 +1147,8 @@ jobs:
           }
 
           # The ripgrep bypass applies to every package's publish run — each one
-          # runs the same strict `Install ripgrep` step in release.yml. Reads the
-          # job-global AUTO_SKIP_RIPGREP_CHECK at call time (set below).
+          # runs the same strict `Install ripgrep` step in release.yml, so unlike
+          # `skip_applies_to` this takes no package argument.
           ripgrep_skip_applies() {
             [ "$AUTO_SKIP_RIPGREP_CHECK" = "true" ]
           }
@@ -1264,7 +1268,7 @@ jobs:
           QUICKJS_RELEASE="${QUICKJS_RELEASE:-false}"; assert_bool QUICKJS_RELEASE "$QUICKJS_RELEASE"
 
           AUTO_SKIP_SDK_PIN_CHECK=false
-          if [ "$CODE_RELEASE" = "true" ] && release_pr_has_label "$SDK_PIN_BYPASS_LABEL"; then
+          if [ "$CODE_RELEASE" = "true" ] && release_pr_has_label "$SDK_PIN_BYPASS_LABEL" "the SDK pin check for deepagents-code"; then
             AUTO_SKIP_SDK_PIN_CHECK=true
             echo "Release PR has '$SDK_PIN_BYPASS_LABEL'; dispatching deepagents-code with dangerous-skip-sdk-pin-check=true."
           fi
@@ -1272,7 +1276,7 @@ jobs:
           # Not package-gated like the SDK-pin check: every package's publish run
           # shares the same strict ripgrep install, so the label softens them all.
           AUTO_SKIP_RIPGREP_CHECK=false
-          if release_pr_has_label "$RIPGREP_BYPASS_LABEL"; then
+          if release_pr_has_label "$RIPGREP_BYPASS_LABEL" "the strict ripgrep install"; then
             AUTO_SKIP_RIPGREP_CHECK=true
             echo "Release PR has '$RIPGREP_BYPASS_LABEL'; dispatching with dangerous-skip-ripgrep-check=true."
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1006,6 +1006,7 @@ jobs:
       VERSION: ${{ needs.detect-release-commit.outputs.release-version }}
       RELEASE_SHA: ${{ github.sha }}
       SDK_PIN_BYPASS_LABEL: "release: skip sdk pin check"
+      RIPGREP_BYPASS_LABEL: "bypass-ripgrep-check"
       RELEASE_WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository
         }}/actions/workflows/release.yml
       CLI_RELEASE: ${{ needs.detect-release-commit.outputs.cli-release }}
@@ -1141,6 +1142,13 @@ jobs:
             [ "$1" = "deepagents-code" ] && [ "$AUTO_SKIP_SDK_PIN_CHECK" = "true" ]
           }
 
+          # The ripgrep bypass applies to every package's publish run — each one
+          # runs the same strict `Install ripgrep` step in release.yml. Reads the
+          # job-global AUTO_SKIP_RIPGREP_CHECK at call time (set below).
+          ripgrep_skip_applies() {
+            [ "$AUTO_SKIP_RIPGREP_CHECK" = "true" ]
+          }
+
           dispatch() {
             local package="$1"
             local cmd=(
@@ -1151,12 +1159,16 @@ jobs:
               -f version="$VERSION"
               -f release-sha="$RELEASE_SHA"
             )
+            local notes=""
             if skip_applies_to "$package"; then
               cmd+=(-f dangerous-skip-sdk-pin-check=true)
-              echo "Dispatching release for $package (version=$VERSION, sha=$RELEASE_SHA, dangerous-skip-sdk-pin-check=true)"
-            else
-              echo "Dispatching release for $package (version=$VERSION, sha=$RELEASE_SHA)"
+              notes="dangerous-skip-sdk-pin-check=true"
             fi
+            if ripgrep_skip_applies; then
+              cmd+=(-f dangerous-skip-ripgrep-check=true)
+              notes="${notes:+$notes, }dangerous-skip-ripgrep-check=true"
+            fi
+            echo "Dispatching release for $package (version=$VERSION, sha=$RELEASE_SHA${notes:+, $notes})"
             # `--repo` is required: this job has no `actions/checkout` step, so
             # `gh` cannot discover the target repo from a local `.git/` and
             # would otherwise fail with `fatal: not a git repository`.
@@ -1257,6 +1269,14 @@ jobs:
             echo "Release PR has '$SDK_PIN_BYPASS_LABEL'; dispatching deepagents-code with dangerous-skip-sdk-pin-check=true."
           fi
 
+          # Not package-gated like the SDK-pin check: every package's publish run
+          # shares the same strict ripgrep install, so the label softens them all.
+          AUTO_SKIP_RIPGREP_CHECK=false
+          if release_pr_has_label "$RIPGREP_BYPASS_LABEL"; then
+            AUTO_SKIP_RIPGREP_CHECK=true
+            echo "Release PR has '$RIPGREP_BYPASS_LABEL'; dispatching with dangerous-skip-ripgrep-check=true."
+          fi
+
           # Banner: log + step summary. The step summary renders at the top of the
           # run page, so operators see the link before scrolling through step logs.
           echo ""
@@ -1316,6 +1336,9 @@ jobs:
                 if skip_applies_to "$p"; then
                   suffix=" _(SDK pin check skipped from release PR label)_"
                 fi
+                if ripgrep_skip_applies; then
+                  suffix="$suffix _(ripgrep check skipped from release PR label)_"
+                fi
                 url="${RUN_URLS[$p]:-}"
                 if [ -n "$url" ]; then
                   echo "- [\`$p\` @ \`$VERSION\`]($url)$suffix"
@@ -1335,11 +1358,14 @@ jobs:
               echo ""
               echo '```'
               for p in "${FAILED[@]}"; do
+                rec="gh workflow run release.yml -f package=$p -f version=$VERSION -f release-sha=$RELEASE_SHA"
                 if skip_applies_to "$p"; then
-                  echo "gh workflow run release.yml -f package=$p -f version=$VERSION -f release-sha=$RELEASE_SHA -f dangerous-skip-sdk-pin-check=true"
-                else
-                  echo "gh workflow run release.yml -f package=$p -f version=$VERSION -f release-sha=$RELEASE_SHA"
+                  rec="$rec -f dangerous-skip-sdk-pin-check=true"
                 fi
+                if ripgrep_skip_applies; then
+                  rec="$rec -f dangerous-skip-ripgrep-check=true"
+                fi
+                echo "$rec"
               done
               echo '```'
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -753,13 +753,20 @@ jobs:
           # `uv pip`; unset it so the install targets the existing `.venv`.
           env -u UV_PYTHON VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"
 
-      # No timeout here: release artifacts must be validated with the real
-      # ripgrep path exercised. `DEEPAGENTS_RIPGREP_EXPECTED=1` makes the
-      # rg-gated tests fail rather than skip if `rg` goes missing anyway. A
-      # dispatch carrying `dangerous-skip-ripgrep-check=true` (set from the
-      # `bypass-ripgrep-check` label on the merged release PR) tolerates an apt
-      # failure instead: the install still runs, but a failure neither sets the
-      # expectation nor fails the job, so the gated tests skip rather than error.
+      # The install itself has no timeout: release artifacts must be validated
+      # with the real ripgrep path exercised. `DEEPAGENTS_RIPGREP_EXPECTED=1`
+      # makes the rg-gated tests fail rather than skip if `rg` goes missing
+      # anyway. A dispatch carrying `dangerous-skip-ripgrep-check=true` (set
+      # from the `bypass-ripgrep-check` label on the merged release PR)
+      # tolerates an apt failure instead: the install still runs, but a failure
+      # neither fails the job nor promises ripgrep, so the gated tests skip
+      # rather than error.
+      #
+      # The failure path mirrors `_test.yml`'s strict step: unwind dpkg, then
+      # probe for a usable `rg`. Without the probe a publish run would discard
+      # ripgrep coverage that is actually available whenever apt reports
+      # failure but the binary landed (or was already on the image) -- and this
+      # is the run where losing the symlink containment check matters most.
       - name: Install ripgrep
         env:
           SKIP_RIPGREP_CHECK: ${{ inputs.dangerous-skip-ripgrep-check }}
@@ -772,12 +779,32 @@ jobs:
             echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
             exit 0
           fi
-          if [ "$SKIP_RIPGREP_CHECK" = "true" ]; then
-            echo "::warning::ripgrep install failed; dangerous-skip-ripgrep-check set — the rg-gated artifact tests will skip"
+          if [ "$SKIP_RIPGREP_CHECK" != "true" ]; then
+            echo "::error::ripgrep install failed (apt exit $status) and dangerous-skip-ripgrep-check is not set."
+            exit "$status"
+          fi
+          # A killed or half-applied apt transaction can leave dpkg holding the
+          # lock, which would surface as an unrelated failure in a later step.
+          # A failed recovery is tolerated; the `rg` probe is what decides.
+          sudo timeout --signal=TERM --kill-after=10s 60s \
+            dpkg --configure -a || true
+          if rg --version >/dev/null 2>&1; then
+            echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
+            echo "::notice::ripgrep install reported failure (apt exit $status) but a usable rg is present; continuing with ripgrep"
             exit 0
           fi
-          echo "::error::ripgrep install failed and dangerous-skip-ripgrep-check is not set."
-          exit "$status"
+          echo "::warning::ripgrep install failed (apt exit $status); dangerous-skip-ripgrep-check set — the rg-gated artifact tests will skip"
+          # A step annotation alone is not a record: the dispatch-inputs summary
+          # says only that the *input* was set, which cannot distinguish "apt
+          # succeeded, full coverage" from "apt failed, tests skipped". Write
+          # the degraded outcome where an operator reviewing the release sees it.
+          {
+            echo "### ⚠️ Published without ripgrep coverage"
+            echo ""
+            echo "\`apt-get\` failed (exit $status) and \`dangerous-skip-ripgrep-check\` was set, so the job continued."
+            echo "The real-binary grep tests did **not** run against this artifact, including the symlink containment check."
+          } >> "$GITHUB_STEP_SUMMARY" || echo "::warning::Failed to write ripgrep-bypass summary to GITHUB_STEP_SUMMARY (non-fatal, continuing)"
+          exit 0
 
       - name: Run unit tests
         run: make test COV_ARGS= PYTEST_EXTRA="-v"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,14 @@ on:
         description:
           "(deepagents-code only) Skip SDK pin validation
           (danger!) - Only use when intentionally pinning an older SDK"
+      dangerous-skip-ripgrep-check:
+        required: false
+        type: boolean
+        default: false
+        description:
+          "Tolerate a ripgrep install failure in pre-release checks
+          (danger!) - the rg-gated artifact tests will skip. Passed automatically
+          when the merged release PR carries the bypass-ripgrep-check label"
 
 env:
   UV_NO_SYNC: "true"
@@ -181,6 +189,7 @@ jobs:
           INPUT_SHA: ${{ inputs.release-sha }}
           IS_DANGEROUS: ${{ inputs.dangerous-nonmain-release }}
           SKIP_SDK_PIN_CHECK: ${{ inputs.dangerous-skip-sdk-pin-check }}
+          SKIP_RIPGREP_CHECK: ${{ inputs.dangerous-skip-ripgrep-check }}
         run: |
           set -euo pipefail
 
@@ -220,6 +229,9 @@ jobs:
             fi
             if [ "${SKIP_SDK_PIN_CHECK}" = "true" ]; then
               echo "| \`dangerous-skip-sdk-pin-check\` | ⚠️ enabled |"
+            fi
+            if [ "${SKIP_RIPGREP_CHECK}" = "true" ]; then
+              echo "| \`dangerous-skip-ripgrep-check\` | ⚠️ enabled |"
             fi
             echo ""
           } >> "$GITHUB_STEP_SUMMARY" || echo "::warning::Failed to write dispatch-inputs summary to GITHUB_STEP_SUMMARY (non-fatal, continuing)"
@@ -743,11 +755,29 @@ jobs:
 
       # No timeout here: release artifacts must be validated with the real
       # ripgrep path exercised. `DEEPAGENTS_RIPGREP_EXPECTED=1` makes the
-      # rg-gated tests fail rather than skip if `rg` goes missing anyway.
+      # rg-gated tests fail rather than skip if `rg` goes missing anyway. A
+      # dispatch carrying `dangerous-skip-ripgrep-check=true` (set from the
+      # `bypass-ripgrep-check` label on the merged release PR) tolerates an apt
+      # failure instead: the install still runs, but a failure neither sets the
+      # expectation nor fails the job, so the gated tests skip rather than error.
       - name: Install ripgrep
+        env:
+          SKIP_RIPGREP_CHECK: ${{ inputs.dangerous-skip-ripgrep-check }}
         run: |
+          set +e
           sudo apt-get update && sudo apt-get install -y ripgrep
-          echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "DEEPAGENTS_RIPGREP_EXPECTED=1" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          if [ "$SKIP_RIPGREP_CHECK" = "true" ]; then
+            echo "::warning::ripgrep install failed; dangerous-skip-ripgrep-check set — the rg-gated artifact tests will skip"
+            exit 0
+          fi
+          echo "::error::ripgrep install failed and dangerous-skip-ripgrep-check is not set."
+          exit "$status"
 
       - name: Run unit tests
         run: make test COV_ARGS= PYTEST_EXTRA="-v"

--- a/.github/workflows/ripgrep_timeout_comment.yml
+++ b/.github/workflows/ripgrep_timeout_comment.yml
@@ -108,6 +108,22 @@ jobs:
               return;
             }
 
+            // A labeled release PR produces the same artifacts via the strict
+            // step's bypass path, so the comment text must distinguish "hit the
+            // soft timeout" from "bypassed under bypass-ripgrep-check". Read the
+            // label fail-closed: an API error means the bypass note is simply
+            // omitted, never wrongly claimed.
+            let hasBypassLabel = false;
+            try {
+              const labels = await github.paginate(
+                github.rest.issues.listLabelsOnIssue,
+                { owner, repo, issue_number: prNumber, per_page: 100 },
+              );
+              hasBypassLabel = labels.some(label => label.name === 'bypass-ripgrep-check');
+            } catch (error) {
+              core.warning(`Could not read labels for PR #${prNumber}; treating bypass-ripgrep-check as absent.`);
+            }
+
             const comments = await github.paginate(
               github.rest.issues.listComments,
               { owner, repo, issue_number: prNumber, per_page: 100 },
@@ -147,20 +163,33 @@ jobs:
               .map(artifact => artifact.name.replace(/^ripgrep-timeout-/, ''))
               .sort();
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${run.id}`;
-            const body = [
-              marker,
-              '**Warning: ripgrep did not install in time.**',
-              '',
-              'Installation took more than two minutes on these test runners:',
-              '',
-              ...legs.map(leg => `- \`${leg}\``),
-              '',
-              'Those runners ran without ripgrep. The real-binary grep tests were skipped there, including the symlink containment check. `grep` on the filesystem backend used the Python fallback, which is slower and does not skip `.gitignore`d or hidden files, so some results differ.',
-              '',
-              'Release PRs, merge-queue runs, and the release workflow do not use this timeout. They fail if ripgrep does not install.',
-              '',
-              `No action is needed to merge. Re-run CI to get ripgrep coverage. [View the CI run](${runUrl})`,
-            ].join('\n');
+            const body = hasBypassLabel
+              ? [
+                  marker,
+                  '**Notice: the strict ripgrep install failed and was bypassed.**',
+                  '',
+                  'Installation failed on these release-PR test runners:',
+                  '',
+                  ...legs.map(leg => `- \`${leg}\``),
+                  '',
+                  'Those runners continued without ripgrep under the `bypass-ripgrep-check` label, so the real-binary grep tests — including the symlink containment check — were skipped there. When this PR merges, the publish run is dispatched with `dangerous-skip-ripgrep-check=true`, so its artifact tests skip ripgrep the same way.',
+                  '',
+                  `Merge only if the apt failure is genuinely transient. Remove the label and re-run CI to restore ripgrep coverage. [View the CI run](${runUrl})`,
+                ].join('\n')
+              : [
+                  marker,
+                  '**Warning: ripgrep did not install in time.**',
+                  '',
+                  'Installation took more than two minutes on these test runners:',
+                  '',
+                  ...legs.map(leg => `- \`${leg}\``),
+                  '',
+                  'Those runners ran without ripgrep. The real-binary grep tests were skipped there, including the symlink containment check. `grep` on the filesystem backend used the Python fallback, which is slower and does not skip `.gitignore`d or hidden files, so some results differ.',
+                  '',
+                  'Release PRs, merge-queue runs, and the release workflow do not use this timeout. They fail if ripgrep does not install — unless the PR carries `bypass-ripgrep-check`, which reports the failure through this same comment instead.',
+                  '',
+                  `No action is needed to merge. Re-run CI to get ripgrep coverage. [View the CI run](${runUrl})`,
+                ].join('\n');
 
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/ripgrep_timeout_comment.yml
+++ b/.github/workflows/ripgrep_timeout_comment.yml
@@ -1,5 +1,8 @@
-# Posts a sticky PR comment when the bounded ripgrep install in `_test.yml`
-# gave up, so a reviewer can see that the affected legs ran without ripgrep.
+# Posts a sticky PR comment when a ripgrep install in `_test.yml` gave up, so a
+# reviewer can see that the affected legs ran without ripgrep. Two steps produce
+# the marker artifact: the bounded install on an ordinary PR (hit its timeout)
+# and the unbounded strict install on a release PR (failed and was bypassed
+# under `bypass-ripgrep-check`). The comment wording distinguishes the two.
 #
 # Trigger — `workflow_run` of ci.yml, completed, rather than `pull_request`:
 # a `pull_request` run from a fork gets a read-only token and cannot comment.
@@ -108,14 +111,19 @@ jobs:
               return;
             }
 
-            // A labeled release PR produces the same artifacts via the strict
-            // step's bypass path. Match `_test.yml`'s release-PR predicate so a
-            // non-release PR with the label still receives the ordinary soft-
-            // timeout guidance. Read the label fail-closed: an API error means
-            // the bypass note is simply omitted, never wrongly claimed.
+            // Which failure mode the comment describes is decided by the PR
+            // kind, not by the label. On a release PR the only producer of
+            // these artifacts is the strict step's bypass path, which has no
+            // timeout -- so claiming "took more than two minutes" there would
+            // be false. Matches `_test.yml`'s release-PR predicate; keep the
+            // two in step (`test_ci_workflow.py` asserts they agree).
             const isReleasePullRequest =
               pullRequest.head.ref.startsWith('release-please--') ||
               pullRequest.title.startsWith('release(');
+            // The label only decides one sentence: whether the merge will carry
+            // the bypass into the publish run. A failed read leaves it false,
+            // which downgrades that sentence to "could not confirm" rather than
+            // asserting either outcome.
             let hasBypassLabel = false;
             try {
               const labels = await github.paginate(
@@ -124,7 +132,11 @@ jobs:
               );
               hasBypassLabel = labels.some(label => label.name === 'bypass-ripgrep-check');
             } catch (error) {
-              core.warning(`Could not read labels for PR #${prNumber}; treating bypass-ripgrep-check as absent.`);
+              core.warning(
+                `Could not read labels for PR #${prNumber} ` +
+                  `(status ${error.status ?? 'unknown'}: ${error.message}); ` +
+                  'treating bypass-ripgrep-check as unconfirmed.',
+              );
             }
 
             const comments = await github.paginate(
@@ -166,7 +178,7 @@ jobs:
               .map(artifact => artifact.name.replace(/^ripgrep-timeout-/, ''))
               .sort();
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${run.id}`;
-            const body = isReleasePullRequest && hasBypassLabel
+            const body = isReleasePullRequest
               ? [
                   marker,
                   '**Notice: the strict ripgrep install failed and was bypassed.**',
@@ -175,9 +187,13 @@ jobs:
                   '',
                   ...legs.map(leg => `- \`${leg}\``),
                   '',
-                  'Those runners continued without ripgrep under the `bypass-ripgrep-check` label, so the real-binary grep tests — including the symlink containment check — were skipped there. When this PR merges, the publish run is dispatched with `dangerous-skip-ripgrep-check=true`, so its artifact tests skip ripgrep the same way.',
+                  'Those runners continued without ripgrep. The real-binary grep tests were skipped there, including the symlink containment check.',
                   '',
-                  `Merge only if the apt failure is genuinely transient. Remove the label and re-run CI to restore ripgrep coverage. [View the CI run](${runUrl})`,
+                  hasBypassLabel
+                    ? 'If the `bypass-ripgrep-check` label is still on this PR when it merges, the publish run is dispatched with `dangerous-skip-ripgrep-check=true`. A repeat apt failure there is then tolerated, and the rg-gated artifact tests skip instead of failing the release.'
+                    : 'The `bypass-ripgrep-check` label could not be read on this PR. If it is absent at merge time, the publish run enforces the strict install and an apt failure there fails the release.',
+                  '',
+                  `Merge only if the apt failure is transient. Remove the label and re-run CI to restore ripgrep coverage. [View the CI run](${runUrl})`,
                 ].join('\n')
               : [
                   marker,
@@ -189,7 +205,7 @@ jobs:
                   '',
                   'Those runners ran without ripgrep. The real-binary grep tests were skipped there, including the symlink containment check. `grep` on the filesystem backend used the Python fallback, which is slower and does not skip `.gitignore`d or hidden files, so some results differ.',
                   '',
-                  'Release PRs, merge-queue runs, and the release workflow do not use this timeout. They fail if ripgrep does not install — unless the PR carries `bypass-ripgrep-check`, which reports the failure through this same comment instead.',
+                  'Release PRs, merge-queue runs, and the release workflow do not use this timeout. They fail if ripgrep does not install.',
                   '',
                   `No action is needed to merge. Re-run CI to get ripgrep coverage. [View the CI run](${runUrl})`,
                 ].join('\n');

--- a/.github/workflows/ripgrep_timeout_comment.yml
+++ b/.github/workflows/ripgrep_timeout_comment.yml
@@ -109,10 +109,13 @@ jobs:
             }
 
             // A labeled release PR produces the same artifacts via the strict
-            // step's bypass path, so the comment text must distinguish "hit the
-            // soft timeout" from "bypassed under bypass-ripgrep-check". Read the
-            // label fail-closed: an API error means the bypass note is simply
-            // omitted, never wrongly claimed.
+            // step's bypass path. Match `_test.yml`'s release-PR predicate so a
+            // non-release PR with the label still receives the ordinary soft-
+            // timeout guidance. Read the label fail-closed: an API error means
+            // the bypass note is simply omitted, never wrongly claimed.
+            const isReleasePullRequest =
+              pullRequest.head.ref.startsWith('release-please--') ||
+              pullRequest.title.startsWith('release(');
             let hasBypassLabel = false;
             try {
               const labels = await github.paginate(
@@ -163,7 +166,7 @@ jobs:
               .map(artifact => artifact.name.replace(/^ripgrep-timeout-/, ''))
               .sort();
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${run.id}`;
-            const body = hasBypassLabel
+            const body = isReleasePullRequest && hasBypassLabel
               ? [
                   marker,
                   '**Notice: the strict ripgrep install failed and was bypassed.**',

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -33,8 +33,11 @@ def require_ripgrep() -> None:
     of them guards symlink containment. A skip would let a containment
     regression merge with a green build.
 
-    Locally, and on runners where the install was allowed to time out, a
-    missing `rg` is expected and still skips.
+    Locally, and on runners where the install was allowed to fail, a missing
+    `rg` is expected and still skips. CI allows the failure in two cases: the
+    bounded install on an ordinary PR hit its two-minute timeout, or the
+    unbounded strict install on a release PR failed and was bypassed under the
+    `bypass-ripgrep-check` label.
     """
     if shutil.which("rg") is not None:
         return


### PR DESCRIPTION
A release PR whose strict ripgrep install hits a transient apt or mirror failure currently fails CI with no recourse but a re-run. Maintainers can now add the `bypass-ripgrep-check` label to the release PR to tolerate that failure: the affected legs skip the ripgrep-gated tests, a sticky comment on the PR records which legs ran without ripgrep, and when the PR merges the publish run is dispatched with `dangerous-skip-ripgrep-check=true` so its own ripgrep install tolerates the same flake instead of re-failing.

---

## Why

The strict install in `_test.yml` (and the matching `Install ripgrep` step in `release.yml`) runs with no timeout on release-sensitive paths on purpose: the rg-gated tests, including the symlink-containment check, must exercise the real binary rather than the Python fallback, and a silent skip at that gate is worse than a red job. The cost is that pure infrastructure flake — an apt mirror timeout, a wedged dpkg — blocks an otherwise-good release.

This mirrors the existing `bypass-warnings-check` and `release: skip sdk pin check` patterns rather than inventing a new mechanism:

- **`_test.yml`**: a new `🏷️ Resolve ripgrep bypass` step reads the live PR labels via `gh api` (not the event payload, so a label added before a re-run takes effect) and fails closed on an API error. The strict step keeps trying to install, but on a labeled PR an apt failure exits 0 instead of failing. `DEEPAGENTS_RIPGREP_EXPECTED` is only set when `rg` is actually usable, so a genuinely missing binary lets `require_ripgrep()` skip the gated tests on that leg rather than fail them.
- **`ripgrep_timeout_comment.yml`**: the bypassed strict leg emits the same `ripgrep-timeout-*` marker artifact as the soft path, so the existing sticky-comment workflow reports it. The comment now reads the PR's labels (fail-closed) and branches its wording — a bypassed release PR says so explicitly and notes that the publish run was dispatched with the override, instead of the old (now-inaccurate) "release PRs fail if ripgrep does not install" line.
- **`release-please.yml`**: after the SDK-pin block, it checks the merged release PR for `bypass-ripgrep-check` via the existing fail-closed `release_pr_has_label` helper and, when present, passes `-f dangerous-skip-ripgrep-check=true` to every dispatched package. Unlike the SDK-pin check this is not package-gated, because every package's publish run shares the same ripgrep step. The dispatch log, step summary, and recovery commands all surface the override.
- **`release.yml`**: a new `dangerous-skip-ripgrep-check` boolean input is logged in the dispatch-inputs summary and softens the `Install ripgrep` step — a failure is tolerated and `DEEPAGENTS_RIPGREP_EXPECTED` left unset only when the input is `true`.

Scope: the label is honored only on release PRs. `push`-to-`main` and merge-queue runs have no PR label to read, so they always enforce the strict install.

The label must be created in repo settings (`bypass-ripgrep-check`) before this can take effect; documented under "Release Failed: Ripgrep Install" in `RELEASING.md`.

<details>
<summary>Test plan</summary>

- Extended `test_ci_workflow.py` with an executable `test_strict_ripgrep_install_bypass` that runs the strict step's real `run:` body against stubbed `apt-get`/`rg`/`dpkg`: unlabeled apt failures fail with the original exit code; labeled failures are tolerated; ripgrep is only promised to the tests when `rg` is actually usable; a bypassed leg with no usable `rg` emits the marker artifact.
- Updated the strict-step and upload-step drift assertions to match the new condition and artifact selection, and added comment-workflow assertions for the label read and bypass wording.
- All 1108 workflow-helper tests pass; the touched YAML files parse; the new bash bodies pass `bash -n`; the comment workflow's JS passes `node --check`; ruff check/format clean on the test file.

</details>
