### PR TITLE
feat(code): show copy tooltip for thread ID

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/welcome.py
+++ b/libs/code/deepagents_code/tui/widgets/welcome.py
@@ -427,13 +427,16 @@ class WelcomeBanner(Static):
         )
 
     def on_mouse_move(self, event: MouseMove) -> None:
-        """Show a hand pointer over clickable spans and reset it elsewhere."""
-        clickable = bool(event.style.link) or copy_span_target(event.style) is not None
+        """Show pointer and tooltip affordances for interactive spans."""
+        copy_target = copy_span_target(event.style)
+        clickable = bool(event.style.link) or copy_target is not None
         self.styles.pointer = "pointer" if clickable else "default"
+        self.tooltip = "Copy" if copy_target is not None else None
 
     def on_leave(self) -> None:
-        """Reset the pointer shape when the mouse leaves the banner."""
+        """Reset hover affordances when the mouse leaves the banner."""
         self.styles.pointer = "default"
+        self.tooltip = None
 
     def _build_banner(self) -> Content:
         """Build the banner content.

--- a/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
@@ -893,6 +893,19 @@ def _click_offset(banner: WelcomeBanner, needle: str) -> tuple[int, int]:
 class TestThreadIdClickToCopy:
     """Clicking the thread ID copies it; the trace link still opens."""
 
+    async def test_hover_shows_copy_tooltip_only_for_thread_id(self) -> None:
+        """Hovering the thread ID shows `Copy`, then clears it elsewhere."""
+        banner = _make_banner(thread_id="abc-123", show_model=False, env={DEBUG: "1"})
+        app = _BannerApp(banner)
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.hover(banner, offset=_click_offset(banner, "abc-123"))
+            await pilot.pause()
+            assert banner.tooltip == "Copy"
+
+            await pilot.hover(banner, offset=_click_offset(banner, "thread:"))
+            await pilot.pause()
+            assert banner.tooltip is None
+
     async def test_click_copies_thread_id(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Hovering the splash-screen thread ID now displays a “Copy” tooltip.

---

The thread ID was already clickable, but lacked a clear hover affordance. The banner now sets and clears Textual’s tooltip with the copy-span hover state, covered by a pilot regression test.

Made by [Open SWE](https://openswe.vercel.app/agents/af56a37d-5be7-5aee-a85c-c36c06b7c7bd)