### PR TITLE
perf(code): omit middleware trace inputs

### DIFF
--- a/libs/code/deepagents_code/_glm_5p2_profile.py
+++ b/libs/code/deepagents_code/_glm_5p2_profile.py
@@ -158,6 +158,7 @@ class _GlmTerminalStallRecovery(AgentMiddleware):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     @staticmethod
     def _is_terminal_stall(response: ModelResponse) -> bool:

--- a/libs/code/deepagents_code/_glm_5p2_profile.py
+++ b/libs/code/deepagents_code/_glm_5p2_profile.py
@@ -21,6 +21,8 @@ from langchain.agents.middleware.types import (
     AgentMiddleware,
     ModelRequest,
     ModelResponse,
+    TracePolicy,
+    omit_payload,
 )
 from langchain_core.messages import AIMessage
 
@@ -154,6 +156,8 @@ class _GlmTerminalStallRecovery(AgentMiddleware):
         so only `_FIREWORKS_GLM_5P2_SPEC` recovers. The output cap that produces
         the stall was measured only there; OpenRouter and Baseten are excluded.
     """
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     @staticmethod
     def _is_terminal_stall(response: ModelResponse) -> bool:

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -795,6 +795,7 @@ class ShellAllowListMiddleware(AgentMiddleware):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def __init__(self, allow_list: list[str]) -> None:
         """Initialize with the shell allow-list to validate commands against.
@@ -2005,6 +2006,7 @@ class AsyncApprovalHITLMiddleware(HumanInTheLoopMiddleware[Any, Any, Any]):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     # Report the stock middleware name so the SDK dedups us into the single HITL
     # slot rather than appending a second stock HITL alongside us. This pairs

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -49,7 +49,12 @@ from langchain.agents.middleware import (
     HumanInTheLoopMiddleware,
     InterruptOnConfig,
 )
