### PR TITLE
fix(sdk): reject empty old_string in edit to prevent file corr…

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -469,6 +469,11 @@ try:
     # file on disk is CRLF. Try old as sent, then a CRLF variant, then an LF
     # variant. The first match reveals the file line-ending style in that
     # region; apply the same transform to new so the file style is preserved.
+    # An empty old string matches at every character boundary; replacing it
+    # would corrupt the whole file (issue #5589). Reject it up front.
+    if old == '':
+        print(json.dumps({{'error': 'empty_old_string'}}))
+        sys.exit(0)
     old_crlf = old.replace('\\r\\n', '\\n').replace('\\n', '\\r\\n')
     old_lf = old.replace('\\r\\n', '\\n')
     new_crlf = new.replace('\\r\\n', '\\n').replace('\\n', '\\r\\n')
@@ -562,6 +567,11 @@ try:
         sys.exit(0)
 
     # Match-driven CRLF handling -- see _EDIT_COMMAND_TEMPLATE and issue #2880.
+    # Reject an empty old string (issue #5589): it matches everywhere and would
+    # corrupt the whole file.
+    if old == '':
+        print(json.dumps({{'error': 'empty_old_string'}}))
+        sys.exit(0)
     old_crlf = old.replace('\\r\\n', '\\n').replace('\\n', '\\r\\n')
     old_lf = old.replace('\\r\\n', '\\n')
     new_crlf = new.replace('\\r\\n', '\\n').replace('\\n', '\\r\\n')
@@ -1101,6 +1111,7 @@ def _map_edit_error(error: str, file_path: str, old_string: str) -> EditResult:
         "not_a_file": f"Error: '{file_path}' is not a regular file",
         "not_a_text_file": f"Error: File '{file_path}' is not a text file",
         "string_not_found": f"Error: String not found in file: '{old_string}'",
+        "empty_old_string": "Error: old_string cannot be empty. Provide the exact text to replace.",
         "multiple_occurrences": (f"Error: String '{old_string}' appears multiple times. Use replace_all=True to replace all occurrences."),
     }
     return EditResult(error=messages.get(error, f"Error editing file '{file_path}': {error}"))

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -516,6 +516,13 @@ def perform_string_replacement(
     Returns:
         Tuple of `(new_content, occurrences)` on success, or error message string
     """
+    # Reject an empty `old_string`. `str.count("")` matches at every character
+    # boundary and `str.replace("", new_string)` would insert `new_string`
+    # around every character, silently corrupting the file (issue #5589).
+    # An empty search string is never a meaningful edit.
+    if old_string == "":
+        return "Error: old_string cannot be empty. Provide the exact text to replace."
+
     occurrences = content.count(old_string)
 
     if occurrences == 0:

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1141,7 +1141,10 @@ class EditFileSchema(BaseModel):
 
     file_path: str = Field(description="Absolute path to the file to edit. Must be absolute, not relative.")
 
-    old_string: str = Field(description="The exact text to find and replace. Must be unique in the file unless replace_all is True.")
+    old_string: str = Field(
+        min_length=1,
+        description="The exact text to find and replace. Must be unique in the file unless replace_all is True.",
+    )
 
     new_string: str = Field(description="The text to replace old_string with. Must be different from old_string.")
 

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -488,6 +488,18 @@ class TestPerformStringReplacement:
         assert "not found" in result
         assert "old_string ends with a newline" not in result
 
+    def test_empty_old_string_returns_error_without_modifying(self) -> None:
+        """An empty `old_string` must error, never rewrite the file (#5589)."""
+        result = perform_string_replacement("abc", "", "X")
+        assert isinstance(result, str)
+        assert "cannot be empty" in result
+
+    def test_empty_old_string_with_replace_all_returns_error(self) -> None:
+        """`replace_all=True` must not turn 'abc' into 'XaXbXcX' (#5589)."""
+        result = perform_string_replacement("abc", "", "X", replace_all=True)
+        assert isinstance(result, str)
+        assert "cannot be empty" in result
+
 
 class TestSliceReadResponse:
     """`slice_read_response` must round-trip the file's trailing-newline state.


### PR DESCRIPTION

An empty old_string caused str.count("") to match at every character boundary; with replace_all=True, str.replace("", new) inserted the replacement around every character, silently corrupting files (e.g. 'abc' -> 'XaXbXcX').

Reject empty old_string in perform_string_replacement (covers Filesystem/State/Store/ContextHub backends) and in both sandbox server-side edit scripts, add the empty_old_string error mapping, and add min_length=1 to EditFileSchema.old_string. Includes regression tests.

Closes #5589

<!-- Optional: Replace this comment with `Fixes #` / `Closes #` / or `Resolves #` with the issue number to auto-close the issue when this PR is merged. If applicable, add separate `Depends on #` or `Related: #` lines. -->

<!-- For a net new feature or behavior-changing bugfix: replace this comment with one plain-English sentence on the user-visible change. Usually not needed for chores/refactors/test-only PRs. -->

---

<!-- Why this change, and why this approach. No `# Summary` or `## Release note` headings, please. -->

Thanks for contributing! A few essentials below. Remove these instructions before submission.

1. **Title:** `type(scope): description` — e.g. `fix(sdk): ...`, `feat(cli): ...`. Allowed values: [pr_lint.yml](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/pr_lint.yml).
2. One package per PR unless a maintainer says otherwise
3. External contributors: don't change `uv.lock` / add deps without maintainer approval
4. Large pasted AI descriptions may be ignored or closed
5. English only — [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)

Full guide: https://docs.langchain.com/oss/python/contributing/overview
Remove the above instructions before submission!

## Social handles (optional)
<!-- For external contributors: get a shoutout on release -->
Twitter: @YOUR_USERNAME
LinkedIn: https://linkedin.com/in/YOUR_USERNAME
