### PR TITLE
fix(sdk): exclude tools from execution when setting `excluded_tools` in harness profiles

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -334,9 +334,11 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             (filesystem tools, `execute`, and `task`).
 
             Passing tools here is additive — it never removes a built-in.
-            To drop a built-in tool, register a
+            To stop offering a built-in tool to the model, register a
             [`HarnessProfile`][deepagents.HarnessProfile] with
-            `excluded_tools`.
+            `excluded_tools`. To remove one entirely, pass your own
+            [`FilesystemMiddleware`][deepagents.middleware.filesystem.FilesystemMiddleware]
+            with `tools=[...]`.
         system_prompt: Caller-authored system instructions (`USER`) placed
             first in the system prompt sent to the model.
 

--- a/libs/deepagents/deepagents/middleware/_tool_exclusion.py
+++ b/libs/deepagents/deepagents/middleware/_tool_exclusion.py
@@ -40,8 +40,8 @@ class _ToolExclusionMiddleware(AgentMiddleware[Any, Any, Any]):
 
     Excluded names are also rejected at the tool-call boundary, since the
     executor still has them registered and dispatches on the name the model
-    emits. That keeps execution consistent with what was advertised. Exclusions
-    resolve per model.
+    emits. That keeps execution consistent with what was advertised; it is not a
+    security surface. Exclusions resolve per model.
 
     Args:
         excluded: Tool names to remove before the model sees them.

--- a/libs/deepagents/deepagents/middleware/_tool_exclusion.py
+++ b/libs/deepagents/deepagents/middleware/_tool_exclusion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import ToolMessage
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -17,6 +18,8 @@ if TYPE_CHECKING:
     )
     from langchain_core.messages import AIMessage
     from langchain_core.tools import BaseTool
+    from langgraph.prebuilt.tool_node import ToolCallRequest
+    from langgraph.types import Command
 
 
 def _tool_name(tool: BaseTool | dict[str, str]) -> str | None:
@@ -34,6 +37,11 @@ class _ToolExclusionMiddleware(AgentMiddleware[Any, Any, Any]):
     Should be placed late in the middleware stack (after all
     tool-injecting middleware) so it can strip middleware-injected tools
     (filesystem, subagent, etc.) that the harness profile marks as excluded.
+
+    Excluded names are also rejected at the tool-call boundary, since the
+    executor still has them registered and dispatches on the name the model
+    emits. That keeps execution consistent with what was advertised. Exclusions
+    resolve per model.
 
     Args:
         excluded: Tool names to remove before the model sees them.
@@ -63,3 +71,31 @@ class _ToolExclusionMiddleware(AgentMiddleware[Any, Any, Any]):
             filtered = [t for t in request.tools if _tool_name(t) not in self._excluded]
             request = request.override(tools=filtered)
         return await handler(request)
+
+    def _rejection(self, request: ToolCallRequest) -> ToolMessage | None:
+        """Build the error result for a call naming an excluded tool."""
+        name = request.tool_call["name"]
+        if name not in self._excluded:
+            return None
+        return ToolMessage(
+            content=f"Error: {name} is not available.",
+            tool_call_id=request.tool_call["id"] or "",
+            name=name,
+            status="error",
+        )
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        """Reject calls naming an excluded tool instead of executing them."""
+        return self._rejection(request) or handler(request)
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        """Async variant of `wrap_tool_call`."""
+        return self._rejection(request) or await handler(request)

--- a/libs/deepagents/deepagents/profiles/harness/harness_profiles.py
+++ b/libs/deepagents/deepagents/profiles/harness/harness_profiles.py
@@ -621,6 +621,9 @@ class HarnessProfile:
     each other. For example, if a provider profile excludes `execute` and an
     exact-model profile excludes `grep`, the resolved profile excludes both
     tools.
+
+    Exclusions are model-facing calibration resolved per model; they are not a
+    security surface.
     """
 
     excluded_middleware: frozenset[type[AgentMiddleware] | str] = frozenset()

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_exclusion.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_exclusion.py
@@ -1,0 +1,93 @@
+"""Tests that a profile's `excluded_tools` are refused at the tool-call boundary.
+
+`_ToolExclusionMiddleware.wrap_model_call` keeps excluded tools out of the
+request, but the executor still has them registered and dispatches on the name
+the model emits. These tests drive a compiled agent with a scripted model that
+emits an excluded name anyway, and assert the call is answered with an error
+instead of running, while a non-excluded call in the same turn still runs.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.graph.state import CompiledStateGraph
+
+from deepagents import create_deep_agent
+from deepagents.profiles.harness.harness_profiles import (
+    _HARNESS_PROFILES,
+    HarnessProfile,
+    register_harness_profile,
+)
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+_EXCLUDED = "write_file"
+_ALLOWED = "ls"
+_TARGET = "/excluded.txt"
+
+_Agent = CompiledStateGraph[Any, Any, Any, Any]
+
+
+@pytest.fixture
+def agent() -> Iterator[_Agent]:
+    """A compiled agent whose profile excludes `write_file`.
+
+    The scripted model calls the excluded tool and an allowed tool in one turn,
+    then finishes.
+    """
+    original = dict(_HARNESS_PROFILES)
+    register_harness_profile("exclprov", HarnessProfile(excluded_tools=frozenset({_EXCLUDED})))
+    model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": _EXCLUDED,
+                            "args": {"file_path": _TARGET, "content": "written anyway"},
+                            "id": "call_excluded",
+                            "type": "tool_call",
+                        },
+                        {"name": _ALLOWED, "args": {"path": "/"}, "id": "call_allowed", "type": "tool_call"},
+                    ],
+                ),
+                AIMessage(content="done"),
+            ]
+        )
+    )
+    try:
+        with patch("deepagents.graph.resolve_model", return_value=model):
+            yield create_deep_agent(model="exclprov:some-model")
+    finally:
+        _HARNESS_PROFILES.clear()
+        _HARNESS_PROFILES.update(original)
+
+
+def _results(result: dict[str, Any]) -> dict[str, ToolMessage]:
+    return {m.name: m for m in result["messages"] if isinstance(m, ToolMessage)}
+
+
+def _assert_refused(result: dict[str, Any]) -> None:
+    tool_messages = _results(result)
+
+    refused = tool_messages[_EXCLUDED]
+    assert refused.status == "error"
+    assert _EXCLUDED in str(refused.content)
+    # The tool never reached the backend, so no file was created.
+    assert _TARGET not in (result.get("files") or {})
+
+    # A non-excluded call in the same turn is unaffected.
+    assert tool_messages[_ALLOWED].status != "error"
+
+
+def test_excluded_tool_call_is_refused(agent: _Agent) -> None:
+    """A call naming an excluded tool errors instead of executing."""
+    _assert_refused(agent.invoke({"messages": [{"role": "user", "content": "go"}]}))
+
+
+async def test_excluded_tool_call_is_refused_async(agent: _Agent) -> None:
+    """The async path refuses the same call."""
+    _assert_refused(await agent.ainvoke({"messages": [{"role": "user", "content": "go"}]}))


### PR DESCRIPTION
`excluded_tools` prevents tools from being bound to model requests, but the tools remain executable.

Harness profiles are intended to calibrate an agent to a specific model. `excluded_tools` is documented as controlling visibility: they determine what tools are seen by the model. But here we make the middleware robust to tool calls that do end up in state.