### PR TITLE
style(code): prefix interruptions with square glyph

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -1324,6 +1324,7 @@ class Glyphs:
     error: str  # ✗ vs [X]
     circle_empty: str  # ○ vs [ ]
     circle_filled: str  # ● vs [*]
+    square_filled: str  # ■ vs [#]
     checkbox_empty: str  # ☐ vs [ ]
     checkbox_checked: str  # ☑ vs [x]
     output_prefix: str  # ⎿ vs L
@@ -1359,6 +1360,7 @@ UNICODE_GLYPHS = Glyphs(
     error="✗",
     circle_empty="○",
     circle_filled="●",
+    square_filled="■",
     checkbox_empty="☐",
     checkbox_checked="☑",
     output_prefix="⎿",
@@ -1392,6 +1394,7 @@ ASCII_GLYPHS = Glyphs(
     error="[X]",
     circle_empty="[ ]",
     circle_filled="[*]",
+    square_filled="[#]",
     checkbox_empty="[ ]",
     checkbox_checked="[x]",
     output_prefix="L",

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -3401,7 +3401,10 @@ async def _handle_interrupt_cleanup(
     await _stop_assistant_streams(adapter, assistant_message_by_namespace)
 
     if recover_interrupted_turn:
-        await adapter._mount_message(AppMessage("Interrupted by user"))
+        glyphs = get_glyphs()
+        await adapter._mount_message(
+            AppMessage(f"{glyphs.square_filled} Interrupted by user")
+        )
 
     # Proactively cancel server-side runs before persisting recovery state, so
     # the aupdate_state writes below don't 409 against a still-busy thread. This

--- a/libs/code/tests/unit_tests/test_charset.py
+++ b/libs/code/tests/unit_tests/test_charset.py
@@ -51,6 +51,7 @@ class TestGlyphs:
         assert ord(UNICODE_GLYPHS.error) > 127
         assert ord(UNICODE_GLYPHS.circle_empty) > 127
         assert ord(UNICODE_GLYPHS.circle_filled) > 127
+        assert UNICODE_GLYPHS.square_filled == "■"
         assert ord(UNICODE_GLYPHS.checkbox_empty) > 127
         assert ord(UNICODE_GLYPHS.checkbox_checked) > 127
         assert ord(UNICODE_GLYPHS.output_prefix) > 127
@@ -81,6 +82,8 @@ class TestGlyphs:
         for char in ASCII_GLYPHS.circle_empty:
             assert ord(char) < 128
         for char in ASCII_GLYPHS.circle_filled:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.square_filled:
             assert ord(char) < 128
         for char in ASCII_GLYPHS.checkbox_empty:
             assert ord(char) < 128

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -685,20 +685,25 @@ class TestInterruptCleanup:
             set_active_message=MagicMock(),
         )
 
-        await _handle_interrupt_cleanup(
-            adapter=adapter,
-            agent=agent,
-            config={"configurable": {"thread_id": "t-1"}},
-            pending_text_by_namespace={(): "partial answer"},
-            captured_input_tokens=10,
-            captured_output_tokens=5,
-            turn_stats=SessionStats(),
-            start_time=0.0,
-        )
+        with patch(
+            "deepagents_code.tui.textual_adapter.get_glyphs",
+            return_value=UNICODE_GLYPHS,
+        ):
+            await _handle_interrupt_cleanup(
+                adapter=adapter,
+                agent=agent,
+                config={"configurable": {"thread_id": "t-1"}},
+                pending_text_by_namespace={(): "partial answer"},
+                captured_input_tokens=10,
+                captured_output_tokens=5,
+                turn_stats=SessionStats(),
+                start_time=0.0,
+            )
 
         assert any(
             isinstance(widget, AppMessage)
-            and str(widget._content) == "Interrupted by user"
+            and str(widget._content)
+            == f"{UNICODE_GLYPHS.square_filled} Interrupted by user"
             for widget in mounted
         )
         assert len(agent.aupdate_state.await_args_list) == 2


### PR DESCRIPTION
Interrupted chat turns now display a charset-aware filled-square marker before the cancellation message.

---

The interruption notice uses the shared `Glyphs` configuration so Unicode terminals render `■` while ASCII mode falls back safely. Covered by focused charset and cleanup tests.

Made by [Open SWE](https://openswe.vercel.app/agents/03643951-fb5d-537c-9bb4-b93b7825ded9)