### PR TITLE
ci(infra): test release wheels across supported Python versions

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -932,10 +932,12 @@ The `pre-release-checks` job runs after the package is built but before anything
 
 **Steps:**
 
-1. **Look at the workflow logs** to see why it failed. Pre-release checks install the built package in a clean environment and run:
+1. **Look at the workflow logs** to see why it failed. Pre-release checks run on every Python version allowed by the package's `requires-python`, install the built package in a clean environment, and run:
    - `python -c "import <pkg>"` — does the package even import?
    - `make test` — do the unit tests pass against the built wheel?
    - `make integration_test` (if defined) — do the integration tests pass?
+
+   A failure on only one matrix leg usually indicates a version-specific dependency or compatibility problem rather than a broken wheel on every interpreter.
 
 2. **Open a `hotfix(<scope>): <description>` PR with the fix.** Merge it to `main` on top of the release-please commit. **Leave `pyproject.toml`'s version exactly as the release-please PR set it.**
 

--- a/.github/scripts/release/resolve_python_matrix.py
+++ b/.github/scripts/release/resolve_python_matrix.py
@@ -1,0 +1,110 @@
+"""Resolve the Python versions a package's release checks should run on."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from typing import Final
+
+
+SUPPORTED_PYTHON_VERSIONS: Final[tuple[str, ...]] = (
+    "3.11",
+    "3.12",
+    "3.13",
+    "3.14",
+)
+_OPERATORS: Final[tuple[str, ...]] = (">=", "<=", "!=", "==", ">", "<")
+
+
+def _parse_version(version: str) -> tuple[int, ...]:
+    """Parse a dotted release version into comparable integers."""
+    try:
+        return tuple(int(part) for part in version.split("."))
+    except ValueError as error:
+        msg = f"Cannot parse Python version {version!r}: {error}"
+        raise ValueError(msg) from None
+
+
+def _pad(
+    left: tuple[int, ...], right: tuple[int, ...]
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Pad two version tuples to a common length."""
+    width = max(len(left), len(right))
+    return (
+        left + (0,) * (width - len(left)),
+        right + (0,) * (width - len(right)),
+    )
+
+
+def _satisfies(candidate: tuple[int, ...], clause: str) -> bool:
+    """Check one clause from a `requires-python` specifier."""
+    for operator in _OPERATORS:
+        if not clause.startswith(operator):
+            continue
+        bound_text = clause[len(operator) :].strip()
+        if bound_text.endswith(".*"):
+            msg = f"Wildcard specifiers are not supported: {clause!r}"
+            raise ValueError(msg)
+        left, right = _pad(candidate, _parse_version(bound_text))
+        if operator == ">=":
+            return left >= right
+        if operator == "<=":
+            return left <= right
+        if operator == "!=":
+            return left != right
+        if operator == "==":
+            return left == right
+        if operator == ">":
+            return left > right
+        return left < right
+    msg = f"Unsupported requires-python clause: {clause!r}"
+    raise ValueError(msg)
+
+
+def resolve_python_versions(requires_python: str) -> list[str]:
+    """Return supported interpreters allowed by `requires-python`."""
+    clauses = [
+        clause.strip() for clause in requires_python.split(",") if clause.strip()
+    ]
+    if not clauses:
+        msg = "requires-python is empty"
+        raise ValueError(msg)
+    versions = [
+        version
+        for version in SUPPORTED_PYTHON_VERSIONS
+        if all(_satisfies(_parse_version(version), clause) for clause in clauses)
+    ]
+    if not versions:
+        msg = (
+            f"requires-python {requires_python!r} matches none of "
+            f"{list(SUPPORTED_PYTHON_VERSIONS)}"
+        )
+        raise ValueError(msg)
+    return versions
+
+
+def resolve_from_pyproject(contents: str) -> list[str]:
+    """Resolve supported interpreters from `pyproject.toml` text."""
+    data = tomllib.loads(contents)
+    requires_python = data.get("project", {}).get("requires-python")
+    if not isinstance(requires_python, str):
+        msg = "pyproject.toml does not declare [project].requires-python"
+        raise ValueError(msg)
+    return resolve_python_versions(requires_python)
+
+
+def main() -> int:
+    """Print the baseline and matrix as GitHub Actions outputs."""
+    try:
+        versions = resolve_from_pyproject(sys.stdin.read())
+    except (ValueError, tomllib.TOMLDecodeError) as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 1
+    print(f"python-version={versions[0]}")
+    print(f"python-versions={json.dumps(versions)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
+++ b/.github/scripts/tests/release/test_check_wheel_dep_freshness.py
@@ -791,7 +791,7 @@ def test_workflow_mirrors_release_install_flags() -> None:
         in freshness
     )
 
