### PR TITLE
fix(sdk): count read_file lines the way grep and the gutter do

### DIFF
--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -425,6 +425,44 @@ def normalize_read_bounds(offset: int, limit: int) -> tuple[int, int]:
     return normalized_offset, normalized_limit
 
 
+_UNIVERSAL_NEWLINE_SPLIT_RE = re.compile(r"(?<=\n)|(?<=\r)(?!\n)")
+"""Zero-width split after every LF, and after every CR not part of a CRLF."""
+
+
+def split_lines_keepends(content: str) -> list[str]:
+    r"""Split `content` into lines on universal newlines, keeping terminators.
+
+    Breaks on `\n`, `\r\n` and bare `\r` only -- deliberately *not* on the
+    rest of the Unicode line-boundary set (`\v`, `\f`, `\x1c`, `\x1d`,
+    `\x1e`, `\x85`, `\u2028`, `\u2029`), which `str.splitlines()` also
+    breaks on.
+
+    That distinction is the whole point. `grep_matches_from_files` and
+    `format_content_with_line_numbers` both index lines with
+    `str.split("\n")`, so using `str.splitlines()` here gave `read_file` a
+    different definition of "line N" than grep and the rendered gutter. A file
+    carrying a form feed (the Emacs/GNU page separator, common in real source
+    trees) or `\u2028`/`\u2029` (routine in JavaScript and JSON) made the
+    canonical agent loop -- grep for a symbol, read the reported line -- return
+    a *different* line, labelled with the number that was asked for, with no
+    error anywhere.
+
+    Joining the result with `""` reproduces `content` exactly, so the file's
+    trailing-newline state still round-trips for `edit()`'s EOF detection.
+
+    Args:
+        content: Text to split.
+
+    Returns:
+        The lines of `content`, each retaining its terminator; the final line
+            has none when `content` does not end with one.
+    """
+    lines = _UNIVERSAL_NEWLINE_SPLIT_RE.split(content)
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
 def slice_read_response(
     file_data: FileData,
     offset: int,
@@ -471,13 +509,15 @@ def slice_read_response(
     if limit == 0:
         return ReadResult(file_data=_copy_file_data_with_content(file_data, ""), no_lines_requested=True)
 
-    # `splitlines(keepends=True)` retains each line's terminator, including
-    # the absence of one on the final line. Joining with `""` therefore
-    # round-trips the trailing-newline state of the file faithfully —
-    # required so `edit()` can report EOF-newline mismatches accurately. It
-    # also splits on CR / CRLF, so line indexing matches the LF-normalized
-    # form without first rewriting the whole (potentially huge) string.
-    lines = content.splitlines(keepends=True)
+    # `split_lines_keepends` retains each line's terminator, including the
+    # absence of one on the final line. Joining with `""` therefore round-trips
+    # the trailing-newline state of the file faithfully — required so `edit()`
+    # can report EOF-newline mismatches accurately. It splits on CR / CRLF too,
+    # so line indexing matches the LF-normalized form without first rewriting
+    # the whole (potentially huge) string, and — unlike `str.splitlines()` — it
+    # leaves the other Unicode line boundaries alone so that `read_file`,
+    # `grep` and the rendered gutter all agree on which line is line N.
+    lines = split_lines_keepends(content)
     start_idx = offset
     end_idx = min(start_idx + limit, len(lines))
     total_lines = len(lines)

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -15,6 +15,7 @@ from deepagents.backends.utils import (
     _looks_like_regex,
     compile_grep_include_glob,
     compile_recursive_glob,
+    format_content_with_line_numbers,
     grep_matches_from_files,
     perform_string_replacement,
     regex_literal_hint,
@@ -671,3 +672,88 @@ class TestGrepMaxCount:
         assert result.matches is not None
         assert len(result.matches) == 3
         assert result.truncated is False
+
+
+# ---------------------------------------------------------------------------
+# One definition of "a line"
+# ---------------------------------------------------------------------------
+
+# `str.splitlines()` breaks on the full Unicode boundary set. `grep` and the
+# line-number gutter both index with `str.split("\n")`. Those two disagree for
+# any file containing one of the characters below, so `grep` would report a
+# symbol on line N while `read_file(offset=N-1)` returned a different line --
+# and labelled it N.
+UNICODE_NON_TERMINATORS = [
+    pytest.param("\v", id="vertical-tab"),
+    pytest.param("\f", id="form-feed"),
+    pytest.param("\x1c", id="file-separator"),
+    pytest.param("\x1d", id="group-separator"),
+    pytest.param("\x1e", id="record-separator"),
+    pytest.param("\x85", id="next-line"),
+    pytest.param("\u2028", id="line-separator"),
+    pytest.param("\u2029", id="paragraph-separator"),
+]
+
+
+class TestReadLineDefinitionMatchesGrep:
+    """`read` must count lines the way `grep` and the gutter renderer do."""
+
+    @staticmethod
+    def _file(content: str) -> FileData:
+        return FileData(content=content, encoding="utf-8")
+
+    @pytest.mark.parametrize("char", UNICODE_NON_TERMINATORS)
+    def test_unicode_boundary_is_not_a_line_terminator(self, char: str) -> None:
+        content = f"alpha\nbeta{char}gamma\ndelta\n"
+        result = slice_read_response(self._file(content), offset=0, limit=2000)
+        assert result.total_lines == 3
+        assert result.end_line == 3
+
+    @pytest.mark.parametrize("char", UNICODE_NON_TERMINATORS)
+    def test_grep_line_number_reads_back_the_same_line(self, char: str) -> None:
+        """The canonical agent loop: grep for a symbol, then read that line."""
+        content = f"alpha\nbeta{char}gamma\nTARGET\ndelta\n"
+        files = {"/f.txt": {"content": content, "modified_at": "2024-01-01T00:00:00Z"}}
+
+        matches = grep_matches_from_files(files, "TARGET", "/").matches
+        assert len(matches) == 1
+        line_number = matches[0]["line"]
+
+        window = slice_read_response(self._file(content), offset=line_number - 1, limit=1)
+        assert window.file_data is not None
+        assert "TARGET" in window.file_data["content"]
+        assert window.start_line == line_number
+
+    @pytest.mark.parametrize("char", UNICODE_NON_TERMINATORS)
+    def test_rendered_gutter_row_count_matches_metadata(self, char: str) -> None:
+        content = f"alpha\nbeta{char}gamma\ndelta\n"
+        result = slice_read_response(self._file(content), offset=0, limit=2000)
+        assert result.file_data is not None
+        assert result.start_line is not None
+        assert result.end_line is not None
+
+        rendered = format_content_with_line_numbers(result.file_data["content"], start_line=result.start_line)
+        rows = rendered.split("\n")
+        assert len(rows) == result.end_line - result.start_line + 1
+
+    def test_crlf_is_still_a_line_terminator(self) -> None:
+        result = slice_read_response(self._file("r1\r\nr2\r\nr3\r\n"), offset=0, limit=2000)
+        assert result.total_lines == 3
+
+    def test_bare_cr_is_still_a_line_terminator(self) -> None:
+        """Unchanged behaviour: universal newlines stay universal."""
+        result = slice_read_response(self._file("foo\rbar\r"), offset=0, limit=2000)
+        assert result.total_lines == 2
+
+    def test_form_feed_page_break_paginates_contiguously(self) -> None:
+        """Two sequential pages of a form-feed file must not skip or repeat."""
+        content = "one\ntwo\fthree\nfour\nfive\n"
+        page_one = slice_read_response(self._file(content), offset=0, limit=2)
+        assert page_one.next_offset is not None
+        page_two = slice_read_response(self._file(content), offset=page_one.next_offset, limit=2)
+
+        assert page_one.file_data is not None
+        assert page_two.file_data is not None
+        assert page_one.file_data["content"] == "one\ntwo\fthree\n"
+        assert page_two.file_data["content"] == "four\nfive\n"
+        assert page_two.start_line == page_one.end_line + 1

--- a/libs/deepagents/tests/unit_tests/test_file_system_tools.py
+++ b/libs/deepagents/tests/unit_tests/test_file_system_tools.py
@@ -587,3 +587,49 @@ def test_ls_with_invalid_path_returns_error_message() -> None:
 
     error_message = tool_messages[0].content
     assert error_message == "Error: Path traversal not allowed: ../../../etc"
+
+
+def test_grep_line_number_reads_back_the_same_line_across_a_form_feed() -> None:
+    """End-to-end: grep for a symbol, read the line it reported, get that line.
+
+    A form feed (the Emacs/GNU page separator) used to make `read_file` count
+    lines differently from `grep`, so the agent asked for the line grep named
+    and was handed the line before it -- rendered under the requested number.
+    """
+    source = "def alpha():\n    return 1\n\n\f\ndef beta():\n    SECRET = 1\n    return 2\n"
+
+    fake_model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "write_file", "args": {"file_path": "/mod.py", "content": source}, "id": "w", "type": "tool_call"}],
+                ),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "grep",
+                            "args": {"pattern": "SECRET", "path": "/", "output_mode": "content"},
+                            "id": "g",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "read_file", "args": {"file_path": "/mod.py", "offset": 5, "limit": 1}, "id": "r", "type": "tool_call"}],
+                ),
+                AIMessage(content="Found it."),
+            ]
+        )
+    )
+
+    result = create_deep_agent(model=fake_model, backend=StateBackend()).invoke({"messages": [HumanMessage(content="find SECRET")]})
+    by_name = {m.name: str(m.content) for m in result["messages"] if isinstance(m, ToolMessage)}
+
+    # grep reports the 1-indexed line; SECRET is on LF line 6.
+    assert "6:" in by_name["grep"], by_name["grep"]
+    # read_file(offset=5) is that same line, and the gutter agrees.
+    assert "SECRET" in by_name["read_file"], by_name["read_file"]
+    assert by_name["read_file"].lstrip().startswith("6"), by_name["read_file"]


