### PR TITLE
style(code): make user messages easier to spot

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -1484,7 +1484,7 @@ class ToolCallMessage(Vertical):
     DEFAULT_CSS = """
     ToolCallMessage {
         height: auto;
-        padding: 0 1;
+        padding: 0 1 0 0;
         margin: 0 0 1 0;
         background: transparent;
         border-left: wide $tool;

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -22,6 +22,7 @@ from textual.message import Message
 from textual.message_pump import NoActiveAppError
 from textual.reactive import var
 from textual.selection import Selection
+from textual.strip import Strip
 from textual.style import Style as TStyle
 from textual.widgets import Static
 
@@ -83,9 +84,12 @@ if TYPE_CHECKING:
         RenderResult,
     )
     from textual.app import ComposeResult
+    from textual.content import _FormattedLine
+    from textual.css.styles import RulesMap
     from textual.css.types import PointerShape
     from textual.events import MouseMove
     from textual.timer import Timer
+    from textual.visual import RenderOptions
     from textual.widget import Widget
     from textual.widgets import Markdown
     from textual.widgets._markdown import MarkdownStream
@@ -480,6 +484,132 @@ def _truncate_for_display(text: str) -> str:
     return _collapse_user_message(text).text
 
 
+class _UserMessageContent(Content):
+    """Content visual that wraps prompt bodies beside a fixed two-cell gutter."""
+
+    _PREFIX_WIDTH = 2
+
+    @classmethod
+    def from_content(cls, content: Content) -> _UserMessageContent:
+        """Promote styled content without changing its text or spans.
+
+        Returns:
+            Hanging-indent content with the same text and spans.
+        """
+        return cls(
+            content.plain,
+            list(content.spans),
+            strip_control_codes=False,
+        )
+
+    @classmethod
+    def _body_selection(cls, selection: Selection | None) -> Selection | None:
+        """Translate selection offsets after removing the first-line prefix.
+
+        Returns:
+            Selection expressed in body-relative coordinates.
+        """
+        if selection is None:
+            return None
+
+        def translate(offset: Offset | None) -> Offset | None:
+            if offset is None or offset.y != 0:
+                return offset
+            return Offset(max(0, offset.x - cls._PREFIX_WIDTH), 0)
+
+        return Selection(translate(selection.start), translate(selection.end))
+
+    def _render_lines(
+        self,
+        width: int,
+        options: RenderOptions,
+        selection: Selection | None,
+    ) -> list[_FormattedLine]:
+        """Wrap this content with the active widget rendering options.
+
+        Returns:
+            Formatted physical lines ready for strip rendering.
+        """
+        get_rule = options.rules.get
+        return super()._wrap_and_format(
+            width,
+            align=get_rule("text_align", "left"),
+            overflow=get_rule("text_overflow", "fold"),
+            no_wrap=get_rule("text_wrap", "wrap") == "nowrap",
+            line_pad=get_rule("line_pad", 0),
+            tab_size=8,
+            selection=selection,
+            selection_style=options.selection_style,
+            post_style=options.post_style,
+            get_style=options.get_style,
+        )
+
+    def _measure_lines(self, width: int, rules: RulesMap) -> list[_FormattedLine]:
+        """Wrap unstyled content for auto-height measurement.
+
+        Returns:
+            Formatted lines used to derive the widget height.
+        """
+        get_rule = rules.get
+        return super()._wrap_and_format(
+            width,
+            overflow=get_rule("text_overflow", "fold"),
+            no_wrap=get_rule("text_wrap", "wrap") == "nowrap",
+            line_pad=get_rule("line_pad", 0),
+        )
+
+    def get_height(self, rules: RulesMap, width: int) -> int:
+        """Measure body wrapping at the width left beside the prompt gutter.
+
+        Returns:
+            Number of rendered lines required at `width`.
+        """
+        if width <= self._PREFIX_WIDTH:
+            return super().get_height(rules, width)
+        body = type(self)(self.plain[self._PREFIX_WIDTH :])
+        return len(body._measure_lines(width - self._PREFIX_WIDTH, rules))
+
+    def render_strips(
+        self,
+        width: int,
+        height: int | None,
+        style: TStyle,
+        options: RenderOptions,
+    ) -> list[Strip]:
+        """Render the prefix once and reserve its gutter on subsequent lines.
+
+        Returns:
+            Rendered strips with a fixed prompt gutter.
+        """
+        if width <= self._PREFIX_WIDTH:
+            return super().render_strips(width, height, style, options)
+
+        prefix = type(self).from_content(self[: self._PREFIX_WIDTH])
+        body = type(self).from_content(self[self._PREFIX_WIDTH :])
+        prefix_lines = prefix._render_lines(
+            self._PREFIX_WIDTH,
+            options,
+            options.selection,
+        )
+        body_lines = body._render_lines(
+            width - self._PREFIX_WIDTH,
+            options,
+            self._body_selection(options.selection),
+        )
+        for line in body_lines:
+            if line.y == 0:
+                line.x += self._PREFIX_WIDTH
+
+        prefix_strip = Strip(*prefix_lines[0].to_strip(style))
+        body_strips = [Strip(*line.to_strip(style)) for line in body_lines]
+        indent = Strip.blank(self._PREFIX_WIDTH, style.background_style.rich_style)
+        strips = [
+            Strip.join((prefix_strip, body_strips[0])),
+            *(Strip.join((indent, line)) for line in body_strips[1:]),
+        ]
+        return strips if height is None else strips[:height]
+
+
 class UserMessage(Static):
     """Widget displaying a user message.
 
