### PR TITLE
fix(cli): preserve case-sensitive MCP URL components

### DIFF
--- a/libs/cli/deepagents_cli/deploy/mcp_resolver.py
+++ b/libs/cli/deepagents_cli/deploy/mcp_resolver.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit, urlunsplit
 
 if TYPE_CHECKING:
     from deepagents_cli.deploy.api_client import ApiClient
@@ -31,7 +32,21 @@ class UninvokableServersError(_ServerResolutionError):
 
 
 def _normalize_url(url: str) -> str:
-    return url.strip().rstrip("/").lower()
+    parsed = urlsplit(url.strip().rstrip("/"))
+    host_start = parsed.netloc.rfind("@") + 1
+    if parsed.netloc.startswith("[", host_start):
+        host_end = parsed.netloc.find("]", host_start) + 1
+    else:
+        port_start = parsed.netloc.find(":", host_start)
+        host_end = port_start if port_start >= 0 else len(parsed.netloc)
+    netloc = (
+        parsed.netloc[:host_start]
+        + parsed.netloc[host_start:host_end].lower()
+        + parsed.netloc[host_end:]
+    )
+    return urlunsplit(
+        (parsed.scheme.lower(), netloc, parsed.path, parsed.query, parsed.fragment)
+    )
 
 
 def _collect_referenced_urls(payload: dict[str, Any]) -> set[str]:

--- a/libs/cli/tests/unit_tests/deploy/test_mcp_resolver.py
+++ b/libs/cli/tests/unit_tests/deploy/test_mcp_resolver.py
@@ -18,7 +18,7 @@ def _client(monkeypatch: pytest.MonkeyPatch, handler) -> ApiClient:
     return ApiClient.from_env(transport=httpx.MockTransport(handler))
 
 
-def test_url_normalization_strips_trailing_slash_and_lowercases() -> None:
+def test_url_normalization_strips_trailing_slash_and_normalizes_origin() -> None:
     from deepagents_cli.deploy.mcp_resolver import _normalize_url
 
     assert (
@@ -26,6 +26,15 @@ def test_url_normalization_strips_trailing_slash_and_lowercases() -> None:
     )
     assert (
         _normalize_url("HTTPS://Tools.LangChain.com") == "https://tools.langchain.com"
+    )
+
+
+def test_url_normalization_preserves_case_sensitive_components() -> None:
+    from deepagents_cli.deploy.mcp_resolver import _normalize_url
+
+    assert (
+        _normalize_url("https://tools.example/Mcp?Token=AbC")
+        == "https://tools.example/Mcp?Token=AbC"
     )
 
 
@@ -68,6 +77,26 @@ def test_unresolved_server_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(UnresolvedServersError) as excinfo:
         resolve_referenced_servers(client, payload, cache={})
     assert excinfo.value.urls == ("https://missing.example",)
+
+
+def test_case_sensitive_path_does_not_match_different_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=[{"id": "s1", "url": "https://tools.example/mcp"}],
+        )
+
+    client = _client(monkeypatch, handler)
+    payload = {
+        "tools": {
+            "tools": [{"name": "x", "mcp_server_url": "https://tools.example/Mcp"}]
+        }
+    }
+    with pytest.raises(UnresolvedServersError) as excinfo:
+        resolve_referenced_servers(client, payload, cache={})
+    assert excinfo.value.urls == ("https://tools.example/Mcp",)
 
 
 def test_uninvokable_server_raises(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Preserves case-sensitive path, query, and fragment components when resolving registered MCP server URLs.

---

URL schemes and hostnames are case-insensitive, but paths and query values may not be. Lowercasing the complete URL could incorrectly bind a tool to a different registered endpoint, such as treating `/Mcp` and `/mcp` as identical.

Normalize only the scheme and hostname while retaining the existing whitespace and trailing-slash handling. Regression coverage exercises both URL normalization and the server-resolution mismatch.