### PR TITLE
fix(code): separate YOLO exit hint

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
+++ b/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
@@ -45,8 +45,8 @@ YOLO_MODE_NOTICE_BODY = (
     "You are about to enable **YOLO mode**. The agent may run shell commands, "
     "edit files, make network calls, and use other tools on this machine "
     "**without asking you first**.\n\n"
-    "Only continue if you're comfortable letting it act unsupervised. Leave "
-    "YOLO any time with **Shift+Tab**.\n\n"
+    "Only continue if you're comfortable letting it act unsupervised.\n"
+    "Leave YOLO any time with **Shift+Tab**.\n\n"
     "This notice appears **once** on this machine.\n\n"
     f"[Learn more about approval modes]({YOLO_MODE_DOCS_URL})"
 )

--- a/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
+++ b/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
@@ -45,7 +45,7 @@ YOLO_MODE_NOTICE_BODY = (
     "You are about to enable **YOLO mode**. The agent may run shell commands, "
     "edit files, make network calls, and use other tools on this machine "
     "**without asking you first**.\n\n"
-    "Only continue if you're comfortable letting it act unsupervised.\n"
+    "Only continue if you're comfortable letting it act unsupervised.\n\n"
     "Leave YOLO any time with **Shift+Tab**.\n\n"
     "This notice appears **once** on this machine.\n\n"
     f"[Learn more about approval modes]({YOLO_MODE_DOCS_URL})"

--- a/libs/code/tests/unit_tests/tui/widgets/test_yolo_mode_notice.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_yolo_mode_notice.py
@@ -1,0 +1,8 @@
+"""Tests for the YOLO first-enable notice body."""
+
+from deepagents_code.tui.widgets.yolo_mode_notice import YOLO_MODE_NOTICE_BODY
+
+
+def test_exit_hint_starts_on_a_new_line() -> None:
+    """Keep the YOLO exit hint visually separate from the warning."""
+    assert "\nLeave YOLO any time with **Shift+Tab**." in YOLO_MODE_NOTICE_BODY


### PR DESCRIPTION
The YOLO confirmation now puts the Shift+Tab exit hint on its own line.

---

This separates the recovery action from the preceding warning without changing the notice flow. A focused regression test preserves the line break.

Verified with the focused YOLO notice test and the `libs/code` format, lint, type, and command-catalog checks.

Made by [Open SWE](https://openswe.vercel.app/agents/c8c8a096-fda6-5642-af5b-816c9b05f228)