### PR TITLE
feat(code): prompt clipboard

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -8,7 +8,7 @@ Regenerate this file with `make commands-catalog` after changing command names,
 aliases, descriptions, visibility, or hidden-command metadata.
 
 
-## Public (40)
+## Public (41)
 
 | Command | Aliases | Description |
 | --- | --- | --- |
@@ -36,6 +36,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/notifications` |  | Configure warning notifications |
 | `/offload` | `/compact` | Summarize and offload older messages to free context |
 | `/plugins` |  | Manage plugins |
+| `/prompts` |  | Search and reuse a previous prompt |
 | `/quit` | `/q` | Exit app |
 | `/reload` |  | Reload environment and config |
 | `/remember` |  | Save useful context to memory or skills |

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -21720,9 +21720,8 @@ class DeepAgentsApp(App):
 
         The first Ctrl+R opens the composer's inline search panel; pressing
         Ctrl+R again while that panel is open escalates to the full
-        `PromptClipboardScreen`. The modal opens directly when the inline tier
-        is unavailable (autocomplete open or composer missing), so the chord
-        never dead-ends.
+        `PromptClipboardScreen`. The modal also opens directly when autocomplete
+        owns the inline rows.
         """
         if self._prompt_clipboard_blocked():
             return
@@ -21750,16 +21749,27 @@ class DeepAgentsApp(App):
             def apply_result() -> None:
                 current_input = self._chat_input
                 if current_input is None:
+                    if result is not None:
+                        self.notify(
+                            "Could not insert the prompt: the composer is gone",
+                            severity="warning",
+                        )
                     return
-                if result is not None:
-                    current_input.insert_at_cursor(result)
+                if result is not None and not current_input.insert_at_cursor(result):
+                    self.notify(
+                        "Could not insert the prompt: the composer is unavailable",
+                        severity="warning",
+                    )
                 current_input.focus_input()
 
             self.call_after_refresh(apply_result)
 
+        prompts = chat_input.recent_prompts()
         self.push_screen(
             PromptClipboardScreen(
-                chat_input.recent_prompts(), initial_query=initial_query
+                prompts,
+                initial_query=initial_query,
+                empty_message=chat_input.prompt_history_error(),
             ),
             handle_result,
         )
@@ -23253,7 +23263,7 @@ class DeepAgentsApp(App):
             under a `ModalScreen` that lacks dedicated `shift+tab` handling
             (as `DebugConsoleScreen` does), so the key would be silently
             swallowed. `PromptClipboardScreen` also steps aside so its own
-            priority `shift+tab -> ignore` binding wins and the key does not
+            priority `shift+tab -> page_newer` binding wins and the key does not
             fall through to `Screen.focus_previous`. Note this keys on the
             action, and `toggle_auto_approve` is also bound to `ctrl+t`, so
             that binding is stepped aside under either screen.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -21769,7 +21769,10 @@ class DeepAgentsApp(App):
             return
 
         # Escalating from the inline panel carries the typed query into the
-        # modal's filter and leaves the draft as the user had it.
+        # modal's filter and leaves the draft as the user had it. The
+        # autocomplete case reaches "modal" without a panel ever opening, so
+        # `escalate_prompt_search` returns "" there and the filter starts
+        # empty.
         self._open_prompt_clipboard_modal(chat_input.escalate_prompt_search())
 
     def _open_prompt_clipboard_modal(self, initial_query: str = "") -> None:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -15233,7 +15233,15 @@ class DeepAgentsApp(App):
                 )
                 await self._mount_message(AppMessage(fail_msg))
         elif cmd == "/prompts":
-            self.action_open_prompt_clipboard()
+            # Unlike Ctrl+R, the command cannot silently no-op. `/prompts`
+            # carries `BypassTier.IMMEDIATE_UI`, so it runs while the agent is
+            # busy -- exactly when an approval is on screen and the clipboard
+            # is blocked. A bare return there reads as a broken command.
+            reason = self._prompt_clipboard_block_reason()
+            if reason is not None:
+                await self._mount_message(AppMessage(reason))
+            else:
+                self.action_open_prompt_clipboard()
         elif cmd == "/editor":
             await self.action_open_editor()
         elif cmd in {"/offload", "/compact"}:
@@ -21700,15 +21708,33 @@ class DeepAgentsApp(App):
         finally:
             restore_focus()
 
+    def _prompt_clipboard_block_reason(self) -> str | None:
+        """Return why the prompt clipboard cannot open, or `None` if it can.
+
+        The reason is user-facing: `/prompts` echoes it so the command never
+        appears to do nothing. `Ctrl+R` discards it, because `check_action`
+        steps the binding aside and the key belongs to whatever is blocking.
+        """
+        if self._chat_input is None:
+            return "The prompt clipboard needs the composer, which is not ready yet."
+        if isinstance(self.screen, ModalScreen):
+            return "Close the open dialog before opening the prompt clipboard."
+        if self._pending_approval_widget is not None:
+            return "Answer the pending approval before opening the prompt clipboard."
+        if self._pending_ask_user_widget is not None:
+            return "Answer the pending question before opening the prompt clipboard."
+        if self._pending_goal_review_widget is not None:
+            return "Finish the goal review before opening the prompt clipboard."
+        return None
+
     def _prompt_clipboard_blocked(self) -> bool:
-        """Return whether another input surface currently owns keyboard input."""
-        return (
-            self._chat_input is None
-            or isinstance(self.screen, ModalScreen)
-            or self._pending_approval_widget is not None
-            or self._pending_ask_user_widget is not None
-            or self._pending_goal_review_widget is not None
-        )
+        """Return whether the prompt clipboard cannot open right now.
+
+        True when the composer does not exist, or when another input surface
+        (a modal, an approval, an ask-user prompt, a goal review) owns the
+        keyboard.
+        """
+        return self._prompt_clipboard_block_reason() is not None
 
     def _inline_prompt_search_active(self) -> bool:
         """Return whether the composer's inline prompt search panel is open."""
@@ -21730,7 +21756,16 @@ class DeepAgentsApp(App):
             return
 
         tier = chat_input.open_prompt_search()
-        if tier in {"inline", "noop"}:
+        if tier == "inline":
+            return
+        if tier == "noop":
+            # The composer is mounted but its text area or search panel is not.
+            # Nothing opens; log it rather than leaving a bare silent return,
+            # since this only happens when the widget tree is malformed.
+            logger.warning(
+                "Prompt search unavailable: composer is missing its text area "
+                "or search panel"
+            )
             return
 
         # Escalating from the inline panel carries the typed query into the

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -23266,15 +23266,15 @@ class DeepAgentsApp(App):
             priority `shift+tab -> page_newer` binding wins and the key does not
             fall through to `Screen.focus_previous`. Note this keys on the
             action, and `toggle_auto_approve` is also bound to `ctrl+t`, so
-            that binding is stepped aside under either screen.
+            that binding is stepped aside under either screen. The composer's
+            inline prompt search gets the same step-aside so shift+tab pages
+            its results, but only while the query input holds focus: an
+            approval that arrives mid-search must keep the chord.
         - `quit_or_interrupt` (`ctrl+c`): the prompt clipboard owns this chord for
             copying the selected prompt rather than the focused search text.
         - `interrupt` (`escape`): while the prompt-search query has focus,
             escape belongs to its abandon-search binding, not the global
             interrupt cascade. A newly focused inline approval keeps priority.
-        - `toggle_auto_approve` (`shift+tab`): while the inline prompt search
-            is open, shift+tab pages its results (the same step-aside the
-            prompt clipboard modal and debug console already get).
         - `approval_reject_with_reason` (`tab`): unlike the other approval keys
             this one must be `priority=True` to beat `Screen`'s
             `tab -> app.focus_next`, which means it would otherwise swallow
@@ -23302,11 +23302,19 @@ class DeepAgentsApp(App):
                 PromptClipboardScreen,
             )
             from deepagents_code.tui.widgets.debug_console import DebugConsoleScreen
+            from deepagents_code.tui.widgets.prompt_search import PromptSearchInput
 
             if isinstance(self.screen, (DebugConsoleScreen, PromptClipboardScreen)):
                 return False
             # The inline prompt search pages its results with shift+tab.
-            if self._inline_prompt_search_active():
+            # Gate on focus, not just on the panel being open. An inline
+            # approval that arrives mid-search takes focus, and its menu needs
+            # shift+tab/ctrl+t to keep toggling auto-approve; stepping aside on
+            # panel state alone also drops shift+tab through to
+            # `Screen.focus_previous`, moving focus off the pending approval.
+            if self._inline_prompt_search_active() and isinstance(
+                self.focused, PromptSearchInput
+            ):
                 return False
         # The prompt-search query owns escape only while it has focus. An inline
         # approval that arrived after search opened must keep the global binding

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -21769,11 +21769,10 @@ class DeepAgentsApp(App):
             )
             return
 
-        # Escalating from the inline panel carries the typed query into the
-        # modal's filter and leaves the draft as the user had it. The
-        # autocomplete case reaches "modal" without a panel ever opening, so
-        # `escalate_prompt_search` returns "" there and the filter starts
-        # empty.
+        # Escalating from the inline panel carries its query into the modal's
+        # filter and leaves the draft as the user had it. The autocomplete
+        # case reaches "modal" without a panel ever opening, so the current
+        # chat input becomes the modal query directly.
         self._open_prompt_clipboard_modal(chat_input.escalate_prompt_search())
 
     def _open_prompt_clipboard_modal(self, initial_query: str = "") -> None:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -15087,6 +15087,7 @@ class DeepAgentsApp(App):
                 f"  {newline_shortcut():<15} Insert newline\n"
                 f"  Ctrl+X          {editor_help}\n"
                 "  Ctrl+R          Search and reuse submitted prompts\n"
+                "                  (press again for the full-screen view)\n"
                 "  Ctrl+N          Review pending notifications\n"
                 "  Ctrl+\\          Toggle the debug console\n"
                 "  Shift+Tab       Toggle auto-approve mode\n"

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -23221,10 +23221,11 @@ class DeepAgentsApp(App):
             cursor-style modals via `_SupportsReverseNav` and otherwise no-ops
             under a `ModalScreen` that lacks dedicated `shift+tab` handling
             (as `DebugConsoleScreen` does), so the key would be silently
-            swallowed. `PromptClipboardScreen` also steps aside so its
-            `action_move_up` method is not mistaken for reverse navigation. Note
-            this keys on the action, and `toggle_auto_approve` is also bound to
-            `ctrl+t`, so that binding is stepped aside under either screen.
+            swallowed. `PromptClipboardScreen` also steps aside so its own
+            priority `shift+tab -> ignore` binding wins and the key does not
+            fall through to `Screen.focus_previous`. Note this keys on the
+            action, and `toggle_auto_approve` is also bound to `ctrl+t`, so
+            that binding is stepped aside under either screen.
         - `quit_or_interrupt` (`ctrl+c`): the prompt clipboard owns this chord for
             copying the selected prompt rather than the focused search text.
         - `approval_reject_with_reason` (`tab`): unlike the other approval keys

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -21800,11 +21800,22 @@ class DeepAgentsApp(App):
             self.call_after_refresh(apply_result)
 
         prompts = chat_input.recent_prompts()
+        history_error = chat_input.prompt_history_error()
+        if history_error is not None and prompts:
+            # `empty_message` only reaches the user when the list is empty, but
+            # `recent_prompts` falls back to this session's entries on a read
+            # failure -- so the common outcome is a non-empty list that looks
+            # complete and is silently truncated. Warn independently of count.
+            self.notify(
+                f"{history_error}; showing this session's prompts only",
+                severity="warning",
+                markup=False,
+            )
         self.push_screen(
             PromptClipboardScreen(
                 prompts,
                 initial_query=initial_query,
-                empty_message=chat_input.prompt_history_error(),
+                empty_message=history_error,
             ),
             handle_result,
         )

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -23259,9 +23259,9 @@ class DeepAgentsApp(App):
             that binding is stepped aside under either screen.
         - `quit_or_interrupt` (`ctrl+c`): the prompt clipboard owns this chord for
             copying the selected prompt rather than the focused search text.
-        - `interrupt` (`escape`): while the composer's inline prompt search is
-            open, escape belongs to the query input's abandon-search binding,
-            not the global interrupt cascade.
+        - `interrupt` (`escape`): while the prompt-search query has focus,
+            escape belongs to its abandon-search binding, not the global
+            interrupt cascade. A newly focused inline approval keeps priority.
         - `toggle_auto_approve` (`shift+tab`): while the inline prompt search
             is open, shift+tab pages its results (the same step-aside the
             prompt clipboard modal and debug console already get).
@@ -23298,10 +23298,14 @@ class DeepAgentsApp(App):
             # The inline prompt search pages its results with shift+tab.
             if self._inline_prompt_search_active():
                 return False
-        # The inline prompt search owns escape (abandon + restore draft) while
-        # open; the focused query input's own binding handles it.
+        # The prompt-search query owns escape only while it has focus. An inline
+        # approval that arrived after search opened must keep the global binding
+        # enabled so `action_interrupt` can reject it.
         if action == "interrupt" and self._inline_prompt_search_active():
-            return False
+            from deepagents_code.tui.widgets.prompt_search import PromptSearchInput
+
+            if isinstance(self.focused, PromptSearchInput):
+                return False
         if action == "quit_or_interrupt":
             from deepagents_code.tui.modals.prompt_clipboard import (
                 PromptClipboardScreen,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3062,6 +3062,13 @@ class DeepAgentsApp(App):
             show=False,
             priority=True,
         ),
+        Binding(
+            "ctrl+r",
+            "open_prompt_clipboard",
+            "Prompt Clipboard",
+            show=False,
+            priority=True,
+        ),
         # `check_action` steps this binding aside (returns `False`) while a
         # `ModelSelectorScreen` is active so the selector's own priority
         # `ctrl+n` (toggle_names) wins; keep the action name in sync there.
@@ -15079,6 +15086,7 @@ class DeepAgentsApp(App):
                 "  Enter           Submit your message\n"
                 f"  {newline_shortcut():<15} Insert newline\n"
                 f"  Ctrl+X          {editor_help}\n"
+                "  Ctrl+R          Search and reuse submitted prompts\n"
                 "  Ctrl+N          Review pending notifications\n"
                 "  Ctrl+\\          Toggle the debug console\n"
                 "  Shift+Tab       Toggle auto-approve mode\n"
@@ -15224,6 +15232,8 @@ class DeepAgentsApp(App):
                     else "Failed to copy latest assistant message to clipboard."
                 )
                 await self._mount_message(AppMessage(fail_msg))
+        elif cmd == "/prompts":
+            self.action_open_prompt_clipboard()
         elif cmd == "/editor":
             await self.action_open_editor()
         elif cmd in {"/offload", "/compact"}:
@@ -21690,6 +21700,42 @@ class DeepAgentsApp(App):
         finally:
             restore_focus()
 
+    def _prompt_clipboard_blocked(self) -> bool:
+        """Return whether another input surface currently owns keyboard input."""
+        return (
+            self._chat_input is None
+            or isinstance(self.screen, ModalScreen)
+            or self._pending_approval_widget is not None
+            or self._pending_ask_user_widget is not None
+            or self._pending_goal_review_widget is not None
+        )
+
+    def action_open_prompt_clipboard(self) -> None:
+        """Open searchable local prompt history without blocking the message pump."""
+        if self._prompt_clipboard_blocked():
+            return
+        chat_input = self._chat_input
+        if chat_input is None:
+            return
+
+        from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
+
+        def handle_result(result: str | None) -> None:
+            def apply_result() -> None:
+                current_input = self._chat_input
+                if current_input is None:
+                    return
+                if result is not None:
+                    current_input.insert_at_cursor(result)
+                current_input.focus_input()
+
+            self.call_after_refresh(apply_result)
+
+        self.push_screen(
+            PromptClipboardScreen(chat_input.recent_prompts()),
+            handle_result,
+        )
+
     async def action_open_editor(self) -> None:
         """Open the focused editable surface in $VISUAL/$EDITOR."""
         goal_editor = self._focused_goal_review_editor()
@@ -23164,6 +23210,8 @@ class DeepAgentsApp(App):
         reverts to the active screen's own handling. Depending on the screen that
         is either a competing screen binding or default key handling:
 
+        - `open_prompt_clipboard` (`ctrl+r`): every modal and inline prompt keeps
+            ownership of the chord, including selectors with their own Ctrl+R.
         - `open_notifications` (`ctrl+n`): `ModelSelectorScreen` has its own
             priority `ctrl+n -> toggle_names` binding that then wins.
         - `toggle_auto_approve` (`shift+tab`): `DebugConsoleScreen` has no
@@ -23173,10 +23221,12 @@ class DeepAgentsApp(App):
             cursor-style modals via `_SupportsReverseNav` and otherwise no-ops
             under a `ModalScreen` that lacks dedicated `shift+tab` handling
             (as `DebugConsoleScreen` does), so the key would be silently
-            swallowed. Note this keys on the action, and `toggle_auto_approve`
-            is also bound to `ctrl+t`, so that (harmless, already a no-op
-            under modals) binding is stepped aside too while the console is
-            open.
+            swallowed. `PromptClipboardScreen` also steps aside so its
+            `action_move_up` method is not mistaken for reverse navigation. Note
+            this keys on the action, and `toggle_auto_approve` is also bound to
+            `ctrl+t`, so that binding is stepped aside under either screen.
+        - `quit_or_interrupt` (`ctrl+c`): the prompt clipboard owns this chord for
+            copying the selected prompt rather than the focused search text.
         - `approval_reject_with_reason` (`tab`): unlike the other approval keys
             this one must be `priority=True` to beat `Screen`'s
             `tab -> app.focus_next`, which means it would otherwise swallow
@@ -23192,15 +23242,27 @@ class DeepAgentsApp(App):
                 active screen or default key handling take the key); `True` to
                 leave it enabled.
         """
+        if action == "open_prompt_clipboard":
+            return not self._prompt_clipboard_blocked()
         if action == "open_notifications":
             from deepagents_code.tui.widgets.model_selector import ModelSelectorScreen
 
             if isinstance(self.screen, ModelSelectorScreen):
                 return False
         if action == "toggle_auto_approve":
+            from deepagents_code.tui.modals.prompt_clipboard import (
+                PromptClipboardScreen,
+            )
             from deepagents_code.tui.widgets.debug_console import DebugConsoleScreen
 
-            if isinstance(self.screen, DebugConsoleScreen):
+            if isinstance(self.screen, (DebugConsoleScreen, PromptClipboardScreen)):
+                return False
+        if action == "quit_or_interrupt":
+            from deepagents_code.tui.modals.prompt_clipboard import (
+                PromptClipboardScreen,
+            )
+
+            if isinstance(self.screen, PromptClipboardScreen):
                 return False
         if action == "approval_reject_with_reason":
             return self._pending_approval_widget is not None and (

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -21711,9 +21711,30 @@ class DeepAgentsApp(App):
         )
 
     def action_open_prompt_clipboard(self) -> None:
-        """Open searchable local prompt history without blocking the message pump."""
+        """Open prompt history: inline panel first, full modal on a second press.
+
+        The first Ctrl+R opens the composer's inline search panel; pressing
+        Ctrl+R again while that panel is open escalates to the full
+        `PromptClipboardScreen`. The modal opens directly when the inline tier
+        is unavailable (autocomplete open or composer missing), so the chord
+        never dead-ends.
+        """
         if self._prompt_clipboard_blocked():
             return
+        chat_input = self._chat_input
+        if chat_input is None:
+            return
+
+        tier = chat_input.open_prompt_search()
+        if tier in {"inline", "noop"}:
+            return
+
+        # Escalating from the inline panel carries the typed query into the
+        # modal's filter and leaves the draft as the user had it.
+        self._open_prompt_clipboard_modal(chat_input.escalate_prompt_search())
+
+    def _open_prompt_clipboard_modal(self, initial_query: str = "") -> None:
+        """Open the full searchable prompt history modal."""
         chat_input = self._chat_input
         if chat_input is None:
             return
@@ -21732,7 +21753,9 @@ class DeepAgentsApp(App):
             self.call_after_refresh(apply_result)
 
         self.push_screen(
-            PromptClipboardScreen(chat_input.recent_prompts()),
+            PromptClipboardScreen(
+                chat_input.recent_prompts(), initial_query=initial_query
+            ),
             handle_result,
         )
 
@@ -23210,8 +23233,11 @@ class DeepAgentsApp(App):
         reverts to the active screen's own handling. Depending on the screen that
         is either a competing screen binding or default key handling:
 
-        - `open_prompt_clipboard` (`ctrl+r`): every modal and inline prompt keeps
+        - `open_prompt_clipboard` (`ctrl+r`): modals and inline prompts keep
             ownership of the chord, including selectors with their own Ctrl+R.
+            The one deliberate pass-through is the composer's inline prompt
+            search panel: it is not a screen, so the key reaches the app
+            action, which lets a second Ctrl+R escalate to the full modal.
         - `open_notifications` (`ctrl+n`): `ModelSelectorScreen` has its own
             priority `ctrl+n -> toggle_names` binding that then wins.
         - `toggle_auto_approve` (`shift+tab`): `DebugConsoleScreen` has no

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -21710,6 +21710,11 @@ class DeepAgentsApp(App):
             or self._pending_goal_review_widget is not None
         )
 
+    def _inline_prompt_search_active(self) -> bool:
+        """Return whether the composer's inline prompt search panel is open."""
+        chat_input = self._chat_input
+        return chat_input is not None and chat_input._prompt_search_active
+
     def action_open_prompt_clipboard(self) -> None:
         """Open prompt history: inline panel first, full modal on a second press.
 
@@ -23254,6 +23259,12 @@ class DeepAgentsApp(App):
             that binding is stepped aside under either screen.
         - `quit_or_interrupt` (`ctrl+c`): the prompt clipboard owns this chord for
             copying the selected prompt rather than the focused search text.
+        - `interrupt` (`escape`): while the composer's inline prompt search is
+            open, escape belongs to the query input's abandon-search binding,
+            not the global interrupt cascade.
+        - `toggle_auto_approve` (`shift+tab`): while the inline prompt search
+            is open, shift+tab pages its results (the same step-aside the
+            prompt clipboard modal and debug console already get).
         - `approval_reject_with_reason` (`tab`): unlike the other approval keys
             this one must be `priority=True` to beat `Screen`'s
             `tab -> app.focus_next`, which means it would otherwise swallow
@@ -23284,6 +23295,13 @@ class DeepAgentsApp(App):
 
             if isinstance(self.screen, (DebugConsoleScreen, PromptClipboardScreen)):
                 return False
+            # The inline prompt search pages its results with shift+tab.
+            if self._inline_prompt_search_active():
+                return False
+        # The inline prompt search owns escape (abandon + restore draft) while
+        # open; the focused query input's own binding handles it.
+        if action == "interrupt" and self._inline_prompt_search_active():
+            return False
         if action == "quit_or_interrupt":
             from deepagents_code.tui.modals.prompt_clipboard import (
                 PromptClipboardScreen,

--- a/libs/code/deepagents_code/clipboard.py
+++ b/libs/code/deepagents_code/clipboard.py
@@ -105,7 +105,7 @@ def copy_text_with_feedback(
     app: App,
     text: str,
     *,
-    failure_noun: Literal["input", "selection"],
+    failure_noun: Literal["input", "prompt", "selection"],
     success_message: str | None = None,
 ) -> bool:
     """Copy text to the clipboard and surface the outcome as a toast.
@@ -117,7 +117,7 @@ def copy_text_with_feedback(
         app: The active Textual app, used for the clipboard backend and toasts.
         text: Text to copy.
         failure_noun: Noun used in the warning toast (e.g. `"input"`,
-            `"selection"`).
+            `"prompt"`, `"selection"`).
         success_message: Toast shown on success. When `None`, success is silent
             (used by the selection-copy path, which has no visible draft to
             confirm).

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -181,6 +181,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
         hidden_keywords="plugin marketplace skills mcp enable disable install",
     ),
     SlashCommand(
+        name="/prompts",
+        description="Search and reuse a previous prompt",
+        bypass_tier=BypassTier.IMMEDIATE_UI,
+        hidden_keywords="history clipboard recent recall submitted",
+    ),
+    SlashCommand(
         name="/model",
         description="Switch models or edit model settings",
         bypass_tier=BypassTier.IMMEDIATE_UI,

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -14,9 +14,8 @@ if TYPE_CHECKING:
     from textual.app import ComposeResult
 
 _TITLE_MAX = 72
-_EXCERPT_MAX = 120
 
-_PROMPT_LIST_MAX_HEIGHT = 10
+_PROMPT_LIST_MAX_HEIGHT = 20
 """Upper bound (in cells) for the prompt list; mirrors the tcss max-height."""
 
 _PROMPT_LIST_MIN_HEIGHT = 1
@@ -32,7 +31,9 @@ class _PromptRow(Static):
 
     @staticmethod
     def _content(prompt: str) -> Content:
-        """Build a bounded literal-text title and excerpt.
+        """Build a bounded literal-text title.
+
+        Rows show only the title; the full prompt renders in the preview pane.
 
         Returns:
             Safe Textual content for the row.
@@ -41,12 +42,7 @@ class _PromptRow(Static):
         title = nonempty[0] if nonempty else prompt.strip()
         if len(title) > _TITLE_MAX:
             title = title[: _TITLE_MAX - 1] + "…"
-        excerpt = " ".join(prompt.split())
-        if len(excerpt) > _EXCERPT_MAX:
-            excerpt = excerpt[: _EXCERPT_MAX - 1] + "…"
-        return Content.assemble(
-            (title or "(empty prompt)", "bold"), (f"\n{excerpt}", "dim")
-        )
+        return Content.styled(title or "(empty prompt)", "bold")
 
 
 class PromptClipboardScreen(ModalScreen[str | None]):

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -19,7 +19,7 @@ from deepagents_code.tui.widgets.prompt_search import (
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
-    from textual.events import MouseMove
+    from textual.events import Click, MouseMove
 
 
 class _PromptRow(Static):
@@ -31,12 +31,14 @@ class _PromptRow(Static):
         self._index = index
 
     def on_mouse_move(self, event: MouseMove) -> None:
-        """Highlight the row under the cursor without submitting it.
+        """Hover-mark the row under the cursor without moving the selection."""
+        event.stop()
+        screen = self.screen
+        if isinstance(screen, PromptClipboardScreen):
+            screen.hover_row(self._index)
 
-        Hover moves the highlight so a following Enter inserts what the user
-        is pointing at; the parent screen maps this row's index into the
-        filtered list.
-        """
+    def on_click(self, event: Click) -> None:
+        """Select the clicked row; Enter is still required to insert it."""
         event.stop()
         screen = self.screen
         if isinstance(screen, PromptClipboardScreen):
@@ -99,6 +101,7 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         self._empty_message = empty_message
         self._selected_index = 0
         self._rows: list[_PromptRow] = []
+        self._hovered_index: int | None = None
 
     @override
     def compose(self) -> ComposeResult:
@@ -182,6 +185,9 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         rows_list = self.query_one("#prompt-list", VerticalScroll)
         await rows_list.remove_children()
         self._rows = []
+        # The hovered row is unmounted below, so its mark dies with it; the
+        # next mouse movement re-marks whichever row the cursor is over.
+        self._hovered_index = None
         if not self._filtered:
             if self._prompts:
                 message = "No matching prompts."
@@ -208,11 +214,28 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             return
         preview.update(Content(self._filtered[self._selected_index]))
 
-    def select_row(self, index: int) -> None:
-        """Highlight the row at `index`, as if navigated to by key.
+    def hover_row(self, index: int) -> None:
+        """Hover-mark the row at `index` without moving the selection.
 
-        Called by a row's mouse hover; Enter is still required to insert.
-        Ignores hovers that arrive while a filter edit is still queued, since
+        Hover is transient pointing, not a commitment: it must not disturb
+        `_selected_index`, or arrow keys would resume from wherever the mouse
+        last rested instead of from the row the user actually selected.
+        """
+        if len(self._rows) != len(self._filtered):
+            # A filter edit is still queued, so row indexes describe the old
+            # list; the hover is stale and the rebuild drops the mark anyway.
+            return
+        if self._hovered_index is not None and self._hovered_index < len(self._rows):
+            self._rows[self._hovered_index].remove_class("prompt-row-hovered")
+        self._hovered_index = index
+        if 0 <= index < len(self._rows):
+            self._rows[index].add_class("prompt-row-hovered")
+
+    def select_row(self, index: int) -> None:
+        """Move the selection to `index`, as if navigated to by key.
+
+        Called by a row's mouse click; Enter is still required to insert.
+        Ignores clicks that arrive while a filter edit is still queued, since
         the row indexes then describe a different list than `_filtered`.
         """
         self._sync_filter_value()
@@ -229,6 +252,14 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         self._rows[index].add_class("prompt-row-selected")
         self._update_preview()
 
+    def _apply_selection(self, index: int) -> None:
+        self._rows[self._selected_index].remove_class("prompt-row-selected")
+        self._selected_index = index
+        selected = self._rows[index]
+        selected.add_class("prompt-row-selected")
+        selected.scroll_visible(animate=False)
+        self._update_preview()
+
     async def _move(self, delta: int) -> None:
         if not self._filtered:
             self.app.bell()
@@ -240,17 +271,11 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             # so settle the render before moving.
             await self._render_rows()
         previous = self._selected_index
-        self._selected_index = max(
-            0, min(self._selected_index + delta, len(self._filtered) - 1)
-        )
-        if previous == self._selected_index:
+        new_index = max(0, min(previous + delta, len(self._filtered) - 1))
+        if previous == new_index:
             self.app.bell()
             return
-        self._rows[previous].remove_class("prompt-row-selected")
-        selected = self._rows[self._selected_index]
-        selected.add_class("prompt-row-selected")
-        selected.scroll_visible(animate=False)
-        self._update_preview()
+        self._apply_selection(new_index)
 
     async def action_move_up(self) -> None:
         """Move selection toward newer prompts."""

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -15,12 +15,6 @@ if TYPE_CHECKING:
 
 _TITLE_MAX = 72
 
-_PROMPT_LIST_MAX_HEIGHT = 20
-"""Upper bound (in cells) for the prompt list; mirrors the tcss max-height."""
-
-_PROMPT_LIST_MIN_HEIGHT = 1
-"""Floor (in cells) so the prompt list never collapses to zero."""
-
 
 class _PromptRow(Static):
     """One prompt summary row."""
@@ -100,34 +94,6 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         """Render the initial rows and focus search."""
         await self._render_rows()
         self.query_one("#prompt-filter", Input).focus()
-        self.call_after_refresh(self._fit_prompt_list)
-
-    def on_resize(self) -> None:
-        """Refit the prompt list when terminal dimensions change."""
-        self.call_after_refresh(self._fit_prompt_list)
-
-    def _fit_prompt_list(self) -> None:
-        """Cap the list so preview and help stay on screen.
-
-        The outer `Vertical` is `height: auto`, so it always grows to its
-        natural content height even when that exceeds the terminal; clamping
-        the container would not shrink its auto-height children. The list is
-        the only child meant to give up space, so its `max-height` is shrunk
-        to what the terminal can actually fit, keeping every control visible
-        — the same approach as the `/model` selector's `_fit_model_list`.
-        """
-        container = self.query_one(Vertical)
-        body = self.query_one("#prompt-list", VerticalScroll)
-        non_body_height = max(0, container.region.height - body.region.height)
-        available_height = self.size.height - non_body_height
-        max_height = max(
-            _PROMPT_LIST_MIN_HEIGHT,
-            min(_PROMPT_LIST_MAX_HEIGHT, available_height),
-        )
-        current = body.styles.max_height
-        if current is not None and current.cells == max_height:
-            return
-        body.styles.max_height = max_height
 
     def on_input_changed(self, event: Input.Changed) -> None:
         """Filter prompts using the current search value."""

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -247,6 +247,18 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         self._update_preview()
 
     def _apply_selection(self, index: int) -> None:
+        """Move the selection to an already-rendered row.
+
+        Preconditions, established by every caller before it gets here:
+        `_rows` mirrors `_filtered` one-to-one, and both `index` and
+        `_selected_index` are in range. Callers settle any queued filter edit
+        (`_sync_filter_value`, then `_render_rows` if the lengths disagree) to
+        guarantee that, which is why this indexes without guarding. A new
+        caller that skips those steps will raise `IndexError` here.
+
+        Args:
+            index: Row to select. Must be a valid index into `_rows`.
+        """
         self._rows[self._selected_index].remove_class("prompt-row-selected")
         self._selected_index = index
         selected = self._rows[index]

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -10,11 +10,15 @@ from textual.content import Content
 from textual.screen import ModalScreen
 from textual.widgets import Input, Static
 
+from deepagents_code.config import get_glyphs
+from deepagents_code.tui.widgets.prompt_search import (
+    PROMPT_SEARCH_PAGE_SIZE,
+    filter_prompts,
+    prompt_title,
+)
+
 if TYPE_CHECKING:
     from textual.app import ComposeResult
-
-_PAGE_SIZE = 5
-"""Rows Tab/Shift+Tab jump through the filtered list, matching the inline panel."""
 
 
 class _PromptRow(Static):
@@ -31,13 +35,13 @@ class _PromptRow(Static):
         Rows show only the title; the full prompt renders in the preview pane.
         The row is one cell high, so overlong titles clip visually; the
         `text-overflow: ellipsis` rule on `.prompt-row` marks the clipped end.
+        The title comes from the inline panel's helper so both tiers summarize a
+        prompt the same way.
 
         Returns:
             Safe Textual content for the row.
         """
-        nonempty = [line.strip() for line in prompt.splitlines() if line.strip()]
-        title = nonempty[0] if nonempty else prompt.strip()
-        return Content.styled(title or "(empty prompt)", "bold")
+        return Content.styled(prompt_title(prompt), "bold")
 
 
 class PromptClipboardScreen(ModalScreen[str | None]):
@@ -46,8 +50,8 @@ class PromptClipboardScreen(ModalScreen[str | None]):
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("up", "move_up", "Up", show=False, priority=True),
         Binding("down", "move_down", "Down", show=False, priority=True),
-        Binding("tab", "page_down", "Page Down", show=False, priority=True),
-        Binding("shift+tab", "page_up", "Page Up", show=False, priority=True),
+        Binding("tab", "page_older", "Page Down", show=False, priority=True),
+        Binding("shift+tab", "page_newer", "Page Up", show=False, priority=True),
         Binding("enter", "select", "Insert", show=False, priority=True),
         Binding("ctrl+c", "copy", "Copy", show=False, priority=True),
         Binding("escape", "cancel", "Cancel", show=False, priority=True),
@@ -55,7 +59,13 @@ class PromptClipboardScreen(ModalScreen[str | None]):
 
     CSS_PATH = "prompt_clipboard.tcss"
 
-    def __init__(self, prompts: tuple[str, ...], initial_query: str = "") -> None:
+    def __init__(
+        self,
+        prompts: tuple[str, ...],
+        initial_query: str = "",
+        *,
+        empty_message: str | None = None,
+    ) -> None:
         """Initialize the modal with a newest-first prompt snapshot.
 
         Args:
@@ -63,12 +73,16 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             initial_query: Filter text to seed the search input with, used when
                 escalating from the inline search panel so the typed query
                 carries over.
+            empty_message: Replaces the "no prompts yet" text when `prompts` is
+                empty for a reason worth naming, such as an unreadable history
+                file.
         """
         super().__init__()
         self._prompts = prompts
         self._filtered = list(prompts)
         self._filter_value = ""
         self._initial_query = initial_query
+        self._empty_message = empty_message
         self._selected_index = 0
         self._rows: list[_PromptRow] = []
 
@@ -89,8 +103,18 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             yield Static("Preview", classes="prompt-preview-label")
             with VerticalScroll(id="prompt-preview-scroll"):
                 yield Static("", id="prompt-preview")
+            glyphs = get_glyphs()
+            sep = f"  {glyphs.bullet}  "
             yield Static(
-                "↑/↓ navigate  •  Enter insert  •  Ctrl+C copy  •  Esc cancel",
+                sep.join(
+                    (
+                        f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate",
+                        "Tab/Shift+Tab page",
+                        "Enter insert",
+                        "Ctrl+C copy",
+                        "Esc cancel",
+                    )
+                ),
                 classes="prompt-help",
             )
 
@@ -114,17 +138,26 @@ class PromptClipboardScreen(ModalScreen[str | None]):
     def _apply_filter(self, value: str) -> None:
         """Synchronize filtered prompts with literal search text."""
         self._filter_value = value
-        query = value.strip().casefold()
-        self._filtered = [
-            prompt for prompt in self._prompts if query in prompt.casefold()
-        ]
+        self._filtered = list(filter_prompts(self._prompts, value))
         self._selected_index = 0
 
     def _sync_filter_value(self) -> None:
         """Consume a filter edit whose Changed message is still queued."""
         value = self.query_one("#prompt-filter", Input).value
-        if value != self._filter_value:
-            self._apply_filter(value)
+        if value == self._filter_value:
+            return
+        # The highlighted row is what the user is acting on, so follow that
+        # prompt into the new list rather than snapping to index 0 and copying
+        # or inserting something they never selected.
+        selected = (
+            self._filtered[self._selected_index]
+            if 0 <= self._selected_index < len(self._filtered)
+            else None
+        )
+        self._apply_filter(value)
+        if selected is not None and selected in self._filtered:
+            self._selected_index = self._filtered.index(selected)
+        self.call_after_refresh(self._render_rows)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Insert the selected prompt when search receives Enter."""
@@ -136,11 +169,13 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         await rows_list.remove_children()
         self._rows = []
         if not self._filtered:
-            message = (
-                "No matching prompts."
-                if self._prompts
-                else "No prompts yet. Submitted prompts appear here."
-            )
+            if self._prompts:
+                message = "No matching prompts."
+            else:
+                message = (
+                    self._empty_message
+                    or "No prompts yet. Submitted prompts appear here."
+                )
             await rows_list.mount(Static(Content.styled(message, "dim")))
             self.query_one("#prompt-preview", Static).update("")
             return
@@ -159,10 +194,16 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             return
         preview.update(Content(self._filtered[self._selected_index]))
 
-    def _move(self, delta: int) -> None:
+    async def _move(self, delta: int) -> None:
         if not self._filtered:
             self.app.bell()
             return
+        if len(self._rows) != len(self._filtered):
+            # A filter edit already updated `_filtered` but its deferred
+            # `_render_rows` has not landed, so the rows still describe the old
+            # list. Indexing them with a bound taken from the new one raises,
+            # so settle the render before moving.
+            await self._render_rows()
         previous = self._selected_index
         self._selected_index = max(
             0, min(self._selected_index + delta, len(self._filtered) - 1)
@@ -176,21 +217,25 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         selected.scroll_visible(animate=False)
         self._update_preview()
 
-    def action_move_up(self) -> None:
+    async def action_move_up(self) -> None:
         """Move selection toward newer prompts."""
-        self._move(-1)
+        await self._move(-1)
 
-    def action_move_down(self) -> None:
+    async def action_move_down(self) -> None:
         """Move selection toward older prompts."""
-        self._move(1)
+        await self._move(1)
 
-    def action_page_up(self) -> None:
-        """Jump selection one page toward newer prompts."""
-        self._move(-_PAGE_SIZE)
+    async def action_page_newer(self) -> None:
+        """Jump selection one page toward newer prompts.
 
-    def action_page_down(self) -> None:
+        Named for direction rather than `page_up`/`page_down`, which are
+        sync `Widget` methods this would otherwise override incompatibly.
+        """
+        await self._move(-PROMPT_SEARCH_PAGE_SIZE)
+
+    async def action_page_older(self) -> None:
         """Jump selection one page toward older prompts."""
-        self._move(_PAGE_SIZE)
+        await self._move(PROMPT_SEARCH_PAGE_SIZE)
 
     def action_select(self) -> None:
         """Dismiss with the selected prompt."""
@@ -218,6 +263,3 @@ class PromptClipboardScreen(ModalScreen[str | None]):
     def action_cancel(self) -> None:
         """Dismiss without selecting a prompt."""
         self.dismiss(None)
-
-    def action_ignore(self) -> None:
-        """Swallow a key that has no meaning in this modal."""

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -13,8 +13,6 @@ from textual.widgets import Input, Static
 if TYPE_CHECKING:
     from textual.app import ComposeResult
 
-_TITLE_MAX = 72
-
 
 class _PromptRow(Static):
     """One prompt summary row."""
@@ -25,17 +23,17 @@ class _PromptRow(Static):
 
     @staticmethod
     def _content(prompt: str) -> Content:
-        """Build a bounded literal-text title.
+        """Build a single-line literal-text title.
 
         Rows show only the title; the full prompt renders in the preview pane.
+        The row is one cell high, so overlong titles clip visually; the
+        `text-overflow: ellipsis` rule on `.prompt-row` marks the clipped end.
 
         Returns:
             Safe Textual content for the row.
         """
         nonempty = [line.strip() for line in prompt.splitlines() if line.strip()]
         title = nonempty[0] if nonempty else prompt.strip()
-        if len(title) > _TITLE_MAX:
-            title = title[: _TITLE_MAX - 1] + "…"
         return Content.styled(title or "(empty prompt)", "bold")
 
 

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -233,6 +233,12 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         self._update_preview()
 
     async def _move(self, delta: int) -> None:
+        # Every user-facing action settles a queued filter edit first. Without
+        # this, an edit whose `Changed` message has not been dispatched yet
+        # leaves `_filtered` and `_rows` both describing the pre-edit list --
+        # the lengths match, the guard below does not fire, and the arrow keys
+        # navigate a list the user has already filtered away from.
+        self._sync_filter_value()
         if not self._filtered:
             self.app.bell()
             return

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, ClassVar, override
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical, VerticalScroll
 from textual.content import Content
+from textual.message import Message
 from textual.screen import ModalScreen
 from textual.widgets import Input, Static
 
@@ -22,20 +23,36 @@ if TYPE_CHECKING:
     from textual.events import Click
 
 
-class _PromptRow(Static):
-    """One prompt summary row."""
+class PromptRow(Static):
+    """One prompt summary row.
+
+    Public so its `Clicked` message resolves to the idiomatic
+    `on_prompt_row_clicked` handler; nothing outside this module builds one.
+    """
+
+    class Clicked(Message):
+        """Message sent when a prompt row is clicked."""
+
+        def __init__(self, index: int) -> None:
+            """Initialize with the clicked row index."""
+            super().__init__()
+            self.index = index
 
     def __init__(self, prompt: str, index: int, *, selected: bool) -> None:
+        """Initialize the row with its title, list position, and selection."""
         classes = "prompt-row prompt-row-selected" if selected else "prompt-row"
         super().__init__(self._content(prompt), classes=classes)
         self._index = index
 
     def on_click(self, event: Click) -> None:
-        """Select the clicked row; Enter is still required to insert it."""
+        """Announce the click; Enter is still required to insert the prompt.
+
+        Posting a message rather than calling back into the screen keeps the
+        row independent of what contains it, and matches how
+        `PromptSearchOption` reports clicks in the inline panel.
+        """
         event.stop()
-        screen = self.screen
-        if isinstance(screen, PromptClipboardScreen):
-            screen.select_row(self._index)
+        self.post_message(self.Clicked(self._index))
 
     @staticmethod
     def _content(prompt: str) -> Content:
@@ -93,7 +110,7 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         self._initial_query = initial_query
         self._empty_message = empty_message
         self._selected_index = 0
-        self._rows: list[_PromptRow] = []
+        self._rows: list[PromptRow] = []
 
     @override
     def compose(self) -> ComposeResult:
@@ -190,7 +207,7 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             return
 
         self._rows = [
-            _PromptRow(prompt, index, selected=index == self._selected_index)
+            PromptRow(prompt, index, selected=index == self._selected_index)
             for index, prompt in enumerate(self._filtered)
         ]
         await rows_list.mount(*self._rows)
@@ -203,12 +220,17 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             return
         preview.update(Content(self._filtered[self._selected_index]))
 
-    def select_row(self, index: int) -> None:
+    def on_prompt_row_clicked(self, event: PromptRow.Clicked) -> None:
+        """Move the selection to the clicked row."""
+        event.stop()
+        self._select_row(event.index)
+
+    def _select_row(self, index: int) -> None:
         """Move the selection to `index`, as if navigated to by key.
 
-        Called by a row's mouse click; Enter is still required to insert.
-        Ignores clicks that arrive while a filter edit is still queued, since
-        the row indexes then describe a different list than `_filtered`.
+        Enter is still required to insert. Ignores clicks that arrive while a
+        filter edit is still queued, since the row indexes then describe a
+        different list than `_filtered`.
         """
         self._sync_filter_value()
         if (

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -54,6 +54,13 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         Binding("enter", "select", "Insert", show=False, priority=True),
         Binding("ctrl+c", "copy", "Copy", show=False, priority=True),
         Binding("escape", "cancel", "Cancel", show=False, priority=True),
+        # The search input is the only focusable widget, so focus traversal
+        # would just leave and re-enter it; swallow tab and shift+tab instead.
+        # Without the shift+tab binding the app's `check_action` steps its
+        # priority binding aside for this screen, and the key would fall
+        # through to `Screen.focus_previous`.
+        Binding("tab", "ignore", "Ignore", show=False, priority=True),
+        Binding("shift+tab", "ignore", "Ignore", show=False, priority=True),
     ]
 
     CSS_PATH = "prompt_clipboard.tcss"
@@ -226,3 +233,6 @@ class PromptClipboardScreen(ModalScreen[str | None]):
     def action_cancel(self) -> None:
         """Dismiss without selecting a prompt."""
         self.dismiss(None)
+
+    def action_ignore(self) -> None:
+        """Swallow a key that has no meaning in this modal."""

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar, override
 
 from textual.binding import Binding, BindingType
-from textual.containers import Container, Vertical, VerticalScroll
+from textual.containers import Vertical, VerticalScroll
 from textual.content import Content
 from textual.screen import ModalScreen
 from textual.widgets import Input, Static
@@ -15,6 +15,12 @@ if TYPE_CHECKING:
 
 _TITLE_MAX = 72
 _EXCERPT_MAX = 120
+
+_PROMPT_LIST_MAX_HEIGHT = 10
+"""Upper bound (in cells) for the prompt list; mirrors the tcss max-height."""
+
+_PROMPT_LIST_MIN_HEIGHT = 1
+"""Floor (in cells) so the prompt list never collapses to zero."""
 
 
 class _PromptRow(Static):
@@ -75,8 +81,10 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         with Vertical():
             yield Static("Prompt Clipboard", classes="prompt-title")
             yield Input(placeholder="Search submitted prompts", id="prompt-filter")
-            with VerticalScroll(id="prompt-list"):
-                yield Container(id="prompt-rows")
+            # Rows mount directly into the scroll container: a nested
+            # auto-height wrapper is clamped to the list's max-height, which
+            # hides the overflow and leaves the list unscrollable.
+            yield VerticalScroll(id="prompt-list")
             yield Static("Preview", classes="prompt-preview-label")
             with VerticalScroll(id="prompt-preview-scroll"):
                 yield Static("", id="prompt-preview")
@@ -89,6 +97,34 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         """Render the initial rows and focus search."""
         await self._render_rows()
         self.query_one("#prompt-filter", Input).focus()
+        self.call_after_refresh(self._fit_prompt_list)
+
+    def on_resize(self) -> None:
+        """Refit the prompt list when terminal dimensions change."""
+        self.call_after_refresh(self._fit_prompt_list)
+
+    def _fit_prompt_list(self) -> None:
+        """Cap the list so preview and help stay on screen.
+
+        The outer `Vertical` is `height: auto`, so it always grows to its
+        natural content height even when that exceeds the terminal; clamping
+        the container would not shrink its auto-height children. The list is
+        the only child meant to give up space, so its `max-height` is shrunk
+        to what the terminal can actually fit, keeping every control visible
+        — the same approach as the `/model` selector's `_fit_model_list`.
+        """
+        container = self.query_one(Vertical)
+        body = self.query_one("#prompt-list", VerticalScroll)
+        non_body_height = max(0, container.region.height - body.region.height)
+        available_height = self.size.height - non_body_height
+        max_height = max(
+            _PROMPT_LIST_MIN_HEIGHT,
+            min(_PROMPT_LIST_MAX_HEIGHT, available_height),
+        )
+        current = body.styles.max_height
+        if current is not None and current.cells == max_height:
+            return
+        body.styles.max_height = max_height
 
     def on_input_changed(self, event: Input.Changed) -> None:
         """Filter prompts using the current search value."""
@@ -116,8 +152,8 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         self.action_select()
 
     async def _render_rows(self) -> None:
-        container = self.query_one("#prompt-rows", Container)
-        await container.remove_children()
+        rows_list = self.query_one("#prompt-list", VerticalScroll)
+        await rows_list.remove_children()
         self._rows = []
         if not self._filtered:
             message = (
@@ -125,7 +161,7 @@ class PromptClipboardScreen(ModalScreen[str | None]):
                 if self._prompts
                 else "No prompts yet. Submitted prompts appear here."
             )
-            await container.mount(Static(Content.styled(message, "dim")))
+            await rows_list.mount(Static(Content.styled(message, "dim")))
             self.query_one("#prompt-preview", Static).update("")
             return
 
@@ -133,7 +169,7 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             _PromptRow(prompt, selected=index == self._selected_index)
             for index, prompt in enumerate(self._filtered)
         ]
-        await container.mount(*self._rows)
+        await rows_list.mount(*self._rows)
         self._update_preview()
 
     def _update_preview(self) -> None:
@@ -157,7 +193,7 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         self._rows[previous].remove_class("prompt-row-selected")
         selected = self._rows[self._selected_index]
         selected.add_class("prompt-row-selected")
-        selected.scroll_visible()
+        selected.scroll_visible(animate=False)
         self._update_preview()
 
     def action_move_up(self) -> None:

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -96,9 +96,8 @@ class PromptClipboardScreen(ModalScreen[str | None]):
 
         Args:
             prompts: Unique prompts, newest first.
-            initial_query: Filter text to seed the search input with, used when
-                escalating from the inline search panel so the typed query
-                carries over.
+            initial_query: Filter text to seed the search input with, either
+                from the chat input or an inline search query.
             empty_message: Replaces the "no prompts yet" text when `prompts` is
                 empty for a reason worth naming, such as an unreadable history
                 file.

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -13,6 +13,9 @@ from textual.widgets import Input, Static
 if TYPE_CHECKING:
     from textual.app import ComposeResult
 
+_PAGE_SIZE = 5
+"""Rows Tab/Shift+Tab jump through the filtered list, matching the inline panel."""
+
 
 class _PromptRow(Static):
     """One prompt summary row."""
@@ -43,16 +46,11 @@ class PromptClipboardScreen(ModalScreen[str | None]):
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("up", "move_up", "Up", show=False, priority=True),
         Binding("down", "move_down", "Down", show=False, priority=True),
+        Binding("tab", "page_down", "Page Down", show=False, priority=True),
+        Binding("shift+tab", "page_up", "Page Up", show=False, priority=True),
         Binding("enter", "select", "Insert", show=False, priority=True),
         Binding("ctrl+c", "copy", "Copy", show=False, priority=True),
         Binding("escape", "cancel", "Cancel", show=False, priority=True),
-        # The search input is the only focusable widget, so focus traversal
-        # would just leave and re-enter it; swallow tab and shift+tab instead.
-        # Without the shift+tab binding the app's `check_action` steps its
-        # priority binding aside for this screen, and the key would fall
-        # through to `Screen.focus_previous`.
-        Binding("tab", "ignore", "Ignore", show=False, priority=True),
-        Binding("shift+tab", "ignore", "Ignore", show=False, priority=True),
     ]
 
     CSS_PATH = "prompt_clipboard.tcss"
@@ -185,6 +183,14 @@ class PromptClipboardScreen(ModalScreen[str | None]):
     def action_move_down(self) -> None:
         """Move selection toward older prompts."""
         self._move(1)
+
+    def action_page_up(self) -> None:
+        """Jump selection one page toward newer prompts."""
+        self._move(-_PAGE_SIZE)
+
+    def action_page_down(self) -> None:
+        """Jump selection one page toward older prompts."""
+        self._move(_PAGE_SIZE)
 
     def action_select(self) -> None:
         """Dismiss with the selected prompt."""

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -19,7 +19,7 @@ from deepagents_code.tui.widgets.prompt_search import (
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
-    from textual.events import Click, MouseMove
+    from textual.events import Click
 
 
 class _PromptRow(Static):
@@ -29,13 +29,6 @@ class _PromptRow(Static):
         classes = "prompt-row prompt-row-selected" if selected else "prompt-row"
         super().__init__(self._content(prompt), classes=classes)
         self._index = index
-
-    def on_mouse_move(self, event: MouseMove) -> None:
-        """Hover-mark the row under the cursor without moving the selection."""
-        event.stop()
-        screen = self.screen
-        if isinstance(screen, PromptClipboardScreen):
-            screen.hover_row(self._index)
 
     def on_click(self, event: Click) -> None:
         """Select the clicked row; Enter is still required to insert it."""
@@ -101,7 +94,6 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         self._empty_message = empty_message
         self._selected_index = 0
         self._rows: list[_PromptRow] = []
-        self._hovered_index: int | None = None
 
     @override
     def compose(self) -> ComposeResult:
@@ -185,9 +177,6 @@ class PromptClipboardScreen(ModalScreen[str | None]):
         rows_list = self.query_one("#prompt-list", VerticalScroll)
         await rows_list.remove_children()
         self._rows = []
-        # The hovered row is unmounted below, so its mark dies with it; the
-        # next mouse movement re-marks whichever row the cursor is over.
-        self._hovered_index = None
         if not self._filtered:
             if self._prompts:
                 message = "No matching prompts."
@@ -213,23 +202,6 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             preview.update("")
             return
         preview.update(Content(self._filtered[self._selected_index]))
-
-    def hover_row(self, index: int) -> None:
-        """Hover-mark the row at `index` without moving the selection.
-
-        Hover is transient pointing, not a commitment: it must not disturb
-        `_selected_index`, or arrow keys would resume from wherever the mouse
-        last rested instead of from the row the user actually selected.
-        """
-        if len(self._rows) != len(self._filtered):
-            # A filter edit is still queued, so row indexes describe the old
-            # list; the hover is stale and the rebuild drops the mark anyway.
-            return
-        if self._hovered_index is not None and self._hovered_index < len(self._rows):
-            self._rows[self._hovered_index].remove_class("prompt-row-hovered")
-        self._hovered_index = index
-        if 0 <= index < len(self._rows):
-            self._rows[index].add_class("prompt-row-hovered")
 
     def select_row(self, index: int) -> None:
         """Move the selection to `index`, as if navigated to by key.

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -19,14 +19,28 @@ from deepagents_code.tui.widgets.prompt_search import (
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
+    from textual.events import MouseMove
 
 
 class _PromptRow(Static):
     """One prompt summary row."""
 
-    def __init__(self, prompt: str, *, selected: bool) -> None:
+    def __init__(self, prompt: str, index: int, *, selected: bool) -> None:
         classes = "prompt-row prompt-row-selected" if selected else "prompt-row"
         super().__init__(self._content(prompt), classes=classes)
+        self._index = index
+
+    def on_mouse_move(self, event: MouseMove) -> None:
+        """Highlight the row under the cursor without submitting it.
+
+        Hover moves the highlight so a following Enter inserts what the user
+        is pointing at; the parent screen maps this row's index into the
+        filtered list.
+        """
+        event.stop()
+        screen = self.screen
+        if isinstance(screen, PromptClipboardScreen):
+            screen.select_row(self._index)
 
     @staticmethod
     def _content(prompt: str) -> Content:
@@ -181,7 +195,7 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             return
 
         self._rows = [
-            _PromptRow(prompt, selected=index == self._selected_index)
+            _PromptRow(prompt, index, selected=index == self._selected_index)
             for index, prompt in enumerate(self._filtered)
         ]
         await rows_list.mount(*self._rows)
@@ -193,6 +207,27 @@ class PromptClipboardScreen(ModalScreen[str | None]):
             preview.update("")
             return
         preview.update(Content(self._filtered[self._selected_index]))
+
+    def select_row(self, index: int) -> None:
+        """Highlight the row at `index`, as if navigated to by key.
+
+        Called by a row's mouse hover; Enter is still required to insert.
+        Ignores hovers that arrive while a filter edit is still queued, since
+        the row indexes then describe a different list than `_filtered`.
+        """
+        self._sync_filter_value()
+        if (
+            not self._filtered
+            or len(self._rows) != len(self._filtered)
+            or index == self._selected_index
+            or not 0 <= index < len(self._rows)
+        ):
+            return
+        previous = self._selected_index
+        self._selected_index = index
+        self._rows[previous].remove_class("prompt-row-selected")
+        self._rows[index].add_class("prompt-row-selected")
+        self._update_preview()
 
     async def _move(self, delta: int) -> None:
         if not self._filtered:

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -57,12 +57,20 @@ class PromptClipboardScreen(ModalScreen[str | None]):
 
     CSS_PATH = "prompt_clipboard.tcss"
 
-    def __init__(self, prompts: tuple[str, ...]) -> None:
-        """Initialize the modal with a newest-first prompt snapshot."""
+    def __init__(self, prompts: tuple[str, ...], initial_query: str = "") -> None:
+        """Initialize the modal with a newest-first prompt snapshot.
+
+        Args:
+            prompts: Unique prompts, newest first.
+            initial_query: Filter text to seed the search input with, used when
+                escalating from the inline search panel so the typed query
+                carries over.
+        """
         super().__init__()
         self._prompts = prompts
         self._filtered = list(prompts)
         self._filter_value = ""
+        self._initial_query = initial_query
         self._selected_index = 0
         self._rows: list[_PromptRow] = []
 
@@ -90,8 +98,15 @@ class PromptClipboardScreen(ModalScreen[str | None]):
 
     async def on_mount(self) -> None:
         """Render the initial rows and focus search."""
+        if self._initial_query:
+            search = self.query_one("#prompt-filter", Input)
+            search.value = self._initial_query
+            self._apply_filter(self._initial_query)
         await self._render_rows()
-        self.query_one("#prompt-filter", Input).focus()
+        search = self.query_one("#prompt-filter", Input)
+        search.focus()
+        if self._initial_query:
+            search.cursor_position = len(self._initial_query)
 
     def on_input_changed(self, event: Input.Changed) -> None:
         """Filter prompts using the current search value."""

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.py
@@ -1,0 +1,196 @@
+"""Searchable local prompt history modal."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, override
+
+from textual.binding import Binding, BindingType
+from textual.containers import Container, Vertical, VerticalScroll
+from textual.content import Content
+from textual.screen import ModalScreen
+from textual.widgets import Input, Static
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+_TITLE_MAX = 72
+_EXCERPT_MAX = 120
+
+
+class _PromptRow(Static):
+    """One prompt summary row."""
+
+    def __init__(self, prompt: str, *, selected: bool) -> None:
+        classes = "prompt-row prompt-row-selected" if selected else "prompt-row"
+        super().__init__(self._content(prompt), classes=classes)
+
+    @staticmethod
+    def _content(prompt: str) -> Content:
+        """Build a bounded literal-text title and excerpt.
+
+        Returns:
+            Safe Textual content for the row.
+        """
+        nonempty = [line.strip() for line in prompt.splitlines() if line.strip()]
+        title = nonempty[0] if nonempty else prompt.strip()
+        if len(title) > _TITLE_MAX:
+            title = title[: _TITLE_MAX - 1] + "…"
+        excerpt = " ".join(prompt.split())
+        if len(excerpt) > _EXCERPT_MAX:
+            excerpt = excerpt[: _EXCERPT_MAX - 1] + "…"
+        return Content.assemble(
+            (title or "(empty prompt)", "bold"), (f"\n{excerpt}", "dim")
+        )
+
+
+class PromptClipboardScreen(ModalScreen[str | None]):
+    """Filter, preview, copy, or select a previously submitted prompt."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("up", "move_up", "Up", show=False, priority=True),
+        Binding("down", "move_down", "Down", show=False, priority=True),
+        Binding("enter", "select", "Insert", show=False, priority=True),
+        Binding("ctrl+c", "copy", "Copy", show=False, priority=True),
+        Binding("escape", "cancel", "Cancel", show=False, priority=True),
+    ]
+
+    CSS_PATH = "prompt_clipboard.tcss"
+
+    def __init__(self, prompts: tuple[str, ...]) -> None:
+        """Initialize the modal with a newest-first prompt snapshot."""
+        super().__init__()
+        self._prompts = prompts
+        self._filtered = list(prompts)
+        self._filter_value = ""
+        self._selected_index = 0
+        self._rows: list[_PromptRow] = []
+
+    @override
+    def compose(self) -> ComposeResult:
+        """Compose the filter, results, preview, and keyboard help.
+
+        Yields:
+            Widgets for the prompt clipboard.
+        """
+        with Vertical():
+            yield Static("Prompt Clipboard", classes="prompt-title")
+            yield Input(placeholder="Search submitted prompts", id="prompt-filter")
+            with VerticalScroll(id="prompt-list"):
+                yield Container(id="prompt-rows")
+            yield Static("Preview", classes="prompt-preview-label")
+            with VerticalScroll(id="prompt-preview-scroll"):
+                yield Static("", id="prompt-preview")
+            yield Static(
+                "↑/↓ navigate  •  Enter insert  •  Ctrl+C copy  •  Esc cancel",
+                classes="prompt-help",
+            )
+
+    async def on_mount(self) -> None:
+        """Render the initial rows and focus search."""
+        await self._render_rows()
+        self.query_one("#prompt-filter", Input).focus()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Filter prompts using the current search value."""
+        self._apply_filter(event.value)
+        self.call_after_refresh(self._render_rows)
+
+    def _apply_filter(self, value: str) -> None:
+        """Synchronize filtered prompts with literal search text."""
+        self._filter_value = value
+        query = value.strip().casefold()
+        self._filtered = [
+            prompt for prompt in self._prompts if query in prompt.casefold()
+        ]
+        self._selected_index = 0
+
+    def _sync_filter_value(self) -> None:
+        """Consume a filter edit whose Changed message is still queued."""
+        value = self.query_one("#prompt-filter", Input).value
+        if value != self._filter_value:
+            self._apply_filter(value)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Insert the selected prompt when search receives Enter."""
+        event.stop()
+        self.action_select()
+
+    async def _render_rows(self) -> None:
+        container = self.query_one("#prompt-rows", Container)
+        await container.remove_children()
+        self._rows = []
+        if not self._filtered:
+            message = (
+                "No matching prompts."
+                if self._prompts
+                else "No prompts yet. Submitted prompts appear here."
+            )
+            await container.mount(Static(Content.styled(message, "dim")))
+            self.query_one("#prompt-preview", Static).update("")
+            return
+
+        self._rows = [
+            _PromptRow(prompt, selected=index == self._selected_index)
+            for index, prompt in enumerate(self._filtered)
+        ]
+        await container.mount(*self._rows)
+        self._update_preview()
+
+    def _update_preview(self) -> None:
+        preview = self.query_one("#prompt-preview", Static)
+        if not self._filtered:
+            preview.update("")
+            return
+        preview.update(Content(self._filtered[self._selected_index]))
+
+    def _move(self, delta: int) -> None:
+        if not self._filtered:
+            self.app.bell()
+            return
+        previous = self._selected_index
+        self._selected_index = max(
+            0, min(self._selected_index + delta, len(self._filtered) - 1)
+        )
+        if previous == self._selected_index:
+            self.app.bell()
+            return
+        self._rows[previous].remove_class("prompt-row-selected")
+        selected = self._rows[self._selected_index]
+        selected.add_class("prompt-row-selected")
+        selected.scroll_visible()
+        self._update_preview()
+
+    def action_move_up(self) -> None:
+        """Move selection toward newer prompts."""
+        self._move(-1)
+
+    def action_move_down(self) -> None:
+        """Move selection toward older prompts."""
+        self._move(1)
+
+    def action_select(self) -> None:
+        """Dismiss with the selected prompt."""
+        self._sync_filter_value()
+        if self._filtered:
+            self.dismiss(self._filtered[self._selected_index])
+        else:
+            self.app.bell()
+
+    def action_copy(self) -> None:
+        """Copy the selected prompt without dismissing the modal."""
+        self._sync_filter_value()
+        if not self._filtered:
+            self.app.bell()
+            return
+        from deepagents_code.clipboard import copy_text_with_feedback
+
+        copy_text_with_feedback(
+            self.app,
+            self._filtered[self._selected_index],
+            failure_noun="prompt",
+            success_message="Prompt copied to clipboard",
+        )
+
+    def action_cancel(self) -> None:
+        """Dismiss without selecting a prompt."""
+        self.dismiss(None)

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -21,12 +21,19 @@ PromptClipboardScreen .prompt-title {
 }
 
 PromptClipboardScreen #prompt-filter {
-    /* Vertical spacing lives on the two fixed-height boxes (this input and the
-       preview) as padding. Margins and padding on auto-height widgets are not
-       deducted from the fr list's share, so they would push the controls below
-       past the fixed modal's edge; border-box fixed boxes absorb padding
-       without inflating their footprint. */
-    padding-bottom: 1;
+    /* The input is 3 rows tall and its default `tall` border occupies the top
+       and bottom rows, leaving exactly one row for text. Any vertical padding
+       would consume that row and collapse the content region to zero height,
+       hiding the placeholder and typed text entirely — so padding stays
+       zero. */
+    padding: 0;
+}
+
+PromptClipboardScreen #prompt-filter > .input--placeholder {
+    /* The default placeholder color is $text-disabled (dim gray), which is
+       nearly invisible on the dark input background. Use muted text so the
+       "Search submitted prompts" hint is actually readable. */
+    color: $text-muted;
 }
 
 PromptClipboardScreen #prompt-list {
@@ -73,7 +80,7 @@ PromptClipboardScreen #prompt-preview-scroll {
     height: 1fr;
     min-height: 0;
     max-height: 8;
-    border: round $surface-lighten-2;
+    border: solid $surface-lighten-2;
     padding: 1 1 0 1;
     /* Match the prompt list's content width: the list reserves a stable
        gutter for its vertical scrollbar, so the preview box would otherwise

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -1,0 +1,69 @@
+PromptClipboardScreen {
+    align: center middle;
+}
+
+PromptClipboardScreen > Vertical {
+    width: 90%;
+    max-width: 100;
+    height: auto;
+    max-height: 90%;
+    background: $surface;
+    border: solid $primary;
+    padding: 1 2;
+}
+
+PromptClipboardScreen .prompt-title {
+    height: auto;
+    text-style: bold;
+    color: $primary;
+    text-align: center;
+    margin-bottom: 1;
+}
+
+PromptClipboardScreen #prompt-filter {
+    margin-bottom: 1;
+}
+
+PromptClipboardScreen #prompt-list {
+    height: auto;
+    min-height: 3;
+    max-height: 10;
+    background: $background;
+    scrollbar-gutter: stable;
+}
+
+PromptClipboardScreen .prompt-row {
+    height: 2;
+    padding: 0 1;
+}
+
+PromptClipboardScreen .prompt-row-selected {
+    background: $primary;
+    color: $background;
+}
+
+PromptClipboardScreen .prompt-preview-label {
+    height: auto;
+    color: $text-muted;
+    margin-top: 1;
+}
+
+PromptClipboardScreen #prompt-preview-scroll {
+    height: auto;
+    min-height: 3;
+    max-height: 8;
+    border: round $surface-lighten-2;
+    padding: 0 1;
+}
+
+PromptClipboardScreen #prompt-preview {
+    height: auto;
+}
+
+PromptClipboardScreen .prompt-help {
+    height: auto;
+    color: $text-muted;
+    text-style: italic;
+    text-align: center;
+    margin-top: 1;
+}

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -46,6 +46,9 @@ PromptClipboardScreen #prompt-list {
 PromptClipboardScreen .prompt-row {
     height: 1;
     padding: 0 1;
+    /* Rows are one cell high, so titles longer than the row clip; an ellipsis
+       marks the clipped end without a fixed character cap. */
+    text-overflow: ellipsis;
 }
 
 PromptClipboardScreen .prompt-row-selected {

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -79,6 +79,21 @@ PromptClipboardScreen .prompt-row:hover {
     background: $surface-lighten-2;
 }
 
+PromptClipboardScreen .prompt-row.prompt-row-selected:hover {
+    /* Restating the selected colors here is load-bearing, not redundant.
+
+       A pseudo-class bumps the class slot of Textual's specificity tuple, so
+       the plain `.prompt-row:hover` above scores (0, 2, 1) and outranks
+       `.prompt-row-selected` at (0, 1, 1). Without this rule, pointing at the
+       selected row strips its $primary background while `color: $background`
+       still applies -- near-invisible text on light themes, on the one row the
+       user is most likely to point at. Doubling the class and keeping :hover
+       scores (0, 3, 1), which wins outright rather than by source order.
+       Textual has no :not(), so exclusion is not an option here. */
+    background: $primary;
+    color: $background;
+}
+
 PromptClipboardScreen .prompt-preview-label {
     height: auto;
     color: $text-muted;

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -72,9 +72,10 @@ PromptClipboardScreen .prompt-row-selected {
     color: $background;
 }
 
-PromptClipboardScreen .prompt-row-hovered {
-    /* Hover marks where the cursor is pointing without implying a selection
-       change, so it stays subtler than the selected row's solid primary. */
+PromptClipboardScreen .prompt-row:hover {
+    /* Textual's built-in :hover covers transient pointing: it never touches
+       the selection, so arrow keys still resume from the selected row. It
+       stays subtler than the selected row's solid primary. */
     background: $surface-lighten-2;
 }
 

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -6,7 +6,10 @@ PromptClipboardScreen > Vertical {
     width: 90%;
     max-width: 100;
     height: auto;
-    max-height: 90%;
+    /* No max-height here: a clamped auto container does not shrink its
+       children, so the list would keep its natural height and push the
+       preview/help past the border. `_fit_prompt_list` clamps the list
+       instead, same as the `/model` selector. */
     background: $surface;
     border: solid $primary;
     padding: 1 2;

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -46,8 +46,10 @@ PromptClipboardScreen #prompt-list {
 PromptClipboardScreen .prompt-row {
     height: 1;
     padding: 0 1;
-    /* Rows are one cell high, so titles longer than the row clip; an ellipsis
-       marks the clipped end without a fixed character cap. */
+    /* Rows are one cell high, so overlong titles clip visually. Textual only
+       ellipsizes truncated (nowrap) lines, so nowrap must accompany
+       text-overflow: ellipsis for the clipped end to be marked. */
+    text-wrap: nowrap;
     text-overflow: ellipsis;
 }
 

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -5,11 +5,9 @@ PromptClipboardScreen {
 PromptClipboardScreen > Vertical {
     width: 90%;
     max-width: 100;
-    height: auto;
-    /* No max-height here: a clamped auto container does not shrink its
-       children, so the list would keep its natural height and push the
-       preview/help past the border. `_fit_prompt_list` clamps the list
-       instead, same as the `/model` selector. */
+    /* Fixed size: the modal must not grow or shrink with the selected
+       prompt's preview length, so the list below takes all leftover space. */
+    height: 80%;
     background: $surface;
     border: solid $primary;
     padding: 1 2;
@@ -20,16 +18,26 @@ PromptClipboardScreen .prompt-title {
     text-style: bold;
     color: $primary;
     text-align: center;
-    margin-bottom: 1;
 }
 
 PromptClipboardScreen #prompt-filter {
-    margin-bottom: 1;
+    /* Vertical spacing lives on the two fixed-height boxes (this input and the
+       preview) as padding. Margins and padding on auto-height widgets are not
+       deducted from the fr list's share, so they would push the controls below
+       past the fixed modal's edge; border-box fixed boxes absorb padding
+       without inflating their footprint. */
+    padding-bottom: 1;
 }
 
 PromptClipboardScreen #prompt-list {
-    height: auto;
-    min-height: 3;
+    /* Absorbs the fixed-size modal's leftover space so the outer height never
+       depends on prompt content. max-height caps the row count the list
+       requests — fr units share space by requested height, so an uncapped
+       long list would force the fixed-height container to overflow.
+       min-height: 0 lets the list collapse below one row on very short
+       terminals so the controls below stay inside the fixed modal. */
+    height: 1fr;
+    min-height: 0;
     max-height: 20;
     background: $background;
     scrollbar-gutter: stable;
@@ -48,15 +56,20 @@ PromptClipboardScreen .prompt-row-selected {
 PromptClipboardScreen .prompt-preview-label {
     height: auto;
     color: $text-muted;
-    margin-top: 1;
 }
 
 PromptClipboardScreen #prompt-preview-scroll {
-    height: auto;
-    min-height: 3;
+    /* Preferred height so the modal size stays constant no matter which prompt
+       is previewed; longer prompts scroll inside the box. It shares the
+       leftover as a fraction with the list (min-height: 0) so that on very
+       short terminals both scrollable panes give space back and the controls
+       stay inside the fixed modal. padding-top here (not margin on the
+       label/help) keeps the box model exact — see #prompt-filter. */
+    height: 1fr;
+    min-height: 0;
     max-height: 8;
     border: round $surface-lighten-2;
-    padding: 0 1;
+    padding: 1 1 0 1;
     /* Match the prompt list's content width: the list reserves a stable
        gutter for its vertical scrollbar, so the preview box would otherwise
        render two cells wider than the rows above it. */
@@ -64,6 +77,8 @@ PromptClipboardScreen #prompt-preview-scroll {
 }
 
 PromptClipboardScreen #prompt-preview {
+    /* Content stays auto-height inside the fixed preview box so long prompts
+       scroll instead of growing the modal. */
     height: auto;
 }
 
@@ -72,5 +87,4 @@ PromptClipboardScreen .prompt-help {
     color: $text-muted;
     text-style: italic;
     text-align: center;
-    margin-top: 1;
 }

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -14,7 +14,7 @@ PromptClipboardScreen > Vertical {
        Textual centers the overflowing modal and clips it top and bottom, so
        the filter stays on screen and the preview is clipped last, while the
        `min-height: 0` panes still absorb leftover space above this floor. */
-    min-height: 12;
+    min-height: 13;
     background: $surface;
     border: solid $primary;
     padding: 1 2;

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -57,6 +57,10 @@ PromptClipboardScreen #prompt-preview-scroll {
     max-height: 8;
     border: round $surface-lighten-2;
     padding: 0 1;
+    /* Match the prompt list's content width: the list reserves a stable
+       gutter for its vertical scrollbar, so the preview box would otherwise
+       render two cells wider than the rows above it. */
+    scrollbar-gutter: stable;
 }
 
 PromptClipboardScreen #prompt-preview {

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -30,13 +30,13 @@ PromptClipboardScreen #prompt-filter {
 PromptClipboardScreen #prompt-list {
     height: auto;
     min-height: 3;
-    max-height: 10;
+    max-height: 20;
     background: $background;
     scrollbar-gutter: stable;
 }
 
 PromptClipboardScreen .prompt-row {
-    height: 2;
+    height: 1;
     padding: 0 1;
 }
 

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -72,6 +72,12 @@ PromptClipboardScreen .prompt-row-selected {
     color: $background;
 }
 
+PromptClipboardScreen .prompt-row-hovered {
+    /* Hover marks where the cursor is pointing without implying a selection
+       change, so it stays subtler than the selected row's solid primary. */
+    background: $surface-lighten-2;
+}
+
 PromptClipboardScreen .prompt-preview-label {
     height: auto;
     color: $text-muted;

--- a/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
+++ b/libs/code/deepagents_code/tui/modals/prompt_clipboard.tcss
@@ -8,6 +8,13 @@ PromptClipboardScreen > Vertical {
     /* Fixed size: the modal must not grow or shrink with the selected
        prompt's preview length, so the list below takes all leftover space. */
     height: 80%;
+    /* 80% of a very short terminal can be shorter than the fixed controls
+       (title, filter, borders, padding, wrapped help), pushing the preview
+       and help below the screen. Clamp to roughly the fixed-controls height;
+       Textual centers the overflowing modal and clips it top and bottom, so
+       the filter stays on screen and the preview is clipped last, while the
+       `min-height: 0` panes still absorb leftover space above this floor. */
+    min-height: 12;
     background: $surface;
     border: solid $primary;
     padding: 1 2;

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -3640,6 +3640,13 @@ class ChatInput(Vertical):
 
     def focus_input(self) -> None:
         """Focus the input field."""
+        if (
+            self._prompt_search_active
+            and self._prompt_search is not None
+            and self._prompt_search._query_input is not None
+        ):
+            self._prompt_search._query_input.focus()
+            return
         if self._text_area:
             self._text_area.focus()
 

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -3760,6 +3760,7 @@ class ChatInput(Vertical):
         self._prompt_search_prompts = self.recent_prompts()
         self._prompt_search_query = ""
         self._prompt_search_index = 0
+        self._warn_if_history_unreadable()
         self._refresh_prompt_search_panel()
         # The query field is a real Input, so the blinking cursor lives in it
         # while the search is open rather than in the frozen draft above.
@@ -3844,6 +3845,25 @@ class ChatInput(Vertical):
             )
         self._prompt_search.update_state(
             self._prompt_search_query, titles, self._prompt_search_index, empty
+        )
+
+    def _warn_if_history_unreadable(self) -> None:
+        """Warn when the shown prompts are a degraded fallback.
+
+        The empty-state message already names an unreadable history file, but
+        only when there is nothing to list. `recent_prompts` falls back to this
+        session's entries on a read failure, so the usual outcome is a
+        *non-empty* list that looks like a complete history and is silently
+        truncated. Warn whenever the read failed and there is something to
+        show, since that is the case the empty state cannot cover.
+        """
+        error = self.prompt_history_error()
+        if error is None or not self._prompt_search_prompts:
+            return
+        self.app.notify(
+            f"{error}; showing this session's prompts only",
+            severity="warning",
+            markup=False,
         )
 
     def _prompt_search_insert_selected(self) -> None:

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -3766,22 +3766,27 @@ class ChatInput(Vertical):
                 modal skips this so the modal's own filter input takes focus.
         """
         draft = self._prompt_search_draft
+        cursor = self._prompt_search_cursor
         self._prompt_search_draft = None
+        self._prompt_search_cursor = None
         self._prompt_search_query = ""
         self._prompt_search_prompts = ()
         self._prompt_search_filtered = []
         self._prompt_search_index = 0
         if self._prompt_search is not None:
             self._prompt_search.hide()
-        if restore_draft and draft is not None and self._text_area is not None:
+        if (
+            restore_draft
+            and draft is not None
+            and self._text_area is not None
+            and self._text_area.text == draft
+        ):
             self._text_area._skip_history_change_events += 1
             self._text_area.text = draft
             # Restore the exact cursor position from the snapshot, matching
             # readline/codex cancel semantics rather than jumping to the end.
-            cursor = self._prompt_search_cursor
             if cursor is not None:
                 self._text_area.move_cursor(cursor)
-            self._prompt_search_cursor = None
         if refocus:
             self.focus_input()
 

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -636,6 +636,12 @@ class ChatTextArea(PasteBurstTextArea):
         self._line_cache.clear()
         self.refresh()
 
+    def on_focus(self) -> None:
+        """Keep an open prompt search focused when the composer is clicked."""
+        owner = self._chat_input_owner
+        if owner is not None and owner._prompt_search_active:
+            owner.focus_input()
+
     def _render_line(self, y: int) -> Strip:
         """Render a line, keeping shell token colors visible on the cursor line.
 

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -24,7 +24,7 @@ from textual.highlight import highlight
 from textual.message import Message
 from textual.reactive import reactive
 from textual.strip import Strip
-from textual.widgets import Static, TextArea
+from textual.widgets import Input, Static, TextArea
 
 from deepagents_code import theme
 from deepagents_code.command_registry import CommandEntry, get_slash_commands
@@ -60,7 +60,9 @@ from deepagents_code.tui.widgets.autocomplete import (
 from deepagents_code.tui.widgets.history import HistoryManager
 from deepagents_code.tui.widgets.prompt_search import (
     PROMPT_SEARCH_MAX_ROWS,
+    PROMPT_SEARCH_PAGE_SIZE,
     PROMPT_SEARCH_PANEL_ROWS,
+    PromptSearchInput,
     PromptSearchPanel,
     filter_prompts,
     prompt_title,
@@ -2352,6 +2354,7 @@ class ChatInput(Vertical):
         # grabbed in `on_mount` (it is composed with the input box).
         self._prompt_search: PromptSearchPanel | None = None
         self._prompt_search_draft: str | None = None
+        self._prompt_search_cursor: tuple[int, int] | None = None
         self._prompt_search_query = ""
         self._prompt_search_prompts: tuple[str, ...] = ()
         self._prompt_search_filtered: list[str] = []
@@ -3724,10 +3727,15 @@ class ChatInput(Vertical):
             return "modal"
 
         self._prompt_search_draft = self._text_area.text
+        self._prompt_search_cursor = self._text_area.cursor_location
         self._prompt_search_prompts = self._history.recent_prompts()
         self._prompt_search_query = ""
         self._prompt_search_index = 0
         self._refresh_prompt_search_panel()
+        # The query field is a real Input, so the blinking cursor lives in it
+        # while the search is open rather than in the frozen draft above.
+        if self._prompt_search._query_input is not None:
+            self._prompt_search._query_input.focus()
         return "inline"
 
     def escalate_prompt_search(self) -> str:
@@ -3737,15 +3745,19 @@ class ChatInput(Vertical):
             The typed query, so the modal's filter can be seeded with it.
         """
         query = self._prompt_search_query
-        self._close_prompt_search(restore_draft=False)
+        self._close_prompt_search(restore_draft=False, refocus=False)
         return query
 
-    def _close_prompt_search(self, *, restore_draft: bool) -> None:
+    def _close_prompt_search(
+        self, *, restore_draft: bool, refocus: bool = True
+    ) -> None:
         """Hide the inline panel and clear search state.
 
         Args:
             restore_draft: Whether to put the snapshot from `open_prompt_search`
                 back. Only Escape does; other exits leave the draft alone.
+            refocus: Whether to return focus to the composer. Escalating to the
+                modal skips this so the modal's own filter input takes focus.
         """
         draft = self._prompt_search_draft
         self._prompt_search_draft = None
@@ -3758,7 +3770,14 @@ class ChatInput(Vertical):
         if restore_draft and draft is not None and self._text_area is not None:
             self._text_area._skip_history_change_events += 1
             self._text_area.text = draft
-            self._text_area.move_cursor_to_end()
+            # Restore the exact cursor position from the snapshot, matching
+            # readline/codex cancel semantics rather than jumping to the end.
+            cursor = self._prompt_search_cursor
+            if cursor is not None:
+                self._text_area.move_cursor(cursor)
+            self._prompt_search_cursor = None
+        if refocus:
+            self.focus_input()
 
     def _refresh_prompt_search_panel(self) -> None:
         """Filter the snapshot by the query and re-render the panel."""
@@ -3823,46 +3842,79 @@ class ChatInput(Vertical):
                 self.app.bell()
             return True
 
-        if event.key == "up":
+        if event.key in {"up", "down"}:
             event.prevent_default()
             event.stop()
-            if self._prompt_search_index > 0:
-                self._prompt_search_index -= 1
-                if self._prompt_search is not None:
-                    self._prompt_search.update_selection(self._prompt_search_index)
-            return True
-
-        if event.key == "down":
-            event.prevent_default()
-            event.stop()
-            if self._prompt_search_index < len(self._prompt_search_filtered) - 1:
-                self._prompt_search_index += 1
-                if self._prompt_search is not None:
-                    self._prompt_search.update_selection(self._prompt_search_index)
-            return True
-
-        if event.key == "backspace":
-            event.prevent_default()
-            event.stop()
-            if not self._prompt_search_query:
-                # Readline-style affordance: backspace on an empty query
-                # abandons the search instead of eating the draft.
-                self._close_prompt_search(restore_draft=True)
+            last = len(self._prompt_search_filtered) - 1
+            if last < 0:
                 return True
-            self._prompt_search_query = self._prompt_search_query[:-1]
-            self._prompt_search_index = 0
-            self._refresh_prompt_search_panel()
-            return True
-
-        if event.is_printable and event.character is not None:
-            event.prevent_default()
-            event.stop()
-            self._prompt_search_query += event.character
-            self._prompt_search_index = 0
-            self._refresh_prompt_search_panel()
+            new_index = (
+                max(0, self._prompt_search_index - 1)
+                if event.key == "up"
+                else min(last, self._prompt_search_index + 1)
+            )
+            if new_index != self._prompt_search_index:
+                self._prompt_search_index = new_index
+                if self._prompt_search is not None:
+                    self._prompt_search.update_selection(new_index)
             return True
 
         return False
+
+    def _page_prompt_search(self, *, older: bool) -> None:
+        """Move the selection one page through the filtered prompts."""
+        last = len(self._prompt_search_filtered) - 1
+        if last < 0:
+            return
+        new_index = (
+            max(0, self._prompt_search_index - PROMPT_SEARCH_PAGE_SIZE)
+            if not older
+            else min(last, self._prompt_search_index + PROMPT_SEARCH_PAGE_SIZE)
+        )
+        if new_index != self._prompt_search_index:
+            self._prompt_search_index = new_index
+            if self._prompt_search is not None:
+                self._prompt_search.update_selection(new_index)
+
+    def on_prompt_search_input_page_requested(
+        self, event: PromptSearchInput.PageRequested
+    ) -> None:
+        """Page the selection on Tab (older) or Shift+Tab (newer)."""
+        if not self._prompt_search_active:
+            return
+        event.stop()
+        self._page_prompt_search(older=event.older)
+
+    def on_prompt_search_input_abandon_search(
+        self, event: PromptSearchInput.AbandonSearch
+    ) -> None:
+        """Close the search, restoring the draft, on empty-query Backspace."""
+        if not self._prompt_search_active:
+            return
+        event.stop()
+        self._close_prompt_search(restore_draft=True)
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Filter prompts as the query input's text changes."""
+        if not self._prompt_search_active:
+            return
+        if not isinstance(event.input, PromptSearchInput):
+            return
+        self._prompt_search_query = event.value
+        self._prompt_search_index = 0
+        self._refresh_prompt_search_panel()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Insert the selected prompt when the query input receives Enter."""
+        if not self._prompt_search_active:
+            return
+        if not isinstance(event.input, PromptSearchInput):
+            return
+        event.stop()
+        if self._prompt_search_filtered:
+            self._prompt_search_insert_selected()
+        elif self.app is not None:
+            self.app.bell()
 
     def on_prompt_search_panel_option_selected(
         self, event: PromptSearchPanel.OptionSelected

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -59,7 +59,6 @@ from deepagents_code.tui.widgets.autocomplete import (
 )
 from deepagents_code.tui.widgets.history import HistoryManager
 from deepagents_code.tui.widgets.prompt_search import (
-    PROMPT_SEARCH_MAX_ROWS,
     PROMPT_SEARCH_PAGE_SIZE,
     PROMPT_SEARCH_PANEL_ROWS,
     PromptSearchInput,
@@ -3789,10 +3788,11 @@ class ChatInput(Vertical):
         self._prompt_search_index = max(
             0, min(self._prompt_search_index, len(self._prompt_search_filtered) - 1)
         )
-        titles = [
-            prompt_title(prompt)
-            for prompt in self._prompt_search_filtered[:PROMPT_SEARCH_MAX_ROWS]
-        ]
+        # Render every filtered prompt, not just the first visible page: the
+        # results container scrolls (CSS max-height), and rows that do not
+        # exist cannot be scrolled into view — which previously made arrow/Tab
+        # moves past row 5 invisible and left scrolling with nothing to do.
+        titles = [prompt_title(prompt) for prompt in self._prompt_search_filtered]
         empty: str | None
         if self._prompt_search_filtered:
             empty = None

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -3615,6 +3615,25 @@ class ChatInput(Vertical):
         self._text_area.move_cursor_to_end()
         return True
 
+    def recent_prompts(self) -> tuple[str, ...]:
+        """Refresh and return submitted prompts in newest-first order.
+
+        Returns:
+            An immutable snapshot of recent unique prompts.
+        """
+        return self._history.recent_prompts()
+
+    def insert_at_cursor(self, text: str) -> bool:
+        """Insert text at the current cursor through the undoable edit path.
+
+        Returns:
+            Whether the text area was available for insertion.
+        """
+        if not self._text_area:
+            return False
+        self._text_area.insert(text)
+        return True
+
     def discard_text(self) -> bool:
         """Clear the draft, keeping it restorable via undo (ctrl+z).
 

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -3958,13 +3958,17 @@ class ChatInput(Vertical):
     def on_prompt_search_panel_option_selected(
         self, event: PromptSearchPanel.OptionSelected
     ) -> None:
-        """Insert a clicked prompt row."""
+        """Select a clicked prompt row; Enter is still required to insert."""
         event.stop()
         if not self._prompt_search_active:
             return
-        if 0 <= event.index < len(self._prompt_search_filtered):
+        if (
+            0 <= event.index < len(self._prompt_search_filtered)
+            and event.index != self._prompt_search_index
+        ):
             self._prompt_search_index = event.index
-            self._prompt_search_insert_selected()
+            if self._prompt_search is not None:
+                self._prompt_search.update_selection(event.index)
 
     def discard_text(self) -> bool:
         """Clear the draft, keeping it restorable via undo (ctrl+z).

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -2363,6 +2363,10 @@ class ChatInput(Vertical):
         self._prompt_search_prompts: tuple[str, ...] = ()
         self._prompt_search_filtered: list[str] = []
         self._prompt_search_index = 0
+        # Latches once the "history is not being saved" warning has been shown,
+        # so a read-only home directory costs one toast rather than one per
+        # submission.
+        self._warned_history_unwritable = False
 
         # Set up history manager
         if history_file is None:
@@ -3110,6 +3114,7 @@ class ChatInput(Vertical):
             )
 
         self._history.add(value)
+        self._warn_if_history_unwritable()
         self.post_message(self.Submitted(value, mode))
 
         if self._text_area:
@@ -3862,6 +3867,24 @@ class ChatInput(Vertical):
             return
         self.app.notify(
             f"{error}; showing this session's prompts only",
+            severity="warning",
+            markup=False,
+        )
+
+    def _warn_if_history_unwritable(self) -> None:
+        """Say once that prompts are no longer being saved.
+
+        A failed append keeps the entry in memory, so up-arrow and the prompt
+        clipboard keep working and nothing on screen suggests a problem. The
+        prompts are still lost at exit, and the clipboard advertises itself as
+        durable history, so the loss has to be stated rather than only logged.
+        """
+        if self._warned_history_unwritable or not self._history.history_unwritable:
+            return
+        self._warned_history_unwritable = True
+        self.app.notify(
+            f"Could not save prompt history to {self._history.history_file}; "
+            "this session's prompts will be lost when it ends",
             severity="warning",
             markup=False,
         )

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -3900,6 +3900,7 @@ class ChatInput(Vertical):
             return
         if not isinstance(event.input, PromptSearchInput):
             return
+        self.post_message(self.Typing())
         self._prompt_search_query = event.value
         self._prompt_search_index = 0
         self._refresh_prompt_search_panel()

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -3660,13 +3660,13 @@ class ChatInput(Vertical):
 
     def focus_input(self) -> None:
         """Focus the input field."""
-        if (
-            self._prompt_search_active
-            and self._prompt_search is not None
-            and self._prompt_search._query_input is not None
-        ):
-            self._prompt_search._query_input.focus()
-            return
+        if self._prompt_search_active and self._prompt_search is not None:
+            if self._prompt_search.focus_query():
+                return
+            # The session is open but the query input is not mounted yet, so
+            # keys would route into a panel the user cannot type in. Worth a
+            # trace: this combination is a lifecycle bug, not a normal state.
+            logger.warning("Prompt search is active but its query input is not mounted")
         if self._text_area:
             self._text_area.focus()
 
@@ -3774,8 +3774,7 @@ class ChatInput(Vertical):
         self._refresh_prompt_search_panel()
         # The query field is a real Input, so the blinking cursor lives in it
         # while the search is open rather than in the frozen draft above.
-        if self._prompt_search._query_input is not None:
-            self._prompt_search._query_input.focus()
+        self._prompt_search.focus_query()
         return "inline"
 
     def escalate_prompt_search(self) -> str:

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -3744,9 +3744,10 @@ class ChatInput(Vertical):
     def open_prompt_search(self) -> Literal["inline", "modal", "noop"]:
         """Open the inline prompt search, or escalate an open one to the modal.
 
-        First call shows the inline panel with a fresh prompt snapshot and
-        saves the current draft for cancel-restore; a call while the panel is
-        already open means the second Ctrl+R tier.
+        First call shows the inline panel with a fresh prompt snapshot, seeds
+        its filter from the current draft, and saves that draft for
+        cancel-restore; a call while the panel is already open means the second
+        Ctrl+R tier.
 
         Returns:
             `"inline"` when the panel opened, `"modal"` when the caller should
@@ -3768,7 +3769,7 @@ class ChatInput(Vertical):
         # Both tiers go through the public accessor so they always show the
         # same snapshot.
         self._prompt_search_prompts = self.recent_prompts()
-        self._prompt_search_query = ""
+        self._prompt_search_query = self._text_area.text
         self._prompt_search_index = 0
         self._warn_if_history_unreadable()
         self._refresh_prompt_search_panel()
@@ -3778,12 +3779,20 @@ class ChatInput(Vertical):
         return "inline"
 
     def escalate_prompt_search(self) -> str:
-        """Close the inline panel for the modal tier, keeping the draft.
+        """Return the modal filter and close any open inline panel.
+
+        An active inline search supplies its current query. When autocomplete
+        sends Ctrl+R directly to the modal tier, the current chat input is the
+        query instead.
 
         Returns:
-            The typed query, so the modal's filter can be seeded with it.
+            The text to seed the modal's filter with.
         """
-        query = self._prompt_search_query
+        query = (
+            self._prompt_search_query
+            if self._prompt_search_active
+            else (self._text_area.text if self._text_area is not None else "")
+        )
         self._close_prompt_search(restore_draft=False, refocus=False)
         return query
 

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -118,12 +118,16 @@ leave the box's corner glyphs visible.
 """
 
 _CHAT_INPUT_BOX_MAX_HEIGHT = 25
-"""Rows the bordered input box may occupy, including its border and any popup.
+"""Rows the bordered input box may occupy for its own content and border.
 
-`ChatInputBox._apply_manual_height` subtracts the gutter and the completion
-popup from this to derive the composer budget, so it is load-bearing arithmetic
-rather than a cosmetic cap. Interpolated into `ChatInput.DEFAULT_CSS` as the
-`#input-box` `max-height`.
+`ChatInputBox._apply_manual_height` subtracts the gutter and every inline panel
+row (completion popup and prompt search) from this to derive the composer
+budget, so it is load-bearing arithmetic rather than a cosmetic cap.
+
+This is the composer's budget, not the box's rendered ceiling: the `#input-box`
+`max-height` in `ChatInput.DEFAULT_CSS` interpolates
+`_CHAT_INPUT_BOX_MAX_HEIGHT + PROMPT_SEARCH_PANEL_ROWS`, so a fully expanded
+prompt search panel fits inside the border instead of pushing the draft out.
 """
 
 _CHAT_INPUT_MANUAL_MAX_HEIGHT = 20
@@ -1288,7 +1292,8 @@ class ChatTextArea(PasteBurstTextArea):
             self.post_message(self.Typing())
 
         # While the inline prompt search is open, printable keys feed the
-        # panel's query (handled in `ChatInput.on_key`), so they must never be
+        # panel's query -- the focused `PromptSearchInput` consumes them and
+        # `ChatInput.on_input_changed` re-filters -- so they must never be
         # mistaken for paste-burst replay.
         prompt_search_active = (
             self._chat_input_owner is not None
@@ -3908,11 +3913,17 @@ class ChatInput(Vertical):
         no frames.
 
         Args:
-            event: The key event bubbling up from the text area.
+            event: The key event, bubbling from either the search query input
+                (the usual case, since `open_prompt_search` focuses it) or the
+                text area when focus never moved.
 
         Returns:
-            Whether the key was consumed. A `False` return lets the event
-            continue to completion/default handling.
+            `True` when the panel consumed the key and stopped it here.
+                `False` means the panel does not own the key and the caller
+                decides: `ChatInput.on_key` lets it bubble to the query
+                input's own bindings, while `ChatTextArea._on_key` suppresses
+                it so an unrecognized key cannot edit the frozen draft behind
+                the panel.
         """
         if event.key == "escape":
             self._close_prompt_search(restore_draft=True)

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -1349,8 +1349,7 @@ class ChatTextArea(PasteBurstTextArea):
                 and self._chat_input_owner._handle_prompt_search_key(event)
             ):
                 return
