### PR TITLE
fix(code): stream tool-call args in linear time

### DIFF
--- a/libs/code/deepagents_code/_tool_stream.py
+++ b/libs/code/deepagents_code/_tool_stream.py
@@ -258,77 +258,6 @@ def tool_call_buffer_key(
     return f"unknown-{count}"
 
 
-def _exceeds_json_container_depth(s: str) -> bool:
-    """Return whether `s` exceeds the safe nesting depth for JSON args."""
-    depth = 0
-    in_string = False
-    escaped = False
-    for ch in s:
-        if in_string:
-            if escaped:
-                escaped = False
-            elif ch == "\\":
-                escaped = True
-            elif ch == '"':
-                in_string = False
-            continue
-        if ch == '"':
-            in_string = True
-        elif ch in "{[":
-            depth += 1
-            if depth > MAX_JSON_CONTAINER_DEPTH:
-                return True
-        elif ch in "}]":
-            depth -= 1
-    return False
-
-
-def _looks_structurally_complete(s: str) -> bool:
-    """Return whether `s` is a balanced JSON container, string-state aware.
-
-    Scans for bracket balance while tracking whether the cursor is inside a
-    string literal (honoring backslash escapes), so a value is "complete" only
-    when every `{`/`[` is matched and the text does not end mid-string. Used
-    solely to decide whether a `json.loads` failure is worth warning about: a
-    balanced-but-unparseable value is malformed, whereas a partial stream — e.g.
-    a chunk boundary landing right after an inner `}` in `{"edits": [{"a": 1}` —
-    leaves an outer container open and returns `False`, so no false warning fires
-    on a healthy mid-stream fragment. A stray closer (`depth < 0`) is unbalanced
-    and can never be completed by more input, so it is reported complete
-    (malformed) too. Iterative, so it never raises `RecursionError` on
-    pathologically nested input.
-
-    Args:
-        s: The accumulated, stripped tool-call argument text.
-
-    Returns:
-        `True` if the brackets are matched (or over-closed) and the text does not
-            end inside a string; `False` while a container is still open.
-    """
-    depth = 0
-    in_string = False
-    escaped = False
-    for ch in s:
-        if in_string:
-            if escaped:
-                escaped = False
-            elif ch == "\\":
-                escaped = True
-            elif ch == '"':
-                in_string = False
-            continue
-        if ch == '"':
-            in_string = True
-        elif ch in "{[":
-            depth += 1
-        elif ch in "}]":
-            depth -= 1
-            if depth < 0:
-                # More closers than openers: unbalanced, not a partial stream.
-                return True
-    return depth == 0 and not in_string
-
-
 @dataclass
 class ToolCallBuffer:
     """In-progress state for a single streamed tool call.
@@ -363,6 +292,30 @@ class ToolCallBuffer:
     even though `parse_args` re-runs on every later chunk for the retained
     buffer."""
 
+    _args_parts_ref: list[str] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _args_parts_scanned: int = field(default=0, init=False, repr=False, compare=False)
+    _args_first_non_whitespace: str | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _args_last_non_whitespace: str | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _args_container_depth: int = field(default=0, init=False, repr=False, compare=False)
+    _args_max_container_depth: int = field(
+        default=0, init=False, repr=False, compare=False
+    )
+    _args_in_string: bool = field(default=False, init=False, repr=False, compare=False)
+    _args_escaped: bool = field(default=False, init=False, repr=False, compare=False)
+    _args_overclosed: bool = field(default=False, init=False, repr=False, compare=False)
+    _materialized_args: str | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _parsed_args: dict[str, Any] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
     def __post_init__(self) -> None:
         """Enforce the `args` XOR `args_parts` invariant at construction time.
 
@@ -380,6 +333,97 @@ class ToolCallBuffer:
         if self.args is not None and self.args_parts:
             msg = "ToolCallBuffer cannot hold both args and args_parts"
             raise ValueError(msg)
+        self._reset_args_fragment_state()
+        self._sync_args_fragment_state()
+
+    def _reset_args_fragment_state(self) -> None:
+        """Reset incremental state for the current fragment list."""
+        self._args_parts_ref = self.args_parts
+        self._args_parts_scanned = 0
+        self._args_first_non_whitespace = None
+        self._args_last_non_whitespace = None
+        self._args_container_depth = 0
+        self._args_max_container_depth = 0
+        self._args_in_string = False
+        self._args_escaped = False
+        self._args_overclosed = False
+        self._materialized_args = None
+        self._parsed_args = None
+
+    def _sync_args_fragment_state(self) -> None:
+        """Scan each newly appended argument fragment exactly once."""
+        if (
+            self._args_parts_ref is not self.args_parts
+            or self._args_parts_scanned > len(self.args_parts)
+        ):
+            self._reset_args_fragment_state()
+
+        while self._args_parts_scanned < len(self.args_parts):
+            fragment = self.args_parts[self._args_parts_scanned]
+            self._scan_args_fragment(fragment)
+            self._args_parts_scanned += 1
+            self._materialized_args = None
+            self._parsed_args = None
+
+    def _scan_args_fragment(self, fragment: str) -> None:
+        """Advance JSON lexical state through one new fragment."""
+        for char in fragment:
+            if not char.isspace():
+                if self._args_first_non_whitespace is None:
+                    self._args_first_non_whitespace = char
+                self._args_last_non_whitespace = char
+
+            if self._args_in_string:
+                if self._args_escaped:
+                    self._args_escaped = False
+                elif char == "\\":
+                    self._args_escaped = True
+                elif char == '"':
+                    self._args_in_string = False
+                continue
+
+            if char == '"':
+                self._args_in_string = True
+            elif char in "{[":
+                self._args_container_depth += 1
+                self._args_max_container_depth = max(
+                    self._args_max_container_depth, self._args_container_depth
+                )
+            elif char in "}]":
+                self._args_container_depth -= 1
+                if self._args_container_depth < 0:
+                    self._args_overclosed = True
+
+    def _materialize_args(self) -> str:
+        """Join fragments once for the current accumulated prefix.
+
+        Returns:
+            The full accumulated argument text.
+        """
+        if self._materialized_args is None:
+            self._materialized_args = "".join(self.args_parts)
+        return self._materialized_args
+
+    def _args_preview(self, limit: int = 200) -> str:
+        """Return a bounded prefix without materializing the full payload."""
+        remaining = limit
+        preview: list[str] = []
+        for fragment in self.args_parts:
+            if remaining <= 0:
+                break
+            preview.append(fragment[:remaining])
+            remaining -= len(preview[-1])
+        return "".join(preview)
+
+    def _warn_invalid_args(self) -> None:
+        """Log one bounded warning for an irrecoverably invalid payload."""
+        if self.warned:
+            return
+        self.warned = True
+        logger.warning(
+            "Tool-call args look complete but failed to parse: %r",
+            self._args_preview(),
+        )
 
     def _reset_for_new_call(self) -> None:
         """Discard retained state before this buffer is reused for another call."""
@@ -387,6 +431,7 @@ class ToolCallBuffer:
         self.tool_id = None
         self.args = None
         self.args_parts = []
+        self._reset_args_fragment_state()
         self.displayed = False
         self.warned = False
 
@@ -460,6 +505,7 @@ class ToolCallBuffer:
         if isinstance(args, dict):
             self.args = args
             self.args_parts = []
+            self._reset_args_fragment_state()
         elif isinstance(args, str):
             # Append every non-empty fragment unconditionally. An earlier
             # TUI-only version skipped a fragment equal to the immediately
@@ -472,9 +518,11 @@ class ToolCallBuffer:
             if args:
                 self.args = None
                 self.args_parts.append(args)
+                self._sync_args_fragment_state()
         elif args is not None:
             self.args = args
             self.args_parts = []
+            self._reset_args_fragment_state()
 
     def parse_args(self) -> dict[str, Any] | None:
         """Return the tool-call args once enough data has arrived, else `None`.
@@ -510,73 +558,41 @@ class ToolCallBuffer:
 
         if not self.args_parts:
             return None
-        joined = "".join(self.args_parts)
-        stripped = joined.strip()
-        if not stripped:
+
+        self._sync_args_fragment_state()
+        first = self._args_first_non_whitespace
+        if first is None:
             return None
-        # Cheap structural pre-check: bail while a JSON object/array is still
-        # open so we don't attempt to parse a partial streamed fragment. A
-        # well-formed object's closing brace is always its last char. The
-        # `"".join` still runs per fragment (so accumulation stays O(n^2) across
-        # the stream); the win is deferring the costlier `json.loads` until the
-        # value looks complete, rather than re-parsing the whole prefix on every
-        # fragment.
-        #
-        # A bracketed value with trailing junk after its close (e.g.
-        # `{"a": 1} x`) also returns here and is treated as still-streaming, so
-        # it never reaches the malformed warning below — the same deliberate
-        # trade as the non-bracketed-scalar exclusion documented at the end of
-        # this method. Real provider arg streams are pure JSON, so this shape
-        # does not occur in practice; if such a call still executes, its
-        # `tool.result` logs the correlation miss.
-        if stripped[0] in "{[":
-            if not stripped.endswith(("}", "]")):
+        if self._parsed_args is not None:
+            return self._parsed_args
+
+        is_container = first in "{["
+        if is_container:
+            last = self._args_last_non_whitespace
+            if last is None or last not in "}]":
                 return None
-            if _exceeds_json_container_depth(stripped):
-                if not self.warned:
-                    self.warned = True
-                    logger.warning(
-                        "Tool-call args look complete but failed to parse: %r",
-                        joined[:200],
-                    )
+            if not self._args_overclosed and (
+                self._args_container_depth != 0 or self._args_in_string
+            ):
                 return None
+            if self.warned:
+                return None
+            if self._args_max_container_depth > MAX_JSON_CONTAINER_DEPTH:
+                self._warn_invalid_args()
+                return None
+        elif first == '"' and self._args_in_string:
+            return None
+
+        joined = self._materialize_args()
         try:
             parsed = json.loads(joined)
         except (json.JSONDecodeError, RecursionError):
-            # Args that are structurally balanced (all brackets matched, not
-            # ending mid-string) but still fail to parse are malformed, not
-            # mid-stream — surface them rather than silently dropping the
-            # tool.use hook. `_looks_structurally_complete` does a string-aware
-            # balance check rather than the cheaper "starts with {/[ and ends
-            # with }/]" heuristic, which false-positives on a normal chunk
-            # boundary inside nested args (e.g. `{"edits": [{"a": 1}`) and would
-            # warn on a perfectly healthy stream. `RecursionError` is caught
-            # alongside the decode error: pathologically nested model output
-            # makes `json.loads` exceed the interpreter recursion limit, and that
-            # is one malformed call to skip, not a reason to let the exception
-            # escape and abort the whole turn. `%r` escapes any control
-            # characters in the model-generated fragment. The `warned` latch
-            # keeps this to one line per call, since the buffer is retained and
-            # parse_args re-runs on every later chunk for the same call.
-            if (
-                stripped[0] in "{["
-                and _looks_structurally_complete(stripped)
-                and not self.warned
-            ):
-                self.warned = True
-                logger.warning(
-                    "Tool-call args look complete but failed to parse: %r",
-                    joined[:200],
-                )
-            # A non-bracketed complete-but-malformed value is deliberately not
-            # warned here: it is indistinguishable from a still-streaming scalar
-            # fragment, so warning would be noisy. If such a call still executes,
-            # its `tool.result` logs the correlation miss at info; if it never
-            # executes there is no result to audit, so nothing is lost.
+            if is_container:
+                self._warn_invalid_args()
             return None
-        if not isinstance(parsed, dict):
-            return {"value": parsed}
-        return parsed
+
+        self._parsed_args = parsed if isinstance(parsed, dict) else {"value": parsed}
+        return self._parsed_args
 
 
 class UnemittedToolCalls(NamedTuple):

--- a/libs/code/deepagents_code/_tool_stream.py
+++ b/libs/code/deepagents_code/_tool_stream.py
@@ -157,6 +157,12 @@ raise), so a hook consumer still sees the result rather than a dropped event."""
 MAX_JSON_CONTAINER_DEPTH = sys.getrecursionlimit()
 """Maximum JSON container nesting accepted for streamed tool-call args."""
 
+INVALID_ARGS_PREVIEW_LIMIT = 200
+"""Characters of an unparseable tool-call payload included in its warning.
+
+Bounds the log line: a streamed payload can be arbitrarily large, and the
+preview exists to identify the call, not to reproduce it."""
+
 
 def normalize_tool_status(raw_status: object, tool_name: str) -> ToolStatus:
     """Map a raw `ToolMessage.status` to the two-value hook domain, fail-closed.
