### PR TITLE
fix(code): resolve origin from worktree common Git dir

### DIFF
--- a/libs/code/deepagents_code/_git.py
+++ b/libs/code/deepagents_code/_git.py
@@ -336,6 +336,72 @@ def find_git_common_dir(path: str | Path) -> Path | None:
     return common_dir
 
 
+def _read_git_config_value(raw: str, section: str, key: str) -> str | None:
+    """Read one value from a Git config section.
+
+    Returns:
+        The configured value, or `None` when it is absent.
+    """
+    in_section = False
+    expected = section.replace(" ", "").lower()
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_section = stripped.replace(" ", "").lower() == expected
+            continue
+        name, separator, value = stripped.partition("=")
+        if in_section and separator and name.strip().lower() == key:
+            return value.strip() or None
+    return None
+
+
+def _submodule_git_dir(root: Path, parent_config_dir: Path) -> Path | None:
+    """Resolve a validated submodule administration directory.
+
+    Returns:
+        The administration directory, or `None` when validation fails.
+    """
+    git_entry = root / ".git"
+    if git_entry.is_symlink() or not git_entry.is_file():
+        return None
+    git_dir = _parse_trusted_git_dir_pointer(git_entry)
+    if git_dir is None or not _is_valid_git_common_dir(git_dir):
+        return None
+    try:
+        git_dir.relative_to(parent_config_dir / "modules")
+        raw = (git_dir / "config").read_text(encoding="utf-8")
+        worktree = _read_git_config_value(raw, "[core]", "worktree")
+        if worktree is None:
+            return None
+        candidate = Path(worktree)
+        if not candidate.is_absolute():
+            candidate = git_dir / candidate
+        return git_dir if candidate.resolve(strict=True) == root else None
+    except (OSError, RuntimeError, ValueError):
+        logger.debug("Failed to validate submodule Git metadata")
+        return None
+
+
+def _find_git_config_dir(path: str | Path) -> Path | None:
+    """Locate a validated repository config directory.
+
+    Returns:
+        The config directory, or `None` when validation fails.
+    """
+    root = find_git_root(path)
+    if root is None:
+        return None
+    common_dir = find_git_common_dir(root)
+    if common_dir is not None:
+        return common_dir
+    parent_config_dir = _find_git_config_dir(root.parent)
+    return (
+        _submodule_git_dir(root, parent_config_dir)
+        if parent_config_dir is not None
+        else None
+    )
+
+
 def read_git_branch_from_filesystem(path: str | Path) -> str | None:
     """Read the current git branch from repository metadata.
 
@@ -556,35 +622,19 @@ def read_git_remote_url_from_filesystem(path: str | Path) -> str | None:
         The `origin` remote URL, an empty string when `path` is not inside a
         git repository, or `None` when no `origin` URL is configured.
     """
-    common_dir = find_git_common_dir(path)
-    if common_dir is None:
-        root = find_git_root(path)
-        common_dir = find_git_common_dir(root) if root is not None else None
-    if common_dir is None:
+    config_dir = _find_git_config_dir(path)
+    if config_dir is None:
         return ""
 
     try:
-        raw = (common_dir / "config").read_text(encoding="utf-8")
+        raw = (config_dir / "config").read_text(encoding="utf-8")
     except FileNotFoundError:
         return None
     except OSError:
-        logger.debug("Failed to read git config in %s", common_dir, exc_info=True)
+        logger.debug("Failed to read Git config")
         return None
 
-    in_origin = False
-    for line in raw.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            # Section header, e.g. [remote "origin"]. Match case-insensitively
-            # on the remote name to mirror git's own behavior.
-            in_origin = stripped.replace(" ", "").lower() == '[remote"origin"]'
-            continue
-        if in_origin and stripped.lower().startswith("url"):
-            _, _, value = stripped.partition("=")
-            url = value.strip()
-            if url:
-                return url
-    return None
+    return _read_git_config_value(raw, '[remote "origin"]', "url")
 
 
 def read_git_remote_url_via_subprocess(path: str | Path) -> str:

