### PR TITLE
fix(code): hide thread IDs when tracing is disabled

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12079,6 +12079,20 @@ class DeepAgentsApp(App):
         await self._mount_message(AppMessage(link))
 
     @staticmethod
+    def _thread_links_configured() -> bool:
+        """Return whether LangSmith thread links can be resolved."""
+        from deepagents_code.config import get_langsmith_project_name
+
+        try:
+            return get_langsmith_project_name() is not None
+        except Exception:
+            logger.debug(
+                "Could not determine whether LangSmith thread links are configured",
+                exc_info=True,
+            )
+            return False
+
+    @staticmethod
     async def _build_thread_message(
         prefix: str, thread_id: str, *, suffix: str = ""
     ) -> str | Content:
@@ -15210,13 +15224,20 @@ class DeepAgentsApp(App):
                     logger.debug(
                         "Screen stack empty during thread reset", exc_info=True
                     )
-                thread_msg_widget = AppMessage(f"Started new thread: {new_thread_id}")
-                await self._mount_message(thread_msg_widget)
-                self._schedule_thread_message_link(
-                    thread_msg_widget,
-                    prefix="Started new thread",
-                    thread_id=new_thread_id,
+                thread_links_configured = self._thread_links_configured()
+                started_message = (
+                    f"Started new thread: {new_thread_id}"
+                    if thread_links_configured
+                    else "Started new thread"
                 )
+                thread_msg_widget = AppMessage(started_message)
+                await self._mount_message(thread_msg_widget)
+                if thread_links_configured:
+                    self._schedule_thread_message_link(
+                        thread_msg_widget,
+                        prefix="Started new thread",
+                        thread_id=new_thread_id,
+                    )
                 await self._mount_previous_thread_hint(
                     self._session_state.previous_thread_id,
                     had_agent_output=outgoing_had_agent_output,
@@ -18505,10 +18526,14 @@ class DeepAgentsApp(App):
         if not owner or (owner != active_agent and self._server_kwargs is None):
             return False
 
+        thread_links_configured = self._thread_links_configured()
         resume_hint = " (Resume with /threads -r)"
-        previous_msg_widget = AppMessage(
+        previous_message = (
             f"Previous thread: {previous_thread_id}{resume_hint}"
+            if thread_links_configured
+            else "Resume previous thread with /threads -r"
         )
+        previous_msg_widget = AppMessage(previous_message)
         # The hint is cosmetic, so a mount fault must not escape into the
         # caller's error handling. Two callers wrap this in a rollback: a raise
         # from `_resume_thread` would undo an already-completed switch and
@@ -18517,12 +18542,13 @@ class DeepAgentsApp(App):
         # server came up healthy. Both would misreport success as failure.
         try:
             await self._mount_message(previous_msg_widget)
-            self._schedule_thread_message_link(
-                previous_msg_widget,
-                prefix="Previous thread",
-                thread_id=previous_thread_id,
-                suffix=resume_hint,
-            )
+            if thread_links_configured:
+                self._schedule_thread_message_link(
+                    previous_msg_widget,
+                    prefix="Previous thread",
+                    thread_id=previous_thread_id,
+                    suffix=resume_hint,
+                )
         except Exception:
             logger.warning(
                 "Could not mount previous-thread hint for %s",

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3494,10 +3494,7 @@ def get_langsmith_project_name() -> str | None:
     langsmith_key = resolve_env_var("LANGSMITH_API_KEY") or resolve_env_var(
         "LANGCHAIN_API_KEY"
     )
-    langsmith_tracing = resolve_env_var("LANGSMITH_TRACING") or resolve_env_var(
-        "LANGCHAIN_TRACING_V2"
-    )
-    if not (langsmith_key and langsmith_tracing):
+    if not (langsmith_key and _tracing_enabled()):
         return None
 
     return (

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -7533,6 +7533,7 @@ class TestClearCommand:
 
             with (
                 patch("deepagents_code.app._new_thread_id", return_value="new-thread"),
+                patch.object(app, "_thread_links_configured", return_value=True),
                 patch.object(app, "_schedule_thread_message_link") as schedule,
             ):
                 await app._handle_command("/clear")
@@ -7585,6 +7586,7 @@ class TestClearCommand:
                     "deepagents_code.sessions.get_thread_agent",
                     AsyncMock(return_value="agent"),
                 ),
+                patch.object(app, "_thread_links_configured", return_value=True),
                 patch.object(app, "_schedule_thread_message_link") as schedule,
             ):
                 await app._handle_command("/clear")
@@ -7608,6 +7610,43 @@ class TestClearCommand:
                 "suffix": " (Resume with /threads -r)",
             }
 
+    async def test_clear_hides_thread_ids_without_tracing(self) -> None:
+        """Unlinked thread notices should stay concise."""
+        from deepagents_code.tui.widgets.message_store import MessageData, MessageType
+
+        app = DeepAgentsApp(thread_id="old-thread")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._session_state = TextualSessionState(thread_id="old-thread")
+            app._lc_thread_id = "old-thread"
+            app._message_store.append(
+                MessageData(type=MessageType.ASSISTANT, content="existing response")
+            )
+
+            with (
+                patch("deepagents_code.app._new_thread_id", return_value="new-thread"),
+                patch(
+                    "deepagents_code.sessions.thread_exists",
+                    AsyncMock(return_value=True),
+                ),
+                patch(
+                    "deepagents_code.sessions.get_thread_agent",
+                    AsyncMock(return_value="agent"),
+                ),
+                patch.object(app, "_thread_links_configured", return_value=False),
+                patch.object(app, "_schedule_thread_message_link") as schedule,
+            ):
+                await app._handle_command("/clear")
+                await pilot.pause()
+
+            contents = [str(widget._content) for widget in app.query(AppMessage)]
+            assert "Started new thread" in contents
+            assert "Resume previous thread with /threads -r" in contents
+            assert not any(
+                "old-thread" in text or "new-thread" in text for text in contents
+            )
+            schedule.assert_not_called()
+
     async def test_clear_omits_previous_thread_without_checkpoint(self) -> None:
         """/clear should not advertise a thread that cannot be resumed."""
         app = DeepAgentsApp(thread_id="old-thread")
@@ -7622,6 +7661,7 @@ class TestClearCommand:
                     "deepagents_code.sessions.thread_exists",
                     AsyncMock(return_value=False),
                 ),
+                patch.object(app, "_thread_links_configured", return_value=True),
                 patch.object(app, "_schedule_thread_message_link") as schedule,
             ):
                 await app._handle_command("/clear")

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -25014,13 +25014,15 @@ class TestRestartServerForAgentSwap:
                     "deepagents_code.sessions.get_thread_agent",
                     AsyncMock(return_value="coder"),
                 ),
