### PR TITLE
fix(filesystem): drop the execute hint from read_file's truncation notice on non-sandbox backends

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -891,13 +891,35 @@ DEFAULT_READ_OFFSET = 0
 DEFAULT_READ_LIMIT = 100
 # Template for truncation message in read_file
 # {file_path} will be filled in at runtime
-READ_FILE_TRUNCATION_MSG = (
+# Carries its own leading space so the empty-string substitution below leaves no
+# double space behind. Both sentences depend on a shell, so both sit in the slot.
+_READ_FILE_TRUNCATION_EXECUTE_HINT = (
+    " For example, if this is JSON, use execute(command='jq . {file_path}') to pretty-print it with line breaks. "
+    "For other formats, you can use appropriate formatting tools to split long lines."
+)
+
+_READ_FILE_TRUNCATION_MSG_TEMPLATE = (
     "\n\n[Output was truncated due to size limits. "
     "The file content is very large. "
-    "Consider reformatting the file to make it easier to navigate. "
-    "For example, if this is JSON, use execute(command='jq . {file_path}') to pretty-print it with line breaks. "
-    "For other formats, you can use appropriate formatting tools to split long lines.]"
+    "Consider reformatting the file to make it easier to navigate.{execute_hint}]"
 )
+
+READ_FILE_TRUNCATION_MSG = _READ_FILE_TRUNCATION_MSG_TEMPLATE.format(execute_hint=_READ_FILE_TRUNCATION_EXECUTE_HINT)
+_READ_FILE_TRUNCATION_MSG_WITHOUT_EXECUTE = _READ_FILE_TRUNCATION_MSG_TEMPLATE.format(execute_hint="")
+
+
+def _read_file_truncation_msg(backend: BackendProtocol) -> str:
+    """Pick the truncation notice matching the backend's execution support.
+
+    `execute` is filtered out of the request for backends that do not implement
+    `SandboxBackendProtocol`, so on those the `jq` suggestion names a tool the
+    model was never given. Mirrors `_GREP_TOOL_DESCRIPTION_WITHOUT_EXECUTE`,
+    which is swapped in at request time for the same reason.
+    """
+    if supports_execution(backend):
+        return READ_FILE_TRUNCATION_MSG
+    return _READ_FILE_TRUNCATION_MSG_WITHOUT_EXECUTE
+
 
 # Approximate number of characters per token for truncation calculations.
 # Using 4 chars per token as a conservative approximation (actual ratio varies by content)
@@ -910,6 +932,7 @@ def _truncate_paginated_read(
     file_path: str,
     read_result: ReadResult,
     token_limit: int | None,
+    truncation_msg: str = READ_FILE_TRUNCATION_MSG,
 ) -> str:
     """Truncate a paginated read without skipping undisplayed source lines.
 
@@ -930,6 +953,10 @@ def _truncate_paginated_read(
             adjusted `next_offset` is derived from its 1-indexed line range.
         token_limit: Char budget is `NUM_CHARS_PER_TOKEN * token_limit`; when
             falsy, content is returned with its notice untouched.
+        truncation_msg: Notice appended when the budget is exceeded, with
+            `{file_path}` still unsubstituted. Defaults to the variant naming
+            `execute`; pass `_read_file_truncation_msg(backend)` to drop that
+            suggestion on backends where `execute` is filtered out.
 
     Returns:
         The (possibly truncated) content with a notice that never overstates
@@ -948,7 +975,7 @@ def _truncate_paginated_read(
     if not token_limit or len(content) + len(notice) < NUM_CHARS_PER_TOKEN * token_limit:
         return content + notice
 
-    truncation_msg = READ_FILE_TRUNCATION_MSG.format(file_path=file_path)
+    truncation_msg = truncation_msg.format(file_path=file_path)
     threshold = NUM_CHARS_PER_TOKEN * token_limit
     if read_result.start_line is not None and read_result.end_line is not None:
         # Build the safe places where the content can be truncated. A long source
@@ -1849,7 +1876,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     content = "".join(lines[:line_limit])
 
             if token_limit and len(content) >= NUM_CHARS_PER_TOKEN * token_limit:
-                truncation_msg = READ_FILE_TRUNCATION_MSG.format(file_path=file_path)
+                truncation_msg = _read_file_truncation_msg(self.backend).format(file_path=file_path)
                 max_content_length = NUM_CHARS_PER_TOKEN * token_limit - len(truncation_msg)
                 content = content[:max_content_length] + truncation_msg
 
@@ -1945,7 +1972,14 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             # push real source lines off the end of the page (#2453).
             # The clamp notice is appended after truncation so it cannot be cut.
             return ToolMessage(
-                content=_truncate_paginated_read(content, validated_path, read_result, token_limit) + _clamped_offset_notice(offset),
+                content=_truncate_paginated_read(
+                    content,
+                    validated_path,
+                    read_result,
+                    token_limit,
+                    _read_file_truncation_msg(self.backend),
+                )
+                + _clamped_offset_notice(offset),
                 name="read_file",
                 tool_call_id=tool_call_id,
                 status="success",

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1,5 +1,7 @@
 import mimetypes
+import tempfile
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,6 +23,7 @@ from pydantic import ValidationError
 
 import deepagents.middleware.filesystem as filesystem_middleware
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
+from deepagents.backends.local_shell import LocalShellBackend
 from deepagents.backends.protocol import (
     BackendProtocol,
     ExecuteResponse,
@@ -1730,6 +1733,47 @@ class TestFilesystemMiddleware:
         assert isinstance(result, ToolMessage)
         assert "Output was truncated due to size limits" in result.content
         assert "remaining from offset" not in result.content
+
+    def test_read_file_truncation_omits_execute_hint_without_sandbox(self):
+        """`execute` is filtered out on a non-sandbox backend, so do not name it.
+
+        The suggestion arrives at the one moment the model is stuck with content
+        it cannot handle inline, which is when a model most likely to act on bad
+        advice will act on it.
+        """
+        backend, _ = _make_backend()
+        assert not supports_execution(backend)
+        read_result = ReadResult(
+            file_data=FileData(content="\n".join("x" * 80 for _ in range(100)), encoding="utf-8"),
+            total_lines=100,
+            start_line=1,
+            end_line=100,
+            next_offset=100,
+        )
+        middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=100)
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        with patch.object(backend, "read", return_value=read_result):
+            result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 100})
+
+        assert "Output was truncated due to size limits" in result.content
+        assert "execute(" not in result.content
+        assert "jq" not in result.content
+
+    def test_read_file_truncation_keeps_execute_hint_on_a_sandbox_backend(self):
+        """A backend that can run commands still gets the `jq` suggestion."""
+        root = tempfile.mkdtemp()
+        backend = LocalShellBackend(root_dir=root)
+        assert supports_execution(backend)
+        (Path(root) / "notes.txt").write_text("\n".join("x" * 80 for _ in range(100)))
+
+        middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=100)
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 100})
+
+        assert "Output was truncated due to size limits" in result.content
+        assert "execute(command='jq . /notes.txt')" in result.content
 
     def test_read_file_truncation_recomputes_remaining_lines_notice(self):
         backend, _ = _make_backend()


### PR DESCRIPTION
Fixes #5798.

## Problem

`READ_FILE_TRUNCATION_MSG` tells the model to run `execute(command='jq . <path>')` whenever a read passes `tool_token_limit_before_evict`. On a backend that does not implement `SandboxBackendProtocol`, `_filter_unsupported_tools_and_apply_prompt` has already removed `execute` from the request, so the notice names a tool the model was never given, at the moment it is stuck with content it cannot handle inline.

Before, on a `StoreBackend`:

```
[Output was truncated due to size limits. The file content is very large.
Consider reformatting the file to make it easier to navigate. For example,
if this is JSON, use execute(command='jq . /notes.txt') to pretty-print it
with line breaks. For other formats, you can use appropriate formatting
tools to split long lines.]
```

After:

```
[Output was truncated due to size limits. The file content is very large.
Consider reformatting the file to make it easier to navigate.]
```

Unchanged on a `LocalShellBackend`, where `execute` is real.

## Approach

Split the message into a template with an `{execute_hint}` slot and pick the variant from `supports_execution(backend)`. This mirrors `_GREP_TOOL_DESCRIPTION_WITHOUT_EXECUTE`, which the same file already swaps in at request time for exactly this reason, so the pattern is yours rather than mine.

Both shell-dependent sentences move into the slot. "For other formats, you can use appropriate formatting tools" only makes sense alongside the `jq` example, so keeping it without the example would leave a dangling reference.

`READ_FILE_TRUNCATION_MSG` keeps its name and its with-execute value, so anything importing it is unaffected. `_truncate_paginated_read` takes the notice as a parameter defaulting to that same constant, so its behaviour is unchanged when called without it.

## Tests

Two added next to the existing truncation tests in `test_middleware.py`: the hint is absent on a non-sandbox backend, and still present on `LocalShellBackend`.

```
pytest tests/unit_tests/test_middleware.py -k truncation
22 passed, 169 deselected
```

Wider filesystem suites (`test_middleware`, `test_file_system_tools`, `test_file_system_tools_async`, `test_eviction_replay`, `backends/`) are unchanged against a clean checkout: same failures before and after, +2 passing from the new tests. My local run cannot load your `pytest_benchmark` warning filter so I ran with `-c /dev/null`, which is why that baseline has pre-existing async failures on both sides. Worth re-running in CI.

## One thing I left alone

The suggestion is arguably not ideal even when `execute` is available: `read_file` supports `offset`/`limit`, and the pagination notice printed directly below already says where to resume, so pointing at `jq` invites a shell round trip for something the tool does natively. That is an editorial call about your default prompt, so this PR only removes the case that is factually wrong.

## Context

Found while debugging an agent that wrote a Python script to build an oversized payload and then went looking for a shell to run it. To be straight about it: I originally attributed that behaviour to this notice, then ran the A/B and could not reproduce a difference, so the incident is not evidence for this change (noted in #5798). The narrow argument is enough on its own: the notice names a tool that is not in the model's tool list.
