### PR TITLE
docs(repo): add Corridor agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This file contains repository-wide rules for agents and contributors. Use these 
 
 ## Corridor security analysis
 
-Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+When Corridor's `analyzePlan` tool is available, create a plan and use the tool to analyze it before generating or modifying code. Apply the resulting security guidance before writing code.
 
 </corridor>
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,14 @@ This file contains repository-wide rules for agents and contributors. Use these 
 - [`.github/RELEASING.md`](.github/RELEASING.md) — releases, version lines, fan-out, CI labels, and troubleshooting.
 - [LangChain contributing guide](https://docs.langchain.com/oss/python/contributing/overview) — general contribution policy.
 
+<corridor>
+
+## Corridor security analysis
+
+Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+
+</corridor>
+
 ## Development workflow
 
 Work inside the package you are changing; [`libs/DEVELOPMENT.md`](libs/DEVELOPMENT.md) covers environment setup (`uv`, `make`) and the edit-test-lint loop.


### PR DESCRIPTION
Add a repository-wide `<corridor>` block to `AGENTS.md` requiring agents to plan first and run Corridor `analyzePlan` before generating or modifying code.

The tags are explicit and balanced so Corridor-specific guidance remains scoped.

---

Validation: `git diff --check` and a tag-balance assertion.