### PR TITLE
fix(sdk): stop rendering the empty-file reminder as file content

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1885,7 +1885,15 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             # Empty files get a uniform warning regardless of encoding/type, so
             # check before routing to avoid a degenerate empty content block for
             # binary reads.
-            empty_msg = check_empty_content(content)
+            # Backends disagree about how an empty file arrives here. Most
+            # return empty content and let `check_empty_content` label it, but
+            # `FilesystemBackend` and the sandbox read script bake
+            # `EMPTY_CONTENT_WARNING` into `file_data["content"]` instead.
+            # Without the second arm that string looks like ordinary text, so
+            # it falls through to the gutter renderer and the model is told
+            # line 1 of the file reads "System reminder: File exists but has
+            # empty contents".
+            empty_msg = check_empty_content(content) or (EMPTY_CONTENT_WARNING if content == EMPTY_CONTENT_WARNING else None)
             if empty_msg:
                 # Empty content has two causes that must not be conflated: a
                 # zero-line window, where the file was never inspected, and a

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1,5 +1,6 @@
 import mimetypes
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,6 +22,7 @@ from pydantic import ValidationError
 
 import deepagents.middleware.filesystem as filesystem_middleware
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
+from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import (
     BackendProtocol,
     ExecuteResponse,
@@ -3708,3 +3710,47 @@ class TestBuiltinTruncationTools:
 
         with pytest.raises(ValueError, match="max_execute_timeout must be positive"):
             FilesystemMiddleware(max_execute_timeout=-1)
+
+
+class TestEmptyFileReminderIsNotRenderedAsContent:
+    """The empty-file reminder must not arrive wearing a line-number gutter.
+
+    `FilesystemBackend.read` (and the sandbox read script) report an empty file
+    by putting `EMPTY_CONTENT_WARNING` *into* `file_data["content"]` rather than
+    returning empty content. The middleware's `check_empty_content` then sees a
+    non-empty string, skips the empty-file branch, and line-numbers the
+    reminder -- so the model is told the file's line 1 reads "System reminder:
+    File exists but has empty contents".
+
+    Backends that return genuinely empty content already produce the clean
+    reminder, and `TestReadFileEmptyContent` pins that as the contract.
+    """
+
+    @staticmethod
+    def _read(tmp_path: Path, name: str, body: str) -> ToolMessage:
+        (tmp_path / name).write_text(body, encoding="utf-8")
+        middleware = FilesystemMiddleware(backend=FilesystemBackend(root_dir=str(tmp_path)))
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+        result = read_file_tool.invoke({"runtime": _runtime(), "file_path": f"/{name}", "offset": 0, "limit": 100})
+        assert isinstance(result, ToolMessage)
+        return result
+
+    def test_empty_file_reports_the_bare_reminder(self, tmp_path: Path) -> None:
+        result = self._read(tmp_path, "empty.txt", "")
+        assert result.status == "success"
+        assert result.content == EMPTY_CONTENT_WARNING
+
+    def test_whitespace_only_file_reports_the_bare_reminder(self, tmp_path: Path) -> None:
+        result = self._read(tmp_path, "blank.txt", "   \n  \n")
+        assert result.status == "success"
+        assert result.content == EMPTY_CONTENT_WARNING
+
+    def test_reminder_is_not_given_a_line_number_gutter(self, tmp_path: Path) -> None:
+        result = self._read(tmp_path, "empty.txt", "")
+        assert not str(result.content).startswith("1 ")
+        assert "1  System reminder" not in str(result.content)
+
+    def test_file_with_real_content_is_unaffected(self, tmp_path: Path) -> None:
+        result = self._read(tmp_path, "notes.txt", "alpha\nbeta\n")
+        assert result.status == "success"
+        assert str(result.content).startswith("1  alpha")


### PR DESCRIPTION

Fixes #5785.

---

Reading an empty file through `FilesystemBackend` now returns the bare empty-file reminder instead of `1  System reminder: File exists but has empty contents` dressed up as the file's first line.

---

Backends disagree about how an empty file reaches the `read_file` tool. Most return empty content and let `check_empty_content` label it. `FilesystemBackend` and the sandbox read script instead bake `EMPTY_CONTENT_WARNING` into `file_data["content"]`.

The middleware only asked `check_empty_content`, which sees a non-empty string in that second case, so the reminder fell through to the gutter renderer. For a whitespace-only file the real contents were discarded and replaced by that line too.

Treating a backend-supplied `EMPTY_CONTENT_WARNING` as the empty case makes every backend produce the bare reminder that `TestReadFileEmptyContent` already pins for the others. Fixing it in the middleware rather than in `FilesystemBackend.read` covers the sandbox backend at the same time — its remote read script returns the same sentinel — and leaves both backends' contracts untouched.

The `NO_LINES_REQUESTED_WARNING` branch is unaffected: a zero-line window still reports that the file was not inspected, which stays distinct from "the file is empty".

## How did you verify your code works?

Test-driven — the tests were written first and observed failing against unpatched `main` with the exact signature `'1  System reminder: File exists but has empty contents'`, then passing.

- `tests/unit_tests/test_middleware.py` — new `TestEmptyFileReminderIsNotRenderedAsContent`, driving the real `read_file` tool over a real `FilesystemBackend`: an empty file and a whitespace-only file both report the bare reminder; the reminder carries no gutter; and a file with real content is unaffected.

From `libs/deepagents`, on a clean clone of `main` @ `19de73d`:

- `pytest tests/unit_tests/` → **2637 passed, 106 skipped, 4 xfailed** (baseline is 2633; +4 new)
- `ruff check` → All checks passed
- `ruff format --check` → 130 files already formatted
- `ty check deepagents` → All checks passed

## Breaking changes

None. The tool message for an empty file changes from a line-numbered variant to the documented bare reminder, which is what every other backend already produced.