-from langchain.agents.middleware.types import AgentMiddleware, ToolCallRequest
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ToolCallRequest,
+    TracePolicy,
+    omit_payload,
+)
 from langchain.tools import (
     BaseTool,
     ToolRuntime,  # LangChain inspects this annotation for runtime injection.
@@ -788,6 +793,8 @@ class ShellAllowListMiddleware(AgentMiddleware):
     Use this middleware in non-interactive mode to avoid the
     interrupt/resume cycle that fragments traces.
     """
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     def __init__(self, allow_list: list[str]) -> None:
         """Initialize with the shell allow-list to validate commands against.
@@ -1996,6 +2003,8 @@ class AsyncApprovalHITLMiddleware(HumanInTheLoopMiddleware[Any, Any, Any]):
     without the process-local `_RoutingDecision` type identity, so graph input
     cannot forge an autonomous mode.
     """
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     # Report the stock middleware name so the SDK dedups us into the single HITL
     # slot rather than appending a second stock HITL alongside us. This pairs

--- a/libs/code/deepagents_code/ask_user.py
+++ b/libs/code/deepagents_code/ask_user.py
@@ -344,6 +344,7 @@ class AskUserMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def __init__(
         self,

--- a/libs/code/deepagents_code/ask_user.py
+++ b/libs/code/deepagents_code/ask_user.py
@@ -17,6 +17,8 @@ from langchain.agents.middleware.types import (
     ModelResponse,
     ResponseT,
     ToolCallRequest,
+    TracePolicy,
+    omit_payload,
 )
 from langchain.tools import InjectedToolCallId, ToolRuntime
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
@@ -340,6 +342,8 @@ class AskUserMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     (pick exactly one), or multi-select (pick one or more).
     The tool uses LangGraph interrupts to pause execution and wait for user input.
     """
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     def __init__(
         self,

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -39,6 +39,8 @@ from langchain.agents.middleware.types import (
     ModelResponse,
     PrivateStateAttr,
     ToolCallRequest,
+    TracePolicy,
+    omit_payload,
 )
 from langchain.tools import ToolRuntime  # noqa: TC002  # runtime injection marker
 from langchain_core.messages import (
@@ -1945,6 +1947,7 @@ def _validate_classifier_ids(batch: AutoDecisionBatch, expected_ids: set[str]) -
 class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
     """Apply deterministic policy, classifier review, and HITL fallback."""
 
+    trace_policy = TracePolicy(process_inputs=omit_payload)
     state_schema = AutoModeState
 
     @property
@@ -3646,6 +3649,8 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
 
 class HeadlessMCPGuardMiddleware(HumanInTheLoopMiddleware[AgentState[Any], Any, Any]):
     """Reject dynamically gated MCP calls when no approval UI exists."""
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     def __init__(self, tool_names: set[str]) -> None:
         """Initialize the guard.

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -1948,6 +1948,8 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
     """Apply deterministic policy, classifier review, and HITL fallback."""
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
+
     state_schema = AutoModeState
 
     @property
@@ -3651,6 +3653,7 @@ class HeadlessMCPGuardMiddleware(HumanInTheLoopMiddleware[AgentState[Any], Any, 
     """Reject dynamically gated MCP calls when no approval UI exists."""
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def __init__(self, tool_names: set[str]) -> None:
         """Initialize the guard.

--- a/libs/code/deepagents_code/configurable_model.py
+++ b/libs/code/deepagents_code/configurable_model.py
@@ -23,6 +23,8 @@ from langchain.agents.middleware.types import (
     ExtendedModelResponse,
     ModelRequest,
     ModelResponse,
+    TracePolicy,
+    omit_payload,
 )
 from langgraph.types import Command
 
@@ -824,6 +826,8 @@ class ConfigurableModelMiddleware(AgentMiddleware):
     model call before provider-specific middleware (like
     `AnthropicPromptCachingMiddleware`) runs.
     """
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     def __init__(
         self,

--- a/libs/code/deepagents_code/configurable_model.py
+++ b/libs/code/deepagents_code/configurable_model.py
@@ -828,6 +828,7 @@ class ConfigurableModelMiddleware(AgentMiddleware):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def __init__(
         self,

--- a/libs/code/deepagents_code/cost_tracking.py
+++ b/libs/code/deepagents_code/cost_tracking.py
@@ -2226,6 +2226,8 @@ class CostTrackingMiddleware(AgentMiddleware[CostState, ContextT]):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
+
     state_schema = CostState
 
     def __init__(self, *, nested: bool = False) -> None:

--- a/libs/code/deepagents_code/cost_tracking.py
+++ b/libs/code/deepagents_code/cost_tracking.py
@@ -67,6 +67,8 @@ from langchain.agents.middleware.types import (
     ContextT,
     OmitFromInput,
     PrivateStateAttr,
+    TracePolicy,
+    omit_payload,
 )
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import AIMessage
@@ -2223,6 +2225,7 @@ class CostTrackingMiddleware(AgentMiddleware[CostState, ContextT]):
     subagent total through state for its owning parent graph to checkpoint.
     """
 
+    trace_policy = TracePolicy(process_inputs=omit_payload)
     state_schema = CostState
 
     def __init__(self, *, nested: bool = False) -> None:

--- a/libs/code/deepagents_code/goal_rubric.py
+++ b/libs/code/deepagents_code/goal_rubric.py
@@ -378,6 +378,7 @@ class _GoalContextFallbackMiddleware(AgentMiddleware[Any, Any]):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     @override
     def wrap_model_call(
@@ -460,6 +461,7 @@ class _CriteriaContextBudgetMiddleware(AgentMiddleware[GoalCriteriaAgentState, N
     """Bound tool-result text accumulated by one nested context operation."""
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def __init__(self, *, label: str = "Criteria context") -> None:
         """Initialize bounded per-operation context counters.
@@ -546,6 +548,7 @@ class _ContextToolCallBudgetMiddleware(AgentMiddleware[Any, Any]):
     """Bound selected context-tool calls independently for each nested operation."""
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def __init__(self, tool_names: set[str], *, limit: int) -> None:
         """Initialize a per-operation call budget for the selected tools.
@@ -625,6 +628,7 @@ class _RepositoryToolBudgetMiddleware(AgentMiddleware[FilesystemState, None]):
     """Bound repository inspection calls and read/result sizes."""
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def __init__(self, backend: BackendProtocol, *, root: str = "/") -> None:
         """Initialize a per-operation repository tool budget.
@@ -780,6 +784,7 @@ class _WebSearchBudgetMiddleware(AgentMiddleware[GoalCriteriaAgentState, None]):
     """Limit web searches independently for each nested context operation."""
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def __init__(self) -> None:
         """Initialize bounded per-operation search counters."""
@@ -1336,6 +1341,8 @@ class GoalCriteriaMiddleware(AgentMiddleware[GoalCriteriaState, Any]):
     """Run goal-criteria requests entirely inside the main server graph."""
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
+
     state_schema = GoalCriteriaState
 
     def __init__(

--- a/libs/code/deepagents_code/goal_rubric.py
+++ b/libs/code/deepagents_code/goal_rubric.py
@@ -23,7 +23,9 @@ from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
     OmitFromOutput,
+    TracePolicy,
     hook_config,
+    omit_payload,
 )
 from langchain_core.messages import (
     AIMessage,
@@ -375,6 +377,8 @@ class _GoalContextFallbackMiddleware(AgentMiddleware[Any, Any]):
     "fix" the retry by re-adding tools.
     """
 
+    trace_policy = TracePolicy(process_inputs=omit_payload)
+
     @override
     def wrap_model_call(
         self,
@@ -454,6 +458,8 @@ def _goal_only_messages(messages: Sequence[BaseMessage]) -> list[AnyMessage]:
 
 class _CriteriaContextBudgetMiddleware(AgentMiddleware[GoalCriteriaAgentState, None]):
     """Bound tool-result text accumulated by one nested context operation."""
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     def __init__(self, *, label: str = "Criteria context") -> None:
         """Initialize bounded per-operation context counters.
@@ -539,6 +545,8 @@ class _CriteriaContextBudgetMiddleware(AgentMiddleware[GoalCriteriaAgentState, N
 class _ContextToolCallBudgetMiddleware(AgentMiddleware[Any, Any]):
     """Bound selected context-tool calls independently for each nested operation."""
 
+    trace_policy = TracePolicy(process_inputs=omit_payload)
+
     def __init__(self, tool_names: set[str], *, limit: int) -> None:
         """Initialize a per-operation call budget for the selected tools.
 
@@ -615,6 +623,8 @@ class _ContextToolCallBudgetMiddleware(AgentMiddleware[Any, Any]):
 
 class _RepositoryToolBudgetMiddleware(AgentMiddleware[FilesystemState, None]):
     """Bound repository inspection calls and read/result sizes."""
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     def __init__(self, backend: BackendProtocol, *, root: str = "/") -> None:
         """Initialize a per-operation repository tool budget.
@@ -768,6 +778,8 @@ class _RepositoryToolBudgetMiddleware(AgentMiddleware[FilesystemState, None]):
 
 class _WebSearchBudgetMiddleware(AgentMiddleware[GoalCriteriaAgentState, None]):
     """Limit web searches independently for each nested context operation."""
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     def __init__(self) -> None:
         """Initialize bounded per-operation search counters."""
@@ -1323,6 +1335,7 @@ def _prompt_with_conversation_context(
 class GoalCriteriaMiddleware(AgentMiddleware[GoalCriteriaState, Any]):
     """Run goal-criteria requests entirely inside the main server graph."""
 
+    trace_policy = TracePolicy(process_inputs=omit_payload)
     state_schema = GoalCriteriaState
 
     def __init__(

--- a/libs/code/deepagents_code/goal_tools.py
+++ b/libs/code/deepagents_code/goal_tools.py
@@ -289,6 +289,8 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
+
     state_schema = GoalToolState
 
     def __init__(self) -> None:

--- a/libs/code/deepagents_code/goal_tools.py
+++ b/libs/code/deepagents_code/goal_tools.py
@@ -19,6 +19,8 @@ from langchain.agents.middleware.types import (
     ContextT,
     ModelRequest,
     ModelResponse,
+    TracePolicy,
+    omit_payload,
 )
 from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.tools import InjectedToolCallId, tool
@@ -286,6 +288,7 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
     registered.
     """
 
+    trace_policy = TracePolicy(process_inputs=omit_payload)
     state_schema = GoalToolState
 
     def __init__(self) -> None:

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -30,7 +30,9 @@ from langchain.agents.middleware.types import (
     ContextT,
     PrivateStateAttr,
     ResponseT,
+    TracePolicy,
     hook_config,
+    omit_payload,
 )
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.types import Command, interrupt
@@ -291,6 +293,7 @@ def _subagent_transcript_config(
 class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, ResponseT]):
     """Emit server-owned lifecycle events over the hook interrupt transport."""
 
+    trace_policy = TracePolicy(process_inputs=omit_payload)
     state_schema = ServerHooksState
 
     def __init__(

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -294,6 +294,8 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
     """Emit server-owned lifecycle events over the hook interrupt transport."""
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
+
     state_schema = ServerHooksState
 
     def __init__(

--- a/libs/code/deepagents_code/local_context.py
+++ b/libs/code/deepagents_code/local_context.py
@@ -702,6 +702,8 @@ class LocalContextMiddleware(AgentMiddleware):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
+
     state_schema = LocalContextState
 
     def __init__(

--- a/libs/code/deepagents_code/local_context.py
+++ b/libs/code/deepagents_code/local_context.py
@@ -28,6 +28,8 @@ from langchain.agents.middleware.types import (
     ModelRequest,
     ModelResponse,
     PrivateStateAttr,
+    TracePolicy,
+    omit_payload,
 )
 
 from deepagents_code.unicode_security import sanitize_control_chars
@@ -699,6 +701,7 @@ class LocalContextMiddleware(AgentMiddleware):
     and remote sandboxes.
     """
 
+    trace_policy = TracePolicy(process_inputs=omit_payload)
     state_schema = LocalContextState
 
     def __init__(

--- a/libs/code/deepagents_code/memory_guard.py
+++ b/libs/code/deepagents_code/memory_guard.py
@@ -105,6 +105,7 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
     def __init__(self, guarded_paths: Iterable[str | Path]) -> None:
         """Initialize the guard with the memory files to protect.

--- a/libs/code/deepagents_code/memory_guard.py
+++ b/libs/code/deepagents_code/memory_guard.py
@@ -31,7 +31,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from langchain.agents.middleware.types import AgentMiddleware
+from langchain.agents.middleware.types import AgentMiddleware, TracePolicy, omit_payload
 from langchain_core.messages import ToolMessage
 
 from deepagents_code.onboarding import (
@@ -103,6 +103,8 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
     the file holds a managed block or exists but cannot be read. If the restore
     itself fails, an error is still returned so the failure is never silent.
     """
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     def __init__(self, guarded_paths: Iterable[str | Path]) -> None:
         """Initialize the guard with the memory files to protect.

--- a/libs/code/deepagents_code/resume_state.py
+++ b/libs/code/deepagents_code/resume_state.py
@@ -67,6 +67,8 @@ from langchain.agents.middleware.types import (
     AgentState,
     ContextT,
     PrivateStateAttr,
+    TracePolicy,
+    omit_payload,
 )
 from langchain_core.messages import AIMessage
 
@@ -263,6 +265,7 @@ class ResumeStateMiddleware(AgentMiddleware[ResumeState, ContextT]):
     run in LangSmith and works identically against remote graphs).
     """
 
+    trace_policy = TracePolicy(process_inputs=omit_payload)
     state_schema = ResumeState
 
     def after_model(  # noqa: PLR6301  # AgentMiddleware hook must be an instance method.

--- a/libs/code/deepagents_code/resume_state.py
+++ b/libs/code/deepagents_code/resume_state.py
@@ -266,6 +266,8 @@ class ResumeStateMiddleware(AgentMiddleware[ResumeState, ContextT]):
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
+    """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
+
     state_schema = ResumeState
 
     def after_model(  # noqa: PLR6301  # AgentMiddleware hook must be an instance method.

--- a/libs/code/tests/unit_tests/test_middleware_trace_policy.py
+++ b/libs/code/tests/unit_tests/test_middleware_trace_policy.py
@@ -1,0 +1,55 @@
+"""Trace-policy contracts for coding-agent middleware."""
+
+import pytest
+from langchain.agents.middleware.types import AgentMiddleware
+
+from deepagents_code._glm_5p2_profile import _GlmTerminalStallRecovery
+from deepagents_code.agent import AsyncApprovalHITLMiddleware, ShellAllowListMiddleware
+from deepagents_code.ask_user import AskUserMiddleware
+from deepagents_code.auto_mode import AutoModeHITLMiddleware, HeadlessMCPGuardMiddleware
+from deepagents_code.configurable_model import ConfigurableModelMiddleware
+from deepagents_code.cost_tracking import CostTrackingMiddleware
+from deepagents_code.goal_rubric import (
+    GoalCriteriaMiddleware,
+    _ContextToolCallBudgetMiddleware,
+    _CriteriaContextBudgetMiddleware,
+    _GoalContextFallbackMiddleware,
+    _RepositoryToolBudgetMiddleware,
+    _WebSearchBudgetMiddleware,
+)
+from deepagents_code.goal_tools import GoalToolsMiddleware
+from deepagents_code.hooks.server_middleware import ServerHooksMiddleware
+from deepagents_code.local_context import LocalContextMiddleware
+from deepagents_code.memory_guard import ManagedMemoryGuardMiddleware
+from deepagents_code.resume_state import ResumeStateMiddleware
+
+
+@pytest.mark.parametrize(
+    "middleware",
+    [
+        _GlmTerminalStallRecovery,
+        ShellAllowListMiddleware,
+        AsyncApprovalHITLMiddleware,
+        AskUserMiddleware,
+        AutoModeHITLMiddleware,
+        HeadlessMCPGuardMiddleware,
+        ConfigurableModelMiddleware,
+        CostTrackingMiddleware,
+        _GoalContextFallbackMiddleware,
+        _CriteriaContextBudgetMiddleware,
+        _ContextToolCallBudgetMiddleware,
+        _RepositoryToolBudgetMiddleware,
+        _WebSearchBudgetMiddleware,
+        GoalCriteriaMiddleware,
+        GoalToolsMiddleware,
+        ServerHooksMiddleware,
+        LocalContextMiddleware,
+        ManagedMemoryGuardMiddleware,
+        ResumeStateMiddleware,
+    ],
+)
+def test_middleware_omits_trace_inputs(middleware: type[AgentMiddleware]) -> None:
+    """Coding-agent middleware must not duplicate state in trace inputs."""
+    assert middleware.trace_policy is not None
+    assert middleware.trace_policy.process_inputs is not None
+    assert middleware.trace_policy.process_inputs({"messages": ["secret"]}) == {}


### PR DESCRIPTION
Coding-agent middleware spans no longer serialize duplicate message and state payloads.

---

This extends the SDK trace policy from #5377 to all middleware owned by `deepagents-code`, while avoiding a process-wide policy that could change third-party middleware tracing. A contract test keeps every owned middleware class opted in.

Made by [Open SWE](https://openswe.vercel.app/agents/a391e2dc-ba5f-53fb-82fe-ad847a895937)