### PR TITLE
feat(code): show cached updates in version output

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -165,17 +165,24 @@ def build_version_text() -> str:
 
     try:
         from deepagents_code.update_check import (
+            cached_release_requires_prereleases,
             get_cached_update_available,
             is_update_check_enabled,
             upgrade_command,
         )
 
-        if is_update_check_enabled():
+        if not editable and is_update_check_enabled():
             available, latest = get_cached_update_available()
             if available and latest:
-                text = (
-                    f"{text}\n\nUpdate available: v{latest}. Run: {upgrade_command()}"
-                )
+                needs_prereleases = cached_release_requires_prereleases(latest)
+                if needs_prereleases is not None:
+                    command = upgrade_command(
+                        include_prereleases=True if needs_prereleases else None,
+                        version=latest if needs_prereleases else None,
+                    )
+                    text = f"{text}\n\nUpdate available: v{latest}. Run: {command}"
+                else:
+                    text = f"{text}\n\nUpdate available: v{latest}."
     except Exception:
         logger.debug("Failed to read cached update status", exc_info=True)
 

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -122,9 +122,9 @@ def build_version_text() -> str:
     the resolved versions of the core LangChain-ecosystem dependencies.
 
     Reports the same version facts as the `/version` slash command, in the
-    same section order (versions, editable path, core dependencies, optional
-    dependencies), but omits its network-dependent release-age suffixes and
-    update-available hint so `--version` stays offline.
+    same section order (versions, editable path, update status, core dependencies,
+    optional dependencies). Release-age suffixes stay omitted so `--version`
+    remains offline; update status comes only from the fresh local cache.
 
     Returns:
         Multi-line version string suitable for stdout.
@@ -162,6 +162,22 @@ def build_version_text() -> str:
             text += f"\nEditable install: {path}" if path else "\nEditable install"
     except Exception:
         logger.warning("Unexpected error detecting editable install", exc_info=True)
+
+    try:
+        from deepagents_code.update_check import (
+            get_cached_update_available,
+            is_update_check_enabled,
+            upgrade_command,
+        )
+
+        if is_update_check_enabled():
+            available, latest = get_cached_update_available()
+            if available and latest:
+                text = (
+                    f"{text}\n\nUpdate available: v{latest}. Run: {upgrade_command()}"
+                )
+    except Exception:
+        logger.debug("Failed to read cached update status", exc_info=True)
 
     # Core dependencies precede optional dependencies to match the section
     # order of the `/version` slash command (see `_handle_version_command`).

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -349,6 +349,28 @@ def read_installed_distribution_version() -> str | None:
         return None
 
 
