### PR TITLE
Fix/truncate list rendered size

### DIFF
--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -572,19 +572,17 @@ def truncate_if_too_long(result: list[str] | str) -> list[str] | str:
         if len(str(result)) <= budget:
             return result
 
-        available_budget = budget - len(TRUNCATION_GUIDANCE)
-
         truncated: list[str] = []
 
         for item in result:
-            candidate = truncated + [item, TRUNCATION_GUIDANCE]
+            candidate = [*truncated, item, TRUNCATION_GUIDANCE]
 
             if len(str(candidate)) > budget:
                 break
 
             truncated.append(item)
 
-        return truncated + [TRUNCATION_GUIDANCE]
+        return [*truncated, TRUNCATION_GUIDANCE]
 
     if len(result) > budget:
         return result[:budget] + "\n" + TRUNCATION_GUIDANCE

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -566,14 +566,29 @@ def truncate_if_too_long(result: str) -> str: ...
 
 def truncate_if_too_long(result: list[str] | str) -> list[str] | str:
     """Truncate list or string result if it exceeds token limit (rough estimate: 4 chars/token)."""
+    budget = TOOL_RESULT_TOKEN_LIMIT * 4
+
     if isinstance(result, list):
-        total_chars = sum(len(item) for item in result)
-        if total_chars > TOOL_RESULT_TOKEN_LIMIT * 4:
-            return result[: len(result) * TOOL_RESULT_TOKEN_LIMIT * 4 // total_chars] + [TRUNCATION_GUIDANCE]  # noqa: RUF005  # Concatenation preferred for clarity
-        return result
-    # string
-    if len(result) > TOOL_RESULT_TOKEN_LIMIT * 4:
-        return result[: TOOL_RESULT_TOKEN_LIMIT * 4] + "\n" + TRUNCATION_GUIDANCE
+        if len(str(result)) <= budget:
+            return result
+
+        available_budget = budget - len(TRUNCATION_GUIDANCE)
+
+        truncated: list[str] = []
+
+        for item in result:
+            candidate = truncated + [item, TRUNCATION_GUIDANCE]
+
+            if len(str(candidate)) > budget:
+                break
+
+            truncated.append(item)
+
+        return truncated + [TRUNCATION_GUIDANCE]
+
+    if len(result) > budget:
+        return result[:budget] + "\n" + TRUNCATION_GUIDANCE
+
     return result
 
 

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -3413,6 +3413,28 @@ class TestTruncation:
         assert "results truncated" in result
         assert "try being more specific" in result
 
+    def test_truncate_list_accounts_for_rendered_size(self):
+        budget = TOOL_RESULT_TOKEN_LIMIT * 4
+        paths = [f"/{index:04x}" for index in range(10_000)]
+
+        result = truncate_if_too_long(paths)
+
+        assert len(str(result)) <= budget
+        assert result[-1] == TRUNCATION_GUIDANCE
+
+    def test_truncate_list_handles_uneven_item_lengths(self):
+        items = [
+                "a" * 100_000,
+                "small",
+                "small",
+                "small",
+            ]
+
+        result = truncate_if_too_long(items)
+
+        assert len(str(result)) <= TOOL_RESULT_TOKEN_LIMIT * 4
+        assert result[-1] == TRUNCATION_GUIDANCE
+
 
 class TestBuiltinTruncationTools:
     def test_builtin_truncation_tool_not_evicted(self):

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -3424,11 +3424,11 @@ class TestTruncation:
 
     def test_truncate_list_handles_uneven_item_lengths(self):
         items = [
-                "a" * 100_000,
-                "small",
-                "small",
-                "small",
-            ]
+            "a" * 100_000,
+            "small",
+            "small",
+            "small",
+        ]
 
         result = truncate_if_too_long(items)
 


### PR DESCRIPTION
Fixes #5676 

Ensure list results are truncated based on their rendered size rather than only the combined length of their items.

The previous implementation could return results larger than the configured tool-result budget because list formatting overhead (quotes, commas, brackets, etc.) was not included in the size calculation. The proportional truncation could also retain oversized results when list items had significantly different lengths.

This change selects list items based on the actual rendered representation and reserves space for the truncation guidance. Regression tests were added for rendered-size overhead and uneven item lengths.

## Social handles 
<!-- For external contributors: get a shoutout on release -->
LinkedIn: https://www.linkedin.com/in/debankur-dutta-8871a22b0/
