### PR TITLE
feat(code): open footer pickers on click

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import logging
 from contextlib import suppress
 from pathlib import Path
-from time import monotonic
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
+from textual import events
 from textual.containers import Horizontal, Vertical
 from textual.content import Content
 from textual.css.query import NoMatches
@@ -26,9 +26,9 @@ from deepagents_code.tui.widgets.loading import Spinner
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from textual import events
     from textual.app import ComposeResult, RenderResult
     from textual.geometry import Size
+    from textual.message import Message
     from textual.timer import Timer
 
 PROVIDER_PREFIX_STRIPS: dict[str, tuple[str, ...]] = {
@@ -85,9 +85,6 @@ _PICKER_HOVER_STYLE = Style(underline=True)
 
 Carries no metadata of its own, so merging it keeps the target resolvable."""
 
-_APP_REFOCUS_CLICK_GUARD_SECONDS = 0.2
-"""Maximum delay between app refocus and the click that caused it."""
-
 _LEFT_BUTTON = 1
 """Textual `MouseEvent.button` value for the left mouse button."""
 
@@ -134,8 +131,8 @@ class ModelLabel(Widget):
     _hovered_target: reactive[PickerTarget | None] = reactive(None)
     """Target under the pointer, or `None` when there is none."""
 
-    _last_app_focus_time: float | None = None
-    """Monotonic time when the app most recently regained focus."""
+    _refocus_press_pending = False
+    """Whether an app refocus is awaiting its adjacent input event."""
 
     def _clean_model(self) -> str:
         """Strip the provider's registered prefix so the status bar stays compact.
@@ -225,29 +222,41 @@ class ModelLabel(Widget):
         )
 
     def on_mount(self) -> None:
-        """Track app refocuses so their initiating click stays inert."""
-        self.watch(self.app, "app_focus", self._on_app_focus_changed, init=False)
+        """Track app input so a focus-restoring press stays inert."""
+        self.app.message_signal.subscribe(self, self._on_app_message, immediate=True)
 
-    def _on_app_focus_changed(self, focused: bool) -> None:
-        """Record when the app regains focus.
+    def on_unmount(self) -> None:
+        """Stop tracking app input after the label is detached."""
+        self.app.message_signal.unsubscribe(self)
+
+    def _clear_refocus_press(self) -> None:
+        """Expire a refocus that had no adjacent input event."""
+        self._refocus_press_pending = False
+
+    def _on_app_message(self, message: Message) -> None:
+        """Associate an app refocus with its immediately queued mouse press.
 
         Args:
-            focused: Whether the app now has focus.
+            message: App-level message that just finished processing.
         """
-        self._last_app_focus_time = monotonic() if focused else None
-
-    def _is_refocus_click(self) -> bool:
-        """Consume and identify a click that immediately follows app refocus.
-
-        Returns:
-            Whether the click should be suppressed as part of app refocus.
-        """
-        focused_at = self._last_app_focus_time
-        self._last_app_focus_time = None
-        return (
-            focused_at is not None
-            and monotonic() - focused_at <= _APP_REFOCUS_CLICK_GUARD_SECONDS
-        )
+        if isinstance(message, events.AppFocus):
+            self._refocus_press_pending = True
+            self.app.call_later(self._clear_refocus_press)
+            return
+        if isinstance(message, events.AppBlur):
+            self._refocus_press_pending = False
+            return
+        if not self._refocus_press_pending or not isinstance(
+            message, events.InputEvent
+        ):
+            return
+        self._refocus_press_pending = False
+        if (
+            isinstance(message, events.MouseDown)
+            and message.button == _LEFT_BUTTON
+            and self._picker_target(message) is not None
+        ):
+            self.suppress_click()
 
     async def on_click(self, event: events.Click) -> None:
         """Open a picker for a left-click on a target span in the status bar.
@@ -263,7 +272,7 @@ class ModelLabel(Widget):
         # Stop every target click so it cannot bubble to the app handler that
         # refocuses the chat input behind a picker.
         event.stop()
-        if event.chain > _SINGLE_CLICK_CHAIN or self._is_refocus_click():
+        if event.chain > _SINGLE_CLICK_CHAIN:
             return
         await self.run_action(_PICKER_ACTIONS[target])
 

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from contextlib import suppress
 from pathlib import Path
