### PR TITLE
feat(code): show Escape hint in model picker

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -591,11 +591,10 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
     def _help_text(self) -> str:
         """Build the footer help text.
 
-        Curated/onboarding mode omits the Ctrl+S, Ctrl+R, and Ctrl+N hints.
-        Escape stays bound but is left off the hint line — modal dismissal via
-        Escape is conventional, and advertising it would only lengthen an
-        already-wrapping line. Shift+Tab is likewise bound (`action_move_up`,
-        routed by `_SupportsReverseNav`) but omitted: this modal binds Tab to
+        Curated/onboarding mode omits the Ctrl+S, Ctrl+R, Ctrl+N, and Escape
+        hints. Standard mode advertises Escape as `Esc close`. Shift+Tab is
+        likewise bound (`action_move_up`, routed by `_SupportsReverseNav`) but
+        omitted: this modal binds Tab to
         autocomplete, so the shared "Tab/Shift+Tab navigate" phrasing from
         `tui.key_hints` would misdescribe Tab here. In standard mode the full
         line exceeds the modal width, so the help `Static` is sized to grow
@@ -626,7 +625,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             names_hint = "Ctrl+N names" if self._show_specs else "Ctrl+N IDs"
             if self._default_scope is not None:
                 parts.append(f"Ctrl+S {self._default_scope.hint}")
-            parts.extend(("Ctrl+R recommended", names_hint))
+            parts.extend(("Ctrl+R recommended", names_hint, "Esc close"))
         sep = f" {glyphs.bullet} "
         return sep.join(parts)
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -288,6 +288,7 @@ class TestModelSelectorChrome:
             assert "Tab/Shift+Tab navigate" not in str(help_text.content)
             assert "Tab autocomplete" in str(help_text.content)
             assert "Esc skip setup" not in str(help_text.content)
+            assert "Esc close" not in str(help_text.content)
             assert "Esc cancel" not in str(help_text.content)
 
     async def test_curated_selector_help_hides_default_hint(self) -> None:
@@ -329,8 +330,8 @@ class TestModelSelectorChrome:
         assert max_height.cells is not None
         assert max_height.cells <= 16
 
-    async def test_standard_selector_help_hides_cancel_hint(self) -> None:
-        """The regular /model selector should not leave a trailing separator."""
+    async def test_standard_selector_help_shows_close_hint(self) -> None:
+        """The regular `/model` selector should advertise Escape dismissal."""
         app = ModelSelectorTestApp()
         async with app.run_test() as pilot:
             screen = ModelSelectorScreen(default_scope=MAIN_MODEL_DEFAULT_SCOPE)
@@ -343,7 +344,7 @@ class TestModelSelectorChrome:
             # Standard mode still advertises the default-setting shortcut that
             # curated/onboarding mode hides.
             assert "Ctrl+S set default" in str(help_text.content)
-            assert "Esc cancel" not in str(help_text.content)
+            assert "Esc close" in str(help_text.content)
 
     async def test_standard_selector_help_wraps_to_two_rows(self) -> None:
         """The standard footer is wider than the modal, so it must wrap.


### PR DESCRIPTION
The `/model` picker footer now shows `Esc close` so its dismissal shortcut is discoverable.

---

The hint is limited to the standard picker; curated onboarding remains compact. Focused selector tests cover both variants.

![The model picker showing Esc close in its footer](https://01a034db-a75f-7390-bf34-ff9732cbf412--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGMxT1RNNE1UQXNJbXAwYVNJNklqQXhZVEF6TkdVMExXVXhOell0TnpoaU5DMWlOR0ZoTFRVMU5qbGxNamhpTVRoak55SXNJbk5wWkNJNklqQXhZVEF6TkdSaUxXRTNOV1l0TnpNNU1DMWlaak0wTFdabU9UY3pNbU5pWmpReE1pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjF2WkdWc0xYQnBZMnRsY2kxbGMyTXRZMnh2YzJVdWMzWm5JaXdpWTNRaU9pSnBiV0ZuWlM5emRtY3JlRzFzSWl3aVkyUWlPaUpwYm14cGJtVWlmUS5uOXBwMUlXUDBhUmJMSW0tU3J0d1hmZDUxUW5OQUdaSjlDMHl1ZGJLYmdTSUJiblQ0ZWhGREpqZDRpMnV6Q0YtNzRTMVlnS2EzSXlpWUloVW9SdndEQQ)

Made by [Open SWE](https://openswe.vercel.app/agents/383433e3-6793-5759-871b-b676e46a00a3)
