### PR TITLE
ci(infra): fence package names in auto-created bump PR titles

### DIFF
--- a/.github/workflows/bump_code_sdk_pin.yml
+++ b/.github/workflows/bump_code_sdk_pin.yml
@@ -232,7 +232,7 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add "$code_pyproject" "$lockfile"
-          git commit -m "chore(deps): bump deepagents pin in deepagents-code to $SDK_VERSION"
+          git commit -m "chore(deps): bump `deepagents` pin in `deepagents-code` to $SDK_VERSION"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH:$BRANCH"
 
           body_file="$(mktemp)"
@@ -244,7 +244,7 @@ jobs:
           pr_url=$(gh pr create \
             --head "$BRANCH" \
             --base "$DEFAULT_BRANCH" \
-            --title "chore(deps): bump deepagents pin in deepagents-code to $SDK_VERSION" \
+            --title "chore(deps): bump `deepagents` pin in `deepagents-code` to $SDK_VERSION" \
             --body-file "$body_file")
           echo "Opened SDK pin bump PR: $pr_url"
           echo "::notice::Opened SDK pin bump PR: $pr_url"

--- a/.github/workflows/bump_code_sdk_pin.yml
+++ b/.github/workflows/bump_code_sdk_pin.yml
@@ -232,19 +232,19 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add "$code_pyproject" "$lockfile"
-          git commit -m "chore(deps): bump `deepagents` pin in `deepagents-code` to $SDK_VERSION"
+          git commit -m "chore(deps): bump "'`deepagents`'" pin in "'`deepagents-code`'" to $SDK_VERSION"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH:$BRANCH"
 
           body_file="$(mktemp)"
           {
-            printf 'Bumps the exact `deepagents` pin in `libs/code/pyproject.toml` from `%s` to `%s` (current workspace SDK version) and regenerates `libs/code/uv.lock`.\n\n' "$CODE_PIN" "$SDK_VERSION"
-            printf 'Opened automatically by `bump_code_sdk_pin.yml` after a commit on `main` changed the SDK version. Merge this before the next `deepagents-code` release so the SDK pin check goes green.\n'
+            printf 'Bumps the exact %s pin in %s from `%s` to `%s` (current workspace SDK version) and regenerates %s.\n\n' '`deepagents`' '`libs/code/pyproject.toml`' "$CODE_PIN" "$SDK_VERSION" '`libs/code/uv.lock`'
+            printf 'Opened automatically by %s after a commit on `main` changed the SDK version. Merge this before the next %s release so the SDK pin check goes green.\n' '`bump_code_sdk_pin.yml`' '`deepagents-code`'
           } > "$body_file"
 
           pr_url=$(gh pr create \
             --head "$BRANCH" \
             --base "$DEFAULT_BRANCH" \
-            --title "chore(deps): bump `deepagents` pin in `deepagents-code` to $SDK_VERSION" \
+            --title "chore(deps): bump "'`deepagents`'" pin in "'`deepagents-code`'" to $SDK_VERSION" \
             --body-file "$body_file")
           echo "Opened SDK pin bump PR: $pr_url"
           echo "::notice::Opened SDK pin bump PR: $pr_url"

--- a/.github/workflows/bump_genai_prices.yml
+++ b/.github/workflows/bump_genai_prices.yml
@@ -340,7 +340,7 @@ jobs:
             git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git checkout -b "$BRANCH"
             git add "$lockfile" "$manifest"
-            git commit -m "chore(deps): bump genai-prices in deepagents-code to $LATEST"
+            git commit -m "chore(deps): bump "'`genai-prices`'" in "'`deepagents-code`'" to $LATEST"
 
             # The bump branch is rebuilt on top of `main` every run, so there
             # is no shared history worth preserving and the push must be
@@ -360,7 +360,7 @@ jobs:
           body_file="$(mktemp)"
           printf 'Bumps `genai-prices` from `%s` to `%s`.\n\nOpened automatically by `bump_genai_prices.yml`.\n' "$LOCKED" "$LATEST" > "$body_file"
 
-          title="chore(deps): bump genai-prices in deepagents-code to $LATEST"
+          title="chore(deps): bump `genai-prices` in `deepagents-code` to $LATEST"
 
           if [ -n "$pr_number" ]; then
             # Retitle and rewrite the body: the branch just moved to a newer

--- a/.github/workflows/bump_genai_prices.yml
+++ b/.github/workflows/bump_genai_prices.yml
@@ -358,9 +358,9 @@ jobs:
           fi
 
           body_file="$(mktemp)"
-          printf 'Bumps `genai-prices` from `%s` to `%s`.\n\nOpened automatically by `bump_genai_prices.yml`.\n' "$LOCKED" "$LATEST" > "$body_file"
+          printf 'Bumps %s from `%s` to `%s`.\n\nOpened automatically by %s.\n' '`genai-prices`' "$LOCKED" "$LATEST" '`bump_genai_prices.yml`' > "$body_file"
 
-          title="chore(deps): bump `genai-prices` in `deepagents-code` to $LATEST"
+          title="chore(deps): bump "'`genai-prices`'" in "'`deepagents-code`'" to $LATEST"
 
           if [ -n "$pr_number" ]; then
             # Retitle and rewrite the body: the branch just moved to a newer


### PR DESCRIPTION
Auto-created dependency bump PRs (e.g. #5707, #5704) now title themselves with fenced package names — `` chore(deps): bump `deepagents` pin in `deepagents-code` to 0.7.9 `` instead of `chore(deps): bump deepagents pin in deepagents-code to 0.7.9` — matching the repo convention of wrapping named entities in backticks.

---

Both workflows that generate these titles (one drives the SDK pin bump, the other the daily `genai-prices` bump) build the commit message and PR title from the same string, so both the commit and the title get the fencing. The version stays bare, matching the `release(scope): x.y.z` convention and previously merged pin-bump titles.

The `genai-prices` workflow retitles its open bump PR on every run, so an in-flight PR picks up the new title automatically the next time the workflow runs.

No release-please or title-lint impact: the description after `type(scope):` is free-form for both, and the `chore(deps):` type/scope pair that keeps these out of the changelog is unchanged.
