### PR TITLE
fix(code): protect TUI from native stderr writes

### DIFF
--- a/libs/code/deepagents_code/_terminal_stderr.py
+++ b/libs/code/deepagents_code/_terminal_stderr.py
@@ -1,0 +1,103 @@
+"""Protect the Textual viewport from unmanaged macOS stderr writes."""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class TerminalStderrGuard:
+    """Suppress native stderr writes while the TUI owns the terminal."""
+
+    def __init__(self, *, enabled: bool = False) -> None:
+        self._enabled = enabled
+        self._saved_stderr: int | None = None
+        self._closed = False
+        self._lock = threading.Lock()
+
+    @classmethod
+    def install(cls) -> TerminalStderrGuard:
+        """Install suppression when stdout and stderr share a macOS terminal.
+
+        Returns:
+            The installed guard, which may be inactive on unsupported streams.
+        """
+        guard = cls(enabled=sys.platform == "darwin" and _stderr_targets_stdout())
+        guard.resume()
+        return guard
+
+    @property
+    def active(self) -> bool:
+        """Whether stderr is currently suppressed."""
+        with self._lock:
+            return self._saved_stderr is not None
+
+    def pause(self) -> None:
+        """Restore stderr while terminal ownership is released."""
+        with self._lock:
+            if self._saved_stderr is None:
+                return
+            os.dup2(self._saved_stderr, 2)
+            saved_stderr = self._saved_stderr
+            self._saved_stderr = None
+            os.close(saved_stderr)
+
+    def resume(self) -> None:
+        """Suppress stderr after terminal ownership returns."""
+        with self._lock:
+            if not self._enabled or self._closed or self._saved_stderr is not None:
+                return
+            saved_stderr = os.dup(2)
+            try:
+                devnull = os.open(os.devnull, os.O_WRONLY)
+                try:
+                    os.dup2(devnull, 2)
+                finally:
+                    os.close(devnull)
+            except BaseException:
+                os.close(saved_stderr)
+                raise
+            self._saved_stderr = saved_stderr
+
+    @contextmanager
+    def paused(self) -> Iterator[None]:
+        """Restore stderr for the duration of a terminal handoff.
+
+        Yields:
+            Control while stderr targets the caller's terminal.
+        """
+        was_active = self.active
+        if was_active:
+            self.pause()
+        try:
+            yield
+        finally:
+            if was_active:
+                self.resume()
+
+    def close(self) -> None:
+        """Restore stderr permanently when the TUI session ends."""
+        self.pause()
+        with self._lock:
+            self._closed = True
+
+
+def _stderr_targets_stdout() -> bool:
+    """Return whether stdout and stderr are the same terminal."""
+    if not os.isatty(1) or not os.isatty(2):
+        return False
+    try:
+        stdout_stat = os.fstat(1)
+        stderr_stat = os.fstat(2)
+    except OSError:
+        return False
+    return (stdout_stat.st_dev, stdout_stat.st_ino) == (
+        stderr_stat.st_dev,
+        stderr_stat.st_ino,
+    )

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -16,7 +16,7 @@ import time
 import uuid
 import webbrowser
 from collections import deque
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager, contextmanager, suppress
 from dataclasses import dataclass, field, replace
 from itertools import groupby
 from pathlib import Path
@@ -1002,6 +1002,7 @@ if TYPE_CHECKING:
         Awaitable,
         Callable,
         Coroutine,
+        Iterator,
         Mapping,
         Sequence,
     )
@@ -1020,6 +1021,7 @@ if TYPE_CHECKING:
     from textual.worker import Worker
 
     from deepagents_code._ask_user_types import AskUserWidgetResult, Question
+    from deepagents_code._terminal_stderr import TerminalStderrGuard
     from deepagents_code.approval_mode import ApprovalMode
     from deepagents_code.client.launch.server import ServerProcess
     from deepagents_code.client.remote_client import RemoteAgent
@@ -3098,6 +3100,35 @@ class DeepAgentsApp(App):
         """Return the main screen with chat-specific startup focus."""
         return _MainScreen(id="_default")
 
+    @override
+    @contextmanager
+    def suspend(self) -> Iterator[None]:
+        """Restore native stderr while another program owns the terminal.
+
+        Yields:
+            Control while the Textual application is suspended.
+        """
+        guard = self._terminal_stderr_guard
+        if guard is None:
+            with super().suspend():
+                yield
+            return
+        with guard.paused(), super().suspend():
+            yield
+
+    @override
+    def action_suspend_process(self) -> None:
+        """Restore native stderr while the process is suspended."""
+        guard = self._terminal_stderr_guard
+        if guard is None:
+            super().action_suspend_process()
+            return
+        guard.pause()
+        try:
+            super().action_suspend_process()
+        finally:
+            guard.resume()
+
     class ServerReady(Message):
         """Posted by the background server-startup worker on success."""
 