-            # Keys the search ignores (arrows handled above pass through here
-            # only when unhandled) must not edit the draft either.
+            # Keys the search ignores must not edit the draft either.
             event.prevent_default()
             event.stop()
             return
@@ -3502,8 +3501,13 @@ class ChatInput(Vertical):
 
         # The inline prompt search owns the keyboard while open; this must run
         # before completion routing so arrows/enter reach the panel rather
-        # than the autocomplete controllers.
-        if self._prompt_search_active and self._handle_prompt_search_key(event):
+        # than the autocomplete controllers. Returning unconditionally matters:
+        # a key the search does not own (Backspace with a non-empty query) must
+        # still bubble to the query input's own bindings rather than fall
+        # through to the mode-exit branch and the completion manager, which
+        # would edit the composer behind the open panel.
+        if self._prompt_search_active:
+            self._handle_prompt_search_key(event)
             return
 
         # Backspace at the start of a mode prompt exits the current mode. Prefix
@@ -3690,6 +3694,17 @@ class ChatInput(Vertical):
         """
         return self._history.recent_prompts()
 
+    def prompt_history_error(self) -> str | None:
+        """Describe why the last prompt refresh came back empty, if it failed.
+
+        Returns:
+            A message naming the unreadable history file, or `None` when the
+            file was read (including when it does not exist yet).
+        """
+        if not self._history.history_unreadable:
+            return None
+        return f"Could not read prompt history from {self._history.history_file}"
+
     def insert_at_cursor(self, text: str) -> bool:
         """Insert text at the current cursor through the undoable edit path.
 
