### PR TITLE
fix(code): warn and ignore `--auto-approve`/`--yolo` in headless mode

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -4527,6 +4527,13 @@ def cli_main() -> None:
 
     try:
         args = parse_args()
+        explicit_approval_flag = (
+            "--yolo"
+            if getattr(args, "yolo", False)
+            else "--auto-approve"
+            if getattr(args, "auto_approve", False)
+            else None
+        )
         allow_fs_tools = _parse_allow_fs_tools_flag(
             getattr(args, "allow_fs_tools", None)
         )
@@ -4774,16 +4781,13 @@ def cli_main() -> None:
         # predicate that selects the headless branch below), so this reliably
         # clears interactive approval flags on both the `-n` and piped-stdin
         # paths while leaving interactive launches untouched.
-        if (
-            args.auto_approve or getattr(args, "yolo", False)
-        ) and args.non_interactive_message:
+        if explicit_approval_flag is not None and args.non_interactive_message:
             from rich.console import Console as _Console
 
-            flag = "--yolo" if getattr(args, "yolo", False) else "--auto-approve"
             _Console(stderr=True).print(
-                f"[bold yellow]Warning:[/bold yellow] {flag} has no effect in "
-                "headless mode; ignoring it. Shell access is governed by "
-                "--shell-allow-list, and MCP routing is fail-closed."
+                f"[bold yellow]Warning:[/bold yellow] {explicit_approval_flag} has "
+                "no effect in headless mode; ignoring it. Shell access is "
+                "governed by --shell-allow-list, and MCP routing is fail-closed."
             )
             args.auto_approve = False
             args.yolo = False

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -4391,9 +4391,10 @@ def _apply_managed_runtime_policy(args: argparse.Namespace) -> None:
     if found:
         # Only *revoke*: `_resolve_approval_mode` ends at
         # `coerce_approval_mode(load_startup_mode())`, which already reads
-        # merged managed policy, so the positive value needs no flag. Setting
-        # the flags positively would also make every headless launch warn about
-        # and ignore a flag the user never passed.
+        # merged managed policy, so the positive value needs no flag. The
+        # headless warning keys off `explicit_approval_flag`, captured before
+        # this runs, so a positive value set here would not warn — but it would
+        # still misreport a user-supplied flag to every other reader of `args`.
         if startup_mode != "auto":
             args.auto_approve = False
         if startup_mode != "yolo":
@@ -4776,18 +4777,60 @@ def cli_main() -> None:
 
             warn_if_editable_deps_stale()
 
-        # Handled here, before mode dispatch and any heavy session setup:
-        # `apply_stdin_pipe` has finalized `non_interactive_message` (the same
-        # predicate that selects the headless branch below), so this reliably
-        # clears interactive approval flags on both the `-n` and piped-stdin
-        # paths while leaving interactive launches untouched.
+        # Checked *before* the approval-flag warning below, so a run that
+        # exits here does not first print a warning about `--auto-approve`
+        # being ignored — the exit is the outcome, and the warning would only
+        # add noise. Both flags are final by now: `args.sandbox` comes from
+        # `parse_args` and `apply_stdin_pipe` has settled
+        # `non_interactive_message`.
+        #
+        # Auto approval mode (and therefore its classifier) requires the
+        # interactive TUI *and* no sandbox — `agent.create_cli_agent` disables
+        # Auto for either. Accepting the flag in those runs would silently do
+        # nothing to a setting that governs action authorization.
+        if getattr(args, "auto_classifier_model", None) is not None and (
+            args.non_interactive_message or args.sandbox not in {"none", None}
+        ):
+            from rich.console import Console as _Console
+
+            unavailable_because = (
+                "a sandbox is in use"
+                if not args.non_interactive_message
+                else "it runs headlessly"
+            )
+            _Console(stderr=True).print(
+                "[bold red]Error:[/bold red] --auto-classifier-model is only "
+                "supported in the interactive TUI, where Auto approval mode "
+                f"runs; {unavailable_because}.\n"
+                "  dcode --auto-classifier-model anthropic:claude-haiku-4-5"
+            )
+            sys.exit(2)
+
+        # Cleared here, before mode dispatch reads the flags and before any
+        # session output could bury the warning: `apply_stdin_pipe` has
+        # finalized `non_interactive_message` (the same predicate that selects
+        # the headless branch below), so this reliably clears the flags on both
+        # the `-n` and piped-stdin paths while leaving interactive launches
+        # untouched. `explicit_approval_flag` was captured at parse time, so
+        # only a flag the user actually typed warns.
         if explicit_approval_flag is not None and args.non_interactive_message:
             from rich.console import Console as _Console
 