@@ -265,6 +271,14 @@ class ToolCallBuffer:
     `args` and `args_parts` are two representations of the arguments used one at
     a time, depending on whether the provider delivers the value whole or in
     JSON string fragments.
+
+    Fragments are scanned incrementally as they arrive: the private `_args_*`
+    fields hold a JSON lexer folded over everything scanned so far, so
+    `parse_args` can tell "still streaming" from "complete" without re-reading
+    the accumulated prefix on every chunk. That makes the fragment path linear
+    over a stream, at the cost of a second invariant — the lexer state must stay
+    in step with `args_parts`. Mutate `args_parts` only by appending or by
+    rebinding it wholesale (see its docstring).
     """
 
     name: str | None = None
@@ -281,20 +295,52 @@ class ToolCallBuffer:
     args_parts: list[str] = field(default_factory=list)
     """JSON string fragments accumulated across chunks, reassembled by
     `parse_args` once the payload looks complete. Mutually exclusive with
-    `args` (see `__post_init__` and `ingest`)."""
+    `args` (see `__post_init__` and `ingest`).
+
+    Append to this list or rebind it wholesale; do not mutate entries in place.
+    The `_args_*` fields hold a JSON lexer folded over the fragments scanned so
+    far, and `_sync_args_fragment_state` detects a rebind or a truncation but
+    cannot detect an edit that leaves the list's identity and length unchanged
+    (e.g. `pop()` then `append()`), which would leave the scan stale and yield
+    another payload's args. Detecting that would cost a per-chunk rescan, which
+    is the quadratic behavior this state exists to remove."""
 
     displayed: bool = False
     """One-shot latch guarding the single "Calling tool" console line (used only
     by the headless surface)."""
 
     warned: bool = False
