### PR TITLE
fix(code): clarify Auto mode file-edit example

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/auto_mode_notice.py
+++ b/libs/code/deepagents_code/tui/widgets/auto_mode_notice.py
@@ -36,8 +36,8 @@ without updating this value would silently drop the disclosure — hence the
 
 AUTO_MODE_NOTICE_BODY = (
     "You switched to **Auto**. The agent can approve **routine gated actions** "
-    "without asking first — for example ordinary source edits and read-only "
-    "Git commands.\n\n"
+    "without asking first — for example, file edits and read-only Git "
+    "commands.\n\n"
     f"Anything uncertain is reviewed against your **literal request** by "
     f"{AUTO_MODE_NOTICE_MODEL_ANCHOR}. If review keeps failing, you're asked "
     "to approve.\n\n"


### PR DESCRIPTION
Auto mode's confirmation notice now describes routine gated actions as file edits and read-only Git commands.

---

The simpler wording better matches the intended example while preserving approval semantics.

Made by [Open SWE](https://openswe.vercel.app/agents/545d8962-872d-5973-8dc8-eaa4e22d2e50)