### PR TITLE
fix(code): clarify auth environment setup

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/auth.py
+++ b/libs/code/deepagents_code/tui/widgets/auth.py
@@ -881,18 +881,15 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
             if self._env_var:
                 key_meta = Static(
                     Content.assemble(
-                        "Alternatively, environment variables can be used in place "
-                        "of the key stored above. Set ",
+                        "Environment variables: ",
                         (f"DEEPAGENTS_CODE_{self._env_var}", TStyle(bold=True)),
-                        " for a dcode-only key; it has the highest priority. Set ",
+                        " (dcode only, highest priority) or ",
                         (self._env_var, TStyle(bold=True)),
-                        " to share a key with other provider SDK tools; it is used "
-                        "only when no scoped or stored key exists. After setting one "
-                        "in a .env file, press ",
+                        " (shared, lowest priority). Put either in the project .env "
+                        "or ~/.deepagents/.env; press ",
                         ("Ctrl+R", TStyle(bold=True)),
-                        " to reload without restarting. A variable exported in a "
-                        "separate shell after launch is invisible to this process; "
-                        "it needs a full relaunch. ",
+                        " in this dialog to reload. New shell exports require "
+                        "restarting dcode. ",
                         (
                             "Configuration docs",
                             self._link_style(CONFIGURATION_DOCS_URL),

--- a/libs/code/deepagents_code/tui/widgets/auth.py
+++ b/libs/code/deepagents_code/tui/widgets/auth.py
@@ -889,7 +889,7 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
                         "or ~/.deepagents/.env; press ",
                         ("Ctrl+R", TStyle(bold=True)),
                         " in this dialog to reload. New shell exports require "
-                        "restarting dcode. ",
+                        "restarting the app. ",
                         (
                             "Configuration docs",
                             self._link_style(CONFIGURATION_DOCS_URL),

--- a/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
@@ -1515,7 +1515,7 @@ api_key_url = "javascript:alert(1)"
                 app.screen.query_one("#auth-prompt-key-meta", Static).content
             )
         assert "Ctrl+R" in key_meta
-        assert "New shell exports require restarting dcode" in key_meta
+        assert "New shell exports require restarting the app" in key_meta
 
     async def test_ctrl_d_opens_confirm_then_deletes(self) -> None:
         """Ctrl+D opens the confirmation modal; Enter completes the delete."""
@@ -1813,7 +1813,7 @@ api_key_url = "javascript:alert(1)"
             assert "shared, lowest priority" in text
             assert "project .env or ~/.deepagents/.env" in text
             assert "Ctrl+R in this dialog to reload" in text
-            assert "New shell exports require restarting dcode" in text
+            assert "New shell exports require restarting the app" in text
             assert "Configuration docs" in text
 
     async def test_base_url_hint_names_endpoint_var(

--- a/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
@@ -1799,30 +1799,21 @@ api_key_url = "javascript:alert(1)"
             assert glyphs.warning not in title_text
             assert glyphs.checkmark not in title_text
 
-    async def test_helper_text_describes_precedence(self) -> None:
-        """Helper text names both env vars and their order vs the stored key.
-
-        A stored key sits between the plain var (which it beats) and the
-        `DEEPAGENTS_CODE_`-prefixed var (which beats it). The meta line must
-        convey that ordering, not imply the three are interchangeable.
-        """
+    async def test_helper_text_describes_precedence_and_reload_location(self) -> None:
+        """Helper text names env precedence, dotenv paths, and the reload scope."""
         app = _AuthHostApp()
         async with app.run_test() as pilot:
             app.show_prompt("openai", "OPENAI_API_KEY")
             await pilot.pause()
             meta = app.screen.query_one("#auth-prompt-key-meta", Static)
             text = str(meta.content)
-            assert "dcode stores" not in text
-            assert (
-                "Alternatively, environment variables can be used in place "
-                "of the key stored above." in text
-            )
             assert "DEEPAGENTS_CODE_OPENAI_API_KEY" in text
-            assert "dcode-only key" in text
-            assert "highest priority" in text
+            assert "dcode only, highest priority" in text
             assert "OPENAI_API_KEY" in text
-            assert "share a key with other provider SDK tools" in text
-            assert "used only when no scoped or stored key exists" in text
+            assert "shared, lowest priority" in text
+            assert "project .env or ~/.deepagents/.env" in text
+            assert "Ctrl+R in this dialog to reload" in text
+            assert "New shell exports require restarting dcode" in text
             assert "Configuration docs" in text
 
     async def test_base_url_hint_names_endpoint_var(

--- a/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
@@ -1505,7 +1505,7 @@ api_key_url = "javascript:alert(1)"
             content = str(help_line.content)
         assert "Ctrl+R reload" in content
 
-    async def test_advanced_copy_flags_reload_and_relaunch_caveat(self) -> None:
+    async def test_advanced_copy_flags_reload_and_restart_caveat(self) -> None:
         """Advanced env-var copy points at Ctrl+R and the separate-shell caveat."""
         app = _AuthHostApp()
         async with app.run_test() as pilot:
@@ -1515,7 +1515,7 @@ api_key_url = "javascript:alert(1)"
                 app.screen.query_one("#auth-prompt-key-meta", Static).content
             )
         assert "Ctrl+R" in key_meta
-        assert "relaunch" in key_meta
+        assert "New shell exports require restarting dcode" in key_meta
 
     async def test_ctrl_d_opens_confirm_then_deletes(self) -> None:
         """Ctrl+D opens the confirmation modal; Enter completes the delete."""


### PR DESCRIPTION
Environment-variable guidance in the auth dialog is now shorter and identifies both supported `.env` locations plus the exact scope of `Ctrl+R`.

---

The previous copy was verbose and made the reload shortcut sound global rather than dialog-specific.

**Before**
> Alternatively, environment variables can be used in place of the key stored above. Set `DEEPAGENTS_CODE_TAVILY_API_KEY` for a dcode-only key; it has the highest priority. Set `TAVILY_API_KEY` to share a key with other provider SDK tools; it is used only when no scoped or stored key exists. After setting one in a .env file, press Ctrl+R to reload without restarting. A variable exported in a separate shell after launch is invisible to this process; it needs a full relaunch. Configuration docs.

**After**
> Environment variables: `DEEPAGENTS_CODE_TAVILY_API_KEY` (dcode only, highest priority) or `TAVILY_API_KEY` (shared, lowest priority). Put either in the project `.env` or `~/.deepagents/.env`; press Ctrl+R in this dialog to reload. New shell exports require restarting the app. Configuration docs.

**Example scenario:** A user has the Tavily auth dialog open and adds `DEEPAGENTS_CODE_TAVILY_API_KEY` to the project `.env`. They can press `Ctrl+R` in that dialog to load it immediately. If they instead export the variable from another shell, they must restart dcode because the running process cannot inherit later shell changes.

Focused auth-widget tests cover precedence, dotenv locations, reload scope, and restart guidance.

Made by [Open SWE](https://openswe.vercel.app/agents/3e770dd7-d5a5-5aa2-b7e7-5fd34e54f359)

