### PR TITLE
chore(ci): make talon check failures advisory on PRs that don't touch `libs/talon`

### DIFF
--- a/.github/scripts/checks/ci_gate.py
+++ b/.github/scripts/checks/ci_gate.py
@@ -1,0 +1,117 @@
+"""Evaluate the aggregate `ci_success` job result from per-job results.
+
+Why this exists:
+    `talon` editable-installs `deepagents-code`
+    (`libs/talon/pyproject.toml`, `[tool.uv.sources]`), so the `talon` path
+    filter in `ci.yml` watches `libs/code/**` and every libs/code PR runs the
+    `lint-talon`/`test-talon` jobs. A libs/code change can therefore break
+    talon CI, and failing `ci_success` used to force the author to fix the
+    talon regression inside their libs/code PR — which also made
+    release-please fan out changelog entries across both packages.
+
+    The maintainers accept merging PRs that do not touch `libs/talon` with
+    talon red at HEAD; the breakage is fixed in a follow-up `fix(talon): ...`
+    PR. This script encodes exactly that waiver so the `ci_success` shell step
+    stays readable and the decision matrix is unit-testable.
+
+What it does:
+    - On `pull_request` runs where the `talon` filter output is not `'true'`,
+      `failure` results from `lint-talon`/`test-talon` are waived (reported as
+      notices) instead of failing the gate. Every other job result is strict.
+    - `cancelled` results are never waived — a cancelled talon job still
+      blocks, matching the pre-existing rule that cancellations are not
+      allowed on PR/merge_group runs.
+    - On genuine talon PRs (`talon == 'true'`) and on `push`/`merge_group`
+      runs, talon failures block exactly as before. Push runs stay strict so
+      a broken talon stays visible on main, where every job runs
+      unconditionally.
+
+Inputs are a JSON object mapping job name to its result (the `skipped`
+entries filtered out by the workflow step), the `talon` path-filter output,
+and the event name. Output is a single JSON line consumed by the workflow
+step. The exit code is always 0; the pass/fail decision lives only in the
+JSON payload so a caller bug surfaces as an explicit failure, not a crash.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import TypedDict
+
+# Jobs whose `failure` results may be waived on non-talon PRs.
+WAIVABLE_JOBS = ("lint-talon", "test-talon")
+
+
+class GateResult(TypedDict):
+    """Structured gate report consumed by the `ci_success` workflow step."""
+
+    ok: bool
+    waived: list[str]
+    failed: list[str]
+    cancelled: list[str]
+
+
+def evaluate_gate(results: dict[str, str], *, event: str, talon: str) -> GateResult:
+    """Decide whether the aggregate CI gate passes.
+
+    Args:
+        results: Map of job name to job result (`success`/`failure`/
+            `cancelled`); `skipped` jobs are omitted by the caller.
+        event: `github.event_name` for the run.
+        talon: The `changes` job's `talon` path-filter output.
+
+    Returns:
+        A `GateResult`. `ok` is True only when no blocking results remain
+        after applying the talon waiver. `waived` names talon jobs whose
+        failures were excused; `failed`/`cancelled` name blocking jobs.
+    """
+    waiver_applies = event == "pull_request" and talon != "true"
+    waived: list[str] = []
+    failed: list[str] = []
+    cancelled: list[str] = []
+    for job, result in results.items():
+        if result == "failure":
+            if waiver_applies and job in WAIVABLE_JOBS:
+                waived.append(job)
+            else:
+                failed.append(job)
+        elif result == "cancelled":
+            cancelled.append(job)
+    return GateResult(
+        ok=not failed and not cancelled,
+        waived=waived,
+        failed=failed,
+        cancelled=cancelled,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments, evaluate the gate, and print one JSON line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--event",
+        required=True,
+        help="github.event_name (push, pull_request, merge_group, ...)",
+    )
+    parser.add_argument(
+        "--talon",
+        required=True,
+        help="needs.changes.outputs.talon path-filter output",
+    )
+    parser.add_argument(
+        "--results",
+        required=True,
+        help="JSON object mapping job name to job result",
+    )
+    args = parser.parse_args(argv)
+    results = json.loads(args.results)
+    gate = evaluate_gate(results, event=args.event, talon=args.talon)
+    json.dump(gate, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/checks/test_ci_gate.py
+++ b/.github/scripts/tests/checks/test_ci_gate.py
@@ -1,0 +1,133 @@
+"""Tests for the `ci_success` talon-failure waiver matrix."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "checks" / "ci_gate.py"
+
+sys.path.insert(0, str(SCRIPT.parent))
+
+from ci_gate import evaluate_gate
+
+ALL_GREEN = {"lint-code": "success", "test-code": "success"}
+
+
+def test_pr_without_talon_changes_waives_test_talon_failure() -> None:
+    gate = evaluate_gate(
+        {**ALL_GREEN, "test-talon": "failure"},
+        event="pull_request",
+        talon="false",
+    )
+
+    assert gate["ok"] is True
+    assert gate["waived"] == ["test-talon"]
+    assert gate["failed"] == []
+
+
+def test_pr_without_talon_changes_waives_lint_talon_failure() -> None:
+    gate = evaluate_gate(
+        {**ALL_GREEN, "lint-talon": "failure"},
+        event="pull_request",
+        talon="false",
+    )
+
+    assert gate["ok"] is True
+    assert gate["waived"] == ["lint-talon"]
+
+
+def test_pr_without_talon_changes_still_fails_on_other_jobs() -> None:
+    gate = evaluate_gate(
+        {**ALL_GREEN, "test-talon": "failure", "test-code": "failure"},
+        event="pull_request",
+        talon="false",
+    )
+
+    assert gate["ok"] is False
+    assert gate["waived"] == ["test-talon"]
+    assert gate["failed"] == ["test-code"]
+
+
+def test_genuine_talon_pr_still_fails_on_talon_failure() -> None:
+    gate = evaluate_gate(
+        {**ALL_GREEN, "test-talon": "failure"},
+        event="pull_request",
+        talon="true",
+    )
+
+    assert gate["ok"] is False
+    assert gate["waived"] == []
+    assert gate["failed"] == ["test-talon"]
+
+
+def test_push_still_fails_on_talon_failure() -> None:
+    gate = evaluate_gate(
+        {**ALL_GREEN, "test-talon": "failure"},
+        event="push",
+        talon="false",
+    )
+
+    assert gate["ok"] is False
+    assert gate["failed"] == ["test-talon"]
+
+
+def test_merge_group_still_fails_on_talon_failure() -> None:
+    gate = evaluate_gate(
+        {**ALL_GREEN, "test-talon": "failure"},
+        event="merge_group",
+        talon="false",
+    )
+
+    assert gate["ok"] is False
+    assert gate["failed"] == ["test-talon"]
+
+
+def test_cancelled_talon_job_is_never_waived() -> None:
+    gate = evaluate_gate(
+        {**ALL_GREEN, "test-talon": "cancelled"},
+        event="pull_request",
+        talon="false",
+    )
+
+    assert gate["ok"] is False
+    assert gate["waived"] == []
+    assert gate["cancelled"] == ["test-talon"]
+
+
+def test_successful_talon_jobs_have_nothing_to_waive() -> None:
+    gate = evaluate_gate(
+        {**ALL_GREEN, "lint-talon": "success", "test-talon": "success"},
+        event="pull_request",
+        talon="false",
+    )
+
+    assert gate["ok"] is True
+    assert gate["waived"] == []
+    assert gate["failed"] == []
+    assert gate["cancelled"] == []
+
+
+def test_cli_emits_single_json_line() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--event",
+            "pull_request",
+            "--talon",
+            "false",
+            "--results",
+            json.dumps({"test-talon": "failure"}),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    gate = json.loads(result.stdout)
+    assert gate["ok"] is True
+    assert gate["waived"] == ["test-talon"]