+                patch.object(app, "_thread_links_configured", return_value=False),
                 patch.object(app, "_mount_message", side_effect=mounted.append),
                 patch.object(app, "run_worker", side_effect=_closing_run_worker_mock),
             ):
                 await app._restart_server_for_agent_swap("researcher")
 
         plain = [str(getattr(m, "_content", m)) for m in mounted]
-        assert any("Previous thread: old-thread" in s for s in plain)
+        assert "Resume previous thread with /threads -r" in plain
+        assert not any("old-thread" in s for s in plain)
         assert not any("Relaunch with" in s for s in plain)
 
     async def test_resume_hint_echoes_launch_command(

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -2008,6 +2008,20 @@ class TestGetLangsmithProjectName:
         with patch.dict("os.environ", env, clear=False):
             assert get_langsmith_project_name() is None
 
+    @pytest.mark.parametrize(
+        "flag",
+        ["LANGSMITH_TRACING", "DEEPAGENTS_CODE_LANGSMITH_TRACING"],
+    )
+    def test_returns_none_when_tracing_explicitly_disabled(self, flag: str) -> None:
+        """Recognized tracing opt-outs should disable project resolution."""
+        env = {
+            "LANGSMITH_API_KEY": "lsv2_test",
+            "LANGSMITH_PROJECT": "configured-project",
+            flag: "false",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            assert get_langsmith_project_name() is None
+
     def test_returns_project_from_settings(self) -> None:
         """Should prefer settings.deepagents_langchain_project."""
         env = {

--- a/libs/code/tests/unit_tests/test_threads_resume.py
+++ b/libs/code/tests/unit_tests/test_threads_resume.py
@@ -494,6 +494,7 @@ class TestPreviousThreadHintOwnership:
                 "deepagents_code.sessions.get_thread_agent",
                 AsyncMock(return_value="researcher"),
             ),
+            patch.object(app, "_thread_links_configured", return_value=True),
             patch.object(app, "_schedule_thread_message_link") as schedule,
         ):
             hinted = await app._mount_previous_thread_hint(

--- a/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
@@ -3390,6 +3390,7 @@ class TestResumeThread:
         )
         _app_test_double(app)._load_thread_history = AsyncMock()
         _app_test_double(app)._mount_message = AsyncMock()
+        _app_test_double(app)._thread_links_configured = MagicMock(return_value=True)
         _app_test_double(app).query_one = MagicMock(side_effect=_NoMatches())
         return app
 
@@ -4685,6 +4686,26 @@ class TestEffectiveModelSpec:
             patch.object(settings, "model_name", ""),
         ):
             assert app._effective_model_spec() is None
+
+
+class TestThreadLinksConfigured:
+    """Tests for DeepAgentsApp._thread_links_configured."""
+
+    def test_false_without_langsmith_project(self) -> None:
+        """Tracing without a project cannot produce thread links."""
+        app = DeepAgentsApp()
+        with patch(
+            "deepagents_code.config.get_langsmith_project_name", return_value=None
+        ):
+            assert app._thread_links_configured() is False
+
+    def test_true_with_langsmith_project(self) -> None:
+        """An active LangSmith project enables thread links."""
+        app = DeepAgentsApp()
+        with patch(
+            "deepagents_code.config.get_langsmith_project_name", return_value="project"
+        ):
+            assert app._thread_links_configured() is True
 
 
 class TestUpgradeThreadMessageLink:


### PR DESCRIPTION
Thread transition notices now omit opaque IDs when LangSmith tracing is unavailable, while preserving clickable IDs when tracing is configured.

---

Unlinked IDs add noise without helping users navigate. The concise fallback retains the `/threads -r` recovery action and skips unnecessary URL-resolution workers.

Made by [Open SWE](https://openswe.vercel.app/agents/6886da8e-3d62-5c8d-8bc0-ff3c05d59ba6)