### PR TITLE
chore(code): remove low-value unit tests

### DIFF
--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -489,18 +489,6 @@ async def test_live_approval_round_trip_flips_interrupt_decision() -> None:
     )
 
 
-def test_cli_context_schema_fields_mirror_typed_dict() -> None:
-    """`CLIContextSchema` and `CLIContext` must stay structurally identical.
-
-    The two shapes carry the same payload across the API boundary (dataclass
-    in-process, dict over RemoteGraph). A field added to one but not the other
-    would silently drop across that boundary; this pins the documented mirror.
-    """
-    from deepagents_code._cli_context import CLIContext
-
-    assert {f.name for f in fields(CLIContextSchema)} == set(CLIContext.__annotations__)
-
-
 def test_should_interrupt_tool_call_fails_closed_when_live_mode_missing() -> None:
     """A configured but missing live mode should interrupt for safety."""
     from deepagents_code.approval_mode import approval_mode_key

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -71,12 +71,6 @@ def _snapshot() -> list[SnapshotField]:
     ]
 
 
-def test_snapshot_field_tuple_contract_includes_interaction_metadata() -> None:
-    field = SnapshotField("Thread", "thread-abc", copyable=True, thread_id="thread-abc")
-
-    assert tuple(field) == ("Thread", "thread-abc", True, "thread-abc")
-
-
 class TestDebugConsoleScreen:
     async def test_renders_snapshot_fields(self) -> None:
         app = _Harness()

--- a/libs/code/tests/unit_tests/test_local_context.py
+++ b/libs/code/tests/unit_tests/test_local_context.py
@@ -965,9 +965,6 @@ class TestBuildDetectScript:
         assert script.startswith("bash <<'__DETECT_CONTEXT_EOF__'")
         assert script.rstrip().endswith("__DETECT_CONTEXT_EOF__")
 
-    def test_module_constant_matches_builder(self) -> None:
-        assert build_detect_script() == DETECT_CONTEXT_SCRIPT
-
 
 class TestSectionHeader:
     """Tests for _section_header."""

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -2674,41 +2674,9 @@ class TestLangSmithTeardownUrl:
         # Without LangSmith configured, should return None
         assert thread_url is None
 
-    def test_thread_url_not_shown_for_none_thread_id(self) -> None:
-        """Guard condition: thread_url and thread_exists both needed."""
-        thread_url = None
-        thread_exists = True
-        show_link = bool(thread_url and thread_exists)
-        assert not show_link
-
-    def test_thread_url_not_shown_when_no_checkpoints(self) -> None:
-        """Guard condition: thread must have checkpointed content."""
-        thread_url = "https://smith.langchain.com/o/org/projects/p/proj/t/abc"
-        thread_exists = False
-        show_link = bool(thread_url and thread_exists)
-        assert not show_link
-
-    def test_thread_url_shown_when_all_conditions_met(self) -> None:
-        """Guard condition: both thread_url and thread_exists must be truthy."""
-        thread_url = "https://smith.langchain.com/o/org/projects/p/proj/t/abc"
-        thread_exists = True
-        show_link = bool(thread_url and thread_exists)
-        assert show_link
-
 
 class TestAppResult:
     """Tests for the AppResult dataclass."""
-
-    def test_fields_accessible(self) -> None:
-        """AppResult should expose return_code and thread_id."""
-        result = AppResult(return_code=0, thread_id="tid-abc")
-        assert result.return_code == 0
-        assert result.thread_id == "tid-abc"
-
-    def test_thread_id_none(self) -> None:
-        """AppResult should accept None for thread_id."""
-        result = AppResult(return_code=1, thread_id=None)
-        assert result.thread_id is None
 
     def test_frozen(self) -> None:
         """AppResult should be immutable."""
@@ -2717,45 +2685,6 @@ class TestAppResult:
         result = AppResult(return_code=0, thread_id="tid")
         with pytest.raises(FrozenInstanceError):
             result.return_code = 1  # ty: ignore
-
-
-class TestRunTextualAppReturnType:
-    """Test that run_textual_app returns AppResult."""
-
-    async def test_run_textual_app_returns_app_result(self) -> None:
-        """run_textual_app should return an AppResult."""
-        sig = inspect.signature(run_textual_app)
-        annotation = sig.return_annotation
-        assert annotation in (AppResult, "AppResult"), (
-            f"run_textual_app should return AppResult, got {annotation}"
-        )
-
-
-class TestRunTextualCliAsyncReturnType:
-    """Test that run_textual_cli_async returns AppResult."""
-
-    def test_run_textual_cli_async_returns_app_result(self) -> None:
-        """run_textual_cli_async should return an AppResult."""
-        sig = inspect.signature(run_textual_cli_async)
-        assert sig.return_annotation in (AppResult, "AppResult"), (
-            "run_textual_cli_async should return AppResult, "
-            f"got {sig.return_annotation}"
-        )
-
-
-class TestThreadMessage:
-    """Test thread info display format.
-
-    Thread info is now displayed in the WelcomeBanner widget rather than via
-    pre-TUI console output, so we verify the banner receives the thread ID.
-    """
-
-    def test_thread_id_forwarded_to_app(self) -> None:
-        """run_textual_cli_async passes thread_id to run_textual_app."""
-        source = inspect.getsource(run_textual_cli_async)
-        assert "thread_id=thread_id" in source, (
-            "thread_id should be forwarded to run_textual_app"
-        )
 
 
 class TestRunTextualCliAsyncMcp:

--- a/libs/code/tests/unit_tests/tui/test_key_hints.py
+++ b/libs/code/tests/unit_tests/tui/test_key_hints.py
@@ -22,12 +22,3 @@ def test_modal_navigation_hint_copy(glyphs: Glyphs, expected: str) -> None:
     instead of passing against its own f-string.
     """
     assert modal_navigation_hint(glyphs) == expected
-
-
-def test_modal_navigation_hint_advertises_both_tab_directions() -> None:
-    """The copy names Shift+Tab, not just Tab.
-
-    Reverse navigation is routed by the app rather than the screen, so it is
-    the direction most likely to be dropped without the footer noticing.
-    """
-    assert "Tab/Shift+Tab" in modal_navigation_hint(UNICODE_GLYPHS)


### PR DESCRIPTION
Remove tests that only exercise local expressions, language/dataclass mechanics, annotations, or source text, plus an exact duplicate and assertions already covered by stronger behavior tests. Production behavior and meaningful regression coverage are unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/105f8f81-8407-5183-be73-7f5df20dd8f7)