+from time import monotonic
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from textual.containers import Horizontal, Vertical
@@ -46,7 +47,7 @@ CONNECTION_STATES = frozenset(get_args(ConnectionState))
 Derived from the `Literal` so the two can never drift."""
 
 PickerTarget = Literal["model", "effort"]
-"""Spans in the model label that open a picker on Ctrl+click.
+"""Clickable spans in the model label that open their corresponding picker.
 
 Each member names both an entry in `_PICKER_ACTIONS` and one in
 `_PICKER_STYLES`, so the two mappings stay keyed by this `Literal`."""
@@ -79,10 +80,13 @@ _PICKER_STYLES = {
 
 Derived from `PickerTarget` so a new member cannot be left without a style."""
 
-_PICKER_READY_STYLE = Style(underline=True)
-"""Added on top of a hit-target style while Ctrl is held over that span.
+_PICKER_HOVER_STYLE = Style(underline=True)
+"""Added on top of a hit-target style while the pointer is over that span.
 
 Carries no metadata of its own, so merging it keeps the target resolvable."""
+
+_APP_REFOCUS_CLICK_GUARD_SECONDS = 0.2
+"""Maximum delay between app refocus and the click that caused it."""
 
 _LEFT_BUTTON = 1
 """Textual `MouseEvent.button` value for the left mouse button."""
@@ -118,8 +122,8 @@ class ModelLabel(Widget):
     model left-truncated to make room) and is only dropped once even the
     left-truncated model plus effort cannot fit.
 
-    Whatever text survives that ladder is also a hit target: Ctrl+click on the
-    model span opens the model selector and on the effort span the reasoning
+    Whatever text survives that ladder is also a hit target: clicking the model
+    span opens the model selector and clicking the effort span opens the reasoning
     effort picker, via the `_PICKER_ACTIONS` app actions. A span that the ladder
     dropped is not clickable, because only rendered text carries the metadata.
     """
@@ -127,11 +131,11 @@ class ModelLabel(Widget):
     provider: reactive[str] = reactive("", layout=True)
     model: reactive[str] = reactive("", layout=True)
     effort: reactive[str] = reactive("", layout=True)
-    _ctrl_hint_target: reactive[PickerTarget | None] = reactive(None)
-    """Target under the pointer while Ctrl is held, or `None` when there is none.
+    _hovered_target: reactive[PickerTarget | None] = reactive(None)
+    """Target under the pointer, or `None` when there is none."""
 
-    Repaints on change so the underline hint appears; only `on_mouse_move` and
-    `on_leave` write it, because terminals do not report modifier release."""
+    _last_app_focus_time: float | None = None
+    """Monotonic time when the app most recently regained focus."""
 
     def _clean_model(self) -> str:
         """Strip the provider's registered prefix so the status bar stays compact.
@@ -170,13 +174,13 @@ class ModelLabel(Widget):
             target: Picker represented by the styled span.
 
         Returns:
-            The cached hit-target style, underlined while Ctrl is held over
+            The cached hit-target style, underlined while the pointer is over
                 this span. `Style` is frozen, so the cached entry is never
                 mutated.
         """
         style = _PICKER_STYLES[target]
-        if self._ctrl_hint_target == target:
-            style += _PICKER_READY_STYLE
+        if self._hovered_target == target:
+            style += _PICKER_HOVER_STYLE
         return style
 
     @staticmethod
@@ -220,36 +224,58 @@ class ModelLabel(Widget):
             Content.styled(effort, self._picker_style("effort")),
         )
 
+    def on_mount(self) -> None:
+        """Track app refocuses so their initiating click stays inert."""
+        self.watch(self.app, "app_focus", self._on_app_focus_changed, init=False)
+
+    def _on_app_focus_changed(self, focused: bool) -> None:
+        """Record when the app regains focus.
+
+        Args:
+            focused: Whether the app now has focus.
+        """
+        self._last_app_focus_time = monotonic() if focused else None
+
+    def _is_refocus_click(self) -> bool:
+        """Consume and identify a click that immediately follows app refocus.
+
+        Returns:
+            Whether the click should be suppressed as part of app refocus.
+        """
+        focused_at = self._last_app_focus_time
+        self._last_app_focus_time = None
+        return (
+            focused_at is not None
+            and monotonic() - focused_at <= _APP_REFOCUS_CLICK_GUARD_SECONDS
+        )
+
     async def on_click(self, event: events.Click) -> None:
-        """Open a picker for a Ctrl+left-click on a target span in the status bar.
+        """Open a picker for a left-click on a target span in the status bar.
 
         Textual synthesizes `Click` for any button and posts one per release, so
-        filter on both: without the button check a Ctrl+right-click would open a
-        picker, and without the chain check a Ctrl+double-click would open two.
+        filter on both: without the button check a right-click would open a picker,
+        and without the chain check a double-click would open two. A click that
+        restores terminal focus is consumed without opening anything.
         """
         target = self._picker_target(event)
