### PR TITLE
fix(code): keep installed providers visible in `/auth`

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/auth.py
+++ b/libs/code/deepagents_code/tui/widgets/auth.py
@@ -61,7 +61,6 @@ from deepagents_code.model_config import (
     ProviderAuthState,
     ProviderAuthStatus,
     clear_caches,
-    get_available_models,
     get_base_url_env_var,
     get_base_url_env_vars,
     get_credential_env_var,
@@ -1879,19 +1878,25 @@ class AuthManagerScreen(ModalScreen[None]):
             name for name, cfg in config.providers.items() if cfg.get("api_key_env")
         }
 
-        # Only show well-known providers whose LangChain package is actually
-        # installed. `get_available_models` returns providers it could
-        # successfully import profiles for, so it doubles as an install
-        # gate. Stored and config-defined providers are always shown — even
-        # if the package was later uninstalled — so a stale credential can
-        # still be cleaned up and an explicitly-declared provider stays
-        # visible.
-        installed = set(get_available_models().keys())
-        well_known_installed = set(PROVIDER_API_KEY_ENV) & installed
+        # Show well-known providers whenever their LangChain package is
+        # installed, even if none of the package's model profiles pass dcode's
+        # tool-calling filter. Stored and config-defined providers are always
+        # shown too, so stale credentials can still be cleaned up and an
+        # explicitly-declared provider stays visible.
+        from deepagents_code.config_manifest import is_provider_package_installed
+
+        well_known_installed = {
+            provider
+            for provider in PROVIDER_API_KEY_ENV
+            if config.is_provider_enabled(provider)
+            and is_provider_package_installed(provider)
+        }
         # `openai_codex` is gated on `langchain-openai` being installed (we
-        # surface it whenever `openai` was discovered) rather than on
+        # surface it whenever `openai` is available) rather than on
         # `PROVIDER_API_KEY_ENV`, since it has no env var of its own.
-        codex_installed = {CODEX_PROVIDER} if "openai" in installed else set()
+        codex_installed = (
+            {CODEX_PROVIDER} if "openai" in well_known_installed else set()
+        )
 
         shown = well_known_installed | codex_installed | stored | config_providers
         # Surface well-known providers whose package isn't installed yet as

--- a/libs/code/deepagents_code/tui/widgets/auth.py
+++ b/libs/code/deepagents_code/tui/widgets/auth.py
@@ -1895,7 +1895,10 @@ class AuthManagerScreen(ModalScreen[None]):
         # surface it whenever `openai` is available) rather than on
         # `PROVIDER_API_KEY_ENV`, since it has no env var of its own.
         codex_installed = (
-            {CODEX_PROVIDER} if "openai" in well_known_installed else set()
+            {CODEX_PROVIDER}
+            if "openai" in well_known_installed
+            and config.is_provider_enabled(CODEX_PROVIDER)
+            else set()
         )
 
         shown = well_known_installed | codex_installed | stored | config_providers

--- a/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
@@ -2039,10 +2039,6 @@ api_key_env = "MY_GATEWAY_API_KEY"
         ):
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
-        )
-        monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda _provider: True,
         )
@@ -2068,10 +2064,6 @@ api_key_env = "MY_GATEWAY_API_KEY"
             "DEEPAGENTS_CODE_TAVILY_API_KEY",
         ):
             monkeypatch.delenv(var, raising=False)
-        monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"anthropic": ["claude-opus-4-7"]},
-        )
         monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda _provider: True,
@@ -2110,10 +2102,6 @@ api_key_env = "MY_GATEWAY_API_KEY"
         ):
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
-        )
-        monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda provider: provider != "groq",
         )
@@ -2148,10 +2136,6 @@ api_key_env = "MY_GATEWAY_API_KEY"
             "DEEPAGENTS_CODE_ANTHROPIC_API_KEY",
         ):
             monkeypatch.delenv(var, raising=False)
-        monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
-        )
         monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda _provider: True,
