### PR TITLE
feat(sdk): add orcarouter provider profile

### DIFF
--- a/libs/deepagents/deepagents/_models.py
+++ b/libs/deepagents/deepagents/_models.py
@@ -22,6 +22,30 @@ LangChain specs and LangSmith params use different provider names for some
 integrations. Canonicalize only known aliases before comparing providers.
 """
 
+
+def _normalize_provider(provider: str) -> str:
+    """Canonicalize a provider name so equal providers compare equal.
+
+    Specs use the `provider:model` spelling (lowercase, underscore-separated,
+    e.g. `azure_openai`), while the `ls_provider` reported by `_get_ls_params`
+    may differ in case, use hyphens (`openai-codex`), or use an entirely
+    different name (`mistralai` vs `mistral`). Folding both sides through this
+    function before comparison keeps those spellings from reading as a
+    mismatch.
+    """
+    normalized = provider.lower().replace("-", "_")
+    return _PROVIDER_ALIASES.get(normalized, normalized)
+
+
+# OrcaRouter does not ship a dedicated LangChain integration package. Its API
+# is OpenAI-compatible, so `orcarouter:<model>` specs are routed through
+# LangChain's `openrouter` provider (whose `ChatOpenRouter` is an
+# OpenAI-compatible client) with the OrcaRouter base URL injected by the
+# built-in provider profile. The spec keeps the `orcarouter` prefix for the
+# profile registry and user-facing labels; only the `init_chat_model` provider
+# name is rewritten here.
+_ORCAROUTER_LANGCHAIN_PROVIDER = "openrouter"
+
 _BEDROCK_PROVIDERS = frozenset({"amazon_bedrock", "anthropic_bedrock", "aws", "bedrock", "bedrock_converse"})
 """Normalized provider names that identify AWS Bedrock chat models."""
 
@@ -44,6 +68,11 @@ def resolve_model(model: str | BaseChatModel) -> BaseChatModel:
     users can layer additional providers or overrides via
     `register_provider_profile`.
 
+    `orcarouter:<model>` specs are rewritten to the `openrouter` provider name
+    for `init_chat_model` (OrcaRouter's API is OpenAI-compatible and has no
+    dedicated LangChain package), while the `orcarouter` provider profile still
+    applies.
+
     Args:
         model: Model string (e.g. `"openai:gpt-5.4"`) or pre-configured
             `BaseChatModel` subclass instance.
@@ -54,7 +83,12 @@ def resolve_model(model: str | BaseChatModel) -> BaseChatModel:
     if isinstance(model, BaseChatModel):
         return model
 
-    return init_chat_model(model, **apply_provider_profile(model))
+    init_spec = model
+    provider, sep, _ = model.partition(":")
+    if sep and _normalize_provider(provider) == "orcarouter":
+        init_spec = f"{_ORCAROUTER_LANGCHAIN_PROVIDER}{model[len(provider) :]}"
+
+    return init_chat_model(init_spec, **apply_provider_profile(model))
 
 
 def get_model_identifier(model: BaseChatModel) -> str | None:
@@ -187,20 +221,6 @@ def model_matches_spec(model: BaseChatModel, spec: str) -> bool:
         )
         return True
     return _normalize_provider(provider) == _normalize_provider(current_provider)
-
-
-def _normalize_provider(provider: str) -> str:
-    """Canonicalize a provider name so equal providers compare equal.
-
-    Specs use the `provider:model` spelling (lowercase, underscore-separated,
-    e.g. `azure_openai`), while the `ls_provider` reported by `_get_ls_params`
-    may differ in case, use hyphens (`openai-codex`), or use an entirely
-    different name (`mistralai` vs `mistral`). Folding both sides through this
-    function before comparison keeps those spellings from reading as a
-    mismatch.
-    """
-    normalized = provider.lower().replace("-", "_")
-    return _PROVIDER_ALIASES.get(normalized, normalized)
 
 
 def _string_attr(obj: object, attr: str) -> str | None:

--- a/libs/deepagents/deepagents/profiles/_builtin_profiles.py
+++ b/libs/deepagents/deepagents/profiles/_builtin_profiles.py
@@ -34,7 +34,7 @@ from deepagents.profiles.harness import (
     _openai_codex,
 )
 from deepagents.profiles.harness.harness_profiles import _HARNESS_PROFILES
-from deepagents.profiles.provider import _nvidia, _openai, _openrouter
+from deepagents.profiles.provider import _nvidia, _openai, _openrouter, _orcarouter
 from deepagents.profiles.provider.provider_profiles import _PROVIDER_PROFILES
 
 logger = logging.getLogger(__name__)
@@ -149,6 +149,7 @@ def _ensure_builtin_profiles_loaded() -> None:
         _nvidia.register()
         _openai.register()
         _openrouter.register()
+        _orcarouter.register()
         _anthropic_opus_4_7.register()
         _anthropic_sonnet_4_6.register()
         _anthropic_haiku_4_5.register()

--- a/libs/deepagents/deepagents/profiles/provider/_orcarouter.py
+++ b/libs/deepagents/deepagents/profiles/provider/_orcarouter.py
@@ -1,0 +1,84 @@
+"""Built-in OrcaRouter provider profile and helpers.
+
+OrcaRouter is an OpenAI-compatible AI gateway. It exposes a provider/model
+namespace across many models (like OpenRouter) and runs gateway-level
+security for AI agents on the same endpoint. There is no dedicated
+`langchain-orcarouter` integration package, so the model is constructed
+through `langchain-openrouter`'s `ChatOpenRouter` (an OpenAI-compatible
+client) with the OrcaRouter base URL and app attribution injected here.
+
+Registered directly by `_ensure_builtin_profiles_loaded` during the
+first profile-registry access. Not exposed as an `importlib.metadata` entry
+point — built-ins ship with the SDK and should not depend on install-time
+metadata to activate.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from deepagents.profiles.provider.provider_profiles import ProviderProfile, _register_provider_profile_impl
+
+ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+"""Default OrcaRouter API base URL.
+
+Mapped to `base_url` on `ChatOpenRouter`, which forwards it to the
+OpenAI-compatible client as the server URL.
+"""
+
+ORCAROUTER_APP_URL = "https://github.com/langchain-ai/deepagents"
+"""Default `app_url` (maps to `HTTP-Referer`) for OrcaRouter attribution."""
+
+ORCAROUTER_APP_TITLE = "Deep Agents"
+"""Default `app_title` (maps to `X-Title`) for OrcaRouter attribution."""
+
+ORCAROUTER_API_KEY_ENV = "ORCAROUTER_API_KEY"
+"""Env var holding the OrcaRouter API key.
+
+The model is built through `ChatOpenRouter`, which reads `OPENROUTER_API_KEY`
+by default. This profile reads `ORCAROUTER_API_KEY` and forwards it as
+`api_key`, so `orcarouter:<model>` specs authenticate with the OrcaRouter key
+without also exporting `OPENROUTER_API_KEY`.
+"""
+
+
+def _orcarouter_init_kwargs() -> dict[str, Any]:
+    """Build default OrcaRouter kwargs, deferring to env var overrides.
+
+    `ChatOpenRouter` reads `OPENROUTER_APP_URL` and `OPENROUTER_APP_TITLE`
+    via `from_env()` defaults. Explicit kwargs passed to the constructor take
+    precedence over those env-var defaults, so we only inject our SDK defaults
+    when the corresponding env var is **not** set — otherwise the user's env var
+    would be overridden.
+
+    `base_url` is always injected so `orcarouter:<model>` resolves against the
+    OrcaRouter endpoint by default. Callers may override it with their own
+    `base_url` kwarg, which `apply_provider_profile` layers on top.
+
+    `api_key` is read from `ORCAROUTER_API_KEY` so a single env var
+    authenticates the provider; an explicit `api_key` kwarg from the caller
+    still wins.
+
+    Returns:
+        Dictionary of kwargs to spread into `init_chat_model`.
+    """
+    kwargs: dict[str, Any] = {"base_url": ORCAROUTER_BASE_URL}
+    api_key = os.environ.get(ORCAROUTER_API_KEY_ENV)
+    if api_key:
+        kwargs["api_key"] = api_key
+    if os.environ.get("OPENROUTER_APP_URL") is None:
+        kwargs["app_url"] = ORCAROUTER_APP_URL
+    if os.environ.get("OPENROUTER_APP_TITLE") is None:
+        kwargs["app_title"] = ORCAROUTER_APP_TITLE
+    return kwargs
+
+
+def register() -> None:
+    """Register the built-in OrcaRouter provider profile."""
+    _register_provider_profile_impl(
+        "orcarouter",
+        ProviderProfile(
+            init_kwargs_factory=_orcarouter_init_kwargs,
+        ),
+    )

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -44,6 +44,7 @@ from deepagents.profiles.provider._openrouter import (
     _openrouter_attribution_kwargs,
     check_openrouter_version,
 )