-        if not event.ctrl or event.button != _LEFT_BUTTON or target is None:
+        if event.button != _LEFT_BUTTON or target is None:
             return
-        # Stop every chained click, so a repeat does not bubble to the app
-        # handler that refocuses the chat input behind the picker.
+        # Stop every target click so it cannot bubble to the app handler that
+        # refocuses the chat input behind a picker.
         event.stop()
-        if event.chain > _SINGLE_CLICK_CHAIN:
+        if event.chain > _SINGLE_CLICK_CHAIN or self._is_refocus_click():
             return
         await self.run_action(_PICKER_ACTIONS[target])
 
     def on_mouse_move(self, event: events.MouseMove) -> None:
-        """Underline the hovered target and show a pointer while Ctrl is held.
-
-        Clears both otherwise. Terminals do not report modifier release, so the
-        hint goes stale until the next move if Ctrl is released in place.
-        """
-        target = self._picker_target(event) if event.ctrl else None
-        self._ctrl_hint_target = target
+        """Underline the hovered target and show a pointer."""
+        target = self._picker_target(event)
+        self._hovered_target = target
         self.styles.pointer = "pointer" if target is not None else "default"
 
     def on_leave(self) -> None:
         """Clear the underline and the pointer when the pointer leaves the label."""
-        self._ctrl_hint_target = None
+        self._hovered_target = None
         self.styles.pointer = "default"
 
     def get_content_width(self, container: Size, viewport: Size) -> int:  # noqa: ARG002

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -1045,6 +1045,30 @@ class TestModelLabelClickTargets:
         msg = f"No painted cell at x={x}"
         raise AssertionError(msg)
 
+    @classmethod
+    def _app_mouse_event(
+        cls,
+        event_type: type[events.MouseDown | events.MouseUp],
+        label: ModelLabel,
+        offset: Offset,
+    ) -> events.MouseDown | events.MouseUp:
+        """Build an app-level mouse event that follows Textual's real input path."""
+        target = label.content_region.offset + offset
+        return event_type(
+            None,
+            x=target.x,
+            y=target.y,
+            delta_x=0,
+            delta_y=0,
+            button=1,
+            shift=False,
+            meta=False,
+            ctrl=False,
+            screen_x=target.x,
+            screen_y=target.y,
+            style=cls._style_at(label, offset.x),
+        )
+
     @staticmethod
     def _rendered_targets(label: ModelLabel) -> dict[str, tuple[str, bool]]:
         """Collect picker targets from painted output, not from `render`.
@@ -1119,8 +1143,8 @@ class TestModelLabelClickTargets:
             assert app.unhandled_clicks == 0
             assert app.opened_pickers == ["model"]
 
-    async def test_click_that_refocuses_app_is_inert(self) -> None:
-        """The focus-restoring click is consumed; the next click opens the picker."""
+    async def test_slow_click_that_refocuses_app_is_inert(self) -> None:
+        """A focus-restoring press stays inert even when its release is delayed."""
         app = StatusBarApp()
         async with app.run_test(size=(150, 24)) as pilot:
             label = pilot.app.query_one("#model-display", ModelLabel)
@@ -1132,8 +1156,9 @@ class TestModelLabelClickTargets:
             app.post_message(events.AppBlur())
             await pilot.pause()
             app.post_message(events.AppFocus())
-            await pilot.pause()
-            await pilot.click(label, offset=offset)
+            app.post_message(self._app_mouse_event(events.MouseDown, label, offset))
+            await pilot.pause(0.25)
+            app.post_message(self._app_mouse_event(events.MouseUp, label, offset))
             await pilot.pause()
 
             assert app.opened_pickers == []
@@ -1143,18 +1168,22 @@ class TestModelLabelClickTargets:
             await pilot.pause()
             assert app.opened_pickers == ["model"]
 
-    async def test_old_refocus_does_not_block_click(self) -> None:
-        """A keyboard refocus must not leave a later target click inert."""
+    async def test_keyboard_refocus_does_not_block_click(self) -> None:
+        """A refocus without an adjacent mouse press must not consume a later click."""
         app = StatusBarApp()
         async with app.run_test(size=(150, 24)) as pilot:
             label = pilot.app.query_one("#model-display", ModelLabel)
             label.provider = "openai"
             label.model = "gpt-5.5"
             await pilot.pause()
-            label._last_app_focus_time = 0.0
 
+            app.post_message(events.AppBlur())
+            await pilot.pause()
+            app.post_message(events.AppFocus())
+            await pilot.pause()
             await pilot.click(label, offset=self._offset_for_target(label, "model"))
             await pilot.pause()
+
             assert app.opened_pickers == ["model"]
 
     async def test_click_ignores_non_left_buttons(self) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -1015,7 +1015,7 @@ class TestPickerTargetRegistries:
 
 
 class TestModelLabelClickTargets:
-    """Tests for the model and effort status-bar Ctrl+click targets."""
+    """Tests for the model and effort status-bar click targets."""
 
     @staticmethod
     def _offset_for_target(label: ModelLabel, target: str) -> Offset:
@@ -1050,7 +1050,7 @@ class TestModelLabelClickTargets:
         """Collect picker targets from painted output, not from `render`.
 
         Reading `render_line` is what makes the assertions fail if