@@ -2200,15 +2184,6 @@ api_key_env = "MY_GATEWAY_API_KEY"
         ):
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {
-                "openai": ["gpt-5.4"],
-                "anthropic": ["claude-opus-4-7"],
-                "cohere": ["command"],
-                "mistralai": ["mistral-large"],
-            },
-        )
-        monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda _provider: True,
         )
@@ -2244,10 +2219,6 @@ api_key_env = "MY_GATEWAY_API_KEY"
             "DEEPAGENTS_CODE_ANTHROPIC_API_KEY",
         ):
             monkeypatch.delenv(var, raising=False)
-        monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
-        )
         monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda _provider: True,
@@ -2343,34 +2314,27 @@ api_key_env = "MY_GATEWAY_API_KEY"
     ) -> None:
         """Installed providers show as live rows; uninstalled ones grey out.
 
-        When `openai` is "installed", `openai_codex` rides along — it shares
-        the same `langchain-openai` package, so the manager surfaces the
-        OAuth-backed twin alongside the API-key entry. With every known
-        package reported installed, no greyed install-on-select rows appear,
-        so the listing equals the installed set.
+        When `openai` is installed, `openai_codex` rides along because it shares
+        the same `langchain-openai` package. Every other known provider remains
+        a greyed install-on-select row below the live entries.
         """
-        # Pretend only `openai` and `anthropic` are installed.
-        monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
-        )
-        # Report every known package installed so no greyed-out
-        # install-on-select rows are appended to the listing.
         monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
-            lambda _provider: True,
+            lambda provider: provider in {"openai", "anthropic"},
         )
         app = _AuthHostApp()
         async with app.run_test() as pilot:
             app.show_manager()
             await pilot.pause()
-            options = app.screen.query_one("#auth-manager-options", OptionList)
+            screen = cast("AuthManagerScreen", app.screen)
+            options = screen.query_one("#auth-manager-options", OptionList)
             ids = {
                 options.get_option_at_index(i).id for i in range(options.option_count)
             }
+            live_ids = ids - set(screen._install_extras)
         # Non-model services (Tavily search, LangSmith tracing) are always
         # listed for key entry.
-        assert ids == {
+        assert live_ids == {
             "openai",
             "openai_codex",
             "anthropic",
@@ -2387,8 +2351,8 @@ api_key_env = "MY_GATEWAY_API_KEY"
         would look up a credential env var the service doesn't have.
         """
         monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"]},
+            "deepagents_code.config_manifest.is_provider_package_installed",
+            lambda provider: provider == "openai",
         )
         app = _AuthHostApp()
         async with app.run_test() as pilot:
@@ -2413,8 +2377,8 @@ api_key_env = "MY_GATEWAY_API_KEY"
         """
         auth_store.set_stored_key("tavily", "k")
         monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"]},
+            "deepagents_code.config_manifest.is_provider_package_installed",
+            lambda provider: provider == "openai",
         )
         app = _AuthHostApp()
         async with app.run_test() as pilot:
@@ -2438,8 +2402,8 @@ api_key_env = "MY_GATEWAY_API_KEY"
         """
         auth_store.set_stored_key("groq", "k")
         monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"]},
+            "deepagents_code.config_manifest.is_provider_package_installed",
+            lambda provider: provider == "openai",
         )
         app = _AuthHostApp()
         async with app.run_test() as pilot:
@@ -2461,10 +2425,6 @@ api_key_env = "MY_GATEWAY_API_KEY"
         so `groq` is surfaced as a `[not installed]` install-on-select entry
         for discoverability rather than being hidden.
         """
-        monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
-        )
         monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda provider: provider in {"openai", "anthropic"},
@@ -2493,10 +2453,6 @@ api_key_env = "MY_GATEWAY_API_KEY"
         )
 
         monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"]},
-        )
-        monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda provider: provider == "openai",
         )
