### PR TITLE
feat(code): add `editable` trace metadata

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2050,6 +2050,9 @@ def build_stream_config(
     `lc_versions["deepagents"]`; for sibling monorepo packages that suffix
     identifies workspace HEAD relative to the pinned published SDK baseline.
 
+    Also records `editable` as an always-present boolean so editable dcode installs
+    can be filtered without parsing the `lc_versions["deepagents-code"]` suffix.
+
     Also records `dcode_experimental=True` when `DEEPAGENTS_CODE_EXPERIMENTAL`
     is enabled, so experimental runs are filterable in trace metadata.
 
@@ -2120,10 +2123,10 @@ def build_stream_config(
 
     # Legacy / diagnostic keys preserved for backward-compatibility during the
     # coding-agent-v1 rollout (not part of the contract).
+    editable = _is_editable_install()
+    metadata["editable"] = editable
     metadata["lc_versions"] = {
-        "deepagents-code": _format_lc_version(
-            __version__, editable=_is_editable_install()
-        )
+        "deepagents-code": _format_lc_version(__version__, editable=editable)
     }
     deepagents_version = _get_deepagents_version()
     if deepagents_version is not None:

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -1212,6 +1212,7 @@ class TestBuildStreamConfig:
             patch("deepagents_code.config._get_deepagents_version", return_value=None),
         ):
             config = build_stream_config("t-ver", assistant_id=None)
+        assert config["metadata"]["editable"] is False
         assert config["metadata"]["lc_versions"] == {"deepagents-code": __version__}
 
     def test_versions_marks_editable_cli_version(self) -> None:
@@ -1223,6 +1224,7 @@ class TestBuildStreamConfig:
             patch("deepagents_code.config._get_deepagents_version", return_value=None),
         ):
             config = build_stream_config("t-editable", assistant_id=None)
+        assert config["metadata"]["editable"] is True
         assert config["metadata"]["lc_versions"] == {
             "deepagents-code": f"{__version__}+editable"
         }


### PR DESCRIPTION
Deep Agents Code traces now expose whether the client is an editable install as a filterable boolean.

---

Trace consumers currently must parse `lc_versions["deepagents-code"]` for a `+editable` suffix. `build_stream_config` now emits an always-present `editable` boolean derived from the same cached PEP 610 lookup, keeping both values consistent.

Made by [Open SWE](https://openswe.vercel.app/agents/6e666be6-44be-5afd-abb0-945fac4d7912)