### PR TITLE
fix(sdk): clarify zero execute timeout semantics

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1215,7 +1215,7 @@ class ExecuteSchema(BaseModel):
 
     timeout: int | None = Field(
         default=None,
-        description="Optional positive timeout in seconds for this command. Overrides the default timeout.",
+        description="Optional timeout in seconds for this command. Overrides the default timeout.",
     )
 
 
@@ -1316,7 +1316,7 @@ _EXECUTE_TOOL_DESCRIPTION_TEMPLATE = """Executes a shell command in an isolated 
 Usage:
 - Quote paths containing spaces (e.g. cd "/path/with spaces").
 - Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.
-- Use absolute paths and avoid `cd` so the working directory stays stable; use a positive timeout to override the default.
+- Use absolute paths and avoid `cd` so the working directory stays stable; use the optional timeout to override the default.
 - {search_guidance}Use read_file rather than cat/head/tail.{glob_bad_example}{grep_bad_example}
 
 Only available on backends implementing SandboxBackendProtocol; otherwise it returns an error."""

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1215,7 +1215,11 @@ class ExecuteSchema(BaseModel):
 
     timeout: int | None = Field(
         default=None,
-        description="Optional timeout in seconds for this command. Overrides the default timeout. Use 0 for no-timeout execution on backends that support it.",
+        description=(
+            "Optional timeout in seconds for this command. Overrides the default timeout. "
+            "Use a positive value unless the active backend explicitly supports 0. On "
+            "supported backends, 0 disables the command timeout and may wait indefinitely."
+        ),
     )
 
 
@@ -1316,7 +1320,7 @@ _EXECUTE_TOOL_DESCRIPTION_TEMPLATE = """Executes a shell command in an isolated 
 Usage:
 - Quote paths containing spaces (e.g. cd "/path/with spaces").
 - Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.
-- Use absolute paths and avoid `cd` so the working directory stays stable; use the optional timeout to override the default (0 disables it on backends that support that).
+- Use absolute paths and avoid `cd` so the working directory stays stable; timeout overrides should be positive unless the active backend explicitly supports 0 (which disables the command timeout and may wait indefinitely).
 - {search_guidance}Use read_file rather than cat/head/tail.{glob_bad_example}{grep_bad_example}
 
 Only available on backends implementing SandboxBackendProtocol; otherwise it returns an error."""

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1215,11 +1215,7 @@ class ExecuteSchema(BaseModel):
 
     timeout: int | None = Field(
         default=None,
-        description=(
-            "Optional timeout in seconds for this command. Overrides the default timeout. "
-            "Use a positive value unless the active backend explicitly supports 0. On "
-            "supported backends, 0 disables the command timeout and may wait indefinitely."
-        ),
+        description="Optional positive timeout in seconds for this command. Overrides the default timeout.",
     )
 
 
