### PR TITLE
fix(code): preload auth UI before notification handoff

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/notification_center.py
+++ b/libs/code/deepagents_code/tui/widgets/notification_center.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from importlib import import_module
 from typing import TYPE_CHECKING, ClassVar
 
 from textual.binding import Binding, BindingType
@@ -356,6 +357,12 @@ class NotificationCenterScreen(ModalScreen[NotificationActionResult | None]):
         self._set_selected(index)
         self._drill_into(self._notifications[index])
 
+    @staticmethod
+    def _preload_follow_up(entry: PendingNotification) -> None:
+        """Load deferred follow-up UI before its detail screen becomes active."""
+        if any(action.action_id == ActionId.ENTER_API_KEY for action in entry.actions):
+            import_module("deepagents_code.tui.widgets.auth")
+
     def _drill_into(self, entry: PendingNotification) -> None:
         """Push a detail modal for *entry*.
 
@@ -367,6 +374,7 @@ class NotificationCenterScreen(ModalScreen[NotificationActionResult | None]):
         """
         if self._drilling:
             return
+        self._preload_follow_up(entry)
         detail_screen = self._detail_screen_for(entry)
         self._drilling = True
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_notification_center.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_notification_center.py
@@ -12,6 +12,7 @@ from deepagents_code.notifications import (
     PendingNotification,
     UpdateAvailablePayload,
 )
+from deepagents_code.tui.widgets import notification_center
 from deepagents_code.tui.widgets.notification_center import (
     NotificationActionRequested,
     NotificationActionResult,
@@ -121,6 +122,28 @@ class TestNotificationCenterScreen:
             await pilot.press("enter")
             await pilot.pause()
             assert isinstance(app.screen, UpdateAvailableScreen)
+
+    async def test_enter_preloads_api_key_screen_before_detail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """API-key UI loads while the center still covers the base screen."""
+        imports: list[tuple[str, object]] = []
+        app = App()
+        screen = NotificationCenterScreen([_service_entry()])
+
+        def capture_import(name: str) -> None:
+            imports.append((name, app.screen))
+
+        monkeypatch.setattr(notification_center, "import_module", capture_import)
+        async with app.run_test() as pilot:
+            app.push_screen(screen)
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert isinstance(app.screen, NotificationDetailScreen)
+
+        assert imports == [("deepagents_code.tui.widgets.auth", screen)]
 
     async def test_detail_action_dismisses_center_with_result(self) -> None:
         """Selecting an action in the detail dismisses the center with it."""


### PR DESCRIPTION
The auth prompt now opens without exposing the notification center for a frame on first use.

---

`AuthPromptScreen` stays lazy-loaded for startup performance, but its first import now happens while the notification center is still the expected visible screen instead of after the detail modal dismisses. A focused Textual regression test locks that ordering.

Made by [Open SWE](https://openswe.vercel.app/agents/c32d2311-c4d4-5554-a9e8-9380b67e46ea)