### PR TITLE
style(code): match context percentage token color

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -985,21 +985,6 @@ class StatusBar(Vertical):
         display.display = bool(new_value)
         display.update(new_value)
 
-    _CONTEXT_WARNING_PERCENT = 60.0
-    """Context usage at which the percentage turns from calm to caution."""
-
-    _CONTEXT_CRITICAL_PERCENT = 80.0
-    """Context usage at which the percentage turns to alert."""
-
-    def _percent_color(self, percent: float) -> str:
-        """Return the color that encodes how full the context window is."""
-        colors = theme.get_theme_colors(self)
-        if percent > self._CONTEXT_CRITICAL_PERCENT:
-            return colors.error
-        if percent > self._CONTEXT_WARNING_PERCENT:
-            return colors.warning
-        return colors.muted
-
     def _context_segment(self, count: int, *, approximate: bool = False) -> Content:
         """Build the context percentage and absolute-usage segment.
 
@@ -1016,9 +1001,7 @@ class StatusBar(Vertical):
             count_text = f"{_compact_tokens(count)}{suffix}"
         else:
             percent = min(100.0, max(0.0, count / self.context_limit * 100))
-            percent_content = Content.styled(
-                f"{percent:.0f}%", self._percent_color(percent)
-            )
+            percent_content = Content(f"{percent:.0f}%")
             count_text = f"{_compact_tokens(count)}{suffix}"
         muted = theme.get_theme_colors(self).muted
         return Content.assemble(

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -89,15 +89,18 @@ class TestTwoLineMetrics:
             assert str(cache.render()) == ("Cache 80% hit • 12.5K read / 750 write")
             assert str(context.render()) == "Context: 6% / Tokens: 12.5K • $0.42"
 
-    async def test_context_percentage_color_thresholds(self) -> None:
+    async def test_context_percentage_matches_token_count_color(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
-            colors = theme.get_theme_colors(bar)
+            bar.set_context_limit(100_000)
 
-            assert bar._percent_color(60.0) == colors.muted
-            assert bar._percent_color(60.1) == colors.warning
-            assert bar._percent_color(80.0) == colors.warning
-            assert bar._percent_color(80.1) == colors.error
+            context = bar._context_segment(71_400)
+            percent_offset = context.plain.index("71%")
+            tokens_offset = context.plain.index("71.4K")
+
+            assert context.get_style_at_offset(percent_offset) == (
+                context.get_style_at_offset(tokens_offset)
+            )
 
     @pytest.mark.parametrize(
         ("read", "color"),


### PR DESCRIPTION
The context percentage now uses the same foreground color as the token count instead of changing at usage thresholds.

---

This keeps the status-bar metrics visually consistent and adds a focused style regression test.

### Before

![Before: context percentage uses a different color than token count](https://01a034e8-ccbe-7946-930d-316c0f25dceb--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGMxT1RjMk9UVXNJbXAwYVNJNklqQXhZVEF6TlRJd0xUSmlORGd0TnpJeU55MDROelk0TFRJek9EUTBOamM1TlRnMk9TSXNJbk5wWkNJNklqQXhZVEF6TkdVNExXTmpZbVV0TnprME5pMDVNekJrTFRNeE5tTXdaakkxWkdObFlpSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMkZ5ZEdsbVlXTjBjeTlqYjI1MFpYaDBMWEJsY21ObGJuUmhaMlV0WW1WbWIzSmxMbkJ1WnlJc0ltTjBJam9pYVcxaFoyVXZjRzVuSWl3aVkyUWlPaUpwYm14cGJtVWlmUS5YNGF6T242MVNFZG5jWmtESl9tWXIwaU1LUmdyWWpyeFd4aEdyOWg3ZjBvQzE0dFR2VkNMYUZ3eEwxc0NPOXFWZWFfRjV3eTZQcWZyazMxOXRTNDhEQQ)

### After

![After: context percentage matches token count color](https://01a034e8-ccbe-7946-930d-316c0f25dceb--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGMxT1RjMk9UVXNJbXAwYVNJNklqQXhZVEF6TlRJd0xUSmlOR010Tnprek15MWlNRGxpTFRZeU9HUTVabVpsTkRsa05DSXNJbk5wWkNJNklqQXhZVEF6TkdVNExXTmpZbVV0TnprME5pMDVNekJrTFRNeE5tTXdaakkxWkdObFlpSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMkZ5ZEdsbVlXTjBjeTlqYjI1MFpYaDBMWEJsY21ObGJuUmhaMlV0WVdaMFpYSXVjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkubnVtOGdxR2hqQm8yaHpfVWNUQ0g3VmRiNlUtdmxjbG9VeDhDeUxkZjdtV0xic0lBVzVuY05ZcEFKZjFBYTFYZF9tbXRmeXlkbmRnT0ktbEgweTZnQkE)

Made by [Open SWE](https://openswe.vercel.app/agents/69a4a147-0fbf-5322-b953-5362efc02e66)


