### PR TITLE
fix(code): rename OpenAI subscription login label

### DIFF
--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -462,7 +462,7 @@ class ProviderConfig(TypedDict, total=False):
     short_name: str
     """Compact brand label for space-constrained UI (e.g. the `/model` Recent
     tag), where the full `display_name` — which may carry a parenthetical
-    qualifier like `"OpenAI Codex (ChatGPT login)"` — is too long. Optional;
+    qualifier like `"OpenAI (Subscription login)"` — is too long. Optional;
     when unset, callers fall back to `display_name`.
     """
 

--- a/libs/code/deepagents_code/tui/widgets/auth.py
+++ b/libs/code/deepagents_code/tui/widgets/auth.py
@@ -175,7 +175,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     "mistralai": "Mistral AI",
     "nvidia": "NVIDIA",
     "openai": "OpenAI",
-    "openai_codex": "OpenAI Codex (ChatGPT login)",
+    "openai_codex": "OpenAI (Subscription login)",
     "openrouter": "OpenRouter",
     "perplexity": "Perplexity",
     "together": "Together AI",
@@ -193,7 +193,7 @@ PROVIDER_SHORT_NAMES: dict[str, str] = {
 
 Sparse companion to `PROVIDER_DISPLAY_NAMES`: an entry exists only when the full
 display name carries a parenthetical qualifier that reads badly inside a tag
-(e.g. `"OpenAI Codex (ChatGPT login)"`). Resolved via `provider_short_name`.
+(e.g. `"OpenAI (Subscription login)"`). Resolved via `provider_short_name`.
 """
 
 

--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -1331,7 +1331,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
 
         # Resolve friendly provider labels via the shared helper so headers
         # match the `/auth` and install UIs (e.g. `openai_codex` renders as
-        # "OpenAI Codex (ChatGPT login)"). Load config once; the helper reads a
+        # "OpenAI (Subscription login)"). Load config once; the helper reads a
         # user-configured `display_name` before the built-in map.
         from deepagents_code.tui.widgets.auth import provider_display_name
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
@@ -1977,7 +1977,7 @@ class TestAuthManagerScreen:
                 for i in range(options.option_count)
                 if options.get_option_at_index(i).id == "openai_codex"
             )
-            assert "OpenAI Codex (ChatGPT login)" in label
+            assert "OpenAI (Subscription login)" in label
 
     async def test_configured_provider_uses_display_name(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -1693,7 +1693,7 @@ class TestRecentModelsSection:
                 str(h.content)
                 for h in screen.query(".model-provider-header").results(Static)
             ]
-            assert any("OpenAI Codex (ChatGPT login)" in h for h in headers)
+            assert any("OpenAI (Subscription login)" in h for h in headers)
             assert not any("openai_codex" in h for h in headers)
 
     async def test_recent_row_shows_name_and_provider_tag(
@@ -1756,7 +1756,7 @@ class TestRecentModelsSection:
             text = str(recent.content)
             assert "(OpenAI Codex)" in text
             # The verbose auth label must not leak into the compact tag.
-            assert "ChatGPT login" not in text
+            assert "Subscription login" not in text
 
     async def test_recent_entries_appear_in_provider_section_too(
         self, monkeypatch: pytest.MonkeyPatch
@@ -2476,10 +2476,10 @@ class TestModelSelectorFuzzyMatching:
     def test_fuzzy_matches_provider_friendly_label(self) -> None:
         """The provider display label — not just the key — is searchable.
 
-        Searches "chatgpt", which appears in neither the spec
+        Searches "subscription", which appears in neither the spec
         (`openai_codex:gpt-5.2`), the friendly model name ("GPT-5.2"), nor the
         provider key (`openai_codex`) — only in the resolved display label
-        "OpenAI Codex (ChatGPT login)". So a match proves the provider-label
+        "OpenAI (Subscription login)". So a match proves the provider-label
         branch of the haystack is doing the work; there is no other source for
         it. Guards against the label term being silently dropped.
         """
@@ -2493,12 +2493,12 @@ class TestModelSelectorFuzzyMatching:
             screen._filtered_models,
         ):
             models.append(codex)
-        screen._filter_text = "chatgpt"
+        screen._filter_text = "subscription"
         screen._update_filtered_list()
 
         specs = [spec for spec, _ in screen._filtered_models]
         assert specs == ["openai_codex:gpt-5.2"], (
-            f"'chatgpt' should match only via the provider label. Got: {specs}"
+            f"'subscription' should match only via the provider label. Got: {specs}"
         )
 
     async def test_tab_noop_when_no_matches(self) -> None:


### PR DESCRIPTION
OpenAI subscription authentication now appears as `OpenAI (Subscription login)` throughout Deep Agents Code.

---

The previous label conflated the Codex provider with ChatGPT login terminology. The provider key and compact `OpenAI Codex` tag remain unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/d59dcb80-9456-5dd1-8797-49ee240c7540)