+def cached_release_requires_prereleases(version: str | None) -> bool | None:
+    """Return cached pre-release-pin status, or `None` without a fresh answer."""
+    if not version:
+        return None
+    try:
+        data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return None
+        checked_at = _coerce_checked_at(data.get("checked_at"))
+        if not is_update_cache_fresh(checked_at):
+            return None
+        values = data.get(_RELEASE_PRERELEASE_PINS_KEY)
+        cached = values.get(version) if isinstance(values, dict) else None
+        if not isinstance(cached, list):
+            return None
+        pins = [_canonical_prerelease_pin(pin) for pin in cached]
+        return bool(pins) if all(pin is not None for pin in pins) else None
+    except (OSError, json.JSONDecodeError, TypeError):
+        logger.debug("Failed to read cached release pre-release pins", exc_info=True)
+        return None
+
+
 def get_cached_update_available() -> tuple[bool, str | None]:
     """Check for updates using only a fresh local cache entry.
 

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -46,6 +46,7 @@ from deepagents_code.update_check import (
     _terminate_install_process,
     _uv_tool_bin_dir,
     _write_release_prerelease_pins,
+    cached_release_requires_prereleases,
     cleanup_update_logs,
     clear_resume_auto_update_deferral,
     clear_startup_auto_update_failure,
@@ -339,6 +340,67 @@ class TestLatestFromReleases:
         }
         assert _latest_from_releases(releases, include_prereleases=False) is None
         assert _latest_from_releases(releases, include_prereleases=True) == "1.0.0b1"
+
+
+class TestCachedReleaseRequiresPrereleases:
+    def test_fresh_cache_reports_prerelease_pin_without_http(self, cache_file) -> None:
+        """Fresh validated pin metadata is sufficient for the version hint."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "checked_at": time.time(),
+                    "release_prerelease_pins": {"99.0.0": ["deepagents==0.7.0a7"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("requests.get") as mock_get:
+            assert cached_release_requires_prereleases("99.0.0") is True
+
+        mock_get.assert_not_called()
+
+    def test_stale_cache_does_not_report_prerelease_pin(self, cache_file) -> None:
+        """Stale prerequisite metadata is not treated as authoritative."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "checked_at": time.time() - CACHE_TTL - 1,
+                    "release_prerelease_pins": {"99.0.0": ["deepagents==0.7.0a7"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert cached_release_requires_prereleases("99.0.0") is None
+
+    def test_empty_cached_pins_report_stable_only(self, cache_file) -> None:
+        """An explicit empty pin list authorizes the normal stable command."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "checked_at": time.time(),
+                    "release_prerelease_pins": {"99.0.0": []},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert cached_release_requires_prereleases("99.0.0") is False
+
+    def test_invalid_cached_pin_is_rejected(self, cache_file) -> None:
+        """Untrusted cache directives never influence the upgrade command."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "checked_at": time.time(),
+                    "release_prerelease_pins": {"99.0.0": ["-r /tmp/evil"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert cached_release_requires_prereleases("99.0.0") is None
 
 
 class TestCachedUpdateAvailable:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -510,12 +510,20 @@ def test_build_version_text_reports_cached_update() -> None:
 
     with (
         patch(
+            "deepagents_code.config._is_editable_install",
+            return_value=False,
+        ),
+        patch(
             "deepagents_code.update_check.get_cached_update_available",
             return_value=(True, "99.99.99"),
         ),
         patch(
             "deepagents_code.update_check.is_update_check_enabled",
             return_value=True,
+        ),
+        patch(
+            "deepagents_code.update_check.cached_release_requires_prereleases",
+            return_value=False,
         ),
         patch(
             "deepagents_code.update_check.upgrade_command",
@@ -527,6 +535,92 @@ def test_build_version_text_reports_cached_update() -> None:
     assert (
         "Update available: v99.99.99. Run: uv tool install -U deepagents-code" in text
     )
+
+
+def test_build_version_text_omits_cached_update_for_editable_install() -> None:
+    """`--version` never recommends package updates for editable checkouts."""
+    from deepagents_code.main import build_version_text
+
+    with (
+        patch(
+            "deepagents_code.config._is_editable_install",
+            return_value=True,
+        ),
+        patch(
+            "deepagents_code.update_check.is_update_check_enabled",
+            return_value=True,
+        ),
+        patch("deepagents_code.update_check.get_cached_update_available") as get_cached,
+    ):
+        text = build_version_text()
+
+    assert "Update available" not in text
+    get_cached.assert_not_called()
+
+
+def test_build_version_text_uses_prerelease_aware_upgrade_command() -> None:
+    """Cached prerequisite pins produce an installable upgrade command."""
+    from deepagents_code.main import build_version_text
+
+    with (
+        patch(
+            "deepagents_code.config._is_editable_install",
+            return_value=False,
+        ),
+        patch(
+            "deepagents_code.update_check.get_cached_update_available",
+            return_value=(True, "99.99.99"),
+        ),
+        patch(
+            "deepagents_code.update_check.is_update_check_enabled",
+            return_value=True,
+        ),
+        patch(
+            "deepagents_code.update_check.cached_release_requires_prereleases",
+            return_value=True,
+        ),
+        patch(
+            "deepagents_code.update_check.upgrade_command",
+            return_value="prerelease command",
+        ) as upgrade_command,
+    ):
+        text = build_version_text()
+
+    assert "Update available: v99.99.99. Run: prerelease command" in text
+    upgrade_command.assert_called_once_with(
+        include_prereleases=True,
+        version="99.99.99",
+    )
+
+
+def test_build_version_text_omits_command_without_cached_prerequisite_status() -> None:
+    """Unknown prerequisite status warns without suggesting a broken command."""
+    from deepagents_code.main import build_version_text
+
+    with (
+        patch(
+            "deepagents_code.config._is_editable_install",
+            return_value=False,
+        ),
+        patch(
+            "deepagents_code.update_check.get_cached_update_available",
+            return_value=(True, "99.99.99"),
+        ),
+        patch(
+            "deepagents_code.update_check.is_update_check_enabled",
+            return_value=True,
+        ),
+        patch(
+            "deepagents_code.update_check.cached_release_requires_prereleases",
+            return_value=None,
+        ),
+        patch("deepagents_code.update_check.upgrade_command") as upgrade_command,
+    ):
+        text = build_version_text()
+
+    assert "Update available: v99.99.99." in text
+    assert "Run:" not in text
+    upgrade_command.assert_not_called()
 
 
 def test_build_version_text_honors_disabled_update_checks() -> None:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -504,6 +504,68 @@ def test_build_version_text_omits_core_deps_when_not_editable() -> None:
     assert "Core dependencies:" not in text
 
 
+def test_build_version_text_reports_cached_update() -> None:
+    """`--version` warns when the local cache knows about a newer release."""
+    from deepagents_code.main import build_version_text
+
+    with (
+        patch(
+            "deepagents_code.update_check.get_cached_update_available",
+            return_value=(True, "99.99.99"),
+        ),
+        patch(
+            "deepagents_code.update_check.is_update_check_enabled",
+            return_value=True,
+        ),
+        patch(
+            "deepagents_code.update_check.upgrade_command",
+            return_value="uv tool install -U deepagents-code",
+        ),
+    ):
+        text = build_version_text()
+
+    assert (
+        "Update available: v99.99.99. Run: uv tool install -U deepagents-code" in text
+    )
+
+
+def test_build_version_text_honors_disabled_update_checks() -> None:
+    """`--version` does not inspect or report updates after an opt-out."""
+    from deepagents_code.main import build_version_text
+
+    with (
+        patch(
+            "deepagents_code.update_check.is_update_check_enabled",
+            return_value=False,
+        ),
+        patch("deepagents_code.update_check.get_cached_update_available") as get_cached,
+    ):
+        text = build_version_text()
+
+    assert "Update available" not in text
+    get_cached.assert_not_called()
+
+
+def test_build_version_text_ignores_cached_update_failure() -> None:
+    """A cache read failure never breaks `--version` output."""
+    from deepagents_code.main import build_version_text
+
+    with (
+        patch(
+            "deepagents_code.update_check.is_update_check_enabled",
+            return_value=True,
+        ),
+        patch(
+            "deepagents_code.update_check.get_cached_update_available",
+            side_effect=OSError,
+        ),
+    ):
+        text = build_version_text()
+
+    assert f"deepagents-code {__version__}" in text
+    assert "Update available" not in text
+
+
 def _editable_exact_pin_version_report(cli_metadata: str = "0.1.40") -> VersionReport:
     """Build a report with editable installs, CLI drift, and a newer SDK pin."""
     from packaging.requirements import Requirement


### PR DESCRIPTION
`dcode -v` and `dcode --version` now warn when the fresh local update cache knows about a newer release. The check stays offline, honors update-check opt-outs, and fails softly when cached status is unavailable.

**Before**
```text
deepagents-code 0.1.61
deepagents (SDK) 0.7.8
```

**After (when a cached update is known)**
```text
deepagents-code 0.1.61
deepagents (SDK) 0.7.8

Update available: v0.1.62. Run: uv tool install -U deepagents-code
```

---

The warning uses the existing fresh local update cache and install-method-aware upgrade command, so version output does not make a network request.

Made by [Open SWE](https://openswe.vercel.app/agents/b0010396-c78a-554c-a946-99194751d0aa)