### PR TITLE
style(code): align execute output details

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -1672,6 +1672,7 @@ class ToolCallMessage(Vertical):
         layout: horizontal;
         height: auto;
         width: 1fr;
+        margin-left: 2;
     }
 
     /* Fixed gutter holds the output glyph so soft-wrapped content lines stay
@@ -2217,6 +2218,8 @@ class ToolCallMessage(Vertical):
         self._status_widget.update(
             Content.styled(f"Took {format_duration(duration)}", "dim")
         )
+        if self._hint_widget is not None:
+            self.move_child(self._status_widget, after=self._hint_widget)
         self._status_widget.display = True
 
     def _show_success_status(self) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -1017,6 +1017,9 @@ class TestToolCallMessageDuration:
             content = status._Static__content  # ty: ignore
             assert isinstance(content, Content)
             assert content.plain == "Took 4.9s"
+            assert app.msg._preview_row is not None
+            children = list(app.msg.children)
+            assert children.index(status) > children.index(app.msg._preview_row)
 
     async def test_execute_shows_fractional_seconds(self) -> None:
         """Sub-minute `execute` runs report tenths — `elapsed` is a float.
@@ -1577,6 +1580,13 @@ class TestToolCallMessageAppearance:
         async with app.run_test():
             assert app.msg.styles.padding.left == 0
             assert app.msg.styles.padding.right == 1
+
+    async def test_output_prefix_aligns_with_tool_name(self) -> None:
+        """The output prefix starts beneath the tool name after its marker."""
+        app = _tool_msg_app("execute", {"command": "echo hi"})
+        async with app.run_test():
+            assert app.msg._preview_row is not None
+            assert app.msg._preview_row.styles.margin.left == 2
 
 
 class TestToolCallMessageOutputGutter:


### PR DESCRIPTION
Execute output prefixes now align beneath the tool name, and elapsed time appears below command output.

---

The output row gains the missing header-prefix inset, while timed status rows move after output only when completed. Focused widget tests cover both positions.

**Before**

<img width="604" alt="Execute widget before alignment fix" src="https://01a03412-974b-7c1f-aa7a-73b8dff20c79--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGMxT0RFeE1UY3NJbXAwYVNJNklqQXhZVEF6TkRJekxUTXpaV0l0TjJJM1l5MDVaalZrTFdJM05qVmtNREZrWWpVM1lTSXNJbk5wWkNJNklqQXhZVEF6TkRFeUxUazNOR0l0TjJNeFppMWhZVGRoTFRjellqaGtabVl5TUdNM09TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkRzF3TDJWNFpXTjFkR1V0ZDJsa1oyVjBMV0psWm05eVpTNXpkbWNpTENKamRDSTZJbWx0WVdkbEwzTjJaeXQ0Yld3aUxDSmpaQ0k2SW1sdWJHbHVaU0o5LnpGWWVFT2xNZjJpWXc3djUxRTl4ekU2Q0lCaHR1VXFCMkI5dWpVS0w3UkRLUzN0TUFINlFlZzZhUWlibVVjZm94R04waXRsQXp4cGV4NXAyOHZ4UEN3">

**After**

<img width="604" alt="Execute widget showing aligned output and elapsed time" src="https://01a03412-974b-7c1f-aa7a-73b8dff20c79--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGMxT0RBNU5UZ3NJbXAwYVNJNklqQXhZVEF6TkRJd0xXTTRPV010TnpZd09DMWlOR05sTFdaaFpUbGxaVEpoWmpnMk1TSXNJbk5wWkNJNklqQXhZVEF6TkRFeUxUazNOR0l0TjJNeFppMWhZVGRoTFRjellqaGtabVl5TUdNM09TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkRzF3TDJWNFpXTjFkR1V0ZDJsa1oyVjBMbk4yWnlJc0ltTjBJam9pYVcxaFoyVXZjM1puSzNodGJDSXNJbU5rSWpvaWFXNXNhVzVsSW4wLjh6YU1xU2lJbWpjRGV0cFVWa3Z5THlFZ0YzZUtaVGtzVkdMY1FDQWE1bDVsZWZaemlBNUZMek5pNXNNQm5GNkxLSFh3NEJsaDFKUnF6ODJMVjM2eEF3">

Made by [Open SWE](https://openswe.vercel.app/agents/f2a4ef6d-3823-522b-8381-15666275dcbc)