-    """One-shot latch so a malformed-but-complete payload is logged at most once,
-    even though `parse_args` re-runs on every later chunk for the retained
-    buffer."""
+    """One-shot latch for an irrecoverably invalid payload.
 
+    Serves two roles. It keeps the warning to one line per payload, even though
+    `parse_args` re-runs on every later chunk for the retained buffer. It also
+    short-circuits `parse_args` itself: every condition that sets it is
+    permanent (see `_warn_invalid_args`), so re-running `json.loads` per
+    fragment could only fail again — which is what made the pre-incremental
+    version quadratic on a malformed payload.
+
+    That second role means the latch now gates data, not just logging: keep it
+    private to `_warn_invalid_args`, since setting it for any other reason would
+    silently drop a valid tool call. Its lifetime must match the payload whose
+    parse it blocks, so `_reset_args_fragment_state` clears it alongside the
+    fragment state."""
+
+    # Incremental JSON lexer state plus join/parse memos, folded over
+    # `args_parts[:_args_parts_scanned]` and reset as a unit by
+    # `_reset_args_fragment_state`. Deferring the join and the `json.loads` until
+    # the payload is structurally complete is what keeps accumulation linear
+    # across a stream instead of re-scanning the whole prefix per chunk. All are
+    # `compare=False`, so `__eq__` stays a comparison of the public streaming
+    # fields; note that two buffers can therefore be equal while answering
+    # `parse_args` differently, so never use `==` as a proxy for "same state".
     _args_parts_ref: list[str] | None = field(
         default=None, init=False, repr=False, compare=False
     )
