### PR TITLE
fix(infra): warn instead of failing when the ripgrep timeout PR is unresolvable

### DIFF
--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -758,8 +758,12 @@ def test_ripgrep_timeout_comment_uses_isolated_workflow_run() -> None:
     # the only lookup that works for them.
     assert "pulls.list" in script
     assert "run.head_repository.owner.login" in script
-    # An unreportable timeout is a broken mechanism, not a no-op.
-    assert "core.setFailed" in script
+    # An unresolvable PR is a normal race (closed PR / deleted head branch
+    # between CI completing and this workflow firing), so the job warns in the
+    # run log instead of failing: the CI run's own `::warning::` annotation is
+    # the record of the timeout, and there is no conversation left to post to.
+    assert "core.setFailed" not in script
+    assert "core.warning(`${message} A ripgrep timeout goes unreported" in script
 
 
 def test_ripgrep_comment_wording_is_keyed_on_pr_kind_not_the_label() -> None:

--- a/.github/workflows/ripgrep_timeout_comment.yml
+++ b/.github/workflows/ripgrep_timeout_comment.yml
@@ -87,12 +87,14 @@ jobs:
             );
 
             if (!prNumber) {
-              // Failing to notify about a real timeout is a broken mechanism,
-              // not a no-op: say so loudly instead of logging into a run page
-              // nobody opens.
+              // A PR that was closed or had its head branch deleted between
+              // CI completing and this workflow firing resolves to nothing —
+              // that is a normal race, not a broken mechanism, and there is
+              // no conversation left to warn. The `::warning::` annotation in
+              // the CI run itself is the record of the timeout.
               const message = `CI run ${run.id} has no resolvable pull request.`;
               if (timeoutArtifacts.length > 0) {
-                core.setFailed(`${message} A ripgrep timeout went unreported.`);
+                core.warning(`${message} A ripgrep timeout goes unreported; the artifacts are ${timeoutArtifacts.map(a => a.name).join(', ')}.`);
               } else {
                 core.info(`${message} No timeout to report.`);
               }


### PR DESCRIPTION
The ripgrep timeout warning workflow no longer fails when the CI run's pull request cannot be resolved. It now logs a warning naming the timeout artifacts and exits cleanly.

---

The `🔍 Ripgrep timeout warning` workflow fires on `workflow_run` after CI completes and posts a sticky comment on the PR when a ripgrep install gave up. When it cannot resolve a PR for the completed run, it currently hard-fails with `CI run <id> has no resolvable pull request. A ripgrep timeout went unreported.` — as seen on [this run](https://github.com/langchain-ai/deepagents/actions/runs/32306207706).

The only reachable way to hit that branch is a race: the CI run was a `pull_request` event (the job's `if:` filters everything else out), but the PR was closed or its head branch deleted between CI completing and the dispatcher firing. Non-PR events can't produce the `ripgrep-timeout-*` artifacts at all — the strict install's bypass path that writes them only activates when a `bypass-ripgrep-check` label resolves, which requires a `pull_request` context.

So the failure was the alarm going off in a hallway with no PR in it: there is no conversation left to warn, and the CI run's own `::warning::` annotation is already the durable record of the timeout. The unresolvable-PR path now uses `core.warning` (naming the artifacts) instead of `core.setFailed`.

<details>
<summary>Test plan</summary>

- `uv run --no-project --with pytest --with pyyaml python -m pytest .github/scripts/tests/workflows/test_ci_workflow.py -q` — 44 passed.

</details>
