### PR TITLE
fix(code): hide onboarding Tavily cancel hint

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10730,6 +10730,7 @@ class DeepAgentsApp(App):
                 allow_empty_submit=True,
                 input_placeholder="Tavily API key (optional)",
                 submit_label="Enter save/skip",
+                show_cancel_hint=False,
             )
         )
         if result is not AuthResult.SAVED:

--- a/libs/code/deepagents_code/tui/widgets/auth.py
+++ b/libs/code/deepagents_code/tui/widgets/auth.py
@@ -633,6 +633,7 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
         allow_empty_submit: bool = False,
         input_placeholder: str | None = None,
         submit_label: str | None = None,
+        show_cancel_hint: bool = True,
     ) -> None:
         """Initialize the prompt for `provider`.
 
@@ -647,6 +648,7 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
                 with `AuthResult.CANCELLED` instead of showing a validation error.
             input_placeholder: Optional placeholder override for the key input.
             submit_label: Optional help-label override for the Enter action.
+            show_cancel_hint: Whether the footer advertises the Escape action.
         """
         super().__init__()
         self._provider = provider
@@ -655,6 +657,7 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
         self._allow_empty_submit = allow_empty_submit
         self._input_placeholder = input_placeholder
         self._submit_label = submit_label
+        self._show_cancel_hint = show_cancel_hint
         # LangSmith is configured as a tracing service: it carries an optional
         # project name and an endpoint chosen from a region selector (US/EU SaaS
         # or a custom self-hosted URL), and saving a key turns tracing on.
@@ -1000,8 +1003,13 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
             save_label = self._submit_label or (
                 "Enter replace" if self._has_existing else "Enter save"
             )
+            save_help = (
+                f"{save_label} {glyphs.bullet} Esc cancel"
+                if self._show_cancel_hint
+                else save_label
+            )
             help_parts = [
-                f"{save_label} {glyphs.bullet} Esc cancel",
+                save_help,
                 "F2 advanced",
                 "Ctrl+R reload",
             ]

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2137,6 +2137,7 @@ class TestStartupSequence:
         assert prompt._allow_empty_submit is True
         assert prompt._input_placeholder == "Tavily API key (optional)"
         assert prompt._submit_label == "Enter save/skip"
+        assert prompt._show_cancel_hint is False
         assert "Web search is optional" in (prompt._reason or "")
         apply_credentials.assert_called_once_with()
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
@@ -82,6 +82,7 @@ class _AuthHostApp(App[None]):
         allow_empty_submit: bool = False,
         input_placeholder: str | None = None,
         submit_label: str | None = None,
+        show_cancel_hint: bool = True,
     ) -> None:
         """Push the prompt and capture the dismissal result."""
 
@@ -97,6 +98,7 @@ class _AuthHostApp(App[None]):
                 allow_empty_submit=allow_empty_submit,
                 input_placeholder=input_placeholder,
                 submit_label=submit_label,
+                show_cancel_hint=show_cancel_hint,
             ),
             handle,
         )
@@ -1155,6 +1157,7 @@ api_key_url = "javascript:alert(1)"
                 allow_empty_submit=True,
                 input_placeholder="Tavily API key (optional)",
                 submit_label="Enter save/skip",
+                show_cancel_hint=False,
             )
             await pilot.pause()
 
@@ -1167,10 +1170,21 @@ api_key_url = "javascript:alert(1)"
         assert key_input.password is True
         assert "Web search is optional" in copy
         assert "Enter save/skip" in str(help_text.content)
+        assert "Esc cancel" not in str(help_text.content)
         # Services (Tavily) omit the storage note entirely — the title and
         # reason already explain the key, so it would only be redundant copy.
         assert has_storage_note is False
         assert "stores the above key locally" not in copy
+
+    async def test_default_prompt_keeps_cancel_hint(self) -> None:
+        """Regular auth prompts continue to advertise Escape."""
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_prompt("openai", "OPENAI_API_KEY")
+            await pilot.pause()
+            help_text = app.screen.query_one(".auth-prompt-help", Static)
+
+        assert "Esc cancel" in str(help_text.content)
 
     async def test_optional_prompt_surfaces_save_failure_and_stays_open(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
The Tavily API-key prompt no longer shows the `Esc cancel` footer hint during first-run onboarding; Escape remains functional and regular `/auth` prompts are unchanged.

---

Onboarding already offers an explicit `Enter save/skip` action, so the shared auth prompt now exposes a narrow presentation option for this one flow.

Made by [Open SWE](https://openswe.vercel.app/agents/6fc1d69b-5456-527f-95de-c951eee6404e)