### PR TITLE
feat(cli)!: deprecate `deepagents-cli` in favor of `managed-deepagents`

### DIFF
--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -1,17 +1,25 @@
-# Deep Agents CLI — Deployment Tooling
+# Deep Agents CLI — Deployment Tooling (Deprecated)
 
 [![PyPI - Version](https://img.shields.io/pypi/v/deepagents-cli?label=%20)](https://pypi.org/project/deepagents-cli/#history)
 [![PyPI - License](https://img.shields.io/pypi/l/deepagents-cli)](https://opensource.org/licenses/MIT)
 [![PyPI - Downloads](https://img.shields.io/pepy/dt/deepagents-cli)](https://pypistats.org/packages/deepagents-cli)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/langchain_oss.svg?style=social&label=Follow%20%40LangChain)](https://x.com/langchain_oss)
 
-> [!IMPORTANT]
-> **The interactive coding agent moved.** As of `deepagents-cli==0.1.0`, this package contains only the deployment subcommands (`init`, `deploy`, `agents`, `mcp-servers`). The interactive REPL — previously launched via `deepagents` — now ships as [`deepagents-code`](https://docs.langchain.com/deepagents-code) (`dcode`).
+> [!WARNING]
+> **`deepagents-cli` is deprecated and no longer maintained. This is the final release.** It is superseded by the [`managed-deepagents`](https://pypi.org/project/managed-deepagents/) package and its `mda` CLI, which build, deploy, and run agents from a project directory with no local CLI infrastructure. See the [Managed Deep Agents overview](https://docs.langchain.com/langsmith/python/managed-deep-agents-overview).
+>
+> **What to do:** install the `mda` CLI and re-scaffold your project:
 >
 > ```bash
-> curl -LsSf https://langch.in/dcode | bash
-> dcode
+> uv tool install managed-deepagents
+> mda init my-agent
+> cd my-agent
+> mda deploy
 > ```
+>
+> The `mda` CLI covers everything `deepagents init` / `deploy` / `agents` / `mcp-servers` did — project scaffolding, deployment, agent management, and MCP servers — against the Managed Deep Agents platform. See the [quickstart](https://docs.langchain.com/langsmith/python/managed-deep-agents-quickstart) and [CLI reference](https://docs.langchain.com/langsmith/python/managed-deep-agents-cli).
+>
+> The interactive coding agent (`dcode`) already lives in [`deepagents-code`](https://docs.langchain.com/deepagents-code) and is unaffected by this deprecation.
 
 ## Install
 

--- a/libs/cli/deepagents_cli/__init__.py
+++ b/libs/cli/deepagents_cli/__init__.py
@@ -1,13 +1,31 @@
 """Deep Agents CLI - deployment tooling (`init`, `dev`, `deploy`).
 
+.. deprecated:: 0.3.0
+    `deepagents-cli` is deprecated and will not receive further releases.
+    Use the ``managed-deepagents`` package (``uv tool install
+    managed-deepagents``, then ``mda``) instead:
+    https://docs.langchain.com/langsmith/python/managed-deep-agents-overview
+
 For the interactive coding agent, install the `deepagents-code` package.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 from deepagents_cli._version import __version__
+
+# The deprecation warning lives here (not a submodule) so it fires on
+# `import deepagents_cli` itself.
+warnings.warn(  # noqa: RUF067
+    "deepagents-cli is deprecated and will not receive further releases. "
+    "Use the `managed-deepagents` package (`uv tool install "
+    "managed-deepagents`, then `mda`) instead: "
+    "https://docs.langchain.com/langsmith/python/managed-deep-agents-overview",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "hatchling.build"
 [project]
 name = "deepagents-cli"
 version = "0.2.2"
-description = "Deployment tooling for Deep Agents - bundle, run, and ship agents to LangGraph Platform."
+description = "DEPRECATED: Deployment tooling for Deep Agents. Use Managed Deep Agents (`uv tool install managed-deepagents`, `mda`) instead: https://docs.langchain.com/langsmith/python/managed-deep-agents-overview"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.11,<4.0"
 keywords = ["agents", "ai", "cli", "deploy", "llm", "langgraph", "langchain", "deep-agent"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 7 - Inactive",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
@@ -178,6 +178,8 @@ timeout = 30  # Default timeout for all tests (can be overridden per-test)
 filterwarnings = [
     # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
     "error",
+    # deepagents-cli is deprecated; the package warns at import time on purpose.
+    "default:deepagents-cli is deprecated:DeprecationWarning",
 ]
 
 addopts = "--strict-markers --strict-config --durations=5"


### PR DESCRIPTION
`deepagents-cli` is deprecated. This is the final release before `libs/cli` is removed from the repo.

It is superseded by the [`managed-deepagents`](https://pypi.org/project/managed-deepagents/) package and its `mda` CLI, which build, deploy, and run agents from a project directory on the Managed Deep Agents platform — no local CLI infrastructure.

```bash
uv tool install managed-deepagents
mda init my-agent
cd my-agent
mda deploy
```

The `mda` CLI covers everything `deepagents init` / `deploy` / `agents` / `mcp-servers` did. See the [overview](https://docs.langchain.com/langsmith/python/managed-deep-agents-overview), [quickstart](https://docs.langchain.com/langsmith/python/managed-deep-agents-quickstart), and [CLI reference](https://docs.langchain.com/langsmith/python/managed-deep-agents-cli). The interactive coding agent (`dcode`) lives in [`deepagents-code`](https://docs.langchain.com/deepagents-code) and is unaffected.

---

### ⚠️ Breaking change

This is marked `feat(cli)!` and carries a `BREAKING CHANGE:` footer so the deprecation surfaces under **⚠ BREAKING CHANGES** at the top of the generated release notes — the point is that no one can miss it. (`deepagents-cli` is pre-1.0, so release-please still bumps the **minor** version → **0.3.0**, but flags it as breaking.)

### What this PR changes

- **README** — replaced the top "coding agent moved" note with a `> [!WARNING]` deprecation banner and a "What to do" migration block pointing to `managed-deepagents` / `mda`.
- **`pyproject.toml`** — description now leads with `DEPRECATED:` and a migration pointer; classifier `Development Status :: 4 - Beta` → `7 - Inactive` so PyPI shows the package as inactive. Added a scoped pytest `filterwarnings` entry (`default:deepagents-cli is deprecated:DeprecationWarning`) so the new import-time warning doesn't trip the repo's warnings-as-errors policy.
- **`deepagents_cli/__init__.py`** — emits a `DeprecationWarning` on `import deepagents_cli` directing users to `managed-deepagents`, plus a `.. deprecated:: 0.3.0` docstring note.