### PR TITLE
fix(sdk): match `edit` against LF content so CRLF files stay editable

### DIFF
--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -40,6 +40,7 @@ from deepagents.backends.protocol import (
 from deepagents.backends.utils import (
     compile_grep_include_glob,
     create_file_data,
+    normalize_newlines,
     perform_string_replacement,
     slice_read_response,
 )
@@ -498,13 +499,18 @@ class ContextHubBackend(BackendProtocol):
     ) -> EditResult:
         """Replace `old_string` with `new_string` in a file."""
         hub_path = self._strip_prefix(file_path)
+        # See `StateBackend.edit`: `read` returns LF, so `old_string` is
+        # LF-shaped even for CRLF-stored content. Normalize before matching and
+        # before recording the replay intent.
+        old_string = old_string.replace("\r\n", "\n").replace("\r", "\n")
+        new_string = new_string.replace("\r\n", "\n").replace("\r", "\n")
         try:
             with self._mutations.condition:
                 current = self._visible_cache_locked().get(hub_path)
                 if current is None:
                     return EditResult(error=f"Error: File '{file_path}' not found")
 
-                result = perform_string_replacement(current, old_string, new_string, replace_all)
+                result = perform_string_replacement(normalize_newlines(current), old_string, new_string, replace_all)
                 if isinstance(result, str):
                     return EditResult(error=result)
 

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -28,6 +28,7 @@ from deepagents.backends.utils import (
     create_file_data,
     file_data_to_string,
     grep_matches_from_files,
+    normalize_newlines,
     perform_string_replacement,
     slice_read_response,
     update_file_data,
@@ -235,7 +236,15 @@ class StateBackend(BackendProtocol):
         if file_data is None:
             return EditResult(error=f"Error: File '{file_path}' not found")
 
-        content = file_data_to_string(file_data)
+        # `read` hands the model LF-normalized content (the shared slicer
+        # rewrites the window it returns), so `old_string` arrives LF-shaped
+        # even when the stored file is CRLF. Normalize both sides before
+        # matching, and store the LF form -- this mirrors
+        # `FilesystemBackend.edit`, which gets the same behaviour for free by
+        # reading in universal-newline mode and writing back with newline="".
+        old_string = old_string.replace("\r\n", "\n").replace("\r", "\n")
+        new_string = new_string.replace("\r\n", "\n").replace("\r", "\n")
+        content = normalize_newlines(file_data_to_string(file_data))
         result = perform_string_replacement(content, old_string, new_string, replace_all)
 
         if isinstance(result, str):

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -29,6 +29,7 @@ from deepagents.backends.utils import (
     create_file_data,
     file_data_to_string,
     grep_matches_from_files,
+    normalize_newlines,
     perform_string_replacement,
     slice_read_response,
     update_file_data,
@@ -492,7 +493,15 @@ class StoreBackend(BackendProtocol):
         except ValueError as e:
             return EditResult(error=f"Error: {e}")
 
-        content = file_data_to_string(file_data)
+        # `read` hands the model LF-normalized content (the shared slicer
+        # rewrites the window it returns), so `old_string` arrives LF-shaped
+        # even when the stored file is CRLF. Normalize both sides before
+        # matching, and store the LF form -- this mirrors
+        # `FilesystemBackend.edit`, which gets the same behaviour for free by
+        # reading in universal-newline mode and writing back with newline="".
+        old_string = old_string.replace("\r\n", "\n").replace("\r", "\n")
+        new_string = new_string.replace("\r\n", "\n").replace("\r", "\n")
+        content = normalize_newlines(file_data_to_string(file_data))
         result = perform_string_replacement(content, old_string, new_string, replace_all)
 
         if isinstance(result, str):
@@ -530,7 +539,15 @@ class StoreBackend(BackendProtocol):
         except ValueError as e:
             return EditResult(error=f"Error: {e}")
 
-        content = file_data_to_string(file_data)
+        # `read` hands the model LF-normalized content (the shared slicer
+        # rewrites the window it returns), so `old_string` arrives LF-shaped
+        # even when the stored file is CRLF. Normalize both sides before
+        # matching, and store the LF form -- this mirrors
+        # `FilesystemBackend.edit`, which gets the same behaviour for free by
+        # reading in universal-newline mode and writing back with newline="".
+        old_string = old_string.replace("\r\n", "\n").replace("\r", "\n")
+        new_string = new_string.replace("\r\n", "\n").replace("\r", "\n")
+        content = normalize_newlines(file_data_to_string(file_data))
         result = perform_string_replacement(content, old_string, new_string, replace_all)
 
         if isinstance(result, str):

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -387,6 +387,24 @@ def _copy_file_data_with_content(file_data: FileData, content: str) -> FileData:
     return sliced_fd
 
 
+def normalize_newlines(content: str) -> str:
+    r"""Convert CRLF and bare CR line endings to LF.
+
+    `read` returns an LF-normalized window (see `slice_read_response`), so the
+    `old_string` a model builds from a read is LF-shaped regardless of how the
+    file is stored. Backends that match `old_string` against their raw stored
+    content must normalize both sides first, or no multi-line edit of a CRLF
+    file can ever succeed.
+
+    Args:
+        content: Text that may use CRLF or bare CR line endings.
+
+    Returns:
+        The same text with every `\r\n` and bare `\r` replaced by `\n`.
+    """
+    return content.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def normalize_read_bounds(offset: int, limit: int) -> tuple[int, int]:
     """Floor a requested read window at a zero offset and zero lines.
 

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -1257,3 +1257,16 @@ def test_later_same_path_enqueue_wins_coalesced_batch() -> None:
     mock_client.push_agent.assert_called_once()
     payload = mock_client.push_agent.call_args.kwargs["files"]
     assert payload["same.md"].content == "second"
+
+
+def test_edit_matches_lf_old_string_against_crlf_content() -> None:
+    """`read` hands back LF, so `edit` must accept LF for a CRLF-stored file."""
+    backend, mock_client = _make_backend(**{"a.md": FileEntry(type="file", content="alpha\r\nbeta\r\n")})
+
+    result = backend.edit("/a.md", "alpha\nbeta\n", "alpha\nBETA\n")
+
+    assert result.error is None
+    assert result.occurrences == 1
+    call = mock_client.push_agent.call_args
+    assert "BETA" in call.kwargs["files"]["a.md"].content
+    assert "\r" not in call.kwargs["files"]["a.md"].content

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
@@ -109,3 +109,75 @@ def test_state_backend_edit_migrates_legacy_list_content(monkeypatch: pytest.Mon
     assert result.error is None
     assert updates[0]["/legacy.txt"]["content"] == "hello\nthere"
     assert updates[0]["/legacy.txt"]["encoding"] == "utf-8"
+
+
+# CRLF content is stored verbatim, but `read` hands the model LF (the shared
+# slicer normalizes the window it returns). `edit` therefore has to match the
+# model's LF `old_string` against LF content, or the agent can never edit a
+# file it was just shown. `FilesystemBackend.edit` already does this.
+_CRLF_SOURCE = "def main():\r\n    print('hi')\r\n    return 0\r\n"
+
+
+def test_state_backend_edit_matches_lf_old_string_against_crlf_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`edit` accepts the LF text `read` just handed back for a CRLF file."""
+    backend = StateBackend()
+    files: dict[str, Any] = {"/main.py": {"content": _CRLF_SOURCE, "encoding": "utf-8"}}
+    sent: dict[str, Any] = {}
+    monkeypatch.setattr(backend, "_read_files", lambda: files)
+    monkeypatch.setattr(backend, "_send_files_update", sent.update)
+
+    read_result = backend.read("/main.py")
+    assert read_result.file_data is not None
+    shown = read_result.file_data["content"]
+    assert "\r" not in shown, "read must hand the model LF-normalized content"
+
+    # The model copies two lines verbatim out of what it was shown.
+    old_string = "    print('hi')\n    return 0\n"
+    result = backend.edit("/main.py", old_string, "    print('bye')\n    return 0\n")
+
+    assert result.error is None
+    assert result.occurrences == 1
+    assert "print('bye')" in sent["/main.py"]["content"]
+
+
+def test_state_backend_edit_accepts_crlf_old_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A caller that supplies CRLF in `old_string` still matches."""
+    backend = StateBackend()
+    files: dict[str, Any] = {"/main.py": {"content": _CRLF_SOURCE, "encoding": "utf-8"}}
+    sent: dict[str, Any] = {}
+    monkeypatch.setattr(backend, "_read_files", lambda: files)
+    monkeypatch.setattr(backend, "_send_files_update", sent.update)
+
+    result = backend.edit("/main.py", "    print('hi')\r\n", "    print('bye')\r\n")
+
+    assert result.error is None
+    assert result.occurrences == 1
+    assert "print('bye')" in sent["/main.py"]["content"]
+
+
+def test_state_backend_edit_normalizes_stored_content_to_lf(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rewritten file is LF, matching what `FilesystemBackend.edit` writes."""
+    backend = StateBackend()
+    files: dict[str, Any] = {"/main.py": {"content": _CRLF_SOURCE, "encoding": "utf-8"}}
+    sent: dict[str, Any] = {}
+    monkeypatch.setattr(backend, "_read_files", lambda: files)
+    monkeypatch.setattr(backend, "_send_files_update", sent.update)
+
+    backend.edit("/main.py", "def main():", "def run():")
+
+    assert "\r" not in sent["/main.py"]["content"]
+
+
+def test_state_backend_edit_handles_bare_cr_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy bare-CR line endings are normalized the same way."""
+    backend = StateBackend()
+    files: dict[str, Any] = {"/old.txt": {"content": "one\rtwo\rthree\r", "encoding": "utf-8"}}
+    sent: dict[str, Any] = {}
+    monkeypatch.setattr(backend, "_read_files", lambda: files)
+    monkeypatch.setattr(backend, "_send_files_update", sent.update)
+
+    result = backend.edit("/old.txt", "two\n", "TWO\n")
+
+    assert result.error is None
+    assert result.occurrences == 1
+    assert "TWO" in sent["/old.txt"]["content"]

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -729,3 +729,53 @@ async def test_store_backend_adelete_treats_wildcard_as_literal_key() -> None:
 
     missing = await be.adelete("*")
     assert missing.error is not None and "not found" in missing.error
+
+
+_CRLF_SOURCE = "def main():\r\n    print('hi')\r\n    return 0\r\n"
+
+
+def test_store_backend_edit_matches_lf_old_string_against_crlf_content():
+    """`read` hands back LF; `edit` must accept that same LF text.
+
+    The shared slicer normalizes the window `read` returns, so the model never
+    sees the stored CRLF. Matching `old_string` against raw CRLF content made
+    every multi-line edit of a CRLF file fail with "String not found in file".
+    """
+    be = StoreBackend(store=InMemoryStore(), namespace=lambda _rt: ("filesystem",))
+    be.write("/main.py", _CRLF_SOURCE)
+
+    read_result = be.read("/main.py")
+    assert read_result.file_data is not None
+    assert "\r" not in read_result.file_data["content"]
+
+    result = be.edit("/main.py", "    print('hi')\n    return 0\n", "    print('bye')\n    return 0\n")
+
+    assert isinstance(result, EditResult)
+    assert result.error is None
+    assert result.occurrences == 1
+    after = be.read("/main.py")
+    assert after.file_data is not None
+    assert "print('bye')" in after.file_data["content"]
+
+
+def test_store_backend_edit_normalizes_stored_content_to_lf():
+    """The rewritten file is LF, matching `FilesystemBackend.edit`."""
+    be = StoreBackend(store=InMemoryStore(), namespace=lambda _rt: ("filesystem",))
+    be.write("/main.py", _CRLF_SOURCE)
+
+    be.edit("/main.py", "def main():", "def run():")
+
+    item = be._get_store().get(("filesystem",), "/main.py")
+    assert item is not None
+    assert "\r" not in item.value["content"]
+
+
+def test_store_backend_edit_handles_bare_cr_content():
+    """Legacy bare-CR line endings are normalized the same way."""
+    be = StoreBackend(store=InMemoryStore(), namespace=lambda _rt: ("filesystem",))
+    be.write("/old.txt", "one\rtwo\rthree\r")
+
+    result = be.edit("/old.txt", "two\n", "TWO\n")
+
+    assert result.error is None
+    assert result.occurrences == 1

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
@@ -423,3 +423,22 @@ async def test_store_backend_aintercept_large_tool_result_async():
     stored_content = await mem_store.aget(("filesystem",), "/large_tool_results/test_async_789")
     assert stored_content is not None
     assert stored_content.value["content"] == large_content
+
+
+_CRLF_SOURCE_ASYNC = "def main():\r\n    print('hi')\r\n    return 0\r\n"
+
+
+async def test_store_backend_aedit_matches_lf_old_string_against_crlf_content():
+    """`aedit` is a separate method body from `edit`, so it needs its own case."""
+    be = StoreBackend(store=InMemoryStore(), namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/main.py", _CRLF_SOURCE_ASYNC)
+
+    read_result = await be.aread("/main.py")
+    assert read_result.file_data is not None
+    assert "\r" not in read_result.file_data["content"]
+
+    result = await be.aedit("/main.py", "    print('hi')\n    return 0\n", "    print('bye')\n    return 0\n")
+
+    assert isinstance(result, EditResult)
+    assert result.error is None
+    assert result.occurrences == 1

--- a/libs/deepagents/tests/unit_tests/test_file_system_tools.py
+++ b/libs/deepagents/tests/unit_tests/test_file_system_tools.py
@@ -587,3 +587,53 @@ def test_ls_with_invalid_path_returns_error_message() -> None:
 
     error_message = tool_messages[0].content
     assert error_message == "Error: Path traversal not allowed: ../../../etc"
+
+
+def test_edit_file_accepts_lf_text_read_back_from_crlf_file() -> None:
+    """End-to-end: write CRLF, read it, edit exactly what the read returned.
+
+    `read_file` shows the model LF-normalized content. Before the fix the
+    subsequent `edit_file` matched that LF `old_string` against the raw CRLF
+    content in state and failed with "String not found in file" -- for text the
+    agent had been shown one tool call earlier.
+    """
+    crlf = "def main():\r\n    print('hi')\r\n    return 0\r\n"
+    old_string = "    print('hi')\n    return 0\n"
+
+    fake_model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "write_file", "args": {"file_path": "/main.py", "content": crlf}, "id": "w", "type": "tool_call"}],
+                ),
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "read_file", "args": {"file_path": "/main.py"}, "id": "r", "type": "tool_call"}],
+                ),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "edit_file",
+                            "args": {
+                                "file_path": "/main.py",
+                                "old_string": old_string,
+                                "new_string": "    print('bye')\n    return 0\n",
+                            },
+                            "id": "e",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="Edited."),
+            ]
+        )
+    )
+
+    result = create_deep_agent(model=fake_model, backend=StateBackend()).invoke({"messages": [HumanMessage(content="edit the file")]})
+
+    edit_messages = [m for m in result["messages"] if isinstance(m, ToolMessage) and m.name == "edit_file"]
+    assert len(edit_messages) == 1
+    assert edit_messages[0].status == "success", edit_messages[0].content
+    assert "print('bye')" in result["files"]["/main.py"]["content"]


### PR DESCRIPTION


Fixes #5783.
---

`edit_file` now succeeds on a file with CRLF line endings instead of rejecting the exact text `read_file` returned a moment earlier.

---

`slice_read_response` normalizes the window `read` returns, so a model is always shown LF text regardless of how the file is stored. `StateBackend`, `StoreBackend` and `ContextHubBackend` then matched `old_string` against their raw stored content, which is still CRLF — so every multi-line edit of a CRLF file failed with `String not found in file`, for text the agent had just been shown. Re-reading returns the same LF text, so the natural retry fails identically.

`FilesystemBackend.edit` already avoids this: reading in universal-newline mode and writing back with `newline=""` leaves both sides LF. This gives the other three backends the same behaviour through a shared `normalize_newlines` helper in `backends/utils.py`, applied to `old_string`, `new_string` and the stored content before matching. The rewritten file is stored LF, matching what `FilesystemBackend.edit` already writes.

`StoreBackend.aedit` is a separate method body and is covered too.

`StateBackend` is the default backend for `create_deep_agent`, so this is the default configuration.

## Note on the first attempt

Normalizing only `old_string`/`new_string` is not sufficient — the haystack is still CRLF, so the match still fails. The stored content has to be normalized as well. Worth flagging for reviewers, since the partial fix looks correct at a glance.

## How did you verify your code works?

Test-driven — the tests were written first and observed failing against unpatched `main` (7 failures), then passing.

- `tests/unit_tests/backends/test_state_backend.py` — LF `old_string` against CRLF content, a CRLF `old_string` (regression guard: it matched before and must keep matching), LF normalization of the stored result, and bare-CR content.
- `tests/unit_tests/backends/test_store_backend.py` and `..._async.py` — the same for `edit` and `aedit`.
- `tests/unit_tests/backends/test_context_hub_backend.py` — the same against the mocked hub client.
- `tests/unit_tests/test_file_system_tools.py` — end-to-end `write_file` → `read_file` → `edit_file` on `StateBackend`, asserting the edit succeeds and the file actually changed.

From `libs/deepagents`, on a clean clone of `main` @ `19de73d`:

- `pytest tests/unit_tests/` → **2643 passed, 106 skipped, 4 xfailed** (baseline is 2633; +10 new)
- `ruff check` → All checks passed
- `ruff format --check` → 130 files already formatted
- `ty check deepagents` → All checks passed

## Breaking changes

Editing a CRLF-stored file now rewrites it with LF endings. That already matched `FilesystemBackend.edit`'s behaviour, so this makes the backends consistent rather than introducing a new convention — but it is a visible change for state/store/hub callers that previously could not edit such files at all.

