### PR TITLE
test(code): await the connection refresh task instead of polling `_state`

### DIFF
--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -1040,7 +1040,6 @@ async def test_connection_refresh_waits_for_initial_refresh(
     # the await side must not depend on the default executor, which the blocked
     # initial load can starve on a loaded CI runner.
     initial_started = asyncio.Event()
-    settled_applied = asyncio.Event()
     # Read from the load thread and written once on the event loop; a one-element
     # list acts as the cross-thread release cell (item assignment is atomic).
     release_initial: list[bool] = []
@@ -1063,10 +1062,6 @@ async def test_connection_refresh_waits_for_initial_refresh(
             while not release_initial:
                 time.sleep(0.005)
             return loading_state
-
-        # The connection refresh has been dequeued and rerun with the settled
-        # snapshot; signal the await side before returning the settled state.
-        loop.call_soon_threadsafe(settled_applied.set)
         return settled_state
 
     monkeypatch.setattr(
@@ -1096,16 +1091,21 @@ async def test_connection_refresh_waits_for_initial_refresh(
         # Release the initial load; once it finishes, the queued settled refresh runs.
         release_initial.append(True)
         await initial_refresh
-        # Wait for the settled refresh to finish and apply its snapshot.
-        # `settled_applied` is set from the load thread, so also yield once to let
-        # the connection task run its `_state` assignment (the continuation after
-        # `await asyncio.to_thread(...)`).
-        await wait_for(settled_applied, "the settled refresh")
-        for _ in range(100):
-            if screen._state == settled_state:
-                break
-            await asyncio.sleep(0)
-        else:
+        # Await the connection refresh task itself rather than polling `_state`:
+        # a `sleep(0)` spin can out-poll the resumed `to_thread` continuation on
+        # a starved CI executor, failing even though the refresh would have
+        # applied the settled snapshot moments later.
+        (connection_refresh,) = screen._refresh_tasks
+        try:
+            async with asyncio.timeout(10):
+                await connection_refresh
+        except TimeoutError:
+            msg = (
+                "timed out waiting for the settled refresh; "
+                f"snapshots so far: {snapshots}"
+            )
+            raise AssertionError(msg) from None
+        if screen._state != settled_state:
             msg = (
                 f"settled load ran but `_state` was not applied; snapshots: {snapshots}"
             )


### PR DESCRIPTION
`test_connection_refresh_waits_for_initial_refresh` no longer spins on a fixed number of event-loop yields: it awaits the settled connection-refresh task itself, so the test passes no matter how long a loaded CI runner takes to schedule the refresh task's continuation.

---

The event-driven rewrite in #5636 removed the test's fixed 1-second timeouts but left one scheduling-sensitive wait. After the stubbed state loader signaled the settled refresh from the `to_thread` worker, the test polled `screen._state` across 100 `asyncio.sleep(0)` iterations, assuming that was enough yields for the connection task's `_state = ...` continuation (the resume after `await asyncio.to_thread(...)`) to run.

It usually is — but the thread-side signal fires strictly before that continuation, and the continuation needs a fresh default-executor thread spawn plus a loop iteration. Under `-n auto` xdist load on the 2-core CI runner the test task can exhaust all 100 iterations while the connection task is still suspended, failing with:

```
AssertionError: settled load ran but `_state` was not applied; snapshots: [True, False]
```

even though the ordering under test held (`snapshots == [True, False]` proves the settled load ran second) and the refresh would have applied the settled snapshot moments later. Example failure: https://github.com/langchain-ai/deepagents/actions/runs/32299324726/job/96218579664?pr=5591 (Python 3.13 leg; 3.14 passed in the same run).

The fix awaits the connection refresh task directly:

- `update_connection_state` already keeps each refresh task strongly referenced in `screen._refresh_tasks` so it cannot vanish mid-flight, so the test can unpack the single queued task and `await` it under the existing 10-second descriptive timeout. Awaiting the task waits for the entire `_refresh_state` body — including the `_state` assignment — instead of racing it.
- The thread-side `settled_applied` event is no longer needed and is removed; `snapshots` still asserts the load ordering.

Behavior under test is unchanged; only the wait mechanism moves off the bounded spin loop.