### PR DESCRIPTION

Fixes #5787.

---

`read_file` and `grep` now agree on which line is line N for files containing a form feed or other Unicode line-boundary characters, so grepping for a symbol and reading the reported line returns that line rather than its neighbour.

---

`slice_read_response` indexed lines with `str.splitlines(keepends=True)`, which breaks on the full Unicode line-boundary set. `grep_matches_from_files` and `format_content_with_line_numbers` both index with `str.split("\n")`. The two disagree for any file containing a vertical tab, form feed, file/group/record separator, NEL, LINE SEPARATOR or PARAGRAPH SEPARATOR.

Those are not exotic inputs: a form feed is the Emacs/GNU page separator and appears throughout real source trees, and the Unicode separators turn up in JavaScript and JSON. On such a file the canonical agent loop — grep for a symbol, read the line grep reported — returned a *different* line, rendered under the number that was asked for, with no error anywhere. `total_lines` was overstated for the same reason.

This adds `split_lines_keepends`, which breaks on universal newlines only (LF, CRLF and bare CR) and leaves the other boundaries alone, and uses it for the read window. Two properties the old call relied on are preserved deliberately:

- Joining the result with `""` reproduces the input exactly, so the trailing-newline state `edit()`'s EOF-mismatch detection depends on still round-trips.
- CR and CRLF remain terminators, so `test_normalizes_bare_cr_to_lf` and `test_normalizes_crlf_to_lf` are unchanged.