@@ -3720,7 +3735,7 @@ class ChatInput(Vertical):
         Returns:
             `"inline"` when the panel opened, `"modal"` when the caller should
             open the full `PromptClipboardScreen`, or `"noop"` when the
-            composer is unavailable or another input surface is active.
+            composer is unavailable.
         """
         if self._text_area is None or self._prompt_search is None:
             return "noop"
@@ -3734,7 +3749,9 @@ class ChatInput(Vertical):
 
         self._prompt_search_draft = self._text_area.text
         self._prompt_search_cursor = self._text_area.cursor_location
-        self._prompt_search_prompts = self._history.recent_prompts()
+        # Both tiers go through the public accessor so they always show the
+        # same snapshot.
+        self._prompt_search_prompts = self.recent_prompts()
         self._prompt_search_query = ""
         self._prompt_search_index = 0
         self._refresh_prompt_search_panel()
@@ -3760,8 +3777,9 @@ class ChatInput(Vertical):
         """Hide the inline panel and clear search state.
 
         Args:
-            restore_draft: Whether to put the snapshot from `open_prompt_search`
-                back. Only Escape does; other exits leave the draft alone.
+            restore_draft: Whether to restore the cursor from the
+                `open_prompt_search` snapshot. Escape and empty-query Backspace
+                do; insert and modal escalation leave the composer alone.
             refocus: Whether to return focus to the composer. Escalating to the
                 modal skips this so the modal's own filter input takes focus.
         """
@@ -3775,18 +3793,20 @@ class ChatInput(Vertical):
         self._prompt_search_index = 0
         if self._prompt_search is not None:
             self._prompt_search.hide()
+        # Only the cursor needs restoring. Edits made while the panel was open
+        # are kept, and in the unedited case the text already equals the
+        # snapshot -- assigning it back would be a no-op that clears the undo
+        # history, because `TextArea.text` aliases `load_text`. The cursor goes
+        # back to the snapshot position, matching readline/codex cancel
+        # semantics rather than jumping to the end.
         if (
             restore_draft
             and draft is not None
+            and cursor is not None
             and self._text_area is not None
             and self._text_area.text == draft
         ):
-            self._text_area._skip_history_change_events += 1
-            self._text_area.text = draft
-            # Restore the exact cursor position from the snapshot, matching
-            # readline/codex cancel semantics rather than jumping to the end.
-            if cursor is not None:
-                self._text_area.move_cursor(cursor)
+            self._text_area.move_cursor(cursor)
         if refocus:
             self.focus_input()
 
@@ -3800,10 +3820,10 @@ class ChatInput(Vertical):
         self._prompt_search_index = max(
             0, min(self._prompt_search_index, len(self._prompt_search_filtered) - 1)
         )
-        # Render every filtered prompt, not just the first visible page: the
-        # results container scrolls (CSS max-height), and rows that do not
-        # exist cannot be scrolled into view — which previously made arrow/Tab
-        # moves past row 5 invisible and left scrolling with nothing to do.
+        # Pass every filtered title, not just the first visible page: the panel
+        # renders a window around the selection, and a row that is not mounted
+        # cannot be scrolled into view — which previously made arrow/Tab moves
+        # past row 5 invisible and left scrolling with nothing to do.
         titles = [prompt_title(prompt) for prompt in self._prompt_search_filtered]
         empty: str | None
         if self._prompt_search_filtered:
@@ -3811,7 +3831,11 @@ class ChatInput(Vertical):
         elif self._prompt_search_prompts:
             empty = "No matching prompts."
         else:
-            empty = "No prompts yet. Submitted prompts appear here."
+            # Never claim the history is empty when it is only unreadable.
+            empty = (
+                self.prompt_history_error()
+                or "No prompts yet. Submitted prompts appear here."
+            )
         self._prompt_search.update_state(
             self._prompt_search_query, titles, self._prompt_search_index, empty
         )
@@ -3827,8 +3851,10 @@ class ChatInput(Vertical):
     def _handle_prompt_search_key(self, event: events.Key) -> bool:
         """Handle one key while the inline prompt search is open.
 
-        Runs in `ChatInput.on_key` ahead of completion routing and may not
-        `await`; the panel rebuild it triggers is already message-pumped
+        Runs from `ChatInput.on_key` (ahead of completion routing) and from
+        `ChatTextArea._on_key` (ahead of the TextArea's own editing defaults,
+        which is what the no-`await` rule below protects); it may not
+        `await`, because the panel rebuild it triggers is already message-pumped
         through `PromptSearchPanel.call_next`, so synchronous handling loses
         no frames.
 

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -58,6 +58,13 @@ from deepagents_code.tui.widgets.autocomplete import (
     SlashCommandController,
 )
 from deepagents_code.tui.widgets.history import HistoryManager