@@ -1320,7 +1316,7 @@ _EXECUTE_TOOL_DESCRIPTION_TEMPLATE = """Executes a shell command in an isolated 
 Usage:
 - Quote paths containing spaces (e.g. cd "/path/with spaces").
 - Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.
-- Use absolute paths and avoid `cd` so the working directory stays stable; timeout overrides should be positive unless the active backend explicitly supports 0 (which disables the command timeout and may wait indefinitely).
+- Use absolute paths and avoid `cd` so the working directory stays stable; use a positive timeout to override the default.
 - {search_guidance}Use read_file rather than cat/head/tail.{glob_bad_example}{grep_bad_example}
 
 Only available on backends implementing SandboxBackendProtocol; otherwise it returns an error."""

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -223,7 +223,7 @@
   },
   {
     "function": {
-      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use a positive timeout to override the default.\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
+      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use the optional timeout to override the default.\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
       "name": "execute",
       "parameters": {
         "properties": {
@@ -241,7 +241,7 @@
               }
             ],
             "default": null,
-            "description": "Optional positive timeout in seconds for this command. Overrides the default timeout."
+            "description": "Optional timeout in seconds for this command. Overrides the default timeout."
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -223,7 +223,7 @@
   },
   {
     "function": {
-      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; timeout overrides should be positive unless the active backend explicitly supports 0 (which disables the command timeout and may wait indefinitely).\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
+      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use a positive timeout to override the default.\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
       "name": "execute",
       "parameters": {
         "properties": {
@@ -241,7 +241,7 @@
               }
             ],
             "default": null,
-            "description": "Optional timeout in seconds for this command. Overrides the default timeout. Use a positive value unless the active backend explicitly supports 0. On supported backends, 0 disables the command timeout and may wait indefinitely."
+            "description": "Optional positive timeout in seconds for this command. Overrides the default timeout."
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -223,7 +223,7 @@
   },
   {
     "function": {
-      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use the optional timeout to override the default (0 disables it on backends that support that).\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
+      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; timeout overrides should be positive unless the active backend explicitly supports 0 (which disables the command timeout and may wait indefinitely).\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
       "name": "execute",
       "parameters": {
         "properties": {
@@ -241,7 +241,7 @@
               }
             ],
             "default": null,
-            "description": "Optional timeout in seconds for this command. Overrides the default timeout. Use 0 for no-timeout execution on backends that support it."
+            "description": "Optional timeout in seconds for this command. Overrides the default timeout. Use a positive value unless the active backend explicitly supports 0. On supported backends, 0 disables the command timeout and may wait indefinitely."
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_media_extra_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_media_extra_tools.json
@@ -223,7 +223,7 @@
   },
   {
     "function": {
-      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use a positive timeout to override the default.\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
+      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use the optional timeout to override the default.\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
       "name": "execute",
       "parameters": {
         "properties": {
@@ -241,7 +241,7 @@
               }
             ],
             "default": null,
-            "description": "Optional positive timeout in seconds for this command. Overrides the default timeout."
+            "description": "Optional timeout in seconds for this command. Overrides the default timeout."
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_media_extra_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_media_extra_tools.json
@@ -223,7 +223,7 @@
   },
   {
     "function": {
-      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; timeout overrides should be positive unless the active backend explicitly supports 0 (which disables the command timeout and may wait indefinitely).\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
+      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use a positive timeout to override the default.\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
       "name": "execute",
       "parameters": {
         "properties": {
@@ -241,7 +241,7 @@
               }
             ],
             "default": null,
-            "description": "Optional timeout in seconds for this command. Overrides the default timeout. Use a positive value unless the active backend explicitly supports 0. On supported backends, 0 disables the command timeout and may wait indefinitely."
+            "description": "Optional positive timeout in seconds for this command. Overrides the default timeout."
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_media_extra_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_media_extra_tools.json
@@ -223,7 +223,7 @@
   },
   {
     "function": {
-      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use the optional timeout to override the default (0 disables it on backends that support that).\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
+      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; timeout overrides should be positive unless the active backend explicitly supports 0 (which disables the command timeout and may wait indefinitely).\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
       "name": "execute",
       "parameters": {
         "properties": {
@@ -241,7 +241,7 @@
               }
             ],
             "default": null,
-            "description": "Optional timeout in seconds for this command. Overrides the default timeout. Use 0 for no-timeout execution on backends that support it."
+            "description": "Optional timeout in seconds for this command. Overrides the default timeout. Use a positive value unless the active backend explicitly supports 0. On supported backends, 0 disables the command timeout and may wait indefinitely."
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
@@ -223,7 +223,7 @@
   },
   {
     "function": {
-      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use a positive timeout to override the default.\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
+      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use the optional timeout to override the default.\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
       "name": "execute",
       "parameters": {
         "properties": {
@@ -241,7 +241,7 @@
               }
             ],
             "default": null,
-            "description": "Optional positive timeout in seconds for this command. Overrides the default timeout."
+            "description": "Optional timeout in seconds for this command. Overrides the default timeout."
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
@@ -223,7 +223,7 @@
   },
   {
     "function": {
-      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; timeout overrides should be positive unless the active backend explicitly supports 0 (which disables the command timeout and may wait indefinitely).\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
+      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use a positive timeout to override the default.\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
       "name": "execute",
       "parameters": {
         "properties": {
@@ -241,7 +241,7 @@
               }
             ],
             "default": null,
-            "description": "Optional timeout in seconds for this command. Overrides the default timeout. Use a positive value unless the active backend explicitly supports 0. On supported backends, 0 disables the command timeout and may wait indefinitely."
+            "description": "Optional positive timeout in seconds for this command. Overrides the default timeout."
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
@@ -223,7 +223,7 @@
   },
   {
     "function": {
-      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; use the optional timeout to override the default (0 disables it on backends that support that).\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
+      "description": "Executes a shell command in an isolated sandbox and returns combined stdout/stderr with the exit code (truncated if very large).\n\nUsage:\n- Quote paths containing spaces (e.g. cd \"/path/with spaces\").\n- Chain commands with ';' or '&&' (use '&&' when a command depends on the previous); do not use newlines except inside quoted strings.\n- Use absolute paths and avoid `cd` so the working directory stays stable; timeout overrides should be positive unless the active backend explicitly supports 0 (which disables the command timeout and may wait indefinitely).\n- You MUST avoid using search commands like find and grep. Instead use the grep, glob tools to search. Use read_file rather than cat/head/tail.\n    - execute(command=\"find . -name '*.py'\")  # Use glob tool instead\n    - execute(command=\"grep -r 'pattern' .\")  # Use grep tool instead\n\nOnly available on backends implementing SandboxBackendProtocol; otherwise it returns an error.",
       "name": "execute",
       "parameters": {
         "properties": {
@@ -241,7 +241,7 @@
               }
             ],
             "default": null,
-            "description": "Optional timeout in seconds for this command. Overrides the default timeout. Use 0 for no-timeout execution on backends that support it."
+            "description": "Optional timeout in seconds for this command. Overrides the default timeout. Use a positive value unless the active backend explicitly supports 0. On supported backends, 0 disables the command timeout and may wait indefinitely."
           }
         },
         "required": [


### PR DESCRIPTION
Removes shared `execute` guidance for backend-specific `timeout=0` behavior that models cannot discover.

---

The shared schema does not identify the active backend or its capabilities, so conditional guidance about `0` was not actionable. The timeout description now only explains the portable override behavior; backend behavior remains unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/fc90f455-6495-54a4-9011-ac0e40ca2a40)