### PR TITLE
fix(sdk): move client lookup inside try in `acheck_async_task` and `acancel_async_task`

### DIFF
--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -442,10 +442,10 @@ def _build_check_tool(  # noqa: C901  # complexity from necessary error handling
         if isinstance(task, str):
             return task
 
-        client = clients.get_async(task["agent_name"])
         try:
+            client = clients.get_async(task["agent_name"])
             run = await client.runs.get(thread_id=task["thread_id"], run_id=task["run_id"])
-        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        except Exception as e:  # noqa: BLE001  # get_async() may raise ValueError; SDK raises untyped errors
             return f"Failed to get run status: {e}"
 
         thread_values: dict[str, Any] = {}
@@ -622,10 +622,10 @@ def _build_cancel_tool(
         if isinstance(tracked, str):
             return tracked
 
-        client = clients.get_async(tracked["agent_name"])
         try:
+            client = clients.get_async(tracked["agent_name"])
             await client.runs.cancel(thread_id=tracked["thread_id"], run_id=tracked["run_id"])
-        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        except Exception as e:  # noqa: BLE001  # get_async() may raise ValueError; SDK raises untyped errors
             return f"Failed to cancel run: {e}"
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         updated = AsyncTask(

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -768,6 +768,38 @@ class TestCancelTool:
         assert "connection refused" in result
 
 
+class TestStaleAgentNameClientLookup:
+    """Regression test for a stale `agent_name` escaping as an unhandled `KeyError`.
+
+    A tracked task's `agent_name` may no longer be configured (the subagent was
+    renamed or removed). `_ClientCache.get_sync`/`get_async` raise `KeyError` in
+    that case; every tool entry point must turn it into an error string like any
+    other client-lookup failure, not let it escape. Covers the async entry points
+    of `check_async_task` and `cancel_async_task`.
+    """
+
+    @pytest.mark.parametrize(
+        ("tool_name", "entrypoint", "expected"),
+        [
+            ("check_async_task", "sync", "Failed to get run status: 'researcher'"),
+            ("check_async_task", "async", "Failed to get run status: 'researcher'"),
+            ("cancel_async_task", "sync", "Failed to cancel run: 'researcher'"),
+            ("cancel_async_task", "async", "Failed to cancel run: 'researcher'"),
+        ],
+    )
+    async def test_returns_error_string_instead_of_raising(self, tool_name: str, entrypoint: str, expected: str) -> None:
+        tools = _build_async_subagent_tools([_make_spec("worker")])
+        tool = _get_tool(tools, tool_name)
+        rt = _make_runtime_with_task(agent_name="researcher")
+
+        if entrypoint == "async":
+            result = await tool.coroutine(task_id="thread_abc", runtime=rt)
+        else:
+            result = tool.func(task_id="thread_abc", runtime=rt)
+
+        assert result == expected
+
+
 class TestUnknownTaskId:
     """Tests that check/update/cancel return error strings for unknown task IDs."""
 


### PR DESCRIPTION
Fixes #5640

`acheck_async_task` and `acancel_async_task` no longer crash with an unhandled `KeyError` when a checkpointed task references a subagent that was later renamed or removed; they now return the same error string as their sync counterparts, `check_async_task` and `cancel_async_task`.

---

`_ClientCache.get_async` looks up the async subagent's client via `self._agents[name]`, which raises `KeyError` if that agent is no longer configured. The sync tools already guard this lookup inside their `try` block (from a prior fix), but `acheck_async_task` and `acancel_async_task` called `clients.get_async(...)` before their `try`, so the same failure escaped unhandled instead of degrading to an error message like the sync path.

The fix moves the lookup inside the existing `try`, mirroring the sync implementation exactly, and updates the stale `except` comment to match. Added a parametrized regression test covering all four entry points (`check`/`cancel` x sync/async) with a stale `agent_name`, which fails on the two async cases without the fix and passes with it.