+from deepagents_code.tui.widgets.prompt_search import (
+    PROMPT_SEARCH_MAX_ROWS,
+    PROMPT_SEARCH_PANEL_ROWS,
+    PromptSearchPanel,
+    filter_prompts,
+    prompt_title,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1273,14 +1280,23 @@ class ChatTextArea(PasteBurstTextArea):
         if event.is_printable or event.key == "backspace":
             self.post_message(self.Typing())
 
-        if await self._absorb_key_into_burst(event, now):
+        # While the inline prompt search is open, printable keys feed the
+        # panel's query (handled in `ChatInput.on_key`), so they must never be
+        # mistaken for paste-burst replay.
+        prompt_search_active = (
+            self._chat_input_owner is not None
+            and self._chat_input_owner._prompt_search_active
+        )
+
+        if not prompt_search_active and await self._absorb_key_into_burst(event, now):
             event.prevent_default()
             event.stop()
             return
 
         # Track rapid keystroke runs so terminals without bracketed paste keep
         # embedded newlines grouped without delaying ordinary text insertion.
-        self._track_burst_run(event, now)
+        if not prompt_search_active:
+            self._track_burst_run(event, now)
 
         # A mode trigger (`!`, `!!`, `/`) typed at the very start of an
         # unselected input switches modes. Handle it before TextArea inserts the
@@ -1322,6 +1338,22 @@ class ChatTextArea(PasteBurstTextArea):
             event.stop()
             return
 
+        # While the inline prompt search is open, the panel owns the keyboard.
+        # Route the key to the search handler before TextArea defaults (Enter
+        # newline, printable insertion) consume it; the draft stays frozen for
+        # the whole session.
+        if prompt_search_active:
+            if (
+                self._chat_input_owner is not None
+                and self._chat_input_owner._handle_prompt_search_key(event)
+            ):
+                return
+            # Keys the search ignores (arrows handled above pass through here
+            # only when unhandled) must not edit the draft either.
+            event.prevent_default()
+            event.stop()
+            return
+
         # If completion is active, let parent handle navigation keys.
         # Space is included so that slash-command completion can accept the
         # selected suggestion via the same code path as Tab (avoiding a
@@ -1355,7 +1387,7 @@ class ChatTextArea(PasteBurstTextArea):
         if event.key == "enter":
             event.prevent_default()
             event.stop()
-            if self._consume_enter_as_burst_newline(now):
+            if not prompt_search_active and self._consume_enter_as_burst_newline(now):
                 return
             if (
                 self._chat_input_owner is not None
@@ -1371,7 +1403,8 @@ class ChatTextArea(PasteBurstTextArea):
 
         # Must follow `super()._on_key`: promotion verifies the run against the
         # document, so the current character has to be in it already.
-        self._check_burst_run_for_promotion()
+        if not prompt_search_active:
+            self._check_burst_run_for_promotion()
 
     def action_delete_right(self) -> None:
         """Delete a bound placeholder atomically or the next character."""
@@ -1725,6 +1758,7 @@ class ChatInputBox(Vertical):
         """Initialize sizing state."""
         super().__init__(**kwargs)
         self._completion_rows = 0
+        self._prompt_search_rows = 0
         self._requested_height: int | None = None
         self._applied_height: int | None = None
 
@@ -1798,10 +1832,10 @@ class ChatInputBox(Vertical):
 
         - the screen ceiling, which reserves rows for the rest of the app;
         - the box ceiling, `_CHAT_INPUT_BOX_MAX_HEIGHT` minus the border gutter
-          and any completion popup, so the popup renders inside the border
-          rather than overflowing it;
-        - the same screen budget again but with the popup subtracted, since a
-          popup adds rows to the box that the plain screen ceiling ignores.
+          and any inline panels (completion popup, prompt search), so a panel
+          renders inside the border rather than overflowing it;
+        - the same screen budget again but with the panels subtracted, since a
+          panel adds rows to the box that the plain screen ceiling ignores.
 
         The result is then floored by the visible draft, so a manual height
         never hides text. Both `height` and `max_height` are set because
@@ -1813,20 +1847,18 @@ class ChatInputBox(Vertical):
         screen_height = self._screen_height()
         if text_area is None or screen_height is None:
             return
+        panel_rows = self._completion_rows + self._prompt_search_rows
         # The plain screen cap already allows for the composer's own gutter; a
-        # popup needs it reserved explicitly because it adds rows to the box.
-        popup_gutter = self.gutter.height if self._completion_rows else 0
+        # panel needs it reserved explicitly because it adds rows to the box.
+        panel_gutter = self.gutter.height if panel_rows else 0
         screen_available = (
-            screen_height
-            - _CHAT_INPUT_RESERVED_SCREEN_ROWS
-            - self._completion_rows
-            - popup_gutter
+            screen_height - _CHAT_INPUT_RESERVED_SCREEN_ROWS - panel_rows - panel_gutter
         )
         available = min(
             _manual_height_ceiling(screen_height),
             max(
                 1,
-                _CHAT_INPUT_BOX_MAX_HEIGHT - self.gutter.height - self._completion_rows,
+                _CHAT_INPUT_BOX_MAX_HEIGHT - self.gutter.height - panel_rows,
             ),
             max(1, screen_available),
         )
@@ -1893,6 +1925,14 @@ class ChatInputBox(Vertical):
     ) -> None:
         """Fit a manual composer around the completion popup."""
         self._completion_rows = event.rows
+        self._apply_manual_height()
+        event.stop()
+
+    def on_prompt_search_panel_rows_changed(
+        self, event: PromptSearchPanel.RowsChanged
+    ) -> None:
+        """Fit a manual composer around the prompt search panel."""
+        self._prompt_search_rows = event.rows
         self._apply_manual_height()
         event.stop()
 
@@ -2185,7 +2225,7 @@ class ChatInput(Vertical):
        `ChatInputBox`. Appended rather than inlined above to keep the rest of
        this block free of doubled braces. */
     ChatInput #input-box {{
-        max-height: {_CHAT_INPUT_BOX_MAX_HEIGHT};
+        max-height: {_CHAT_INPUT_BOX_MAX_HEIGHT + PROMPT_SEARCH_PANEL_ROWS};
     }}
 
     ChatInput ChatTextArea {{
@@ -2307,6 +2347,16 @@ class ChatInput(Vertical):
         # slash commands after skill discovery cannot replace them.
         self._argument_hint_overrides: dict[str, str] = {}
 
+        # Inline prompt search (first Ctrl+R tier). `None` draft means inactive;
+        # the snapshot is what Escape restores. The panel widget itself is
+        # grabbed in `on_mount` (it is composed with the input box).
+        self._prompt_search: PromptSearchPanel | None = None
+        self._prompt_search_draft: str | None = None
+        self._prompt_search_query = ""
+        self._prompt_search_prompts: tuple[str, ...] = ()
+        self._prompt_search_filtered: list[str] = []
+        self._prompt_search_index = 0
+
         # Set up history manager
         if history_file is None:
             history_file = _default_history_path()
@@ -2327,6 +2377,7 @@ class ChatInput(Vertical):
                 yield Static(">", classes="input-prompt", id="prompt")
                 yield ChatTextArea(id="chat-input")
             yield CompletionPopup(id="completion-popup")
+            yield PromptSearchPanel(id="prompt-search-panel")
 
         yield ChatInputResizeHandle(id="input-resize-handle")
 
@@ -2359,6 +2410,7 @@ class ChatInput(Vertical):
 
         self._text_area = self.query_one("#chat-input", ChatTextArea)
         self._popup = self.query_one("#completion-popup", CompletionPopup)
+        self._prompt_search = self.query_one("#prompt-search-panel", PromptSearchPanel)
         self._text_area._chat_input_owner = self
         self._text_area.set_shell_highlighting(
             enabled=self.mode in {"shell", "shell_incognito"}
@@ -3446,6 +3498,12 @@ class ChatInput(Vertical):
         if not self._completion_manager or not self._text_area:
             return
 
+        # The inline prompt search owns the keyboard while open; this must run
+        # before completion routing so arrows/enter reach the panel rather
+        # than the autocomplete controllers.
+        if self._prompt_search_active and self._handle_prompt_search_key(event):
+            return
+
         # Backspace at the start of a mode prompt exits the current mode. Prefix
         # characters are mode selectors, not hidden draft text, so exiting the
         # mode does not restore `/`, `!`, or `!!` into the input.
@@ -3633,6 +3691,189 @@ class ChatInput(Vertical):
             return False
         self._text_area.insert(text)
         return True
+
+    @property
+    def _prompt_search_active(self) -> bool:
+        """Whether the inline prompt search panel is open.
+
+        A `None` draft is the discriminator: the snapshot only exists for the
+        lifetime of a search session.
+        """
+        return self._prompt_search_draft is not None
+
+    def open_prompt_search(self) -> Literal["inline", "modal", "noop"]:
+        """Open the inline prompt search, or escalate an open one to the modal.
+
+        First call shows the inline panel with a fresh prompt snapshot and
+        saves the current draft for cancel-restore; a call while the panel is
+        already open means the second Ctrl+R tier.
+
+        Returns:
+            `"inline"` when the panel opened, `"modal"` when the caller should
+            open the full `PromptClipboardScreen`, or `"noop"` when the
+            composer is unavailable or another input surface is active.
+        """
+        if self._text_area is None or self._prompt_search is None:
+            return "noop"
+        if self._prompt_search_active:
+            return "modal"
+        if self._current_suggestions:
+            # Completion owns the shared panel rows; inserting the search panel
+            # between the popup and the input row would break the completion
+            # flow's keyboard assumptions, so the modal serves this case.
+            return "modal"
+
+        self._prompt_search_draft = self._text_area.text
+        self._prompt_search_prompts = self._history.recent_prompts()
+        self._prompt_search_query = ""
+        self._prompt_search_index = 0
+        self._refresh_prompt_search_panel()
+        return "inline"
+
+    def escalate_prompt_search(self) -> str:
+        """Close the inline panel for the modal tier, keeping the draft.
+
+        Returns:
+            The typed query, so the modal's filter can be seeded with it.
+        """
+        query = self._prompt_search_query
+        self._close_prompt_search(restore_draft=False)
+        return query
+
+    def _close_prompt_search(self, *, restore_draft: bool) -> None:
+        """Hide the inline panel and clear search state.
+
+        Args:
+            restore_draft: Whether to put the snapshot from `open_prompt_search`
+                back. Only Escape does; other exits leave the draft alone.
+        """
+        draft = self._prompt_search_draft
+        self._prompt_search_draft = None
+        self._prompt_search_query = ""
+        self._prompt_search_prompts = ()
+        self._prompt_search_filtered = []
+        self._prompt_search_index = 0
+        if self._prompt_search is not None:
+            self._prompt_search.hide()
+        if restore_draft and draft is not None and self._text_area is not None:
+            self._text_area._skip_history_change_events += 1
+            self._text_area.text = draft
+            self._text_area.move_cursor_to_end()
+
+    def _refresh_prompt_search_panel(self) -> None:
+        """Filter the snapshot by the query and re-render the panel."""
+        if self._prompt_search is None:
+            return
+        self._prompt_search_filtered = filter_prompts(
+            self._prompt_search_prompts, self._prompt_search_query
+        )
+        self._prompt_search_index = max(
+            0, min(self._prompt_search_index, len(self._prompt_search_filtered) - 1)
+        )
+        titles = [
+            prompt_title(prompt)
+            for prompt in self._prompt_search_filtered[:PROMPT_SEARCH_MAX_ROWS]
+        ]
+        empty: str | None
+        if self._prompt_search_filtered:
+            empty = None
+        elif self._prompt_search_prompts:
+            empty = "No matching prompts."
+        else:
+            empty = "No prompts yet. Submitted prompts appear here."
+        self._prompt_search.update_state(
+            self._prompt_search_query, titles, self._prompt_search_index, empty
+        )
+
+    def _prompt_search_insert_selected(self) -> None:
+        """Insert the selected prompt into the draft and close the panel."""
+        prompt = self._prompt_search_filtered[self._prompt_search_index]
+        self._close_prompt_search(restore_draft=False)
+        if self._text_area is not None:
+            self._text_area.insert(prompt)
+            self._text_area.scroll_cursor_visible()
+
+    def _handle_prompt_search_key(self, event: events.Key) -> bool:
+        """Handle one key while the inline prompt search is open.
+
+        Runs in `ChatInput.on_key` ahead of completion routing and may not
+        `await`; the panel rebuild it triggers is already message-pumped
+        through `PromptSearchPanel.call_next`, so synchronous handling loses
+        no frames.
+
+        Args:
+            event: The key event bubbling up from the text area.
+
+        Returns:
+            Whether the key was consumed. A `False` return lets the event
+            continue to completion/default handling.
+        """
+        if event.key == "escape":
+            self._close_prompt_search(restore_draft=True)
+            event.prevent_default()
+            event.stop()
+            return True
+
+        if event.key == "enter":
+            event.prevent_default()
+            event.stop()
+            if self._prompt_search_filtered:
+                self._prompt_search_insert_selected()
+            elif self.app is not None:
+                self.app.bell()
+            return True
+
+        if event.key == "up":
+            event.prevent_default()
+            event.stop()
+            if self._prompt_search_index > 0:
+                self._prompt_search_index -= 1
+                if self._prompt_search is not None:
+                    self._prompt_search.update_selection(self._prompt_search_index)
+            return True
+
+        if event.key == "down":
+            event.prevent_default()
+            event.stop()
+            if self._prompt_search_index < len(self._prompt_search_filtered) - 1:
+                self._prompt_search_index += 1
+                if self._prompt_search is not None:
+                    self._prompt_search.update_selection(self._prompt_search_index)
+            return True
+
+        if event.key == "backspace":
+            event.prevent_default()
+            event.stop()
+            if not self._prompt_search_query:
+                # Readline-style affordance: backspace on an empty query
+                # abandons the search instead of eating the draft.
+                self._close_prompt_search(restore_draft=True)
+                return True
+            self._prompt_search_query = self._prompt_search_query[:-1]
+            self._prompt_search_index = 0
+            self._refresh_prompt_search_panel()
+            return True
+
+        if event.is_printable and event.character is not None:
+            event.prevent_default()
+            event.stop()
+            self._prompt_search_query += event.character
+            self._prompt_search_index = 0
+            self._refresh_prompt_search_panel()
+            return True
+
+        return False
+
+    def on_prompt_search_panel_option_selected(
+        self, event: PromptSearchPanel.OptionSelected
+    ) -> None:
+        """Insert a clicked prompt row."""
+        event.stop()
+        if not self._prompt_search_active:
+            return
+        if 0 <= event.index < len(self._prompt_search_filtered):
+            self._prompt_search_index = event.index
+            self._prompt_search_insert_selected()
 
     def discard_text(self) -> bool:
         """Clear the draft, keeping it restorable via undo (ctrl+z).

--- a/libs/code/deepagents_code/tui/widgets/history.py
+++ b/libs/code/deepagents_code/tui/widgets/history.py
@@ -29,7 +29,7 @@ class HistoryManager:
         self.history_file = history_file
         self.max_entries = max_entries
         self._entries: list[str] = []
-        self._failed_persist: set[str] = set()
+        self._failed_persist: list[str] = []
         self._read_failed = False
         self._current_index: int = -1
         self._temp_input: str = ""
@@ -108,15 +108,14 @@ class HistoryManager:
         if entries is None:
             entries = list(self._entries)
         else:
-            # Prompts whose append failed live only in memory; re-append them
-            # so the refresh does not silently drop them from navigation.
-            unpersisted = self._failed_persist - set(entries)
-            entries.extend(entry for entry in self._entries if entry in unpersisted)
+            # Each failed append is a distinct occurrence, even when the same
+            # text already exists on disk. Keep those occurrences in submission
+            # order so the newest one remains newest after a refresh.
+            entries.extend(self._failed_persist)
             self._entries = entries[-self.max_entries :]
-            # Unpersisted texts stay tracked until they reach disk, but ones
-            # that aged out of the window are unrecoverable anyway. Dropping
-            # them bounds the set to `max_entries` instead of the session.
-            self._failed_persist &= set(self._entries)
+            # Failed occurrences are appended after persisted history, so only
+            # their newest bounded suffix can remain in the navigation window.
+            self._failed_persist = self._failed_persist[-self.max_entries :]
         self.reset_navigation()
 
         recent: list[str] = []
@@ -194,7 +193,7 @@ class HistoryManager:
         # session; `_failed_persist` lets a later `recent_prompts` refresh
         # merge it back instead of dropping it.
         if not self._append_to_file(text):
-            self._failed_persist.add(text)
+            self._failed_persist.append(text)
 
         # Compact only when we have 2x max entries (rare operation)
         if len(self._entries) > self.max_entries * 2:

--- a/libs/code/deepagents_code/tui/widgets/history.py
+++ b/libs/code/deepagents_code/tui/widgets/history.py
@@ -31,6 +31,7 @@ class HistoryManager:
         self._entries: list[str] = []
         self._failed_persist: list[str] = []
         self._read_failed = False
+        self._write_failed = False
         self._current_index: int = -1
         self._temp_input: str = ""
         self._query: str = ""
@@ -82,6 +83,19 @@ class HistoryManager:
             `True` when the history file exists but could not be read.
         """
         return self._read_failed
+
+    @property
+    def history_unwritable(self) -> bool:
+        """Whether any write to the history file has failed this session.
+
+        Sticky by design: once a write fails, prompts recorded from then on
+        live only in memory and are lost at exit. Callers use this to say so
+        once rather than letting the loss go unmentioned.
+
+        Returns:
+            `True` when an append or a compaction has failed.
+        """
+        return self._write_failed
 
     def _load_history(self) -> None:
         """Load the bounded navigation history from file."""
@@ -145,6 +159,7 @@ class HistoryManager:
                 self.history_file,
                 exc_info=True,
             )
+            self._write_failed = True
             return False
         return True
 
@@ -164,6 +179,7 @@ class HistoryManager:
                 self.history_file,
                 exc_info=True,
             )
+            self._write_failed = True
 
     def add(self, text: str) -> None:
         """Add a command to history.

--- a/libs/code/deepagents_code/tui/widgets/history.py
+++ b/libs/code/deepagents_code/tui/widgets/history.py
@@ -29,19 +29,21 @@ class HistoryManager:
         self.history_file = history_file
         self.max_entries = max_entries
         self._entries: list[str] = []
+        self._failed_persist: set[str] = set()
         self._current_index: int = -1
         self._temp_input: str = ""
         self._query: str = ""
         self._load_history()
 
-    def _read_history(self) -> list[str]:
+    def _read_history(self) -> list[str] | None:
         """Read all persisted entries, tolerating legacy malformed lines.
 
         Returns:
-            Persisted entries in file order.
+            Persisted entries in file order, or `None` when the file could
+            not be read.
         """
         if not self.history_file.exists():
-            return []
+            return None
 
         try:
             with self.history_file.open("r", encoding="utf-8") as f:
@@ -62,20 +64,30 @@ class HistoryManager:
                 self.history_file,
                 exc_info=True,
             )
-            return []
+            return None
 
     def _load_history(self) -> None:
         """Load the bounded navigation history from file."""
-        self._entries = self._read_history()[-self.max_entries :]
+        self._entries = (self._read_history() or [])[-self.max_entries :]
 
     def recent_prompts(self) -> tuple[str, ...]:
         """Refresh and return unique prompts in newest-first order.
+
+        On a read failure the in-memory entries are kept, so prompts whose
+        file append failed earlier in the session are not destroyed.
 
         Returns:
             A bounded immutable prompt snapshot.
         """
         entries = self._read_history()
-        self._entries = entries[-self.max_entries :]
+        if entries is None:
+            entries = list(self._entries)
+        else:
+            # Prompts whose append failed live only in memory; re-append them
+            # so the refresh does not silently drop them from navigation.
+            unpersisted = self._failed_persist - set(entries)
+            entries.extend(entry for entry in self._entries if entry in unpersisted)
+            self._entries = entries[-self.max_entries :]
         self.reset_navigation()
 
         recent: list[str] = []
@@ -89,8 +101,12 @@ class HistoryManager:
                 break
         return tuple(recent)
 
-    def _append_to_file(self, text: str) -> None:
-        """Append a single entry to history file (concurrent-safe)."""
+    def _append_to_file(self, text: str) -> bool:
+        """Append a single entry to history file (concurrent-safe).
+
+        Returns:
+            `True` when the entry was persisted, `False` otherwise.
+        """
         try:
             self.history_file.parent.mkdir(parents=True, exist_ok=True)
             with self.history_file.open("a", encoding="utf-8") as f:
@@ -101,6 +117,8 @@ class HistoryManager:
                 self.history_file,
                 exc_info=True,
             )
+            return False
+        return True
 
     def _compact_history(self) -> None:
         """Rewrite history file to remove old entries.
@@ -142,8 +160,12 @@ class HistoryManager:
 
         self._entries.append(text)
 
-        # Append to file (fast, concurrent-safe)
-        self._append_to_file(text)
+        # Append to file (fast, concurrent-safe). The entry stays in memory
+        # even when the write fails, so up-arrow recall keeps working for the
+        # session; `_failed_persist` lets a later `recent_prompts` refresh
+        # merge it back instead of dropping it.
+        if not self._append_to_file(text):
+            self._failed_persist.add(text)
 
         # Compact only when we have 2x max entries (rare operation)
         if len(self._entries) > self.max_entries * 2:

--- a/libs/code/deepagents_code/tui/widgets/history.py
+++ b/libs/code/deepagents_code/tui/widgets/history.py
@@ -30,6 +30,7 @@ class HistoryManager:
         self.max_entries = max_entries
         self._entries: list[str] = []
         self._failed_persist: set[str] = set()
+        self._read_failed = False
         self._current_index: int = -1
         self._temp_input: str = ""
         self._query: str = ""
@@ -38,11 +39,16 @@ class HistoryManager:
     def _read_history(self) -> list[str] | None:
         """Read all persisted entries, tolerating legacy malformed lines.
 
+        Sets `history_unreadable` so callers can tell a file they cannot read
+        from one that is simply not there yet. The two are opposite facts to
+        report to the user, and both arrive here as `None`.
+
         Returns:
             Persisted entries in file order, or `None` when the file could
             not be read.
         """
         if not self.history_file.exists():
+            self._read_failed = False
             return None
 
         try:
@@ -57,14 +63,25 @@ class HistoryManager:
                     except json.JSONDecodeError:
                         entry = line
                     entries.append(entry if isinstance(entry, str) else str(entry))
+                self._read_failed = False
                 return entries
         except (OSError, UnicodeDecodeError):
             logger.warning(
-                "Failed to load history from %s; starting with empty history",
+                "Failed to read history from %s",
                 self.history_file,
                 exc_info=True,
             )
+            self._read_failed = True
             return None
+
+    @property
+    def history_unreadable(self) -> bool:
+        """Whether the last read failed, as opposed to finding no file.
+
+        Returns:
+            `True` when the history file exists but could not be read.
+        """
+        return self._read_failed
 
     def _load_history(self) -> None:
         """Load the bounded navigation history from file."""
@@ -74,7 +91,15 @@ class HistoryManager:
         """Refresh and return unique prompts in newest-first order.
 
         On a read failure the in-memory entries are kept, so prompts whose
-        file append failed earlier in the session are not destroyed.
+        file append failed earlier in the session are not destroyed. Check
+        `history_unreadable` afterwards to tell an unreadable file from an
+        empty one.
+
+        Side effects: re-reads the file into the in-memory entries and resets
+        up-arrow navigation.
+
+        The dedup runs over the whole file rather than the bounded navigation
+        window, so this can surface prompts older than up-arrow reaches.
 
         Returns:
             A bounded immutable prompt snapshot.
@@ -88,6 +113,10 @@ class HistoryManager:
             unpersisted = self._failed_persist - set(entries)
             entries.extend(entry for entry in self._entries if entry in unpersisted)
             self._entries = entries[-self.max_entries :]
+            # Unpersisted texts stay tracked until they reach disk, but ones
+            # that aged out of the window are unrecoverable anyway. Dropping
+            # them bounds the set to `max_entries` instead of the session.
+            self._failed_persist &= set(self._entries)
         self.reset_navigation()
 
         recent: list[str] = []

--- a/libs/code/deepagents_code/tui/widgets/history.py
+++ b/libs/code/deepagents_code/tui/widgets/history.py
@@ -112,8 +112,11 @@ class HistoryManager:
         Side effects: re-reads the file into the in-memory entries and resets
         up-arrow navigation.
 
-        The dedup runs over the whole file rather than the bounded navigation
-        window, so this can surface prompts older than up-arrow reaches.
+        When the read succeeds the dedup runs over the persisted file rather
+        than the bounded navigation window, so this can surface prompts older
+        than up-arrow reaches. (The file is itself bounded: `_compact_history`
+        truncates it at twice `max_entries`.) On a read failure the fallback is
+        the navigation window, so that reach is lost along with it.
 
         Returns:
             A bounded immutable prompt snapshot.

--- a/libs/code/deepagents_code/tui/widgets/history.py
+++ b/libs/code/deepagents_code/tui/widgets/history.py
@@ -34,10 +34,14 @@ class HistoryManager:
         self._query: str = ""
         self._load_history()
 
-    def _load_history(self) -> None:
-        """Load history from file."""
+    def _read_history(self) -> list[str]:
+        """Read all persisted entries, tolerating legacy malformed lines.
+
+        Returns:
+            Persisted entries in file order.
+        """
         if not self.history_file.exists():
-            return
+            return []
 
         try:
             with self.history_file.open("r", encoding="utf-8") as f:
@@ -51,14 +55,39 @@ class HistoryManager:
                     except json.JSONDecodeError:
                         entry = line
                     entries.append(entry if isinstance(entry, str) else str(entry))
-                self._entries = entries[-self.max_entries :]
+                return entries
         except (OSError, UnicodeDecodeError):
             logger.warning(
                 "Failed to load history from %s; starting with empty history",
                 self.history_file,
                 exc_info=True,
             )
-            self._entries = []
+            return []
+
+    def _load_history(self) -> None:
+        """Load the bounded navigation history from file."""
+        self._entries = self._read_history()[-self.max_entries :]
+
+    def recent_prompts(self) -> tuple[str, ...]:
+        """Refresh and return unique prompts in newest-first order.
+
+        Returns:
+            A bounded immutable prompt snapshot.
+        """
+        entries = self._read_history()
+        self._entries = entries[-self.max_entries :]
+        self.reset_navigation()
+
+        recent: list[str] = []
+        seen: set[str] = set()
+        for entry in reversed(entries):
+            if entry in seen:
+                continue
+            seen.add(entry)
+            recent.append(entry)
+            if len(recent) == self.max_entries:
+                break
+        return tuple(recent)
 
     def _append_to_file(self, text: str) -> None:
         """Append a single entry to history file (concurrent-safe)."""

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -128,8 +128,15 @@ class PromptSearchInput(Input):
 
     BINDINGS: ClassVar[list[BindingType]] = [
         # The app binds these chords with priority, so they never reach a
-        # focused widget unless `check_action` steps them aside; it does while
-        # the panel is open (see `DeepAgentsApp.check_action`).
+        # focused widget unless `check_action` steps them aside.
+        #
+        # `escape` and `shift+tab` get an explicit panel-aware clause there
+        # (see `DeepAgentsApp.check_action`). `tab` does not: its app binding
+        # is `approval_reject_with_reason`, which steps aside whenever an
+        # approval is pending *and* the chat input is unfocused. This works
+        # here only because `_is_input_focused()` walks `ChatInput`'s children
+        # and finds the query input -- narrowing it to the text area alone
+        # would silently break Tab paging with nothing to flag it.
         Binding("escape", "abandon_search", "Cancel", show=False, priority=True),
         Binding("tab", "page(True)", "Page Down", show=False, priority=True),
         Binding("shift+tab", "page(False)", "Page Up", show=False, priority=True),
@@ -321,6 +328,9 @@ class PromptSearchPanel(Vertical):
         self._hint_static: Static | None = None
         self._options: list[PromptSearchOption] = []
         self._empty_widget: Static | None = None
+        # `_selected_index` is the selection currently applied to the mounted
+        # rows; `_pending_selected` is the one the next rebuild will apply.
+        # They diverge whenever a rebuild is queued but has not run.
         self._selected_index = 0
         self._pending_titles: list[str] = []
         self._pending_selected: int = 0
@@ -377,10 +387,17 @@ class PromptSearchPanel(Vertical):
             titles: All filtered row titles; the panel renders a window of
                 them around `selected_index`.
             selected_index: Index of the selected row.
-            empty: Empty-state message to show instead of rows, if any.
+            empty: Empty-state message to show instead of rows, if any. It
+                replaces the rows rather than joining them, so passing both is
+                a caller error; `titles` is dropped in that case rather than
+                rendered underneath the message.
         """
+        if empty is not None:
+            titles = []
         self._selected_index = selected_index
-        self._pending_titles = titles
+        # Copy: the panel keeps this list across frames, so an owner that
+        # mutated the list it passed would rewrite the pending window in place.
+        self._pending_titles = list(titles)
         self._pending_selected = selected_index
         self._pending_empty = empty
         # Increment generation so stale callbacks from prior calls are skipped.
@@ -389,6 +406,54 @@ class PromptSearchPanel(Vertical):
         if self._query_input is not None and self._query_input.value != query:
             self._query_input.value = query
         self.call_next(lambda: self._rebuild_options(gen))
+
+    async def _fit_rows_to_window(
+        self, window: list[str], start: int, selected_index: int
+    ) -> None:
+        """Make the mounted rows match `window`, reusing what is already there.
+
+        Reusing DOM nodes avoids the flicker of a full teardown/mount cycle
+        while the panel is visible, so this re-titles the overlap and only
+        mounts or removes the difference.
+
+        Args:
+            window: Titles for the slice of the list being shown.
+            start: Index in the full list that `window[0]` corresponds to.
+            selected_index: Index in the full list of the selected row.
+        """
+        existing = len(self._options)
+        needed = len(window)
+
+        for offset in range(min(existing, needed)):
+            self._options[offset].set_content(
+                window[offset],
+                start + offset,
+                is_selected=(start + offset == selected_index),
+            )
+
+        # The empty-state message is a single tracked widget, not a
+        # per-rebuild mount: the previous one must come down before anything
+        # new goes up, or every no-match keystroke adds a row.
+        if self._empty_widget is not None:
+            await self._empty_widget.remove()
+            self._empty_widget = None
+
+        if existing > needed:
+            for option in self._options[needed:]:
+                await option.remove()
+            del self._options[needed:]
+        elif needed > existing:
+            new_widgets = [
+                PromptSearchOption(
+                    title=window[offset],
+                    index=start + offset,
+                    is_selected=(start + offset == selected_index),
+                )
+                for offset in range(existing, needed)
+            ]
+            self._options.extend(new_widgets)
+            if self._results is not None:
+                await self._results.mount(*new_widgets)
 
     async def _rebuild_options(self, generation: int) -> None:
         """Rebuild row widgets from pending state.
@@ -402,44 +467,12 @@ class PromptSearchPanel(Vertical):
         if generation != self._rebuild_generation or self._results is None:
             return
 
-        titles = self._pending_titles
         selected_index = self._pending_selected
-
-        start, stop = _window_bounds(len(titles), selected_index)
-        window = titles[start:stop]
-
-        existing = len(self._options)
-        needed = len(window)
-
-        for i in range(min(existing, needed)):
-            self._options[i].set_content(
-                window[i], start + i, is_selected=(start + i == selected_index)
-            )
+        start, stop = _window_bounds(len(self._pending_titles), selected_index)
+        window = self._pending_titles[start:stop]
 
         try:
-            # The empty-state message is a single tracked widget, not a
-            # per-rebuild mount: the previous one must come down before
-            # anything new goes up, or every no-match keystroke adds a row.
-            if self._empty_widget is not None:
-                await self._empty_widget.remove()
-                self._empty_widget = None
-
-            if existing > needed:
-                for option in self._options[needed:]:
-                    await option.remove()
-                del self._options[needed:]
-
-            if needed > existing:
-                new_widgets = [
-                    PromptSearchOption(
-                        title=window[idx],
-                        index=start + idx,
-                        is_selected=(start + idx == selected_index),
-                    )
-                    for idx in range(existing, needed)
-                ]
-                self._options.extend(new_widgets)
-                await self._results.mount(*new_widgets)
+            await self._fit_rows_to_window(window, start, selected_index)
         except Exception:
             logger.exception("Failed to rebuild prompt search panel; abandoning search")
             # Hiding alone would leave `ChatInput` still holding a draft
@@ -483,7 +516,9 @@ class PromptSearchPanel(Vertical):
                 Content(self._pending_empty), classes="prompt-search-empty"
             )
             await self._results.mount(self._empty_widget)
-        self.show(len(self._options) if not self._pending_empty else 1)
+        # `update_state` clears `titles` whenever `empty` is set, so exactly
+        # one of the two is ever on screen.
+        self.show(1 if self._pending_empty else len(self._options))
 
         if start <= selected_index < start + len(self._options):
             self._options[selected_index - start].scroll_visible(animate=False)

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -178,6 +178,21 @@ class PromptSearchOption(Static):
            primary. */
         background: $surface-lighten-2;
     }
+
+    PromptSearchOption.prompt-search-selected:hover {
+        /* Restating the selected colors here is load-bearing, not redundant.
+
+           A pseudo-class bumps the class slot of Textual's specificity tuple,
+           so the plain `PromptSearchOption:hover` above ties the selected rule
+           at (0, 1, 1) and wins on source order. Without this rule, pointing
+           at the selected row strips its $primary background while
+           `color: $background` still applies -- near-invisible text on light
+           themes. Adding the class alongside :hover scores (0, 2, 1), which
+           wins outright. Textual has no :not(), so exclusion is not an
+           option here. */
+        background: $primary;
+        color: $background;
+    }
     """
 
     class Clicked(Message):

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -73,8 +73,10 @@ PROMPT_SEARCH_PANEL_ROWS = 1 + PROMPT_SEARCH_MAX_ROWS + PROMPT_SEARCH_MAX_HINT_R
 
 This is the ceiling on what `show()` can report, so it is what `ChatInputBox`
 reserves when fitting a manual composer height and what the panel's own
-`max-height` clamps to. `show()` clamps its hint estimate to
-`PROMPT_SEARCH_MAX_HINT_ROWS` so the two can never disagree.
+`max-height` clamps to. `_hint_rows()` clamps the hint estimate to
+`PROMPT_SEARCH_MAX_HINT_ROWS` so the two can never disagree -- the clamp lives
+there, not in `show()`, because `on_resize` re-measures through the same helper
+without going through `show()`.
 """
 
 
@@ -331,7 +333,11 @@ class PromptSearchPanel(Vertical):
     def update_state(
         self, query: str, titles: list[str], selected_index: int, empty: str | None
     ) -> None:
-        """Show the panel for a new query/result set.
+        """Queue a rebuild that shows the panel for a new query/result set.
+
+        The panel is shown by `_rebuild_options` via `call_next`, not here, and
+        not at all if that rebuild hits its recovery path -- which hides and
+        abandons the search instead.
 
         Args:
             query: Current filter text, rendered on the query line.

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -68,6 +68,16 @@ unmounted rows are simply never the selection target.
 PROMPT_SEARCH_MAX_HINT_ROWS = 3
 """Hint rows the panel is willing to render; it wraps on narrow windows."""
 
+PROMPT_SEARCH_REWINDOW_MARGIN = 5
+"""How close to a mounted edge the selection gets before the window re-centers.
+
+`update_selection` re-styles two rows when the selection stays comfortably
+inside the mounted window, and rebuilds all of it otherwise. Rebuilding
+whenever the *ideal* start moved would rebuild on every single-step move once
+the list outgrows `PROMPT_SEARCH_WINDOW`, which is the common case. This margin
+keeps that on the cheap path until the selection nears an edge.
+"""
+
 PROMPT_SEARCH_PANEL_ROWS = 1 + PROMPT_SEARCH_MAX_ROWS + PROMPT_SEARCH_MAX_HINT_ROWS
 """Rows the panel reports at its tallest: query, results, and wrapped hint.
 
@@ -519,14 +529,34 @@ class PromptSearchPanel(Vertical):
         if self._selected_index == selected_index:
             return
         start, _stop = _window_bounds(len(self._pending_titles), selected_index)
-        if (
-            not self._options
-            or not (start <= selected_index < start + len(self._options))
-            or self._options[0].index != start
-        ):
-            # Selection left the mounted window (or the window is stale); a
-            # rebuild is the only way to show it. `_rebuild_options` applies
-            # the selection as it mounts, so nothing else is needed here.
+        if not self._options:
+            needs_rebuild = True
+        else:
+            mounted_start = self._options[0].index
+            mounted_stop = mounted_start + len(self._options)
+            needs_rebuild = (
+                # The selection is not mounted, so only a rebuild can show it.
+                not (mounted_start <= selected_index < mounted_stop)
+                # The window outruns the current list: it is stale after a
+                # shrink and its indexes no longer address real prompts.
+                or mounted_stop > len(self._pending_titles)
+                # The selection is close enough to an edge that the next move
+                # would leave the window, and re-centering would actually move
+                # it. Comparing against `start` alone would rebuild on every
+                # single-step move once the list is longer than the window,
+                # restyling all mounted rows per keystroke instead of two.
+                or (
+                    min(
+                        selected_index - mounted_start,
+                        mounted_stop - 1 - selected_index,
+                    )
+                    < PROMPT_SEARCH_REWINDOW_MARGIN
+                    and start != mounted_start
+                )
+            )
+        if needs_rebuild:
+            # `_rebuild_options` applies the selection as it mounts, so nothing
+            # else is needed here.
             self._selected_index = selected_index
             self._rebuild_generation += 1
             gen = self._rebuild_generation

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -234,6 +234,7 @@ class PromptSearchPanel(Vertical):
         self._results: VerticalScroll | None = None
         self._hint_static: Static | None = None
         self._options: list[PromptSearchOption] = []
+        self._empty_widget: Static | None = None
         self._selected_index = 0
         self._pending_titles: list[str] = []
         self._pending_selected: int = 0
@@ -325,6 +326,13 @@ class PromptSearchPanel(Vertical):
             )
 
         try:
+            # The empty-state message is a single tracked widget, not a
+            # per-rebuild mount: the previous one must come down before
+            # anything new goes up, or every no-match keystroke adds a row.
+            if self._empty_widget is not None:
+                await self._empty_widget.remove()
+                self._empty_widget = None
+
             if existing > needed:
                 for option in self._options[needed:]:
                     await option.remove()
@@ -354,9 +362,10 @@ class PromptSearchPanel(Vertical):
             return
 
         if self._pending_empty is not None:
-            await self._results.mount(
-                Static(self._pending_empty, classes="prompt-search-empty")
+            self._empty_widget = Static(
+                self._pending_empty, classes="prompt-search-empty"
             )
+            await self._results.mount(self._empty_widget)
         self.show(len(self._options) if not self._pending_empty else 1)
 
         if start <= selected_index < start + len(self._options):
@@ -413,6 +422,9 @@ class PromptSearchPanel(Vertical):
         self._pending_titles = []
         self._pending_empty = None
         self._rebuild_generation += 1
+        # Drop the tracked reference so a rebuild after re-open starts clean;
+        # the widget itself is torn down with the hidden panel's children.
+        self._empty_widget = None
         self.styles.display = "none"  # ty: ignore[invalid-assignment]  # Textual accepts string display values
         self._report_rows(0)
 

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -35,6 +35,16 @@ PROMPT_SEARCH_HINT = (
 PROMPT_SEARCH_PAGE_SIZE = PROMPT_SEARCH_MAX_ROWS
 """Rows Tab/Shift+Tab jump through the filtered list."""
 
+PROMPT_SEARCH_WINDOW = 50
+"""Most rows rendered in the DOM at once, windowed around the selection.
+
+Mounting one `PromptSearchOption` per filtered prompt costs real time at the
+100-entry history cap and throws most of them away above the 5-row viewport, so
+the panel renders a sliding window instead. Navigation re-windows via
+`update_selection`, so any reachable row is mounted before it can be selected;
+unmounted rows are simply never the selection target.
+"""
+
 PROMPT_SEARCH_PANEL_ROWS = 1 + PROMPT_SEARCH_MAX_ROWS + 1
 """Rows the panel reports at its tallest: query, results, hint.
 
@@ -47,6 +57,19 @@ def prompt_title(prompt: str) -> str:
     """Return a prompt's first non-empty line for a one-row summary."""
     nonempty = [line.strip() for line in prompt.splitlines() if line.strip()]
     return (nonempty[0] if nonempty else prompt.strip()) or "(empty prompt)"
+
+
+def _window_bounds(total: int, selected_index: int) -> tuple[int, int]:
+    """Return the [start, stop) window of rows to render around a selection."""
+    if total <= PROMPT_SEARCH_WINDOW:
+        return 0, total
+    # Keep the selection comfortably inside the window so single-step moves
+    # stay mounted; the bias toward newer rows matches newest-first scanning.
+    start = max(
+        0,
+        min(selected_index - PROMPT_SEARCH_WINDOW // 5, total - PROMPT_SEARCH_WINDOW),
+    )
+    return start, start + PROMPT_SEARCH_WINDOW
 
 
 def filter_prompts(prompts: tuple[str, ...], query: str) -> list[str]:
@@ -259,7 +282,8 @@ class PromptSearchPanel(Vertical):
 
         Args:
             query: Current filter text, rendered on the query line.
-            titles: Row titles to display (already capped by the caller).
+            titles: All filtered row titles; the panel renders a window of
+                them around `selected_index`.
             selected_index: Index of the selected row.
             empty: Empty-state message to show instead of rows, if any.
         """
@@ -289,12 +313,15 @@ class PromptSearchPanel(Vertical):
         titles = self._pending_titles
         selected_index = self._pending_selected
 
+        start, stop = _window_bounds(len(titles), selected_index)
+        window = titles[start:stop]
+
         existing = len(self._options)
-        needed = len(titles)
+        needed = len(window)
 
         for i in range(min(existing, needed)):
             self._options[i].set_content(
-                titles[i], i, is_selected=(i == selected_index)
+                window[i], start + i, is_selected=(start + i == selected_index)
             )
 
         try:
@@ -306,9 +333,9 @@ class PromptSearchPanel(Vertical):
             if needed > existing:
                 new_widgets = [
                     PromptSearchOption(
-                        title=titles[idx],
-                        index=idx,
-                        is_selected=(idx == selected_index),
+                        title=window[idx],
+                        index=start + idx,
+                        is_selected=(start + idx == selected_index),
                     )
                     for idx in range(existing, needed)
                 ]
@@ -332,20 +359,41 @@ class PromptSearchPanel(Vertical):
             )
         self.show(len(self._options) if not self._pending_empty else 1)
 
-        if 0 <= selected_index < len(self._options):
-            self._options[selected_index].scroll_visible(animate=False)
+        if start <= selected_index < start + len(self._options):
+            self._options[selected_index - start].scroll_visible(animate=False)
 
     def update_selection(self, selected_index: int) -> None:
-        """Update which row is selected without rebuilding the list."""
+        """Update which row is selected, re-windowing the DOM when needed.
+
+        Rows are windowed around the selection, so a move beyond the mounted
+        range (a Tab page, or arrows past the window edge) rebuilds the window
+        instead of just re-styling a row.
+        """
         self._pending_selected = selected_index
         if self._selected_index == selected_index:
             return
-        if 0 <= self._selected_index < len(self._options):
-            self._options[self._selected_index].set_selected(is_selected=False)
+        start, _stop = _window_bounds(len(self._pending_titles), selected_index)
+        if (
+            not self._options
+            or not (start <= selected_index < start + len(self._options))
+            or self._options[0].index != start
+        ):
+            # Selection left the mounted window (or the window is stale); a
+            # rebuild is the only way to show it. `_rebuild_options` applies
+            # the selection as it mounts, so nothing else is needed here.
+            self._selected_index = selected_index
+            self._rebuild_generation += 1
+            gen = self._rebuild_generation
+            self.call_next(lambda: self._rebuild_options(gen))
+            return
+        old_local = self._selected_index - self._options[0].index
+        if 0 <= old_local < len(self._options):
+            self._options[old_local].set_selected(is_selected=False)
         self._selected_index = selected_index
-        if 0 <= selected_index < len(self._options):
-            self._options[selected_index].set_selected(is_selected=True)
-            self._options[selected_index].scroll_visible(animate=False)
+        new_local = selected_index - self._options[0].index
+        if 0 <= new_local < len(self._options):
+            self._options[new_local].set_selected(is_selected=True)
+            self._options[new_local].scroll_visible(animate=False)
 
     def on_prompt_search_option_clicked(
         self, event: PromptSearchOption.Clicked

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -9,14 +9,16 @@ routes to.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
+from textual.binding import Binding, BindingType
 from textual.containers import Vertical, VerticalScroll
 from textual.content import Content
 from textual.message import Message
-from textual.widgets import Static
+from textual.widgets import Input, Static
 
 if TYPE_CHECKING:
+    from textual import events
     from textual.app import ComposeResult
 
 logger = logging.getLogger(__name__)
@@ -25,10 +27,13 @@ PROMPT_SEARCH_MAX_ROWS = 5
 """Result rows the inline panel shows before the list scrolls."""
 
 PROMPT_SEARCH_HINT = (
-    "type to filter  •  ↑/↓ navigate  •  Enter insert  •  "
-    "Ctrl+R full view  •  Esc cancel"
+    "type to filter  •  ↑/↓ navigate  •  Tab/Shift+Tab page  •  "
+    "Enter insert  •  Ctrl+R full view  •  Esc cancel"
 )
 """Footer line; the Ctrl+R mention is what makes the modal tier discoverable."""
+
+PROMPT_SEARCH_PAGE_SIZE = PROMPT_SEARCH_MAX_ROWS
+"""Rows Tab/Shift+Tab jump through the filtered list."""
 
 PROMPT_SEARCH_PANEL_ROWS = 1 + PROMPT_SEARCH_MAX_ROWS + 1
 """Rows the panel reports at its tallest: query, results, hint.
@@ -50,6 +55,52 @@ def filter_prompts(prompts: tuple[str, ...], query: str) -> list[str]:
     if not needle:
         return list(prompts)
     return [prompt for prompt in prompts if needle in prompt.casefold()]
+
+
+class PromptSearchInput(Input):
+    """Query field for the inline prompt search panel.
+
+    Plain `Input` apart from the class name, which scopes the CSS above and
+    lets `ChatInput` filter `Input.Changed` / `Input.Submitted` messages to
+    this field, plus bindings for the keys the panel owns while focused.
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        # The app binds these chords with priority, so they never reach a
+        # focused widget unless `check_action` steps them aside; it does while
+        # the panel is open (see `DeepAgentsApp.check_action`).
+        Binding("escape", "abandon_search", "Cancel", show=False, priority=True),
+        Binding("tab", "page(True)", "Page Down", show=False, priority=True),
+        Binding("shift+tab", "page(False)", "Page Up", show=False, priority=True),
+    ]
+
+    class AbandonSearch(Message):
+        """Posted on Escape or empty-query Backspace, to close the search."""
+
+    class PageRequested(Message):
+        """Posted on Tab (older) or Shift+Tab (newer) to page the results."""
+
+        def __init__(self, *, older: bool) -> None:
+            """Initialize with the page direction."""
+            super().__init__()
+            self.older = older
+
+    def action_abandon_search(self) -> None:
+        """Forward Escape as an abandon request."""
+        self.post_message(self.AbandonSearch())
+
+    def action_page(self, older: bool) -> None:
+        """Forward Tab/Shift+Tab as a page request."""
+        self.post_message(self.PageRequested(older=older))
+
+    async def _on_key(self, event: events.Key) -> None:
+        """Forward the empty-query Backspace chord; defer the rest to Input."""
+        if event.key == "backspace" and not self.value:
+            event.prevent_default()
+            event.stop()
+            self.post_message(self.AbandonSearch())
+            return
+        await super()._on_key(event)
 
 
 class PromptSearchOption(Static):
@@ -121,9 +172,15 @@ class PromptSearchPanel(Vertical):
         max-height: {PROMPT_SEARCH_PANEL_ROWS};
     }}
 
-    PromptSearchPanel .prompt-search-query {{
+    PromptSearchPanel #prompt-search-input {{
         height: 1;
         padding: 0 1;
+        border: none;
+        background: transparent;
+    }}
+
+    PromptSearchPanel #prompt-search-input:focus {{
+        border: none;
     }}
 
     PromptSearchPanel #prompt-search-results {{
@@ -150,7 +207,7 @@ class PromptSearchPanel(Vertical):
         """Initialize display state."""
         super().__init__(**kwargs)
         self.can_focus = False
-        self._query_static: Static | None = None
+        self._query_input: PromptSearchInput | None = None
         self._results: VerticalScroll | None = None
         self._hint_static: Static | None = None
         self._options: list[PromptSearchOption] = []
@@ -183,13 +240,15 @@ class PromptSearchPanel(Vertical):
         Yields:
             Widgets for the prompt search panel.
         """
-        yield Static("", classes="prompt-search-query")
+        yield PromptSearchInput(
+            placeholder="Search submitted prompts", id="prompt-search-input"
+        )
         yield VerticalScroll(id="prompt-search-results")
         yield Static(PROMPT_SEARCH_HINT, classes="prompt-search-hint")
 
     def on_mount(self) -> None:
         """Grab the composed children."""
-        self._query_static = self.query_one(".prompt-search-query", Static)
+        self._query_input = self.query_one("#prompt-search-input", PromptSearchInput)
         self._results = self.query_one("#prompt-search-results", VerticalScroll)
         self._hint_static = self.query_one(".prompt-search-hint", Static)
 
@@ -211,10 +270,8 @@ class PromptSearchPanel(Vertical):
         # Increment generation so stale callbacks from prior calls are skipped.
         self._rebuild_generation += 1
         gen = self._rebuild_generation
-        if self._query_static is not None:
-            self._query_static.update(
-                Content.assemble(("prompt search: ", "dim"), (query, "bold"))
-            )
+        if self._query_input is not None and self._query_input.value != query:
+            self._query_input.value = query
         self.call_next(lambda: self._rebuild_options(gen))
 
     async def _rebuild_options(self, generation: int) -> None:

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -26,11 +26,31 @@ logger = logging.getLogger(__name__)
 PROMPT_SEARCH_MAX_ROWS = 5
 """Result rows the inline panel shows before the list scrolls."""
 
-PROMPT_SEARCH_HINT = (
-    "type to filter  •  ↑/↓ navigate  •  Tab/Shift+Tab page  •  "
-    "Enter insert  •  Ctrl+R full view  •  Esc cancel"
-)
-"""Footer line; the Ctrl+R mention is what makes the modal tier discoverable."""
+
+def prompt_search_hint() -> str:
+    """Build the footer line for the current charset mode.
+
+    The Ctrl+R mention is what makes the modal tier discoverable. The line is
+    kept short enough to wrap within `PROMPT_SEARCH_MAX_HINT_ROWS` at the
+    narrow widths the composer supports.
+
+    Returns:
+        The hint text, using ASCII glyphs on terminals that need them.
+    """
+    from deepagents_code.config import get_glyphs
+
+    glyphs = get_glyphs()
+    sep = f"  {glyphs.bullet}  "
+    return sep.join(
+        (
+            f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate",
+            "Tab/Shift+Tab page",
+            "Enter insert",
+            "Ctrl+R full view",
+            "Esc cancel",
+        )
+    )
+
 
 PROMPT_SEARCH_PAGE_SIZE = PROMPT_SEARCH_MAX_ROWS
 """Rows Tab/Shift+Tab jump through the filtered list."""
@@ -45,12 +65,16 @@ the panel renders a sliding window instead. Navigation re-windows via
 unmounted rows are simply never the selection target.
 """
 
-PROMPT_SEARCH_PANEL_ROWS = 1 + PROMPT_SEARCH_MAX_ROWS + 2
-"""Rows the panel reports at its tallest: query, results, and up to two for
-the hint (it wraps on narrow windows).
+PROMPT_SEARCH_MAX_HINT_ROWS = 3
+"""Hint rows the panel is willing to render; it wraps on narrow windows."""
 
-`ChatInputBox` reserves exactly this when fitting a manual composer height,
-so the constant must match what the panel actually renders.
+PROMPT_SEARCH_PANEL_ROWS = 1 + PROMPT_SEARCH_MAX_ROWS + PROMPT_SEARCH_MAX_HINT_ROWS
+"""Rows the panel reports at its tallest: query, results, and wrapped hint.
+
+This is the ceiling on what `show()` can report, so it is what `ChatInputBox`
+reserves when fitting a manual composer height and what the panel's own
+`max-height` clamps to. `show()` clamps its hint estimate to
+`PROMPT_SEARCH_MAX_HINT_ROWS` so the two can never disagree.
 """
 
 
@@ -65,7 +89,8 @@ def _window_bounds(total: int, selected_index: int) -> tuple[int, int]:
     if total <= PROMPT_SEARCH_WINDOW:
         return 0, total
     # Keep the selection comfortably inside the window so single-step moves
-    # stay mounted; the bias toward newer rows matches newest-first scanning.
+    # stay mounted. It sits near the window top, so most mounted rows are the
+    # older ones the user is scanning toward.
     start = max(
         0,
         min(selected_index - PROMPT_SEARCH_WINDOW // 5, total - PROMPT_SEARCH_WINDOW),
@@ -84,9 +109,9 @@ def filter_prompts(prompts: tuple[str, ...], query: str) -> list[str]:
 class PromptSearchInput(Input):
     """Query field for the inline prompt search panel.
 
-    Plain `Input` apart from the class name, which scopes the CSS above and
-    lets `ChatInput` filter `Input.Changed` / `Input.Submitted` messages to
-    this field, plus bindings for the keys the panel owns while focused.
+    Plain `Input` apart from the class name, which lets `ChatInput` filter
+    `Input.Changed` / `Input.Submitted` messages down to this field, plus
+    bindings for the keys the panel owns while focused.
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
@@ -244,6 +269,7 @@ class PromptSearchPanel(Vertical):
         self._pending_empty: str | None = None
         self._rebuild_generation: int = 0
         self._reported_rows = 0
+        self._result_rows = 0
 
     class RowsChanged(Message):
         """Message sent when the panel's rendered row count changes."""
@@ -271,7 +297,7 @@ class PromptSearchPanel(Vertical):
             placeholder="Search submitted prompts", id="prompt-search-input"
         )
         yield VerticalScroll(id="prompt-search-results")
-        yield Static(PROMPT_SEARCH_HINT, classes="prompt-search-hint")
+        yield Static(prompt_search_hint(), classes="prompt-search-hint")
 
     def on_mount(self) -> None:
         """Grab the composed children."""
@@ -353,9 +379,22 @@ class PromptSearchPanel(Vertical):
                 self._options.extend(new_widgets)
                 await self._results.mount(*new_widgets)
         except Exception:
-            logger.exception("Failed to rebuild prompt search panel; hiding to recover")
+            logger.exception("Failed to rebuild prompt search panel; abandoning search")
+            # Hiding alone would leave `ChatInput` still holding a draft
+            # snapshot, so `_prompt_search_active` stays true and the composer
+            # swallows every key into an invisible panel. `AbandonSearch` ends
+            # the session and restores the draft, and the rows have to come out
+            # of the DOM here: `hide()` only sets `display: none`, so dropping
+            # the list without unmounting orphans them beside the next rebuild.
+            try:
+                await self._results.remove_children()
+            except Exception:  # Recovery must not raise in turn
+                logger.exception("Failed to clear prompt search rows")
             self._options = []
+            self._empty_widget = None
             self.hide()
+            self.post_message(PromptSearchInput.AbandonSearch())
+            self.notify("Prompt search could not be displayed", severity="warning")
             return
 
         # The DOM mutations above can await, during which a hide() (or a newer
@@ -433,6 +472,25 @@ class PromptSearchPanel(Vertical):
         self.styles.display = "none"  # ty: ignore[invalid-assignment]  # Textual accepts string display values
         self._report_rows(0)
 
+    def _hint_rows(self) -> int:
+        """Measure the hint's wrapped height.
+
+        Textual wraps the hint on word boundaries, so a cell-count estimate
+        undercounts. Before the first layout the width is 0 and there is
+        nothing to measure; reserving the maximum then is the safe direction to
+        be wrong, because under-reporting clips the hint's last row.
+
+        Returns:
+            Rows the hint needs, clamped to `PROMPT_SEARCH_MAX_HINT_ROWS`.
+        """
+        if self._hint_static is None:
+            return PROMPT_SEARCH_MAX_HINT_ROWS
+        width = self._hint_static.content_region.width
+        if width <= 0:
+            return PROMPT_SEARCH_MAX_HINT_ROWS
+        measured = self._hint_static.get_content_height(self.size, self.size, width)
+        return max(1, min(measured, PROMPT_SEARCH_MAX_HINT_ROWS))
+
     def show(self, result_rows: int) -> None:
         """Show the panel.
 
@@ -442,14 +500,16 @@ class PromptSearchPanel(Vertical):
                 count. Capped at `PROMPT_SEARCH_MAX_ROWS`.
         """
         self.styles.display = "block"
-        # The hint line wraps on narrow windows. Estimate its wrapped height
-        # from the panel width (minus its horizontal padding); before the first
-        # layout the width is 0, which the max() floors to one row.
-        hint_rows = 1
-        if self._hint_static is not None:
-            from rich.cells import cell_len
+        self._result_rows = min(result_rows, PROMPT_SEARCH_MAX_ROWS)
+        self._report_rows(1 + self._result_rows + self._hint_rows())
 
-            width = self._hint_static.content_region.width
-            if width > 0:
-                hint_rows = max(1, -(-cell_len(PROMPT_SEARCH_HINT) // width))
-        self._report_rows(1 + min(result_rows, PROMPT_SEARCH_MAX_ROWS) + hint_rows)
+    def on_resize(self) -> None:
+        """Re-report the height once a width is known, or when it changes.
+
+        The first `show()` of a session runs before layout, so it reserves the
+        maximum hint height. This corrects the reservation to the measured one
+        instead of leaving the composer over-shrunk until the next keystroke.
+        """
+        if self.styles.display == "none":
+            return
+        self._report_rows(1 + self._result_rows + self._hint_rows())

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -427,8 +427,13 @@ class PromptSearchPanel(Vertical):
             return
 
         if self._pending_empty is not None:
+            # `Content` keeps the message literal. `_pending_empty` can be
+            # `ChatInput.prompt_history_error()`, which interpolates the history
+            # file path, and `Static` markup-parses a bare `str`: a path segment
+            # shaped like a tag is swallowed, and one shaped like a closing tag
+            # raises `MarkupError`. The modal wraps the same message this way.
             self._empty_widget = Static(
-                self._pending_empty, classes="prompt-search-empty"
+                Content(self._pending_empty), classes="prompt-search-empty"
             )
             await self._results.mount(self._empty_widget)
         self.show(len(self._options) if not self._pending_empty else 1)

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -170,6 +170,13 @@ class PromptSearchOption(Static):
         background: $primary;
         color: $background;
     }
+
+    PromptSearchOption.prompt-search-hovered {
+        /* Hover marks where the cursor is pointing without implying a
+           selection change, so it stays subtler than the selected row's
+           solid primary. */
+        background: $surface-lighten-2;
+    }
     """
 
     class Clicked(Message):
@@ -177,6 +184,14 @@ class PromptSearchOption(Static):
 
         def __init__(self, index: int) -> None:
             """Initialize with the clicked row index."""
+            super().__init__()
+            self.index = index
+
+    class Hovered(Message):
+        """Message sent when the mouse moves over a prompt row."""
+
+        def __init__(self, index: int) -> None:
+            """Initialize with the hovered row index."""
             super().__init__()
             self.index = index
 
@@ -199,9 +214,17 @@ class PromptSearchOption(Static):
         self._is_selected = is_selected
         self.set_class(is_selected, "prompt-search-selected")
 
+    def set_hovered(self, *, is_hovered: bool) -> None:
+        """Toggle the hover styling."""
+        self.set_class(is_hovered, "prompt-search-hovered")
+
     def on_click(self) -> None:
         """Post the click up to `ChatInput`."""
         self.post_message(self.Clicked(self.index))
+
+    def on_mouse_move(self) -> None:
+        """Hover-mark the row under the cursor without moving the selection."""
+        self.post_message(self.Hovered(self.index))
 
 
 class PromptSearchPanel(Vertical):
@@ -270,6 +293,7 @@ class PromptSearchPanel(Vertical):
         self._rebuild_generation: int = 0
         self._reported_rows = 0
         self._result_rows = 0
+        self._hovered_index: int | None = None
 
     class RowsChanged(Message):
         """Message sent when the panel's rendered row count changes."""
@@ -342,6 +366,10 @@ class PromptSearchPanel(Vertical):
 
         titles = self._pending_titles
         selected_index = self._pending_selected
+        # Rows are restyled or remounted below, so any hover mark dies with
+        # this rebuild; the next mouse movement re-marks the row under the
+        # cursor.
+        self._hovered_index = None
 
         start, stop = _window_bounds(len(titles), selected_index)
         window = titles[start:stop]
@@ -452,6 +480,27 @@ class PromptSearchPanel(Vertical):
         """Forward row clicks as this panel's own message for `ChatInput`."""
         event.stop()
         self.post_message(self.OptionSelected(event.index))
+
+    def on_prompt_search_option_hovered(
+        self, event: PromptSearchOption.Hovered
+    ) -> None:
+        """Hover-mark the row under the cursor without moving the selection.
+
+        Hover is transient pointing, not a commitment: it stays inside the
+        panel instead of going to `ChatInput`, or arrow keys would resume from
+        wherever the mouse last rested instead of from the selected row.
+        """
+        event.stop()
+        if not self._options:
+            return
+        if self._hovered_index is not None:
+            old_local = self._hovered_index - self._options[0].index
+            if 0 <= old_local < len(self._options):
+                self._options[old_local].set_hovered(is_hovered=False)
+        self._hovered_index = event.index
+        new_local = event.index - self._options[0].index
+        if 0 <= new_local < len(self._options):
+            self._options[new_local].set_hovered(is_hovered=True)
 
     def _report_rows(self, rows: int) -> None:
         """Announce the rendered row count when it changes."""

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -171,10 +171,11 @@ class PromptSearchOption(Static):
         color: $background;
     }
 
-    PromptSearchOption.prompt-search-hovered {
-        /* Hover marks where the cursor is pointing without implying a
-           selection change, so it stays subtler than the selected row's
-           solid primary. */
+    PromptSearchOption:hover {
+        /* Textual's built-in :hover covers transient pointing: it never
+           touches the selection, so arrow keys still resume from the
+           selected row. It stays subtler than the selected row's solid
+           primary. */
         background: $surface-lighten-2;
     }
     """
@@ -184,14 +185,6 @@ class PromptSearchOption(Static):
 
         def __init__(self, index: int) -> None:
             """Initialize with the clicked row index."""
-            super().__init__()
-            self.index = index
-
-    class Hovered(Message):
-        """Message sent when the mouse moves over a prompt row."""
-
-        def __init__(self, index: int) -> None:
-            """Initialize with the hovered row index."""
             super().__init__()
             self.index = index
 
@@ -214,17 +207,9 @@ class PromptSearchOption(Static):
         self._is_selected = is_selected
         self.set_class(is_selected, "prompt-search-selected")
 
-    def set_hovered(self, *, is_hovered: bool) -> None:
-        """Toggle the hover styling."""
-        self.set_class(is_hovered, "prompt-search-hovered")
-
     def on_click(self) -> None:
         """Post the click up to `ChatInput`."""
         self.post_message(self.Clicked(self.index))
-
-    def on_mouse_move(self) -> None:
-        """Hover-mark the row under the cursor without moving the selection."""
-        self.post_message(self.Hovered(self.index))
 
 
 class PromptSearchPanel(Vertical):
@@ -293,7 +278,6 @@ class PromptSearchPanel(Vertical):
         self._rebuild_generation: int = 0
         self._reported_rows = 0
         self._result_rows = 0
-        self._hovered_index: int | None = None
 
     class RowsChanged(Message):
         """Message sent when the panel's rendered row count changes."""
@@ -366,10 +350,6 @@ class PromptSearchPanel(Vertical):
 
         titles = self._pending_titles
         selected_index = self._pending_selected
-        # Rows are restyled or remounted below, so any hover mark dies with
-        # this rebuild; the next mouse movement re-marks the row under the
-        # cursor.
-        self._hovered_index = None
 
         start, stop = _window_bounds(len(titles), selected_index)
         window = titles[start:stop]
@@ -480,27 +460,6 @@ class PromptSearchPanel(Vertical):
         """Forward row clicks as this panel's own message for `ChatInput`."""
         event.stop()
         self.post_message(self.OptionSelected(event.index))
-
-    def on_prompt_search_option_hovered(
-        self, event: PromptSearchOption.Hovered
-    ) -> None:
-        """Hover-mark the row under the cursor without moving the selection.
-
-        Hover is transient pointing, not a commitment: it stays inside the
-        panel instead of going to `ChatInput`, or arrow keys would resume from
-        wherever the mouse last rested instead of from the selected row.
-        """
-        event.stop()
-        if not self._options:
-            return
-        if self._hovered_index is not None:
-            old_local = self._hovered_index - self._options[0].index
-            if 0 <= old_local < len(self._options):
-                self._options[old_local].set_hovered(is_hovered=False)
-        self._hovered_index = event.index
-        new_local = event.index - self._options[0].index
-        if 0 <= new_local < len(self._options):
-            self._options[new_local].set_hovered(is_hovered=True)
 
     def _report_rows(self, rows: int) -> None:
         """Announce the rendered row count when it changes."""

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -45,8 +45,9 @@ the panel renders a sliding window instead. Navigation re-windows via
 unmounted rows are simply never the selection target.
 """
 
-PROMPT_SEARCH_PANEL_ROWS = 1 + PROMPT_SEARCH_MAX_ROWS + 1
-"""Rows the panel reports at its tallest: query, results, hint.
+PROMPT_SEARCH_PANEL_ROWS = 1 + PROMPT_SEARCH_MAX_ROWS + 2
+"""Rows the panel reports at its tallest: query, results, and up to two for
+the hint (it wraps on narrow windows).
 
 `ChatInputBox` reserves exactly this when fitting a manual composer height,
 so the constant must match what the panel actually renders.
@@ -219,7 +220,9 @@ class PromptSearchPanel(Vertical):
     }}
 
     PromptSearchPanel .prompt-search-hint {{
-        height: 1;
+        /* auto height + wrapping so a narrow window wraps the hint onto a
+           second line instead of dropping its tail. */
+        height: auto;
         padding: 0 1;
         color: $text-muted;
         text-style: italic;
@@ -437,4 +440,14 @@ class PromptSearchPanel(Vertical):
                 count. Capped at `PROMPT_SEARCH_MAX_ROWS`.
         """
         self.styles.display = "block"
-        self._report_rows(2 + min(result_rows, PROMPT_SEARCH_MAX_ROWS))
+        # The hint line wraps on narrow windows. Estimate its wrapped height
+        # from the panel width (minus its horizontal padding); before the first
+        # layout the width is 0, which the max() floors to one row.
+        hint_rows = 1
+        if self._hint_static is not None:
+            from rich.cells import cell_len
+
+            width = self._hint_static.content_region.width
+            if width > 0:
+                hint_rows = max(1, -(-cell_len(PROMPT_SEARCH_HINT) // width))
+        self._report_rows(1 + min(result_rows, PROMPT_SEARCH_MAX_ROWS) + hint_rows)

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -208,25 +208,48 @@ class PromptSearchOption(Static):
     def __init__(self, title: str, index: int, *, is_selected: bool) -> None:
         """Initialize the row."""
         super().__init__(Content.styled(title, "bold"))
-        self.index = index
-        self._is_selected = is_selected
-        if is_selected:
-            self.add_class("prompt-search-selected")
+        self._index = index
+        self.set_selected(is_selected=is_selected)
+
+    @property
+    def index(self) -> int:
+        """Position of this row in the filtered list.
+
+        Read-only from outside: `PromptSearchPanel` treats `_options[0].index`
+        as the authority on which window is currently mounted, so an external
+        write would silently defeat its staleness check. `set_content` is the
+        only way to move a row.
+
+        Returns:
+            The row's index in the filtered list.
+        """
+        return self._index
+
+    @property
+    def is_selected(self) -> bool:
+        """Whether this row currently renders as selected.
+
+        Derived from the CSS class rather than mirrored in a field, so the two
+        cannot drift.
+
+        Returns:
+            `True` when the selected styling is applied.
+        """
+        return self.has_class("prompt-search-selected")
 
     def set_content(self, title: str, index: int, *, is_selected: bool) -> None:
         """Update the row in place during a panel rebuild."""
         self.update(Content.styled(title, "bold"))
-        self.index = index
+        self._index = index
         self.set_selected(is_selected=is_selected)
 
     def set_selected(self, *, is_selected: bool) -> None:
         """Toggle the selected styling."""
-        self._is_selected = is_selected
         self.set_class(is_selected, "prompt-search-selected")
 
     def on_click(self) -> None:
         """Post the click up to `ChatInput`."""
-        self.post_message(self.Clicked(self.index))
+        self.post_message(self.Clicked(self._index))
 
 
 class PromptSearchPanel(Vertical):
@@ -524,6 +547,21 @@ class PromptSearchPanel(Vertical):
         """Forward row clicks as this panel's own message for `ChatInput`."""
         event.stop()
         self.post_message(self.OptionSelected(event.index))
+
+    def focus_query(self) -> bool:
+        """Move focus to the query input.
+
+        Keeps the panel's composition private to it: the owner asks for focus
+        rather than reaching through to `_query_input`, which is `None` until
+        `on_mount` has run.
+
+        Returns:
+            `True` when focus moved, `False` when the input is not mounted yet.
+        """
+        if self._query_input is None:
+            return False
+        self._query_input.focus()
+        return True
 
     def _report_rows(self, rows: int) -> None:
         """Announce the rendered row count when it changes."""

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -409,15 +409,23 @@ class PromptSearchPanel(Vertical):
             # the session and restores the draft, and the rows have to come out
             # of the DOM here: `hide()` only sets `display: none`, so dropping
             # the list without unmounting orphans them beside the next rebuild.
+            #
+            # Every step below is guarded, not just the unmount. `hide()`,
+            # `post_message`, and `notify` all reach for `self.app`, which
+            # raises `NoActiveAppError` on a detached widget -- and detachment
+            # is one of the plausible causes of the failure being recovered
+            # from. `_rebuild_options` runs as a `call_next` callback, so a
+            # second exception here escapes into Textual's callback machinery
+            # and panics the app during error recovery, masking the first.
+            # Ending the session is what matters most, so `AbandonSearch` is
+            # attempted even if the unmount or `hide()` failed.
             try:
                 await self._results.remove_children()
-            except Exception:  # Recovery must not raise in turn
+            except Exception:
                 logger.exception("Failed to clear prompt search rows")
             self._options = []
             self._empty_widget = None
-            self.hide()
-            self.post_message(PromptSearchInput.AbandonSearch())
-            self.notify("Prompt search could not be displayed", severity="warning")
+            self._abandon_quietly()
             return
 
         # The DOM mutations above can await, during which a hide() (or a newer
@@ -440,6 +448,36 @@ class PromptSearchPanel(Vertical):
 
         if start <= selected_index < start + len(self._options):
             self._options[selected_index - start].scroll_visible(animate=False)
+
+    def _abandon_quietly(self) -> None:
+        """End the search session without letting recovery raise in turn.
+
+        Each step is attempted independently and logged on failure. `hide()`,
+        `post_message`, and `notify` all reach for `self.app`, which raises
+        `NoActiveAppError` on a detached widget -- and detachment is one of the
+        plausible causes of the failure being recovered from. `_rebuild_options`
+        runs as a `call_next` callback, so a second exception escapes into
+        Textual's callback machinery and panics the app during error recovery,
+        masking the original. Ending the session matters most, so
+        `AbandonSearch` is attempted even when `hide()` has already failed.
+        """
+        for description, step in (
+            ("hide the prompt search panel", self.hide),
+            (
+                "end the prompt search session",
+                lambda: self.post_message(PromptSearchInput.AbandonSearch()),
+            ),
+            (
+                "report the prompt search failure",
+                lambda: self.notify(
+                    "Prompt search could not be displayed", severity="warning"
+                ),
+            ),
+        ):
+            try:
+                step()
+            except Exception:
+                logger.exception("Failed to %s during recovery", description)
 
     def update_selection(self, selected_index: int) -> None:
         """Update which row is selected, re-windowing the DOM when needed.

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -1,0 +1,323 @@
+"""Inline prompt history search panel for the chat composer.
+
+Opened by a first Ctrl+R; a second Ctrl+R escalates to the full
+`PromptClipboardScreen` modal. Key handling lives on `ChatInput`
+(`_prompt_search_active` / `_handle_prompt_search_key`), which the app action
+routes to.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from textual.containers import Vertical, VerticalScroll
+from textual.content import Content
+from textual.message import Message
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+logger = logging.getLogger(__name__)
+
+PROMPT_SEARCH_MAX_ROWS = 5
+"""Result rows the inline panel shows before the list scrolls."""
+
+PROMPT_SEARCH_HINT = (
+    "type to filter  •  ↑/↓ navigate  •  Enter insert  •  "
+    "Ctrl+R full view  •  Esc cancel"
+)
+"""Footer line; the Ctrl+R mention is what makes the modal tier discoverable."""
+
+PROMPT_SEARCH_PANEL_ROWS = 1 + PROMPT_SEARCH_MAX_ROWS + 1
+"""Rows the panel reports at its tallest: query, results, hint.
+
+`ChatInputBox` reserves exactly this when fitting a manual composer height,
+so the constant must match what the panel actually renders.
+"""
+
+
+def prompt_title(prompt: str) -> str:
+    """Return a prompt's first non-empty line for a one-row summary."""
+    nonempty = [line.strip() for line in prompt.splitlines() if line.strip()]
+    return (nonempty[0] if nonempty else prompt.strip()) or "(empty prompt)"
+
+
+def filter_prompts(prompts: tuple[str, ...], query: str) -> list[str]:
+    """Return prompts containing the query, case-insensitively."""
+    needle = query.strip().casefold()
+    if not needle:
+        return list(prompts)
+    return [prompt for prompt in prompts if needle in prompt.casefold()]
+
+
+class PromptSearchOption(Static):
+    """One clickable prompt row in the inline search panel."""
+
+    DEFAULT_CSS = """
+    PromptSearchOption {
+        height: 1;
+        padding: 0 1;
+        /* Rows are one cell high, so overlong titles clip visually. Textual
+           only ellipsizes truncated (nowrap) lines, so nowrap must accompany
+           text-overflow: ellipsis for the clipped end to be marked. */
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    PromptSearchOption.prompt-search-selected {
+        background: $primary;
+        color: $background;
+    }
+    """
+
+    class Clicked(Message):
+        """Message sent when a prompt row is clicked."""
+
+        def __init__(self, index: int) -> None:
+            """Initialize with the clicked row index."""
+            super().__init__()
+            self.index = index
+
+    def __init__(self, title: str, index: int, *, is_selected: bool) -> None:
+        """Initialize the row."""
+        super().__init__(Content.styled(title, "bold"))
+        self.index = index
+        self._is_selected = is_selected
+        if is_selected:
+            self.add_class("prompt-search-selected")
+
+    def set_content(self, title: str, index: int, *, is_selected: bool) -> None:
+        """Update the row in place during a panel rebuild."""
+        self.update(Content.styled(title, "bold"))
+        self.index = index
+        self.set_selected(is_selected=is_selected)
+
+    def set_selected(self, *, is_selected: bool) -> None:
+        """Toggle the selected styling."""
+        self._is_selected = is_selected
+        self.set_class(is_selected, "prompt-search-selected")
+
+    def on_click(self) -> None:
+        """Post the click up to `ChatInput`."""
+        self.post_message(self.Clicked(self.index))
+
+
+class PromptSearchPanel(Vertical):
+    """Inline prompt history search rendered above the input row.
+
+    Display-only: `ChatInput` owns the query, filtered snapshot, and
+    selection, drives key handling, and re-opens the modal tier. The panel
+    mirrors `CompletionPopup`: hidden by default, rebuilt via generation
+    counters so a stale async rebuild cannot re-show a dismissed panel, and
+    reports its rendered row count so `ChatInputBox` can reserve space.
+    """
+
+    DEFAULT_CSS = f"""
+    PromptSearchPanel {{
+        display: none;
+        height: auto;
+        max-height: {PROMPT_SEARCH_PANEL_ROWS};
+    }}
+
+    PromptSearchPanel .prompt-search-query {{
+        height: 1;
+        padding: 0 1;
+    }}
+
+    PromptSearchPanel #prompt-search-results {{
+        height: auto;
+        max-height: {PROMPT_SEARCH_MAX_ROWS};
+        scrollbar-gutter: stable;
+    }}
+
+    PromptSearchPanel .prompt-search-empty {{
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+    }}
+
+    PromptSearchPanel .prompt-search-hint {{
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+        text-style: italic;
+    }}
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize display state."""
+        super().__init__(**kwargs)
+        self.can_focus = False
+        self._query_static: Static | None = None
+        self._results: VerticalScroll | None = None
+        self._hint_static: Static | None = None
+        self._options: list[PromptSearchOption] = []
+        self._selected_index = 0
+        self._pending_titles: list[str] = []
+        self._pending_selected: int = 0
+        self._pending_empty: str | None = None
+        self._rebuild_generation: int = 0
+        self._reported_rows = 0
+
+    class RowsChanged(Message):
+        """Message sent when the panel's rendered row count changes."""
+
+        def __init__(self, rows: int) -> None:
+            """Initialize with the row count (0 when hidden)."""
+            super().__init__()
+            self.rows = rows
+
+    class OptionSelected(Message):
+        """Message sent when a prompt row is clicked in the panel."""
+
+        def __init__(self, index: int) -> None:
+            """Initialize with the clicked row index."""
+            super().__init__()
+            self.index = index
+
+    def compose(self) -> ComposeResult:  # noqa: PLR6301  # Textual convention
+        """Compose the query line, results list, and hint line.
+
+        Yields:
+            Widgets for the prompt search panel.
+        """
+        yield Static("", classes="prompt-search-query")
+        yield VerticalScroll(id="prompt-search-results")
+        yield Static(PROMPT_SEARCH_HINT, classes="prompt-search-hint")
+
+    def on_mount(self) -> None:
+        """Grab the composed children."""
+        self._query_static = self.query_one(".prompt-search-query", Static)
+        self._results = self.query_one("#prompt-search-results", VerticalScroll)
+        self._hint_static = self.query_one(".prompt-search-hint", Static)
+
+    def update_state(
+        self, query: str, titles: list[str], selected_index: int, empty: str | None
+    ) -> None:
+        """Show the panel for a new query/result set.
+
+        Args:
+            query: Current filter text, rendered on the query line.
+            titles: Row titles to display (already capped by the caller).
+            selected_index: Index of the selected row.
+            empty: Empty-state message to show instead of rows, if any.
+        """
+        self._selected_index = selected_index
+        self._pending_titles = titles
+        self._pending_selected = selected_index
+        self._pending_empty = empty
+        # Increment generation so stale callbacks from prior calls are skipped.
+        self._rebuild_generation += 1
+        gen = self._rebuild_generation
+        if self._query_static is not None:
+            self._query_static.update(
+                Content.assemble(("prompt search: ", "dim"), (query, "bold"))
+            )
+        self.call_next(lambda: self._rebuild_options(gen))
+
+    async def _rebuild_options(self, generation: int) -> None:
+        """Rebuild row widgets from pending state.
+
+        Reuses existing DOM nodes where possible to avoid flicker from a full
+        teardown/mount cycle while the panel is visible.
+
+        Args:
+            generation: Caller's generation counter; skipped if superseded.
+        """
+        if generation != self._rebuild_generation or self._results is None:
+            return
+
+        titles = self._pending_titles
+        selected_index = self._pending_selected
+
+        existing = len(self._options)
+        needed = len(titles)
+
+        for i in range(min(existing, needed)):
+            self._options[i].set_content(
+                titles[i], i, is_selected=(i == selected_index)
+            )
+
+        try:
+            if existing > needed:
+                for option in self._options[needed:]:
+                    await option.remove()
+                del self._options[needed:]
+
+            if needed > existing:
+                new_widgets = [
+                    PromptSearchOption(
+                        title=titles[idx],
+                        index=idx,
+                        is_selected=(idx == selected_index),
+                    )
+                    for idx in range(existing, needed)
+                ]
+                self._options.extend(new_widgets)
+                await self._results.mount(*new_widgets)
+        except Exception:
+            logger.exception("Failed to rebuild prompt search panel; hiding to recover")
+            self._options = []
+            self.hide()
+            return
+
+        # The DOM mutations above can await, during which a hide() (or a newer
+        # rebuild) bumps the generation to cancel this one. Re-check so a stale
+        # rebuild cannot re-show a dismissed panel.
+        if generation != self._rebuild_generation:
+            return
+
+        if self._pending_empty is not None:
+            await self._results.mount(
+                Static(self._pending_empty, classes="prompt-search-empty")
+            )
+        self.show(len(self._options) if not self._pending_empty else 1)
+
+        if 0 <= selected_index < len(self._options):
+            self._options[selected_index].scroll_visible(animate=False)
+
+    def update_selection(self, selected_index: int) -> None:
+        """Update which row is selected without rebuilding the list."""
+        self._pending_selected = selected_index
+        if self._selected_index == selected_index:
+            return
+        if 0 <= self._selected_index < len(self._options):
+            self._options[self._selected_index].set_selected(is_selected=False)
+        self._selected_index = selected_index
+        if 0 <= selected_index < len(self._options):
+            self._options[selected_index].set_selected(is_selected=True)
+            self._options[selected_index].scroll_visible(animate=False)
+
+    def on_prompt_search_option_clicked(
+        self, event: PromptSearchOption.Clicked
+    ) -> None:
+        """Forward row clicks as this panel's own message for `ChatInput`."""
+        event.stop()
+        self.post_message(self.OptionSelected(event.index))
+
+    def _report_rows(self, rows: int) -> None:
+        """Announce the rendered row count when it changes."""
+        if self._reported_rows != rows:
+            self._reported_rows = rows
+            self.post_message(self.RowsChanged(rows))
+
+    def hide(self) -> None:
+        """Hide the panel and cancel any in-flight rebuild."""
+        self._pending_titles = []
+        self._pending_empty = None
+        self._rebuild_generation += 1
+        self.styles.display = "none"  # ty: ignore[invalid-assignment]  # Textual accepts string display values
+        self._report_rows(0)
+
+    def show(self, result_rows: int) -> None:
+        """Show the panel.
+
+        Args:
+            result_rows: Number of result rows about to render, so the reported
+                height tracks the caller's list rather than a stale widget
+                count. Capped at `PROMPT_SEARCH_MAX_ROWS`.
+        """
+        self.styles.display = "block"
+        self._report_rows(2 + min(result_rows, PROMPT_SEARCH_MAX_ROWS))

--- a/libs/code/deepagents_code/tui/widgets/prompt_search.py
+++ b/libs/code/deepagents_code/tui/widgets/prompt_search.py
@@ -425,9 +425,11 @@ class PromptSearchPanel(Vertical):
         self._pending_titles = []
         self._pending_empty = None
         self._rebuild_generation += 1
-        # Drop the tracked reference so a rebuild after re-open starts clean;
-        # the widget itself is torn down with the hidden panel's children.
-        self._empty_widget = None
+        # Keep the `_empty_widget` reference: hide() only sets display: none,
+        # so a mounted empty-state row survives the hide, and the next rebuild
+        # is the only code path that removes it. Dropping the reference here
+        # would orphan the row, leaving a stale "No matching prompts." beside
+        # the options when the panel reopens with matches.
         self.styles.display = "none"  # ty: ignore[invalid-assignment]  # Textual accepts string display values
         self._report_rows(0)
 

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -26,6 +26,7 @@ _TIPS: dict[str, int] = {
     "Use /offload to summarize older messages and free up the context window": 2,
     "Use /context to see context window usage and remaining space": 1,
     "Use /copy to copy the latest message": 3,
+    "Press Ctrl+R to search and reuse submitted prompts": 2,
     "Use /cost to see a breakdown of estimated spend": 1,
     "Use /tools to list the tools available to the agent": 1,
     "Open /mcp and press Enter on a remote server to sign in again": 1,

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -40795,6 +40795,42 @@ class TestPromptClipboard:
             await pilot.pause()
             assert screen._selected_index == 0
 
+    async def test_shift_tab_pages_the_inline_panel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The inline panel pages with shift+tab under the real app dispatch.
+
+        The widget-level paging test runs on a bare host with no competing
+        binding, so it cannot catch the `toggle_auto_approve` step-aside
+        regressing. Without it shift+tab would toggle auto-approve — a
+        permissions change — instead of paging results.
+        """
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            monkeypatch.setattr(
+                chat_input,
+                "recent_prompts",
+                lambda: tuple(f"prompt {i}" for i in range(12)),
+            )
+            approval_mode_before = app._approval_mode
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            await pilot.pause()
+            assert chat_input._prompt_search_active is True
+
+            await pilot.press("tab")
+            await pilot.pause()
+            assert chat_input._prompt_search_index == 5
+
+            await pilot.press("shift+tab")
+            await pilot.pause()
+            assert chat_input._prompt_search_index == 0
+            assert app._approval_mode == approval_mode_before
+
     @pytest.mark.parametrize(
         "pending_field",
         [
@@ -40806,12 +40842,25 @@ class TestPromptClipboard:
     async def test_ctrl_r_is_disabled_for_inline_prompts(
         self, pending_field: str
     ) -> None:
+        from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchPanel
+
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
             setattr(app, pending_field, MagicMock())
 
             assert app.check_action("open_prompt_clipboard", ()) is False
+
+            # Press the chord too: asserting the predicate alone would still
+            # pass if the routing stopped consulting `check_action`.
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert not isinstance(app.screen, PromptClipboardScreen)
+            panel = app.screen.query_one(PromptSearchPanel)
+            assert panel.styles.display == "none"
 
     async def test_prompts_command_opens_without_awaiting_modal(self) -> None:
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -18316,6 +18316,34 @@ class TestActionOpenEditor:
         assert text_area.text == "edited"
         chat_input.focus_input.assert_called_once()
 
+    async def test_prompt_search_cancel_preserves_external_editor_result(self) -> None:
+        """Escape after Ctrl+X should not restore the pre-editor draft."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            text_area = chat_input._text_area
+            assert text_area is not None
+            text_area.insert("original draft")
+            chat_input.open_prompt_search()
+            await pilot.pause()
+
+            with (
+                patch.object(app, "suspend"),
+                patch(
+                    "deepagents_code.editor.open_in_editor",
+                    return_value="external editor result",
+                ),
+            ):
+                await app.action_open_editor()
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert chat_input._prompt_search_active is False
+            assert text_area.text == "external editor result"
+
     async def test_no_update_when_editor_returns_none(self) -> None:
         app = DeepAgentsApp(agent=MagicMock())
         text_area = MagicMock()

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -40599,6 +40599,10 @@ class TestPromptClipboard:
             text_area.insert("hello world")
             text_area.move_cursor((0, len("hello ")))
 
+            # First Ctrl+R opens the inline panel; a second escalates to the
+            # full modal.
+            await pilot.press("ctrl+r")
+            await pilot.pause()
             await pilot.press("ctrl+r")
             await pilot.pause()
             assert isinstance(app.screen, PromptClipboardScreen)
@@ -40648,6 +40652,8 @@ class TestPromptClipboard:
                 chat_input, "recent_prompts", lambda: ("copy this prompt",)
             )
 
+            await pilot.press("ctrl+r")
+            await pilot.pause()
             await pilot.press("ctrl+r")
             await pilot.pause()
             screen = cast("PromptClipboardScreen", app.screen)
@@ -40711,6 +40717,8 @@ class TestPromptClipboard:
                 chat_input, "recent_prompts", lambda: ("newest", "older")
             )
 
+            await pilot.press("ctrl+r")
+            await pilot.pause()
             await pilot.press("ctrl+r")
             await pilot.pause()
             screen = cast("PromptClipboardScreen", app.screen)

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -17657,6 +17657,59 @@ class TestInterruptApprovalPriority:
             assert future.result() == {"type": "reject"}
             assert chat_input._prompt_search_active is True
 
+    async def test_approval_arriving_during_prompt_search_keeps_shift_tab(
+        self,
+    ) -> None:
+        """A focused approval should retain shift+tab/ctrl+t after search opened.
+
+        The inline panel steps `toggle_auto_approve` aside so shift+tab can page
+        its results, but only while the query input has focus. Gating on panel
+        state alone left auto-approve untogglable and dropped shift+tab through
+        to `Screen.focus_previous`, moving focus off the pending approval.
+        """
+        from deepagents_code.tui.widgets.approval import ApprovalMenu
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            chat_input.open_prompt_search()
+            await pilot.pause()
+
+            # While the query owns focus the panel keeps the chord.
+            assert app.check_action("toggle_auto_approve", ()) is False
+
+            menu = ApprovalMenu({"name": "execute", "args": {"command": "pwd"}})
+            future: asyncio.Future[dict[str, str]] = (
+                asyncio.get_running_loop().create_future()
+            )
+            menu.set_future(future)
+            app._pending_approval_widget = menu
+            messages = app.query_one("#messages", Container)
+            await messages.mount(menu)
+            menu.focus()
+            await pilot.pause()
+            assert app.focused is menu
+
+            assert app.check_action("toggle_auto_approve", ()) is True
+
+            # Spy rather than assert on `_approval_mode`: whether the mode
+            # actually advances depends on sandbox and YOLO eligibility, but
+            # the chord reaching the action at all is what regressed.
+            with patch.object(
+                DeepAgentsApp, "action_toggle_auto_approve", new=AsyncMock()
+            ) as toggle:
+                await pilot.press("shift+tab")
+                await pilot.pause()
+
+            # With the binding enabled the app action consumes the key. When it
+            # was disabled the chord fell through to `Screen.focus_previous`,
+            # traversing focus off the pending approval.
+            toggle.assert_awaited_once()
+            assert app.focused is menu
+            assert chat_input._prompt_search_active is True
+
     async def test_escape_rejects_approval_before_canceling_worker(self) -> None:
         """When both HITL approval and worker are active, reject approval first."""
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -40703,9 +40703,10 @@ class TestPromptClipboard:
             assert app.screen is screen
             assert screen._recommended_only is False
 
-    async def test_shift_tab_does_not_route_to_prompt_navigation(
+    async def test_shift_tab_pages_in_prompt_modal(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """The modal pages with shift+tab; it must not hit the app binding."""
         from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
 
         app = DeepAgentsApp(agent=MagicMock())
@@ -40714,7 +40715,9 @@ class TestPromptClipboard:
             chat_input = app._chat_input
             assert chat_input is not None
             monkeypatch.setattr(
-                chat_input, "recent_prompts", lambda: ("newest", "older")
+                chat_input,
+                "recent_prompts",
+                lambda: tuple(f"prompt {i}" for i in range(12)),
             )
 
             await pilot.press("ctrl+r")
@@ -40723,13 +40726,14 @@ class TestPromptClipboard:
             await pilot.pause()
             screen = cast("PromptClipboardScreen", app.screen)
             assert isinstance(screen, PromptClipboardScreen)
-            await pilot.press("down")
+
+            await pilot.press("tab")
             await pilot.pause()
-            assert screen._selected_index == 1
+            assert screen._selected_index == 5
 
             await pilot.press("shift+tab")
             await pilot.pause()
-            assert screen._selected_index == 1
+            assert screen._selected_index == 0
 
     @pytest.mark.parametrize(
         "pending_field",

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -40925,6 +40925,54 @@ class TestPromptClipboard:
 
         open_clipboard.assert_called_once_with()
 
+    async def test_modal_warns_when_history_is_unreadable_but_listable(
+        self, tmp_path: Path
+    ) -> None:
+        """The modal's `empty_message` cannot cover a non-empty degraded list.
+
+        `recent_prompts` falls back to this session's entries on a read
+        failure, so the modal usually opens with rows and its empty state --
+        the only place the error was reported -- never renders.
+        """
+        history_file = tmp_path / "history.jsonl"
+        history_file.mkdir()
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            chat_input._history.history_file = history_file
+            chat_input._history.add("this session only")
+
+            with patch.object(app, "notify") as notify:
+                app._open_prompt_clipboard_modal()
+                await pilot.pause()
+
+            notify.assert_called_once()
+            message = notify.call_args.args[0]
+            assert "Could not read prompt history" in message
+            assert "this session's prompts only" in message
+            assert notify.call_args.kwargs["severity"] == "warning"
+            assert notify.call_args.kwargs["markup"] is False
+
+    async def test_modal_stays_quiet_when_history_reads_cleanly(
+        self, tmp_path: Path
+    ) -> None:
+        """The healthy path opens the modal without a warning."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            chat_input._history.history_file = tmp_path / "history.jsonl"
+            chat_input._history.add("a prompt")
+
+            with patch.object(app, "notify") as notify:
+                app._open_prompt_clipboard_modal()
+                await pilot.pause()
+
+            notify.assert_not_called()
+
     async def test_prompts_command_explains_why_it_cannot_open(self) -> None:
         """A blocked `/prompts` must say so instead of doing nothing.
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -17625,6 +17625,38 @@ class TestAppArgumentHints:
 class TestInterruptApprovalPriority:
     """Tests for escape interrupt priority when HITL approval is pending."""
 
+    async def test_escape_rejects_approval_arriving_during_prompt_search(
+        self,
+    ) -> None:
+        """A focused approval should retain Escape after search was opened."""
+        from deepagents_code.tui.widgets.approval import ApprovalMenu
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            chat_input.open_prompt_search()
+            await pilot.pause()
+
+            menu = ApprovalMenu({"name": "execute", "args": {"command": "pwd"}})
+            future: asyncio.Future[dict[str, str]] = (
+                asyncio.get_running_loop().create_future()
+            )
+            menu.set_future(future)
+            app._pending_approval_widget = menu
+            messages = app.query_one("#messages", Container)
+            await messages.mount(menu)
+            menu.focus()
+            await pilot.pause()
+            assert app.focused is menu
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert future.result() == {"type": "reject"}
+            assert chat_input._prompt_search_active is True
+
     async def test_escape_rejects_approval_before_canceling_worker(self) -> None:
         """When both HITL approval and worker are active, reject approval first."""
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -40567,3 +40567,183 @@ class TestColdCacheConfirmationBoundary:
         message = app.notify.call_args[0][0]
         assert "is not a table" in message
         assert "permissions" not in message
+
+
+class TestPromptClipboard:
+    """App wiring and priority-key routing for prompt recall."""
+
+    def test_ctrl_r_binding_is_priority(self) -> None:
+        bindings = [
+            binding
+            for binding in DeepAgentsApp.BINDINGS
+            if isinstance(binding, Binding) and binding.key == "ctrl+r"
+        ]
+
+        assert len(bindings) == 1
+        assert bindings[0].action == "open_prompt_clipboard"
+        assert bindings[0].priority is True
+
+    async def test_ctrl_r_inserts_selection_at_current_cursor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            text_area = chat_input._text_area
+            assert text_area is not None
+            monkeypatch.setattr(chat_input, "recent_prompts", lambda: ("saved prompt",))
+            text_area.insert("hello world")
+            text_area.move_cursor((0, len("hello ")))
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            assert isinstance(app.screen, PromptClipboardScreen)
+
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert chat_input.value == "hello saved promptworld"
+            assert app.focused is text_area
+
+    async def test_escape_preserves_draft_and_cursor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            text_area = chat_input._text_area
+            assert text_area is not None
+            monkeypatch.setattr(chat_input, "recent_prompts", lambda: ("saved prompt",))
+            text_area.insert("draft text")
+            text_area.move_cursor((0, 3))
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert chat_input.value == "draft text"
+            assert text_area.cursor_location == (0, 3)
+            assert app.focused is text_area
+
+    async def test_ctrl_c_in_modal_copies_prompt_not_filter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            monkeypatch.setattr(
+                chat_input, "recent_prompts", lambda: ("copy this prompt",)
+            )
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            screen = cast("PromptClipboardScreen", app.screen)
+            assert isinstance(screen, PromptClipboardScreen)
+
+            with patch(
+                "deepagents_code.clipboard.copy_text_with_feedback"
+            ) as copy_text:
+                await pilot.press("ctrl+c")
+                await pilot.pause()
+
+            copy_text.assert_called_once_with(
+                app,
+                "copy this prompt",
+                failure_noun="prompt",
+                success_message="Prompt copied to clipboard",
+            )
+            assert app.screen is screen
+
+    async def test_ctrl_r_steps_aside_for_model_selector(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_code.tui.widgets import model_selector
+        from deepagents_code.tui.widgets.model_selector import (
+            MAIN_MODEL_DEFAULT_SCOPE,
+            ModelSelectorScreen,
+        )
+
+        monkeypatch.setattr(
+            model_selector,
+            "get_available_models",
+            lambda: {"anthropic": ["claude-sonnet-5"]},
+        )
+        monkeypatch.setattr(model_selector, "load_recent_models", list)
+        app = DeepAgentsApp(agent=MagicMock())
+        screen = ModelSelectorScreen(default_scope=MAIN_MODEL_DEFAULT_SCOPE)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.push_screen(screen)
+            await pilot.pause()
+            assert screen._recommended_only is True
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+
+            assert app.screen is screen
+            assert screen._recommended_only is False
+
+    async def test_shift_tab_does_not_route_to_prompt_navigation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            monkeypatch.setattr(
+                chat_input, "recent_prompts", lambda: ("newest", "older")
+            )
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            screen = cast("PromptClipboardScreen", app.screen)
+            assert isinstance(screen, PromptClipboardScreen)
+            await pilot.press("down")
+            await pilot.pause()
+            assert screen._selected_index == 1
+
+            await pilot.press("shift+tab")
+            await pilot.pause()
+            assert screen._selected_index == 1
+
+    @pytest.mark.parametrize(
+        "pending_field",
+        [
+            "_pending_approval_widget",
+            "_pending_ask_user_widget",
+            "_pending_goal_review_widget",
+        ],
+    )
+    async def test_ctrl_r_is_disabled_for_inline_prompts(
+        self, pending_field: str
+    ) -> None:
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            setattr(app, pending_field, MagicMock())
+
+            assert app.check_action("open_prompt_clipboard", ()) is False
+
+    async def test_prompts_command_opens_without_awaiting_modal(self) -> None:
+        app = DeepAgentsApp()
+        with patch.object(app, "action_open_prompt_clipboard") as open_clipboard:
+            await app._handle_command("/prompts")
+
+        open_clipboard.assert_called_once_with()

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -40786,6 +40786,98 @@ class TestPromptClipboard:
             )
             assert app.screen is screen
 
+    async def test_escalation_carries_the_typed_query_into_the_modal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The second Ctrl+R must seed the modal filter with what was typed.
+
+        The inline side asserts an empty query and the modal side constructs
+        its filter directly, so the seam between them -- `escalate_prompt_search`
+        returning the query and `_open_prompt_clipboard_modal` passing it on --
+        had no coverage. A reordering in `_close_prompt_search` that cleared
+        the query before it was captured would open the modal unfiltered.
+        """
+        from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            monkeypatch.setattr(
+                chat_input,
+                "recent_prompts",
+                lambda: ("fix the bug", "add a feature"),
+            )
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            await pilot.press("f", "i", "x")
+            await pilot.pause()
+            assert chat_input._prompt_search_query == "fix"
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            await pilot.pause()
+
+            screen = cast("PromptClipboardScreen", app.screen)
+            assert isinstance(screen, PromptClipboardScreen)
+            assert screen.query_one("#prompt-filter", Input).value == "fix"
+            assert list(screen._filtered) == ["fix the bug"]
+
+    async def test_insertion_failure_is_reported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refused insert must say so rather than dropping the prompt."""
+        from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            monkeypatch.setattr(chat_input, "recent_prompts", lambda: ("a prompt",))
+            monkeypatch.setattr(chat_input, "insert_at_cursor", lambda _text: False)
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            assert isinstance(app.screen, PromptClipboardScreen)
+
+            with patch.object(app, "notify") as notify:
+                await pilot.press("enter")
+                await pilot.pause()
+                await pilot.pause()
+
+            notify.assert_called_once()
+            assert "Could not insert the prompt" in notify.call_args.args[0]
+            assert notify.call_args.kwargs["severity"] == "warning"
+
+    async def test_insertion_into_a_vanished_composer_is_reported(self) -> None:
+        """Losing the composer between dismiss and apply must not be silent."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+
+            app._open_prompt_clipboard_modal()
+            await pilot.pause()
+
+            # The callback re-reads `_chat_input`, so clearing it stands in for
+            # the composer being torn down while the modal was open.
+            app._chat_input = None
+            with patch.object(app, "notify") as notify:
+                app.screen.dismiss("a prompt")
+                await pilot.pause()
+                await pilot.pause()
+
+            notify.assert_called_once()
+            assert "the composer is gone" in notify.call_args.args[0]
+            assert notify.call_args.kwargs["severity"] == "warning"
+            app._chat_input = chat_input
+
     async def test_ctrl_r_steps_aside_for_model_selector(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -40917,7 +40917,53 @@ class TestPromptClipboard:
 
     async def test_prompts_command_opens_without_awaiting_modal(self) -> None:
         app = DeepAgentsApp()
-        with patch.object(app, "action_open_prompt_clipboard") as open_clipboard:
+        with (
+            patch.object(app, "action_open_prompt_clipboard") as open_clipboard,
+            patch.object(app, "_prompt_clipboard_block_reason", return_value=None),
+        ):
             await app._handle_command("/prompts")
 
         open_clipboard.assert_called_once_with()
+
+    async def test_prompts_command_explains_why_it_cannot_open(self) -> None:
+        """A blocked `/prompts` must say so instead of doing nothing.
+
+        `/prompts` carries `BypassTier.IMMEDIATE_UI`, so it runs while the
+        agent is busy -- exactly when an approval owns the screen and the
+        clipboard is blocked. A bare return there reads as a broken command.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._pending_approval_widget = MagicMock()
+
+            with (
+                patch.object(app, "action_open_prompt_clipboard") as open_clipboard,
+                patch.object(app, "_mount_message", new=AsyncMock()) as mount,
+            ):
+                await app._handle_command("/prompts")
+
+            open_clipboard.assert_not_called()
+            mount.assert_awaited_once()
+            assert mount.await_args is not None
+            message = mount.await_args.args[0]
+            assert "approval" in str(message.render()).lower()
+
+    async def test_prompts_command_reports_each_blocking_surface(self) -> None:
+        """Every blocked branch names the surface that is in the way."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            for attribute, expected in (
+                ("_pending_approval_widget", "approval"),
+                ("_pending_ask_user_widget", "question"),
+                ("_pending_goal_review_widget", "goal review"),
+            ):
+                setattr(app, attribute, MagicMock())
+                reason = app._prompt_clipboard_block_reason()
+                assert reason is not None
+                assert expected in reason.lower()
+                setattr(app, attribute, None)
+
+            assert app._prompt_clipboard_block_reason() is None

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -40708,9 +40708,11 @@ class TestPromptClipboard:
             assert chat_input is not None
             text_area = chat_input._text_area
             assert text_area is not None
-            monkeypatch.setattr(chat_input, "recent_prompts", lambda: ("saved prompt",))
-            text_area.insert("hello world")
-            text_area.move_cursor((0, len("hello ")))
+            monkeypatch.setattr(
+                chat_input, "recent_prompts", lambda: ("hello saved prompt",)
+            )
+            text_area.insert("hello")
+            text_area.move_cursor((0, len("hel")))
 
             # First Ctrl+R opens the inline panel; a second escalates to the
             # full modal.
@@ -40724,7 +40726,7 @@ class TestPromptClipboard:
             await pilot.pause()
             await pilot.pause()
 
-            assert chat_input.value == "hello saved promptworld"
+            assert chat_input.value == "helhello saved promptlo"
             assert app.focused is text_area
 
     async def test_escape_preserves_draft_and_cursor(
@@ -40815,6 +40817,41 @@ class TestPromptClipboard:
             await pilot.press("f", "i", "x")
             await pilot.pause()
             assert chat_input._prompt_search_query == "fix"
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            await pilot.pause()
+
+            screen = cast("PromptClipboardScreen", app.screen)
+            assert isinstance(screen, PromptClipboardScreen)
+            assert screen.query_one("#prompt-filter", Input).value == "fix"
+            assert list(screen._filtered) == ["fix the bug"]
+
+    async def test_existing_chat_input_seeds_the_modal_filter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A draft becomes the initial query across both search tiers."""
+        from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            text_area = chat_input._text_area
+            assert text_area is not None
+            monkeypatch.setattr(
+                chat_input,
+                "recent_prompts",
+                lambda: ("fix the bug", "add a feature"),
+            )
+            text_area.insert("fix")
+            await pilot.pause()
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            assert chat_input._prompt_search_query == "fix"
+            assert chat_input.value == "fix"
 
             await pilot.press("ctrl+r")
             await pilot.pause()

--- a/libs/code/tests/unit_tests/test_command_registry.py
+++ b/libs/code/tests/unit_tests/test_command_registry.py
@@ -149,6 +149,11 @@ class TestSlashCommands:
         names = {entry.name for entry in get_slash_commands()}
         assert "/plugins" in names
 
+    def test_prompts_is_immediate_and_discoverable(self) -> None:
+        names = {entry.name for entry in get_slash_commands()}
+        assert "/prompts" in names
+        assert "/prompts" in IMMEDIATE_UI
+
 
 class TestHiddenCommands:
     """`HIDDEN_COMMANDS` membership and autocomplete absence."""

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -96,6 +96,26 @@ class TestPromptClipboardScreen:
             assert str(preview.content) == prompt
             assert str(screen._rows[0].content).startswith("[bold red]")
 
+    async def test_row_shows_only_first_line_of_multiline_prompt(self) -> None:
+        """Rows are one line; continuation lines belong to the preview pane."""
+        prompt = "title line\ndetails here"
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open((prompt,))
+            await pilot.pause()
+
+            assert str(screen._rows[0].content) == "title line"
+
+    async def test_single_line_prompt_row_does_not_repeat_text(self) -> None:
+        """A one-line prompt renders as one line, not a duplicated excerpt."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("single line prompt",))
+            await pilot.pause()
+
+            assert str(screen._rows[0].content) == "single line prompt"
+            assert screen._rows[0].region.height == 1
+
     async def test_empty_state_fits_narrow_terminal(self) -> None:
         app = _PromptClipboardApp()
         async with app.run_test(size=(45, 18)) as pilot:

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -21,8 +21,16 @@ class _PromptClipboardApp(App[None]):
     def compose(self) -> ComposeResult:
         yield Container()
 
-    def open(self, prompts: tuple[str, ...]) -> PromptClipboardScreen:
-        screen = PromptClipboardScreen(prompts)
+    def open(
+        self,
+        prompts: tuple[str, ...],
+        initial_query: str = "",
+        *,
+        empty_message: str | None = None,
+    ) -> PromptClipboardScreen:
+        screen = PromptClipboardScreen(
+            prompts, initial_query, empty_message=empty_message
+        )
         self.push_screen(screen, self.results.append)
         return screen
 
@@ -217,7 +225,7 @@ class TestPromptClipboardScreen:
             filter_ = screen.query_one("#prompt-filter", Input)
             preview = screen.query_one("#prompt-preview-scroll", VerticalScroll)
             help_ = screen.query_one(".prompt-help", Static)
-            assert outer.region.height == 12
+            assert outer.region.height == 13
             assert filter_.region.y >= 0
             assert filter_.region.bottom <= screen.size.height
             assert preview.region.y >= 0
@@ -266,3 +274,102 @@ class TestPromptClipboardScreen:
                 success_message="Prompt copied to clipboard",
             )
             assert app.screen is screen
+
+    async def test_initial_query_seeds_the_filter(self) -> None:
+        """Escalating from the inline panel carries the typed query over."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("fix the bug", "add feature", "fix tests"), "fix")
+            await pilot.pause()
+            await pilot.pause()
+
+            search = screen.query_one("#prompt-filter", Input)
+            assert search.value == "fix"
+            # The cursor sits at the end so typing extends the carried query.
+            assert search.cursor_position == len("fix")
+            assert screen._filtered == ["fix the bug", "fix tests"]
+            rows = screen.query_one("#prompt-list", VerticalScroll).children
+            assert len(rows) == 2
+
+    async def test_initial_query_matching_nothing_shows_the_empty_state(self) -> None:
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("alpha", "beta"), "zzz")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert screen._filtered == []
+            rows = screen.query_one("#prompt-list", VerticalScroll).children
+            assert len(rows) == 1
+            assert "No matching prompts." in str(rows[0].render())
+
+    async def test_moving_after_a_queued_filter_edit_does_not_raise(self) -> None:
+        """Ctrl+C leaves the modal open, so its re-filter must not desync rows.
+
+        `action_copy` consumes a filter edit whose `Changed` message is still
+        queued, which widens `_filtered` without re-rendering `_rows`. Paging
+        then indexed the stale row list and raised `IndexError`.
+        """
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(tuple(f"prompt {index}" for index in range(12)))
+            await pilot.pause()
+
+            search = screen.query_one("#prompt-filter", Input)
+            search.value = "prompt 1"
+            screen._apply_filter("prompt 1")
+            await pilot.pause()
+            assert len(screen._rows) == len(screen._filtered)
+
+            # Widen the filter behind the modal's back, exactly as a queued
+            # `Input.Changed` does, then act on it without letting the render
+            # land first.
+            search.value = "prompt"
+            with patch("deepagents_code.clipboard.copy_text_with_feedback"):
+                screen.action_copy()
+            assert len(screen._rows) != len(screen._filtered)
+
+            await screen.action_page_older()
+            await pilot.pause()
+
+            assert len(screen._rows) == len(screen._filtered)
+            assert 0 <= screen._selected_index < len(screen._rows)
+
+    async def test_queued_filter_edit_keeps_the_highlighted_prompt(self) -> None:
+        """A consumed filter edit must not silently re-point the selection.
+
+        Snapping to index 0 made Ctrl+C copy a prompt the user never
+        highlighted, under a success toast.
+        """
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("alpha one", "alpha two", "beta"))
+            await pilot.pause()
+
+            await pilot.press("down")
+            await pilot.pause()
+            selected = screen._filtered[screen._selected_index]
+            assert selected == "alpha two"
+
+            search = screen.query_one("#prompt-filter", Input)
+            search.value = "alpha"
+            with patch(
+                "deepagents_code.clipboard.copy_text_with_feedback"
+            ) as copy_text:
+                screen.action_copy()
+
+            copy_text.assert_called_once()
+            assert copy_text.call_args.args[1] == selected
+
+    async def test_empty_message_replaces_the_no_prompts_text(self) -> None:
+        """An unreadable history file must not read as "no prompts yet"."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open((), empty_message="Could not read prompt history from x")
+            await pilot.pause()
+
+            rows = screen.query_one("#prompt-list", VerticalScroll).children
+            assert len(rows) == 1
+            message = str(rows[0].render())
+            assert "Could not read prompt history" in message
+            assert "No prompts yet" not in message

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -399,6 +399,37 @@ class TestPromptClipboardScreen:
             assert str(preview.content) == "middle"
             assert app.results == []
 
+    async def test_hovering_the_selected_row_keeps_its_highlight(self) -> None:
+        """Hover must not repaint the selected row.
+
+        A pseudo-class bumps the class slot of Textual's specificity tuple, so
+        an unqualified `.prompt-row:hover` outranks `.prompt-row-selected` and
+        strips the selection background while `color: $background` still
+        applies -- near-invisible text on light themes. The `:not()` qualifier
+        in the stylesheet is what prevents it.
+        """
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("newest", "middle", "oldest"))
+            await pilot.pause()
+            await pilot.pause()
+
+            selected = screen._rows[0]
+            unselected = screen._rows[1]
+            selected_background = selected.styles.background
+
+            await pilot.hover(selected)
+            await pilot.pause()
+
+            assert selected.mouse_hover
+            assert selected.styles.background == selected_background
+
+            # The same hover on an unselected row does repaint it, so the
+            # assertion above is not passing merely because :hover is inert.
+            await pilot.hover(unselected)
+            await pilot.pause()
+            assert unselected.styles.background != selected_background
+
     async def test_clicking_a_row_selects_but_does_not_submit(self) -> None:
         """Click moves the selection; only Enter dismisses the modal."""
         app = _PromptClipboardApp()

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -197,6 +197,33 @@ class TestPromptClipboardScreen:
             assert rows_list.show_vertical_scrollbar
             assert help_.region.bottom <= outer.region.bottom
 
+    async def test_short_terminal_keeps_filter_and_preview_on_screen(self) -> None:
+        """A terminal shorter than the modal must not bury the controls.
+
+        The modal's `height: 80%` alone can be shorter than the fixed
+        controls (filter, labels, borders/padding, wrapped help), which placed
+        the preview and key help entirely below the screen. The `min-height`
+        clamp makes Textual center the overflowing modal and clip it top and
+        bottom instead, keeping the filter on screen and clipping the preview
+        last.
+        """
+        app = _PromptClipboardApp()
+        async with app.run_test(size=(45, 10)) as pilot:
+            screen = app.open(tuple(f"prompt {index}" for index in range(30)))
+            await pilot.pause()
+            await pilot.pause()
+
+            outer = screen.query_one(Vertical)
+            filter_ = screen.query_one("#prompt-filter", Input)
+            preview = screen.query_one("#prompt-preview-scroll", VerticalScroll)
+            help_ = screen.query_one(".prompt-help", Static)
+            assert outer.region.height == 12
+            assert filter_.region.y >= 0
+            assert filter_.region.bottom <= screen.size.height
+            assert preview.region.y >= 0
+            assert preview.region.bottom <= screen.size.height
+            assert help_.region.bottom <= outer.region.bottom
+
     async def test_tab_and_shift_tab_page_selection(self) -> None:
         """Tab/Shift+Tab page through results; the filter input keeps focus."""
         app = _PromptClipboardApp()

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -197,22 +197,27 @@ class TestPromptClipboardScreen:
             assert rows_list.show_vertical_scrollbar
             assert help_.region.bottom <= outer.region.bottom
 
-    async def test_tab_and_shift_tab_do_not_move_focus(self) -> None:
-        """Focus keys are swallowed; the search input keeps focus throughout."""
+    async def test_tab_and_shift_tab_page_selection(self) -> None:
+        """Tab/Shift+Tab page through results; the filter input keeps focus."""
         app = _PromptClipboardApp()
         async with app.run_test() as pilot:
-            screen = app.open(("alpha", "beta"))
+            screen = app.open(tuple(f"prompt {i}" for i in range(12)))
             await pilot.pause()
             search = screen.query_one("#prompt-filter", Input)
 
             await pilot.press("tab")
             await pilot.pause()
             assert screen.focused is search
-            assert screen._selected_index == 0
+            assert screen._selected_index == 5
 
             await pilot.press("shift+tab")
             await pilot.pause()
             assert screen.focused is search
+            assert screen._selected_index == 0
+
+            # Page up at the top stays put rather than wrapping or erroring.
+            await pilot.press("shift+tab")
+            await pilot.pause()
             assert screen._selected_index == 0
 
     async def test_ctrl_c_copies_selected_prompt_without_dismissing(self) -> None:

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from textual.app import App, ComposeResult
-from textual.containers import Container
+from textual.containers import Container, Vertical, VerticalScroll
 from textual.widgets import Input, Static
 
 from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
@@ -102,12 +102,46 @@ class TestPromptClipboardScreen:
             screen = app.open(())
             await pilot.pause()
 
-            rows = screen.query_one("#prompt-rows", Container)
+            rows = screen.query_one("#prompt-list", VerticalScroll)
             empty = rows.query_one(Static)
             assert (
                 str(empty.content) == "No prompts yet. Submitted prompts appear here."
             )
             assert screen.region.width <= 45
+
+    async def test_list_scrolls_when_rows_exceed_max_height(self) -> None:
+        """Rows past the visible cap must overflow the list, not be clipped."""
+        app = _PromptClipboardApp()
+        async with app.run_test(size=(80, 40)) as pilot:
+            screen = app.open(tuple(f"prompt {index}" for index in range(30)))
+            await pilot.pause()
+            await pilot.pause()
+
+            rows_list = screen.query_one("#prompt-list", VerticalScroll)
+            assert len(screen._rows) == 30
+            assert rows_list.is_scrollable
+            assert rows_list.virtual_size.height > rows_list.region.height
+            assert rows_list.max_scroll_y > 0
+
+            await pilot.press("down")
+            await pilot.pause()
+            assert screen._rows[1].region.height > 0
+
+    async def test_list_shrinks_to_keep_controls_visible(self) -> None:
+        """A short terminal caps the list instead of pushing help off-modal."""
+        app = _PromptClipboardApp()
+        async with app.run_test(size=(80, 18)) as pilot:
+            screen = app.open(tuple(f"prompt {index}" for index in range(30)))
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.pause()
+
+            rows_list = screen.query_one("#prompt-list", VerticalScroll)
+            outer = screen.query_one(Vertical)
+            help_ = screen.query_one(".prompt-help", Static)
+            assert rows_list.region.height < 10
+            assert rows_list.show_vertical_scrollbar
+            assert help_.region.bottom <= outer.region.bottom
 
     async def test_ctrl_c_copies_selected_prompt_without_dismissing(self) -> None:
         app = _PromptClipboardApp()

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -374,8 +374,8 @@ class TestPromptClipboardScreen:
             assert "Could not read prompt history" in message
             assert "No prompts yet" not in message
 
-    async def test_hovering_a_row_selects_but_does_not_submit(self) -> None:
-        """Hover moves the highlight; only Enter dismisses the modal."""
+    async def test_hovering_marks_a_row_without_moving_the_selection(self) -> None:
+        """Hover is visual only: arrows still move from the selected row."""
         app = _PromptClipboardApp()
         async with app.run_test() as pilot:
             screen = app.open(("newest", "middle", "oldest"))
@@ -383,6 +383,30 @@ class TestPromptClipboardScreen:
             await pilot.pause()
 
             await pilot.hover(screen._rows[2])
+            await pilot.pause()
+
+            # The hovered row is marked, but selection and preview stay put.
+            assert "prompt-row-hovered" in screen._rows[2].classes
+            assert screen._selected_index == 0
+            preview = screen.query_one("#prompt-preview", Static)
+            assert str(preview.content) == "newest"
+
+            # Keyboard navigation resumes from the selection, not the hover.
+            await pilot.press("down")
+            await pilot.pause()
+            assert screen._selected_index == 1
+            assert str(preview.content) == "middle"
+            assert app.results == []
+
+    async def test_clicking_a_row_selects_but_does_not_submit(self) -> None:
+        """Click moves the selection; only Enter dismisses the modal."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("newest", "middle", "oldest"))
+            await pilot.pause()
+            await pilot.pause()
+
+            await pilot.click(screen._rows[2])
             await pilot.pause()
 
             assert screen._selected_index == 2
@@ -396,17 +420,3 @@ class TestPromptClipboardScreen:
             await pilot.press("enter")
             await pilot.pause()
             assert app.results == ["oldest"]
-
-    async def test_hovering_the_selected_row_is_a_noop(self) -> None:
-        """Hovering the already-highlighted row must not error or re-render."""
-        app = _PromptClipboardApp()
-        async with app.run_test() as pilot:
-            screen = app.open(("only",))
-            await pilot.pause()
-            await pilot.pause()
-
-            await pilot.hover(screen._rows[0])
-            await pilot.pause()
-
-            assert screen._selected_index == 0
-            assert app.results == []

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -303,6 +303,141 @@ class TestPromptClipboardScreen:
             assert len(rows) == 1
             assert "No matching prompts." in str(rows[0].render())
 
+    async def test_copy_on_an_empty_filter_bells_instead_of_copying(self) -> None:
+        """Ctrl+C with no matches must not copy the last selected prompt.
+
+        `action_copy` leaves the modal open, so without the empty guard it
+        would put stale text on the clipboard under a "Prompt copied" toast.
+        """
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("alpha", "beta"))
+            await pilot.pause()
+            await pilot.pause()
+
+            screen.query_one("#prompt-filter", Input).value = "no such prompt"
+            await pilot.pause()
+            await pilot.pause()
+            assert list(screen._filtered) == []
+
+            with (
+                patch("deepagents_code.clipboard.copy_text_with_feedback") as copy_text,
+                patch.object(app, "bell") as bell,
+            ):
+                screen.action_copy()
+
+            copy_text.assert_not_called()
+            bell.assert_called_once()
+            assert app.results == []
+
+    async def test_enter_on_an_empty_filter_bells_instead_of_dismissing(self) -> None:
+        """Enter with no matches must keep the modal open."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("alpha", "beta"))
+            await pilot.pause()
+            await pilot.pause()
+
+            screen.query_one("#prompt-filter", Input).value = "no such prompt"
+            await pilot.pause()
+            await pilot.pause()
+
+            with patch.object(app, "bell") as bell:
+                screen.action_select()
+                await pilot.pause()
+
+            bell.assert_called_once()
+            assert app.results == []
+            assert app.screen is screen
+
+    async def test_moving_at_a_boundary_bells(self) -> None:
+        """Arrowing past either end is a no-op with feedback."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("newest", "oldest"))
+            await pilot.pause()
+            await pilot.pause()
+            assert screen._selected_index == 0
+
+            with patch.object(app, "bell") as bell:
+                await screen.action_move_up()
+            bell.assert_called_once()
+            assert screen._selected_index == 0
+
+            await screen.action_move_down()
+            await pilot.pause()
+            assert screen._selected_index == 1
+
+            with patch.object(app, "bell") as bell:
+                await screen.action_move_down()
+            bell.assert_called_once()
+            assert screen._selected_index == 1
+
+    async def test_moving_on_an_empty_filter_bells(self) -> None:
+        """Arrowing with no matches has nothing to move to."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("alpha",))
+            await pilot.pause()
+            await pilot.pause()
+
+            screen.query_one("#prompt-filter", Input).value = "no such prompt"
+            await pilot.pause()
+            await pilot.pause()
+
+            with patch.object(app, "bell") as bell:
+                await screen.action_move_down()
+            bell.assert_called_once()
+
+    async def test_clicking_a_stale_row_is_ignored(self) -> None:
+        """A click on rows that no longer match `_filtered` must not select.
+
+        The row indexes then describe a different list, so acting on one would
+        select a prompt the user did not point at.
+        """
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(tuple(f"prompt {index}" for index in range(12)))
+            await pilot.pause()
+
+            search = screen.query_one("#prompt-filter", Input)
+            search.value = "prompt 1"
+            screen._apply_filter("prompt 1")
+            await pilot.pause()
+            assert len(screen._rows) == len(screen._filtered)
+
+            # Widen the filter behind the modal's back, then act before the
+            # deferred re-render lands.
+            search.value = "prompt"
+            with patch("deepagents_code.clipboard.copy_text_with_feedback"):
+                screen.action_copy()
+            assert len(screen._rows) != len(screen._filtered)
+
+            previous = screen._selected_index
+            screen._select_row(len(screen._rows) - 1)
+
+            assert screen._selected_index == previous
+
+    async def test_hovering_moves_the_highlight_between_rows(self) -> None:
+        """Moving the pointer must unmark the row it left."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("newest", "middle", "oldest"))
+            await pilot.pause()
+            await pilot.pause()
+
+            await pilot.hover(screen._rows[1])
+            await pilot.pause()
+            assert screen._rows[1].mouse_hover
+
+            await pilot.hover(screen._rows[2])
+            await pilot.pause()
+
+            # Exactly one row is hovered, so no stale highlight is left behind.
+            assert screen._rows[2].mouse_hover
+            assert not screen._rows[1].mouse_hover
+            assert screen._selected_index == 0
+
     async def test_moving_consumes_a_queued_filter_edit(self) -> None:
         """Arrow keys must settle a queued filter edit before navigating.
 

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -1,0 +1,130 @@
+"""Tests for the searchable prompt clipboard modal."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.widgets import Input, Static
+
+from deepagents_code.tui.modals.prompt_clipboard import PromptClipboardScreen
+
+
+class _PromptClipboardApp(App[None]):
+    """Minimal host recording prompt clipboard results."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.results: list[str | None] = []
+
+    def compose(self) -> ComposeResult:
+        yield Container()
+
+    def open(self, prompts: tuple[str, ...]) -> PromptClipboardScreen:
+        screen = PromptClipboardScreen(prompts)
+        self.push_screen(screen, self.results.append)
+        return screen
+
+
+class TestPromptClipboardScreen:
+    """Keyboard interaction and literal rendering tests."""
+
+    async def test_filter_autofocus_and_typing_c(self) -> None:
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("alpha", "contains c", "charlie"))
+            await pilot.pause()
+
+            search = screen.query_one("#prompt-filter", Input)
+            assert screen.focused is search
+
+            await pilot.press("c")
+            await pilot.pause()
+
+            assert search.value == "c"
+            assert screen._filtered == ["contains c", "charlie"]
+
+    async def test_navigation_preview_and_enter_selection(self) -> None:
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("newest", "older\nwith details"))
+            await pilot.pause()
+
+            await pilot.press("down")
+            await pilot.pause()
+            preview = screen.query_one("#prompt-preview", Static)
+            assert str(preview.content) == "older\nwith details"
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert app.results == ["older\nwith details"]
+
+    async def test_immediate_enter_uses_latest_unrendered_filter(self) -> None:
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("saved prompt",))
+            await pilot.pause()
+            search = screen.query_one("#prompt-filter", Input)
+
+            search.value = "no match"
+            screen.action_select()
+
+            assert app.results == []
+            assert app.screen is screen
+
+    async def test_escape_cancels(self) -> None:
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            app.open(("saved prompt",))
+            await pilot.pause()
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert app.results == [None]
+
+    async def test_markup_like_prompt_renders_literally(self) -> None:
+        prompt = "[bold red]do not style[/]\n<literal>"
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open((prompt,))
+            await pilot.pause()
+
+            preview = screen.query_one("#prompt-preview", Static)
+            assert str(preview.content) == prompt
+            assert str(screen._rows[0].content).startswith("[bold red]")
+
+    async def test_empty_state_fits_narrow_terminal(self) -> None:
+        app = _PromptClipboardApp()
+        async with app.run_test(size=(45, 18)) as pilot:
+            screen = app.open(())
+            await pilot.pause()
+
+            rows = screen.query_one("#prompt-rows", Container)
+            empty = rows.query_one(Static)
+            assert (
+                str(empty.content) == "No prompts yet. Submitted prompts appear here."
+            )
+            assert screen.region.width <= 45
+
+    async def test_ctrl_c_copies_selected_prompt_without_dismissing(self) -> None:
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("copy me",))
+            await pilot.pause()
+
+            with patch(
+                "deepagents_code.clipboard.copy_text_with_feedback"
+            ) as copy_text:
+                await pilot.press("ctrl+c")
+                await pilot.pause()
+
+            copy_text.assert_called_once_with(
+                app,
+                "copy me",
+                failure_noun="prompt",
+                success_message="Prompt copied to clipboard",
+            )
+            assert app.screen is screen

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -147,6 +147,19 @@ class TestPromptClipboardScreen:
             await pilot.pause()
             assert screen._rows[1].region.height > 0
 
+    async def test_preview_matches_list_width_when_rows_scroll(self) -> None:
+        """The preview box spans the same width as the scrollable prompt list."""
+        app = _PromptClipboardApp()
+        async with app.run_test(size=(80, 40)) as pilot:
+            app.open(tuple(f"prompt {index}" for index in range(30)))
+            await pilot.pause()
+            await pilot.pause()
+
+            rows_list = app.screen.query_one("#prompt-list", VerticalScroll)
+            preview = app.screen.query_one("#prompt-preview-scroll", VerticalScroll)
+            assert rows_list.show_vertical_scrollbar
+            assert preview.region.width == rows_list.region.width
+
     async def test_list_shrinks_to_keep_controls_visible(self) -> None:
         """A short terminal caps the list instead of pushing help off-modal."""
         app = _PromptClipboardApp()

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -160,12 +160,33 @@ class TestPromptClipboardScreen:
             assert rows_list.show_vertical_scrollbar
             assert preview.region.width == rows_list.region.width
 
-    async def test_list_shrinks_to_keep_controls_visible(self) -> None:
-        """A short terminal caps the list instead of pushing help off-modal."""
+    async def test_modal_height_is_constant_while_previewing(self) -> None:
+        """Selecting prompts of different lengths must not resize the modal."""
+        app = _PromptClipboardApp()
+        async with app.run_test(size=(80, 40)) as pilot:
+            screen = app.open(("short", "long\n" + "line\n" * 20))
+            await pilot.pause()
+
+            outer = screen.query_one(Vertical)
+            preview = screen.query_one("#prompt-preview-scroll", VerticalScroll)
+            initial_outer = outer.region.height
+            initial_preview = preview.region.height
+
+            await pilot.press("down")
+            await pilot.pause()
+
+            assert str(screen.query_one("#prompt-preview", Static).content).startswith(
+                "long"
+            )
+            assert outer.region.height == initial_outer
+            assert preview.region.height == initial_preview
+            assert preview.is_scrollable
+
+    async def test_list_fills_fixed_modal_and_scrolls(self) -> None:
+        """The list takes the fixed modal's leftover space and clips rows."""
         app = _PromptClipboardApp()
         async with app.run_test(size=(80, 18)) as pilot:
             screen = app.open(tuple(f"prompt {index}" for index in range(30)))
-            await pilot.pause()
             await pilot.pause()
             await pilot.pause()
 

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -373,3 +373,40 @@ class TestPromptClipboardScreen:
             message = str(rows[0].render())
             assert "Could not read prompt history" in message
             assert "No prompts yet" not in message
+
+    async def test_hovering_a_row_selects_but_does_not_submit(self) -> None:
+        """Hover moves the highlight; only Enter dismisses the modal."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("newest", "middle", "oldest"))
+            await pilot.pause()
+            await pilot.pause()
+
+            await pilot.hover(screen._rows[2])
+            await pilot.pause()
+
+            assert screen._selected_index == 2
+            assert "prompt-row-selected" in screen._rows[2].classes
+            assert "prompt-row-selected" not in screen._rows[0].classes
+            preview = screen.query_one("#prompt-preview", Static)
+            assert str(preview.content) == "oldest"
+            assert app.results == []
+            assert app.screen is screen
+
+            await pilot.press("enter")
+            await pilot.pause()
+            assert app.results == ["oldest"]
+
+    async def test_hovering_the_selected_row_is_a_noop(self) -> None:
+        """Hovering the already-highlighted row must not error or re-render."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("only",))
+            await pilot.pause()
+            await pilot.pause()
+
+            await pilot.hover(screen._rows[0])
+            await pilot.pause()
+
+            assert screen._selected_index == 0
+            assert app.results == []

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -303,6 +303,41 @@ class TestPromptClipboardScreen:
             assert len(rows) == 1
             assert "No matching prompts." in str(rows[0].render())
 
+    async def test_moving_consumes_a_queued_filter_edit(self) -> None:
+        """Arrow keys must settle a queued filter edit before navigating.
+
+        When an edit is queued but neither `_filtered` nor `_rows` has been
+        updated yet, their lengths still match, so the desync guard in `_move`
+        does not fire. Without an explicit resync the selection walks the list
+        the user has already filtered away from -- the same class of bug
+        `action_select` and `action_copy` resync to avoid.
+        """
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("alpha one", "alpha two", "beta"))
+            await pilot.pause()
+            await pilot.pause()
+            assert list(screen._filtered) == ["alpha one", "alpha two", "beta"]
+
+            # Type into the widget without letting `Input.Changed` dispatch:
+            # `_filtered` and `_rows` still both describe the unfiltered list.
+            screen.query_one("#prompt-filter", Input).value = "beta"
+            assert len(screen._rows) == len(screen._filtered)
+
+            await screen.action_move_down()
+
+            # Asserted before pumping the queue: once `Input.Changed` is
+            # dispatched the filter lands anyway, so only the state the move
+            # itself left behind distinguishes a resync from a stale walk.
+            # Without the resync the selection has stepped to "alpha two",
+            # a prompt the query no longer matches.
+            assert list(screen._filtered) == ["beta"]
+            assert screen._selected_index == 0
+
+            await pilot.pause()
+            preview = screen.query_one("#prompt-preview", Static)
+            assert str(preview.content) == "beta"
+
     async def test_moving_after_a_queued_filter_edit_does_not_raise(self) -> None:
         """Ctrl+C leaves the modal open, so its re-filter must not desync rows.
 

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -176,6 +176,24 @@ class TestPromptClipboardScreen:
             assert rows_list.show_vertical_scrollbar
             assert help_.region.bottom <= outer.region.bottom
 
+    async def test_tab_and_shift_tab_do_not_move_focus(self) -> None:
+        """Focus keys are swallowed; the search input keeps focus throughout."""
+        app = _PromptClipboardApp()
+        async with app.run_test() as pilot:
+            screen = app.open(("alpha", "beta"))
+            await pilot.pause()
+            search = screen.query_one("#prompt-filter", Input)
+
+            await pilot.press("tab")
+            await pilot.pause()
+            assert screen.focused is search
+            assert screen._selected_index == 0
+
+            await pilot.press("shift+tab")
+            await pilot.pause()
+            assert screen.focused is search
+            assert screen._selected_index == 0
+
     async def test_ctrl_c_copies_selected_prompt_without_dismissing(self) -> None:
         app = _PromptClipboardApp()
         async with app.run_test() as pilot:

--- a/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_prompt_clipboard.py
@@ -374,8 +374,8 @@ class TestPromptClipboardScreen:
             assert "Could not read prompt history" in message
             assert "No prompts yet" not in message
 
-    async def test_hovering_marks_a_row_without_moving_the_selection(self) -> None:
-        """Hover is visual only: arrows still move from the selected row."""
+    async def test_hovering_a_row_does_not_move_the_selection(self) -> None:
+        """Hover is visual only (:hover CSS): arrows move from the selection."""
         app = _PromptClipboardApp()
         async with app.run_test() as pilot:
             screen = app.open(("newest", "middle", "oldest"))
@@ -385,8 +385,9 @@ class TestPromptClipboardScreen:
             await pilot.hover(screen._rows[2])
             await pilot.pause()
 
-            # The hovered row is marked, but selection and preview stay put.
-            assert "prompt-row-hovered" in screen._rows[2].classes
+            # Textual tracks the hovered widget for :hover styling; selection
+            # and preview stay put.
+            assert screen._rows[2].mouse_hover
             assert screen._selected_index == 0
             preview = screen.query_one("#prompt-preview", Static)
             assert str(preview.content) == "newest"

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7437,13 +7437,19 @@ class TestPromptSearchPanel:
             chat._history.add(prompt)
 
     async def test_ctrl_r_opens_inline_panel_above_input(self, tmp_path) -> None:
-        from deepagents_code.tui.widgets.prompt_search import PromptSearchPanel
+        from deepagents_code.tui.widgets.prompt_search import (
+            PromptSearchInput,
+            PromptSearchPanel,
+        )
 
         app = _RecordingApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             chat._history.history_file = tmp_path / "history.jsonl"
             self._seed_history(chat, ["first prompt", "second prompt"])
+            await pilot.pause()
+            assert chat._text_area is not None
+            chat._text_area.insert("second")
             await pilot.pause()
 
             tier = chat.open_prompt_search()
@@ -7454,9 +7460,10 @@ class TestPromptSearchPanel:
             panel = app.query_one(PromptSearchPanel)
             assert panel.styles.display == "block"
             assert chat._prompt_search_active is True
-            # Draft is untouched while searching
-            assert chat._text_area is not None
-            assert chat._text_area.text == ""
+            assert app.query_one(PromptSearchInput).value == "second"
+            assert chat._prompt_search_filtered == ["second prompt"]
+            # Seeding the filter does not consume or change the draft.
+            assert chat._text_area.text == "second"
 
     async def test_second_ctrl_r_escalates_to_modal(self, tmp_path) -> None:
         app = _RecordingApp()
@@ -7720,8 +7727,6 @@ class TestPromptSearchPanel:
             self._seed_history(chat, ["hello"])
             await pilot.pause()
             assert chat._text_area is not None
-            chat._text_area.insert("draft")
-            await pilot.pause()
 
             chat.open_prompt_search()
             await pilot.pause()
@@ -7730,7 +7735,7 @@ class TestPromptSearchPanel:
             await pilot.pause()
 
             assert chat._prompt_search_active is False
-            assert chat._text_area.text == "draft"
+            assert chat._text_area.text == ""
 
     async def test_completion_active_routes_to_modal(self, tmp_path) -> None:
         app = _RecordingApp()
@@ -7739,10 +7744,14 @@ class TestPromptSearchPanel:
             chat._history.history_file = tmp_path / "history.jsonl"
             self._seed_history(chat, ["hello"])
             await pilot.pause()
+            assert chat._text_area is not None
+            chat._text_area.insert("hello")
+            await pilot.pause()
 
             # Simulate an active completion popup
             chat._current_suggestions = [("/help", "Show help")]
             assert chat.open_prompt_search() == "modal"
+            assert chat.escalate_prompt_search() == "hello"
 
     async def test_tab_pages_through_results(self, tmp_path) -> None:
         app = _RecordingApp()

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -8174,6 +8174,95 @@ class TestPromptSearchPanel:
             assert "Could not read prompt history" in messages[0]
             assert "No prompts yet" not in messages[0]
 
+    async def test_rebuild_failure_ends_the_session(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed rebuild must abandon the search, not just hide the panel.
+
+        Hiding alone leaves `_prompt_search_active` true, so the composer keeps
+        swallowing every key into an invisible panel.
+        """
+        from unittest.mock import AsyncMock
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["first prompt", "second prompt"])
+            await pilot.pause()
+            notifications = _capture_notifications(monkeypatch, app)
+
+            panel = chat._prompt_search
+            assert panel is not None
+            results = panel.query_one("#prompt-search-results")
+            monkeypatch.setattr(
+                results, "mount", AsyncMock(side_effect=RuntimeError("boom"))
+            )
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            assert chat._prompt_search_active is False
+            assert panel.styles.display == "none"
+            assert panel._options == []
+            assert [message for message, _ in notifications] == [
+                "Prompt search could not be displayed"
+            ]
+
+            # The composer takes typed keys again rather than routing them into
+            # an invisible panel.
+            text_area = chat._text_area
+            assert text_area is not None
+            text_area.focus()
+            await pilot.pause()
+            await pilot.press("x")
+            await pilot.pause()
+            assert text_area.text == "x"
+
+    async def test_abandon_recovery_survives_a_detached_panel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Recovery must not raise in turn.
+
+        `hide`, `post_message`, and `notify` all reach for `self.app`, and
+        detachment is a plausible cause of the failure being recovered from. A
+        second exception would escape the `call_next` callback that runs
+        `_rebuild_options` and panic the app during error recovery, masking the
+        original failure.
+        """
+        from unittest.mock import MagicMock
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["first prompt"])
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+
+            # Stand in for a detached widget: every app-touching step raises.
+            hide = MagicMock(side_effect=RuntimeError("no app"))
+            post_message = MagicMock(side_effect=RuntimeError("no app"))
+            notify = MagicMock(side_effect=RuntimeError("no app"))
+            monkeypatch.setattr(panel, "hide", hide)
+            monkeypatch.setattr(panel, "post_message", post_message)
+            monkeypatch.setattr(panel, "notify", notify)
+
+            panel._abandon_quietly()
+
+            # Every step was attempted even though each earlier one failed:
+            # ending the session matters more than any single step succeeding.
+            hide.assert_called_once()
+            post_message.assert_called_once()
+            notify.assert_called_once()
+
+            # Restore before the app shuts down: a still-raising `post_message`
+            # would break teardown rather than the code under test.
+            monkeypatch.undo()
+
     async def test_unwritable_history_warns_once_per_session(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -8173,3 +8173,46 @@ class TestPromptSearchPanel:
             assert messages
             assert "Could not read prompt history" in messages[0]
             assert "No prompts yet" not in messages[0]
+
+    async def test_unreadable_history_path_is_not_markup_parsed(
+        self, tmp_path: Path
+    ) -> None:
+        """The empty-state message interpolates a path, so it must stay literal.
+
+        `Static` markup-parses a bare `str`, so a directory named like a
+        Textual tag is swallowed from the message. (A closing-tag shape goes
+        further and raises `MarkupError`, taking the rebuild down its
+        recovery path.)
+        """
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchOption
+
+        # A directory in place of the file is an OSError on read, and the
+        # bracketed segment lands in the interpolated message.
+        history_dir = tmp_path / "proj [v2]"
+        history_dir.mkdir()
+        history_file = history_dir / "history.jsonl"
+        history_file.mkdir()
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = history_file
+            chat._history._entries = []
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            assert chat._prompt_search_active is True
+            results = panel.query_one("#prompt-search-results")
+            messages = [
+                str(child.render())
+                for child in results.children
+                if isinstance(child, Static)
+                and not isinstance(child, PromptSearchOption)
+            ]
+            assert messages
+            # Every literal segment survives rather than being read as markup.
+            assert "proj [v2]" in messages[0]

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7519,10 +7519,10 @@ class TestPromptSearchPanel:
             assert chat._text_area is not None
             assert chat._text_area.text == "newest prompt"
 
-    async def test_hovering_marks_a_row_without_moving_the_selection(
+    async def test_hovering_a_row_does_not_move_the_selection(
         self, tmp_path: Path
     ) -> None:
-        """Hover is visual only: arrows still move from the selected row."""
+        """Hover is visual only (:hover CSS): arrows move from the selection."""
         app = _RecordingApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -7541,8 +7541,9 @@ class TestPromptSearchPanel:
             await pilot.hover(panel._options[2])
             await pilot.pause()
 
-            # The hovered row is marked, but the selection stays put.
-            assert "prompt-search-hovered" in panel._options[2].classes
+            # Textual tracks the hovered widget for :hover styling; the
+            # selection stays put.
+            assert panel._options[2].mouse_hover
             assert chat._prompt_search_index == 0
             assert panel._options[0]._is_selected
             assert not panel._options[2]._is_selected

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -2001,6 +2001,32 @@ class TestSetValueAtEnd:
             assert text_area.cursor_location == (1, len("second"))
 
 
+class TestInsertAtCursor:
+    """Tests for undoable prompt insertion without submission."""
+
+    async def test_inserts_multiline_text_at_cursor_and_is_undoable(self) -> None:
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
+            text_area = chat_input._text_area
+            assert text_area is not None
+            text_area.insert("before after")
+            text_area.move_cursor((0, len("before ")))
+
+            assert chat_input.insert_at_cursor("saved\nprompt") is True
+            await pilot.pause()
+
+            assert chat_input.value == "before saved\npromptafter"
+            assert app.submitted == []
+
+            text_area.undo()
+            await pilot.pause()
+            assert chat_input.value == "before after"
+
+    def test_returns_false_before_text_area_is_mounted(self) -> None:
+        assert ChatInput().insert_at_cursor("saved prompt") is False
+
+
 class TestRefocusClickSuppression:
     """Clicks that re-focus the terminal window should not move the cursor."""
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7600,3 +7600,39 @@ class TestPromptSearchPanel:
             # Simulate an active completion popup
             chat._current_suggestions = [("/help", "Show help")]
             assert chat.open_prompt_search() == "modal"
+
+    async def test_tab_pages_through_results(self, tmp_path) -> None:
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, [f"prompt {i}" for i in range(12)])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            assert chat._prompt_search_index == 0
+
+            await pilot.press("tab")
+            await pilot.pause()
+            assert chat._prompt_search_index == 5
+
+            await pilot.press("shift+tab")
+            await pilot.pause()
+            assert chat._prompt_search_index == 0
+
+    async def test_focus_moves_to_query_input(self, tmp_path) -> None:
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchInput
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["hello"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+
+            assert isinstance(app.focused, PromptSearchInput)

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -5144,6 +5144,20 @@ class TestChatInputTypingBubble:
 
             assert app.chat_input_typing_count == 2
 
+    async def test_prompt_search_typing_bubbles_to_chat_input(self) -> None:
+        """Editing the prompt-search query should count as typing activity."""
+        app = _TextAreaTypingApp()
+        async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
+            chat_input.open_prompt_search()
+            await pilot.pause()
+
+            before = app.chat_input_typing_count
+            await pilot.press("y")
+            await pilot.pause()
+
+            assert app.chat_input_typing_count == before + 1
+
 
 class TestArgumentHints:
     """Test inline argument-hint ghost text for slash commands."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7556,6 +7556,46 @@ class TestPromptSearchPanel:
             assert chat._text_area is not None
             assert chat._text_area.text == ""
 
+    async def test_hovering_the_selected_row_keeps_its_highlight(
+        self, tmp_path: Path
+    ) -> None:
+        """Hover must not repaint the selected row.
+
+        A pseudo-class bumps the class slot of Textual's specificity tuple, so
+        an unqualified `PromptSearchOption:hover` ties the selected rule and
+        wins on source order, stripping the selection background while
+        `color: $background` still applies. The `:not()` qualifier in the
+        stylesheet is what prevents it.
+        """
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["oldest", "middle", "newest"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            selected = panel._options[0]
+            unselected = panel._options[1]
+            selected_background = selected.styles.background
+
+            await pilot.hover(selected)
+            await pilot.pause()
+
+            assert selected.mouse_hover
+            assert selected.styles.background == selected_background
+
+            # The same hover on an unselected row does repaint it, so the
+            # assertion above is not passing merely because :hover is inert.
+            await pilot.hover(unselected)
+            await pilot.pause()
+            assert unselected.styles.background != selected_background
+
     async def test_clicking_a_row_selects_but_does_not_insert(
         self, tmp_path: Path
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7651,6 +7651,26 @@ class TestPromptSearchPanel:
 
             assert isinstance(app.focused, PromptSearchInput)
 
+    async def test_focus_input_restores_query_focus(self, tmp_path) -> None:
+        """App-level focus restoration should keep an active search usable."""
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchInput
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["hello"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            assert chat._text_area is not None
+            chat._text_area.focus()
+            chat.focus_input()
+            await pilot.pause()
+
+            assert isinstance(app.focused, PromptSearchInput)
+
     async def test_selection_past_first_page_stays_mounted_and_visible(
         self, tmp_path
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -8174,6 +8174,73 @@ class TestPromptSearchPanel:
             assert "Could not read prompt history" in messages[0]
             assert "No prompts yet" not in messages[0]
 
+    async def test_unwritable_history_warns_once_per_session(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Prompts that cannot be saved are lost at exit, so say so -- once.
+
+        A failed append keeps the entry in memory, so up-arrow and the prompt
+        clipboard keep working and nothing on screen suggests a problem.
+        """
+        # A regular file in place of the parent directory makes the append's
+        # mkdir/open raise OSError.
+        blocker = tmp_path / "blocker"
+        blocker.touch()
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = blocker / "history.jsonl"
+            await pilot.pause()
+            notifications = _capture_notifications(monkeypatch, app)
+
+            # Drive a real submission so the wiring in `_submit` is covered,
+            # not just the helper.
+            text_area = chat._text_area
+            assert text_area is not None
+            text_area.insert("first prompt")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert [event.value for event in app.submitted] == ["first prompt"]
+            assert len(notifications) == 1
+            message, kwargs = notifications[0]
+            assert "Could not save prompt history" in message
+            assert "lost when it ends" in message
+            assert kwargs["severity"] == "warning"
+            # The message interpolates the history path, so markup must be off.
+            assert kwargs["markup"] is False
+
+            # Still broken, but the user has already been told.
+            text_area.insert("second prompt")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert len(app.submitted) == 2
+            assert len(notifications) == 1
+
+    async def test_writable_history_does_not_warn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The healthy path stays quiet."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            await pilot.pause()
+            notifications = _capture_notifications(monkeypatch, app)
+
+            text_area = chat._text_area
+            assert text_area is not None
+            text_area.insert("a prompt")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert [event.value for event in app.submitted] == ["a prompt"]
+            assert notifications == []
+
     async def test_unreadable_history_warns_when_the_list_is_not_empty(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -8174,6 +8174,60 @@ class TestPromptSearchPanel:
             assert "Could not read prompt history" in messages[0]
             assert "No prompts yet" not in messages[0]
 
+    async def test_unreadable_history_warns_when_the_list_is_not_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A degraded list looks complete, so the failure needs its own warning.
+
+        The empty-state message only reaches the user when there is nothing to
+        list, but `recent_prompts` falls back to this session's entries on a
+        read failure. The usual outcome is a non-empty, silently truncated list
+        that is indistinguishable from a healthy one.
+        """
+        history_file = tmp_path / "history.jsonl"
+        history_file.mkdir()
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = history_file
+            # Session entries survive the failed read, so the list is non-empty
+            # and the empty state never renders.
+            self._seed_history(chat, ["this session only"])
+            await pilot.pause()
+            notifications = _capture_notifications(monkeypatch, app)
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            assert chat._prompt_search_prompts
+            assert len(notifications) == 1
+            message, kwargs = notifications[0]
+            assert "Could not read prompt history" in message
+            assert "this session's prompts only" in message
+            assert kwargs["severity"] == "warning"
+            # The message interpolates the history path, so markup must be off.
+            assert kwargs["markup"] is False
+
+    async def test_readable_history_does_not_warn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The healthy path stays quiet."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["a prompt"])
+            await pilot.pause()
+            notifications = _capture_notifications(monkeypatch, app)
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            assert chat._prompt_search_prompts
+            assert notifications == []
+
     async def test_unreadable_history_path_is_not_markup_parsed(
         self, tmp_path: Path
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7545,8 +7545,8 @@ class TestPromptSearchPanel:
             # selection stays put.
             assert panel._options[2].mouse_hover
             assert chat._prompt_search_index == 0
-            assert panel._options[0]._is_selected
-            assert not panel._options[2]._is_selected
+            assert panel._options[0].is_selected
+            assert not panel._options[2].is_selected
 
             # Keyboard navigation resumes from the selection, not the hover.
             await pilot.press("down")
@@ -7618,7 +7618,7 @@ class TestPromptSearchPanel:
             await pilot.pause()
 
             assert chat._prompt_search_index == 2
-            assert panel._options[2]._is_selected
+            assert panel._options[2].is_selected
             # Clicking alone must not close the panel or touch the draft.
             assert chat._prompt_search_active is True
             assert chat._text_area is not None
@@ -7861,7 +7861,7 @@ class TestPromptSearchPanel:
             selected = [
                 o for o in panel._options if o.index == chat._prompt_search_index
             ]
-            assert selected[0]._is_selected
+            assert selected[0].is_selected
 
             # Enter inserts the exact windowed prompt.
             await pilot.press("enter")
@@ -8034,7 +8034,7 @@ class TestPromptSearchPanel:
             expected = chat._prompt_search_filtered[target]
             mounted = {option.index: option for option in panel._options}
             assert target in mounted
-            assert mounted[target]._is_selected
+            assert mounted[target].is_selected
             # The row's rendered title must describe the prompt at that index.
             assert str(mounted[target].render()).strip() == expected
 
@@ -8242,6 +8242,32 @@ class TestPromptSearchPanel:
 
             assert chat._prompt_search_index == 1
             assert text_area.text == ""
+
+    async def test_focus_query_reports_whether_focus_moved(
+        self, tmp_path: Path
+    ) -> None:
+        """`focus_query` keeps the panel's composition private to it."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["a prompt"])
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            assert panel.focus_query() is True
+            await pilot.pause()
+            assert app.focused is panel._query_input
+
+            # Before `on_mount` there is nothing to focus, and the caller is
+            # told rather than left believing focus moved.
+            query_input = panel._query_input
+            panel._query_input = None
+            try:
+                assert panel.focus_query() is False
+            finally:
+                panel._query_input = query_input
 
     async def test_panel_reports_its_rendered_height(self, tmp_path: Path) -> None:
         """`RowsChanged` drives the composer's height reservation.

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7413,3 +7413,190 @@ class TestPasteCollapseIntegration:
             await pilot.pause()
 
             assert 1 in chat._pasted_contents
+
+
+class TestPromptSearchPanel:
+    """Inline prompt history search (first Ctrl+R tier)."""
+
+    def _seed_history(self, chat: ChatInput, prompts: list[str]) -> None:
+        for prompt in prompts:
+            chat._history.add(prompt)
+
+    async def test_ctrl_r_opens_inline_panel_above_input(self, tmp_path) -> None:
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchPanel
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["first prompt", "second prompt"])
+            await pilot.pause()
+
+            tier = chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            assert tier == "inline"
+            panel = app.query_one(PromptSearchPanel)
+            assert panel.styles.display == "block"
+            assert chat._prompt_search_active is True
+            # Draft is untouched while searching
+            assert chat._text_area is not None
+            assert chat._text_area.text == ""
+
+    async def test_second_ctrl_r_escalates_to_modal(self, tmp_path) -> None:
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["first prompt"])
+            await pilot.pause()
+
+            assert chat.open_prompt_search() == "inline"
+            await pilot.pause()
+            assert chat.open_prompt_search() == "modal"
+            query = chat.escalate_prompt_search()
+            await pilot.pause()
+
+            assert query == ""
+            assert chat._prompt_search_active is False
+
+    async def test_typing_filters_results(self, tmp_path) -> None:
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchPanel
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["fix the bug", "add feature", "fix tests"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            for char in "fix":
+                await pilot.press(char)
+            await pilot.pause()
+            await pilot.pause()
+
+            # newest-first order, both "fix" prompts retained
+            assert chat._prompt_search_filtered == ["fix tests", "fix the bug"]
+            panel = app.query_one(PromptSearchPanel)
+            assert panel.styles.display == "block"
+
+    async def test_enter_inserts_selected_prompt(self, tmp_path) -> None:
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["older prompt", "newest prompt"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            # newest-first: index 0 is "newest prompt"
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert chat._prompt_search_active is False
+            assert chat._text_area is not None
+            assert chat._text_area.text == "newest prompt"
+
+    async def test_escape_restores_draft(self, tmp_path) -> None:
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["some prompt"])
+            await pilot.pause()
+            assert chat._text_area is not None
+            chat._text_area.insert("my draft")
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            # Type a query (does not touch the draft)
+            await pilot.press("x")
+            await pilot.pause()
+            assert chat._text_area.text == "my draft"
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert chat._prompt_search_active is False
+            assert chat._text_area.text == "my draft"
+
+    async def test_typing_does_not_enter_textarea(self, tmp_path) -> None:
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["hello"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            await pilot.press("h")
+            await pilot.pause()
+
+            assert chat._text_area is not None
+            assert chat._text_area.text == ""
+            assert chat._prompt_search_query == "h"
+
+    async def test_arrow_navigation_moves_selection(self, tmp_path) -> None:
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["one", "two", "three"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            assert chat._prompt_search_index == 0
+            await pilot.press("down")
+            await pilot.pause()
+            assert chat._prompt_search_index == 1
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._prompt_search_index == 0
+
+    async def test_backspace_on_empty_query_cancels(self, tmp_path) -> None:
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["hello"])
+            await pilot.pause()
+            assert chat._text_area is not None
+            chat._text_area.insert("draft")
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.press("backspace")
+            await pilot.pause()
+
+            assert chat._prompt_search_active is False
+            assert chat._text_area.text == "draft"
+
+    async def test_completion_active_routes_to_modal(self, tmp_path) -> None:
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["hello"])
+            await pilot.pause()
+
+            # Simulate an active completion popup
+            chat._current_suggestions = [("/help", "Show help")]
+            assert chat.open_prompt_search() == "modal"

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7636,3 +7636,46 @@ class TestPromptSearchPanel:
             await pilot.pause()
 
             assert isinstance(app.focused, PromptSearchInput)
+
+    async def test_selection_past_first_page_stays_mounted_and_visible(
+        self, tmp_path
+    ) -> None:
+        """Regression: rows beyond the first page must exist to be shown.
+
+        The panel windows the DOM around the selection, so navigating past the
+        first page (arrows or a Tab page) must keep the selected row mounted
+        and scrolled into view rather than pointing at a row that was never
+        rendered.
+        """
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, [f"prompt {i}" for i in range(30)])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            panel = chat._prompt_search
+            assert panel is not None
+
+            # Arrow past the first page of 5 rows.
+            for _ in range(12):
+                await pilot.press("down")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert chat._prompt_search_index == 12
+            mounted = {option.index for option in panel._options}
+            assert chat._prompt_search_index in mounted
+            selected = [
+                o for o in panel._options if o.index == chat._prompt_search_index
+            ]
+            assert selected[0]._is_selected
+
+            # Enter inserts the exact windowed prompt.
+            await pilot.press("enter")
+            await pilot.pause()
+            assert chat._text_area is not None
+            assert chat._text_area.text == "prompt 17"  # newest-first: 29-12

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7544,6 +7544,26 @@ class TestPromptSearchPanel:
             assert chat._prompt_search_active is False
             assert chat._text_area.text == "my draft"
 
+    async def test_escape_preserves_concurrently_updated_draft(self, tmp_path) -> None:
+        """Cancel should not replace a draft changed outside prompt search."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["some prompt"])
+            await pilot.pause()
+            assert chat._text_area is not None
+            chat._text_area.insert("original draft")
+            chat.open_prompt_search()
+            await pilot.pause()
+
+            chat.value = "external editor result"
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert chat._prompt_search_active is False
+            assert chat.value == "external editor result"
+
     async def test_typing_does_not_enter_textarea(self, tmp_path) -> None:
         app = _RecordingApp()
         async with app.run_test() as pilot:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7858,4 +7858,183 @@ class TestPromptSearchPanel:
                 if isinstance(child, Static)
                 and not isinstance(child, PromptSearchOption)
             ]
-            assert len(empty_rows) <= 1
+            # Exactly one: `<= 1` also passes when the row vanishes entirely,
+            # which is the other half of the bug this locks in.
+            assert len(empty_rows) == 1
+
+    async def test_selection_beyond_the_render_window_inserts_that_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        """Rows past `PROMPT_SEARCH_WINDOW` must keep index and title aligned.
+
+        Below the window size the panel mounts every row and absolute indices
+        are trivially correct. Past it the window slides, so `PromptSearchOption
+        .index` is an offset into the filtered list; an off-by-one there inserts
+        a different prompt than the highlighted row shows.
+        """
+        from deepagents_code.tui.widgets.prompt_search import PROMPT_SEARCH_WINDOW
+
+        total = PROMPT_SEARCH_WINDOW + 30
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, [f"prompt {i}" for i in range(total)])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            panel = chat._prompt_search
+            assert panel is not None
+            assert len(chat._prompt_search_filtered) == total
+
+            target = PROMPT_SEARCH_WINDOW + 10
+            for _ in range(target):
+                await pilot.press("down")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert chat._prompt_search_index == target
+            expected = chat._prompt_search_filtered[target]
+            mounted = {option.index: option for option in panel._options}
+            assert target in mounted
+            assert mounted[target]._is_selected
+            # The row's rendered title must describe the prompt at that index.
+            assert str(mounted[target].render()).strip() == expected
+
+            await pilot.press("enter")
+            await pilot.pause()
+            assert chat._text_area is not None
+            assert chat._text_area.text == expected
+            # Newest-first, so index N is the (total - 1 - N)th prompt added.
+            assert expected == f"prompt {total - 1 - target}"
+
+    async def test_escape_keeps_the_undo_history(self, tmp_path: Path) -> None:
+        """Cancelling the search must not clear the composer's edit history.
+
+        `TextArea.text` aliases `load_text`, which clears the undo history, so
+        restoring an unchanged draft by assignment silently cost the user their
+        undo stack.
+        """
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["some old prompt"])
+            await pilot.pause()
+
+            assert chat._text_area is not None
+            for char in "draft":
+                await pilot.press(char)
+            await pilot.pause()
+            assert chat._text_area.text == "draft"
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert chat._prompt_search_active is False
+            assert chat._text_area.text == "draft"
+            await pilot.press("ctrl+z")
+            await pilot.pause()
+            assert chat._text_area.text != "draft"
+
+    async def test_backspace_with_a_query_does_not_leave_the_input_mode(
+        self, tmp_path: Path
+    ) -> None:
+        """Keys the search ignores must not reach the composer's own routing.
+
+        Backspace with a non-empty query belongs to the query input. It used to
+        fall through to the mode-exit branch, which dropped shell mode behind
+        the open panel and swallowed the deletion.
+        """
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["find something"])
+            await pilot.pause()
+
+            await pilot.press("!")
+            await pilot.pause()
+            assert chat.mode == "shell"
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.press("f")
+            await pilot.pause()
+            await pilot.press("backspace")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert chat.mode == "shell"
+            assert chat._prompt_search_active is True
+            assert chat._prompt_search_query == ""
+
+    async def test_enter_with_no_matches_inserts_nothing(self, tmp_path: Path) -> None:
+        """Enter on an empty result set must bell, not raise or insert."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["hello world"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            for char in "zzz":
+                await pilot.press(char)
+                await pilot.pause()
+            await pilot.pause()
+            assert chat._prompt_search_filtered == []
+
+            await pilot.press("down")
+            await pilot.press("up")
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert chat._text_area is not None
+            assert chat._text_area.text == ""
+
+    async def test_unreadable_history_is_not_reported_as_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """An unreadable history file must not claim the user has no prompts."""
+        from textual.widgets import Static
+
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchOption
+
+        # A directory in place of the file is an OSError on read, the same path
+        # permissions and encoding failures take.
+        history_file = tmp_path / "history.jsonl"
+        history_file.mkdir()
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = history_file
+            # Nothing cached in memory, so the read failure is the only reason
+            # the list comes back empty.
+            chat._history._entries = []
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            results = panel.query_one("#prompt-search-results")
+            messages = [
+                str(child.render())
+                for child in results.children
+                if isinstance(child, Static)
+                and not isinstance(child, PromptSearchOption)
+            ]
+            assert messages
+            assert "Could not read prompt history" in messages[0]
+            assert "No prompts yet" not in messages[0]

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -8174,6 +8174,169 @@ class TestPromptSearchPanel:
             assert "Could not read prompt history" in messages[0]
             assert "No prompts yet" not in messages[0]
 
+    async def test_text_area_keys_do_not_edit_the_frozen_draft(
+        self, tmp_path: Path
+    ) -> None:
+        """The text area must not accept edits while the panel is open.
+
+        `open_prompt_search` focuses the query input and `ChatTextArea.on_focus`
+        bounces focus back, so this branch is defensive: it only runs if a key
+        reaches the text area anyway. Driving `_on_key` directly is what
+        exercises it. Without the branch the TextArea defaults apply and
+        printable characters insert into the frozen draft behind the panel.
+        """
+        from textual import events
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["oldest", "middle", "newest"])
+            await pilot.pause()
+
+            text_area = chat._text_area
+            assert text_area is not None
+            text_area.insert("draft text")
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            # Printable keys belong to the focused query input, so the panel
+            # handler declines them -- and the text area must decline them too
+            # rather than falling back to its own insertion.
+            for key, character in (("z", "z"), ("space", " ")):
+                event = events.Key(key, character)
+                await text_area._on_key(event)
+                await pilot.pause()
+                assert event._no_default_action
+                assert event._stop_propagation
+
+            assert text_area.text == "draft text"
+            assert app.submitted == []
+            assert chat._prompt_search_active is True
+
+    async def test_text_area_navigation_keys_reach_the_panel(
+        self, tmp_path: Path
+    ) -> None:
+        """Keys the panel owns are routed on even from the text area."""
+        from textual import events
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["oldest", "middle", "newest"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            assert chat._prompt_search_index == 0
+
+            text_area = chat._text_area
+            assert text_area is not None
+            await text_area._on_key(events.Key("down", None))
+            await pilot.pause()
+
+            assert chat._prompt_search_index == 1
+            assert text_area.text == ""
+
+    async def test_panel_reports_its_rendered_height(self, tmp_path: Path) -> None:
+        """`RowsChanged` drives the composer's height reservation.
+
+        `ChatInputBox` subtracts the reported rows from its budget, so an
+        over-report shrinks the draft and an under-report lets the panel
+        overflow the composer border.
+        """
+        from deepagents_code.tui.widgets.prompt_search import (
+            PROMPT_SEARCH_MAX_HINT_ROWS,
+            PROMPT_SEARCH_PANEL_ROWS,
+        )
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["first prompt", "second prompt"])
+            await pilot.pause()
+
+            box = chat.query_one(ChatInputBox)
+            assert box._prompt_search_rows == 0
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            # One query row, one row per result, plus the measured hint.
+            assert box._prompt_search_rows == 1 + 2 + panel._hint_rows()
+            assert 0 < box._prompt_search_rows <= PROMPT_SEARCH_PANEL_ROWS
+            # A wide terminal wraps the hint to fewer than the pre-layout
+            # maximum, so `on_resize` corrected the initial reservation down.
+            assert panel._hint_rows() < PROMPT_SEARCH_MAX_HINT_ROWS
+
+            chat._close_prompt_search(restore_draft=True)
+            await pilot.pause()
+            assert box._prompt_search_rows == 0
+
+    async def test_panel_renders_inside_the_composer_border(
+        self, tmp_path: Path
+    ) -> None:
+        """The reserved rows must actually keep the panel inside the box."""
+        app = _RecordingApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, [f"prompt {index}" for index in range(20)])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            box = chat.query_one(ChatInputBox)
+            assert panel.region.height > 0
+            assert panel.region.y >= box.region.y
+            assert panel.region.bottom <= box.region.bottom
+
+            # The hint is the last thing in the panel, so a short reservation
+            # clips its final row rather than the results.
+            hint = panel._hint_static
+            assert hint is not None
+            assert hint.region.bottom <= panel.region.bottom
+
+    async def test_narrow_terminal_reserves_the_wrapped_hint(
+        self, tmp_path: Path
+    ) -> None:
+        """A wrapped hint claims more rows, and the panel still fits."""
+        app = _RecordingApp()
+        async with app.run_test(size=(40, 24)) as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["first prompt"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            box = chat.query_one(ChatInputBox)
+            hint = panel._hint_static
+            assert hint is not None
+
+            # Narrow enough that the hint wraps past one row.
+            assert panel._hint_rows() > 1
+            assert box._prompt_search_rows == 1 + 1 + panel._hint_rows()
+            assert panel.region.bottom <= box.region.bottom
+            assert hint.region.bottom <= panel.region.bottom
+
     async def test_rebuild_failure_ends_the_session(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7760,6 +7760,32 @@ class TestPromptSearchPanel:
 
             assert isinstance(app.focused, PromptSearchInput)
 
+    async def test_clicking_composer_keeps_query_focus(self, tmp_path: Path) -> None:
+        """Clicking the frozen draft must not strand prompt-search keys."""
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchInput
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["hello"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            assert chat._text_area is not None
+            await pilot.click(chat._text_area)
+            await pilot.pause()
+
+            assert isinstance(app.focused, PromptSearchInput)
+            await pilot.press("h")
+            await pilot.pause()
+            assert chat._prompt_search_query == "h"
+
+            await pilot.press("escape")
+            await pilot.pause()
+            assert chat._prompt_search_active is False
+
     async def test_selection_past_first_page_stays_mounted_and_visible(
         self, tmp_path
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7679,3 +7679,43 @@ class TestPromptSearchPanel:
             await pilot.pause()
             assert chat._text_area is not None
             assert chat._text_area.text == "prompt 17"  # newest-first: 29-12
+
+    async def test_no_match_empty_state_is_a_single_row(self, tmp_path) -> None:
+        """Repeated no-match keystrokes must not stack empty-state rows.
+
+        The empty-state message is one tracked widget replaced per rebuild;
+        previously each rebuild mounted a fresh `Static` without removing the
+        last, so every no-match keystroke added another "No matching prompts."
+        row to the list.
+        """
+        from textual.widgets import Static
+
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchOption
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["hello world"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            for char in "zzzz":
+                await pilot.press(char)
+                await pilot.pause()
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            results = panel.query_one("#prompt-search-results")
+            empty_rows = [
+                child
+                for child in results.children
+                if isinstance(child, Static)
+                and not isinstance(child, PromptSearchOption)
+            ]
+            assert len(empty_rows) == 1
+            assert "No matching prompts." in str(empty_rows[0].content)

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7519,6 +7519,74 @@ class TestPromptSearchPanel:
             assert chat._text_area is not None
             assert chat._text_area.text == "newest prompt"
 
+    async def test_hovering_marks_a_row_without_moving_the_selection(
+        self, tmp_path: Path
+    ) -> None:
+        """Hover is visual only: arrows still move from the selected row."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["oldest", "middle", "newest"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            assert len(panel._options) == 3
+
+            await pilot.hover(panel._options[2])
+            await pilot.pause()
+
+            # The hovered row is marked, but the selection stays put.
+            assert "prompt-search-hovered" in panel._options[2].classes
+            assert chat._prompt_search_index == 0
+            assert panel._options[0]._is_selected
+            assert not panel._options[2]._is_selected
+
+            # Keyboard navigation resumes from the selection, not the hover.
+            await pilot.press("down")
+            await pilot.pause()
+            assert chat._prompt_search_index == 1
+            assert chat._prompt_search_active is True
+            assert chat._text_area is not None
+            assert chat._text_area.text == ""
+
+    async def test_clicking_a_row_selects_but_does_not_insert(
+        self, tmp_path: Path
+    ) -> None:
+        """Click moves the selection; only Enter inserts."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["oldest", "middle", "newest"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+
+            await pilot.click(panel._options[2])
+            await pilot.pause()
+
+            assert chat._prompt_search_index == 2
+            assert panel._options[2]._is_selected
+            # Clicking alone must not close the panel or touch the draft.
+            assert chat._prompt_search_active is True
+            assert chat._text_area is not None
+            assert chat._text_area.text == ""
+
+            await pilot.press("enter")
+            await pilot.pause()
+            assert chat._text_area.text == "oldest"
+
     async def test_escape_restores_draft(self, tmp_path) -> None:
         app = _RecordingApp()
         async with app.run_test() as pilot:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7719,3 +7719,89 @@ class TestPromptSearchPanel:
             ]
             assert len(empty_rows) == 1
             assert "No matching prompts." in str(empty_rows[0].content)
+
+    async def test_empty_state_does_not_survive_hide_and_reopen(self, tmp_path) -> None:
+        """A hidden empty state must not linger beside reopened matches.
+
+        `hide()` only sets `display: none`; it does not tear down children.
+        Dropping the `_empty_widget` reference on hide orphaned the mounted
+        empty-state row, so cancelling a no-match search and reopening with
+        matches left a stale "No matching prompts." row beside the options,
+        and repeated cycles accumulated one orphan per hide.
+        """
+        from textual.widgets import Static
+
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchOption
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["hello world"])
+            await pilot.pause()
+
+            def empty_rows() -> list[Static]:
+                panel = chat._prompt_search
+                assert panel is not None
+                results = panel.query_one("#prompt-search-results")
+                return [
+                    child
+                    for child in results.children
+                    if isinstance(child, Static)
+                    and not isinstance(child, PromptSearchOption)
+                ]
+
+            # Open with a no-match query, then cancel the search.
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.press("z")
+            await pilot.pause()
+            await pilot.pause()
+            assert len(empty_rows()) == 1
+            await pilot.press("escape")
+            await pilot.pause()
+
+            # Reopen: the full unfiltered history matches, so no empty state.
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            assert empty_rows() == []
+            panel = chat._prompt_search
+            assert panel is not None
+            assert len(panel._options) == 1
+
+    async def test_empty_state_reopens_cleanly_after_each_hide(self, tmp_path) -> None:
+        """Empty -> hide cycles must not accumulate orphaned empty rows."""
+        from textual.widgets import Static
+
+        from deepagents_code.tui.widgets.prompt_search import PromptSearchOption
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["hello world"])
+            await pilot.pause()
+
+            for _ in range(3):
+                chat.open_prompt_search()
+                await pilot.pause()
+                await pilot.pause()
+                await pilot.press("z")
+                await pilot.pause()
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            results = panel.query_one("#prompt-search-results")
+            empty_rows = [
+                child
+                for child in results.children
+                if isinstance(child, Static)
+                and not isinstance(child, PromptSearchOption)
+            ]
+            assert len(empty_rows) <= 1

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -7826,6 +7826,65 @@ class TestPromptSearchPanel:
             await pilot.pause()
             assert chat._prompt_search_active is False
 
+    async def test_single_step_moves_inside_the_window_do_not_rebuild(
+        self, tmp_path: Path
+    ) -> None:
+        """Moving within the mounted window re-styles two rows, not all of them.
+
+        `_window_bounds` shifts the ideal start on every single-step move once
+        the list outgrows `PROMPT_SEARCH_WINDOW`, so rebuilding whenever the
+        ideal start differed put every keystroke on the expensive path -- a
+        full `set_content` over all 50 mounted rows instead of two
+        `set_class` calls.
+        """
+        from deepagents_code.tui.widgets.prompt_search import (
+            PROMPT_SEARCH_REWINDOW_MARGIN,
+            PROMPT_SEARCH_WINDOW,
+        )
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            # Comfortably longer than the window, so windowing is in play.
+            self._seed_history(
+                chat, [f"prompt {index}" for index in range(PROMPT_SEARCH_WINDOW * 2)]
+            )
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+            panel = chat._prompt_search
+            assert panel is not None
+            assert len(panel._options) == PROMPT_SEARCH_WINDOW
+
+            generation_before = panel._rebuild_generation
+            mounted_before = list(panel._options)
+
+            # Step to just inside the re-window margin: every one of these
+            # moves stays on the cheap path.
+            steps = PROMPT_SEARCH_WINDOW - PROMPT_SEARCH_REWINDOW_MARGIN - 2
+            for _ in range(steps):
+                await pilot.press("down")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert chat._prompt_search_index == steps
+            assert panel._rebuild_generation == generation_before
+            # The same widget objects, re-styled rather than re-mounted.
+            assert panel._options == mounted_before
+            assert panel._options[steps].is_selected
+
+            # Crossing into the margin re-centers the window.
+            for _ in range(3):
+                await pilot.press("down")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert panel._rebuild_generation > generation_before
+            assert panel._options[0].index > 0
+
     async def test_selection_past_first_page_stays_mounted_and_visible(
         self, tmp_path
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -8302,6 +8302,35 @@ class TestPromptSearchPanel:
             assert chat._prompt_search_index == 1
             assert text_area.text == ""
 
+    async def test_hovering_moves_the_highlight_between_panel_rows(
+        self, tmp_path: Path
+    ) -> None:
+        """Moving the pointer must unmark the row it left."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            chat._history.history_file = tmp_path / "history.jsonl"
+            self._seed_history(chat, ["oldest", "middle", "newest"])
+            await pilot.pause()
+
+            chat.open_prompt_search()
+            await pilot.pause()
+            await pilot.pause()
+
+            panel = chat._prompt_search
+            assert panel is not None
+            await pilot.hover(panel._options[1])
+            await pilot.pause()
+            assert panel._options[1].mouse_hover
+
+            await pilot.hover(panel._options[2])
+            await pilot.pause()
+
+            # Exactly one row is hovered, so no stale highlight is left behind.
+            assert panel._options[2].mouse_hover
+            assert not panel._options[1].mouse_hover
+            assert chat._prompt_search_index == 0
+
     async def test_focus_query_reports_whether_focus_moved(
         self, tmp_path: Path
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_history.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_history.py
@@ -238,6 +238,45 @@ class TestRecentPrompts:
         )
         assert mgr.get_previous("") == "append failed"
 
+    def test_history_unwritable_latches_on_a_failed_append(
+        self, tmp_path: Path
+    ) -> None:
+        """A failed write is sticky: later prompts are memory-only too."""
+        history_file = tmp_path / "history.jsonl"
+        mgr = HistoryManager(history_file)
+        mgr.add("persisted")
+        assert mgr.history_unwritable is False
+
+        blocker = tmp_path / "blocker"
+        blocker.touch()
+        mgr.history_file = blocker / "history.jsonl"
+        mgr.add("append failed")
+
+        assert mgr.history_unwritable is True
+
+        # Stays true after a working path is restored: the earlier prompt is
+        # still only in memory, so the session's history is still incomplete.
+        mgr.history_file = history_file
+        mgr.add("persisted again")
+        assert mgr.history_unwritable is True
+
+    def test_history_unwritable_latches_on_a_failed_compaction(
+        self, tmp_path: Path
+    ) -> None:
+        """Compaction failures count too; they silently drop trimmed entries."""
+        history_file = tmp_path / "history.jsonl"
+        mgr = HistoryManager(history_file, max_entries=2)
+        mgr.add("one")
+        assert mgr.history_unwritable is False
+
+        blocker = tmp_path / "blocker"
+        blocker.touch()
+        mgr.history_file = blocker / "history.jsonl"
+        mgr._entries = [f"entry {index}" for index in range(6)]
+        mgr._compact_history()
+
+        assert mgr.history_unwritable is True
+
     def test_failed_duplicate_append_stays_newest(self, tmp_path: Path) -> None:
         """A failed repeat remains newer than its persisted occurrence."""
         history_file = tmp_path / "history.jsonl"

--- a/libs/code/tests/unit_tests/tui/widgets/test_history.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_history.py
@@ -238,6 +238,24 @@ class TestRecentPrompts:
         )
         assert mgr.get_previous("") == "append failed"
 
+    def test_failed_duplicate_append_stays_newest(self, tmp_path: Path) -> None:
+        """A failed repeat remains newer than its persisted occurrence."""
+        history_file = tmp_path / "history.jsonl"
+        mgr = HistoryManager(history_file)
+        mgr.add("A")
+        mgr.add("B")
+
+        blocker = tmp_path / "blocker"
+        blocker.touch()
+        mgr.history_file = blocker / "history.jsonl"
+        mgr.add("A")
+
+        mgr.history_file = history_file
+        assert mgr.recent_prompts() == ("A", "B")
+        assert mgr.get_previous("") == "A"
+        assert mgr.get_previous("") == "B"
+        assert mgr.get_previous("") == "A"
+
 
 class TestSubstringMatch:
     """Substring matching navigates to entries containing the query."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_history.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_history.py
@@ -238,6 +238,58 @@ class TestRecentPrompts:
         )
         assert mgr.get_previous("") == "append failed"
 
+    def test_history_unreadable_resets_after_a_successful_read(
+        self, tmp_path: Path
+    ) -> None:
+        """A sticky flag would report a transient failure forever.
+
+        Both empty-state messages and the new degraded-list warning hang on
+        this flag, so it has to clear once the file is readable again.
+        """
+        history_file = tmp_path / "history.jsonl"
+        mgr = HistoryManager(history_file)
+        mgr.add("persisted")
+        assert mgr.history_unreadable is False
+
+        # A directory in place of the file is an OSError on read.
+        blocker = tmp_path / "blocker"
+        blocker.mkdir()
+        mgr.history_file = blocker
+        mgr.recent_prompts()
+        assert mgr.history_unreadable is True
+
+        mgr.history_file = history_file
+        mgr.recent_prompts()
+        assert mgr.history_unreadable is False
+
+    def test_history_unreadable_is_false_when_the_file_is_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """An absent file and an unreadable one are opposite facts."""
+        mgr = HistoryManager(tmp_path / "never-written.jsonl")
+        assert mgr.recent_prompts() == ()
+        assert mgr.history_unreadable is False
+
+    def test_failed_persist_is_bounded_by_max_entries(self, tmp_path: Path) -> None:
+        """Unpersisted entries stop being tracked once they age out."""
+        history_file = tmp_path / "history.jsonl"
+        blocker = tmp_path / "blocker"
+        blocker.touch()
+        mgr = HistoryManager(history_file, max_entries=3)
+        mgr.history_file = blocker / "history.jsonl"
+
+        for index in range(10):
+            mgr.add(f"prompt {index}")
+        assert len(mgr._failed_persist) == 10
+
+        # The bounding runs on a successful read, so the file has to exist.
+        history_file.write_text(json.dumps("from disk") + "\n", encoding="utf-8")
+        mgr.history_file = history_file
+        mgr.recent_prompts()
+
+        # Only the newest bounded suffix can still reach the navigation window.
+        assert len(mgr._failed_persist) <= mgr.max_entries
+
     def test_history_unwritable_latches_on_a_failed_append(
         self, tmp_path: Path
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_history.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_history.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -195,6 +196,47 @@ class TestRecentPrompts:
         mgr.add("/skill:remember this")
 
         assert mgr.recent_prompts() == ("/skill:remember this", "regular prompt")
+
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores read-only mode")
+    def test_read_failure_preserves_session_prompts(self, tmp_path: Path) -> None:
+        """A failed refresh keeps in-memory prompts instead of wiping them."""
+        history_file = tmp_path / "history.jsonl"
+        history_file.write_text(json.dumps("persisted") + "\n", encoding="utf-8")
+
+        mgr = HistoryManager(history_file)
+        mgr.add("session only")
+        assert mgr._entries == ["persisted", "session only"]
+
+        history_file.chmod(0o000)
+        try:
+            assert mgr.recent_prompts() == ("session only", "persisted")
+            assert mgr._entries == ["persisted", "session only"]
+        finally:
+            history_file.chmod(0o600)
+
+    def test_failed_append_survives_refresh(self, tmp_path: Path) -> None:
+        """A prompt that could not be written stays through a later refresh."""
+        history_file = tmp_path / "history.jsonl"
+        mgr = HistoryManager(history_file)
+        mgr.add("persisted")
+
+        # Point the manager at a path whose parent is a regular file, so the
+        # append's mkdir/open raises OSError and the entry stays in memory.
+        blocker = tmp_path / "blocker"
+        blocker.touch()
+        mgr.history_file = blocker / "history.jsonl"
+        mgr.add("append failed")
+
+        mgr.history_file = history_file
+        with history_file.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps("from another process") + "\n")
+
+        assert mgr.recent_prompts() == (
+            "append failed",
+            "from another process",
+            "persisted",
+        )
+        assert mgr.get_previous("") == "append failed"
 
 
 class TestSubstringMatch:

--- a/libs/code/tests/unit_tests/tui/widgets/test_history.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_history.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 import pytest
@@ -134,6 +135,66 @@ class TestSkillInvocationHistory:
 
         reloaded = HistoryManager(history_file)
         assert reloaded._entries == ["/skill:web-research find cats"]
+
+
+class TestRecentPrompts:
+    """Prompt snapshots refresh, deduplicate, and bound persisted history."""
+
+    def test_returns_newest_first_and_deduplicates(self, tmp_path: Path) -> None:
+        history_file = tmp_path / "history.jsonl"
+        history_file.write_text(
+            "".join(
+                json.dumps(entry) + "\n"
+                for entry in ("first", "duplicate", "second", "duplicate")
+            ),
+            encoding="utf-8",
+        )
+
+        mgr = HistoryManager(history_file)
+
+        assert mgr.recent_prompts() == ("duplicate", "second", "first")
+
+    def test_refreshes_concurrent_appends(self, tmp_path: Path) -> None:
+        history_file = tmp_path / "history.jsonl"
+        mgr = HistoryManager(history_file)
+        mgr.add("first")
+        with history_file.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps("from another process") + "\n")
+
+        assert mgr.recent_prompts() == ("from another process", "first")
+        assert mgr.get_previous("") == "from another process"
+
+    def test_bounds_unique_entries_after_deduplication(self, tmp_path: Path) -> None:
+        history_file = tmp_path / "history.jsonl"
+        history_file.write_text(
+            "".join(
+                json.dumps(entry) + "\n"
+                for entry in ("old unique", "repeat", "new unique", "repeat")
+            ),
+            encoding="utf-8",
+        )
+
+        mgr = HistoryManager(history_file, max_entries=3)
+
+        assert mgr.recent_prompts() == ("repeat", "new unique", "old unique")
+
+    def test_preserves_malformed_line_fallback(self, tmp_path: Path) -> None:
+        history_file = tmp_path / "history.jsonl"
+        history_file.write_text('"valid"\nnot-json\n', encoding="utf-8")
+
+        mgr = HistoryManager(history_file)
+
+        assert mgr.recent_prompts() == ("not-json", "valid")
+
+    def test_includes_only_slash_commands_eligible_for_history(
+        self, tmp_path: Path
+    ) -> None:
+        mgr = HistoryManager(tmp_path / "history.jsonl")
+        mgr.add("regular prompt")
+        mgr.add("/help")
+        mgr.add("/skill:remember this")
+
+        assert mgr.recent_prompts() == ("/skill:remember this", "regular prompt")
 
 
 class TestSubstringMatch:

--- a/libs/code/tests/unit_tests/tui/widgets/test_prompt_search.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_prompt_search.py
@@ -1,0 +1,125 @@
+"""Unit tests for the prompt search module's pure helpers.
+
+These functions are shared by both prompt clipboard tiers, so a change here
+moves the inline panel and the modal together.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deepagents_code.tui.widgets.prompt_search import (
+    PROMPT_SEARCH_MAX_HINT_ROWS,
+    PROMPT_SEARCH_WINDOW,
+    _window_bounds,
+    filter_prompts,
+    prompt_search_hint,
+    prompt_title,
+)
+
+
+class TestPromptTitle:
+    """Cover the one-row summary, including the degenerate inputs."""
+
+    def test_uses_the_first_non_empty_line(self) -> None:
+        assert prompt_title("first line\nsecond line") == "first line"
+
+    def test_skips_leading_blank_lines(self) -> None:
+        assert prompt_title("\n\n  real content\nmore") == "real content"
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        assert prompt_title("   padded   ") == "padded"
+
+    @pytest.mark.parametrize("prompt", ["", "   ", "\n", "\t\n  \n"])
+    def test_whitespace_only_prompts_get_a_visible_placeholder(
+        self, prompt: str
+    ) -> None:
+        """A blank row would be indistinguishable from its neighbours.
+
+        `_read_history` preserves malformed lines verbatim, so a history file
+        containing a blank line is reachable.
+        """
+        assert prompt_title(prompt) == "(empty prompt)"
+
+
+class TestFilterPrompts:
+    """Cover matching, which decides what both tiers show."""
+
+    PROMPTS = ("fix the bug", "Add A Feature", "write TESTS")
+
+    def test_matches_a_substring(self) -> None:
+        assert filter_prompts(self.PROMPTS, "bug") == ["fix the bug"]
+
+    @pytest.mark.parametrize("query", ["FIX", "Fix", "fIx"])
+    def test_query_case_is_ignored(self, query: str) -> None:
+        assert filter_prompts(self.PROMPTS, query) == ["fix the bug"]
+
+    @pytest.mark.parametrize("query", ["feature", "FEATURE", "FeAtUrE"])
+    def test_prompt_case_is_ignored(self, query: str) -> None:
+        assert filter_prompts(self.PROMPTS, query) == ["Add A Feature"]
+
+    def test_surrounding_whitespace_is_stripped_from_the_query(self) -> None:
+        assert filter_prompts(self.PROMPTS, "  bug  ") == ["fix the bug"]
+
+    @pytest.mark.parametrize("query", ["", "   ", "\t"])
+    def test_a_blank_query_matches_everything(self, query: str) -> None:
+        """Stripping to empty must widen to the full list, not empty it."""
+        assert filter_prompts(self.PROMPTS, query) == list(self.PROMPTS)
+
+    def test_no_match_returns_an_empty_list(self) -> None:
+        assert filter_prompts(self.PROMPTS, "nothing here") == []
+
+    def test_order_is_preserved(self) -> None:
+        assert filter_prompts(self.PROMPTS, "e") == [
+            "fix the bug",
+            "Add A Feature",
+            "write TESTS",
+        ]
+
+
+class TestWindowBounds:
+    """Cover the mounted-row window around the selection."""
+
+    def test_short_lists_are_mounted_whole(self) -> None:
+        assert _window_bounds(10, 4) == (0, 10)
+
+    def test_window_is_clamped_to_the_list_start(self) -> None:
+        start, stop = _window_bounds(PROMPT_SEARCH_WINDOW * 2, 0)
+        assert (start, stop) == (0, PROMPT_SEARCH_WINDOW)
+
+    def test_window_is_clamped_to_the_list_end(self) -> None:
+        total = PROMPT_SEARCH_WINDOW * 2
+        start, stop = _window_bounds(total, total - 1)
+        assert stop == total
+        assert start == total - PROMPT_SEARCH_WINDOW
+
+    @pytest.mark.parametrize(
+        ("total", "selected"),
+        [(0, 0), (1, 0), (200, 0), (200, 100), (200, 199)],
+    )
+    def test_bounds_are_always_orderable_and_in_range(
+        self, total: int, selected: int
+    ) -> None:
+        start, stop = _window_bounds(total, selected)
+        assert 0 <= start <= stop <= total
+
+    def test_the_selection_stays_inside_the_window(self) -> None:
+        total = PROMPT_SEARCH_WINDOW * 3
+        for selected in range(total):
+            start, stop = _window_bounds(total, selected)
+            assert start <= selected < stop
+
+
+class TestPromptSearchHint:
+    """The hint's length is a documented constraint, not a free-form string."""
+
+    def test_hint_fits_the_reserved_rows_at_the_narrowest_width(self) -> None:
+        """The reserved height clamps at `PROMPT_SEARCH_MAX_HINT_ROWS`.
+
+        A hint too long to wrap within that budget is silently clipped, so
+        adding another chord to it needs to be a deliberate decision rather
+        than a surprise at runtime.
+        """
+        narrowest_supported_width = 40
+        hint = prompt_search_hint()
+        assert len(hint) <= narrowest_supported_width * PROMPT_SEARCH_MAX_HINT_ROWS

--- a/libs/code/tests/unit_tests/tui/widgets/test_startup_tip.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_startup_tip.py
@@ -142,6 +142,9 @@ class TestStartupTip:
         """The `/copy` command keeps a discoverability tip."""
         assert any("/copy" in tip for tip in _TIPS)
 
+    def test_prompt_clipboard_tip_registered(self) -> None:
+        assert any("Ctrl+R" in tip and "prompts" in tip for tip in _TIPS)
+
     def test_chat_input_resize_tip_registered(self) -> None:
         """The draggable chat input keeps a discoverability tip."""
         assert any("top border" in tip and "resize" in tip for tip in _TIPS)


### PR DESCRIPTION
Adds a searchable prompt clipboard for reusing previously submitted prompts, with a two-tier Ctrl+R interaction modeled on codex and Claude Code.

The first <kbd>Ctrl</kbd>+<kbd>R</kbd> opens an inline search panel directly above the prompt input — a query field, up to five newest-first matches, and a hint line — so recalling a recent prompt never leaves the composer. Focus and the blinking cursor move into the query field while the panel is open; typing filters matches case-insensitively while the draft stays frozen underneath. <kbd>Enter</kbd> inserts the selected prompt at the cursor, arrow keys navigate, <kbd>Tab</kbd>/<kbd>Shift</kbd>+<kbd>Tab</kbd> page by five rows, and <kbd>Esc</kbd> (or Backspace on an empty query) restores the draft and cursor exactly as they were.

Pressing <kbd>Ctrl</kbd>+<kbd>R</kbd> again while the panel is open escalates to the full-screen prompt clipboard, carrying the typed query into its filter. The full view adds a scrollable list, a multi-line preview pane, the same <kbd>Tab</kbd>/<kbd>Shift</kbd>+<kbd>Tab</kbd> paging, and <kbd>Ctrl</kbd>+<kbd>C</kbd> to copy a prompt without inserting it. `/prompts` opens this full view directly, as does Ctrl+R while autocomplete is open.

---

Prompt history is local-only: it reads the shared JSONL history file, deduplicates newest-first, and refreshes on open, with no telemetry or sync. Both tiers insert through the undoable edit path, so a recalled prompt can be undone with <kbd>Ctrl</kbd>+<kbd>Z</kbd> like any other edit.