+from deepagents.profiles.provider._orcarouter import ORCAROUTER_BASE_URL
 from deepagents.profiles.provider.provider_profiles import (
     _PROVIDER_PROFILES,
     _merge_provider_profiles,
@@ -83,6 +84,16 @@ def _make_model(attrs: dict) -> MagicMock:
 
 class TestResolveModel:
     """Tests for `resolve_model`."""
+
+    @pytest.fixture(autouse=True)
+    def _scrub_orcarouter_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pop `ORCAROUTER_API_KEY` before each test.
+
+        The OrcaRouter provider profile forwards this env var as `api_key`, so
+        an ambient value in the developer's shell would change the kwargs
+        `resolve_model` passes to `init_chat_model`.
+        """
+        monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
 
     def test_passthrough_when_already_model(self) -> None:
         model = MagicMock(spec=BaseChatModel)
@@ -189,6 +200,30 @@ class TestResolveModel:
 
         mock.assert_called_once_with("anthropic:claude-sonnet-4-6")
         assert result is mock.return_value
+
+    def test_orcarouter_prefix_routes_through_openrouter_with_base_url(self) -> None:
+        with patch("deepagents._models.init_chat_model") as mock:
+            mock.return_value = MagicMock(spec=BaseChatModel)
+            result = resolve_model("orcarouter:deepseek/deepseek-chat")
+
+        mock.assert_called_once_with(
+            "openrouter:deepseek/deepseek-chat",
+            base_url="https://api.orcarouter.ai/v1",
+            app_url=_OPENROUTER_APP_URL,
+            app_title=_OPENROUTER_APP_TITLE,
+        )
+        assert result is mock.return_value
+
+    def test_orcarouter_spec_keeps_orcarouter_profile(self) -> None:
+        """Profile lookup uses the original spec, not the rewritten one."""
+        kwargs = apply_provider_profile("orcarouter:deepseek/deepseek-chat")
+        assert kwargs["base_url"] == ORCAROUTER_BASE_URL
+
+    def test_orcarouter_api_key_env_is_forwarded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`ORCAROUTER_API_KEY` authenticates the OpenAI-compatible client."""
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+        kwargs = apply_provider_profile("orcarouter:deepseek/deepseek-chat")
+        assert kwargs["api_key"] == "sk-orca-test"
 
 
 class TestGetModelIdentifier:


### PR DESCRIPTION
Closes #5795

Add [OrcaRouter](https://www.orcarouter.ai) as a built-in provider profile in the Deep Agents SDK.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a built-in provider profile means Deep Agents users can pass `model="orcarouter:<model>"` to `create_deep_agent` directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The SDK already ships built-in provider profiles for OpenAI (Responses API), NVIDIA NIM (app attribution), and OpenRouter (app attribution + version floor). OrcaRouter has no dedicated LangChain integration package — its API is OpenAI-compatible — so this PR registers a profile that rides the existing `openrouter` provider's `ChatOpenRouter` client with the OrcaRouter base URL and `ORCAROUTER_API_KEY` forwarded:

- Add `_orcarouter.py` with a built-in `orcarouter` `ProviderProfile` that injects `base_url` (`https://api.orcarouter.ai/v1`), app attribution, and `api_key` from `ORCAROUTER_API_KEY`.
- Register it in `_builtin_profiles` alongside the other built-ins.
- Rewrite `orcarouter:<model>` specs to the `openrouter` provider name only at the `init_chat_model` boundary in `resolve_model`, so the `orcarouter` label is preserved for the profile registry and user-facing specs.
- Unit tests covering the spec rewrite, base-URL injection, and `ORCAROUTER_API_KEY` forwarding; live-tested with `resolve_model("orcarouter:deepseek/deepseek-v4-flash")` returning a `ChatOpenRouter` pointed at `api.orcarouter.ai` and a real 200 response.

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