It also avoids rewriting the whole (potentially huge) string, which the previous comment called out as intentional — the split is a compiled zero-width regex, not a `.replace()` pass.

## Scope

Deliberately limited to the Unicode boundary set. A bare `\r` is a second trigger of the same shape, but it cannot be closed the same way: `FilesystemBackend`'s grep is ripgrep, which splits on `\n` only, while `test_normalizes_bare_cr_to_lf` pins bare CR as a terminator for reads. Reconciling those is a project-level decision about the canonical line rule, not a mechanical change, so it is left alone here and called out in the issue.

## How did you verify your code works?

Test-driven — the tests were written first and observed failing against unpatched `main` (25 failures), then passing. The end-to-end case was additionally re-checked against unpatched source to confirm it fails with the exact bug signature (`'6  def beta():'` where line 6 should read `SECRET = 1`).

- `tests/unit_tests/backends/test_utils.py` — new `TestReadLineDefinitionMatchesGrep`, parametrized across all eight boundary characters: each is not a terminator; the line `grep` reports reads back as that same line; the rendered gutter row count matches `end_line - start_line + 1`. Plus CRLF and bare-CR regression guards, and contiguous pagination across a form-feed page break.
- `tests/unit_tests/test_file_system_tools.py` — end-to-end agent run: `write_file` → `grep` → `read_file(offset=5)`, asserting grep reports line 6 and the read returns that line under gutter `6`.

From `libs/deepagents`, on a clean clone of `main` @ `19de73d`:

- `pytest tests/unit_tests/` → **2661 passed, 106 skipped, 4 xfailed** (baseline is 2633; +28 new)
- `ruff check` → All checks passed
- `ruff format --check` → 130 files already formatted
- `ty check deepagents` → All checks passed

## Breaking changes

`total_lines`, `start_line`, `end_line` and `next_offset` change for files containing one of the eight characters — from the `splitlines()` count to the count grep and the gutter already used. That is the fix.