@@ -2515,10 +2471,6 @@ api_key_env = "MY_GATEWAY_API_KEY"
     ) -> None:
         """Confirming the install records the extra and dismisses the manager."""
         monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"]},
-        )
-        monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda provider: provider == "openai",
         )
@@ -2534,40 +2486,34 @@ api_key_env = "MY_GATEWAY_API_KEY"
         assert screen.pending_install_extra == "groq"
         assert screen.pending_install_provider == "groq"
 
-    async def test_reopening_manager_highlights_initial_provider(
+    async def test_reopening_highlights_installed_provider_without_compatible_models(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Reopening after an install highlights the just-installed provider.
+        """An installed provider stays live even when its profiles are filtered out.
 
-        Simulates the post-install reopen: `groq` is now installed and listed,
-        and passing it as `initial_provider` lands the cursor on its row rather
-        than resetting to index 0.
+        Perplexity currently declares no tool-calling models, so model discovery
+        excludes it. The auth manager must use package availability instead and
+        highlight it when reopening after the extra install.
         """
         monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"], "groq": ["llama-3"]},
-        )
-        monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
-            lambda provider: provider in {"openai", "groq"},
+            lambda provider: provider in {"openai", "perplexity"},
         )
         app = _AuthHostApp()
         async with app.run_test() as pilot:
-            app.show_manager(initial_provider="groq")
+            app.show_manager(initial_provider="perplexity")
             await pilot.pause()
             screen = cast("AuthManagerScreen", app.screen)
             options = screen.query_one("#auth-manager-options", OptionList)
             assert options.highlighted is not None
-            assert options.get_option_at_index(options.highlighted).id == "groq"
+            selected = options.get_option_at_index(options.highlighted)
+            assert selected.id == "perplexity"
+            assert "not installed" not in str(selected.prompt)
 
     async def test_reopening_manager_ignores_unknown_initial_provider(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """An initial provider absent from the list leaves the cursor at the top."""
-        monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"]},
-        )
         monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda provider: provider == "openai",
@@ -2584,10 +2530,6 @@ api_key_env = "MY_GATEWAY_API_KEY"
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Declining the install records nothing and keeps the user on the manager."""
-        monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"]},
-        )
         monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda provider: provider == "openai",
@@ -2622,10 +2564,6 @@ enabled = false
         monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
         model_config.clear_caches()
         monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
-        )
-        monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda provider: provider in {"openai", "anthropic"},
         )
@@ -2651,10 +2589,6 @@ enabled = false
         so the provider must not appear as an install-on-select row pointing at
         a `None` extra.
         """
-        monkeypatch.setattr(
-            "deepagents_code.tui.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"]},
-        )
         monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
             lambda provider: provider != "groq",

--- a/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
@@ -2671,6 +2671,34 @@ class TestCodexAuthInManager:
             }
         assert "openai_codex" in ids
 
+    async def test_disabled_codex_option_hidden(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A disabled `openai_codex` provider stays out of the auth manager."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.openai_codex]
+enabled = false
+""")
+        monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+        model_config.clear_caches()
+        monkeypatch.setattr(
+            "deepagents_code.config_manifest.is_provider_package_installed",
+            lambda provider: provider == "openai",
+        )
+
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_manager()
+            await pilot.pause()
+            options = app.screen.query_one("#auth-manager-options", OptionList)
+            ids = {
+                options.get_option_at_index(i).id for i in range(options.option_count)
+            }
+
+        assert "openai" in ids
+        assert "openai_codex" not in ids
+
     async def test_codex_badge_reflects_signed_out_state(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Installed provider integrations now remain visible in `/auth`, even when none of their model profiles support tool calling.

---

The auth manager used filtered model discovery as a proxy for package installation. Perplexity's profiles are all filtered out, so its row disappeared immediately after installing the extra; the manager now checks package importability directly.

Made by [Open SWE](https://openswe.vercel.app/agents/88821224-8845-59a9-949b-cbcdd8bdb1d8)