### PR TITLE
feat(code): `/context-doctor`

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -8,7 +8,7 @@ Regenerate this file with `make commands-catalog` after changing command names,
 aliases, descriptions, visibility, or hidden-command metadata.
 
 
-## Public (41)
+## Public (42)
 
 | Command | Aliases | Description |
 | --- | --- | --- |
@@ -19,6 +19,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/changelog` |  | Open the changelog in a browser |
 | `/clear` |  | Clear the chat and start a new thread |
 | `/context` |  | Show current context window usage |
+| `/context-doctor` |  | Audit what a session injects and its estimated token cost |
 | `/copy` |  | Copy the latest assistant message to clipboard |
 | `/cost` |  | Show estimated thread cost |
 | `/docs` |  | Open the docs |

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -2225,6 +2225,71 @@ def _apply_inherited_pythonpath(env: dict[str, str]) -> None:
         env["PYTHONPATH"] = inherited
 
 
+def get_skill_sources(
+    assistant_id: str = DEFAULT_AGENT_NAME,
+    project_context: ProjectContext | None = None,
+) -> list[CodeSkillSource]:
+    """Return ordered skill sources for PluginSkillsMiddleware and audit tooling.
+
+    Lowest to highest precedence:
+    built-in -> plugins -> user .deepagents -> user .agents
+    -> project .deepagents -> project .agents
+    -> user .claude (experimental) -> project .claude (experimental)
+
+    Args:
+        assistant_id: Agent identifier for user skill directories.
+        project_context: Project context for resolving project skill directories.
+
+    Returns:
+        Ordered list of CodeSkillSource entries.
+    """
+    skills_dir = settings.ensure_user_skills_dir(assistant_id)
+    user_agent_skills_dir = settings.get_user_agent_skills_dir()
+    project_skills_dir = (
+        project_context.project_skills_dir()
+        if project_context is not None
+        else settings.get_project_skills_dir()
+    )
+    project_agent_skills_dir = (
+        project_context.project_agent_skills_dir()
+        if project_context is not None
+        else settings.get_project_agent_skills_dir()
+    )
+    sources: list[CodeSkillSource] = [
+        (str(settings.get_built_in_skills_dir()), "Built-in"),
+    ]
+    try:
+        from deepagents_code.plugins import discover_plugins
+        from deepagents_code.plugins.adapters.skills import plugin_skill_sources
+
+        plugin_result = discover_plugins()
+        if plugin_result.warnings:
+            logger.warning("Plugin discovery warnings: %s", plugin_result.warnings)
+        sources.extend(plugin_skill_sources(plugin_result.plugins))
+    except Exception:
+        logger.warning("Could not discover plugin skills", exc_info=True)
+    sources.extend(
+        [
+            (str(skills_dir), "User Deepagents"),
+            (str(user_agent_skills_dir), "User Agents"),
+        ]
+    )
+    if project_skills_dir:
+        sources.append((str(project_skills_dir), "Project Deepagents"))
+    if project_agent_skills_dir:
+        sources.append((str(project_agent_skills_dir), "Project Agents"))
+
+    # Experimental: Claude Code skill directories
+    user_claude_skills_dir = settings.get_user_claude_skills_dir()
+    if user_claude_skills_dir.exists():
+        sources.append((str(user_claude_skills_dir), "User Claude"))
+    project_claude_skills_dir = settings.get_project_claude_skills_dir()
+    if project_claude_skills_dir:
+        sources.append((str(project_claude_skills_dir), "Project Claude"))
+
+    return sources
+
+
 def create_cli_agent(
     model: str | BaseChatModel,
     assistant_id: str,
@@ -2453,25 +2518,6 @@ def create_cli_agent(
             # Create empty file for user customizations
             # Base instructions are loaded fresh from get_system_prompt()
             agent_md.touch()
-
-    # Skills directories (if enabled)
-    skills_dir = None
-    user_agent_skills_dir = None
-    project_skills_dir = None
-    project_agent_skills_dir = None
-    if enable_skills:
-        skills_dir = settings.ensure_user_skills_dir(assistant_id)
-        user_agent_skills_dir = settings.get_user_agent_skills_dir()
-        project_skills_dir = (
-            project_context.project_skills_dir()
-            if project_context is not None
-            else settings.get_project_skills_dir()
-        )
-        project_agent_skills_dir = (
-            project_context.project_agent_skills_dir()
-            if project_context is not None
-            else settings.get_project_agent_skills_dir()
-        )
 
     # Load custom subagents from filesystem
     custom_subagents: list[SubAgent | CompiledSubAgent] = []
@@ -2736,47 +2782,10 @@ def create_cli_agent(
 
     # Add skills middleware
     if enable_skills:
-        # Lowest to highest precedence:
-        # built-in -> plugins -> user .deepagents -> user .agents
-        # -> project .deepagents -> project .agents
-        # -> user .claude (experimental) -> project .claude (experimental)
-        # Plugin skills are namespaced as `{plugin_id}:{skill_name}` to avoid
-        # collisions between plugins and user/project skills.
-        sources: list[CodeSkillSource] = [
-            (str(settings.get_built_in_skills_dir()), "Built-in"),
-        ]
-        try:
-            from deepagents_code.plugins import discover_plugins
-            from deepagents_code.plugins.adapters.skills import plugin_skill_sources
-
-            plugin_result = discover_plugins()
-            if plugin_result.warnings:
-                logger.warning("Plugin discovery warnings: %s", plugin_result.warnings)
-            sources.extend(plugin_skill_sources(plugin_result.plugins))
-        except Exception:
-            logger.warning("Could not discover plugin skills", exc_info=True)
-        sources.extend(
-            [
-                (str(skills_dir), "User Deepagents"),
-                (str(user_agent_skills_dir), "User Agents"),
-            ]
+        sources = get_skill_sources(
+            assistant_id=assistant_id,
+            project_context=project_context,
         )
-        if project_skills_dir:
-            sources.append((str(project_skills_dir), "Project Deepagents"))
-        if project_agent_skills_dir:
-            sources.append((str(project_agent_skills_dir), "Project Agents"))
-
-        # Experimental: Claude Code skill directories
-        user_claude_skills_dir = settings.get_user_claude_skills_dir()
-        if user_claude_skills_dir.exists():
-            sources.append((str(user_claude_skills_dir), "User Claude"))
-        project_claude_skills_dir = settings.get_project_claude_skills_dir()
-        if project_claude_skills_dir:
-            sources.append((str(project_claude_skills_dir), "Project Claude"))
-
-        # `PluginSkillsMiddleware` namespaces plugin skills before dedup while
-        # behaving like the SDK middleware when no plugin namespaces are
-        # present, so it is safe to use for all skill sources.
         agent_middleware.append(
             PluginSkillsMiddleware(
                 backend=FilesystemBackend(virtual_mode=False),

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12657,6 +12657,7 @@ class DeepAgentsApp(App):
         from deepagents_code._constants import DEFAULT_AGENT_NAME
         from deepagents_code.agent import (
             _MEMORY_READONLY_SYSTEM_PROMPT,
+            get_skill_sources,
             get_system_prompt,
         )
         from deepagents_code.config import is_memory_auto_save_enabled, settings
@@ -12676,6 +12677,7 @@ class DeepAgentsApp(App):
         system_prompt: str | None = None
         memory_prompt: str | None = None
         memory_contents: list[tuple[str, str]] = []
+        skill_sources = []
         built_in = None
 
         if managed:
@@ -12713,6 +12715,12 @@ class DeepAgentsApp(App):
             except Exception:
                 logger.exception("Failed to format memory for /context-doctor")
             try:
+                skill_sources = get_skill_sources(
+                    assistant_id=self._assistant_id or DEFAULT_AGENT_NAME
+                )
+            except Exception:
+                logger.exception("Failed to resolve skill sources for /context-doctor")
+            try:
                 built_in = await asyncio.to_thread(
                     collect_built_in_tools,
                     assistant_id=self._assistant_id or DEFAULT_AGENT_NAME,
@@ -12745,7 +12753,7 @@ class DeepAgentsApp(App):
         skills = list(self._discovered_skills)
         skills_prompt = None
         try:
-            skills_prompt = format_skills_prompt(skills)
+            skills_prompt = format_skills_prompt(skills, sources=skill_sources)
         except Exception:
             logger.exception("Failed to format skills for /context-doctor")
         provider_tokens, conversation_tokens = await self._get_context_usage_counts()

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12655,8 +12655,11 @@ class DeepAgentsApp(App):
         from deepagents.middleware.memory import MEMORY_SYSTEM_PROMPT
 
         from deepagents_code._constants import DEFAULT_AGENT_NAME
-        from deepagents_code.agent import get_system_prompt
-        from deepagents_code.config import settings
+        from deepagents_code.agent import (
+            _MEMORY_READONLY_SYSTEM_PROMPT,
+            get_system_prompt,
+        )
+        from deepagents_code.config import is_memory_auto_save_enabled, settings
         from deepagents_code.context_doctor import (
             build_context_doctor_report,
             format_memory_prompt,
@@ -12700,10 +12703,13 @@ class DeepAgentsApp(App):
                         )
                 except OSError:
                     logger.warning("Could not read memory metadata for %s", path)
+            template = (
+                MEMORY_SYSTEM_PROMPT
+                if is_memory_auto_save_enabled()
+                else _MEMORY_READONLY_SYSTEM_PROMPT
+            )
             try:
-                memory_prompt = format_memory_prompt(
-                    memory_contents, MEMORY_SYSTEM_PROMPT
-                )
+                memory_prompt = format_memory_prompt(memory_contents, template)
             except Exception:
                 logger.exception("Failed to format memory for /context-doctor")
             try:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12648,6 +12648,116 @@ class DeepAgentsApp(App):
             AppMessage(self._render_tool_catalog(catalog), markdown=True)
         )
 
+    async def _handle_context_doctor_command(self, command: str) -> None:
+        """Audit the estimated token cost of context injected into a session."""
+        from pathlib import Path
+
+        from deepagents.middleware.memory import MEMORY_SYSTEM_PROMPT
+
+        from deepagents_code._constants import DEFAULT_AGENT_NAME
+        from deepagents_code.agent import get_system_prompt
+        from deepagents_code.config import settings
+        from deepagents_code.context_doctor import (
+            build_context_doctor_report,
+            format_memory_prompt,
+            format_skills_prompt,
+            render_context_doctor_report,
+        )
+        from deepagents_code.tool_catalog import (
+            collect_built_in_tools,
+            collect_tools_from_agent,
+        )
+
+        await self._mount_message(UserMessage(command))
+        managed = self._server_kwargs is not None
+        system_prompt: str | None = None
+        memory_prompt: str | None = None
+        memory_contents: list[tuple[str, str]] = []
+        built_in = None
+
+        if managed:
+            try:
+                system_prompt = get_system_prompt(
+                    assistant_id=self._assistant_id or DEFAULT_AGENT_NAME,
+                    sandbox_type=self._sandbox_type,
+                    interactive=True,
+                    cwd=Path(self._cwd),
+                    fs_tools=self._server_kwargs.get("allow_fs_tools"),
+                )
+            except Exception:
+                logger.exception("Failed to build base prompt for /context-doctor")
+            memory_paths = [
+                settings.get_user_agent_md_path(
+                    self._assistant_id or DEFAULT_AGENT_NAME
+                ),
+                *settings.get_project_agent_md_path(),
+            ]
+            for path in memory_paths:
+                try:
+                    if path.is_file():
+                        memory_contents.append(
+                            (str(path), path.read_text(encoding="utf-8"))
+                        )
+                except OSError:
+                    logger.warning("Could not read memory metadata for %s", path)
+            try:
+                memory_prompt = format_memory_prompt(
+                    memory_contents, MEMORY_SYSTEM_PROMPT
+                )
+            except Exception:
+                logger.exception("Failed to format memory for /context-doctor")
+            try:
+                built_in = await asyncio.to_thread(
+                    collect_built_in_tools,
+                    assistant_id=self._assistant_id or DEFAULT_AGENT_NAME,
+                    enable_interpreter=bool(
+                        self._server_kwargs.get("enable_interpreter")
+                    ),
+                    fs_tools=self._server_kwargs.get("allow_fs_tools"),
+                )
+            except Exception:
+                logger.exception("Failed to enumerate tools for /context-doctor")
+        else:
+            try:
+                active_tools = (
+                    collect_tools_from_agent(self._agent)
+                    if self._agent is not None
+                    else None
+                )
+                if active_tools is not None:
+                    mcp_names = {
+                        tool.name
+                        for server in self._mcp_server_info_for_tools()
+                        for tool in server.tools
+                    }
+                    built_in = [
+                        tool for tool in active_tools if tool.name not in mcp_names
+                    ]
+            except Exception:
+                logger.exception("Failed to inspect custom agent for /context-doctor")
+
+        skills = list(self._discovered_skills)
+        skills_prompt = None
+        try:
+            skills_prompt = format_skills_prompt(skills)
+        except Exception:
+            logger.exception("Failed to format skills for /context-doctor")
+        provider_tokens, conversation_tokens = await self._get_context_usage_counts()
+        report = build_context_doctor_report(
+            system_prompt=system_prompt,
+            memory_prompt=memory_prompt,
+            memory_files=len(memory_contents),
+            skills_prompt=skills_prompt,
+            skills=skills,
+            built_in_tools=built_in,
+            mcp_servers=self._mcp_server_info_for_tools(),
+            conversation_tokens=conversation_tokens,
+            provider_tokens=provider_tokens,
+        )
+        await self._mount_message(
+            AppMessage(render_context_doctor_report(report), markdown=False)
+        )
+
     def _mcp_server_info_for_tools(self) -> list[MCPServerInfo]:
         """Return MCP metadata matching the tools bound to the running agent.
 
@@ -15730,6 +15840,8 @@ class DeepAgentsApp(App):
                 ),
                 lambda _result: self._focus_chat_input_after_refresh(),
             )
+        elif cmd == "/context-doctor":
+            await self._handle_context_doctor_command(command)
         elif cmd == "/tokens":
             await self._mount_message(UserMessage(command))
             if self._context_tokens > 0:

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -131,6 +131,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
         hidden_keywords="tokens window usage remaining offload compact",
     ),
     SlashCommand(
+        name="/context-doctor",
+        description="Audit what a session injects and its estimated token cost",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="tokens prompt skills memory mcp schemas bloat",
+    ),
+    SlashCommand(
         name="/cost",
         description="Show estimated thread cost",
         bypass_tier=BypassTier.QUEUED,

--- a/libs/code/deepagents_code/context_doctor.py
+++ b/libs/code/deepagents_code/context_doctor.py
@@ -1,0 +1,244 @@
+"""Estimated context audit for the `/context-doctor` command."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass
+from operator import itemgetter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from deepagents_code.mcp_tools import MCPServerInfo
+    from deepagents_code.skills.load import ExtendedSkillMetadata
+    from deepagents_code.tool_catalog import ToolEntry
+
+
+@dataclass(frozen=True, slots=True)
+class ContextDoctorRow:
+    """One component in the context audit."""
+
+    label: str
+    tokens: int | None
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ContextDoctorReport:
+    """Structured context audit ready for presentation."""
+
+    rows: tuple[ContextDoctorRow, ...]
+    injected_tokens: int
+    conversation_tokens: int | None
+    provider_tokens: int | None
+
+
+def estimate_text_tokens(text: str) -> int:
+    """Estimate tokens using the same four-characters-per-token rule as whip.
+
+    Returns:
+        Estimated token count.
+    """
+    return math.ceil(len(text) / 4)
+
+
+def _schema_tokens(tools: Sequence[ToolEntry]) -> tuple[int, int]:
+    schemas = [tool.schema for tool in tools if tool.schema is not None]
+    text = "".join(
+        json.dumps(schema, separators=(",", ":"), sort_keys=True) for schema in schemas
+    )
+    return estimate_text_tokens(text), len(schemas)
+
+
+def _bounded(text: str, limit: int = 160) -> str:
+    return text if len(text) <= limit else f"{text[: limit - 1]}…"
+
+
+def _skill_tokens(skill: ExtendedSkillMetadata) -> int:
+    line = f"{skill['name']} {skill['description']} {skill['path']}"
+    return estimate_text_tokens(line)
+
+
+def format_memory_prompt(contents: Sequence[tuple[str, str]], template: str) -> str:
+    """Approximate the memory fragment after middleware strips HTML comments.
+
+    Returns:
+        The formatted memory prompt.
+    """
+    sections = [
+        f"{path}\n\n{re.sub(r'<!--.*?-->', '', text, flags=re.DOTALL).rstrip()}"
+        for path, text in contents
+    ]
+    body = "\n\n".join(section for section in sections if section.strip())
+    return template.format(agent_memory=body or "(No memory loaded)")
+
+
+def format_skills_prompt(skills: Sequence[ExtendedSkillMetadata]) -> str:
+    """Approximate the progressive-disclosure skill index sent to the model.
+
+    Returns:
+        The formatted skills prompt.
+    """
+    from deepagents.middleware.skills import SKILLS_SYSTEM_PROMPT
+
+    lines: list[str] = []
+    for skill in skills:
+        annotations = []
+        if skill.get("license"):
+            annotations.append(f"License: {skill['license']}")
+        if skill.get("compatibility"):
+            annotations.append(f"Compatibility: {skill['compatibility']}")
+        suffix = f" ({', '.join(annotations)})" if annotations else ""
+        lines.append(f"- **{skill['name']}**: {skill['description']}{suffix}")
+        if skill["allowed_tools"]:
+            lines.append(f"  -> Allowed tools: {', '.join(skill['allowed_tools'])}")
+        lines.append(f"  -> Read `{skill['path']}` for full instructions")
+    skills_list = "\n".join(lines) or "(No skills available yet)"
+    return SKILLS_SYSTEM_PROMPT.format(
+        skills_locations="",
+        skills_load_warnings="",
+        skills_list=skills_list,
+    )
+
+
+def _skills_detail(skills: Sequence[ExtendedSkillMetadata]) -> str:
+    ranked = sorted(
+        ((skill["name"], _skill_tokens(skill)) for skill in skills),
+        key=itemgetter(1),
+        reverse=True,
+    )[:5]
+    if not ranked:
+        return ""
+    return "largest: " + ", ".join(f"{name} ~{tokens}" for name, tokens in ranked)
+
+
+def _mcp_row(server: MCPServerInfo) -> ContextDoctorRow:
+    if server.status != "ok":
+        detail = _bounded(server.error or server.status.replace("_", " "))
+        return ContextDoctorRow(_bounded(f"MCP: {server.name}"), 0, detail)
+    definitions = [
+        {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.input_schema or {"type": "object", "properties": {}},
+            },
+        }
+        for tool in server.tools
+    ]
+    text = "".join(
+        json.dumps(definition, separators=(",", ":"), sort_keys=True)
+        for definition in definitions
+    )
+    count = len(server.tools)
+    noun = "tool" if count == 1 else "tools"
+    return ContextDoctorRow(
+        _bounded(f"MCP: {server.name} ({count} {noun})"), estimate_text_tokens(text)
+    )
+
+
+def build_context_doctor_report(
+    *,
+    system_prompt: str | None,
+    memory_prompt: str | None,
+    memory_files: int,
+    skills_prompt: str | None,
+    skills: Sequence[ExtendedSkillMetadata],
+    built_in_tools: Sequence[ToolEntry] | None,
+    mcp_servers: Sequence[MCPServerInfo],
+    conversation_tokens: int | None,
+    provider_tokens: int | None,
+) -> ContextDoctorReport:
+    """Build a fresh-session audit and reconcile it with live usage when available.
+
+    Returns:
+        The structured context audit.
+    """
+    rows = [
+        ContextDoctorRow(
+            "System prompt (base)",
+            None if system_prompt is None else estimate_text_tokens(system_prompt),
+            "unavailable for custom or remote agent" if system_prompt is None else "",
+        ),
+        ContextDoctorRow(
+            f"AGENTS.md memory ({memory_files} files)",
+            None if memory_prompt is None else estimate_text_tokens(memory_prompt),
+            "unavailable for custom or remote agent" if memory_prompt is None else "",
+        ),
+        ContextDoctorRow(
+            f"Skills index ({len(skills)} loaded)",
+            None if skills_prompt is None else estimate_text_tokens(skills_prompt),
+            _skills_detail(skills),
+        ),
+    ]
+    if built_in_tools is None:
+        rows.append(
+            ContextDoctorRow(
+                "Built-in tool schemas",
+                None,
+                "unavailable for custom or remote agent",
+            )
+        )
+    else:
+        tokens, schemas = _schema_tokens(built_in_tools)
+        detail = "sent with every request"
+        if schemas != len(built_in_tools):
+            detail = f"{schemas} of {len(built_in_tools)} schemas available"
+        rows.append(
+            ContextDoctorRow(
+                f"Built-in tool schemas ({len(built_in_tools)} tools)",
+                tokens,
+                detail,
+            )
+        )
+    rows.extend(_mcp_row(server) for server in mcp_servers)
+    injected = sum(row.tokens or 0 for row in rows)
+    return ContextDoctorReport(
+        rows=tuple(rows),
+        injected_tokens=injected,
+        conversation_tokens=conversation_tokens,
+        provider_tokens=provider_tokens,
+    )
+
+
+def render_context_doctor_report(report: ContextDoctorReport) -> str:
+    """Render a plain-text report.
+
+    Returns:
+        Text safe for display without markup parsing.
+    """
+    lines = ["Fresh-session context audit (estimated tokens)", ""]
+    width = max(len(row.label) for row in report.rows)
+    for row in report.rows:
+        value = "unavailable" if row.tokens is None else f"~{row.tokens:,}"
+        detail = f"  {row.detail}" if row.detail else ""
+        lines.append(f"{row.label:<{width}}  {value:>11}{detail}")
+    total_label = "TOTAL injected before conversation"
+    lines.append(f"{total_label:<{width}}  ~{report.injected_tokens:>10,}")
+    if report.conversation_tokens is not None:
+        lines.append(
+            f"{'Conversation history':<{width}}  ~{report.conversation_tokens:>10,}"
+        )
+    if report.provider_tokens is not None:
+        explained = report.injected_tokens + (report.conversation_tokens or 0)
+        remainder = report.provider_tokens - explained
+        provider_label = "Provider-reported context"
+        delta_label = "Unattributed / estimation delta"
+        lines.extend(
+            [
+                f"{provider_label:<{width}}  {report.provider_tokens:>11,}",
+                f"{delta_label:<{width}}  {remainder:>+11,}",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "Approximate: section counts use about four characters per token.",
+            "Trim skills or disable an MCP server, then run /context-doctor again.",
+        ]
+    )
+    return "\n".join(lines)

--- a/libs/code/deepagents_code/context_doctor.py
+++ b/libs/code/deepagents_code/context_doctor.py
@@ -76,7 +76,36 @@ def format_memory_prompt(contents: Sequence[tuple[str, str]], template: str) -> 
     return template.format(agent_memory=body or "(No memory loaded)")
 
 
-def format_skills_prompt(skills: Sequence[ExtendedSkillMetadata]) -> str:
+def format_skills_locations(sources: Sequence[str | tuple[str, ...]]) -> str:
+    """Format skills locations matching SkillsMiddleware display.
+
+    Returns:
+        The formatted skills locations text.
+    """
+    if not sources:
+        return ""
+    from deepagents.middleware.skills import (
+        _derive_source_label,  # noqa: PLC2701  # Matches SkillsMiddleware source label derivation
+        _source_path,  # noqa: PLC2701  # Matches SkillsMiddleware source path resolution
+    )
+
+    normalized_sources: list[tuple[str, str] | str] = [
+        (s[0], s[1]) if isinstance(s, tuple) else s for s in sources
+    ]
+    paths = [_source_path(s) for s in normalized_sources]
+    labels = [_derive_source_label(s) for s in normalized_sources]
+    last = len(normalized_sources) - 1
+    locations = [
+        f"**{label} Skills**: `{path}`{' (higher priority)' if i == last else ''}"
+        for i, (path, label) in enumerate(zip(paths, labels, strict=True))
+    ]
+    return "\n".join(locations)
+
+
+def format_skills_prompt(
+    skills: Sequence[ExtendedSkillMetadata],
+    sources: Sequence[str | tuple[str, ...]] = (),
+) -> str:
     """Approximate the progressive-disclosure skill index sent to the model.
 
     Returns:
@@ -97,8 +126,9 @@ def format_skills_prompt(skills: Sequence[ExtendedSkillMetadata]) -> str:
             lines.append(f"  -> Allowed tools: {', '.join(skill['allowed_tools'])}")
         lines.append(f"  -> Read `{skill['path']}` for full instructions")
     skills_list = "\n".join(lines) or "(No skills available yet)"
+    skills_locations = format_skills_locations(sources)
     return SKILLS_SYSTEM_PROMPT.format(
-        skills_locations="",
+        skills_locations=skills_locations,
         skills_load_warnings="",
         skills_list=skills_list,
     )

--- a/libs/code/deepagents_code/tool_catalog.py
+++ b/libs/code/deepagents_code/tool_catalog.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -67,6 +67,9 @@ class ToolEntry:
 
     description: str
     """First non-empty line of the tool's description, whitespace-collapsed."""
+
+    schema: dict[str, Any] | None = field(default=None, compare=False, repr=False)
+    """Provider-facing function definition used for context-cost estimates."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -321,17 +324,27 @@ def collect_tools_from_agent(agent: object) -> list[ToolEntry] | None:
             type(tool_node),
         )
         return None
+    from langchain_core.utils.function_calling import convert_to_openai_tool
+
     tools: list[ToolEntry] = []
     for name, tool in tools_by_name.items():
         if not isinstance(name, str):
             continue
         description = getattr(tool, "description", None)
+        try:
+            schema = convert_to_openai_tool(tool)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Could not serialize tool schema for %s", name, exc_info=True
+            )
+            schema = None
         tools.append(
             ToolEntry(
                 name=name,
                 description=_first_line(
                     description if isinstance(description, str) else None
                 ),
+                schema=schema,
             )
         )
     return tools

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -25,6 +25,7 @@ _TIPS: dict[str, int] = {
     "Try /threads to resume a previous conversation": 2,
     "Use /offload to summarize older messages and free up the context window": 2,
     "Use /context to see context window usage and remaining space": 1,
+    "Use /context-doctor to audit the token cost of injected context": 1,
     "Use /copy to copy the latest message": 3,
     "Press Ctrl+R to search and reuse submitted prompts": 2,
     "Use /cost to see a breakdown of estimated spend": 1,

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -236,6 +236,18 @@ async def test_context_prefers_checkpoint_total_after_offload(
     focus.assert_called_once_with()
 
 
+async def test_context_doctor_dispatches_to_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = DeepAgentsApp()
+    handler = AsyncMock()
+    monkeypatch.setattr(app, "_handle_context_doctor_command", handler)
+
+    await app._handle_command("/context-doctor")
+
+    handler.assert_awaited_once_with("/context-doctor")
+
+
 async def test_tokens_prompts_for_first_message_when_usage_is_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -248,6 +248,35 @@ async def test_context_doctor_dispatches_to_handler(
     handler.assert_awaited_once_with("/context-doctor")
 
 
+@pytest.mark.parametrize("auto_save", [True, False])
+async def test_handle_context_doctor_command_renders_report(
+    monkeypatch: pytest.MonkeyPatch,
+    auto_save: bool,
+) -> None:
+    app = DeepAgentsApp()
+    app._server_kwargs = {"allow_fs_tools": ["read_file"]}
+    app._cwd = "/tmp"
+    app._discovered_skills = []
+    mount_message = AsyncMock()
+    monkeypatch.setattr(app, "_mount_message", mount_message)
+    monkeypatch.setattr(
+        app,
+        "_get_context_usage_counts",
+        AsyncMock(return_value=(100, 20)),
+    )
+    monkeypatch.setattr(
+        "deepagents_code.config.is_memory_auto_save_enabled",
+        lambda: auto_save,
+    )
+
+    await app._handle_context_doctor_command("/context-doctor")
+
+    assert mount_message.await_count == 2
+    rendered_msg = mount_message.await_args_list[-1].args[0]
+    assert isinstance(rendered_msg, AppMessage)
+    assert "Fresh-session context audit" in str(rendered_msg._content)
+
+
 async def test_tokens_prompts_for_first_message_when_usage_is_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/libs/code/tests/unit_tests/test_context_doctor.py
+++ b/libs/code/tests/unit_tests/test_context_doctor.py
@@ -1,0 +1,90 @@
+"""Tests for context-doctor report construction."""
+
+from __future__ import annotations
+
+from deepagents_code.context_doctor import (
+    build_context_doctor_report,
+    estimate_text_tokens,
+    format_memory_prompt,
+    render_context_doctor_report,
+)
+from deepagents_code.mcp_tools import MCPServerInfo, MCPToolInfo
+from deepagents_code.tool_catalog import ToolEntry
+
+
+def test_estimate_text_tokens_rounds_up() -> None:
+    assert estimate_text_tokens("12345") == 2
+
+
+def test_format_memory_prompt_strips_html_comments() -> None:
+    prompt = format_memory_prompt(
+        [("AGENTS.md", "visible<!-- secret marker -->\ntext")],
+        "<agent_memory>\n{agent_memory}\n</agent_memory>",
+    )
+
+    assert "secret marker" not in prompt
+    assert "AGENTS.md\n\nvisible\ntext" in prompt
+
+
+def test_report_counts_schemas_and_surfaces_mcp_errors() -> None:
+    tools = [
+        ToolEntry(
+            "read_file",
+            "Read a file",
+            {"type": "function", "function": {"name": "read_file"}},
+        )
+    ]
+    servers = [
+        MCPServerInfo(
+            name="docs",
+            transport="http",
+            tools=(
+                MCPToolInfo(
+                    name="search",
+                    description="Search docs",
+                    input_schema={"type": "object", "properties": {}},
+                ),
+            ),
+        ),
+        MCPServerInfo(
+            name="broken*server",
+            transport="http",
+            status="error",
+            error="connection [failed]",
+        ),
+    ]
+
+    report = build_context_doctor_report(
+        system_prompt="system",
+        memory_prompt="memory",
+        memory_files=1,
+        skills_prompt="skills",
+        skills=[],
+        built_in_tools=tools,
+        mcp_servers=servers,
+        conversation_tokens=20,
+        provider_tokens=100,
+    )
+    rendered = render_context_doctor_report(report)
+
+    assert report.injected_tokens > 0
+    assert "MCP: docs (1 tool)" in rendered
+    assert "MCP: broken*server" in rendered
+    assert "connection [failed]" in rendered
+    assert "Provider-reported context" in rendered
+
+
+def test_report_marks_uninspectable_sections_unavailable() -> None:
+    report = build_context_doctor_report(
+        system_prompt=None,
+        memory_prompt=None,
+        memory_files=0,
+        skills_prompt="",
+        skills=[],
+        built_in_tools=None,
+        mcp_servers=[],
+        conversation_tokens=None,
+        provider_tokens=None,
+    )
+
+    assert render_context_doctor_report(report).count("unavailable") >= 3

--- a/libs/code/tests/unit_tests/test_context_doctor.py
+++ b/libs/code/tests/unit_tests/test_context_doctor.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from deepagents.middleware.memory import MEMORY_SYSTEM_PROMPT
+
+from deepagents_code.agent import _MEMORY_READONLY_SYSTEM_PROMPT
 from deepagents_code.context_doctor import (
     build_context_doctor_report,
     estimate_text_tokens,
@@ -88,3 +91,17 @@ def test_report_marks_uninspectable_sections_unavailable() -> None:
     )
 
     assert render_context_doctor_report(report).count("unavailable") >= 3
+
+
+def test_format_memory_prompt_supports_readonly_and_autosave_templates() -> None:
+    contents = [("/path/AGENTS.md", "guidelines here")]
+
+    autosave_prompt = format_memory_prompt(contents, MEMORY_SYSTEM_PROMPT)
+    readonly_prompt = format_memory_prompt(contents, _MEMORY_READONLY_SYSTEM_PROMPT)
+
+    assert "guidelines here" in autosave_prompt
+    assert "Learning from feedback:" in autosave_prompt
+
+    assert "guidelines here" in readonly_prompt
+    assert "Automatic memory saving is disabled:" in readonly_prompt
+    assert "Learning from feedback:" not in readonly_prompt

--- a/libs/code/tests/unit_tests/test_context_doctor.py
+++ b/libs/code/tests/unit_tests/test_context_doctor.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 from deepagents.middleware.memory import MEMORY_SYSTEM_PROMPT
 
-from deepagents_code.agent import _MEMORY_READONLY_SYSTEM_PROMPT
+from deepagents_code.agent import _MEMORY_READONLY_SYSTEM_PROMPT, get_skill_sources
 from deepagents_code.context_doctor import (
     build_context_doctor_report,
     estimate_text_tokens,
     format_memory_prompt,
+    format_skills_locations,
+    format_skills_prompt,
     render_context_doctor_report,
 )
 from deepagents_code.mcp_tools import MCPServerInfo, MCPToolInfo
+from deepagents_code.skills.load import ExtendedSkillMetadata
 from deepagents_code.tool_catalog import ToolEntry
 
 
@@ -93,6 +96,47 @@ def test_report_marks_uninspectable_sections_unavailable() -> None:
     assert render_context_doctor_report(report).count("unavailable") >= 3
 
 
+def test_format_skills_locations_renders_sources_with_priorities() -> None:
+    sources = [
+        ("/built_in_skills", "Built-in"),
+        ("/user/skills", "User Deepagents"),
+        ("/project/skills", "Project Deepagents"),
+    ]
+    rendered = format_skills_locations(sources)
+
+    assert "**Built-in Skills**: `/built_in_skills`" in rendered
+    assert "**User Deepagents Skills**: `/user/skills`" in rendered
+    assert (
+        "**Project Deepagents Skills**: `/project/skills` (higher priority)" in rendered
+    )
+
+
+def test_format_skills_prompt_includes_locations_and_skills() -> None:
+    skills: list[ExtendedSkillMetadata] = [
+        ExtendedSkillMetadata(
+            name="test-skill",
+            description="A test skill",
+            path="/path/to/SKILL.md",
+            license="MIT",
+            compatibility=None,
+            metadata={},
+            allowed_tools=["read_file"],
+            source="user",
+        )
+    ]
+    sources = [
+        ("/built_in_skills", "Built-in"),
+        ("/user/skills", "User Deepagents"),
+    ]
+    prompt = format_skills_prompt(skills, sources=sources)
+
+    assert "**Built-in Skills**: `/built_in_skills`" in prompt
+    assert "**User Deepagents Skills**: `/user/skills` (higher priority)" in prompt
+    assert "- **test-skill**: A test skill (License: MIT)" in prompt
+    assert "-> Allowed tools: read_file" in prompt
+    assert "-> Read `/path/to/SKILL.md` for full instructions" in prompt
+
+
 def test_format_memory_prompt_supports_readonly_and_autosave_templates() -> None:
     contents = [("/path/AGENTS.md", "guidelines here")]
 
@@ -105,3 +149,12 @@ def test_format_memory_prompt_supports_readonly_and_autosave_templates() -> None
     assert "guidelines here" in readonly_prompt
     assert "Automatic memory saving is disabled:" in readonly_prompt
     assert "Learning from feedback:" not in readonly_prompt
+
+
+def test_get_skill_sources_returns_expected_precedence() -> None:
+    sources = get_skill_sources(assistant_id="agent")
+    labels = [s[1] for s in sources]
+
+    assert labels[0] == "Built-in"
+    assert "User Deepagents" in labels
+    assert "User Agents" in labels

--- a/libs/code/tests/unit_tests/test_tool_catalog.py
+++ b/libs/code/tests/unit_tests/test_tool_catalog.py
@@ -65,6 +65,8 @@ class TestCollectBuiltInTools:
         for tool in tools:
             assert tool.description
             assert "\n" not in tool.description
+            assert tool.schema is not None
+            assert tool.schema["type"] == "function"
 
     def test_enumeration_survives_a_policy_blocked_subagent_model(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
`dcode` now includes `/context-doctor` for auditing injected context and token costs.

<img width="719" height="395" alt="Screenshot" src="https://github.com/user-attachments/assets/0f9411d3-906b-4604-975f-1504e85735cb" />

---

Add `/context-doctor` to expose the approximate token cost of base instructions, memory, skills, built-in tool schemas, MCP tools, and conversation history. The report degrades honestly for uninspectable agents and reconciles estimates with provider-reported usage when available.

Made by [Open SWE](https://openswe.vercel.app/agents/368aa683-e22c-580f-b04c-7dc490601b5c)