+            # `soft_wrap` keeps the message on one line. Rich otherwise hard
+            # wraps at width 80 off a TTY, and the break moves with the flag
+            # name — leaving no substring a CI job can grep for both spellings.
+            # With the pre-existing `sys.exit(2)` gone, this text is the only
+            # signal that the requested mode was dropped.
             _Console(stderr=True).print(
                 f"[bold yellow]Warning:[/bold yellow] {explicit_approval_flag} has "
                 "no effect in headless mode; ignoring it. Shell access is "
-                "governed by --shell-allow-list, and MCP routing is fail-closed."
+                "governed by --shell-allow-list, and MCP routing is fail-closed.",
+                soft_wrap=True,
+            )
+            logger.warning(
+                "%s ignored in headless mode; approval is derived from "
+                "--shell-allow-list.",
+                explicit_approval_flag,
             )
             args.auto_approve = False
             args.yolo = False
@@ -4907,28 +4950,6 @@ def cli_main() -> None:
                 "--rubric-max-iterations require "
                 "--non-interactive (-n) or piped stdin\n"
                 "  dcode -n 'implement X' --rubric 'tests pass'"
-            )
-            sys.exit(2)
-
-        # Auto approval mode (and therefore its classifier) requires the
-        # interactive TUI *and* no sandbox — `agent.create_cli_agent` disables
-        # Auto for either. Accepting the flag in those runs would silently do
-        # nothing to a setting that governs action authorization.
-        if getattr(args, "auto_classifier_model", None) is not None and (
-            args.non_interactive_message or args.sandbox not in {"none", None}
-        ):
-            from rich.console import Console as _Console
-
-            unavailable_because = (
-                "a sandbox is in use"
-                if not args.non_interactive_message
-                else "it runs headlessly"
-            )
-            _Console(stderr=True).print(
-                "[bold red]Error:[/bold red] --auto-classifier-model is only "
-                "supported in the interactive TUI, where Auto approval mode "
-                f"runs; {unavailable_because}.\n"
-                "  dcode --auto-classifier-model anthropic:claude-haiku-4-5"
             )
             sys.exit(2)
 

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2302,14 +2302,18 @@ def parse_args() -> argparse.Namespace:
         "--auto-approve",
         action="store_true",
         default=None,
-        help="Enable classifier-backed Auto mode in the local TUI or ACP server.",
+        help=(
+            "Enable classifier-backed Auto mode in the local TUI or ACP server; "
+            "ignored with a warning in headless mode."
+        ),
     )
     approval_group.add_argument(
         "--yolo",
         action="store_true",
         help=(
             "Run gated actions without review after the one-time local risk "
-            "acknowledgement (interactive TUI or ACP mode)."
+            "acknowledgement (interactive TUI or ACP mode); ignored with a "
+            "warning in headless mode."
         ),
     )
 
@@ -4388,9 +4392,8 @@ def _apply_managed_runtime_policy(args: argparse.Namespace) -> None:
         # Only *revoke*: `_resolve_approval_mode` ends at
         # `coerce_approval_mode(load_startup_mode())`, which already reads
         # merged managed policy, so the positive value needs no flag. Setting
-        # the flags positively also breaks every headless launch, because
-        # `--auto-approve` with `--non-interactive-message` exits 2 — naming a
-        # flag the user never passed.
+        # the flags positively would also make every headless launch warn about
+        # and ignore a flag the user never passed.
         if startup_mode != "auto":
             args.auto_approve = False
         if startup_mode != "yolo":
@@ -4766,11 +4769,11 @@ def cli_main() -> None:
 
             warn_if_editable_deps_stale()
 
-        # Validated here, before mode dispatch and any heavy session setup:
+        # Handled here, before mode dispatch and any heavy session setup:
         # `apply_stdin_pipe` has finalized `non_interactive_message` (the same
         # predicate that selects the headless branch below), so this reliably
-        # rejects `--auto-approve` on both the `-n` and piped-stdin paths while
-        # leaving interactive launches untouched.
+        # clears interactive approval flags on both the `-n` and piped-stdin
+        # paths while leaving interactive launches untouched.
         if (
             args.auto_approve or getattr(args, "yolo", False)
         ) and args.non_interactive_message:
@@ -4778,11 +4781,12 @@ def cli_main() -> None:
 
             flag = "--yolo" if getattr(args, "yolo", False) else "--auto-approve"
             _Console(stderr=True).print(
-                f"[bold red]Error:[/bold red] {flag} is only supported in "
-                "interactive mode. Headless mode uses fail-closed MCP routing and "
-                "--shell-allow-list for shell access."
+                f"[bold yellow]Warning:[/bold yellow] {flag} has no effect in "
+                "headless mode; ignoring it. Shell access is governed by "
+                "--shell-allow-list, and MCP routing is fail-closed."
             )
-            sys.exit(2)
+            args.auto_approve = False
+            args.yolo = False
 
         if getattr(args, "no_mcp", False) and getattr(args, "mcp_config", None):
             from rich.console import Console as _Console

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -4820,17 +4820,14 @@ def cli_main() -> None:
             # wraps at width 80 off a TTY, and the break moves with the flag
             # name — leaving no substring a CI job can grep for both spellings.
             # With the pre-existing `sys.exit(2)` gone, this text is the only
-            # signal that the requested mode was dropped.
+            # signal that the requested mode was dropped. Deliberately not also
+            # logged: with no handler configured, `logging.lastResort` would
+            # emit a WARNING to the same stderr and double the message.
             _Console(stderr=True).print(
                 f"[bold yellow]Warning:[/bold yellow] {explicit_approval_flag} has "
                 "no effect in headless mode; ignoring it. Shell access is "
                 "governed by --shell-allow-list, and MCP routing is fail-closed.",
                 soft_wrap=True,
-            )
-            logger.warning(
-                "%s ignored in headless mode; approval is derived from "
-                "--shell-allow-list.",
-                explicit_approval_flag,
             )
             args.auto_approve = False
             args.yolo = False

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -144,7 +144,10 @@ def show_help() -> None:
         "  --startup-cmd CMD          Shell command to run at startup, before first prompt"  # noqa: E501
     )
     console.print(
-        "  -y, --auto-approve         Enable classifier-backed Auto mode (TUI or ACP)"
+        "  -y, --auto-approve         Enable classifier-backed Auto mode (TUI or ACP);"
+    )
+    console.print(
+        "                             ignored with a warning in headless mode"
     )
     console.print("  --auto-classifier-model MODEL")
     console.print(
@@ -156,7 +159,10 @@ def show_help() -> None:
     )
     console.print(
         "  --yolo                     Run gated actions without review after "
-        "acknowledgement (TUI or ACP)"
+        "acknowledgement (TUI or ACP);"
+    )
+    console.print(
+        "                             ignored with a warning in headless mode"
     )
     console.print("  --sandbox TYPE             Remote sandbox for execution")
     console.print(

--- a/libs/code/tests/unit_tests/test_configuration.py
+++ b/libs/code/tests/unit_tests/test_configuration.py
@@ -1497,15 +1497,18 @@ def test_rejected_managed_privilege_value_stops_the_launch(
         service.invalidate_config_sources()
 
 
-def test_managed_auto_mode_does_not_set_the_headless_incompatible_flag(
+def test_managed_auto_mode_does_not_set_the_interactive_only_flag(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Managed policy revokes flags; it never sets `--auto-approve`.
 
-    Regression: assigning the flag positively made every headless launch warn
-    that `--auto-approve` was ignored, naming a flag the user never passed.
-    `_resolve_approval_mode` already ends at
+    Regression: assigning the flag positively made every headless launch exit 2
+    with "--auto-approve is only supported in interactive mode", naming a flag
+    the user never passed. That launch now warns and continues instead, and the
+    warning keys off a parse-time capture that a positive value here would not
+    reach — but the flag would still misreport user intent to every other
+    reader of `args`. `_resolve_approval_mode` already ends at
     `coerce_approval_mode(load_startup_mode())`, which reads merged managed
     policy, so the positive value needs no flag.
     """

--- a/libs/code/tests/unit_tests/test_configuration.py
+++ b/libs/code/tests/unit_tests/test_configuration.py
@@ -1503,9 +1503,9 @@ def test_managed_auto_mode_does_not_set_the_headless_incompatible_flag(
 ) -> None:
     """Managed policy revokes flags; it never sets `--auto-approve`.
 
-    Regression: assigning the flag positively made every headless launch exit 2
-    with "--auto-approve is only supported in interactive mode", naming a flag
-    the user never passed. `_resolve_approval_mode` already ends at
+    Regression: assigning the flag positively made every headless launch warn
+    that `--auto-approve` was ignored, naming a flag the user never passed.
+    `_resolve_approval_mode` already ends at
     `coerce_approval_mode(load_startup_mode())`, which reads merged managed
     policy, so the positive value needs no flag.
     """

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -257,27 +257,63 @@ class TestAutoApproveHeadlessValidation:
     """Tests that headless mode warns and clears interactive approval flags."""
 
     @pytest.mark.parametrize(
-        ("argv", "piped_stdin", "flag"),
+        ("argv", "piped_stdin", "flag", "managed_toml"),
         [
             (
                 ["deepagents", "-y", "-n", "do the thing"],
                 None,
                 "--auto-approve",
+                None,
             ),
-            (["deepagents", "--auto-approve"], "do the thing", "--auto-approve"),
-            (["deepagents", "--yolo", "-n", "task"], None, "--yolo"),
+            (
+                ["deepagents", "--auto-approve"],
+                "do the thing",
+                "--auto-approve",
+                None,
+            ),
+            (["deepagents", "--yolo", "-n", "task"], None, "--yolo", None),
+            (
+                ["deepagents", "--auto-approve", "-n", "task"],
+                None,
+                "--auto-approve",
+                '[startup]\nmode = "manual"\n',
+            ),
+            (
+                ["deepagents", "--yolo", "-n", "task"],
+                None,
+                "--yolo",
+                '[startup]\nmode = "manual"\n',
+            ),
         ],
-        ids=["explicit-headless", "piped-stdin", "yolo"],
+        ids=[
+            "explicit-headless",
+            "piped-stdin",
+            "yolo",
+            "managed-manual-auto-approve",
+            "managed-manual-yolo",
+        ],
     )
     def test_headless_mode_ignores_interactive_approval_flag_with_warning(
         self,
         capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
         argv: list[str],
         piped_stdin: str | None,
         flag: str,
+        managed_toml: str | None,
     ) -> None:
         """Headless mode ignores the interactive approval flag with a warning."""
         from deepagents_code.main import cli_main
+
+        if managed_toml is not None:
+            from deepagents_code.configuration import service
+            from unit_tests.conftest import redirect_managed_config
+
+            managed = tmp_path / "managed.toml"
+            managed.write_text(managed_toml, encoding="utf-8")
+            redirect_managed_config(monkeypatch, managed)
+            service.invalidate_config_sources()
 
         mock_stdin = MagicMock()
         mock_stdin.isatty.return_value = piped_stdin is None

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -253,8 +253,14 @@ class TestYoloAcknowledgement:
         assert console.print.called
 
 
-class TestAutoApproveHeadlessValidation:
-    """Tests that headless mode warns and clears interactive approval flags."""
+class TestHeadlessApprovalFlagHandling:
+    """Headless handling of the approval flags, which is deliberately split.
+
+    `--auto-approve`/`--yolo` are ignored with a warning, because the same
+    command line is commonly reused interactive and headless. Its dependent
+    `--auto-classifier-model` still exits 2 — it has no interactive-reuse case,
+    so a silent no-op there would only hide a typo. Both dispositions live here.
+    """
 
     @pytest.mark.parametrize(
         ("argv", "piped_stdin", "flag", "managed_toml"),
@@ -303,7 +309,18 @@ class TestAutoApproveHeadlessValidation:
         flag: str,
         managed_toml: str | None,
     ) -> None:
-        """Headless mode ignores the interactive approval flag with a warning."""
+        """The run must complete (exit 0), not abort as it did before.
+
+        `_resolve_interpreter_enabled` is patched as a probe, snapshotting the
+        flags *during* the call, so the assertion pins that they are cleared
+        before mode dispatch rather than merely by the time `cli_main` returns
+        (`call_args` holds a live reference to the mutated namespace, so a
+        post-dispatch clear would still look green).
+
+        The managed-policy cases cover the flag the user typed surviving
+        `_apply_managed_runtime_policy` revoking it: the warning keys off a
+        parse-time capture, so it must still fire.
+        """
         from deepagents_code.main import cli_main
 
         if managed_toml is not None:
@@ -318,11 +335,34 @@ class TestAutoApproveHeadlessValidation:
         mock_stdin = MagicMock()
         mock_stdin.isatty.return_value = piped_stdin is None
         mock_stdin.read.return_value = piped_stdin
-        resolve_interpreter = MagicMock(return_value=False)
+        seen: dict[str, object] = {}
+        resolve_interpreter = MagicMock(
+            side_effect=lambda ns: (
+                seen.update(auto_approve=ns.auto_approve, yolo=ns.yolo) or False
+            )
+        )
+        # Scoped to `/dev/tty`: a blanket `os.open` failure also disables the
+        # fail-closed guard in `_prepare_debug_file`, which then floods the
+        # stderr this test asserts on (reachable whenever DEEPAGENTS_CODE_DEBUG
+        # is set, e.g. from a developer's ~/.deepagents/.env).
+        real_open = os.open
+        no_tty = OSError("No controlling terminal")
+
+        def _open_no_tty(
+            path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            if os.fsdecode(path) == "/dev/tty":
+                raise no_tty
+            return real_open(path, flags, mode, dir_fd=dir_fd)
+
         with (
             patch.object(sys, "argv", argv),
             patch.object(sys, "stdin", mock_stdin),
-            patch("os.open", side_effect=OSError("No controlling terminal")),
+            patch("os.open", side_effect=_open_no_tty),
             patch("deepagents_code.main.check_optional_tools", return_value=[]),
             patch(
                 "deepagents_code.main._should_ensure_managed_ripgrep",
@@ -342,13 +382,59 @@ class TestAutoApproveHeadlessValidation:
             cli_main()
 
         assert exc_info.value.code == 0
-        stderr = " ".join(capsys.readouterr().err.split())
-        assert f"Warning: {flag} has no effect in headless mode; ignoring it." in stderr
-        assert "Shell access is governed by --shell-allow-list" in stderr
-        assert "MCP routing is fail-closed" in stderr
-        resolved_args = resolve_interpreter.call_args.args[0]
-        assert resolved_args.auto_approve is False
-        assert resolved_args.yolo is False
+        raw = capsys.readouterr().err
+        # Asserted on the *raw* stream, not whitespace-normalized: with the
+        # pre-existing `sys.exit(2)` gone this line is the only signal a CI job
+        # has, so it must stay greppable. Rich hard wraps at width 80 off a TTY
+        # and the break moves with the flag name, so a normalized assertion
+        # would hide a regression in the `soft_wrap` that prevents it.
+        warning = next(
+            (line for line in raw.splitlines() if "has no effect" in line), None
+        )
+        assert warning is not None, raw
+        assert (
+            warning == f"Warning: {flag} has no effect in headless mode; ignoring it. "
+            "Shell access is governed by --shell-allow-list, and MCP routing "
+            "is fail-closed."
+        )
+        assert seen == {"auto_approve": False, "yolo": False}
+
+    def test_classifier_rejection_precedes_the_approval_flag_warning(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A fatal classifier rejection must not be preceded by the warning.
+
+        `-y --auto-classifier-model X -n ...` used to print "--auto-approve has
+        no effect" and *then* exit 2 about the classifier flag — two verdicts
+        for one command line. The classifier guard now runs first, so the exit
+        is the only thing the user sees.
+        """
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "deepagents",
+                    "-y",
+                    "--auto-classifier-model",
+                    "anthropic:claude-haiku-4-5",
+                    "-n",
+                    "task",
+                ],
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+
+        assert exc_info.value.code == 2
+        stderr = capsys.readouterr().err
+        assert "--auto-classifier-model is only supported" in stderr
+        assert "has no effect in headless mode" not in stderr
 
     def test_rejects_auto_classifier_model_with_sandbox(
         self, capsys: pytest.CaptureFixture[str]
@@ -447,11 +533,12 @@ class TestAutoApproveHeadlessValidation:
     def test_accepts_auto_approve_in_interactive_mode(self) -> None:
         """`--auto-approve` must still be honored on an interactive launch.
 
-        The guard clears the flag only when `args.non_interactive_message` is
-        also set. Without that conjunct it would wrongly ignore `dcode -m ...
-        -y`; this pins the interactive path so a dropped conjunct fails loudly
-        instead of silently breaking the flag's primary use. Also asserts the resolved
-        value flows through to the TUI (`auto_approve=True`).
+        The guard clears the approval flags only when
+        `args.non_interactive_message` is also set. Without that conjunct it
+        would wrongly ignore `dcode -m ... -y`; this pins the interactive path
+        so a dropped conjunct fails loudly instead of silently breaking the
+        flag's primary use. Also asserts the resolved value flows through to
+        the TUI (`auto_approve=True`).
         """
         from deepagents_code.main import cli_main
 

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -254,68 +254,65 @@ class TestYoloAcknowledgement:
 
 
 class TestAutoApproveHeadlessValidation:
-    """Tests that headless mode rejects the interactive approval flag."""
+    """Tests that headless mode warns and clears interactive approval flags."""
 
-    def test_rejects_explicit_non_interactive_mode(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """`-n` must reject `--auto-approve` instead of silently ignoring it."""
-        from deepagents_code.main import cli_main
-
-        mock_stdin = MagicMock()
-        mock_stdin.isatty.return_value = True
-        with (
-            patch.object(
-                sys,
-                "argv",
-                ["deepagents", "--auto-approve", "-n", "do the thing"],
+    @pytest.mark.parametrize(
+        ("argv", "piped_stdin", "flag"),
+        [
+            (
+                ["deepagents", "-y", "-n", "do the thing"],
+                None,
+                "--auto-approve",
             ),
-            patch.object(sys, "stdin", mock_stdin),
-            pytest.raises(SystemExit) as exc_info,
-        ):
-            cli_main()
-
-        assert exc_info.value.code == 2
-        stderr = capsys.readouterr().err
-        assert "--auto-approve is only supported in interactive mode" in stderr
-        assert "--shell-allow-list" in stderr
-
-    def test_rejects_piped_stdin_mode(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """Piped stdin must reject the flag after selecting headless mode."""
+            (["deepagents", "--auto-approve"], "do the thing", "--auto-approve"),
+            (["deepagents", "--yolo", "-n", "task"], None, "--yolo"),
+        ],
+        ids=["explicit-headless", "piped-stdin", "yolo"],
+    )
+    def test_headless_mode_ignores_interactive_approval_flag_with_warning(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        argv: list[str],
+        piped_stdin: str | None,
+        flag: str,
+    ) -> None:
+        """Headless mode ignores the interactive approval flag with a warning."""
         from deepagents_code.main import cli_main
 
         mock_stdin = MagicMock()
-        mock_stdin.isatty.return_value = False
-        mock_stdin.read.return_value = "do the thing"
+        mock_stdin.isatty.return_value = piped_stdin is None
+        mock_stdin.read.return_value = piped_stdin
+        resolve_interpreter = MagicMock(return_value=False)
         with (
-            patch.object(sys, "argv", ["deepagents", "--auto-approve"]),
+            patch.object(sys, "argv", argv),
             patch.object(sys, "stdin", mock_stdin),
             patch("os.open", side_effect=OSError("No controlling terminal")),
+            patch("deepagents_code.main.check_optional_tools", return_value=[]),
+            patch(
+                "deepagents_code.main._should_ensure_managed_ripgrep",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.main._resolve_interpreter_enabled",
+                resolve_interpreter,
+            ),
+            patch(
+                "deepagents_code.client.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
             pytest.raises(SystemExit) as exc_info,
         ):
             cli_main()
 
-        assert exc_info.value.code == 2
-        stderr = capsys.readouterr().err
-        assert "--auto-approve is only supported in interactive mode" in stderr
-        assert "--shell-allow-list" in stderr
-
-    def test_rejects_yolo_in_non_interactive_mode(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        from deepagents_code.main import cli_main
-
-        mock_stdin = MagicMock()
-        mock_stdin.isatty.return_value = True
-        with (
-            patch.object(sys, "argv", ["deepagents", "--yolo", "-n", "task"]),
-            patch.object(sys, "stdin", mock_stdin),
-            pytest.raises(SystemExit) as exc_info,
-        ):
-            cli_main()
-
-        assert exc_info.value.code == 2
-        assert "--yolo is only supported in interactive mode" in capsys.readouterr().err
+        assert exc_info.value.code == 0
+        stderr = " ".join(capsys.readouterr().err.split())
+        assert f"Warning: {flag} has no effect in headless mode; ignoring it." in stderr
+        assert "Shell access is governed by --shell-allow-list" in stderr
+        assert "MCP routing is fail-closed" in stderr
+        resolved_args = resolve_interpreter.call_args.args[0]
+        assert resolved_args.auto_approve is False
+        assert resolved_args.yolo is False
 
     def test_rejects_auto_classifier_model_with_sandbox(
         self, capsys: pytest.CaptureFixture[str]
@@ -323,8 +320,7 @@ class TestAutoApproveHeadlessValidation:
         """Auto is disabled under a sandbox, so its classifier flag is a no-op.
 
         `create_cli_agent` turns Auto off for a sandboxed run, so accepting the
-        flag would silently ignore a setting that governs action authorization —
-        the same reason the headless form is rejected.
+        flag would silently ignore a setting that governs action authorization.
         """
         from deepagents_code.main import cli_main
 
@@ -415,10 +411,10 @@ class TestAutoApproveHeadlessValidation:
     def test_accepts_auto_approve_in_interactive_mode(self) -> None:
         """`--auto-approve` must still be honored on an interactive launch.
 
-        The guard rejects only when `args.non_interactive_message` is also set.
-        Without that conjunct it would wrongly reject `dcode -m ... -y`; this
-        pins the interactive path so a dropped conjunct fails loudly instead of
-        silently breaking the flag's primary use. Also asserts the resolved
+        The guard clears the flag only when `args.non_interactive_message` is
+        also set. Without that conjunct it would wrongly ignore `dcode -m ...
+        -y`; this pins the interactive path so a dropped conjunct fails loudly
+        instead of silently breaking the flag's primary use. Also asserts the resolved
         value flows through to the TUI (`auto_approve=True`).
         """
         from deepagents_code.main import cli_main


### PR DESCRIPTION
A headless launch that receives `--auto-approve` or `--yolo` now warns and continues. Before, it exited 2.

## Why

Neither flag ever reached the headless path. `run_non_interactive` derives its approval mode from `settings.shell_allow_list` alone, and `_resolve_approval_mode` — the only reader of `args.auto_approve` and `args.yolo` — is called only in the interactive branch. The exit was a usage error about a no-op flag, not a security control.

That exit broke a common pattern: one alias or wrapper that passes `-y` unconditionally, used both interactively and headlessly. The run is still fail-closed either way. Shell access needs `--shell-allow-list`, and MCP actions are denied unless routed.

## Before

```console
$ echo "summarize this" | dcode -y --shell-allow-list ls
Error: --auto-approve is only supported in interactive mode. Headless mode uses
fail-closed MCP routing and --shell-allow-list for shell access.
$ echo $?
2
```

## After

```console
$ echo "summarize this" | dcode -y --shell-allow-list ls
Warning: --auto-approve has no effect in headless mode; ignoring it. Shell access is governed by --shell-allow-list, and MCP routing is fail-closed.
… run proceeds …
$ echo $?
0
```

The warning prints on one line with `soft_wrap=True`. Rich otherwise hard wraps at width 80 off a TTY, and the break moves with the flag name, so no single substring matches both `--auto-approve` and `--yolo`. With the exit gone, this line is the only signal a CI job has that the requested mode was dropped, so it must stay greppable.

## `--auto-classifier-model` still exits 2

The dependent flag keeps its hard error. It has no interactive-reuse case, so ignoring it would only hide a typo in a setting that governs action authorization.

That left one command line producing two verdicts:

```console
$ dcode -y --auto-classifier-model anthropic:claude-haiku-4-5 -n "task"
Warning: --auto-approve has no effect in headless mode; ignoring it. …
Error: --auto-classifier-model is only supported in the interactive TUI, where
Auto approval mode runs; it runs headlessly.
```

The classifier guard now runs before the approval warning, so the exit prints alone.

## Notes

- The warning keys off a flag name captured at parse time, before `_apply_managed_runtime_policy` can revoke it. Managed policy only ever revokes, so without the early capture a policy-cleared flag the user did type would warn about nothing.
- Clearing `args.auto_approve` and `args.yolo` is defense in depth. No headless consumer reads them today; the guarantee lives at `client/non_interactive.py:2132`.
- Two pre-existing gaps this does not touch: `THREAT_MODEL.md:526` claims HTTP tools pass the HITL gate in non-interactive mode, which the code contradicts; and the interactive-piped route (`-m` plus a pipe) has no test.