@@ -3239,6 +3270,7 @@ class DeepAgentsApp(App):
             self.sub_title = sub_title
 
         self._register_custom_themes()
+        self._terminal_stderr_guard: TerminalStderrGuard | None = None
         self._hook_trust: WorkspaceTrust | None = hook_trust
         """Project-hook trust shared across pending and live manager state."""
 
@@ -28493,6 +28525,8 @@ async def run_textual_app(
             snapshot with the final thread ID so callers can still render
             teardown hints for the thread that was active at the crash.
     """
+    from deepagents_code._terminal_stderr import TerminalStderrGuard
+
     app = DeepAgentsApp(
         agent=agent,
         assistant_id=assistant_id,
@@ -28520,6 +28554,8 @@ async def run_textual_app(
         title=title,
         sub_title=sub_title,
     )
+    stderr_guard = TerminalStderrGuard.install()
+    app._terminal_stderr_guard = stderr_guard
     try:
         await app.run_async()
     except Exception as e:
@@ -28536,6 +28572,8 @@ async def run_textual_app(
             ),
         ) from e
     finally:
+        stderr_guard.close()
+        app._terminal_stderr_guard = None
         # Guarantee server cleanup regardless of how the app exits.
         # Covers both the pre-started server_proc path and the deferred
         # server_kwargs path (where the background worker sets _server_proc).

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -28554,9 +28554,10 @@ async def run_textual_app(
         title=title,
         sub_title=sub_title,
     )
-    stderr_guard = TerminalStderrGuard.install()
-    app._terminal_stderr_guard = stderr_guard
+    stderr_guard: TerminalStderrGuard | None = None
     try:
+        stderr_guard = TerminalStderrGuard.install()
+        app._terminal_stderr_guard = stderr_guard
         await app.run_async()
     except Exception as e:
         # The app resolves resume intent and `/threads` switches internally, so
@@ -28572,8 +28573,9 @@ async def run_textual_app(
             ),
         ) from e
     finally:
-        stderr_guard.close()
-        app._terminal_stderr_guard = None
+        if stderr_guard is not None:
+            stderr_guard.close()
+            app._terminal_stderr_guard = None
         # Guarantee server cleanup regardless of how the app exits.
         # Covers both the pre-started server_proc path and the deferred
         # server_kwargs path (where the background worker sets _server_proc).

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -19305,6 +19305,23 @@ class TestActionOpenEditor:
         assert app.focused is text_area
         return menu, text_area, future
 
+    def test_suspend_pauses_native_stderr_guard(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock())
+        guard = MagicMock()
+        guard.paused.return_value = contextlib.nullcontext()
+        app._terminal_stderr_guard = guard
+
+        with (
+            patch(
+                "textual.app.App.suspend", return_value=contextlib.nullcontext()
+            ) as textual_suspend,
+            app.suspend(),
+        ):
+            pass
+
+        guard.paused.assert_called_once_with()
+        textual_suspend.assert_called_once_with()
+
     async def test_updates_text_on_successful_edit(self) -> None:
         app = DeepAgentsApp(agent=MagicMock())
         text_area = MagicMock()

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -3050,6 +3050,25 @@ class TestServerCleanupLifecycle:
         server_proc.stop.assert_called_once_with()
         emit.assert_called_once_with()
 
+    async def test_server_proc_stopped_when_stderr_guard_install_fails(self) -> None:
+        """Server cleanup must run when the stderr guard cannot be installed."""
+        server_proc = SimpleNamespace(stop=MagicMock())
+
+        with (
+            patch(
+                "deepagents_code._terminal_stderr.TerminalStderrGuard.install",
+                side_effect=OSError("too many open files"),
+            ),
+            patch(
+                "deepagents_code.client.launch.server.emit_preserved_log_notices",
+            ) as emit,
+            pytest.raises(TextualAppError, match="too many open files"),
+        ):
+            await run_textual_app(server_proc=server_proc, thread_id="t-1")  # ty: ignore
+
+        server_proc.stop.assert_called_once_with()
+        emit.assert_called_once_with()
+
     async def test_server_proc_stopped_even_on_crash(self) -> None:
         """server_proc.stop() must fire even when run_async raises."""
         server_proc = SimpleNamespace(stop=MagicMock())

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -3029,6 +3029,7 @@ class TestServerCleanupLifecycle:
         """run_textual_app must call server_proc.stop() in the finally block."""
         server_proc = SimpleNamespace(stop=MagicMock())
 
+        guard = MagicMock()
         with (
             patch.object(
                 DeepAgentsApp,
@@ -3036,11 +3037,16 @@ class TestServerCleanupLifecycle:
                 new_callable=AsyncMock,
             ),
             patch(
+                "deepagents_code._terminal_stderr.TerminalStderrGuard.install",
+                return_value=guard,
+            ),
+            patch(
                 "deepagents_code.client.launch.server.emit_preserved_log_notices",
             ) as emit,
         ):
             await run_textual_app(server_proc=server_proc, thread_id="t-1")  # ty: ignore
 
+        guard.close.assert_called_once_with()
         server_proc.stop.assert_called_once_with()
         emit.assert_called_once_with()
 

--- a/libs/code/tests/unit_tests/test_terminal_stderr.py
+++ b/libs/code/tests/unit_tests/test_terminal_stderr.py
@@ -1,0 +1,85 @@
+"""Tests for the macOS terminal stderr guard."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from deepagents_code._terminal_stderr import TerminalStderrGuard, _stderr_targets_stdout
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_stderr(message: str) -> None:
+    os.write(2, message.encode())
+
+
+def test_suppresses_stderr_only_while_terminal_is_owned(tmp_path: Path) -> None:
+    output_path = tmp_path / "stderr.log"
+    output_fd = os.open(output_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+    original_stderr = os.dup(2)
+    try:
+        os.dup2(output_fd, 2)
+        guard = TerminalStderrGuard(enabled=True)
+        guard.resume()
+        _write_stderr("hidden while active\n")
+        guard.pause()
+        _write_stderr("visible while paused\n")
+        guard.resume()
+        _write_stderr("hidden after resume\n")
+        guard.close()
+        _write_stderr("visible after close\n")
+    finally:
+        os.dup2(original_stderr, 2)
+        os.close(original_stderr)
+        os.close(output_fd)
+
+    assert output_path.read_text() == "visible while paused\nvisible after close\n"
+
+
+def test_install_preserves_redirected_stderr(tmp_path: Path) -> None:
+    output_path = tmp_path / "stderr.log"
+    output_fd = os.open(output_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+    original_stderr = os.dup(2)
+    try:
+        os.dup2(output_fd, 2)
+        with patch("deepagents_code._terminal_stderr.sys.platform", "darwin"):
+            guard = TerminalStderrGuard.install()
+        _write_stderr("visible while redirected\n")
+        guard.close()
+    finally:
+        os.dup2(original_stderr, 2)
+        os.close(original_stderr)
+        os.close(output_fd)
+
+    assert output_path.read_text() == "visible while redirected\n"
+
+
+def test_install_is_noop_outside_macos() -> None:
+    with (
+        patch("deepagents_code._terminal_stderr.sys.platform", "linux"),
+        patch("deepagents_code._terminal_stderr.os.isatty") as isatty,
+    ):
+        guard = TerminalStderrGuard.install()
+
+    assert guard.active is False
+    isatty.assert_not_called()
+
+
+def test_same_terminal_requires_matching_device_and_inode() -> None:
+    same = SimpleNamespace(st_dev=1, st_ino=2)
+    other = SimpleNamespace(st_dev=1, st_ino=3)
+    with (
+        patch("deepagents_code._terminal_stderr.os.isatty", return_value=True),
+        patch("deepagents_code._terminal_stderr.os.fstat", side_effect=[same, other]),
+    ):
+        assert _stderr_targets_stdout() is False
+
+    with (
+        patch("deepagents_code._terminal_stderr.os.isatty", return_value=True),
+        patch("deepagents_code._terminal_stderr.os.fstat", side_effect=[same, same]),
+    ):
+        assert _stderr_targets_stdout() is True


### PR DESCRIPTION
Native macOS diagnostics no longer corrupt the Textual interface while it owns the terminal.

---

macOS frameworks can write directly to fd 2, bypassing Textual's Python-level stderr capture. Suppress those writes only when stdout and stderr share a TTY, while preserving redirected stderr and restoring it for external editors, process suspension, and teardown.

Tests cover fd suppression/restoration, platform and TTY gates, editor suspension, and app cleanup.

Made by [Open SWE](https://openswe.vercel.app/agents/35f98f77-db79-5fa8-bf6b-12877813719d)