-    assert "deepagents-code|deepagents-talon)" in release
+    assert "resolve_python_matrix.py" in release
     assert "DEEPAGENTS_CODE_BUILD_COMMIT:" in release
     assert 'if [ "$PKG_NAME" = "deepagents-talon" ]; then' in release
     assert 'INSTALL_ARGS=(--prerelease allow "${INSTALL_ARGS[@]}")' in release
@@ -799,7 +799,7 @@ def test_workflow_mirrors_release_install_flags() -> None:
         'env -u UV_PYTHON VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"'
         in release
     )
- # pass if either one reverted.
+    # pass if either one reverted.
     release_install = (
         'env -u UV_PYTHON VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"'
     )

--- a/.github/scripts/tests/workflows/test_release_python_matrix.py
+++ b/.github/scripts/tests/workflows/test_release_python_matrix.py
@@ -1,0 +1,111 @@
+"""Contracts for the release workflow's Python matrix."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+from resolve_python_matrix import (
+    SUPPORTED_PYTHON_VERSIONS,
+    resolve_from_pyproject,
+    resolve_python_versions,
+)
+
+
+ROOT = Path(__file__).resolve().parents[4]
+CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
+RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
+TEST_WORKFLOW_REF = "./.github/workflows/_test.yml"
+
+
+def _ci_test_jobs() -> dict[str, dict]:
+    """Return every CI job using the reusable test workflow."""
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+    return {
+        name: job
+        for name, job in workflow["jobs"].items()
+        if job.get("uses") == TEST_WORKFLOW_REF
+    }
+
+
+def test_ci_matrices_match_requires_python() -> None:
+    """Keep PR and release test matrices aligned."""
+    for name, job in _ci_test_jobs().items():
+        working_directory = job["with"]["working-directory"]
+        pyproject = ROOT / working_directory / "pyproject.toml"
+        expected = resolve_from_pyproject(pyproject.read_text())
+        declared = json.loads(job["with"]["python-versions"])
+        assert declared == expected, (
+            f"{name} tests {declared}, but {working_directory} supports {expected}"
+        )
+
+
+def test_release_uses_resolved_matrix() -> None:
+    """Fan out release checks over the versions resolved by `setup`."""
+    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text())
+    jobs = workflow["jobs"]
+
+    assert jobs["setup"]["outputs"]["python-versions"] == (
+        "${{ steps.python-matrix.outputs.python-versions }}"
+    )
+    strategy = jobs["pre-release-checks"]["strategy"]
+    assert strategy["fail-fast"] is False
+    assert strategy["matrix"]["python-version"] == (
+        "${{ fromJSON(needs.setup.outputs.python-versions) }}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("requires_python", "expected"),
+    [
+        (">=3.11", ["3.11", "3.12", "3.13", "3.14"]),
+        (">=3.11,<4.0", ["3.11", "3.12", "3.13", "3.14"]),
+        (">=3.12,<3.14", ["3.12", "3.13"]),
+        (">=3.11,!=3.12", ["3.11", "3.13", "3.14"]),
+        ("==3.13", ["3.13"]),
+        (">3.11,<=3.13", ["3.12", "3.13"]),
+    ],
+)
+def test_resolve_python_versions(requires_python: str, expected: list[str]) -> None:
+    assert resolve_python_versions(requires_python) == expected
+
+
+@pytest.mark.parametrize(
+    "requires_python",
+    ["", "~=3.11", "==3.12.*", ">=3.15", ">=3.11,<3.11"],
+)
+def test_resolve_python_versions_rejects_unusable_specifiers(
+    requires_python: str,
+) -> None:
+    """Unknown syntax and empty matrices must fail closed."""
+    with pytest.raises(ValueError):
+        resolve_python_versions(requires_python)
+
+
+def test_supported_versions_are_ordered_and_unique() -> None:
+    versions = list(SUPPORTED_PYTHON_VERSIONS)
+    expected = sorted(
+        set(versions), key=lambda value: tuple(map(int, value.split(".")))
+    )
+    assert versions == expected
+
+
+def test_every_release_package_resolves_a_matrix() -> None:
+    """Each release option must yield at least one test interpreter."""
+    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text())
+    options = workflow[True]["workflow_dispatch"]["inputs"]["package"]["options"]
+
+    pyprojects: dict[str, Path] = {}
+    for pyproject in (ROOT / "libs").rglob("pyproject.toml"):
+        relative = pyproject.parent.relative_to(ROOT / "libs").parts
+        if len(relative) == 1 or (len(relative) == 2 and relative[0] == "partners"):
+            with open(pyproject, "rb") as file:
+                name = tomllib.load(file).get("project", {}).get("name")
+            if name:
+                pyprojects[name] = pyproject
+
+    for option in options:
+        assert resolve_from_pyproject(pyprojects[option].read_text())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,8 @@ jobs:
     outputs:
       package: ${{ steps.parse.outputs.package }}
       working-dir: ${{ steps.parse.outputs.working-dir }}
-      python-version: ${{ steps.parse.outputs.python-version }}
+      python-version: ${{ steps.python-matrix.outputs.python-version }}
+      python-versions: ${{ steps.python-matrix.outputs.python-versions }}
       release-sha: ${{ steps.resolve-sha.outputs.sha }}
     steps:
       - name: Parse package input
@@ -118,17 +119,6 @@ jobs:
             PACKAGE="$PACKAGE_INPUT"
           fi
           echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
-
-          # deepagents-code requires Python 3.12 or newer, and deepagents-talon
-          # depends on it. Other packages keep the baseline interpreter.
-          case "$PACKAGE" in
-            deepagents-code|deepagents-talon)
-              echo "python-version=3.12" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "python-version=3.11" >> "$GITHUB_OUTPUT"
-              ;;
-          esac
 
           # Map package name to working directory
           case "$PACKAGE" in
@@ -352,6 +342,17 @@ jobs:
             echo "| Resolution | ${RELEASE_SHA_SOURCE} |"
             echo ""
           } >> "$GITHUB_STEP_SUMMARY" || echo "::warning::Failed to write resolved release target to GITHUB_STEP_SUMMARY (non-fatal, continuing)"
+
+      - name: Resolve Python matrix
+        id: python-matrix
+        env:
+          RELEASE_SHA: ${{ steps.resolve-sha.outputs.sha }}
+          WORKING_DIR: ${{ steps.parse.outputs.working-dir }}
+        run: |
+          set -euo pipefail
+          git show "${RELEASE_SHA}:${WORKING_DIR}/pyproject.toml" \
+            | python .github/scripts/release/resolve_python_matrix.py \
+            >> "$GITHUB_OUTPUT"
 
   # Build the distribution package and extract version info
   # Runs in isolated environment with minimal permissions for security
@@ -614,7 +615,7 @@ jobs:
           attestations: false
 
   pre-release-checks:
-    name: ✅ Pre-release checks
+    name: ✅ Pre-release checks (Python ${{ matrix.python-version }})
     needs:
       - setup
       - build
@@ -623,6 +624,10 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(needs.setup.outputs.python-versions) }}
     env:
       WORKING_DIR: ${{ needs.setup.outputs.working-dir }}
     steps:
@@ -647,7 +652,7 @@ jobs:
         uses: "./.github/actions/uv_setup"
         id: setup-python
         with:
-          python-version: ${{ needs.setup.outputs.python-version }}
+          python-version: ${{ matrix.python-version }}
           enable-cache: "false"
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
Release checks now validate built wheels across every Python version allowed by each package's `requires-python` range.

---

This closes the gap where PR CI covered the full interpreter range while publication tested only one version. The packaging stages stay on the package's minimum supported interpreter, and `pre-release-checks` fans out with `fail-fast: false`.

<details>
<summary>Test plan</summary>

- `python3 -m pytest .github/scripts/tests -q --no-header -p no:cacheprovider` (1144 passed)
- Ruff check and format-check the changed Python helpers and tests

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/75cfe962-24e7-71d3-534b-ad27c0d7bc0e)

## References
- Plan: https://openswe.vercel.app/agents/75cfe962-24e7-71d3-534b-ad27c0d7bc0e/plan