### PR TITLE
docs(code): document configurable MCP web search

### DIFF
--- a/libs/code/README.md
+++ b/libs/code/README.md
@@ -42,6 +42,26 @@ The fastest way to start using Deep Agents. `deepagents-code` is a pre-built cod
 - **Headless mode** — run non-interactively for scripting and CI
 - **Human-in-the-loop** — approve or reject tool calls before execution
 
+## Web search
+
+The built-in `web_search` tool uses Tavily when `TAVILY_API_KEY` is configured.
+To use another search provider, add a compatible remote MCP server to
+`~/.deepagents/.mcp.json`. For example, Parallel provides a keyless search server:
+
+```json
+{
+  "mcpServers": {
+    "parallel": {
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+```
+
+The remote search tool appears as `parallel_web_search` and does not require a
+Parallel or Tavily API key. If `TAVILY_API_KEY` is also configured, the existing
+Tavily-backed `web_search` tool remains available alongside it.
+
 ## 🔒 Security model
 
 By default, `dcode` trusts the directory you run it in. Human-in-the-loop approval gates model-requested tool calls, but project artifacts are read before any approval prompt.

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -1593,6 +1593,66 @@ class TestGetMCPTools:
         ]
         await manager.cleanup()
 
+    @pytest.mark.usefixtures("fake_home")
+    async def test_keyless_remote_search_provider_loads_and_runs(
+        self,
+        write_config: Callable[..., str],
+        fake_create_session: tuple[AsyncMock, list[dict[str, Any]]],
+        fake_tool_result: Any,  # noqa: ANN401
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A URL-only MCP search provider needs neither Tavily nor provider keys."""
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        path = write_config(
+            {"mcpServers": {"parallel": {"url": "https://search.parallel.ai/mcp"}}}
+        )
+        session, recorded = fake_create_session
+        session.list_tools = AsyncMock(
+            return_value=_make_tool_page(
+                [
+                    _make_mcp_tool(
+                        "web_search",
+                        "Search the web",
+                        input_schema={
+                            "type": "object",
+                            "properties": {
+                                "objective": {"type": "string"},
+                                "search_queries": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                            },
+                            "required": ["objective", "search_queries"],
+                        },
+                    )
+                ]
+            )
+        )
+        session.call_tool = AsyncMock(return_value=fake_tool_result)
+
+        tools, manager, server_infos = await get_mcp_tools(path)
+        arguments = {
+            "objective": "Find Deep Agents documentation",
+            "search_queries": ["deep agents documentation"],
+        }
+        result = await tools[0].ainvoke(arguments)
+
+        assert [tool.name for tool in tools] == ["parallel_web_search"]
+        assert server_infos[0].status == "ok"
+        assert all(
+            connection
+            == {
+                "transport": "streamable_http",
+                "url": "https://search.parallel.ai/mcp",
+            }
+            for connection in recorded
+        )
+        session.call_tool.assert_awaited_once_with("web_search", arguments)
+        assert "ok" in str(result)
+        assert manager is not None
+        await manager.cleanup()
+
     async def test_discovery_failure_marks_server_error(
         self,
         write_config: Callable[..., str],

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -487,16 +487,23 @@ class TestServerGraph:
             "enable_interpreter": True,
         }
 
-    async def test_build_tools_delegates_mcp_loading_to_resolver(self) -> None:
+    @pytest.mark.parametrize(
+        "has_tavily", [False, True], ids=["without-tavily", "with-tavily"]
+    )
+    async def test_build_tools_delegates_mcp_loading_to_resolver(
+        self, *, has_tavily: bool
+    ) -> None:
         """`_build_tools` should defer all MCP work to the resolver.
 
         Adapter warmup now lives inside `_load_tools_from_config` (gated on
         active servers existing), so `_build_tools` no longer warms imports
         itself — it just calls the resolver and appends the returned tools.
+        MCP search remains available with or without the built-in Tavily tool.
         """
         fetch_tool = object()
         thread_tool = object()
-        discovered_mcp_tools = [object(), object()]
+        tavily_search = object()
+        discovered_mcp_tools = [SimpleNamespace(name="parallel_web_search"), object()]
 
         class FakeSessionManager:
             pass
@@ -504,13 +511,13 @@ class TestServerGraph:
         resolve_mcp_tools = AsyncMock(return_value=(discovered_mcp_tools, None, []))
         config_module = _module_with_attrs(
             "deepagents_code.config",
-            settings=SimpleNamespace(has_tavily=False),
+            settings=SimpleNamespace(has_tavily=has_tavily),
         )
         tools_module = _module_with_attrs(
             "deepagents_code.tools",
             fetch_url=fetch_tool,
             get_current_thread_id=thread_tool,
-            web_search=object(),
+            web_search=tavily_search,
         )
         mcp_module = _module_with_attrs(
             "deepagents_code.mcp_tools",
@@ -534,7 +541,10 @@ class TestServerGraph:
             )
 
         resolve_mcp_tools.assert_awaited_once()
-        assert tools == [fetch_tool, thread_tool, *discovered_mcp_tools]
+        expected_tools = [fetch_tool, thread_tool]
+        if has_tavily:
+            expected_tools.append(tavily_search)
+        assert tools == [*expected_tools, *discovered_mcp_tools]
         assert mcp_server_info == []
         assert mcp_tools is discovered_mcp_tools
 


### PR DESCRIPTION
Related: #3979

Configure any compatible remote MCP server for web search, including a keyless Parallel example, without changing the existing Tavily default.

---

The existing MCP loader already supports URL-only remote servers and exposes their tools independently of Tavily. Document that configuration instead of adding a separate provider setting, adapter, or dependency.

Add network-free coverage for keyless search discovery and invocation, and verify MCP search works both with and without the existing Tavily tool.

Tests:
- `uv run --no-sync pytest -q tests/unit_tests/test_mcp_tools.py tests/unit_tests/test_server_graph.py tests/unit_tests/test_tool_catalog.py tests/unit_tests/tools/test_tool_arg_schemas.py` (302 passed)
- `uv run --no-sync ruff check tests/unit_tests/test_mcp_tools.py tests/unit_tests/test_server_graph.py`
- `uv run --no-sync ruff format --check tests/unit_tests/test_mcp_tools.py tests/unit_tests/test_server_graph.py`