-        `_ctrl_hint_target` ever stops repainting the widget.
+        `_hovered_target` ever stops repainting the widget.
         """
         targets: dict[str, tuple[str, bool]] = {}
         for segment in label.render_line(0):
@@ -1084,8 +1084,8 @@ class TestModelLabelClickTargets:
                 "high": ("effort", False),
             }
 
-    async def test_clicks_require_ctrl_and_dispatch_distinct_app_actions(self) -> None:
-        """Ordinary clicks should be inert while Ctrl+click opens each picker."""
+    async def test_clicks_dispatch_distinct_app_actions(self) -> None:
+        """Ordinary clicks should open the picker represented by each span."""
         app = StatusBarApp()
         async with app.run_test(size=(150, 24)) as pilot:
             label = pilot.app.query_one("#model-display", ModelLabel)
@@ -1098,20 +1098,12 @@ class TestModelLabelClickTargets:
             effort_offset = self._offset_for_target(label, "effort")
             await pilot.click(label, offset=model_offset)
             await pilot.click(label, offset=effort_offset)
-            assert app.opened_pickers == []
-
-            await pilot.click(label, offset=model_offset, control=True)
-            await pilot.click(label, offset=effort_offset, control=True)
             await pilot.pause()
 
             assert app.opened_pickers == ["model", "effort"]
 
-    async def test_plain_clicks_bubble_but_picker_clicks_do_not(self) -> None:
-        """Only a Ctrl+click on a target should be consumed by the label.
-
-        The real app handler refocuses the chat input, which must not race the
-        picker; a plain click has to keep reaching it.
-        """
+    async def test_picker_clicks_do_not_bubble(self) -> None:
+        """A target click must not race the app's chat-input refocus handler."""
         app = StatusBarApp()
         async with app.run_test(size=(150, 24)) as pilot:
             label = pilot.app.query_one("#model-display", ModelLabel)
@@ -1123,14 +1115,49 @@ class TestModelLabelClickTargets:
             model_offset = self._offset_for_target(label, "model")
             await pilot.click(label, offset=model_offset)
             await pilot.pause()
-            assert app.unhandled_clicks == 1
 
-            await pilot.click(label, offset=model_offset, control=True)
-            await pilot.pause()
-            assert app.unhandled_clicks == 1
+            assert app.unhandled_clicks == 0
             assert app.opened_pickers == ["model"]
 
-    async def test_ctrl_click_ignores_non_left_buttons(self) -> None:
+    async def test_click_that_refocuses_app_is_inert(self) -> None:
+        """The focus-restoring click is consumed; the next click opens the picker."""
+        app = StatusBarApp()
+        async with app.run_test(size=(150, 24)) as pilot:
+            label = pilot.app.query_one("#model-display", ModelLabel)
+            label.provider = "openai"
+            label.model = "gpt-5.5"
+            await pilot.pause()
+            offset = self._offset_for_target(label, "model")
+
+            app.post_message(events.AppBlur())
+            await pilot.pause()
+            app.post_message(events.AppFocus())
+            await pilot.pause()
+            await pilot.click(label, offset=offset)
+            await pilot.pause()
+
+            assert app.opened_pickers == []
+            assert app.unhandled_clicks == 0
+
+            await pilot.click(label, offset=offset)
+            await pilot.pause()
+            assert app.opened_pickers == ["model"]
+
+    async def test_old_refocus_does_not_block_click(self) -> None:
+        """A keyboard refocus must not leave a later target click inert."""
+        app = StatusBarApp()
+        async with app.run_test(size=(150, 24)) as pilot:
+            label = pilot.app.query_one("#model-display", ModelLabel)
+            label.provider = "openai"
+            label.model = "gpt-5.5"
+            await pilot.pause()
+            label._last_app_focus_time = 0.0
+
+            await pilot.click(label, offset=self._offset_for_target(label, "model"))
+            await pilot.pause()
+            assert app.opened_pickers == ["model"]
+
+    async def test_click_ignores_non_left_buttons(self) -> None:
         """Textual reports a Click for any button, so only the left one counts."""
         app = StatusBarApp()
         async with app.run_test(size=(150, 24)) as pilot:
@@ -1152,7 +1179,7 @@ class TestModelLabelClickTargets:
                     button=3,
                     shift=False,
                     meta=False,
-                    ctrl=True,
+                    ctrl=False,
                     screen_x=target.x,
                     screen_y=target.y,
                     style=self._style_at(label, offset.x),
@@ -1162,7 +1189,7 @@ class TestModelLabelClickTargets:
 
             assert app.opened_pickers == []
 
-    async def test_ctrl_double_click_opens_one_picker(self) -> None:
+    async def test_double_click_opens_one_picker(self) -> None:
         """A chained click should not stack a second picker on the first."""
         app = StatusBarApp()
         async with app.run_test(size=(150, 24)) as pilot:
@@ -1173,15 +1200,15 @@ class TestModelLabelClickTargets:
             await pilot.pause()
 
             offset = self._offset_for_target(label, "model")
-            await pilot.click(label, offset=offset, control=True, times=2)
+            await pilot.click(label, offset=offset, times=2)
             await pilot.pause()
 
             assert app.opened_pickers == ["model"]
             assert app.unhandled_clicks == 0
 
     @pytest.mark.parametrize("target", ["model", "effort"])
-    async def test_ctrl_hover_underlines_only_the_target(self, target: str) -> None:
-        """A Ctrl-modified pointer move should expose the target affordance."""
+    async def test_hover_underlines_only_the_target(self, target: str) -> None:
+        """An ordinary pointer move should expose the target affordance."""
         async with StatusBarApp().run_test(size=(150, 24)) as pilot:
             label = pilot.app.query_one("#model-display", ModelLabel)
             label.provider = "openai"
@@ -1197,14 +1224,7 @@ class TestModelLabelClickTargets:
             }
             assert label.styles.pointer == "pointer"
 
-            # Moving over the same span without Ctrl drops the hint again.
-            await self._move(pilot, label, offset, ctrl=False)
-            assert self._rendered_targets(label) == {
-                "openai:gpt-5.5": ("model", False),
-                "high": ("effort", False),
-            }
-
-    async def test_ctrl_hover_moves_the_underline_between_targets(self) -> None:
+    async def test_hover_moves_the_underline_between_targets(self) -> None:
         """Sliding from the model span to the effort span should move the hint.
 
         Both spans set the same pointer shape, so this transition changes no CSS
@@ -1226,7 +1246,7 @@ class TestModelLabelClickTargets:
             }
             assert label.styles.pointer == "pointer"
 
-    async def test_ctrl_hover_off_target_clears_the_underline(self) -> None:
+    async def test_hover_off_target_clears_the_underline(self) -> None:
         """Moving onto the separator should drop the previous target's hint."""
         async with StatusBarApp().run_test(size=(150, 24)) as pilot:
             label = pilot.app.query_one("#model-display", ModelLabel)
@@ -1273,13 +1293,8 @@ class TestModelLabelClickTargets:
         pilot: Pilot[None],
         label: ModelLabel,
         offset: Offset,
-        *,
-        ctrl: bool = True,
     ) -> None:
-        """Post a mouse move at `offset` within `label`, optionally Ctrl-modified.
-
-        `Pilot.hover` accepts no modifiers, so build the event directly.
-        """
+        """Post a mouse move at `offset` within `label`."""
         target = label.content_region.offset + offset
         label.post_message(
             events.MouseMove(
@@ -1291,7 +1306,7 @@ class TestModelLabelClickTargets:
                 button=0,
                 shift=False,
                 meta=False,
-                ctrl=ctrl,
+                ctrl=False,
                 screen_x=target.x,
                 screen_y=target.y,
                 style=cls._style_at(label, offset.x),


### PR DESCRIPTION
Model and reasoning-effort labels in the footer now open their pickers on click without requiring Ctrl.

---

A short refocus guard consumes the click that activates an unfocused terminal window, while preserving hover affordances and bounded targets. Validated with focused status-bar tests plus the code package formatter, linter, and type checker.

Made by [Open SWE](https://openswe.vercel.app/agents/53770cbe-4875-538b-80bf-9d283fe21b47)
