### PR TITLE
feat(code): default the stale editable-deps prompt to `Refresh environment now`

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3490,8 +3490,12 @@ def _run_trust_action_picker(
         refresh_label: Label for an explicit environment refresh, when offered.
         deny_first: When `True`, list the deny option first; callers whose
             "deny" reads as a safe default (e.g. aborting a launch) put it in
-            the leading position. The picker starts highlighted on the deny
-            option in either ordering, so a bare Enter refuses.
+            the leading position. When a refresh option is offered, the picker
+            starts highlighted on it rather than on deny: fixing the
+            environment is the action the prompt is steering toward, and deny
+            is still one keystroke away. Without a refresh option the picker
+            starts highlighted on deny in either ordering, so a bare Enter
+            refuses.
 
     Returns:
         The chosen action, `CANCELLED` for Esc or Ctrl+D, `INTERRUPTED` for
@@ -3545,13 +3549,17 @@ def _run_trust_action_picker(
         )
     elif deny_first:
         actions.reverse()
-    # Highlight the refusing option by identity, not position: `deny_first`
-    # moves it to the front, so a positional index would silently default to
-    # "allow" for exactly the callers that asked for a safer ordering.
+    # Highlight the default action by identity, not position: `deny_first`
+    # moves the deny option to the front, so a positional index would silently
+    # default to "allow" for exactly the callers that asked for a safer
+    # ordering. When a refresh option exists it is the default instead, so a
+    # bare Enter repairs the environment; a deny-only list still defaults to
+    # refusing.
+    default_action = (
+        _TrustAction.REFRESH if refresh_label is not None else _TrustAction.DENY
+    )
     selected_index = next(
-        index
-        for index, (action, _) in enumerate(actions)
-        if action is _TrustAction.DENY
+        index for index, (action, _) in enumerate(actions) if action is default_action
     )
 
     def _rows() -> FormattedText:
@@ -3749,11 +3757,14 @@ def _select_trust_action(
         choices = f"{allow_label} [y] · {remember_label} [r] · {deny_label} [N]"
         prompt = "Choose [y/r/N]: "
     elif deny_first:
+        # Deny keeps its leading position, but the refresh — not the deny —
+        # is the default: the uppercase [U] mirrors the picker's initial
+        # highlight so a bare Enter repairs the environment.
         choices = (
-            f"{deny_label} [N] · {refresh_label} [u] · "
+            f"{deny_label} [n] · {refresh_label} [U] · "
             f"{allow_label} [y] · {remember_label} [r]"
         )
-        prompt = "Choose [N/u/y/r]: "
+        prompt = "Choose [n/U/y/r]: "
     else:
         choices = (
             f"{allow_label} [y] · {remember_label} [r] · "
@@ -3772,7 +3783,9 @@ def _select_trust_action(
         return _TrustAction.ALLOW_ONCE
     if answer in {"r", "remember", "a", "always"}:
         return _TrustAction.REMEMBER
-    if refresh_label is not None and answer in {"u", "update", "f", "refresh"}:
+    # The refresh is the default in this prompt shape, so an empty answer
+    # selects it; anything else (including an explicit "n") refuses.
+    if refresh_label is not None and answer in {"", "u", "update", "f", "refresh"}:
         return _TrustAction.REFRESH
     return _TrustPromptOutcome.CANCELLED if abort_on_deny else _TrustAction.DENY
 

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -5391,11 +5391,16 @@ class TestSelectProjectServersToPersist:
         )
 
     @pytest.mark.usefixtures("_interactive_picker_terminal")
-    def test_refresh_picker_action_follows_abort(
+    def test_refresh_picker_defaults_to_refresh(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Moving down once from the safe default selects environment refresh."""
+        """With a refresh option, a bare Enter repairs the environment.
+
+        "Abort launch" keeps the leading row, but the highlight starts on
+        "Refresh environment now" — fixing the environment is the action the
+        prompt steers toward, and aborting is one keystroke away.
+        """
         from rich.console import Console
 
         from deepagents_code.main import (
@@ -5420,17 +5425,11 @@ class TestSelectProjectServersToPersist:
                         exit=lambda *, result: holder.update(value=result)
                     )
                 )
-                move_down = next(
-                    binding.handler
-                    for binding in bindings
-                    if binding.handler.__name__ == "_down"
-                )
                 confirm = next(
                     binding.handler
                     for binding in bindings
                     if binding.handler.__name__ == "_confirm"
                 )
-                move_down(event)
                 confirm(event)
                 return holder["value"]
 
@@ -5457,6 +5456,62 @@ class TestSelectProjectServersToPersist:
         assert rendered.index("Continue this session only") < rendered.index(
             "Continue and hide until versions change"
         )
+
+    @pytest.mark.usefixtures("_interactive_picker_terminal")
+    def test_refresh_picker_abort_launch_is_one_move_up(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Moving up once from the refresh default selects "Abort launch"."""
+        from rich.console import Console
+
+        from deepagents_code.main import (
+            _run_trust_action_picker,
+            _TrustAction,
+        )
+
+        captured: dict[str, Any] = {}
+
+        class _FakeApplication:
+            def __class_getitem__(cls, _item: object) -> type["_FakeApplication"]:
+                return cls
+
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+            def run(self) -> _TrustAction:
+                bindings = captured["key_bindings"].bindings
+                holder: dict[str, _TrustAction] = {}
+                event = SimpleNamespace(
+                    app=SimpleNamespace(
+                        exit=lambda *, result: holder.update(value=result)
+                    )
+                )
+                move_up = next(
+                    binding.handler
+                    for binding in bindings
+                    if binding.handler.__name__ == "_up"
+                )
+                confirm = next(
+                    binding.handler
+                    for binding in bindings
+                    if binding.handler.__name__ == "_confirm"
+                )
+                move_up(event)
+                confirm(event)
+                return holder["value"]
+
+        monkeypatch.setattr("prompt_toolkit.Application", _FakeApplication)
+        result = _run_trust_action_picker(
+            Console(stderr=True),
+            remember_label="Continue and hide until versions change",
+            allow_label="Continue this session only",
+            deny_label="Abort launch",
+            refresh_label="Refresh environment now",
+            deny_first=True,
+        )
+
+        assert result is _TrustAction.DENY
 
     @pytest.mark.usefixtures("_interactive_picker_terminal")
     def test_abort_on_deny_maps_picker_deny_to_cancelled(
@@ -6318,11 +6373,15 @@ class TestSelectProjectMcpTrustAction:
 
         assert result is _TrustAction[expected_name]
 
-    @pytest.mark.parametrize("token", ["u", "update", "f", "refresh"])
+    @pytest.mark.parametrize("token", ["", "u", "update", "f", "refresh"])
     def test_text_fallback_refresh_tokens(
         self, token: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The dependency-floor fallback accepts update and refresh spellings."""
+        """The dependency-floor fallback accepts update and refresh spellings.
+
+        An empty answer (a bare Enter) also refreshes: refresh is the default
+        in this prompt shape, matching the inline picker's initial highlight.
+        """
         from rich.console import Console
 
         from deepagents_code.main import (
@@ -6341,6 +6400,30 @@ class TestSelectProjectMcpTrustAction:
         )
 
         assert result is _TrustAction.REFRESH
+
+    @pytest.mark.parametrize("token", ["n", "no"])
+    def test_text_fallback_refresh_prompt_refuse_tokens(
+        self, token: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Refusing the dependency-floor prompt stays an explicit choice."""
+        from rich.console import Console
+
+        from deepagents_code.main import (
+            _select_trust_action,
+            _TrustAction,
+        )
+
+        monkeypatch.setattr(
+            "deepagents_code.main._run_trust_action_picker",
+            lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setattr("builtins.input", lambda _prompt="": token)
+
+        result = _select_trust_action(
+            Console(stderr=True), refresh_label="Refresh environment now"
+        )
+
+        assert result is _TrustAction.DENY
 
 
 class TestCheckMcpProjectTrustDedupe:


### PR DESCRIPTION
The stale editable-dependency prompt shown before the TUI launches now defaults to "Refresh environment now" instead of "Abort launch": a bare Enter (or clicking through with the default highlight) repairs the environment rather than killing the launch. "Abort launch" keeps its leading position in the list, one keystroke up from the new default.

---

When an editable `dcode` install falls behind the checkout's dependency floors, the prompt's whole purpose is to steer the user toward refreshing — yet it opened with "Abort launch" highlighted, so the path of least resistance was the least useful outcome and users could reflexively Enter their way out of a launch they wanted. In the text fallback the prompt advertised `Abort launch [N]` as the default, so a bare Enter aborted there too.

The picker now computes its initial highlight by action identity and prefers the refresh action when one is offered; deny-only prompts (project trust, MCP approvals) still default to refusing. The text fallback mirrors the picker: hints read `Abort launch [n] · Refresh environment now [U]` and an empty answer maps to `REFRESH`, while explicit `n`/`no` still aborts.