--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -180,6 +180,28 @@ def test_deepagents_code_collects_coverage_on_python_3_14() -> None:
     assert config["coverage-python-version"] == "3.14"
 
 
+def test_ci_success_builds_named_results_from_needs_object() -> None:
+    """The gate needs job names; the wildcard `needs.*.result` drops them.
+
+    `toJSON(needs.*.result)` yields a bare array of result strings, so the
+    talon waiver (which keys off job names) must instead receive the full
+    `needs` object and extract each entry's `result`. Pin both halves so a
+    refactor cannot silently reintroduce the nameless wildcard.
+    """
+    workflow = _load_workflow(CI_WORKFLOW)
+    step = _find_step(workflow, job="ci_success", name="🎉 All Checks Passed")
+
+    assert step["env"]["NEEDS"] == "${{ toJSON(needs) }}"
+    assert "needs.*.result" not in step["env"]["NEEDS"]
+    assert 'entry["result"]' in step["run"]
+    assert 'job != "changes"' in step["run"]
+    # The advisory job reads the two talon job results by name, which only
+    # works if it needs exactly those jobs (plus `changes` for the filter).
+    advisory = workflow["jobs"]["talon-failure-advisory"]
+    assert sorted(advisory["needs"]) == ["changes", "lint-talon", "test-talon"]
+    assert "talon-failure-advisory" not in workflow["jobs"]["ci_success"]["needs"]
+
+
 @pytest.mark.parametrize(
     ("label", "context", "expected"),
     SELECTION_CASES,

--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -202,6 +202,36 @@ def test_ci_success_builds_named_results_from_needs_object() -> None:
     assert "talon-failure-advisory" not in workflow["jobs"]["ci_success"]["needs"]
 
 
+def test_ci_success_runs_gate_script_from_trusted_base_ref() -> None:
+    """The gate script must not come from the untrusted PR checkout.
+
+    On pull_request runs `actions/checkout` defaults to the PR merge commit,
+    so executing the helper from the default checkout would let a PR author
+    rewrite the gate to always pass. Pin the base-ref checkout, its
+    credential-less configuration, and that the run step invokes the base
+    copy (falling back to the PR copy only during the bootstrap window when
+    the script is not yet on the base branch).
+    """
+    workflow = _load_workflow(CI_WORKFLOW)
+    steps = workflow["jobs"]["ci_success"]["steps"]
+
+    base = _find_step(
+        workflow, job="ci_success", name="📋 Checkout gate script from trusted base ref"
+    )
+    assert base["with"]["ref"] == "${{ github.base_ref || github.sha }}"
+    assert base["with"]["path"] == ".ci-gate-base"
+    assert base["with"]["persist-credentials"] is False
+    assert ".github/scripts/checks/ci_gate.py" in base["with"]["sparse-checkout"]
+
+    step = _find_step(workflow, job="ci_success", name="🎉 All Checks Passed")
+    # The base copy is preferred; the PR copy is only a bootstrap fallback.
+    assert '.ci-gate-base' in step["run"]
+    assert step["run"].index(".ci-gate-base") < step["run"].index(".ci-gate-pr")
+    # No step may execute the helper from the default (untrusted) checkout.
+    for s in steps:
+        assert "python3 .github/scripts/checks/ci_gate.py" not in s.get("run", "")
+
+
 @pytest.mark.parametrize(
     ("label", "context", "expected"),
     SELECTION_CASES,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,6 +499,109 @@ jobs:
       - name: "🔍 Check workflow helper scripts"
         run: python -m pytest .github/scripts/tests -v
 
+  # Advisory-only job: never fails the workflow and is deliberately NOT in
+  # `ci_success.needs`, so its own result cannot gate anything. When the
+  # `ci_success` talon waiver fires (see the comment block there), it posts
+  # or updates a sticky PR comment recording the waived failures; once the
+  # talon jobs pass again it deletes the comment. Mirrors the sticky-comment
+  # pattern in release_fanout_bypass_warn.yml.
+  talon-failure-advisory:
+    name: "⚠️ talon failure advisory"
+    needs: [changes, lint-talon, test-talon]
+    if: always() && github.event_name == 'pull_request' && needs.changes.outputs.talon != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: write
+    # Serialize per-PR so rapid pushes cannot create duplicate stickies.
+    concurrency:
+      group: talon-ci-advisory-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: "Post, update, or delete the talon advisory comment"
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request?.number;
+            if (!prNumber) {
+              core.warning('No PR number in payload; skipping talon advisory comment.');
+              return;
+            }
+            const STICKY_MARKER = '<!-- talon-ci-advisory -->';
+
+            async function findStickyComment() {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: prNumber, per_page: 100,
+              });
+              return comments.find(c => c.body && c.body.startsWith(STICKY_MARKER));
+            }
+
+            const jobNames = ['lint-talon', 'test-talon'];
+            const jobResults = {
+              'lint-talon': '${{ needs.lint-talon.result }}',
+              'test-talon': '${{ needs.test-talon.result }}',
+            };
+            const failed = jobNames.filter(j => jobResults[j] === 'failure');
+
+            async function removeSticky() {
+              try {
+                const existing = await findStickyComment();
+                if (existing) {
+                  await github.rest.issues.deleteComment({
+                    owner, repo, comment_id: existing.id,
+                  });
+                  console.log('talon jobs green (or not run) — deleted advisory comment');
+                }
+              } catch (e) {
+                core.warning(`Could not clean up talon advisory comment for PR #${prNumber}: ${e.message}`);
+              }
+            }
+
+            // Waiver condition no longer holds: talon passed or was skipped.
+            if (failed.length === 0) {
+              await removeSticky();
+              return;
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              STICKY_MARKER,
+              '⚠️ **talon CI failure(s) were waived for this PR.**',
+              '',
+              `Failed job(s): ${failed.map(j => `\`${j}\``).join(', ')} ([workflow run](${runUrl}))`,
+              '',
+              "**Why:** this PR doesn't touch `libs/talon`, so talon breakage does not block merge per repo policy. talon editable-installs `deepagents-code`, so its CI runs on every libs/code PR and can be broken by libs/code changes.",
+              '',
+              '**Required follow-up:** the breakage must be fixed in a separate `fix(talon): ...` PR — talon is red at HEAD until it lands. Please file or self-assign that fix, or confirm a maintainer is tracking it.',
+            ].join('\n');
+
+            try {
+              const existing = await findStickyComment();
+              if (existing) {
+                if (existing.body !== body) {
+                  await github.rest.issues.updateComment({
+                    owner, repo, comment_id: existing.id, body,
+                  });
+                  console.log('Updated talon advisory comment');
+                } else {
+                  console.log('talon advisory comment already up to date');
+                }
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: prNumber, body,
+                });
+                console.log('Posted talon advisory comment');
+              }
+            } catch (commentErr) {
+              core.warning(`Could not post talon advisory comment (fork PR token, rate limit, or transient API error): ${commentErr.message}`);
+              await core.summary
+                .addHeading('talon CI failure(s) waived; advisory comment could not be posted')
+                .addRaw('Paste the following into the PR as a comment:')
+                .addCodeBlock(body, 'markdown')
+                .write();
+            }
+
   # Final status check - ensures all jobs passed
   ci_success:
     name: "✅ CI Success"
@@ -530,16 +633,65 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      # talon editable-installs deepagents-code (`libs/talon/pyproject.toml`,
+      # [tool.uv.sources]), so the `talon` path filter above watches
+      # libs/code/** and every libs/code PR runs lint-talon/test-talon. A
+      # libs/code change can therefore break talon CI. The maintainers accept
+      # merging such PRs with talon red at HEAD: the talon fix lands as its
+      # own `fix(talon): ...` PR instead of forcing a combined PR (which would
+      # also fan release-please out across both packages' changelogs). On
+      # pull_request runs where the talon filter output is not 'true',
+      # `failure` results from lint-talon/test-talon are waived; `cancelled`
+      # results and every other job still block, and push / merge_group runs
+      # stay fully strict so a broken talon stays visible on main, where every
+      # job runs unconditionally. The waiver logic lives in
+      # .github/scripts/checks/ci_gate.py (unit-tested under
+      # .github/scripts/tests/); talon CI still RUNS on these PRs — only its
+      # blocking effect changes, and the talon-failure-advisory job posts a
+      # sticky comment when the waiver fires.
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: "🎉 All Checks Passed"
         env:
           EVENT_NAME: ${{ github.event_name }}
+          # Skipped jobs are filtered out below so the gate only judges jobs
+          # that actually ran.
+          RESULTS: ${{ toJSON(needs.*.result) }}
+          TALON_CHANGED: ${{ needs.changes.outputs.talon }}
         run: |
+          set -euo pipefail
           # Get all job results (excluding 'changes' which always succeeds)
-          results='${{ toJSON(needs.*.result) }}'
+          results="$(printf '%s' "$RESULTS" | python3 -c '
+          import json
+          import sys
+
+          results = json.loads(sys.argv[1])
+          results.pop("changes", None)
+          results = {
+              job: result for job, result in results.items() if result != "skipped"
+          }
+          json.dump(results, sys.stdout)
+          ' "$RESULTS")"
           echo "Job results: $results"
 
-          if echo "$results" | grep -q '"failure"'; then
-            echo "Some jobs failed"
+          gate="$(python3 .github/scripts/checks/ci_gate.py \
+            --event "$EVENT_NAME" \
+            --talon "$TALON_CHANGED" \
+            --results "$results")"
+          echo "Gate decision: $gate"
+
+          waived="$(printf '%s' "$gate" | python3 -c 'import json, sys; print("\n".join(json.loads(sys.argv[1])["waived"]))' "$gate")"
+          if [ -n "$waived" ]; then
+            while IFS= read -r job; do
+              echo "::warning::⚠️ Waiving failing talon check: $job=failure (PR does not touch libs/talon; talon breakage is advisory here). Follow-up: fix talon in a separate fix(talon): ... PR."
+            done <<< "$waived"
+          fi
+
+          failed="$(printf '%s' "$gate" | python3 -c 'import json, sys; print("\n".join(json.loads(sys.argv[1])["failed"]))' "$gate")"
+          if [ -n "$failed" ]; then
+            echo "Some jobs failed:"
+            echo "$failed"
             exit 1
           fi
 
@@ -549,8 +701,10 @@ jobs:
           # On PRs and merge_group runs, a cancellation is almost always a
           # human action or a real problem, so keep the gate strict.
           if [ "$EVENT_NAME" != "push" ]; then
-            if echo "$results" | grep -q '"cancelled"'; then
-              echo "Some jobs were cancelled (not allowed on $EVENT_NAME runs)"
+            cancelled="$(printf '%s' "$gate" | python3 -c 'import json, sys; print("\n".join(json.loads(sys.argv[1])["cancelled"]))' "$gate")"
+            if [ -n "$cancelled" ]; then
+              echo "Some jobs were cancelled (not allowed on $EVENT_NAME runs):"
+              echo "$cancelled"
               exit 1
             fi
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,24 +655,27 @@ jobs:
       - name: "🎉 All Checks Passed"
         env:
           EVENT_NAME: ${{ github.event_name }}
-          # Skipped jobs are filtered out below so the gate only judges jobs
-          # that actually ran.
-          RESULTS: ${{ toJSON(needs.*.result) }}
+          # Full needs context: the wildcard `toJSON(needs.*.result)` form
+          # loses job names (it yields a bare array of result strings), so
+          # the name -> result map is rebuilt from each entry below. Skipped
+          # jobs are filtered out so the gate only judges jobs that ran.
+          NEEDS: ${{ toJSON(needs) }}
           TALON_CHANGED: ${{ needs.changes.outputs.talon }}
         run: |
           set -euo pipefail
           # Get all job results (excluding 'changes' which always succeeds)
-          results="$(printf '%s' "$RESULTS" | python3 -c '
+          results="$(printf '%s' "$NEEDS" | python3 -c '
           import json
           import sys
 
-          results = json.loads(sys.argv[1])
-          results.pop("changes", None)
+          needs = json.loads(sys.argv[1])
           results = {
-              job: result for job, result in results.items() if result != "skipped"
+              job: entry["result"]
+              for job, entry in needs.items()
+              if job != "changes" and entry["result"] != "skipped"
           }
           json.dump(results, sys.stdout)
-          ' "$RESULTS")"
+          ' "$NEEDS")"
           echo "Job results: $results"
 
           gate="$(python3 .github/scripts/checks/ci_gate.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,8 +649,36 @@ jobs:
       # .github/scripts/tests/); talon CI still RUNS on these PRs — only its
       # blocking effect changes, and the talon-failure-advisory job posts a
       # sticky comment when the waiver fires.
-      - name: "📋 Checkout Code"
+      #
+      # The gate script is executed from the PR's BASE ref, not the PR
+      # checkout: on pull_request runs `actions/checkout` defaults to the
+      # (untrusted) PR merge commit, so a PR that edited ci_gate.py could
+      # make the required check pass regardless of real job results. Pinning
+      # to `github.base_ref` keeps the decision logic maintainer-controlled.
+      # `github.base_ref` is empty on push/merge_group, so `||` falls back to
+      # the commit that triggered the run.
+      - name: "📋 Checkout gate script from trusted base ref"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.base_ref || github.sha }}
+          path: .ci-gate-base
+          sparse-checkout: |
+            .github/scripts/checks/ci_gate.py
+          persist-credentials: false
+
+      # Bootstrap window: ci_gate.py does not exist on main until this change
+      # lands, so the base-ref checkout above is empty on the PR that
+      # introduces it. Only for that window, check out the PR's own copy as a
+      # fallback. Once the script is on the base branch, the base-ref copy is
+      # always used and this second checkout never changes what runs.
+      - name: "📋 Checkout PR gate script (bootstrap fallback)"
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: .ci-gate-pr
+          sparse-checkout: |
+            .github/scripts/checks/ci_gate.py
+          persist-credentials: false
 
       - name: "🎉 All Checks Passed"
         env:
@@ -678,7 +706,14 @@ jobs:
           ' "$NEEDS")"
           echo "Job results: $results"
 
-          gate="$(python3 .github/scripts/checks/ci_gate.py \
+          gate_script=".ci-gate-base/.github/scripts/checks/ci_gate.py"
+          if [ ! -f "$gate_script" ]; then
+            # Bootstrap only: the script is not on the base branch yet.
+            gate_script=".ci-gate-pr/.github/scripts/checks/ci_gate.py"
+            echo "::warning::ci_gate.py not found on base ref; running the PR's copy (bootstrap window)."
+          fi
+
+          gate="$(python3 "$gate_script" \
             --event "$EVENT_NAME" \
             --talon "$TALON_CHANGED" \
             --results "$results")"


### PR DESCRIPTION
## Problem

`talon` editable-installs `deepagents-code` (`libs/talon/pyproject.toml`, `[tool.uv.sources]`), so the `talon` filter in `ci.yml` includes `libs/code/**` and every libs/code PR runs `lint-talon`/`test-talon`. When a libs/code change breaks talon, `ci_success` fails, and because branch protection requires `✅ CI Success`, the libs/code PR cannot merge until the author also fixes the talon regression — inside the same PR. That combined PR then makes release-please fan out changelog entries across both packages.

It is acceptable for PRs that don't touch `libs/talon` to merge with talon broken at HEAD; the breakage gets fixed in a follow-up `fix(talon): ...` PR (ideally in a stack). talon is the only consumer of the libs/code path source, so no other package's CI is affected by this policy.

## Approach

Advisory, not skipped: talon CI still *runs* on libs/code PRs (the signal is valuable) — only its blocking effect changes.

- The waiver decision lives in a new helper script, `.github/scripts/checks/ci_gate.py`, which `ci_success` calls instead of grepping the `toJSON(needs.*.result)` blob. On `pull_request` runs where the `talon` filter output is not `'true'`, `failure` results from `lint-talon`/`test-talon` are waived with a loud `::warning::` per waived job; every other job still blocks. `cancelled` results are never waived, genuine talon PRs (`talon == 'true'`) stay strict, and `push`/`merge_group` runs stay fully strict — main runs every job unconditionally, so a broken talon is still visible there and cannot silently go red.
- A new `talon-failure-advisory` job posts/updates a sticky PR comment (`<!-- talon-ci-advisory -->`) when the waiver fires, naming the failed jobs, linking the workflow run, and calling out the required `fix(talon)` follow-up; it deletes the sticky once talon is green again. It mirrors the sticky-comment pattern in `release_fanout_bypass_warn.yml`, including the `core.warning` + job-summary fallback when commenting fails (fork tokens, rate limits). The job is advisory-only and is deliberately not in `ci_success.needs`, so it can never gate.
- Unit tests in `.github/scripts/tests/checks/test_ci_gate.py` cover the waiver matrix (waived lint/test failures, non-talon failures still blocking, talon PRs and push/merge_group staying strict, cancelled never waived). They run in the existing `check-release-options` job, which is unchanged.

No branch-protection settings change is needed: the repo already requires only `✅ CI Success` and `validate release dependencies against PyPI`, both compatible with this change.

Note on scope: the waiver keys off `talon != 'true'`. SDK-only PRs (`libs/deepagents/**`) also flip the `talon` filter on via fan-out, so an SDK PR that breaks talon still blocks — only PRs where talon CI runs *solely* because of the libs/code path source get the waiver.
