### PR TITLE
fix(code): space rows in `/tools`

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12422,7 +12422,11 @@ class DeepAgentsApp(App):
             )
 
         await self._mount_message(
-            AppMessage(self._render_tool_catalog(catalog), markdown=True)
+            AppMessage(
+                self._render_tool_catalog(catalog),
+                markdown=True,
+                table_row_spacing=1,
+            )
         )
 
     def _mcp_server_info_for_tools(self) -> list[MCPServerInfo]:

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -5548,13 +5548,17 @@ class _MutedRichMarkdown:
         "markdown.table.border": "",
     }
 
-    def __init__(self, markup: str) -> None:
+    def __init__(self, markup: str, *, table_row_spacing: int = 0) -> None:
         from rich.markdown import (
             Markdown as RichMarkdown,
             MarkdownElement,
             TableElement,
         )
         from rich.table import Table
+
+        if table_row_spacing < 0:
+            msg = "table_row_spacing must be non-negative"
+            raise ValueError(msg)
 
         class _FoldingTableElement(TableElement):
             """Render long Markdown table cells by folding instead of eliding."""
@@ -5564,6 +5568,7 @@ class _MutedRichMarkdown:
             ) -> RenderResult:
                 for renderable in super().__rich_console__(console, options):
                     if isinstance(renderable, Table):
+                        renderable.leading = table_row_spacing
                         for column in renderable.columns:
                             column.overflow = "fold"
                     yield renderable
@@ -5615,7 +5620,11 @@ _markdown_style_conversion_warned = [False]
 
 
 def _markdown_to_content(
-    markup: str, width: int, console: RichConsole | None = None
+    markup: str,
+    width: int,
+    console: RichConsole | None = None,
+    *,
+    table_row_spacing: int = 0,
 ) -> Content:
     """Render muted markdown to selectable `Content` at a fixed width.
 
@@ -5632,6 +5641,7 @@ def _markdown_to_content(
         width: Target render width in cells; the markdown is laid out to fit.
         console: Console used to render segments; a default is created when
             `None`.
+        table_row_spacing: Blank lines inserted between markdown table rows.
 
     Returns:
         `Content` visually equivalent to the rendered markdown, with trailing
@@ -5646,7 +5656,8 @@ def _markdown_to_content(
     if console is None:
         console = Console(width=render_width)
     segments = console.render(
-        _MutedRichMarkdown(markup), console.options.update_width(render_width)
+        _MutedRichMarkdown(markup, table_row_spacing=table_row_spacing),
+        console.options.update_width(render_width),
     )
     content_lines: list[Content] = []
     for line in Segment.split_lines(segments):
@@ -5708,6 +5719,7 @@ class AppMessage(Static):
         message: str | Content,
         *,
         markdown: bool = False,
+        table_row_spacing: int = 0,
         **kwargs: Any,
     ) -> None:
         """Initialize a system message.
@@ -5719,14 +5731,20 @@ class AppMessage(Static):
 
                 Requires a string message — `Content` objects already carry
                 their own structure.
+            table_row_spacing: Blank lines inserted between markdown table rows.
             **kwargs: Additional arguments passed to parent.
 
         Raises:
             TypeError: If `markdown=True` is combined with a non-string
                 `message`.
+            ValueError: If `table_row_spacing` is negative.
         """
+        if table_row_spacing < 0:
+            msg = "table_row_spacing must be non-negative"
+            raise ValueError(msg)
         self._content = message
         self._is_markdown = markdown
+        self._table_row_spacing = table_row_spacing
         # Markdown is rendered lazily in `render()` so it can be laid out to the
         # widget's current width and rebuilt as selectable `Content`.
         self._markdown_cache: tuple[int, Content] | None = None
@@ -5761,7 +5779,12 @@ class AppMessage(Static):
                 console = self.app.console
             except NoActiveAppError:
                 console = None
-            content = _markdown_to_content(str(self._content), width, console)
+            content = _markdown_to_content(
+                str(self._content),
+                width,
+                console,
+                table_row_spacing=self._table_row_spacing,
+            )
             self._markdown_cache = (width, content)
         return self._markdown_cache[1]
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -19312,10 +19312,13 @@ class TestToolsSlashCommand:
         assert "search_docs" in rendered
         assert "docs" in rendered
 
-    async def test_mounted_catalog_renders_markdown_table(self) -> None:
-        """The mounted message renders through the widget's own markdown path."""
+    async def test_mounted_catalog_renders_spaced_markdown_table(self) -> None:
+        """The mounted message renders a blank line between tool table rows."""
         tool_node = SimpleNamespace(
-            tools_by_name={"read_file": SimpleNamespace(description="Read a file")}
+            tools_by_name={
+                "read_file": SimpleNamespace(description="Read a file"),
+                "write_file": SimpleNamespace(description="Write a file"),
+            }
         )
         agent = MagicMock()
         agent.nodes = {"tools": SimpleNamespace(bound=tool_node)}
@@ -19331,7 +19334,7 @@ class TestToolsSlashCommand:
             assert catalog
             rendered = catalog[-1].render().plain
 
-        assert "1 tool available" in rendered
+        assert "2 tools available" in rendered
         # The column headings and rule prove the source became a real table
         # rather than degenerating into paragraphs or a list.
         assert "Tool" in rendered
@@ -19340,6 +19343,11 @@ class TestToolsSlashCommand:
         # Present unescaped, so the markdown source's `read\_file` resolved.
         assert "read_file" in rendered
         assert "Read a file" in rendered
+        assert "write_file" in rendered
+        lines = rendered.splitlines()
+        read_row = next(i for i, line in enumerate(lines) if "read_file" in line)
+        write_row = next(i for i, line in enumerate(lines) if "write_file" in line)
+        assert lines[read_row + 1 : write_row] == [""]
 
     async def test_built_in_failure_still_shows_mcp(self) -> None:
         from deepagents_code.mcp_tools import MCPServerInfo, MCPToolInfo

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -4741,6 +4741,18 @@ class TestAppMessageMarkdownSelectable:
     `Content` so `/version` tables and incognito shell output stay copyable.
     """
 
+    def test_rejects_negative_table_row_spacing(self) -> None:
+        with pytest.raises(ValueError, match="must be non-negative"):
+            AppMessage("| A |\n| --- |\n| value |", markdown=True, table_row_spacing=-1)
+
+    async def test_default_markdown_table_rows_remain_compact(self) -> None:
+        async with _MarkdownAppMessageApp().run_test(size=(80, 24)) as pilot:
+            lines = pilot.app.query_one("#md", AppMessage).render().plain.splitlines()
+
+        langchain_row = next(i for i, line in enumerate(lines) if "langchain" in line)
+        langgraph_row = next(i for i, line in enumerate(lines) if "langgraph" in line)
+        assert langgraph_row == langchain_row + 1
+
     async def test_markdown_renders_content_visual(self) -> None:
         from textual.content import Content
 


### PR DESCRIPTION
`/tools` now leaves one blank line between built-in tool rows so entries are easier to scan.

---

The spacing is scoped to the tool catalog's markdown table, preserving compact rows in `/version` and other markdown messages. Focused rendering tests cover both behaviors; package formatting, linting, type checks, and command-catalog validation pass.

Made by [Open SWE](https://openswe.vercel.app/agents/7e986252-03e9-519f-886b-af55e201b622)