--- a/libs/code/deepagents_code/_git.py
+++ b/libs/code/deepagents_code/_git.py
@@ -556,16 +556,19 @@ def read_git_remote_url_from_filesystem(path: str | Path) -> str | None:
         The `origin` remote URL, an empty string when `path` is not inside a
         git repository, or `None` when no `origin` URL is configured.
     """
-    git_dir = find_git_dir(path)
-    if git_dir is None:
+    common_dir = find_git_common_dir(path)
+    if common_dir is None:
+        root = find_git_root(path)
+        common_dir = find_git_common_dir(root) if root is not None else None
+    if common_dir is None:
         return ""
 
     try:
-        raw = (git_dir / "config").read_text(encoding="utf-8")
+        raw = (common_dir / "config").read_text(encoding="utf-8")
     except FileNotFoundError:
         return None
     except OSError:
-        logger.debug("Failed to read git config in %s", git_dir, exc_info=True)
+        logger.debug("Failed to read git config in %s", common_dir, exc_info=True)
         return None
 
     in_origin = False

--- a/libs/code/tests/unit_tests/test_git.py
+++ b/libs/code/tests/unit_tests/test_git.py
@@ -658,6 +658,47 @@ class TestReadGitRemoteUrlFromFilesystem:
 
         assert read_git_remote_url_from_filesystem(forged) == ""
 
+    def test_reads_origin_url_from_submodule(self, tmp_path: Path) -> None:
+        child = tmp_path / "child"
+        parent = tmp_path / "parent"
+        _init_git_repo(child)
+        _init_git_repo(parent)
+        _run_git(
+            parent,
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(child),
+            "child",
+        )
+
+        assert read_git_remote_url_from_filesystem(parent / "child") == str(child)
+
+    def test_submodule_pointer_with_mismatched_worktree_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        child = tmp_path / "child"
+        parent = tmp_path / "parent"
+        forged = tmp_path / "forged"
+        _init_git_repo(child)
+        _init_git_repo(parent)
+        _run_git(
+            parent,
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(child),
+            "child",
+        )
+        forged.mkdir()
+        git_dir = _parse_git_dir_pointer(parent / "child" / ".git")
+        assert git_dir is not None
+        (forged / ".git").write_text(f"gitdir: {git_dir}\n")
+
+        assert read_git_remote_url_from_filesystem(forged) == ""
+
     def test_no_origin_returns_none(self, tmp_path: Path) -> None:
         self._write_config(tmp_path, "[core]\n\tbare = false\n")
         assert read_git_remote_url_from_filesystem(tmp_path) is None

--- a/libs/code/tests/unit_tests/test_git.py
+++ b/libs/code/tests/unit_tests/test_git.py
@@ -594,7 +594,9 @@ class TestReadGitCommitShaViaSubprocess:
 class TestReadGitRemoteUrlFromFilesystem:
     def _write_config(self, tmp_path: Path, body: str) -> None:
         git_dir = tmp_path / ".git"
-        git_dir.mkdir(exist_ok=True)
+        (git_dir / "objects").mkdir(parents=True, exist_ok=True)
+        (git_dir / "refs").mkdir(exist_ok=True)
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
         (git_dir / "config").write_text(body)
 
     def test_reads_origin_url(self, tmp_path: Path) -> None:
@@ -619,6 +621,42 @@ class TestReadGitRemoteUrlFromFilesystem:
             read_git_remote_url_from_filesystem(tmp_path)
             == "git@github.com:langchain-ai/deepagents.git"
         )
+
+    def test_reads_origin_url_from_linked_worktree(self, tmp_path: Path) -> None:
+        main = tmp_path / "main"
+        worktree = tmp_path / "worktree"
+        _init_git_repo(main)
+        _run_git(
+            main,
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/langchain-ai/deepagents.git",
+        )
+        _add_git_worktree(main, worktree, "worktree")
+        nested = worktree / "src"
+        nested.mkdir()
+
+        assert (
+            read_git_remote_url_from_filesystem(nested)
+            == "https://github.com/langchain-ai/deepagents.git"
+        )
+
+    def test_forged_pointer_does_not_expose_remote(self, tmp_path: Path) -> None:
+        main = tmp_path / "main"
+        forged = tmp_path / "forged"
+        _init_git_repo(main)
+        _run_git(
+            main,
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/langchain-ai/deepagents.git",
+        )
+        forged.mkdir()
+        (forged / ".git").write_text(f"gitdir: {main / '.git'}\n")
+
+        assert read_git_remote_url_from_filesystem(forged) == ""
 
     def test_no_origin_returns_none(self, tmp_path: Path) -> None:
         self._write_config(tmp_path, "[core]\n\tbare = false\n")


### PR DESCRIPTION
Linked-worktree pushes in Auto mode now recognize the repository's configured `origin` instead of being denied as external sharing.

---

`read_git_remote_url_from_filesystem` now reads config from the validated common Git directory, while malformed or forged worktree pointers remain fail-closed. Added genuine linked-worktree and forged-pointer regressions.

Made by [Open SWE](https://openswe.vercel.app/agents/8d7bdc5b-1f0a-57be-af8c-eb7600ec3e79)

## References
- Plan: https://openswe.vercel.app/agents/8d7bdc5b-1f0a-57be-af8c-eb7600ec3e79/plan