+    """The list the lexer state was reset against, held to notice a rebind.
+
+    An identity sentinel, not data: see the `args_parts` docstring for what this
+    can and cannot detect."""
+
     _args_parts_scanned: int = field(default=0, init=False, repr=False, compare=False)
     _args_first_non_whitespace: str | None = field(
         default=None, init=False, repr=False, compare=False
@@ -309,6 +355,11 @@ class ToolCallBuffer:
     _args_in_string: bool = field(default=False, init=False, repr=False, compare=False)
     _args_escaped: bool = field(default=False, init=False, repr=False, compare=False)
     _args_overclosed: bool = field(default=False, init=False, repr=False, compare=False)
+    """Whether a closer appeared at depth 0 outside a string.
+
+    Latched, and treated as *complete* rather than still-open: a stray closer
+    can never be repaired by more input, so the payload is malformed now."""
+
     _materialized_args: str | None = field(
         default=None, init=False, repr=False, compare=False
     )
@@ -337,7 +388,14 @@ class ToolCallBuffer:
         self._sync_args_fragment_state()
 
     def _reset_args_fragment_state(self) -> None:
-        """Reset incremental state for the current fragment list."""
+        """Reset incremental state for the current fragment list.
+
+        Clears `warned` too. Since `parse_args` short-circuits on the latch, a
+        reset that left it set would strand the *next* payload accumulated in
+        this buffer — a valid one would return `None` forever. `warned` belongs
+        to the payload being scanned, not to the buffer.
+        """
+        self.warned = False
         self._args_parts_ref = self.args_parts
         self._args_parts_scanned = 0
         self._args_first_non_whitespace = None
@@ -351,7 +409,12 @@ class ToolCallBuffer:
         self._parsed_args = None
 
     def _sync_args_fragment_state(self) -> None:
-        """Scan each newly appended argument fragment exactly once."""
+        """Scan each newly appended argument fragment exactly once.
+
+        Starts over when the fragment list was rebound or has shrunk, since the
+        accumulated lexer state no longer describes it. See the `args_parts`
+        docstring for the in-place edit this deliberately does not detect.
+        """
         if (
             self._args_parts_ref is not self.args_parts
             or self._args_parts_scanned > len(self.args_parts)
@@ -366,7 +429,15 @@ class ToolCallBuffer:
             self._parsed_args = None
 
     def _scan_args_fragment(self, fragment: str) -> None:
-        """Advance JSON lexical state through one new fragment."""
+        """Advance JSON lexical state through one new fragment.
+
+        String and escape state carry across fragment boundaries, so a payload
+        split mid-literal — or mid-escape, on a fragment ending in a lone
+        backslash — resumes correctly on the next chunk.
+
+        Args:
+            fragment: The newly appended argument text, scanned exactly once.
+        """
         for char in fragment:
             if not char.isspace():
                 if self._args_first_non_whitespace is None:
@@ -404,8 +475,22 @@ class ToolCallBuffer:
             self._materialized_args = "".join(self.args_parts)
         return self._materialized_args
 
-    def _args_preview(self, limit: int = 200) -> str:
-        """Return a bounded prefix without materializing the full payload."""
+    def _args_preview(self, limit: int = INVALID_ARGS_PREVIEW_LIMIT) -> str:
+        """Return a bounded prefix of the accumulated args.
+
+        Walks fragments only until `limit` is reached, so the depth-guard path
+        can log a preview without joining a pathologically nested payload just
+        to slice 200 characters off it. Once the join has already happened the
+        cached string is sliced directly.
+
+        Args:
+            limit: Maximum characters to return.
+
+        Returns:
+            At most `limit` leading characters of the accumulated argument text.
+        """
+        if self._materialized_args is not None:
+            return self._materialized_args[:limit]
         remaining = limit
         preview: list[str] = []
         for fragment in self.args_parts:
@@ -416,12 +501,22 @@ class ToolCallBuffer:
         return "".join(preview)
 
     def _warn_invalid_args(self) -> None:
-        """Log one bounded warning for an irrecoverably invalid payload."""
+        """Log one bounded warning for an irrecoverably invalid payload.
+
+        Only called for payloads that no further input can repair: depth
+        exceeded (the running max never falls), over-closed (a closer at depth 0
+        cannot be undone), or balanced-but-unparseable (the top-level value has
+        already closed, so any suffix is trailing junk). `parse_args` relies on
+        that permanence to short-circuit on `warned`.
+
+        `%r` escapes any control characters in the model-generated fragment
+        rather than letting a raw newline or BEL through into the log.
+        """
         if self.warned:
             return
         self.warned = True
         logger.warning(
-            "Tool-call args look complete but failed to parse: %r",
+            "Tool-call args are unparseable and cannot be completed: %r",
             self._args_preview(),
         )
 
@@ -531,12 +626,15 @@ class ToolCallBuffer:
         wrapped as `{"value": ...}` so a caller's `tool_args` is always an
         object.
 
+        The returned dict is cached and handed back by identity on a re-run, so
+        callers must treat it as read-only.
+
         Returns:
             Parsed tool-call arguments, or `None` when the args are not yet
                 complete (still streaming), empty, or structurally complete but
-                unparseable — malformed or too deeply nested (the
-                structurally-complete malformed case is logged once via
-                `warned`).
+                unparseable — malformed or too deeply nested. An unparseable
+                *container* is logged once via `warned`; an unparseable bare
+                scalar is not (see the `is_container` guard below).
 
         Raises:
             ValueError: If both `args` and `args_parts` are populated, violating
@@ -568,25 +666,66 @@ class ToolCallBuffer:
 
         is_container = first in "{["
         if is_container:
+            # A well-formed container's closing bracket is always its last
+            # character. A bracketed value with trailing junk after its close
+            # (e.g. `{"a": 1} x`) therefore lands here and is treated as
+            # still-streaming, so it never reaches the malformed warning — the
+            # same deliberate trade as the bare-scalar exclusion below. Real
+            # provider arg streams are pure JSON, so this shape does not occur
+            # in practice; if such a call still executes, its `tool.result` logs
+            # the correlation miss.
             last = self._args_last_non_whitespace
             if last is None or last not in "}]":
                 return None
+            # Balance check, not just the cheap last-character test above: a
+            # chunk boundary landing right after an inner `}` (e.g.
+            # `{"edits": [{"a": 1}`) ends in `}` while the outer container is
+            # still open, and a `}` inside an unterminated string is not a real
+            # close at all. Warning on either would fire on a perfectly healthy
+            # mid-stream fragment. Covered by
+            # `test_midstream_nested_json_does_not_warn` and
+            # `test_trailing_brace_inside_open_string_not_warned`; over-closing
+            # skips this check because a stray closer can never be repaired by
+            # more input, so it is complete (malformed), not partial.
             if not self._args_overclosed and (
                 self._args_container_depth != 0 or self._args_in_string
             ):
                 return None
+            # Every condition that sets `warned` is permanent, so the payload
+            # can never parse later. Short-circuit rather than re-failing
+            # `json.loads` on every subsequent fragment.
             if self.warned:
                 return None
             if self._args_max_container_depth > MAX_JSON_CONTAINER_DEPTH:
                 self._warn_invalid_args()
                 return None
         elif first == '"' and self._args_in_string:
+            # A string scalar whose closing quote has not arrived yet.
             return None
 
+        # Containers and string scalars reach here only once complete, so the
+        # join and the parse happen once per payload. A bare non-string scalar
+        # (a number or literal) has no closing token to wait for, so it still
+        # re-joins per chunk; tool args are never that shape, and adding state to
+        # cover it would not pay for itself.
         joined = self._materialize_args()
         try:
             parsed = json.loads(joined)
         except (json.JSONDecodeError, RecursionError):
+            # `RecursionError` is caught alongside the decode error because
+            # pathologically nested model output can make `json.loads` exceed
+            # the interpreter recursion limit, and that is one malformed call to
+            # skip rather than a reason to let the exception escape and abort the
+            # whole turn. The depth guard above pre-empts it by a wide margin
+            # with CPython's C scanner (which does not consume a Python frame per
+            # level), so this arm is defense-in-depth for a pure-Python-scanner
+            # build — not dead code.
+            #
+            # A non-container complete-but-malformed value is deliberately not
+            # warned: it is indistinguishable from a still-streaming scalar
+            # fragment, so warning would be noisy. If such a call still executes,
+            # its `tool.result` logs the correlation miss at info; if it never
+            # executes there is no result to audit, so nothing is lost.
             if is_container:
                 self._warn_invalid_args()
             return None
@@ -618,8 +757,13 @@ def count_unemitted_tool_calls(buffers: Iterable[ToolCallBuffer]) -> UnemittedTo
     their buffer map when the stream ends: those whose args never parsed, and
     those whose args parsed but whose `tool_id` stayed `None` (so `tool.use` was
     gated out). Sharing the classification here keeps the two diagnostics from
-    drifting; each surface still emits its own log lines. `parse_args` is safe to
-    re-run (idempotent bar its one-shot `warned` latch).
+    drifting; each surface still emits its own log lines.
+
+    `parse_args` is safe to re-run: a re-run populates the incremental scan and
+    the join/parse memos but returns the same value, and its one-shot `warned`
+    latch fires at most once per payload. Only the log line is suppressed on a
+    repeat; the classification below is unaffected either way, since a warned
+    payload counts as `unparsed` however often it is re-read.
 
     Args:
         buffers: The in-progress tool-call buffers remaining at stream end.

--- a/libs/code/tests/unit_tests/test__tool_stream.py
+++ b/libs/code/tests/unit_tests/test__tool_stream.py
@@ -254,6 +254,30 @@ class TestToolCallBufferParseArgs:
         buffer = ToolCallBuffer(args_parts=['{"command": "uv run'])
         assert buffer.parse_args() is None
 
+    def test_incomplete_fragments_are_materialized_only_when_complete(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Incremental parsing avoids rejoining the growing prefix per chunk."""
+        buffer = ToolCallBuffer(args_parts=['{"content": "'])
+        original_materialize = buffer._materialize_args
+        materializations = 0
+
+        def count_materialization() -> str:
+            nonlocal materializations
+            materializations += 1
+            return original_materialize()
+
+        monkeypatch.setattr(buffer, "_materialize_args", count_materialization)
+        for _ in range(1_000):
+            buffer.ingest(name=None, tool_id=None, args="x")
+            assert buffer.parse_args() is None
+
+        assert materializations == 0
+        buffer.ingest(name=None, tool_id=None, args='"}')
+        assert buffer.parse_args() == {"content": "x" * 1_000}
+        assert buffer.parse_args() == {"content": "x" * 1_000}
+        assert materializations == 1
+
     def test_non_object_json_wrapped(self) -> None:
         buffer = ToolCallBuffer(args_parts=["[1, 2, 3]"])
         assert buffer.parse_args() == {"value": [1, 2, 3]}

--- a/libs/code/tests/unit_tests/test__tool_stream.py
+++ b/libs/code/tests/unit_tests/test__tool_stream.py
@@ -8,9 +8,13 @@ surfaces additionally exercise it end-to-end in their own suites).
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from deepagents_code._tool_stream import (
+    INVALID_ARGS_PREVIEW_LIMIT,
+    MAX_JSON_CONTAINER_DEPTH,
     TOOL_OUTPUT_TRUNCATION_MARKER,
     ToolCallBuffer,
     build_tool_error_payload,
@@ -185,6 +189,11 @@ class TestToolCallBufferIngest:
         assert buffer.warned is True
         buffer.ingest(name="write_file", tool_id="toolu_b", args="{also bad}")
         assert buffer.warned is False
+        # The reset must clear the lexer state too, not just the latch: a valid
+        # payload for the new call has to parse, and `parse_args` short-circuits
+        # on `warned` and on stale depth/over-close state.
+        buffer.ingest(name=None, tool_id="toolu_c", args='{"fresh": 1}')
+        assert buffer.parse_args() == {"fresh": 1}
 
     def test_string_fragment_clears_prior_whole_value(self) -> None:
         """A fragment supersedes a prior whole value.
@@ -254,10 +263,19 @@ class TestToolCallBufferParseArgs:
         buffer = ToolCallBuffer(args_parts=['{"command": "uv run'])
         assert buffer.parse_args() is None
 
-    def test_incomplete_fragments_are_materialized_only_when_complete(
+    def test_incomplete_fragments_are_not_rejoined_per_chunk(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Incremental parsing avoids rejoining the growing prefix per chunk."""
+        """Incremental parsing avoids rejoining the growing prefix per chunk.
+
+        The pre-incremental version joined the whole accumulated prefix on every
+        fragment, so a long streamed value cost O(n^2). Counting joins is the
+        directly observable form of that fix: zero while the payload is
+        incomplete, then exactly one for the completed value, reused by the
+        second read. The fragment count is deliberately unrelated to
+        `MAX_JSON_CONTAINER_DEPTH` — nesting plays no part here.
+        """
+        chunks = 2_500
         buffer = ToolCallBuffer(args_parts=['{"content": "'])
         original_materialize = buffer._materialize_args
         materializations = 0
@@ -268,15 +286,200 @@ class TestToolCallBufferParseArgs:
             return original_materialize()
 
         monkeypatch.setattr(buffer, "_materialize_args", count_materialization)
-        for _ in range(1_000):
+        for _ in range(chunks):
             buffer.ingest(name=None, tool_id=None, args="x")
             assert buffer.parse_args() is None
 
         assert materializations == 0
         buffer.ingest(name=None, tool_id=None, args='"}')
-        assert buffer.parse_args() == {"content": "x" * 1_000}
-        assert buffer.parse_args() == {"content": "x" * 1_000}
+        assert buffer.parse_args() == {"content": "x" * chunks}
+        assert buffer.parse_args() == {"content": "x" * chunks}
         assert materializations == 1
+
+    def test_warned_latch_does_not_strand_a_later_payload(self) -> None:
+        """A malformed payload does not poison the next one in the same buffer.
+
+        `parse_args` short-circuits on `warned`, so the latch has to be cleared
+        with the rest of the per-payload state. A whole-value chunk resets the
+        fragment state mid-buffer; if it left `warned` set, the following
+        fragment stream would return `None` forever and silently drop a valid
+        `tool.use`.
+        """
+        buffer = ToolCallBuffer()
+        buffer.ingest(name="write_file", tool_id="t1", args="{bad json}")
+        assert buffer.parse_args() is None
+        assert buffer.warned is True
+
+        buffer.ingest(name=None, tool_id=None, args={"whole": 1})
+        assert buffer.parse_args() == {"whole": 1}
+        assert buffer.warned is False
+
+        buffer.ingest(name=None, tool_id=None, args='{"good": 1}')
+        assert buffer.parse_args() == {"good": 1}
+
+    def test_parse_cache_is_invalidated_by_later_fragments(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A cached parse is dropped as soon as another fragment arrives.
+
+        Once a container parses, the result is memoized so repeated reads are
+        free. A later fragment invalidates that memo: appending to an already
+        closed value makes it malformed, and returning the stale dict would
+        dispatch `tool.use` with args the model did not send.
+        """
+        over_closed = ToolCallBuffer()
+        over_closed.ingest(name=None, tool_id=None, args='{"a": 1}')
+        assert over_closed.parse_args() == {"a": 1}
+        with caplog.at_level("WARNING", logger="deepagents_code._tool_stream"):
+            over_closed.ingest(name=None, tool_id=None, args="}")
+            assert over_closed.parse_args() is None
+
+        continued = ToolCallBuffer()
+        continued.ingest(name=None, tool_id=None, args='{"a": 1}')
+        assert continued.parse_args() == {"a": 1}
+        continued.ingest(name=None, tool_id=None, args=', "b": 2}')
+        assert continued.parse_args() is None
+
+    def test_parse_args_returns_the_cached_dict_by_identity(self) -> None:
+        """Repeated reads share one dict, so callers must treat it as read-only.
+
+        Pinned deliberately: both surfaces forward this object into hook
+        payloads and retain it on the in-flight record, and the end-of-stream
+        diagnostic re-reads it. A caller that mutated it would corrupt every
+        other holder.
+        """
+        buffer = ToolCallBuffer(args_parts=['{"a": 1}'])
+        first = buffer.parse_args()
+        assert first is buffer.parse_args()
+
+        wrapped = ToolCallBuffer(args_parts=["[1, 2]"])
+        assert wrapped.parse_args() is wrapped.parse_args()
+
+    def test_escape_state_carries_across_fragment_boundaries(self) -> None:
+        """A backslash ending a fragment still escapes the next fragment's char.
+
+        The escape flag is scanned once per fragment and must survive the
+        boundary. Losing it makes an escaped quote look like a closing quote (or
+        vice versa), which flips the computed string state and leaves a complete
+        payload permanently unparsed.
+        """
+        # Fragment boundary splits `\"`: the quote is escaped, so the string
+        # stays open and the `}` inside it is not a real close.
+        escaped_quote = ToolCallBuffer(args_parts=[r'{"a": "x' + "\\"])
+        escaped_quote.ingest(name=None, tool_id=None, args=r'"y}"}')
+        assert escaped_quote.parse_args() == {"a": 'x"y}'}
+
+        # Fragment boundary splits `\\`: the backslash is literal, so the next
+        # quote really does close the string.
+        escaped_backslash = ToolCallBuffer(args_parts=[r'{"a": "x\\'])
+        escaped_backslash.ingest(name=None, tool_id=None, args='"}')
+        assert escaped_backslash.parse_args() == {"a": "x\\"}
+
+    def test_open_string_after_balanced_container_not_warned(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An open string with balanced brackets is incomplete, not malformed.
+
+        Complements `test_trailing_brace_inside_open_string_not_warned`, where
+        the depth term alone catches the payload. Here the depth is back to zero
+        and only the open-string term can tell that the value is still
+        streaming, so dropping that term would warn on a healthy fragment.
+        """
+        buffer = ToolCallBuffer(args_parts=['{"a": 1} "x}'])
+        with caplog.at_level("WARNING", logger="deepagents_code._tool_stream"):
+            assert buffer.parse_args() is None
+        assert buffer.warned is False
+        assert not any(
+            "are unparseable and cannot be completed" in r.message
+            for r in caplog.records
+        )
+
+    def test_over_depth_is_skipped_without_parsing(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The depth guard fires on nesting the C scanner would happily parse.
+
+        Nesting just past `MAX_JSON_CONTAINER_DEPTH` is well within what
+        `json.loads` accepts, so a `None` here can only come from the guard —
+        which pins it against rotting into a no-op behind the `RecursionError`
+        arm. The payload arrives in many small fragments, so it also pins the
+        high-water mark surviving fragment boundaries: the final depth is zero,
+        and only the running maximum records how deep it went.
+        """
+        depth = MAX_JSON_CONTAINER_DEPTH + 10
+        assert json.loads("[" * depth + "]" * depth) is not None
+
+        buffer = ToolCallBuffer()
+        for _ in range(depth):
+            buffer.ingest(name=None, tool_id=None, args="[")
+        for _ in range(depth):
+            buffer.ingest(name=None, tool_id=None, args="]")
+        with caplog.at_level("WARNING", logger="deepagents_code._tool_stream"):
+            assert buffer.parse_args() is None
+        assert buffer.warned is True
+
+    def test_over_closed_json_fed_incrementally_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Over-closing is detected across fragments, not just in one chunk.
+
+        The over-close flag latches during the per-fragment scan, so the stray
+        closer is still recognised when it arrives in its own chunk long after
+        the value closed.
+        """
+        buffer = ToolCallBuffer()
+        buffer.ingest(name=None, tool_id=None, args='{"a": ')
+        buffer.ingest(name=None, tool_id=None, args="1}")
+        buffer.ingest(name=None, tool_id=None, args="}")
+        with caplog.at_level("WARNING", logger="deepagents_code._tool_stream"):
+            assert buffer.parse_args() is None
+        assert buffer.warned is True
+        assert any(
+            "are unparseable and cannot be completed" in r.message
+            for r in caplog.records
+        )
+
+    def test_invalid_args_warning_is_length_bounded(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The warning previews a bounded prefix, not the whole payload.
+
+        Streamed args are unbounded, so the log line must not be. The preview
+        walks fragments and stops at the cap rather than slicing a joined string
+        that may never have been built.
+        """
+        filler = "z" * 50
+        buffer = ToolCallBuffer(args_parts=["{"])
+        for _ in range(40):
+            buffer.ingest(name=None, tool_id=None, args=filler)
+        buffer.ingest(name=None, tool_id=None, args="}")
+        with caplog.at_level("WARNING", logger="deepagents_code._tool_stream"):
+            assert buffer.parse_args() is None
+
+        (record,) = [
+            r
+            for r in caplog.records
+            if "are unparseable and cannot be completed" in r.message
+        ]
+        assert len("".join(buffer.args_parts)) > 2_000
+        assert INVALID_ARGS_PREVIEW_LIMIT < len(record.message) < 300
+
+    def test_whole_value_chunk_resets_lexer_state_mid_string(self) -> None:
+        """A dict chunk clears string state left by an abandoned fragment run.
+
+        The fragment stream is discarded mid-literal, so the open-string flag
+        has to go with it. Left set, it would report the *next* fragment run as
+        forever incomplete.
+        """
+        buffer = ToolCallBuffer()
+        buffer.ingest(name=None, tool_id=None, args='{"a": "unterminated')
+        assert buffer.parse_args() is None
+
+        buffer.ingest(name=None, tool_id=None, args={"whole": 1})
+        assert buffer.parse_args() == {"whole": 1}
+
+        buffer.ingest(name=None, tool_id=None, args='{"b": 2}')
+        assert buffer.parse_args() == {"b": 2}
 
     def test_non_object_json_wrapped(self) -> None:
         buffer = ToolCallBuffer(args_parts=["[1, 2, 3]"])
@@ -293,7 +496,8 @@ class TestToolCallBufferParseArgs:
 
         The buffer is retained across chunks on failure, so `parse_args` runs
         again on every later chunk; the `warned` latch keeps that from spamming
-        an identical warning per fragment.
+        an identical warning per fragment. It also short-circuits the re-parse,
+        so calls two and three return before reaching `json.loads` at all.
         """
         buffer = ToolCallBuffer(args_parts=["{bad json}"])
         with caplog.at_level("WARNING", logger="deepagents_code._tool_stream"):
@@ -303,7 +507,7 @@ class TestToolCallBufferParseArgs:
         warnings = [
             r
             for r in caplog.records
-            if "look complete but failed to parse" in r.message
+            if "are unparseable and cannot be completed" in r.message
         ]
         assert len(warnings) == 1
         assert buffer.warned is True
@@ -325,7 +529,8 @@ class TestToolCallBufferParseArgs:
             assert buffer.parse_args() is None
         assert buffer.warned is False
         assert not any(
-            "look complete but failed to parse" in r.message for r in caplog.records
+            "are unparseable and cannot be completed" in r.message
+            for r in caplog.records
         )
         # The completing fragments still parse once they arrive.
         buffer.ingest(name=None, tool_id=None, args=', {"b": 2}]}')
@@ -347,7 +552,8 @@ class TestToolCallBufferParseArgs:
             assert buffer.parse_args() is None
         assert buffer.warned is False
         assert not any(
-            "look complete but failed to parse" in r.message for r in caplog.records
+            "are unparseable and cannot be completed" in r.message
+            for r in caplog.records
         )
 
     def test_pathologically_nested_json_is_skipped_not_raised(
@@ -355,10 +561,12 @@ class TestToolCallBufferParseArgs:
     ) -> None:
         """Deeply nested model output is one skipped call, not an escaped error.
 
-        `json.loads` raises `RecursionError` (not `JSONDecodeError`) on input
-        nested past the interpreter limit. That must be caught like any other
-        malformed-but-complete payload — returning `None` and logging once —
-        rather than escaping `parse_args` and aborting the whole turn.
+        The depth guard pre-empts `json.loads` entirely here, so this pins the
+        guard rather than the `RecursionError` arm behind it — with CPython's C
+        scanner, `json.loads` does not consume a Python frame per level and only
+        raises far past this depth. `test_over_depth_is_skipped_without_parsing`
+        covers the guard at its boundary; the `RecursionError` arm remains
+        defense-in-depth for a pure-Python-scanner build.
         """
         depth = 100_000
         nested = "[" * depth + "]" * depth
@@ -367,7 +575,8 @@ class TestToolCallBufferParseArgs:
             assert buffer.parse_args() is None
         assert buffer.warned is True
         assert any(
-            "look complete but failed to parse" in r.message for r in caplog.records
+            "are unparseable and cannot be completed" in r.message
+            for r in caplog.records
         )
 
     def test_over_closed_json_warns_via_balance_check(
@@ -386,7 +595,8 @@ class TestToolCallBufferParseArgs:
             assert buffer.parse_args() is None
         assert buffer.warned is True
         assert any(
-            "look complete but failed to parse" in r.message for r in caplog.records
+            "are unparseable and cannot be completed" in r.message
+            for r in caplog.records
         )
 
     def test_both_args_and_args_parts_raises_at_read(self) -> None:


### PR DESCRIPTION
Large streamed tool calls no longer repeatedly copy their full argument payload while rendering.

`ToolCallBuffer` scanned the whole accumulated prefix on every chunk to decide whether the payload was complete, so a long argument value cost O(n^2) over its stream. It now tracks JSON lexical state per fragment — first and last non-whitespace character, container depth and its running maximum, string and escape state, over-closing — and defers the join and the `json.loads` until that state says the value is structurally complete. The parsed result is memoized, and invalidated as soon as another fragment arrives.

Each fragment is scanned once, so the container and string-scalar paths are linear over a stream. A bare non-string scalar (a number or literal) has no closing token to wait for and still re-joins per chunk; tool arguments are never that shape.

Measured cost of `ingest` + `parse_args` per fragment:

| fragments | container | bare scalar |
| --- | --- | --- |
| 2000 | 0.68 ms | 5.98 ms |
| 4000 | 1.36 ms | 19.22 ms |
| 8000 | 2.58 ms | 68.34 ms |

## Latch lifetime

`parse_args` short-circuits on `warned`, since every condition that sets it is permanent: depth exceeded (the running maximum never falls), over-closed (a closer at depth 0 cannot be undone), or balanced-but-unparseable (the top-level value has already closed, so any suffix is trailing junk). That makes the latch gate data rather than only logging, so `_reset_args_fragment_state` clears it with the rest of the per-payload state. Otherwise a malformed payload strands the next one in the same buffer:

```
ingest '{bad json}'   -> None          warned=True
ingest {'whole': 1}   -> {'whole': 1}  (whole-value chunk resets fragment state)
ingest '{"good": 1}'  -> None          <- valid payload, tool.use dropped
```

## Warning text

The over-closed path skips the balance check, so a payload can be reported unparseable while it ends mid-string. The old wording described that as complete:

```
before: Tool-call args look complete but failed to parse: '{"a":1}} {"b":"x\n}'
after:  Tool-call args are unparseable and cannot be completed: '{"a":1}} {"b":"x\n}'
```

`%r` keeps control characters in model output escaped, and the preview is capped by `INVALID_ARGS_PREVIEW_LIMIT`.

## Behavior

Verified unchanged against the previous implementation by differential fuzzing over randomized payloads and fragmentations, comparing the full per-fragment return sequence and the warning counts. Deliberate trade-offs are preserved and now documented at the lines that implement them: a bracketed value with trailing junk is treated as still-streaming, and a bare scalar that is complete but malformed is not warned about, being indistinguishable from a still-streaming fragment.

Coverage was added for the state that crosses fragment boundaries, which the previous single-pass helpers did not have: the escape flag straddling a boundary, the parse memo invalidating, the open-string term in the completeness gate, the depth guard at its boundary (nesting that `json.loads` would accept, so only the guard can produce the skip), incremental over-closing, the preview cap, and the latch reset.