@@ -825,12 +955,12 @@ class UserMessage(Static):
 
         if isinstance(collapse, _UserMessageFull):
             self._append_highlighted_body(parts, body, colors=colors)
-            return Content.assemble(*parts)
+            return _UserMessageContent.from_content(Content.assemble(*parts))
 
         if self._expanded:
             self._append_highlighted_body(parts, body, colors=colors)
             parts.extend(("\n", self._expand_hint_content()))
-            return Content.assemble(*parts)
+            return _UserMessageContent.from_content(Content.assemble(*parts))
 
         # Collapsed: head + clickable elision line + tail. The middle marker is
         # the affordance (not a second trailing line) so the collapse stays
@@ -840,7 +970,7 @@ class UserMessage(Static):
         self._append_highlighted_body(parts, collapse.head, colors=colors)
         parts.extend(("\n", self._collapse_hint_content(collapse), "\n"))
         self._append_highlighted_body(parts, collapse.tail, colors=colors)
-        return Content.assemble(*parts)
+        return _UserMessageContent.from_content(Content.assemble(*parts))
 
     def on_mouse_move(self, event: MouseMove) -> None:
         """Match the pointer shape to the cell under the mouse."""

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -506,7 +506,7 @@ class UserMessage(Static):
     DEFAULT_CSS = """
     UserMessage {
         height: auto;
-        padding: 0 1;
+        padding: 0 1 0 0;
         margin: 0 0 1 0;
         background: $primary 15%;
         border-left: wide $primary;

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -1004,7 +1004,7 @@ class SkillMessage(Vertical):
     DEFAULT_CSS = """
     SkillMessage {
         height: auto;
-        padding: 0 1;
+        padding: 0 1 0 0;
         margin: 0 0 1 0;
         background: transparent;
         border-left: wide $skill;

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -508,7 +508,7 @@ class UserMessage(Static):
         height: auto;
         padding: 0 1;
         margin: 0 0 1 0;
-        background: transparent;
+        background: $primary 15%;
         border-left: wide $primary;
         /* The expand affordance carries `@click` meta, which Textual styles as
            a link (underline, and bold on an accent block when hovered).

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -506,7 +506,7 @@ class UserMessage(Static):
     DEFAULT_CSS = """
     UserMessage {
         height: auto;
-        padding: 0 1 0 0;
+        padding: 1 1 1 0;
         margin: 0 0 1 0;
         background: $primary 15%;
         border-left: wide $primary;

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5320,8 +5320,8 @@ class TestStripSuccessExitLine:
 class TestUserMessageAppearance:
     """User prompts remain visually distinct from transcript output."""
 
-    async def test_has_tinted_background(self) -> None:
-        """A user prompt has a dedicated translucent background surface."""
+    async def test_has_distinct_flush_left_surface(self) -> None:
+        """A user prompt has a tinted surface with its glyph at the left edge."""
 
         class _Harness(App[None]):
             def compose(self) -> ComposeResult:
@@ -5330,6 +5330,8 @@ class TestUserMessageAppearance:
         async with _Harness().run_test() as pilot:
             message = pilot.app.query_one(UserMessage)
             assert message.styles.background.a == pytest.approx(0.15)
+            assert message.styles.padding.left == 0
+            assert message.styles.padding.right == 1
 
 
 class TestUserMessageCancelled:

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5362,6 +5362,48 @@ class TestUserMessageAppearance:
             assert message.styles.padding.bottom == 1
             assert message.styles.padding.left == 0
 
+    @pytest.mark.parametrize(
+        ("content", "prefix", "body"),
+        [
+            (
+                "0123456789abcdefghijklmnopqrstuvwxyz",
+                "> ",
+                "0123456789abcdefghijklmnopqrstuvwxyz",
+            ),
+            (
+                "!0123456789abcdefghijklmnopqrstuvwxyz",
+                "$ ",
+                "0123456789abcdefghijklmnopqrstuvwxyz",
+            ),
+            (
+                "/0123456789abcdefghijklmnopqrstuvwxyz",
+                "/ ",
+                "0123456789abcdefghijklmnopqrstuvwxyz",
+            ),
+        ],
+    )
+    async def test_wrapped_body_keeps_prompt_gutter(
+        self,
+        content: str,
+        prefix: str,
+        body: str,
+    ) -> None:
+        """Every continuation starts beneath the body, never beneath its glyph."""
+
+        class _Harness(App[None]):
+            def compose(self) -> ComposeResult:
+                yield UserMessage(content)
+
+        async with _Harness().run_test(size=(18, 12)) as pilot:
+            message = pilot.app.query_one(UserMessage)
+            lines = [
+                message.render_line(y).text for y in range(message.content_size.height)
+            ]
+            assert len(lines) > 1
+            assert lines[0].startswith(prefix)
+            assert all(line.startswith("  ") for line in lines[1:])
+            assert lines[0][2:] + "".join(line[2:] for line in lines[1:]) == body
+
 
 class TestUserMessageCancelled:
     """`set_cancelled` dims a prompt whose turn was interrupted."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -1565,6 +1565,17 @@ def _tool_msg_app(tool_name: str, args: dict | None = None) -> _ToolMsgApp:
     return _ToolMsgApp(tool_name, args)
 
 
+class TestToolCallMessageAppearance:
+    """Tool rows align their prefix glyph with the transcript edge."""
+
+    async def test_has_flush_left_glyph_with_right_padding(self) -> None:
+        """The tool prefix has no left inset while content keeps its right inset."""
+        app = _tool_msg_app("read_file", {"file_path": "example.py"})
+        async with app.run_test():
+            assert app.msg.styles.padding.left == 0
+            assert app.msg.styles.padding.right == 1
+
+
 class TestToolCallMessageOutputGutter:
     """The output glyph lives in a fixed gutter so wrapped lines stay aligned."""
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5082,7 +5082,8 @@ class TestMessageWidgetsDropTextPointerOverBlankSpace:
     @pytest.mark.parametrize(
         ("widget", "text_offset", "blank_offset"),
         [
-            pytest.param(UserMessage("hi"), (2, 0), (10, 0), id="user"),
+            # `UserMessage` pads vertically, so its body sits on row 1.
+            pytest.param(UserMessage("hi"), (2, 1), (10, 1), id="user"),
             pytest.param(QueuedUserMessage("hi"), (2, 0), (10, 0), id="queued"),
             # `ErrorMessage` pads vertically, so its body sits on row 1.
             pytest.param(ErrorMessage("hi"), (2, 1), (15, 1), id="error"),

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5317,6 +5317,21 @@ class TestStripSuccessExitLine:
         assert msg._output == "hi"
 
 
+class TestUserMessageAppearance:
+    """User prompts remain visually distinct from transcript output."""
+
+    async def test_has_tinted_background(self) -> None:
+        """A user prompt has a dedicated translucent background surface."""
+
+        class _Harness(App[None]):
+            def compose(self) -> ComposeResult:
+                yield UserMessage("hello")
+
+        async with _Harness().run_test() as pilot:
+            message = pilot.app.query_one(UserMessage)
+            assert message.styles.background.a == pytest.approx(0.15)
+
+
 class TestUserMessageCancelled:
     """`set_cancelled` dims a prompt whose turn was interrupted."""
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5331,8 +5331,8 @@ class TestStripSuccessExitLine:
 class TestUserMessageAppearance:
     """User prompts remain visually distinct from transcript output."""
 
-    async def test_has_distinct_flush_left_surface(self) -> None:
-        """A user prompt has a tinted surface with its glyph at the left edge."""
+    async def test_has_distinct_padded_flush_left_surface(self) -> None:
+        """A user prompt has a padded tint with its glyph at the left edge."""
 
         class _Harness(App[None]):
             def compose(self) -> ComposeResult:
@@ -5341,8 +5341,10 @@ class TestUserMessageAppearance:
         async with _Harness().run_test() as pilot:
             message = pilot.app.query_one(UserMessage)
             assert message.styles.background.a == pytest.approx(0.15)
-            assert message.styles.padding.left == 0
+            assert message.styles.padding.top == 1
             assert message.styles.padding.right == 1
+            assert message.styles.padding.bottom == 1
+            assert message.styles.padding.left == 0
 
 
 class TestUserMessageCancelled:
@@ -6704,14 +6706,16 @@ class TestUserMessageTruncation:
         # tail all fit on screen — `pilot.click` refuses off-screen targets.
         async with app.run_test(size=(200, 50)) as pilot:
             await pilot.pause()
-            # Locate the affordance in the wrapped output rather than computing
-            # it from the body length, which depends on terminal width.
+            # Locate the affordance in the wrapped content rather than computing
+            # it from the body length, which depends on terminal width. Pilot
+            # offsets include the widget's padding, while render_line rows do not.
             hint_row = next(
                 y
                 for y in range(msg.size.height)
                 if "show full message" in msg.render_line(y).text
             )
-            await pilot.click(UserMessage, offset=Offset(4, hint_row))
+            click_row = hint_row + msg.styles.padding.top
+            await pilot.click(UserMessage, offset=Offset(4, click_row))
             await pilot.pause()
             assert msg._expanded is True
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -5223,6 +5223,22 @@ class TestStripFrontmatter:
         assert _strip_frontmatter(text) == ""
 
 
+class TestSkillMessageAppearance:
+    """Skill invocation rows align their slash marker with the transcript edge."""
+
+    async def test_has_flush_left_marker_with_right_padding(self) -> None:
+        """The skill slash has no left inset while content keeps its right inset."""
+
+        class _Harness(App[None]):
+            def compose(self) -> ComposeResult:
+                yield SkillMessage(skill_name="web-research")
+
+        async with _Harness().run_test() as pilot:
+            message = pilot.app.query_one(SkillMessage)
+            assert message.styles.padding.left == 0
+            assert message.styles.padding.right == 1
+
+
 class TestSkillMessageMarkupSafety:
     """Test SkillMessage handles content with brackets safely."""
 


### PR DESCRIPTION
User messages now have a subtle primary-tinted, vertically padded surface, prompt/tool/skill markers share a flush-left edge, and wrapped user text aligns beneath the message body instead of the prompt glyph.

---

In long dcode transcripts, the former border-only treatment was easy to lose among assistant output and rendered content. The low-alpha surface and one-cell top/bottom inset create a consistent scan target without padding high-frequency assistant or tool output.

Prompt markers (`>`, `$`, `/`), tool-circle markers, and skill slashes no longer carry an extra left inset. A fixed two-cell prompt gutter keeps soft-wrapped and explicit continuation lines aligned with the first line’s body while preserving selection, copy, and clickable expansion behavior. Existing right padding and one-cell external row separation remain unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/98b8aece-9d1a-5b67-be13-4369e8d901ca)