### PR TITLE
style(code): update resize handle after theme changes

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -2259,8 +2259,13 @@ class ChatInput(Vertical):
             self._refresh_file_cache,
         )
         self.call_after_refresh(self._sync_resize_handle_geometry)
+        self.watch(self.app, "theme", self._on_theme_change, init=False)
         self._sync_resize_handle_color()
         self._text_area.focus()
+
+    def _on_theme_change(self) -> None:
+        """Recolor the resize handle when the app theme changes."""
+        self._sync_resize_handle_color()
 
     def _sync_resize_handle_geometry(self) -> None:
         """Inset the resize handle so border corners remain visible."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -9,11 +9,12 @@ from typing import TYPE_CHECKING
 import pytest
 from textual import events
 from textual.app import App, ComposeResult
+from textual.color import Color
 from textual.containers import Container
 from textual.widgets import Static
 from textual.widgets.text_area import Selection
 
-from deepagents_code import _textual_patches as _textual_patches
+from deepagents_code import _textual_patches as _textual_patches, theme
 from deepagents_code.command_registry import get_slash_commands
 from deepagents_code.input import MediaTracker
 from deepagents_code.media_utils import ImageData, create_multimodal_content
@@ -857,6 +858,22 @@ class TestChatInputResize:
                 colors[mode] = handle.styles.color
 
             assert len(set(colors.values())) == len(colors)
+
+    async def test_theme_change_recolors_handle(self) -> None:
+        """Switching themes updates the resize line's inline color."""
+        app = _ChatInputResizeTestApp()
+        async with app.run_test() as pilot:
+            handle = app.query_one(ChatInputResizeHandle)
+            await pilot.pause()
+            original_color = handle.styles.color
+
+            app.theme = "textual-light"
+            await pilot.pause()
+
+            assert handle.styles.color == Color.parse(
+                theme.get_theme_colors(app).primary
+            )
+            assert handle.styles.color != original_color
 
     async def test_non_left_press_does_not_start_drag(self) -> None:
         """A non-left press on the handle leaves resize inactive."""


### PR DESCRIPTION
The chat input's draggable top bar now follows the active theme whenever `/theme` changes it.

---

The resize handle uses an inline color so hover feedback survives captured drags, but that color was only refreshed for mode and hover changes. Watching Textual's app theme keeps the existing mode-aware styling synchronized without changing resize behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/23698746-0a5b-561b-8353-5799c952bbe7)