### PR TITLE
feat(code): enable secret redaction by default

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -314,7 +314,7 @@ LANGSMITH_PROJECT = "DEEPAGENTS_CODE_LANGSMITH_PROJECT"
 """Override LangSmith project name for agent traces."""
 
 LANGSMITH_REDACT = "DEEPAGENTS_CODE_LANGSMITH_REDACT"
-"""Toggle LangSmith secret redaction for agent traces (defaults to off)."""
+"""Toggle LangSmith secret redaction for agent traces (defaults to on)."""
 
 LANGSMITH_REPLICA_PROJECTS = "DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS"
 """Comma-separated LangSmith project names to *also* write agent traces to.

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3764,7 +3764,7 @@ def is_langsmith_redaction_enabled() -> bool:
 
     option = get_option("tracing.langsmith_redact")
     if option is None:
-        return False
+        return True
     resolved = get_config_resolver().get(option)
     _emit_ranked_diagnostics(option, resolved)
     return bool(resolved.value)

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -2018,7 +2018,7 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         group="Tracing",
         summary="Redact detected secrets from LangSmith agent traces before upload.",
         kind=OptionKind.BOOL,
-        default=False,
+        default=True,
         env_var=_env_vars.LANGSMITH_REDACT,
         toml_keys=("tracing", "langsmith_redact"),
     ),

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -2669,23 +2669,19 @@ class TestLangsmithKeyShadowedByEmptyOverride:
 class TestLangsmithSecretRedaction:
     """Tests for LangSmith trace secret redaction configuration."""
 
-    @pytest.fixture(autouse=True)
-    def _enable_redaction(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_REDACT", "true")
+    def test_redaction_enabled_by_default(self) -> None:
+        """LangSmith trace redaction defaults to enabled."""
+        with patch("deepagents_code.config_manifest.load_config_toml", return_value={}):
+            assert is_langsmith_redaction_enabled() is True
 
-    def test_redaction_disabled_by_default(
+    def test_redaction_can_be_disabled_by_env(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """LangSmith trace redaction defaults to disabled."""
-        monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_REDACT")
+        """The redaction env var can opt out for local debugging."""
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_REDACT", "false")
         with patch("deepagents_code.config_manifest.load_config_toml", return_value={}):
             assert is_langsmith_redaction_enabled() is False
-
-    def test_redaction_can_be_enabled_by_env(self) -> None:
-        """The redaction env var can opt in to secret redaction."""
-        with patch("deepagents_code.config_manifest.load_config_toml", return_value={}):
-            assert is_langsmith_redaction_enabled() is True
 
     def test_configures_langsmith_client_with_secret_anonymizer(
         self,
@@ -2714,14 +2710,14 @@ class TestLangsmithSecretRedaction:
         assert secret not in redacted
         assert "[SECRET_DETECTED]" in redacted
 
-    def test_skips_client_configuration_by_default(
+    def test_skips_client_configuration_when_redaction_disabled(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Tracing leaves the LangSmith client untouched until redaction is enabled."""
+        """Opting out leaves the LangSmith client untouched."""
         monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "lsv2_test")
         monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_TRACING", "true")
-        monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_REDACT")
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_REDACT", "false")
 
         with (
             patch("deepagents_code.config_manifest.load_config_toml", return_value={}),
@@ -3013,17 +3009,17 @@ class TestLangsmithSecretRedaction:
         assert "api_key" not in kwargs
         assert "anonymizer" in kwargs
 
-    def test_redaction_can_be_enabled_by_toml(
+    def test_redaction_can_be_disabled_by_toml(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        """A `[tracing] langsmith_redact = true` in config.toml opts in."""
-        monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_REDACT")
+        """A `[tracing] langsmith_redact = false` in config.toml opts out."""
+        monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_REDACT", raising=False)
         (tmp_path / "config.toml").write_text(
-            "[tracing]\nlangsmith_redact = true\n", encoding="utf-8"
+            "[tracing]\nlangsmith_redact = false\n", encoding="utf-8"
         )
-        assert is_langsmith_redaction_enabled() is True
+        assert is_langsmith_redaction_enabled() is False
 
     def test_env_redaction_toggle_overrides_toml(
         self,
@@ -3031,11 +3027,11 @@ class TestLangsmithSecretRedaction:
         tmp_path: Path,
     ) -> None:
         """The redaction env var takes precedence over a conflicting config.toml."""
-        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_REDACT", "false")
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_REDACT", "true")
         (tmp_path / "config.toml").write_text(
-            "[tracing]\nlangsmith_redact = true\n", encoding="utf-8"
+            "[tracing]\nlangsmith_redact = false\n", encoding="utf-8"
         )
-        assert is_langsmith_redaction_enabled() is False
+        assert is_langsmith_redaction_enabled() is True
 
     def test_fail_closed_clears_env_when_sdk_disable_also_fails(
         self,


### PR DESCRIPTION
LangSmith trace secret redaction is enabled by default again; explicit environment or `config.toml` opt-outs remain supported.

---

This restores the security-preserving default and retains the existing fail-closed anonymizer setup.

Made by [Open SWE](https://openswe.vercel.app/agents/4db4dced-66c8-5094-a0e5-de4946cb052c)