### PR TITLE
refactor(code): add configuration provider resolver

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -88,8 +88,14 @@ from deepagents_code._session_stats import (
 
 # All config imports — settings, create_model, detect_provider, is_ascii_mode,
 # etc. — are deferred to local imports at their call sites since they are only
-# accessed after user interaction begins.
+# accessed after user interaction begins. The one exception is
+# `configuration.theme_resolution` below: the theme helpers run before the
+# first frame, and it pulls the `configuration` package but neither
+# `config_manifest` nor `config`.
 from deepagents_code._version import CHANGELOG_URL, DOCS_URL
+
+# Aliased to the names these helpers had while they lived in this module;
+# `tests/unit_tests/test_theme.py` still imports them from here.
 from deepagents_code.configuration.theme_resolution import (
     as_toml_table as _as_toml_table,
     resolve_terminal_mapping as _resolve_terminal_mapping,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -90,6 +90,11 @@ from deepagents_code._session_stats import (
 # etc. — are deferred to local imports at their call sites since they are only
 # accessed after user interaction begins.
 from deepagents_code._version import CHANGELOG_URL, DOCS_URL
+from deepagents_code.configuration.theme_resolution import (
+    as_toml_table as _as_toml_table,
+    resolve_terminal_mapping as _resolve_terminal_mapping,
+    resolve_theme_name as _resolve_theme_name,
+)
 from deepagents_code.formatting import format_message_timestamp
 from deepagents_code.goal_state_notice import (
     build_goal_continuation,
@@ -1191,103 +1196,6 @@ class _PluginFingerprint(NamedTuple):
     components: tuple[_PathStat, ...]
 
     __hash__ = None  # type: ignore[assignment]
-
-
-def _resolve_theme_name(value: object) -> str | None:
-    """Resolve a user-supplied theme name to a canonical registry key.
-
-    Accepts the registry key or the human-readable label, case-insensitive
-    on both, with surrounding whitespace stripped — config values
-    (especially `[ui.terminal_themes]`) and the `DEEPAGENTS_CODE_THEME`
-    env var are commonly hand-edited. Also applies the legacy
-    `textual-ansi` → `ansi-light` migration (pre-Textual 8.2.5).
-
-    Args:
-        value: Raw value read from TOML or an environment variable.
-
-    Returns:
-        The canonical registry key, or `None` if the value is not a string or
-            does not match any registered theme by key or label
-            (case-insensitive).
-    """
-    if not isinstance(value, str):
-        return None
-    name = value.strip()
-    if name == "textual-ansi":
-        name = "ansi-light"
-    registry = theme.get_registry()
-    if name in registry:
-        return name
-    folded = name.casefold()
-    for registered, entry in registry.items():
-        if registered.casefold() == folded or entry.label.casefold() == folded:
-            return registered
-    return None
-
-
-def _as_toml_table(value: object) -> dict[str, object] | None:
-    """Return `value` as a TOML table when it has the expected runtime shape."""
-    if not isinstance(value, dict):
-        return None
-    # `tomllib` parses TOML tables as string-keyed dicts; `ty` cannot infer
-    # that from a runtime `dict` check. Keep the cast at this boundary so it
-    # does not become a general-purpose escape hatch.
-    return cast("dict[str, object]", value)
-
-
-def _resolve_terminal_mapping(ui: Mapping[str, object]) -> str | None:
-    """Resolve `[ui.terminal_themes][TERM_PROGRAM]` to a registered theme.
-
-    Centralizes both the lookup and the misconfiguration warnings shared by
-    `_load_theme_preference` (startup) and `_load_terminal_default` (picker
-    badge). Misconfiguration is logged exactly once per call.
-
-    Args:
-        ui: The `[ui]` table parsed from `config.toml`.
-
-    Returns:
-        The canonical registry key, or `None` if `terminal_themes` is absent,
-            malformed, references an unknown theme, or `TERM_PROGRAM` is unset
-            despite a non-empty mapping.
-    """
-    terminal_themes = ui.get("terminal_themes")
-    if terminal_themes is None:
-        return None
-    terminal_themes_table = _as_toml_table(terminal_themes)
-    if terminal_themes_table is None:
-        logger.warning(
-            "[ui.terminal_themes] should be a table mapping TERM_PROGRAM "
-            "values to theme names; got %s",
-            type(terminal_themes).__name__,
-        )
-        return None
-    term_program = os.environ.get("TERM_PROGRAM", "").strip()
-    if not term_program:
-        if terminal_themes_table:
-            logger.warning(
-                "[ui.terminal_themes] is configured but TERM_PROGRAM is unset; "
-                "no per-terminal theme will be applied",
-            )
-        return None
-    mapped = terminal_themes_table.get(term_program)
-    resolved = _resolve_theme_name(mapped)
-    if resolved is not None:
-        return resolved
-    if isinstance(mapped, str):
-        logger.warning(
-            "Unknown theme '%s' mapped to TERM_PROGRAM='%s' "
-            "in [ui.terminal_themes]; ignoring",
-            mapped,
-            term_program,
-        )
-    elif mapped is not None:
-        logger.warning(
-            "Expected string theme name for TERM_PROGRAM='%s' in "
-            "[ui.terminal_themes], got %s; ignoring",
-            term_program,
-            type(mapped).__name__,
-        )
-    return None
 
 
 def _load_terminal_default() -> str | None:

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2837,7 +2837,18 @@ class Settings:
         )
         from deepagents_code.configuration.resolver import get_config_resolver
 
-        resolved_config = get_config_resolver().resolve_all()
+        # Resolve only the options this constructor reads. `resolve_all()`
+        # would also resolve `display.theme`, whose `THEME_DELEGATE` coercion
+        # reaches the theme registry and imports Textual (~470ms) — see
+        # `libs/code/AGENTS.md` on the startup hot path. Four CLI entry points
+        # in `skills/commands.py` build `Settings` without ever drawing a UI.
+        wanted = tuple(
+            option
+            for option in get_config_options()
+            if option.key in {"shell.allow_list", "skills.extra_allowed_dirs"}
+            or (option.group == "Interpreter" and option.settings_field is not None)
+        )
+        resolved_config = get_config_resolver().resolve_options(wanted)
 
         # No `is None` fallback for either enforced key below. The manifest is a
         # module-level constant, so a missing option is a programming error, not

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field as dataclass_field
 from enum import StrEnum
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -2831,10 +2831,13 @@ class Settings:
         project_root = find_project_root(start_path)
 
         from deepagents_code.config_manifest import (
+            _emit_ranked_diagnostics,
+            get_config_options,
             get_option,
-            load_config_toml,
-            resolve_scalar,
         )
+        from deepagents_code.configuration.resolver import get_config_resolver
+
+        resolved_config = get_config_resolver().resolve_all()
 
         # No `is None` fallback for either enforced key below. The manifest is a
         # module-level constant, so a missing option is a programming error, not
@@ -2847,10 +2850,9 @@ class Settings:
         if shell_option is None:
             msg = "manifest is missing shell.allow_list; refusing to resolve it alone"
             raise RuntimeError(msg)
-        shell_allow_list, _ = resolve_scalar(
-            shell_option,
-            toml_data=load_config_toml(),
-        )
+        shell_resolved = resolved_config[shell_option.key]
+        _emit_ranked_diagnostics(shell_option, shell_resolved)
+        shell_allow_list = cast("list[str] | None", shell_resolved.value)
 
         # Parse extra skill containment roots from env var or config.toml.
         # These extend the path allowlist for load_skill_content but do not
@@ -2862,14 +2864,17 @@ class Settings:
                 "resolve it alone"
             )
             raise RuntimeError(msg)
-        extra_skills_dirs, _ = resolve_scalar(
-            skills_option,
-            toml_data=load_config_toml(),
-        )
+        skills_resolved = resolved_config[skills_option.key]
+        _emit_ranked_diagnostics(skills_option, skills_resolved)
+        extra_skills_dirs = cast("list[Path] | None", skills_resolved.value)
 
-        from deepagents_code.config_manifest import resolve_interpreter_kwargs
-
-        interpreter_kwargs = resolve_interpreter_kwargs()
+        interpreter_kwargs: dict[str, Any] = {}
+        for option in get_config_options():
+            if option.group != "Interpreter" or option.settings_field is None:
+                continue
+            resolved = resolved_config[option.key]
+            _emit_ranked_diagnostics(option, resolved)
+            interpreter_kwargs[option.settings_field] = resolved.value
 
         return cls(
             openai_api_key=openai_key,

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2865,9 +2865,9 @@ class Settings:
         _emit_ranked_diagnostics(shell_option, shell_resolved)
         shell_allow_list = cast("list[str] | None", shell_resolved.value)
 
-        # Parse extra skill containment roots from env var or config.toml.
-        # These extend the path allowlist for load_skill_content but do not
-        # add new skill discovery locations.
+        # Parse extra skill containment roots from managed policy, the env
+        # var, or config.toml. These extend the path allowlist for
+        # load_skill_content but do not add new skill discovery locations.
         skills_option = get_option("skills.extra_allowed_dirs")
         if skills_option is None:
             msg = (
@@ -2879,6 +2879,10 @@ class Settings:
         _emit_ranked_diagnostics(skills_option, skills_resolved)
         extra_skills_dirs = cast("list[Path] | None", skills_resolved.value)
 
+        # Only the Interpreter group is manifest-resolved here. Credentials,
+        # the shell allow-list, and the LangSmith project keep their dedicated
+        # loaders above: their empty-string-to-`None` and reload semantics do
+        # not fit the generic resolver.
         interpreter_kwargs: dict[str, Any] = {}
         for option in get_config_options():
             if option.group != "Interpreter" or option.settings_field is None:
@@ -2978,9 +2982,16 @@ class Settings:
         if shell_option is not None:
             # Read the user layer too, not just managed. `shell.allow_list`
             # gained `toml_keys`, and `Settings.from_environment` resolves it
-            # through `load_config_toml()`; passing `toml_data={}` here reset a
-            # user's `[shell].allow_list` to `None` on every `/reload` and
-            # accepted cwd switch, and reported a change that never happened.
+            # through the shared resolver's user tier; passing `toml_data={}`
+            # here reset a user's `[shell].allow_list` to `None` on every
+            # `/reload` and accepted cwd switch, and reported a change that
+            # never happened.
+            #
+            # This method deliberately stays on `load_config_toml()` rather
+            # than the shared resolver: `get_config_resolver` caches its user
+            # snapshot for the process, and `/reload` exists to pick up an edit
+            # made since then. Unifying the two read paths would silently make
+            # `/reload` a no-op for file changes.
             #
             # Accepting an *env*-tier hit would defeat the `env` argument this
             # method exists to honor: `resolve_scalar` reads `os.environ`

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -645,35 +645,47 @@ def _emit_ranked_diagnostics(
     This compatibility boundary preserves `resolve_scalar`'s fall-through
     messages for callers that expect the historical logging behavior.
 
-    A scalar that shadows a whole table defaults *every* option beneath it, so
-    that rejection is emitted once per process. `config` resolves the full
-    manifest in one pass, and logging per option would print the same line
-    roughly a hundred times for a single typo.
+    Two rejections are file-wide rather than per-option and are therefore
+    emitted once per process: a scalar that shadows a whole table, and a source
+    that could not be read at all. `config` resolves the full manifest in one
+    pass, and logging per option would print the same line roughly a hundred
+    times for a single typo.
 
     Args:
         option: Manifest option being resolved.
         resolved: Rank-keyed provider results and selected value.
     """
-    from deepagents_code.configuration.providers import SHADOWED_TABLE_SUFFIX
+    from deepagents_code.configuration.providers import (
+        SHADOWED_TABLE_SUFFIX,
+        UNUSABLE_SOURCE_SUFFIX,
+    )
     from deepagents_code.configuration.resolver import ENVIRONMENT_RANK
     from deepagents_code.configuration.types import Found, Invalid
+
+    once_per_process = (SHADOWED_TABLE_SUFFIX, UNUSABLE_SOURCE_SUFFIX)
+
+    def emit(reason: str) -> None:
+        """Log one provider rejection, at most once per process when marked."""
+        if any(suffix in reason for suffix in once_per_process):
+            warning_key = ("ranked provider", reason)
+            if warning_key in _warned_non_table_paths:
+                return
+            _warned_non_table_paths.add(warning_key)
+        logger.warning("%s", reason)
 
     accumulating = option.merge_strategy is not MergeStrategy.REPLACE
     for rank in sorted(resolved.tier_health):
         result = resolved.tier_health[rank]
         if isinstance(result, Invalid):
-            reasons = resolved.tier_diagnostics.get(rank) or (result.reason,)
-            for reason in reasons:
-                if SHADOWED_TABLE_SUFFIX in reason:
-                    warning_key = ("ranked provider", reason)
-                    if warning_key in _warned_non_table_paths:
-                        continue
-                    _warned_non_table_paths.add(warning_key)
-                logger.warning("%s", reason)
+            for reason in resolved.tier_diagnostics.get(rank) or (result.reason,):
+                emit(reason)
             continue
-        if isinstance(result, Found):
-            for reason in resolved.tier_diagnostics.get(rank, ()):
-                logger.warning("%s", reason)
+        # A source rejected as a whole coerces to `Unset` for every option, so
+        # its diagnostic has to be emitted from the unset branch too. Otherwise
+        # a corrupt `config.toml` is indistinguishable from one that simply
+        # omits the key, and the user is handed defaults in silence.
+        for reason in resolved.tier_diagnostics.get(rank, ()):
+            emit(reason)
         if not isinstance(result, Found):
             continue
         if rank == ENVIRONMENT_RANK and option.empty_env_is_false:

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -604,29 +604,12 @@ def resolve_ranked_scalar(
 
     Returns:
         A rank-keyed `ResolvedValue`.
-
-    Raises:
-        RuntimeError: If the always-present default provider is unexpectedly unset.
     """
-    from deepagents_code.configuration.providers import (
-        ranked_default_value,
-        ranked_environment_value,
-        ranked_theme_environment_value,
-        ranked_theme_toml_value,
-        ranked_toml_value,
-    )
-    from deepagents_code.configuration.resolver import (
-        DEFAULT_RANK,
-        ENVIRONMENT_RANK,
-        MANAGED_RANK,
-        USER_RANK,
-        RankedProviderValue,
-        resolve_ranked,
-    )
+    from deepagents_code.configuration.resolver import resolver_from_snapshots
     from deepagents_code.configuration.types import (
-        Found,
         ProviderHealth,
         ProviderStatus,
+        TomlSnapshot,
     )
 
     managed_status = managed_status or ProviderStatus(
@@ -636,58 +619,11 @@ def resolve_ranked_scalar(
     managed_data = (
         load_managed_config_toml() if managed_toml_data is None else managed_toml_data
     )
-    if option.kind is OptionKind.THEME_DELEGATE:
-        providers = (
-            ranked_theme_toml_value(
-                managed_data,
-                rank=MANAGED_RANK,
-                durable=True,
-                status=managed_status,
-            ),
-            ranked_theme_environment_value(os.environ, rank=ENVIRONMENT_RANK),
-            ranked_theme_toml_value(
-                toml_data,
-                rank=USER_RANK,
-                durable=True,
-                status=user_status,
-            ),
-            ranked_default_value(option, rank=DEFAULT_RANK),
-        )
-    else:
-        providers = (
-            ranked_toml_value(
-                option,
-                managed_data,
-                rank=MANAGED_RANK,
-                durable=True,
-                status=managed_status,
-            ),
-            ranked_environment_value(option, os.environ, rank=ENVIRONMENT_RANK),
-            ranked_toml_value(
-                option,
-                toml_data,
-                rank=USER_RANK,
-                durable=True,
-                status=user_status,
-            ),
-            ranked_default_value(option, rank=DEFAULT_RANK),
-        )
-    resolved = resolve_ranked(providers, strategy=option.merge_strategy.value)
-    if resolved is None:
-        fallback = RankedProviderValue(
-            DEFAULT_RANK,
-            True,
-            ProviderStatus("default", None, ProviderHealth.OK),
-            Found(option.default),
-        )
-        resolved = resolve_ranked(
-            (*providers[:-1], fallback),
-            strategy=option.merge_strategy.value,
-        )
-    if resolved is None:
-        msg = f"fallback provider was unset for {option.key}"
-        raise RuntimeError(msg)
-    return resolved
+    resolver = resolver_from_snapshots(
+        TomlSnapshot(managed_data, managed_status),
+        TomlSnapshot(toml_data, user_status),
+    )
+    return resolver.get(option)
 
 
 def _ranked_source(resolved: ResolvedValue[object]) -> str:

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -900,42 +900,6 @@ def load_bool_display_preference(
     return resolved
 
 
-def resolve_interpreter_kwargs(
-    *,
-    toml_data: Mapping[str, Any] | None = None,
-    managed_toml_data: Mapping[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Resolve the `[interpreter]` options into `Settings` constructor kwargs.
-
-    Only the interpreter group is resolved through the manifest. Credentials,
-    the shell allow-list, and the LangSmith project keep their dedicated
-    loaders in `config.py` (their empty-string-to-`None` and reload semantics
-    do not fit the generic resolver), so this stays scoped to the section whose
-    defaults this module owns.
-
-    Args:
-        toml_data: Parsed `config.toml`; loaded automatically when omitted.
-        managed_toml_data: Parsed managed TOML; the process snapshot is used when
-            omitted.
-
-    Returns:
-        Mapping of `Settings` field name to resolved value for the interpreter
-        section, suitable for splatting into `Settings(...)`.
-    """
-    data = load_config_toml() if toml_data is None else toml_data
-    resolved: dict[str, Any] = {}
-    for option in get_config_options():
-        if option.group != "Interpreter" or option.settings_field is None:
-            continue
-        value, _ = resolve_scalar(
-            option,
-            toml_data=data,
-            managed_toml_data=managed_toml_data,
-        )
-        resolved[option.settings_field] = value
-    return resolved
-
-
 def _is_valid_auto_classifier_timeout(value: object) -> bool:
     """Return whether `value` is an accepted Auto classifier timeout.
 

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -594,6 +594,14 @@ def resolve_ranked_scalar(
     `resolve_scalar` preserves the established `(value, source)` compatibility
     surface by rendering from the same result.
 
+    Each table must be paired with the status of the source it came from.
+    `TomlSnapshot` rejects a non-`OK` status carrying a non-empty table with a
+    `ValueError`, because an unhealthy source is one every reader must treat as
+    declaring nothing. This is not hypothetical bookkeeping: the two halves are
+    separate parameters, so a caller can supply one snapshot's data beside
+    another's health. A missing default provider surfaces as a `RuntimeError`
+    from the resolver.
+
     Args:
         option: Manifest option to resolve.
         toml_data: Parsed user `config.toml` mapping.

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -656,13 +656,18 @@ def _emit_ranked_diagnostics(
         resolved: Rank-keyed provider results and selected value.
     """
     from deepagents_code.configuration.providers import (
+        RETAINED_SOURCE_SUFFIX,
         SHADOWED_TABLE_SUFFIX,
         UNUSABLE_SOURCE_SUFFIX,
     )
     from deepagents_code.configuration.resolver import ENVIRONMENT_RANK
     from deepagents_code.configuration.types import Found, Invalid
 
-    once_per_process = (SHADOWED_TABLE_SUFFIX, UNUSABLE_SOURCE_SUFFIX)
+    once_per_process = (
+        SHADOWED_TABLE_SUFFIX,
+        UNUSABLE_SOURCE_SUFFIX,
+        RETAINED_SOURCE_SUFFIX,
+    )
 
     def emit(reason: str) -> None:
         """Log one provider rejection, at most once per process when marked."""

--- a/libs/code/deepagents_code/configuration/provider.py
+++ b/libs/code/deepagents_code/configuration/provider.py
@@ -1,0 +1,42 @@
+"""Structural contract for ranked configuration providers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from deepagents_code.config_manifest import ConfigOption
+    from deepagents_code.configuration.resolver import RankedProviderValue
+    from deepagents_code.configuration.types import ProviderStatus
+
+
+@runtime_checkable
+class ConfigProvider(Protocol):
+    """A ranked source of typed configuration values."""
+
+    @property
+    def name(self) -> str:
+        """Provider display label."""
+        ...
+
+    @property
+    def rank(self) -> int:
+        """Numeric precedence rank."""
+        ...
+
+    @property
+    def durable(self) -> bool:
+        """Whether the source survives the process."""
+        ...
+
+    def get(self, option: ConfigOption) -> RankedProviderValue[object]:
+        """Read and coerce one manifest option."""
+        ...
+
+    def status(self) -> ProviderStatus:
+        """Return current provider health and display metadata."""
+        ...
+
+    def reload(self) -> None:
+        """Refresh provider state when the source supports it."""
+        ...

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -709,12 +709,22 @@ class EnvProvider:
 
     name: str = "environment"
     rank: int = ENVIRONMENT_RANK
-    durable: bool = False
     environ: Mapping[str, str] = field(
         default_factory=lambda: os.environ,
         repr=False,
         compare=False,
     )
+
+    @property
+    def durable(self) -> bool:
+        """Never durable: the environment does not survive the process.
+
+        A property rather than a field because the coercion helpers below stamp
+        durability onto every value they emit. A settable field would
+        type-check, enter `__eq__`, and change nothing about masking - a lie in
+        the one attribute that decides whether a tier can hide another.
+        """
+        return False
 
     def get(self, option: ConfigOption) -> RankedProviderValue[object]:
         """Read one option from the live environment.
@@ -745,7 +755,16 @@ class DefaultProvider:
 
     name: str = "default"
     rank: int = DEFAULT_RANK
-    durable: bool = True
+
+    @property
+    def durable(self) -> bool:
+        """Always durable: manifest defaults are compiled into the process.
+
+        A property for the same reason as `EnvProvider.durable`: the value the
+        helpers stamp on each result is the truth, so the attribute must not be
+        able to disagree with it.
+        """
+        return True
 
     def get(self, option: ConfigOption) -> RankedProviderValue[object]:
         """Return one option's manifest default.

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -40,6 +40,13 @@ reworded message that no longer matches would silently restore roughly one
 duplicated line per option for a single typo.
 """
 
+UNUSABLE_SOURCE_SUFFIX = "— using defaults for every option it would have set"
+"""Tail of the rejection raised when a whole TOML source could not be read.
+
+Deduplicated the same way, and for the same reason: a rejected file affects
+every option at once, so the warning belongs to the file, not to each key.
+"""
+
 
 def coerce_environment_value(
     option: ConfigOption, raw: str, name: str
@@ -573,19 +580,51 @@ class TomlFileProvider:
 
         snapshot = self._current_snapshot()
         if option.kind is OptionKind.THEME_DELEGATE:
-            return ranked_theme_toml_value(
+            ranked = ranked_theme_toml_value(
                 snapshot.data,
                 rank=self.rank,
                 durable=self.durable,
                 status=snapshot.status,
             )
-        return ranked_toml_value(
-            option,
-            snapshot.data,
-            rank=self.rank,
-            durable=self.durable,
-            status=snapshot.status,
+        else:
+            ranked = ranked_toml_value(
+                option,
+                snapshot.data,
+                rank=self.rank,
+                durable=self.durable,
+                status=snapshot.status,
+            )
+        return self._with_unusable_diagnostic(ranked, snapshot.status)
+
+    @staticmethod
+    def _with_unusable_diagnostic(
+        ranked: RankedProviderValue[object],
+        status: ProviderStatus,
+    ) -> RankedProviderValue[object]:
+        """Attach the rejection reason when the whole file could not be read.
+
+        A rejected file coerces to `Unset` for every option, which resolution
+        reads as "this source declares nothing" — indistinguishable from a file
+        that simply omits the key. Carrying the reason as a diagnostic lets
+        `_emit_ranked_diagnostics` tell the user their file was thrown away
+        instead of silently handing back defaults.
+
+        Args:
+            ranked: Result already coerced from the snapshot.
+            status: Health of the snapshot the result came from.
+
+        Returns:
+            The result, with a rejection diagnostic when the source is unusable.
+        """
+        if status.usable:
+            return ranked
+        location = f" ({status.path})" if status.path is not None else ""
+        detail = f": {status.detail}" if status.detail else ""
+        reason = (
+            f"Ignoring {status.name}{location} — it is "
+            f"{status.health.value}{detail} {UNUSABLE_SOURCE_SUFFIX}"
         )
+        return replace(ranked, diagnostics=(reason, *ranked.diagnostics))
 
     def status(self) -> ProviderStatus:
         """Return health for the current file snapshot.

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -47,6 +47,14 @@ Deduplicated the same way, and for the same reason: a rejected file affects
 every option at once, so the warning belongs to the file, not to each key.
 """
 
+RETAINED_SOURCE_SUFFIX = "— still applying the last readable version of it"
+"""Tail of the rejection raised when a failed reload kept the previous values.
+
+Distinct from `UNUSABLE_SOURCE_SUFFIX` because the consequence is different:
+nothing fell back to a default, but the file on disk no longer describes what
+the process is enforcing, and an edit the user just made is not in effect.
+"""
+
 
 def coerce_environment_value(
     option: ConfigOption, raw: str, name: str
@@ -613,24 +621,41 @@ class TomlFileProvider:
                 durable=self.durable,
                 status=snapshot.status,
             )
-        return self._with_unusable_diagnostic(ranked, snapshot.status)
+        # The status of the file on disk, which is not the status of the
+        # snapshot resolution just read: a failed reload keeps enforcing the
+        # last readable generation while `failure` records why the current
+        # contents were refused.
+        failure = self._state.failure
+        return self._with_rejection_diagnostic(
+            ranked,
+            failure or snapshot.status,
+            # Values were retained only when the generation in hand is itself
+            # usable. A first read that fails records a failure too, but there
+            # is no earlier generation behind it - those options fall back.
+            retained=snapshot.status.usable,
+        )
 
     @staticmethod
-    def _with_unusable_diagnostic(
+    def _with_rejection_diagnostic(
         ranked: RankedProviderValue[object],
         status: ProviderStatus,
+        *,
+        retained: bool,
     ) -> RankedProviderValue[object]:
-        """Attach the rejection reason when the whole file could not be read.
+        """Attach the reason when the file on disk was rejected as a whole.
 
-        A rejected file coerces to `Unset` for every option, which resolution
-        reads as "this source declares nothing" — indistinguishable from a file
-        that simply omits the key. Carrying the reason as a diagnostic lets
-        `_emit_ranked_diagnostics` tell the user their file was thrown away
-        instead of silently handing back defaults.
+        Neither rejection is visible in the result otherwise. A file refused on
+        first read coerces to `Unset` for every option, which resolution reads
+        as "this source declares nothing" — indistinguishable from a file that
+        omits the key. A file refused on *reload* is quieter still: resolution
+        keeps returning the previous generation's values, so nothing looks
+        wrong at all while the user's latest edit silently fails to apply.
 
         Args:
             ranked: Result already coerced from the snapshot.
-            status: Health of the snapshot the result came from.
+            status: Health of the file on disk.
+            retained: Whether resolution is still serving an earlier generation
+                rather than falling through to lower tiers.
 
         Returns:
             The result, with a rejection diagnostic when the source is unusable.
@@ -639,9 +664,10 @@ class TomlFileProvider:
             return ranked
         location = f" ({status.path})" if status.path is not None else ""
         detail = f": {status.detail}" if status.detail else ""
+        suffix = RETAINED_SOURCE_SUFFIX if retained else UNUSABLE_SOURCE_SUFFIX
         reason = (
             f"Ignoring {status.name}{location} — it is "
-            f"{status.health.value}{detail} {UNUSABLE_SOURCE_SUFFIX}"
+            f"{status.health.value}{detail} {suffix}"
         )
         return replace(ranked, diagnostics=(reason, *ranked.diagnostics))
 

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -473,7 +473,7 @@ class _TomlSnapshotState:
     """Mutable snapshot cell owned by a frozen provider."""
 
     value: TomlSnapshot | None = None
-    """Snapshot used to resolve values; always the last usable generation."""
+    """Last usable snapshot, or the empty failed snapshot from an initial read."""
 
     failure: ProviderStatus | None = None
     """Status of the most recent failed reload, kept for health reporting."""
@@ -623,6 +623,8 @@ class TomlFileProvider:
             self._state.value = snapshot
             self._state.failure = None
         else:
+            if self._state.value is None:
+                self._state.value = snapshot
             self._state.failure = snapshot.status
 
     def _current_snapshot(self) -> TomlSnapshot:

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -2,19 +2,25 @@
 
 from __future__ import annotations
 
+import os
 import tomllib
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, assert_never, cast
 
 from deepagents_code._env_vars import classify_env_bool
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
     from pathlib import Path
 
     from deepagents_code.config_manifest import ConfigOption
     from deepagents_code.configuration.resolver import RankedProviderValue
 
+from deepagents_code.configuration.resolver import (
+    DEFAULT_RANK,
+    ENVIRONMENT_RANK,
+    USER_RANK,
+)
 from deepagents_code.configuration.types import (
     Found,
     Invalid,
@@ -355,8 +361,11 @@ def ranked_theme_toml_value(
     Returns:
         Ranked theme result with the selected TOML path in its display status.
     """
-    from deepagents_code.app import _resolve_terminal_mapping, _resolve_theme_name
     from deepagents_code.configuration.resolver import RankedProviderValue
+    from deepagents_code.configuration.theme_resolution import (
+        resolve_terminal_mapping,
+        resolve_theme_name,
+    )
 
     if not status.usable:
         return RankedProviderValue(rank, durable, status, Unset())
@@ -370,7 +379,7 @@ def ranked_theme_toml_value(
         )
         return RankedProviderValue(rank, durable, status, result)
 
-    resolved = _resolve_terminal_mapping(ui)
+    resolved = resolve_terminal_mapping(ui)
     if resolved is not None:
         import os
 
@@ -382,7 +391,7 @@ def ranked_theme_toml_value(
         return RankedProviderValue(rank, durable, selected, Found(resolved))
 
     saved = ui.get("theme")
-    resolved = _resolve_theme_name(saved)
+    resolved = resolve_theme_name(saved)
     if resolved is not None:
         selected = replace(status, name=f"{status.name} [ui.theme]")
         return RankedProviderValue(rank, durable, selected, Found(resolved))
@@ -405,14 +414,14 @@ def ranked_theme_environment_value(
         Ranked theme result with the concrete variable name in its status.
     """
     from deepagents_code._env_vars import THEME
-    from deepagents_code.app import _resolve_theme_name
     from deepagents_code.configuration.resolver import RankedProviderValue
+    from deepagents_code.configuration.theme_resolution import resolve_theme_name
 
     status = ProviderStatus(f"env ({THEME})", None, ProviderHealth.OK)
     raw = environ.get(THEME)
     if raw is None:
         return RankedProviderValue(rank, False, status, Unset())
-    resolved = _resolve_theme_name(raw)
+    resolved = resolve_theme_name(raw)
     if resolved is not None:
         return RankedProviderValue(rank, False, status, Found(resolved))
     return RankedProviderValue(
@@ -459,12 +468,37 @@ def ranked_default_value(
     return RankedProviderValue(rank, True, status, Found(value))
 
 
+@dataclass(slots=True)
+class _TomlSnapshotState:
+    """Mutable snapshot cell owned by a frozen provider."""
+
+    value: TomlSnapshot | None = None
+
+
 @dataclass(frozen=True, slots=True)
 class TomlFileProvider:
-    """Provider that parses one local TOML file per `load` call."""
+    """Ranked provider backed by one local TOML file snapshot."""
 
     name: str
     path: Path
+    rank: int = USER_RANK
+    durable: bool = True
+    snapshot: TomlSnapshot | None = field(default=None, repr=False, compare=False)
+    loader: Callable[[], TomlSnapshot] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _state: _TomlSnapshotState = field(
+        default_factory=_TomlSnapshotState,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        """Seed the mutable snapshot cell when a generation is supplied."""
+        self._state.value = self.snapshot
 
     def load(self) -> TomlSnapshot:
         """Parse the file and classify missing, unreadable, or corrupt states.
@@ -521,3 +555,122 @@ class TomlFileProvider:
             data,
             ProviderStatus(self.name, self.path, ProviderHealth.OK),
         )
+
+    def get(self, option: ConfigOption) -> RankedProviderValue[object]:
+        """Read one option from the current file snapshot.
+
+        Args:
+            option: Manifest option to read.
+
+        Returns:
+            Ranked and coerced provider result.
+        """
+        from deepagents_code.config_manifest import OptionKind
+
+        snapshot = self._current_snapshot()
+        if option.kind is OptionKind.THEME_DELEGATE:
+            return ranked_theme_toml_value(
+                snapshot.data,
+                rank=self.rank,
+                durable=self.durable,
+                status=snapshot.status,
+            )
+        return ranked_toml_value(
+            option,
+            snapshot.data,
+            rank=self.rank,
+            durable=self.durable,
+            status=snapshot.status,
+        )
+
+    def status(self) -> ProviderStatus:
+        """Return health for the current file snapshot."""
+        return self._current_snapshot().status
+
+    def reload(self) -> None:
+        """Replace the current snapshot with a fresh file read."""
+        snapshot = self.loader() if self.loader is not None else self.load()
+        self._state.value = snapshot
+
+    def _current_snapshot(self) -> TomlSnapshot:
+        """Return the cached snapshot, loading it on first access.
+
+        Returns:
+            Current parsed file snapshot.
+
+        Raises:
+            RuntimeError: If a reload produces no snapshot.
+        """
+        if self._state.value is None:
+            self.reload()
+        snapshot = self._state.value
+        if snapshot is None:
+            msg = f"{self.name} reload produced no snapshot"
+            raise RuntimeError(msg)
+        return snapshot
+
+
+@dataclass(frozen=True, slots=True)
+class EnvProvider:
+    """Live process-environment configuration provider."""
+
+    name: str = "environment"
+    rank: int = ENVIRONMENT_RANK
+    durable: bool = False
+    environ: Mapping[str, str] = field(
+        default_factory=lambda: os.environ,
+        repr=False,
+        compare=False,
+    )
+
+    def get(self, option: ConfigOption) -> RankedProviderValue[object]:
+        """Read one option from the live environment.
+
+        Args:
+            option: Manifest option to read.
+
+        Returns:
+            Ranked and coerced provider result.
+        """
+        from deepagents_code.config_manifest import OptionKind
+
+        if option.kind is OptionKind.THEME_DELEGATE:
+            return ranked_theme_environment_value(self.environ, rank=self.rank)
+        return ranked_environment_value(option, self.environ, rank=self.rank)
+
+    def status(self) -> ProviderStatus:
+        """Return the always-healthy environment provider status."""
+        return ProviderStatus(self.name, None, ProviderHealth.OK)
+
+    def reload(self) -> None:
+        """Keep reading the live environment without cached state."""
+
+
+@dataclass(frozen=True, slots=True)
+class DefaultProvider:
+    """Typed manifest-default configuration provider."""
+
+    name: str = "default"
+    rank: int = DEFAULT_RANK
+    durable: bool = True
+
+    def get(self, option: ConfigOption) -> RankedProviderValue[object]:
+        """Return one option's manifest default.
+
+        Args:
+            option: Manifest option whose default should be returned.
+
+        Returns:
+            Ranked default provider result.
+        """
+        ranked = ranked_default_value(option, rank=self.rank)
+        if isinstance(ranked.result, Unset):
+            return replace(ranked, result=Found(option.default))
+        return ranked
+
+    def status(self) -> ProviderStatus:
+        """Return the always-healthy default provider status."""
+        return ProviderStatus(self.name, None, ProviderHealth.OK)
+
+    def reload(self) -> None:
+        """Retain immutable manifest defaults without cached state."""

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -491,7 +491,14 @@ class TomlFileProvider:
     """Ranked provider backed by one local TOML file snapshot."""
 
     name: str
-    path: Path
+    path: Path | None
+    """File this provider reads, or `None` for a snapshot with no known origin.
+
+    A `None` path is not a filename to guess at. Inventing one would make
+    `load` read a relative path against the process working directory, and for
+    the managed tier that is a trust boundary, not a cosmetic default.
+    """
+
     rank: int = USER_RANK
     durable: bool = True
     snapshot: TomlSnapshot | None = field(default=None, repr=False, compare=False)
@@ -515,8 +522,20 @@ class TomlFileProvider:
         """Parse the file and classify missing, unreadable, or corrupt states.
 
         Returns:
-            Parsed data and provider health.
+            Parsed data and provider health. A provider with no path reports
+            `INDETERMINATE`, which is not usable: an empty read proves nothing
+            about a file whose location is unknown.
         """
+        if self.path is None:
+            return TomlSnapshot(
+                {},
+                ProviderStatus(
+                    self.name,
+                    None,
+                    ProviderHealth.INDETERMINATE,
+                    "no path is known for this source, so it cannot be re-read",
+                ),
+            )
         try:
             with self.path.open("rb") as handle:
                 data = tomllib.load(handle)

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -473,6 +473,10 @@ class _TomlSnapshotState:
     """Mutable snapshot cell owned by a frozen provider."""
 
     value: TomlSnapshot | None = None
+    """Snapshot used to resolve values; always the last usable generation."""
+
+    failure: ProviderStatus | None = None
+    """Status of the most recent failed reload, kept for health reporting."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -584,13 +588,42 @@ class TomlFileProvider:
         )
 
     def status(self) -> ProviderStatus:
-        """Return health for the current file snapshot."""
-        return self._current_snapshot().status
+        """Return health for the current file snapshot.
+
+        A failed reload reports its own health even though resolution keeps
+        using the retained snapshot: diagnostics must describe the file on
+        disk, not the generation still being enforced.
+
+        Raises:
+            RuntimeError: If a reload produces no snapshot.
+        """
+        state = self._state
+        if state.value is None:
+            self.reload()
+        if state.failure is not None:
+            return state.failure
+        snapshot = state.value
+        if snapshot is None:
+            msg = f"{self.name} reload produced no snapshot"
+            raise RuntimeError(msg)
+        return snapshot.status
 
     def reload(self) -> None:
-        """Replace the current snapshot with a fresh file read."""
+        """Replace the current snapshot with a fresh file read.
+
+        A reload the source cannot use never replaces the last usable
+        snapshot. An unusable candidate carries an empty table, which
+        resolution reads as "this source declares nothing"; installing it
+        would drop the source's restrictions and let lower ranks win. The
+        failed status is still recorded so health surfaces report the file on
+        disk.
+        """
         snapshot = self.loader() if self.loader is not None else self.load()
-        self._state.value = snapshot
+        if snapshot.status.usable:
+            self._state.value = snapshot
+            self._state.failure = None
+        else:
+            self._state.failure = snapshot.status
 
     def _current_snapshot(self) -> TomlSnapshot:
         """Return the cached snapshot, loading it on first access.

--- a/libs/code/deepagents_code/configuration/resolver.py
+++ b/libs/code/deepagents_code/configuration/resolver.py
@@ -157,6 +157,29 @@ class ConfigResolver:
             raise RuntimeError(msg)
         return resolved
 
+    def resolve_options(
+        self,
+        options: Sequence[ConfigOption],
+    ) -> Mapping[ConfigKey, ResolvedValue[object]]:
+        """Resolve selected options against one provider generation.
+
+        Resolving an option is not uniformly cheap: `THEME_DELEGATE` reaches
+        the theme registry, which imports Textual (~470ms). Callers on the
+        startup hot path ask for the options they need rather than the whole
+        manifest, and keep the single-generation guarantee either way.
+
+        Args:
+            options: Manifest options to resolve together.
+
+        Returns:
+            Immutable mapping from canonical option key to resolved value.
+        """
+        with self._lock:
+            resolved = {
+                option.key: self._resolve(option, self._providers) for option in options
+            }
+        return MappingProxyType(resolved)
+
     def resolve_all(self) -> Mapping[ConfigKey, ResolvedValue[object]]:
         """Resolve the full manifest against one provider generation.
 
@@ -165,12 +188,7 @@ class ConfigResolver:
         """
         from deepagents_code.config_manifest import get_config_options
 
-        with self._lock:
-            resolved = {
-                option.key: self._resolve(option, self._providers)
-                for option in get_config_options()
-            }
-        return MappingProxyType(resolved)
+        return self.resolve_options(get_config_options())
 
     def reload(self) -> None:
         """Propagate a source refresh to every provider."""

--- a/libs/code/deepagents_code/configuration/resolver.py
+++ b/libs/code/deepagents_code/configuration/resolver.py
@@ -9,6 +9,7 @@ numeric ranks.
 
 from __future__ import annotations
 
+import threading
 from copy import deepcopy
 from dataclasses import dataclass, field
 from types import MappingProxyType
@@ -17,8 +18,13 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
 
+    from deepagents_code.config_manifest import ConfigOption
+    from deepagents_code.configuration.provider import ConfigProvider
+    from deepagents_code.configuration.types import TomlSnapshot
+
 from deepagents_code.configuration.types import (
     Found,
+    ProviderHealth,
     ProviderResult,
     ProviderStatus,
 )
@@ -69,6 +75,211 @@ class ResolvedValue[T]:
     def ranks(self) -> tuple[int, ...]:
         """Contributing ranks in precedence order."""
         return self.selected_ranks or tuple(sorted(self.provenance))
+
+
+type ConfigKey = str
+"""Canonical dotted manifest key."""
+
+
+class ConfigResolver:
+    """Resolve manifest options through an ordered provider chain."""
+
+    def __init__(self, providers: Sequence[ConfigProvider]) -> None:
+        """Build a resolver with providers sorted by precedence.
+
+        Args:
+            providers: Configuration providers with unique numeric ranks.
+
+        Raises:
+            ValueError: If two providers declare the same rank.
+        """
+        ordered = tuple(sorted(providers, key=lambda provider: provider.rank))
+        ranks = tuple(provider.rank for provider in ordered)
+        if len(set(ranks)) != len(ranks):
+            msg = "config providers must have unique ranks"
+            raise ValueError(msg)
+        self._providers = ordered
+        self._lock = threading.RLock()
+
+    def get(self, option: ConfigOption) -> ResolvedValue[object]:
+        """Resolve one option through every provider.
+
+        Args:
+            option: Manifest option to resolve.
+
+        Returns:
+            Resolved value with rank-keyed provenance and health.
+        """
+        with self._lock:
+            return self._resolve(option, self._providers)
+
+    @staticmethod
+    def _resolve(
+        option: ConfigOption,
+        providers: Sequence[ConfigProvider],
+    ) -> ResolvedValue[object]:
+        """Resolve one option against a lock-held provider generation.
+
+        Args:
+            option: Manifest option to resolve.
+            providers: Providers frozen to one generation.
+
+        Returns:
+            Resolved value with rank-keyed provenance and health.
+
+        Raises:
+            RuntimeError: If no provider returns a value.
+        """
+        values = tuple(provider.get(option) for provider in providers)
+        strategy = option.merge_strategy.value
+        effective_values = (
+            tuple(value for value in values if value.rank != DEFAULT_RANK)
+            if strategy in {"union", "deep_merge"}
+            else values
+        )
+        resolved = resolve_ranked(effective_values, strategy=strategy)
+        if resolved is None:
+            fallback = RankedProviderValue(
+                DEFAULT_RANK,
+                True,
+                ProviderStatus("default", None, ProviderHealth.OK),
+                Found(option.default),
+            )
+            without_default = tuple(
+                value for value in values if value.rank != DEFAULT_RANK
+            )
+            resolved = resolve_ranked(
+                (*without_default, fallback),
+                strategy=strategy,
+            )
+        if resolved is None:
+            msg = f"fallback provider was unset for {option.key}"
+            raise RuntimeError(msg)
+        return resolved
+
+    def resolve_all(self) -> Mapping[ConfigKey, ResolvedValue[object]]:
+        """Resolve the full manifest against one provider generation.
+
+        Returns:
+            Immutable mapping from canonical option key to resolved value.
+        """
+        from deepagents_code.config_manifest import get_config_options
+
+        with self._lock:
+            resolved = {
+                option.key: self._resolve(option, self._providers)
+                for option in get_config_options()
+            }
+        return MappingProxyType(resolved)
+
+    def reload(self) -> None:
+        """Propagate a source refresh to every provider."""
+        with self._lock:
+            for provider in self._providers:
+                provider.reload()
+
+    def provider_statuses(self) -> Mapping[int, ProviderStatus]:
+        """Return immutable provider health keyed by precedence rank."""
+        with self._lock:
+            statuses = {
+                provider.rank: provider.status() for provider in self._providers
+            }
+        return MappingProxyType(statuses)
+
+
+def resolver_from_snapshots(
+    managed: TomlSnapshot,
+    user: TomlSnapshot,
+    *,
+    managed_loader: Callable[[], TomlSnapshot] | None = None,
+    user_loader: Callable[[], TomlSnapshot] | None = None,
+) -> ConfigResolver:
+    """Build the standard provider chain from one file-snapshot generation.
+
+    Args:
+        managed: Managed TOML snapshot.
+        user: User TOML snapshot.
+        managed_loader: Optional managed reload operation.
+        user_loader: Optional user reload operation.
+
+    Returns:
+        Resolver containing managed, environment, user, and default providers.
+    """
+    from pathlib import Path
+
+    from deepagents_code.configuration.providers import (
+        DefaultProvider,
+        EnvProvider,
+        TomlFileProvider,
+    )
+
+    managed_path = managed.status.path or Path("managed_config.toml")
+    user_path = user.status.path or Path("config.toml")
+    return ConfigResolver(
+        (
+            TomlFileProvider(
+                managed.status.name,
+                managed_path,
+                MANAGED_RANK,
+                True,
+                managed,
+                managed_loader,
+            ),
+            EnvProvider(),
+            TomlFileProvider(
+                user.status.name,
+                user_path,
+                USER_RANK,
+                True,
+                user,
+                user_loader,
+            ),
+            DefaultProvider(),
+        )
+    )
+
+
+@dataclass(slots=True)
+class _ResolverCache:
+    """Mutable process resolver cache guarded by one lifecycle lock."""
+
+    key: tuple[object, ...] | None = None
+    resolver: ConfigResolver | None = None
+
+
+_resolver_cache_lock = threading.RLock()
+_resolver_cache = _ResolverCache()
+
+
+def get_config_resolver(*, refresh_managed: bool = False) -> ConfigResolver:
+    """Return the shared process resolver for the active config paths.
+
+    Args:
+        refresh_managed: Re-read all providers on an existing matching resolver.
+
+    Returns:
+        Resolver shared by consumers of the active managed and user paths.
+    """
+    from deepagents_code.configuration.providers import TomlFileProvider
+    from deepagents_code.configuration.service import get_managed_snapshot
+    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
+
+    managed = get_managed_snapshot(refresh=refresh_managed)
+    key = (DEFAULT_CONFIG_PATH, managed.status.path, id(get_managed_snapshot))
+    with _resolver_cache_lock:
+        if _resolver_cache.resolver is None or _resolver_cache.key != key:
+            user_provider = TomlFileProvider("config.toml", DEFAULT_CONFIG_PATH)
+            user = user_provider.load()
+            _resolver_cache.resolver = resolver_from_snapshots(
+                managed,
+                user,
+                managed_loader=lambda: get_managed_snapshot(refresh=True),
+                user_loader=user_provider.load,
+            )
+            _resolver_cache.key = key
+        elif refresh_managed:
+            _resolver_cache.resolver.reload()
+        return _resolver_cache.resolver
 
 
 def resolve_ranked[T](

--- a/libs/code/deepagents_code/configuration/resolver.py
+++ b/libs/code/deepagents_code/configuration/resolver.py
@@ -262,10 +262,14 @@ def resolver_from_snapshots(
 
 @dataclass(slots=True)
 class _ResolverCache:
-    """Mutable process resolver cache guarded by one lifecycle lock."""
+    """Mutable process resolver cache guarded by one lifecycle lock.
 
-    key: tuple[object, ...] | None = None
-    resolver: ConfigResolver | None = None
+    One field, not a key and a resolver side by side: those admit a populated
+    key with no resolver, and a lookup that trusts either half alone would then
+    read a stale generation or rebuild one that already exists.
+    """
+
+    entry: tuple[tuple[object, ...], ConfigResolver] | None = None
 
 
 _resolver_cache_lock = threading.RLock()
@@ -302,21 +306,38 @@ def get_config_resolver(*, refresh_managed: bool = False) -> ConfigResolver:
     from deepagents_code.model_config import DEFAULT_CONFIG_PATH
 
     managed = get_managed_snapshot(refresh=refresh_managed)
-    key = (DEFAULT_CONFIG_PATH, managed.status.path, id(get_managed_snapshot))
+    key = (DEFAULT_CONFIG_PATH, managed.status.path)
     with _resolver_cache_lock:
-        if _resolver_cache.resolver is None or _resolver_cache.key != key:
+        entry = _resolver_cache.entry
+        if entry is None or entry[0] != key:
             user_provider = TomlFileProvider("config.toml", DEFAULT_CONFIG_PATH)
             user = user_provider.load()
-            _resolver_cache.resolver = resolver_from_snapshots(
+            resolver = resolver_from_snapshots(
                 managed,
                 user,
                 managed_loader=_reload_enforceable_managed_snapshot,
                 user_loader=user_provider.load,
             )
-            _resolver_cache.key = key
-        elif refresh_managed:
-            _resolver_cache.resolver.reload()
-        return _resolver_cache.resolver
+            _resolver_cache.entry = (key, resolver)
+            return resolver
+        resolver = entry[1]
+        if refresh_managed:
+            resolver.reload()
+        return resolver
+
+
+def reset_config_resolver() -> None:
+    """Drop the cached process resolver.
+
+    Test-only, and paired with `service.invalidate_config_sources`: the two
+    caches are keyed differently, so clearing only the managed snapshot leaves
+    this one serving the previous test's generation. Tests escaped that today
+    only by incidentally monkeypatching `DEFAULT_CONFIG_PATH`, which changes
+    the key; one that exercises the resolver at an unchanged path would inherit
+    stale state.
+    """
+    with _resolver_cache_lock:
+        _resolver_cache.entry = None
 
 
 def resolve_ranked[T](

--- a/libs/code/deepagents_code/configuration/resolver.py
+++ b/libs/code/deepagents_code/configuration/resolver.py
@@ -223,16 +223,19 @@ def resolver_from_snapshots(
     Returns:
         Resolver containing managed, environment, user, and default providers.
     """
-    from pathlib import Path
-
     from deepagents_code.configuration.providers import (
         DefaultProvider,
         EnvProvider,
         TomlFileProvider,
     )
 
-    managed_path = managed.status.path or Path("managed_config.toml")
-    user_path = user.status.path or Path("config.toml")
+    # Snapshots built in-memory carry no path. Pass that through rather than
+    # inventing a relative filename: `TomlFileProvider.load` would resolve it
+    # against the process working directory, so a later `reload()` on a
+    # diagnostic resolver would read whatever `./managed_config.toml` happens
+    # to sit in the repo the agent is running in and treat it as policy.
+    managed_path = managed.status.path
+    user_path = user.status.path
     return ConfigResolver(
         (
             TomlFileProvider(

--- a/libs/code/deepagents_code/configuration/resolver.py
+++ b/libs/code/deepagents_code/configuration/resolver.py
@@ -59,7 +59,16 @@ class RankedProviderValue[T]:
 
 @dataclass(frozen=True, slots=True)
 class ResolvedValue[T]:
-    """Resolved value with rank-keyed provenance and provider health."""
+    """Resolved value with rank-keyed provenance and provider health.
+
+    Six of the seven fields are parallel rank-keyed collections whose mutual
+    consistency is the entire meaning of the type, and consumers index straight
+    into them: `config_manifest._ranked_source` reads
+    `provider_status[rank] for rank in ranks` to render the source column, so
+    an inconsistent instance is a `KeyError` in user-facing output. The
+    invariants are checked at construction rather than documented, following
+    `TomlSnapshot` in the same package.
+    """
 
     value: T
     provenance: Mapping[int, frozenset[tuple[str, ...]]]
@@ -70,6 +79,38 @@ class ResolvedValue[T]:
     tier_diagnostics: Mapping[int, tuple[str, ...]] = field(
         default_factory=lambda: MappingProxyType({})
     )
+
+    def __post_init__(self) -> None:
+        """Reject a value whose rank-keyed halves disagree.
+
+        Also copies each mapping behind a `MappingProxyType`. `frozen=True`
+        protects the field bindings, not the contents: without the copy a
+        caller keeps a live reference to a dict this type presents as a
+        read-only snapshot.
+
+        Raises:
+            ValueError: If a selected rank is missing provider status, or is
+                also reported as masked.
+        """
+        for name in (
+            "provenance",
+            "tier_health",
+            "provider_status",
+            "tier_diagnostics",
+        ):
+            frozen = MappingProxyType(dict(getattr(self, name)))
+            object.__setattr__(self, name, frozen)
+        missing = set(self.selected_ranks) - self.provider_status.keys()
+        if missing:
+            msg = (
+                f"selected ranks {sorted(missing)} have no provider status; "
+                "rendering provenance would raise KeyError"
+            )
+            raise ValueError(msg)
+        both = self.masked_ranks & set(self.selected_ranks)
+        if both:
+            msg = f"ranks {sorted(both)} cannot be both selected and masked"
+            raise ValueError(msg)
 
     @property
     def ranks(self) -> tuple[int, ...]:

--- a/libs/code/deepagents_code/configuration/resolver.py
+++ b/libs/code/deepagents_code/configuration/resolver.py
@@ -251,6 +251,22 @@ _resolver_cache_lock = threading.RLock()
 _resolver_cache = _ResolverCache()
 
 
+def _reload_enforceable_managed_snapshot() -> TomlSnapshot:
+    """Return a refreshed managed snapshot only when policy can enforce it."""
+    from deepagents_code.configuration.service import (
+        get_managed_snapshot,
+        managed_policy_violations,
+    )
+
+    candidate = get_managed_snapshot(refresh=True)
+    if candidate.status.usable and managed_policy_violations(
+        candidate.data,
+        status=candidate.status,
+    ):
+        return get_managed_snapshot()
+    return candidate
+
+
 def get_config_resolver(*, refresh_managed: bool = False) -> ConfigResolver:
     """Return the shared process resolver for the active config paths.
 
@@ -273,7 +289,7 @@ def get_config_resolver(*, refresh_managed: bool = False) -> ConfigResolver:
             _resolver_cache.resolver = resolver_from_snapshots(
                 managed,
                 user,
-                managed_loader=lambda: get_managed_snapshot(refresh=True),
+                managed_loader=_reload_enforceable_managed_snapshot,
                 user_loader=user_provider.load,
             )
             _resolver_cache.key = key

--- a/libs/code/deepagents_code/configuration/service.py
+++ b/libs/code/deepagents_code/configuration/service.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
 
-    from deepagents_code.configuration.resolver import ResolvedValue
+    from deepagents_code.configuration.resolver import ConfigResolver, ResolvedValue
 
 from deepagents_code.configuration.paths import (
     managed_config_path,
@@ -675,9 +675,27 @@ def require_healthy_managed_config(*, refresh: bool = False) -> None:
         raise ManagedPolicyError(status, violations)
 
 
+def _managed_resolver(snapshot: TomlSnapshot) -> ConfigResolver:
+    """Build a resolver whose managed provider owns `snapshot`.
+
+    Returns:
+        Resolver bound to the supplied managed generation.
+    """
+    from deepagents_code.configuration.resolver import resolver_from_snapshots
+
+    user = TomlSnapshot(
+        {},
+        ProviderStatus("config.toml", None, ProviderHealth.MISSING),
+    )
+    return resolver_from_snapshots(snapshot, user)
+
+
 def managed_config_status(*, refresh: bool = False) -> ProviderStatus:
     """Return managed provider health for diagnostics and config inspection."""
-    return get_managed_snapshot(refresh=refresh).status
+    from deepagents_code.configuration.resolver import MANAGED_RANK
+
+    snapshot = get_managed_snapshot(refresh=refresh)
+    return _managed_resolver(snapshot).provider_statuses()[MANAGED_RANK]
 
 
 @dataclass(frozen=True, slots=True)
@@ -713,7 +731,11 @@ def managed_health(*, refresh: bool = False) -> ManagedHealth:
     Returns:
         Health, violations, and ignored rejections that cannot disagree.
     """
-    return managed_snapshot_health(get_managed_snapshot(refresh=refresh))
+    from deepagents_code.configuration.resolver import MANAGED_RANK
+
+    snapshot = get_managed_snapshot(refresh=refresh)
+    status = _managed_resolver(snapshot).provider_statuses()[MANAGED_RANK]
+    return managed_snapshot_health(replace(snapshot, status=status))
 
 
 def managed_snapshot_health(snapshot: TomlSnapshot) -> ManagedHealth:

--- a/libs/code/deepagents_code/configuration/service.py
+++ b/libs/code/deepagents_code/configuration/service.py
@@ -642,14 +642,21 @@ def get_config_sources(
 
 
 def invalidate_config_sources() -> None:
-    """Drop the cached managed snapshot.
+    """Drop the cached managed snapshot and the shared process resolver.
 
     Test-only. Production reloads pass `refresh=True` instead, which keeps the
     last snapshot that parsed cleanly if the new one fails; clearing the cache
     first would leave readers with an empty managed table on a failed reload.
+
+    Both caches are cleared together because they are keyed differently:
+    dropping only the managed snapshot leaves the resolver holding the previous
+    generation, which is the half most tests actually read.
     """
+    from deepagents_code.configuration.resolver import reset_config_resolver
+
     with _snapshot_lock:
         _snapshot_state.managed = None
+    reset_config_resolver()
 
 
 def require_healthy_managed_config(*, refresh: bool = False) -> None:

--- a/libs/code/deepagents_code/configuration/theme_resolution.py
+++ b/libs/code/deepagents_code/configuration/theme_resolution.py
@@ -1,0 +1,94 @@
+"""Lightweight theme preference coercion shared by config providers and the UI."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, cast
+
+from deepagents_code import theme
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_theme_name(value: object) -> str | None:
+    """Resolve a user-supplied theme name to a canonical registry key.
+
+    Args:
+        value: Raw value read from TOML or an environment variable.
+
+    Returns:
+        Canonical registry key, or `None` when the value is not registered.
+    """
+    if not isinstance(value, str):
+        return None
+    name = value.strip()
+    if name == "textual-ansi":
+        name = "ansi-light"
+    registry = theme.get_registry()
+    if name in registry:
+        return name
+    folded = name.casefold()
+    for registered, entry in registry.items():
+        if registered.casefold() == folded or entry.label.casefold() == folded:
+            return registered
+    return None
+
+
+def as_toml_table(value: object) -> dict[str, object] | None:
+    """Return `value` as a TOML table when it has the expected runtime shape."""
+    if not isinstance(value, dict):
+        return None
+    return cast("dict[str, object]", value)
+
+
+def resolve_terminal_mapping(ui: Mapping[str, object]) -> str | None:
+    """Resolve `[ui.terminal_themes][TERM_PROGRAM]` to a registered theme.
+
+    Args:
+        ui: The `[ui]` table parsed from `config.toml`.
+
+    Returns:
+        Canonical registry key, or `None` when no valid mapping applies.
+    """
+    terminal_themes = ui.get("terminal_themes")
+    if terminal_themes is None:
+        return None
+    terminal_themes_table = as_toml_table(terminal_themes)
+    if terminal_themes_table is None:
+        logger.warning(
+            "[ui.terminal_themes] should be a table mapping TERM_PROGRAM "
+            "values to theme names; got %s",
+            type(terminal_themes).__name__,
+        )
+        return None
+    term_program = os.environ.get("TERM_PROGRAM", "").strip()
+    if not term_program:
+        if terminal_themes_table:
+            logger.warning(
+                "[ui.terminal_themes] is configured but TERM_PROGRAM is unset; "
+                "no per-terminal theme will be applied",
+            )
+        return None
+    mapped = terminal_themes_table.get(term_program)
+    resolved = resolve_theme_name(mapped)
+    if resolved is not None:
+        return resolved
+    if isinstance(mapped, str):
+        logger.warning(
+            "Unknown theme '%s' mapped to TERM_PROGRAM='%s' "
+            "in [ui.terminal_themes]; ignoring",
+            mapped,
+            term_program,
+        )
+    elif mapped is not None:
+        logger.warning(
+            "Expected string theme name for TERM_PROGRAM='%s' in "
+            "[ui.terminal_themes], got %s; ignoring",
+            term_program,
+            type(mapped).__name__,
+        )
+    return None

--- a/libs/code/deepagents_code/configuration/theme_resolution.py
+++ b/libs/code/deepagents_code/configuration/theme_resolution.py
@@ -17,11 +17,19 @@ logger = logging.getLogger(__name__)
 def resolve_theme_name(value: object) -> str | None:
     """Resolve a user-supplied theme name to a canonical registry key.
 
+    Accepts the registry key or the human-readable label, case-insensitive on
+    both, with surrounding whitespace stripped - config values (especially
+    `[ui.terminal_themes]`) and the `DEEPAGENTS_CODE_THEME` env var are commonly
+    hand-edited. Also applies the legacy `textual-ansi` to `ansi-light`
+    migration, which predates Textual 8.2.5 and can be dropped once no
+    supported config can still carry the old name.
+
     Args:
         value: Raw value read from TOML or an environment variable.
 
     Returns:
-        Canonical registry key, or `None` when the value is not registered.
+        Canonical registry key, or `None` when the value is not a string or
+        names no registered theme.
     """
     if not isinstance(value, str):
         return None
@@ -39,7 +47,13 @@ def resolve_theme_name(value: object) -> str | None:
 
 
 def as_toml_table(value: object) -> dict[str, object] | None:
-    """Return `value` as a TOML table when it has the expected runtime shape."""
+    """Return `value` as a TOML table when it has the expected runtime shape.
+
+    `tomllib` parses TOML tables as string-keyed dicts, which `ty` cannot infer
+    from a runtime `dict` check. Keep the cast at this boundary so it does not
+    become a general-purpose escape hatch - now more important, not less, since
+    the helper became importable from a shared module.
+    """
     if not isinstance(value, dict):
         return None
     return cast("dict[str, object]", value)
@@ -48,8 +62,12 @@ def as_toml_table(value: object) -> dict[str, object] | None:
 def resolve_terminal_mapping(ui: Mapping[str, object]) -> str | None:
     """Resolve `[ui.terminal_themes][TERM_PROGRAM]` to a registered theme.
 
+    Centralizes both the lookup and the misconfiguration warnings, which are
+    logged exactly once per call. Three callers now share that contract: the
+    managed and user TOML tiers and the UI.
+
     Args:
-        ui: The `[ui]` table parsed from `config.toml`.
+        ui: An `[ui]` table parsed from a managed or user TOML source.
 
     Returns:
         Canonical registry key, or `None` when no valid mapping applies.

--- a/libs/code/deepagents_code/configuration/writer.py
+++ b/libs/code/deepagents_code/configuration/writer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import tempfile
 import threading
@@ -13,6 +14,8 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
 
 USER_CONFIG_WRITE_LOCK = threading.RLock()
 
@@ -56,6 +59,11 @@ def update_user_config(
 
     Writes the user tier only. The managed path is refused rather than trusted
     to be unreachable.
+
+    A committed write to the default path also refreshes the shared process
+    resolver, so later reads see the new value. That refresh is best-effort and
+    never turns a landed write into a reported failure; see
+    `_refresh_shared_resolver`.
 
     Args:
         mutate: Edit applied to the table parsed inside the write lock. It must
@@ -144,7 +152,38 @@ def update_user_config(
             # install without the writer dependency must report "could not
             # update <path>" like any other write failure.
             return WriteResult(False, False, f"could not update {config_path}: {exc}")
+    _refresh_shared_resolver(config_path)
+    return WriteResult(True, True)
+
+
+def _refresh_shared_resolver(config_path: Path) -> None:
+    """Make a committed write visible to the shared process resolver.
+
+    Only the default path is refreshed. `get_config_resolver` is keyed on
+    `DEFAULT_CONFIG_PATH`, so reloading it after a write to an override path
+    would re-read the real user config and the managed policy file - live
+    filesystem reads inside tests that passed a `tmp_path` - while leaving the
+    written path's own view stale anyway.
+
+    Failures are logged rather than returned. The write already landed and was
+    replaced into place; reporting a stale in-process view as a failed write
+    sends the user to retry or hand-edit a file that is already correct.
+
+    Args:
+        config_path: Path the caller just wrote.
+    """
+    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
+
+    if config_path != DEFAULT_CONFIG_PATH:
+        return
     from deepagents_code.configuration.resolver import get_config_resolver
 
-    get_config_resolver().reload()
-    return WriteResult(True, True)
+    try:
+        get_config_resolver().reload()
+    except OSError as exc:
+        logger.warning(
+            "Wrote %s but could not refresh the shared config resolver: %s. "
+            "This process keeps serving the previous values until it restarts.",
+            config_path,
+            exc,
+        )

--- a/libs/code/deepagents_code/configuration/writer.py
+++ b/libs/code/deepagents_code/configuration/writer.py
@@ -144,4 +144,7 @@ def update_user_config(
             # install without the writer dependency must report "could not
             # update <path>" like any other write failure.
             return WriteResult(False, False, f"could not update {config_path}: {exc}")
+    from deepagents_code.configuration.resolver import get_config_resolver
+
+    get_config_resolver().reload()
     return WriteResult(True, True)

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -514,10 +514,27 @@ def _managed_config_diagnostic() -> DiagnosticItem:
     Returns:
         Managed config diagnostic row.
     """
-    from deepagents_code.configuration.service import managed_health
+    from deepagents_code.configuration.resolver import (
+        MANAGED_RANK,
+        resolver_from_snapshots,
+    )
+    from deepagents_code.configuration.service import (
+        get_managed_snapshot,
+        managed_snapshot_health,
+    )
+    from deepagents_code.configuration.types import (
+        ProviderHealth,
+        ProviderStatus,
+        TomlSnapshot,
+    )
 
-    health = managed_health(refresh=True)
-    status = health.status
+    snapshot = get_managed_snapshot(refresh=True)
+    user = TomlSnapshot(
+        {},
+        ProviderStatus("config.toml", None, ProviderHealth.MISSING),
+    )
+    status = resolver_from_snapshots(snapshot, user).provider_statuses()[MANAGED_RANK]
+    health = managed_snapshot_health(TomlSnapshot(snapshot.data, status))
     path = status.path or "(unknown)"
     suffix = status.health.value.lower()
     detail = f" - {status.detail}" if status.detail else ""

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -544,8 +544,9 @@ def _managed_config_diagnostic() -> DiagnosticItem:
     hint = "" if status.usable else "; ask your administrator to repair or remove it"
     # A file that parses is not necessarily enforceable, and both halves of
     # exit 78 have to show up here: reporting only `usable` gives a green row
-    # to the `ManagedPolicyError` half. `managed_health` reads both from one
-    # snapshot, so the refreshed status cannot be paired with stale violations.
+    # to the `ManagedPolicyError` half. Status and violations are both derived
+    # from the single `snapshot` read above, so a refreshed status can never be
+    # paired with stale violations.
     violations = health.violations
     if violations:
         detail += f" - rejects {', '.join(violations)}"
@@ -562,23 +563,50 @@ def _managed_config_diagnostic() -> DiagnosticItem:
     )
 
 
+def _user_config_diagnostic() -> DiagnosticItem:
+    """Report user TOML location and parse health.
+
+    `_path_status` answers only "is there a file there", so a `config.toml`
+    that exists and does not parse produced a green `exists` row - in the one
+    command a user runs when their settings are not taking effect. Resolution
+    treats an unparseable file as declaring nothing, which is exactly the state
+    the row has to distinguish.
+
+    Returns:
+        User config diagnostic row.
+    """
+    from deepagents_code.configuration.providers import TomlFileProvider
+    from deepagents_code.configuration.types import ProviderHealth
+    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
+
+    status = TomlFileProvider("config.toml", DEFAULT_CONFIG_PATH).load().status
+    suffix = {
+        ProviderHealth.OK: "exists",
+        ProviderHealth.MISSING: "not created",
+    }.get(status.health, status.health.value.lower())
+    detail = f" - {status.detail}" if status.detail else ""
+    hint = "" if status.usable else "; every option in it falls back to its default"
+    return DiagnosticItem(
+        "Config file",
+        f"{DEFAULT_CONFIG_PATH} ({suffix}){detail}{hint}",
+        ok=status.usable,
+    )
+
+
 def _collect_configuration() -> DiagnosticSection:
     """Collect on-disk configuration and data locations.
 
     Returns:
         The `Configuration` section.
     """
-    from deepagents_code.model_config import (
-        DEFAULT_CONFIG_DIR,
-        DEFAULT_CONFIG_PATH,
-    )
+    from deepagents_code.model_config import DEFAULT_CONFIG_DIR
 
     return DiagnosticSection(
         title="Configuration",
         items=[
             _path_status("Data directory", DEFAULT_CONFIG_DIR),
             _managed_config_diagnostic(),
-            _path_status("Config file", DEFAULT_CONFIG_PATH),
+            _user_config_diagnostic(),
         ],
     )
 

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -37,7 +37,6 @@ from deepagents_code.config_manifest import (
     options_with_key_prefix,
     provider_install_extra,
     provider_package_name,
-    resolve_interpreter_kwargs,
     resolve_scalar,
 )
 from deepagents_code.model_config import DEFAULT_STARTUP_MODE, PROVIDER_API_KEY_ENV
@@ -1983,17 +1982,6 @@ def test_resolve_ptc_delegates_to_parser() -> None:
     # Invalid PTC value is rejected by the parser and falls back to default.
     value, source = resolve_scalar(opt, toml_data={"interpreter": {"ptc": "bogus"}})
     assert (value, source) == (opt.default, "default")
-
-
-def test_resolve_interpreter_kwargs_maps_settings_fields() -> None:
-    """The interpreter resolver returns Settings-constructor kwargs."""
-    kwargs = resolve_interpreter_kwargs(
-        toml_data={"interpreter": {"memory_limit_mb": 256, "enable_interpreter": True}}
-    )
-    assert kwargs["interpreter_memory_limit_mb"] == 256
-    assert kwargs["enable_interpreter"] is True
-    # Unspecified fields resolve to their manifest defaults.
-    assert kwargs["interpreter_timeout_seconds"] == pytest.approx(5.0)
 
 
 def test_resolve_theme_uses_terminal_mapping_before_saved_theme(monkeypatch) -> None:

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -949,3 +949,44 @@ def test_doctor_is_green_for_a_config_that_parses(
 
     config_path.write_text('[startup]\nmode = "manual"\n', encoding="utf-8")
     assert doctor._user_config_diagnostic().ok
+
+
+def test_invalidate_config_sources_also_drops_the_resolver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clearing only the managed snapshot leaves the resolver serving stale values.
+
+    The two caches are keyed differently. Tests escape pollution today only by
+    incidentally monkeypatching `DEFAULT_CONFIG_PATH`; one that exercises the
+    resolver at an unchanged path would inherit the previous test's generation.
+    """
+    from deepagents_code import model_config
+    from deepagents_code.configuration import resolver as resolver_module, service
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[startup]\nmode = "manual"\n', encoding="utf-8")
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+    monkeypatch.setattr(
+        service,
+        "get_managed_snapshot",
+        lambda refresh=False: TomlSnapshot(  # noqa: ARG005
+            {},
+            ProviderStatus("managed config", None, ProviderHealth.MISSING),
+        ),
+    )
+    service.invalidate_config_sources()
+    try:
+        option = get_option("startup.mode")
+        assert option is not None
+        assert resolver_module.get_config_resolver().get(option).value == "manual"
+
+        # Same path, so the cache key is unchanged: only an explicit reset can
+        # make the edit visible.
+        config_path.write_text('[startup]\nmode = "auto"\n', encoding="utf-8")
+        assert resolver_module.get_config_resolver().get(option).value == "manual"
+
+        service.invalidate_config_sources()
+        assert resolver_module.get_config_resolver().get(option).value == "auto"
+    finally:
+        service.invalidate_config_sources()

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -363,6 +363,31 @@ def test_resolve_all_uses_one_toml_snapshot(
     assert after["test.second"].value is True
 
 
+@pytest.mark.parametrize(
+    "health",
+    [ProviderHealth.CORRUPT, ProviderHealth.UNREADABLE],
+)
+def test_initial_failed_toml_snapshot_falls_through_to_default(
+    health: ProviderHealth,
+    tmp_path: Path,
+) -> None:
+    """A failed first read must remain an empty resolvable generation."""
+    path = tmp_path / "config.toml"
+    snapshot = TomlSnapshot({}, ProviderStatus("config.toml", path, health))
+    provider = TomlFileProvider(
+        "config.toml",
+        path,
+        loader=lambda: snapshot,
+    )
+    option = _bool_option("test.enabled", "enabled")
+
+    resolved = ConfigResolver((provider, DefaultProvider())).get(option)
+
+    assert resolved.value is False
+    assert resolved.ranks == (DEFAULT_RANK,)
+    assert resolved.provider_status[USER_RANK].health is health
+
+
 def test_failed_toml_reload_keeps_the_last_usable_snapshot(tmp_path: Path) -> None:
     """A corrupt re-read must not replace the values still being enforced.
 

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -771,3 +771,30 @@ def test_a_pathless_provider_does_not_read_the_working_directory(
         resolver.provider_statuses()[MANAGED_RANK].health
         is ProviderHealth.INDETERMINATE
     )
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [(EnvProvider(), False), (DefaultProvider(), True)],
+)
+def test_stateless_provider_durability_cannot_be_overridden(
+    provider: ConfigProvider,
+    *,
+    expected: bool,
+) -> None:
+    """Durability decides masking, so the attribute must not be able to lie.
+
+    Both providers delegate to helpers that stamp a hardcoded durability onto
+    every result. While `durable` was a settable field, passing the opposite
+    value type-checked and changed nothing.
+    """
+    option = get_option("startup.mode")
+    assert option is not None
+
+    assert provider.durable is expected
+    assert provider.get(option).durable is expected
+    # Built dynamically so the type checker does not reject the call before
+    # the test can prove the constructor does.
+    overridden: dict[str, Any] = {"durable": not expected}
+    with pytest.raises((TypeError, AttributeError)):
+        type(provider)(**overridden)

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -362,6 +362,76 @@ def test_resolve_all_uses_one_toml_snapshot(
     assert after["test.second"].value is True
 
 
+def test_failed_toml_reload_keeps_the_last_usable_snapshot(tmp_path: Path) -> None:
+    """A corrupt re-read must not replace the values still being enforced.
+
+    An unusable candidate carries an empty table, which resolution reads as
+    "this source declares nothing"; installing it on reload would drop the
+    file's values and let lower ranks win.
+    """
+    path = tmp_path / "managed_config.toml"
+    path.write_text("[test]\nenabled = true\n", encoding="utf-8")
+    provider = TomlFileProvider("managed config", path, MANAGED_RANK)
+    option = _bool_option("test.enabled", "enabled")
+    assert provider.get(option).result == Found(True)
+
+    path.write_text("not toml [", encoding="utf-8")
+    provider.reload()
+
+    assert provider.get(option).result == Found(True)
+    status = provider.status()
+    assert status.health is ProviderHealth.CORRUPT
+
+    path.write_text("[test]\nenabled = false\n", encoding="utf-8")
+    provider.reload()
+
+    assert provider.get(option).result == Found(False)
+    assert provider.status().health is ProviderHealth.OK
+
+
+def test_failed_reload_keeps_managed_policy_enforced(tmp_path: Path) -> None:
+    """A failed managed reload through the resolver must not fail open.
+
+    Regression: `get_managed_snapshot(refresh=True)` returns the failed
+    candidate for diagnostics, and `reload` installed it, so the managed tier
+    read as unset and the user tier won until the file was repaired.
+    """
+    managed_path = tmp_path / "managed_config.toml"
+    user_path = tmp_path / "config.toml"
+    managed_path.write_text("[test]\nenabled = false\n", encoding="utf-8")
+    user_path.write_text("[test]\nenabled = true\n", encoding="utf-8")
+    managed = TomlFileProvider(
+        "managed config",
+        managed_path,
+        MANAGED_RANK,
+        True,
+        loader=lambda: TomlFileProvider("managed config", managed_path).load(),
+    )
+    user = TomlFileProvider(
+        "config.toml",
+        user_path,
+        USER_RANK,
+        True,
+        loader=lambda: TomlFileProvider("config.toml", user_path).load(),
+    )
+    resolver = ConfigResolver((managed, user))
+    option = _bool_option("test.enabled", "enabled")
+    assert resolver.get(option).value is False
+
+    managed_path.write_text("not toml [", encoding="utf-8")
+    resolver.reload()
+
+    resolved = resolver.get(option)
+    assert resolved.value is False
+    assert resolved.provider_status[MANAGED_RANK].health is ProviderHealth.OK
+    assert resolver.provider_statuses()[MANAGED_RANK].health is ProviderHealth.CORRUPT
+
+    managed_path.write_text("[test]\nenabled = false\n", encoding="utf-8")
+    resolver.reload()
+
+    assert resolver.provider_statuses()[MANAGED_RANK].health is ProviderHealth.OK
+
+
 def test_resolver_get_matches_resolve_scalar_for_every_manifest_option() -> None:
     """The compatibility wrapper and provider resolver remain equivalent."""
     managed = TomlSnapshot(

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -798,3 +798,67 @@ def test_stateless_provider_durability_cannot_be_overridden(
     overridden: dict[str, Any] = {"durable": not expected}
     with pytest.raises((TypeError, AttributeError)):
         type(provider)(**overridden)
+
+
+def test_a_failed_reload_warns_that_the_edit_did_not_take_effect(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Retaining the last good generation must not be silent.
+
+    Resolution keeps returning the previous values, so nothing looks wrong -
+    while the edit the user just saved is not in effect and the file on disk no
+    longer describes what the process enforces.
+    """
+    from deepagents_code.config_manifest import _emit_ranked_diagnostics
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[startup]\nmode = "manual"\n', encoding="utf-8")
+    provider = TomlFileProvider("config.toml", config_path)
+    resolver = ConfigResolver((provider, DefaultProvider()))
+    option = get_option("startup.mode")
+    assert option is not None
+    assert resolver.get(option).value == "manual"
+
+    config_path.write_text("[startup\n", encoding="utf-8")
+    resolver.reload()
+
+    with caplog.at_level("WARNING"):
+        resolved = resolver.get(option)
+        _emit_ranked_diagnostics(option, resolved)
+
+    assert resolved.value == "manual"
+    assert any("still applying" in record.message for record in caplog.records)
+    assert any("CORRUPT" in record.message for record in caplog.records)
+
+
+def test_doctor_reports_a_corrupt_user_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command a user runs when settings do not apply must say the file broke."""
+    from deepagents_code import doctor, model_config
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("[shell\n", encoding="utf-8")
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+
+    item = doctor._user_config_diagnostic()
+
+    assert not item.ok
+    assert "corrupt" in item.value.lower()
+
+
+def test_doctor_is_green_for_a_config_that_parses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A healthy or absent file must not be reported as a problem."""
+    from deepagents_code import doctor, model_config
+
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+    assert doctor._user_config_diagnostic().ok
+
+    config_path.write_text('[startup]\nmode = "manual"\n', encoding="utf-8")
+    assert doctor._user_config_diagnostic().ok

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -635,3 +635,106 @@ def test_healthy_source_emits_no_rejection_warning(
     assert not [
         record for record in caplog.records if "using defaults" in record.message
     ]
+
+
+def test_default_path_write_is_visible_to_the_shared_resolver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A committed settings write must not leave the process serving stale values."""
+    from deepagents_code import model_config
+    from deepagents_code.configuration import (
+        resolver as resolver_module,
+        service,
+        writer,
+    )
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[startup]\nmode = "manual"\n', encoding="utf-8")
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+    monkeypatch.setattr(
+        service,
+        "get_managed_snapshot",
+        lambda refresh=False: TomlSnapshot(  # noqa: ARG005
+            {},
+            ProviderStatus("managed config", None, ProviderHealth.MISSING),
+        ),
+    )
+    service.invalidate_config_sources()
+    try:
+        option = get_option("startup.mode")
+        assert option is not None
+        assert resolver_module.get_config_resolver().get(option).value == "manual"
+
+        def set_auto(data: dict[str, Any]) -> bool:
+            data.setdefault("startup", {})["mode"] = "auto"
+            return True
+
+        assert writer.update_user_config(set_auto, config_path=config_path).ok
+        assert resolver_module.get_config_resolver().get(option).value == "auto"
+    finally:
+        service.invalidate_config_sources()
+
+
+def test_write_to_an_override_path_leaves_the_default_resolver_alone(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An override write must not re-read the real user and managed configs.
+
+    `get_config_resolver` is keyed on `DEFAULT_CONFIG_PATH`, so reloading it
+    after a write elsewhere touches files the caller never named - live reads
+    from a test that deliberately passed a `tmp_path`.
+    """
+    from deepagents_code import model_config
+    from deepagents_code.configuration import resolver as resolver_module, writer
+
+    default_path = tmp_path / "default.toml"
+    other_path = tmp_path / "other.toml"
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", default_path)
+    calls: list[int] = []
+
+    def record(**_: object) -> ConfigResolver:
+        calls.append(1)
+        msg = "the shared resolver must not be built for an override write"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(resolver_module, "get_config_resolver", record)
+
+    def set_auto(data: dict[str, Any]) -> bool:
+        data.setdefault("startup", {})["mode"] = "auto"
+        return True
+
+    assert writer.update_user_config(set_auto, config_path=other_path).ok
+    assert calls == []
+
+
+def test_a_failed_resolver_refresh_does_not_fail_a_landed_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The bytes are already on disk; reporting failure sends the user to retry."""
+    from deepagents_code import model_config
+    from deepagents_code.configuration import resolver as resolver_module, writer
+
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+
+    def explode(**_: object) -> ConfigResolver:
+        msg = "disk went away"
+        raise OSError(msg)
+
+    monkeypatch.setattr(resolver_module, "get_config_resolver", explode)
+
+    def set_auto(data: dict[str, Any]) -> bool:
+        data.setdefault("startup", {})["mode"] = "auto"
+        return True
+
+    with caplog.at_level("WARNING"):
+        result = writer.update_user_config(set_auto, config_path=config_path)
+
+    assert result.ok
+    assert result.changed
+    assert 'mode = "auto"' in config_path.read_text(encoding="utf-8")
+    assert any("could not refresh" in record.message for record in caplog.records)

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -1,5 +1,8 @@
 """Unit tests for ranked config precedence and durable masking."""
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -517,3 +520,41 @@ def test_resolver_get_matches_resolve_scalar_for_every_manifest_option() -> None
             actual.provider_status[rank].name for rank in actual.ranks
         )
         assert (actual.value, actual_source) == (value, source), option.key
+
+
+def test_settings_from_environment_does_not_import_textual(tmp_path: Path) -> None:
+    """Building `Settings` must not drag the theme registry onto the hot path.
+
+    `resolve_all()` would resolve `display.theme`, whose `THEME_DELEGATE`
+    coercion reaches the theme registry and imports Textual (~470ms). The four
+    CLI entry points in `skills/commands.py` build `Settings` without drawing
+    a UI, so they must not pay for it.
+    """
+    home = tmp_path / "home"
+    (home / ".deepagents").mkdir(parents=True)
+    (home / ".deepagents" / "config.toml").write_text(
+        '[ui]\ntheme = "monokai"\n',
+        encoding="utf-8",
+    )
+    env: dict[str, str] = os.environ.copy()
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    env.pop("DEEPAGENTS_CODE_THEME", None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys\n"
+                "from deepagents_code.config import Settings\n"
+                "Settings.from_environment()\n"
+                "assert 'textual' not in sys.modules, 'Textual reached the "
+                "startup path'\n"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -29,6 +29,7 @@ from deepagents_code.configuration.resolver import (
     USER_RANK,
     ConfigResolver,
     RankedProviderValue,
+    ResolvedValue,
     resolve_ranked,
     resolver_from_snapshots,
 )
@@ -990,3 +991,56 @@ def test_invalidate_config_sources_also_drops_the_resolver(
         assert resolver_module.get_config_resolver().get(option).value == "auto"
     finally:
         service.invalidate_config_sources()
+
+
+def test_resolved_value_rejects_a_selected_rank_with_no_provider_status() -> None:
+    """`_ranked_source` indexes `provider_status` by every selected rank.
+
+    An instance whose halves disagree is a `KeyError` in the source column of
+    user-facing `config` output, so it must not be constructible.
+    """
+    with pytest.raises(ValueError, match="no provider status"):
+        ResolvedValue(
+            "value",
+            {USER_RANK: frozenset({()})},
+            {},
+            {},
+            frozenset(),
+            (USER_RANK,),
+        )
+
+
+def test_resolved_value_rejects_a_rank_that_is_both_selected_and_masked() -> None:
+    """A tier cannot have won and been hidden by a stronger durable tier."""
+    status = ProviderStatus("config.toml", None, ProviderHealth.OK)
+    with pytest.raises(ValueError, match="both selected and masked"):
+        ResolvedValue(
+            "value",
+            {USER_RANK: frozenset({()})},
+            {USER_RANK: Found("value")},
+            {USER_RANK: status},
+            frozenset({USER_RANK}),
+            (USER_RANK,),
+        )
+
+
+def test_resolved_value_does_not_alias_the_mappings_it_was_given() -> None:
+    """`frozen=True` protects the bindings, not the contents."""
+    status = ProviderStatus("config.toml", None, ProviderHealth.OK)
+    provider_status = {USER_RANK: status}
+    resolved = ResolvedValue(
+        "value",
+        {USER_RANK: frozenset({()})},
+        {USER_RANK: Found("value")},
+        provider_status,
+        frozenset(),
+        (USER_RANK,),
+    )
+
+    provider_status[MANAGED_RANK] = ProviderStatus(
+        "managed config",
+        None,
+        ProviderHealth.OK,
+    )
+
+    assert set(resolved.provider_status) == {USER_RANK}

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -558,3 +558,80 @@ def test_settings_from_environment_does_not_import_textual(tmp_path: Path) -> No
         env=env,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_corrupt_user_toml_warns_instead_of_defaulting_silently(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A file the reader rejected must not look like a file that says nothing.
+
+    An unusable source coerces to `Unset` for every option, which resolution
+    reads as "declares nothing". Without a diagnostic the user's typo silently
+    replaces their `shell.allow_list` with the manifest default.
+    """
+    from deepagents_code.config_manifest import _emit_ranked_diagnostics
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("[shell\nallow_list = []\n", encoding="utf-8")
+    provider = TomlFileProvider("config.toml", config_path)
+    resolver = ConfigResolver((provider, DefaultProvider()))
+    option = get_option("shell.allow_list")
+    assert option is not None
+
+    resolved = resolver.get(option)
+    assert resolved.ranks == (DEFAULT_RANK,)
+
+    with caplog.at_level("WARNING"):
+        _emit_ranked_diagnostics(option, resolved)
+
+    assert any("config.toml" in record.message for record in caplog.records)
+    assert any("CORRUPT" in record.message for record in caplog.records)
+
+
+def test_unusable_source_warning_is_emitted_once_per_process(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The rejection belongs to the file, not to each of its hundred options."""
+    from deepagents_code.config_manifest import _emit_ranked_diagnostics
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("[shell\n", encoding="utf-8")
+    resolver = ConfigResolver(
+        (TomlFileProvider("config.toml", config_path), DefaultProvider())
+    )
+
+    with caplog.at_level("WARNING"):
+        for option in get_config_options():
+            _emit_ranked_diagnostics(option, resolver.get(option))
+
+    rejections = [
+        record for record in caplog.records if "using defaults" in record.message
+    ]
+    assert len(rejections) == 1
+
+
+def test_healthy_source_emits_no_rejection_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A file that parses must stay quiet."""
+    from deepagents_code.config_manifest import _emit_ranked_diagnostics
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[shell]\nallow_list = ["ls"]\n', encoding="utf-8")
+    resolver = ConfigResolver(
+        (TomlFileProvider("config.toml", config_path), DefaultProvider())
+    )
+    option = get_option("shell.allow_list")
+    assert option is not None
+
+    with caplog.at_level("WARNING"):
+        resolved = resolver.get(option)
+        _emit_ranked_diagnostics(option, resolved)
+
+    assert resolved.value == ["ls"]
+    assert not [
+        record for record in caplog.records if "using defaults" in record.message
+    ]

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -738,3 +738,36 @@ def test_a_failed_resolver_refresh_does_not_fail_a_landed_write(
     assert result.changed
     assert 'mode = "auto"' in config_path.read_text(encoding="utf-8")
     assert any("could not refresh" in record.message for record in caplog.records)
+
+
+def test_a_pathless_provider_does_not_read_the_working_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A snapshot with no known origin must not be reloaded from a guessed path.
+
+    `resolver_from_snapshots` used to substitute a bare relative filename, so
+    reloading a diagnostic resolver would read `./managed_config.toml` from
+    whatever directory the process was launched in and enforce it as policy.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "managed_config.toml").write_text(
+        '[startup]\nmode = "auto"\n',
+        encoding="utf-8",
+    )
+    managed = TomlSnapshot(
+        {},
+        ProviderStatus("managed config", None, ProviderHealth.MISSING),
+    )
+    user = TomlSnapshot({}, ProviderStatus("config.toml", None, ProviderHealth.MISSING))
+    resolver = resolver_from_snapshots(managed, user)
+    option = get_option("startup.mode")
+    assert option is not None
+
+    resolver.reload()
+
+    assert resolver.get(option).ranks == (DEFAULT_RANK,)
+    assert (
+        resolver.provider_statuses()[MANAGED_RANK].health
+        is ProviderHealth.INDETERMINATE
+    )

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -9,6 +9,7 @@ from deepagents_code.config_manifest import (
     ConfigOption,
     OptionKind,
     get_config_options,
+    get_option,
     resolve_scalar,
 )
 from deepagents_code.configuration.provider import ConfigProvider
@@ -430,6 +431,41 @@ def test_failed_reload_keeps_managed_policy_enforced(tmp_path: Path) -> None:
     resolver.reload()
 
     assert resolver.provider_statuses()[MANAGED_RANK].health is ProviderHealth.OK
+
+
+def test_rejected_managed_reload_keeps_last_enforceable_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parseable policy violation must not replace managed resolution."""
+    from deepagents_code import model_config
+    from deepagents_code.configuration import resolver as resolver_module, service
+    from unit_tests.conftest import redirect_managed_config
+
+    managed_path = tmp_path / "managed_config.toml"
+    user_path = tmp_path / "config.toml"
+    managed_path.write_text('[startup]\nmode = "manual"\n', encoding="utf-8")
+    user_path.write_text('[startup]\nmode = "yolo"\n', encoding="utf-8")
+    redirect_managed_config(monkeypatch, managed_path)
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", user_path)
+    monkeypatch.setattr(
+        resolver_module,
+        "_resolver_cache",
+        resolver_module._ResolverCache(),
+    )
+    service.invalidate_config_sources()
+    try:
+        resolver = resolver_module.get_config_resolver()
+        option = get_option("startup.mode")
+        assert option is not None
+        assert resolver.get(option).value == "manual"
+
+        managed_path.write_text("startup.mode = 5\n", encoding="utf-8")
+        resolver.reload()
+
+        assert resolver.get(option).value == "manual"
+    finally:
+        service.invalidate_config_sources()
 
 
 def test_resolver_get_matches_resolve_scalar_for_every_manifest_option() -> None:

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -496,14 +496,57 @@ def test_rejected_managed_reload_keeps_last_enforceable_snapshot(
         service.invalidate_config_sources()
 
 
-def test_resolver_get_matches_resolve_scalar_for_every_manifest_option() -> None:
-    """The compatibility wrapper and provider resolver remain equivalent."""
+@pytest.mark.parametrize(
+    ("managed_data", "user_data"),
+    [
+        pytest.param({}, {}, id="both-empty"),
+        pytest.param(
+            {},
+            {
+                "interpreter": {"memory_limit_mb": 256, "enable_interpreter": True},
+                "shell": {"allow_list": ["ls", "cat"]},
+                "startup": {"mode": "auto"},
+                "ui": {"theme": "monokai"},
+                "mcp": {"disabled_servers": ["alpha"]},
+                "threads": {"columns": {"title": {"width": 20}}},
+            },
+            id="user-populated",
+        ),
+        pytest.param(
+            {
+                "interpreter": {"memory_limit_mb": 64},
+                "shell": {"allow_list": ["git"]},
+                "startup": {"mode": "manual"},
+                "mcp": {"disabled_servers": ["alpha"]},
+                "threads": {"columns": {"title": {"width": 10}}},
+            },
+            {
+                "interpreter": {"memory_limit_mb": 256},
+                "shell": {"allow_list": ["ls"]},
+                "startup": {"mode": "auto"},
+                "mcp": {"disabled_servers": ["beta"]},
+                "threads": {"columns": {"summary": {"width": 30}}},
+            },
+            id="both-populated-managed-wins",
+        ),
+    ],
+)
+def test_resolver_get_matches_resolve_scalar_for_every_manifest_option(
+    managed_data: dict[str, Any],
+    user_data: dict[str, Any],
+) -> None:
+    """The compatibility wrapper and provider resolver remain equivalent.
+
+    Parametrized with populated tiers on purpose. With both tables empty every
+    option takes the default path, so the union, deep-merge, and durable-mask
+    surfaces - the ones this extraction could actually regress - never run.
+    """
     managed = TomlSnapshot(
-        {},
+        managed_data,
         ProviderStatus("managed config", None, ProviderHealth.OK),
     )
     user = TomlSnapshot(
-        {},
+        user_data,
         ProviderStatus("config.toml", None, ProviderHealth.OK),
     )
     resolver = resolver_from_snapshots(managed, user)
@@ -520,6 +563,50 @@ def test_resolver_get_matches_resolve_scalar_for_every_manifest_option() -> None
             actual.provider_status[rank].name for rank in actual.ranks
         )
         assert (actual.value, actual_source) == (value, source), option.key
+
+
+def test_populated_tiers_actually_reach_the_resolver() -> None:
+    """Guard the oracle above: its fixtures must not all resolve to defaults.
+
+    The equivalence test compares two paths that now share `_resolve`, so it
+    can only catch a regression in the layers above it - and only for options
+    the fixtures actually populate. If these keys ever stop being read, the
+    parametrization silently degrades back to a default-only sweep.
+    """
+    managed = TomlSnapshot(
+        {
+            "startup": {"mode": "manual"},
+            "mcp": {"disabled_servers": ["alpha"]},
+            "threads": {"columns": {"title": {"width": 10}}},
+        },
+        ProviderStatus("managed config", None, ProviderHealth.OK),
+    )
+    user = TomlSnapshot(
+        {
+            "startup": {"mode": "auto"},
+            "mcp": {"disabled_servers": ["beta"]},
+            "threads": {"columns": {"summary": {"width": 30}}},
+        },
+        ProviderStatus("config.toml", None, ProviderHealth.OK),
+    )
+    resolved = resolver_from_snapshots(managed, user).resolve_all()
+
+    startup = resolved["startup.mode"]
+    assert startup.value == "manual"
+    assert startup.ranks == (MANAGED_RANK,)
+
+    # A deny-list union keeps every tier's contribution rather than letting the
+    # stronger rank replace the weaker one.
+    disabled = resolved["mcp.disabled_servers"]
+    assert set(disabled.ranks) == {MANAGED_RANK, USER_RANK}
+    assert isinstance(disabled.value, list)
+    assert set(disabled.value) == {"alpha", "beta"}
+
+    # A deep merge composes sibling leaves from both tiers.
+    columns = resolved["threads.columns"]
+    assert set(columns.ranks) == {MANAGED_RANK, USER_RANK}
+    assert isinstance(columns.value, dict)
+    assert set(columns.value) == {"title", "summary"}
 
 
 def test_settings_from_environment_does_not_import_textual(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -1,16 +1,32 @@
 """Unit tests for ranked config precedence and durable masking."""
 
+from pathlib import Path
 from typing import Any
 
 import pytest
 
+from deepagents_code.config_manifest import (
+    ConfigOption,
+    OptionKind,
+    get_config_options,
+    resolve_scalar,
+)
+from deepagents_code.configuration.provider import ConfigProvider
+from deepagents_code.configuration.providers import (
+    DefaultProvider,
+    EnvProvider,
+    TomlFileProvider,
+)
 from deepagents_code.configuration.resolver import (
     CLI_RANK,
+    DEFAULT_RANK,
     ENVIRONMENT_RANK,
     MANAGED_RANK,
     USER_RANK,
+    ConfigResolver,
     RankedProviderValue,
     resolve_ranked,
+    resolver_from_snapshots,
 )
 from deepagents_code.configuration.types import (
     Found,
@@ -18,6 +34,7 @@ from deepagents_code.configuration.types import (
     ProviderHealth,
     ProviderResult,
     ProviderStatus,
+    TomlSnapshot,
     Unset,
 )
 
@@ -213,3 +230,159 @@ def test_duplicate_provider_ranks_are_rejected() -> None:
 
     with pytest.raises(ValueError, match="unique ranks"):
         resolve_ranked(providers)
+
+
+class _TrackingProvider:
+    """Synthetic protocol implementation with observable calls."""
+
+    durable = True
+
+    def __init__(
+        self,
+        rank: int,
+        result: ProviderResult[Any],
+        calls: list[int] | None = None,
+    ) -> None:
+        """Store a fixed result and optional shared call log."""
+        self.name = f"rank {rank}"
+        self.rank = rank
+        self.result = result
+        self.calls = calls if calls is not None else []
+        self.reloads = 0
+
+    def get(self, option: ConfigOption) -> RankedProviderValue[object]:
+        """Return the fixed result and record provider order."""
+        del option
+        self.calls.append(self.rank)
+        return RankedProviderValue(
+            self.rank,
+            self.durable,
+            self.status(),
+            self.result,
+        )
+
+    def status(self) -> ProviderStatus:
+        """Return synthetic healthy status."""
+        return ProviderStatus(self.name, None, ProviderHealth.OK)
+
+    def reload(self) -> None:
+        """Record one propagated reload."""
+        self.reloads += 1
+
+
+def _bool_option(key: str, toml_key: str) -> ConfigOption:
+    """Build a synthetic boolean manifest option."""
+    return ConfigOption(
+        key=key,
+        group="Test",
+        summary="test option",
+        kind=OptionKind.BOOL,
+        default=False,
+        toml_keys=("test", toml_key),
+    )
+
+
+def test_concrete_providers_implement_protocol(tmp_path: Path) -> None:
+    """Every built-in source satisfies the structural provider contract."""
+    providers = (
+        TomlFileProvider("config.toml", tmp_path / "config.toml"),
+        EnvProvider(),
+        DefaultProvider(),
+    )
+
+    assert all(isinstance(provider, ConfigProvider) for provider in providers)
+    assert all(callable(provider.get) for provider in providers)
+    assert all(callable(provider.status) for provider in providers)
+    assert all(callable(provider.reload) for provider in providers)
+
+
+def test_config_resolver_sorts_providers_by_rank() -> None:
+    """Provider invocation and status mappings follow numeric precedence."""
+    calls: list[int] = []
+    user = _TrackingProvider(USER_RANK, Found("user"), calls)
+    managed = _TrackingProvider(MANAGED_RANK, Found("managed"), calls)
+    resolver = ConfigResolver((user, managed))
+
+    resolved = resolver.get(_bool_option("test.enabled", "enabled"))
+
+    assert resolved.value == "managed"
+    assert calls == [MANAGED_RANK, USER_RANK]
+    assert tuple(resolver.provider_statuses()) == (MANAGED_RANK, USER_RANK)
+
+
+def test_config_resolver_rejects_duplicate_provider_ranks() -> None:
+    """A colliding rank cannot overwrite provider health or provenance."""
+    with pytest.raises(ValueError, match="unique ranks"):
+        ConfigResolver(
+            (
+                _TrackingProvider(USER_RANK, Found("first")),
+                _TrackingProvider(USER_RANK, Found("second")),
+            )
+        )
+
+
+def test_config_resolver_reload_propagates_to_every_provider() -> None:
+    """Reload reaches every provider in precedence order."""
+    first = _TrackingProvider(MANAGED_RANK, Unset())
+    second = _TrackingProvider(DEFAULT_RANK, Found(False))
+    resolver = ConfigResolver((second, first))
+
+    resolver.reload()
+
+    assert first.reloads == 1
+    assert second.reloads == 1
+
+
+def test_resolve_all_uses_one_toml_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A full-manifest read cannot mix file generations."""
+    from deepagents_code import config_manifest
+
+    path = tmp_path / "config.toml"
+    path.write_text("[test]\nfirst = true\nsecond = false\n", encoding="utf-8")
+    user = TomlFileProvider("config.toml", path)
+    assert user.status().health is ProviderHealth.OK
+    path.write_text("[test]\nfirst = false\nsecond = true\n", encoding="utf-8")
+    options = (
+        _bool_option("test.first", "first"),
+        _bool_option("test.second", "second"),
+    )
+    monkeypatch.setattr(config_manifest, "get_config_options", lambda: options)
+    resolver = ConfigResolver((user, DefaultProvider()))
+
+    before = resolver.resolve_all()
+    resolver.reload()
+    after = resolver.resolve_all()
+
+    assert before["test.first"].value is True
+    assert before["test.second"].value is False
+    assert after["test.first"].value is False
+    assert after["test.second"].value is True
+
+
+def test_resolver_get_matches_resolve_scalar_for_every_manifest_option() -> None:
+    """The compatibility wrapper and provider resolver remain equivalent."""
+    managed = TomlSnapshot(
+        {},
+        ProviderStatus("managed config", None, ProviderHealth.OK),
+    )
+    user = TomlSnapshot(
+        {},
+        ProviderStatus("config.toml", None, ProviderHealth.OK),
+    )
+    resolver = resolver_from_snapshots(managed, user)
+    resolved = resolver.resolve_all()
+
+    for option in get_config_options():
+        value, source = resolve_scalar(
+            option,
+            toml_data=user.data,
+            managed_toml_data=managed.data,
+        )
+        actual = resolved[option.key]
+        actual_source = " + ".join(
+            actual.provider_status[rank].name for rank in actual.ranks
+        )
+        assert (actual.value, actual_source) == (value, source), option.key


### PR DESCRIPTION
Migrates dcode configuration to ranked `ConfigProvider` implementations behind a shared `ConfigResolver`, preserving compatibility while enabling atomic full-manifest reads and reloadable provider state.

Made by [Open SWE](https://openswe.vercel.app/agents/a397e999-1ab8-535f-8763-1e038a25845c)