### PR TITLE
fix(talon): migrate MCP discovery to `discover_mcp_config_sources`

### DIFF
--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -16,7 +16,7 @@ from deepagents_code.mcp_tools import (
     MCP_CONFIG_DISCOVERY_PATHS,
     MCPConfigError,
     MCPServerInfo,
-    discover_mcp_configs,
+    discover_mcp_config_sources,
     resolve_and_load_mcp_tools,
 )
 from deepagents_code.project_utils import ProjectContext
@@ -56,7 +56,10 @@ def discover_mcp_config_paths(config: TalonConfig) -> list[Path]:
     Returns:
         Existing files, ordered from lowest to highest precedence.
     """
-    return discover_mcp_configs(project_context=_project_context(config))
+    return [
+        source.path
+        for source in discover_mcp_config_sources(project_context=_project_context(config))
+    ]
 
 
 async def load_mcp_tools(config: TalonConfig) -> MCPTools:


### PR DESCRIPTION
Stacked on #5773.

---

PR #5773 replaced `discover_mcp_configs` in `deepagents_code.mcp_tools` with `discover_mcp_config_sources`, which returns `DiscoveredMCPConfig` entries carrying trust scope and project root instead of bare `Path`s. Talon's `deepagents_talon/mcp.py` still imported the old name, so its lint job fails with an unresolved import and its test jobs fail at collection with `ImportError` across Python 3.12–3.14.

The fix projects the discovered sources down to their paths at the call site; ordering and filtering semantics are unchanged. Talon does not consume trust provenance here (that flows through `resolve_and_load_mcp_tools` separately), so dropping the wrapper metadata at this boundary is fine.
