### PR TITLE
fix(code): track live dynamic subagent cost

### DIFF
--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -892,6 +892,24 @@ def record_message_usage(
     )
 
 
+def is_model_usage_event(data: object) -> bool:
+    """Report whether a custom-stream payload is a nested model-usage event.
+
+    Lets a client consume its own event whatever `record_model_usage_event` made
+    of it. A duplicate of a request the message stream already recorded is still
+    this client's event, not a payload for the unrelated handlers downstream.
+
+    Args:
+        data: A `custom` stream payload.
+
+    Returns:
+        `True` when the payload claims to be a nested model-usage event.
+    """
+    from deepagents_code.cost_tracking import MODEL_USAGE_EVENT_TYPE
+
+    return isinstance(data, Mapping) and data.get("type") == MODEL_USAGE_EVENT_TYPE
+
+
 def record_model_usage_event(
     stats: SessionStats,
     data: object,
@@ -913,29 +931,43 @@ def record_model_usage_event(
 
     if not isinstance(data, Mapping) or data.get("type") != MODEL_USAGE_EVENT_TYPE:
         return None
-    request_id = data.get("request_id")
-    thread_id = data.get("thread_id")
-    scope = data.get("scope")
     version = data.get("version")
     if (
         not isinstance(version, int)
         or isinstance(version, bool)
         or version != MODEL_USAGE_EVENT_VERSION
-        or not isinstance(request_id, str)
+    ):
+        # A newer graph process can stream a shape this client cannot read. The
+        # spend is still charged and streamed as the thread total, so only the
+        # provisional display is lost -- but silence would make that look like
+        # the graph never emitted anything.
+        logger.debug(
+            "Ignoring a nested usage event of version %r; this client reads %d.",
+            version,
+            MODEL_USAGE_EVENT_VERSION,
+        )
+        return None
+    request_id = data.get("request_id")
+    thread_id = data.get("thread_id")
+    scope = data.get("scope")
+    usage = data.get("usage_metadata")
+    model_name, provider = data.get("model_name"), data.get("provider")
+    if (
+        not isinstance(request_id, str)
         or not request_id
         or not isinstance(thread_id, str)
         or not thread_id
         or not isinstance(scope, str)
         or not scope
+        or not isinstance(usage, Mapping)
+        or not usage
+        or not isinstance(model_name, str)
+        or not isinstance(provider, str)
     ):
+        logger.debug("Ignoring a malformed nested usage event")
         return None
     if active_thread_id and thread_id != active_thread_id:
-        return None
-    usage = data.get("usage_metadata")
-    model_name, provider = data.get("model_name"), data.get("provider")
-    if not isinstance(usage, Mapping) or not usage:
-        return None
-    if not isinstance(model_name, str) or not isinstance(provider, str):
+        # Ordinary: a stream for a thread the user has since switched away from.
         return None
     try:
         from langchain_core.messages import AIMessage

--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -892,6 +892,76 @@ def record_message_usage(
     )
 
 
+def record_model_usage_event(
+    stats: SessionStats,
+    data: object,
+    *,
+    active_thread_id: str = "",
+    fallback_model: str = "",
+    fallback_provider: str = "",
+    recorded_requests: dict[str, RecordedRequest] | None = None,
+) -> RecordedUsage | None:
+    """Record a validated provisional usage event from a nested model call.
+
+    Returns:
+        The recorded usage delta, or `None` when the event is invalid or duplicate.
+    """
+    from deepagents_code.cost_tracking import (
+        MODEL_USAGE_EVENT_TYPE,
+        MODEL_USAGE_EVENT_VERSION,
+    )
+
+    if not isinstance(data, Mapping) or data.get("type") != MODEL_USAGE_EVENT_TYPE:
+        return None
+    request_id = data.get("request_id")
+    thread_id = data.get("thread_id")
+    scope = data.get("scope")
+    version = data.get("version")
+    if (
+        not isinstance(version, int)
+        or isinstance(version, bool)
+        or version != MODEL_USAGE_EVENT_VERSION
+        or not isinstance(request_id, str)
+        or not request_id
+        or not isinstance(thread_id, str)
+        or not thread_id
+        or not isinstance(scope, str)
+        or not scope
+    ):
+        return None
+    if active_thread_id and thread_id != active_thread_id:
+        return None
+    usage = data.get("usage_metadata")
+    model_name, provider = data.get("model_name"), data.get("provider")
+    if not isinstance(usage, Mapping) or not usage:
+        return None
+    if not isinstance(model_name, str) or not isinstance(provider, str):
+        return None
+    try:
+        from langchain_core.messages import AIMessage
+
+        message = AIMessage(
+            content="",
+            id=request_id,
+            usage_metadata=cast("Any", dict(usage)),
+            response_metadata={
+                "model_name": model_name,
+                "model_provider": provider,
+            },
+        )
+    except (TypeError, ValueError):
+        logger.debug("Rejected malformed nested model usage", exc_info=True)
+        return None
+    return record_message_usage(
+        stats,
+        message,
+        fallback_model=fallback_model,
+        fallback_provider=fallback_provider,
+        kind="subagent",
+        recorded_requests=recorded_requests,
+    )
+
+
 def format_token_count(count: int) -> str:
     """Format a token count into a human-readable short string.
 

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -48,6 +48,7 @@ from deepagents_code._session_stats import (
     finalize_recorded_requests,
     print_usage_table,
     record_message_usage,
+    record_model_usage_event,
     usage_table_enabled,
 )
 from deepagents_code._tool_stream import (
@@ -389,6 +390,9 @@ def _plain_hook_notice(console: Console) -> HookNoticeCallback:
 @dataclass
 class StreamState:
     """Mutable state accumulated while iterating over the agent stream."""
+
+    thread_id: str = ""
+    """Thread whose streamed usage this state accepts."""
 
     quiet: bool = False
     """When `True`, stream-time diagnostics (the tool-call and file-operation
@@ -1002,7 +1006,16 @@ def _process_stream_chunk(
 
     # Nested agent spend still counts even when chat rendering is skipped.
     if not is_main_agent:
-        if (
+        if stream_mode == "custom":
+            record_model_usage_event(
+                state.stats,
+                data,
+                active_thread_id=state.thread_id,
+                fallback_model=settings.model_name or "",
+                fallback_provider=settings.model_provider or "",
+                recorded_requests=state.recorded_usage_requests,
+            )
+        elif (
             stream_mode == "messages"
             and isinstance(data, tuple)
             and len(data) == (_MESSAGE_DATA_LENGTH)
@@ -1457,7 +1470,9 @@ async def _run_agent_loop(
         ClientHookStopError: If a client-owned hook stops processing.
     """
     spinner = None if quiet else _ConsoleSpinner(console)
+    thread_id = config.get("configurable", {}).get("thread_id", "")
     state = StreamState(
+        thread_id=thread_id if isinstance(thread_id, str) else "",
         quiet=quiet,
         stream=stream,
         spinner=spinner,
@@ -1473,7 +1488,7 @@ async def _run_agent_loop(
     if rubric is not None:
         stream_input["rubric"] = rubric
 
-    thread_id = config.get("configurable", {}).get("thread_id", "")
+    thread_id = state.thread_id
     # An empty or missing thread ID carries no session identity, so leave it
     # unset in context rather than passing a blank string to model middleware.
     context_thread_id = thread_id if isinstance(thread_id, str) and thread_id else None

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -5817,9 +5817,9 @@ def create_model(
         model = _create_model_via_init(model_name, provider, kwargs)
 
     resolved_provider = provider or getattr(model, "_model_provider", provider)
-    from deepagents_code.cost_tracking import _set_configured_provider_metadata
+    from deepagents_code.cost_tracking import _set_configured_model_metadata
 
-    _set_configured_provider_metadata(model, resolved_provider)
+    _set_configured_model_metadata(model, model_name, resolved_provider)
 
     # Apply profile overrides from config.toml (e.g., max_input_tokens)
     if provider:

--- a/libs/code/deepagents_code/cost_tracking.py
+++ b/libs/code/deepagents_code/cost_tracking.py
@@ -127,35 +127,46 @@ _UNPRICEABLE_PROVIDERS: frozenset[str] = frozenset({"openai_codex"})
 _CONFIGURED_PROVIDER_METADATA_KEY = "deepagents_code_configured_provider"
 """Model metadata key preserving the provider selected by `create_model`."""
 
+_CONFIGURED_MODEL_METADATA_KEY = "deepagents_code_configured_model"
+"""Model metadata key preserving the model selected by `create_model`."""
+
 _CHECKPOINT_NAMESPACE_METADATA_KEY = "langgraph_checkpoint_ns"
 """Callback metadata key identifying the graph node that made a request."""
 
 
-def _set_configured_provider_metadata(model: object, provider: str) -> None:
-    """Attach the configured provider to every request made by a model.
+def _set_configured_model_metadata(
+    model: object,
+    model_name: str,
+    provider: str,
+) -> None:
+    """Attach the configured model identity to every request made by a model.
 
     LangChain provider integrations can report a generic backend in response
-    metadata: Azure and the Codex subscription model both report `openai`.
-    Model metadata reaches `on_chat_model_start`, so recording the configured
-    provider there preserves the distinction for main, side, and nested calls.
+    metadata, and some omit the model name. Model metadata reaches
+    `on_chat_model_start`, so recording the configured identity there preserves
+    the model and provider for main, side, and nested calls.
 
     Args:
-        model: Chat model whose callback metadata should carry the provider.
+        model: Chat model whose callback metadata should carry the identity.
+        model_name: Model selected while constructing the model.
         provider: Provider selected while constructing the model.
     """
-    if not provider:
+    if not model_name and not provider:
         return
     try:
         current = getattr(model, "metadata", None)
         metadata = dict(current) if isinstance(current, Mapping) else {}
-        metadata[_CONFIGURED_PROVIDER_METADATA_KEY] = provider
+        if model_name:
+            metadata[_CONFIGURED_MODEL_METADATA_KEY] = model_name
+        if provider:
+            metadata[_CONFIGURED_PROVIDER_METADATA_KEY] = provider
         model.metadata = metadata  # ty: ignore[unresolved-attribute]
     except Exception:
         # Cost estimation is best-effort and must never make a usable model fail
         # construction. The response metadata and main-message fallback still
         # cover providers whose model object rejects metadata assignment.
         logger.debug(
-            "Could not attach configured provider metadata to %s",
+            "Could not attach configured model metadata to %s",
             type(model).__name__,
             exc_info=True,
         )
@@ -1592,6 +1603,9 @@ class _ModelCallContext:
     thread_id: str
     """Thread that owns the request's eventual cost."""
 
+    configured_model: str
+    """Model selected for this request, or `""` when unavailable."""
+
     configured_provider: str
     """Provider selected for this request, or `""` when unavailable."""
 
@@ -1615,7 +1629,7 @@ def _emit_model_usage(
                 "version": MODEL_USAGE_EVENT_VERSION,
                 "request_id": record.message_id,
                 "usage_metadata": dict(record.usage_metadata),
-                "model_name": record.model_name,
+                "model_name": record.model_name or context.configured_model,
                 "provider": record.provider,
                 "thread_id": context.thread_id,
                 "scope": context.scope,
@@ -1691,12 +1705,21 @@ class _SessionCostRecorder(BaseCallbackHandler):
             with self._lock:
                 self._run_contexts[run_id] = _ModelCallContext(
                     thread_id="",
+                    configured_model="",
                     configured_provider="",
                     scope="",
                 )
                 while len(self._run_contexts) > _MAX_INFLIGHT_REQUESTS:
                     self._run_contexts.popitem(last=False)
             return
+        model_name = (
+            metadata.get(_CONFIGURED_MODEL_METADATA_KEY)
+            if metadata is not None
+            else None
+        )
+        configured_model = (
+            model_name if isinstance(model_name, str) and model_name else ""
+        )
         provider = (
             metadata.get(_CONFIGURED_PROVIDER_METADATA_KEY)
             if metadata is not None
@@ -1713,6 +1736,7 @@ class _SessionCostRecorder(BaseCallbackHandler):
         with self._lock:
             self._run_contexts[run_id] = _ModelCallContext(
                 thread_id=thread_id,
+                configured_model=configured_model,
                 configured_provider=configured_provider,
                 scope=_parent_checkpoint_scope(namespace),
             )

--- a/libs/code/deepagents_code/cost_tracking.py
+++ b/libs/code/deepagents_code/cost_tracking.py
@@ -91,6 +91,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+MODEL_USAGE_EVENT_TYPE = "model_usage"
+"""Custom-stream event type carrying provisional nested model usage."""
+
+MODEL_USAGE_EVENT_VERSION = 1
+"""Current shape version for nested model-usage events."""
+
 SESSION_COST_EVENT_TYPE = "session_cost"
 """Custom-stream event type carrying the thread's absolute cumulative cost.
 
@@ -1593,6 +1599,32 @@ class _ModelCallContext:
     """Checkpoint namespace of the graph that owns this request."""
 
 
+def _emit_model_usage(
+    record: _ModelCallRecord,
+    context: _ModelCallContext,
+) -> None:
+    """Best-effort stream provisional usage for one identified nested call."""
+    if not context.scope or record.message_id is None:
+        return
+    try:
+        from langgraph.config import get_stream_writer
+
+        get_stream_writer()(
+            {
+                "type": MODEL_USAGE_EVENT_TYPE,
+                "version": MODEL_USAGE_EVENT_VERSION,
+                "request_id": record.message_id,
+                "usage_metadata": dict(record.usage_metadata),
+                "model_name": record.model_name,
+                "provider": record.provider,
+                "thread_id": context.thread_id,
+                "scope": context.scope,
+            }
+        )
+    except Exception:
+        logger.debug("Could not emit nested model usage", exc_info=True)
+
+
 def _parent_checkpoint_scope(namespace: object) -> str:
     """Return the graph namespace containing a checkpointed node.
 
@@ -1779,6 +1811,7 @@ class _SessionCostRecorder(BaseCallbackHandler):
                     "their cost is missing from the session total.",
                     dropped,
                 )
+        _emit_model_usage(record, context)
 
     def on_llm_error(
         self,

--- a/libs/code/deepagents_code/cost_tracking.py
+++ b/libs/code/deepagents_code/cost_tracking.py
@@ -1617,7 +1617,17 @@ def _emit_model_usage(
     record: _ModelCallRecord,
     context: _ModelCallContext,
 ) -> None:
-    """Best-effort stream provisional usage for one identified nested call."""
+    """Best-effort stream provisional usage for one identified nested call.
+
+    The client cannot see a nested request until the graph checkpoints and
+    charges it, which for a long subagent is many minutes. Streaming the usage
+    lets the client price it provisionally in the meantime; the graph's absolute
+    total still supersedes the estimate.
+
+    Args:
+        record: The completed request's usage, model, and response ID.
+        context: The request's thread and owning graph scope.
+    """
     if not context.scope or record.message_id is None:
         return
     try:
@@ -1629,7 +1639,7 @@ def _emit_model_usage(
                 "version": MODEL_USAGE_EVENT_VERSION,
                 "request_id": record.message_id,
                 "usage_metadata": dict(record.usage_metadata),
-                "model_name": record.model_name or context.configured_model,
+                "model_name": record.model_name,
                 "provider": record.provider,
                 "thread_id": context.thread_id,
                 "scope": context.scope,
@@ -1802,6 +1812,7 @@ class _SessionCostRecorder(BaseCallbackHandler):
         try:
             record = _record_from_response(
                 response,
+                configured_model=context.configured_model,
                 configured_provider=context.configured_provider,
                 scope=context.scope,
             )
@@ -1914,6 +1925,7 @@ class _SessionCostRecorder(BaseCallbackHandler):
 def _record_from_response(
     response: LLMResult,
     *,
+    configured_model: str = "",
     configured_provider: str = "",
     scope: str = "",
 ) -> _ModelCallRecord | None:
@@ -1921,6 +1933,10 @@ def _record_from_response(
 
     Args:
         response: Completed LangChain model response containing usage metadata.
+        configured_model: Model selected for this specific request. Used when the
+            response names none, so the record carries the model that actually
+            served it rather than leaving pricing to a caller's fallback -- which
+            for a nested call describes the parent, not this request.
         configured_provider: Provider selected for this specific request.
         scope: Checkpoint namespace of the graph that made the request.
 
@@ -1942,6 +1958,7 @@ def _record_from_response(
         return None
     model_name, provider = resolve_message_model(
         message,
+        fallback_model=configured_model,
         fallback_provider=configured_provider,
     )
     message_id = getattr(message, "id", None)

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -1379,6 +1379,31 @@ async def _finalize_usage_round(
         _session_stats.finalize_recorded_requests(recorded_requests)
 
 
+def _apply_recorded_usage(
+    adapter: Any,  # noqa: ANN401  # adapter type is the TUI callback bundle
+    recorded_usage: _session_stats.RecordedUsage | None,
+) -> None:
+    """Refresh the usage display and provisional cost for one recorded request.
+
+    Args:
+        adapter: The stream adapter holding the display callbacks.
+        recorded_usage: What the request added to the turn's stats, or `None`
+            when nothing was recorded and there is nothing to show.
+    """
+    if recorded_usage is None:
+        return
+    if adapter._on_usage_update:
+        adapter._on_usage_update()
+    if recorded_usage.cost_usd is None or not adapter._on_provisional_cost:
+        return
+    # Display-only: the graph checkpoints the same spend and streams the
+    # authoritative total, which supersedes this estimate.
+    try:
+        adapter._on_provisional_cost(recorded_usage.cost_usd)
+    except Exception:
+        logger.warning("on_provisional_cost callback failed", exc_info=True)
+
+
 async def _mount_diff_note(adapter: Any, text: str) -> None:  # noqa: ANN401  # adapter type is the TUI callback bundle
     """Mount a standalone transcript note about a diff that could not be shown.
 
@@ -1821,11 +1846,16 @@ async def execute_task_textual(
                 # nested custom events never reach the panel; forwarding must
                 # never raise into the stream loop.
                 if current_stream_mode == "custom":
-                    try:
-                        from deepagents_code.config import settings
+                    # A nested request's usage arrives as soon as it completes,
+                    # so a long subagent shows its spend while it runs rather
+                    # than only once it returns. Consume the event whatever came
+                    # of it: a duplicate of a request the message stream already
+                    # recorded is still ours, not input for the handlers below.
+                    if not is_main_agent and _session_stats.is_model_usage_event(data):
+                        try:
+                            from deepagents_code.config import settings
 
-                        recorded_usage = (
-                            _session_stats.record_model_usage_event(
+                            recorded_usage = _session_stats.record_model_usage_event(
                                 turn_stats,
                                 data,
                                 active_thread_id=thread_id,
@@ -1833,27 +1863,13 @@ async def execute_task_textual(
                                 fallback_provider=settings.model_provider or "",
                                 recorded_requests=recorded_usage_requests,
                             )
-                            if not is_main_agent
-                            else None
-                        )
-                    except Exception:
-                        logger.warning(
-                            "Nested model usage event handling failed", exc_info=True
-                        )
-                        recorded_usage = None
-                    if recorded_usage is not None:
-                        if adapter._on_usage_update:
-                            adapter._on_usage_update()
-                        if (
-                            recorded_usage.cost_usd is not None
-                            and adapter._on_provisional_cost
-                        ):
-                            try:
-                                adapter._on_provisional_cost(recorded_usage.cost_usd)
-                            except Exception:
-                                logger.warning(
-                                    "on_provisional_cost callback failed", exc_info=True
-                                )
+                        except Exception:
+                            logger.warning(
+                                "Nested model usage event handling failed",
+                                exc_info=True,
+                            )
+                            recorded_usage = None
+                        _apply_recorded_usage(adapter, recorded_usage)
                         continue
 
                     # The graph owns the cumulative thread cost and streams the
@@ -2146,21 +2162,7 @@ async def execute_task_textual(
                             ),
                             recorded_requests=recorded_usage_requests,
                         )
-                    if recorded_usage is not None and adapter._on_usage_update:
-                        adapter._on_usage_update()
-                    if recorded_usage is not None and (
-                        recorded_usage.cost_usd is not None
-                        and adapter._on_provisional_cost
-                    ):
-                        # Display-only: the graph checkpoints the same spend
-                        # and streams the authoritative total, which
-                        # supersedes this estimate.
-                        try:
-                            adapter._on_provisional_cost(recorded_usage.cost_usd)
-                        except Exception:
-                            logger.warning(
-                                "on_provisional_cost callback failed", exc_info=True
-                            )
+                    _apply_recorded_usage(adapter, recorded_usage)
 
                     # Skip subagent outputs - only render main agent content in chat
                     if not is_main_agent:

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -1821,6 +1821,41 @@ async def execute_task_textual(
                 # nested custom events never reach the panel; forwarding must
                 # never raise into the stream loop.
                 if current_stream_mode == "custom":
+                    try:
+                        from deepagents_code.config import settings
+
+                        recorded_usage = (
+                            _session_stats.record_model_usage_event(
+                                turn_stats,
+                                data,
+                                active_thread_id=thread_id,
+                                fallback_model=settings.model_name or "",
+                                fallback_provider=settings.model_provider or "",
+                                recorded_requests=recorded_usage_requests,
+                            )
+                            if not is_main_agent
+                            else None
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Nested model usage event handling failed", exc_info=True
+                        )
+                        recorded_usage = None
+                    if recorded_usage is not None:
+                        if adapter._on_usage_update:
+                            adapter._on_usage_update()
+                        if (
+                            recorded_usage.cost_usd is not None
+                            and adapter._on_provisional_cost
+                        ):
+                            try:
+                                adapter._on_provisional_cost(recorded_usage.cost_usd)
+                            except Exception:
+                                logger.warning(
+                                    "on_provisional_cost callback failed", exc_info=True
+                                )
+                        continue
+
                     # The graph owns the cumulative thread cost and streams the
                     # new absolute total after each step it charges, because the
                     # channel is schema-private and never reaches the state

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -1399,11 +1399,14 @@ class TestCreateModelProfileExtraction:
         assert result.context_limit == 200000
 
     @patch("langchain.chat_models.init_chat_model")
-    def test_attaches_configured_provider_to_model_metadata(
+    def test_attaches_configured_identity_to_model_metadata(
         self, mock_init_chat_model: Mock
     ) -> None:
-        """Every request should retain the provider selected at construction."""
-        from deepagents_code.cost_tracking import _CONFIGURED_PROVIDER_METADATA_KEY
+        """Every request should retain the identity selected at construction."""
+        from deepagents_code.cost_tracking import (
+            _CONFIGURED_MODEL_METADATA_KEY,
+            _CONFIGURED_PROVIDER_METADATA_KEY,
+        )
 
         mock_model = Mock()
         mock_model.metadata = {"existing": "value"}
@@ -1414,6 +1417,7 @@ class TestCreateModelProfileExtraction:
 
         assert result.model.metadata == {
             "existing": "value",
+            _CONFIGURED_MODEL_METADATA_KEY: "claude-sonnet-4-5",
             _CONFIGURED_PROVIDER_METADATA_KEY: "anthropic",
         }
 

--- a/libs/code/tests/unit_tests/test_cost_tracking.py
+++ b/libs/code/tests/unit_tests/test_cost_tracking.py
@@ -47,6 +47,7 @@ from deepagents_code._fake_models import _ToolBindingFakeModel
 from deepagents_code.cost_tracking import (
     _CONFIGURED_PROVIDER_METADATA_KEY,
     _RECORDER_VAR,
+    MODEL_USAGE_EVENT_TYPE,
     SESSION_COST_EVENT_TYPE,
     CostState,
     CostTrackingMiddleware,
@@ -3037,6 +3038,69 @@ class TestSessionCostRecorder:
 
         assert len(recorder.drain(THREAD_ID)) == 1
         assert recorder.drain(THREAD_ID) == []
+
+    def test_nested_request_emits_provisional_usage(
+        self, recorder: _SessionCostRecorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        events: list[dict[str, Any]] = []
+        monkeypatch.setattr("langgraph.config.get_stream_writer", lambda: events.append)
+
+        _collect(
+            recorder,
+            _record(message_id="child-1", usage=_usage(cache_read=200)),
+            checkpoint_ns="tools:task|model:call",
+        )
+
+        assert events == [
+            {
+                "type": MODEL_USAGE_EVENT_TYPE,
+                "version": 1,
+                "request_id": "child-1",
+                "usage_metadata": _usage(cache_read=200),
+                "model_name": KNOWN_MODEL,
+                "provider": KNOWN_PROVIDER,
+                "thread_id": THREAD_ID,
+                "scope": "tools:task",
+            }
+        ]
+        assert [record.message_id for record in recorder.drain(THREAD_ID)] == [
+            "child-1"
+        ]
+
+    def test_root_or_unidentified_request_does_not_emit(
+        self, recorder: _SessionCostRecorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        events: list[dict[str, Any]] = []
+        monkeypatch.setattr("langgraph.config.get_stream_writer", lambda: events.append)
+
+        _collect(recorder, _record(message_id="root"))
+        _collect(
+            recorder,
+            _record(message_id=None),
+            checkpoint_ns="tools:task|model:call",
+        )
+
+        assert events == []
+        assert len(recorder.drain(THREAD_ID)) == 2
+
+    def test_usage_writer_failure_keeps_the_durable_record(
+        self, recorder: _SessionCostRecorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fail(_: object) -> None:
+            msg = "stream closed"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr("langgraph.config.get_stream_writer", lambda: fail)
+
+        _collect(
+            recorder,
+            _record(message_id="child-1"),
+            checkpoint_ns="tools:task|model:call",
+        )
+
+        assert [record.message_id for record in recorder.drain(THREAD_ID)] == [
+            "child-1"
+        ]
 
     def test_thread_comes_from_the_ambient_config_when_metadata_omits_it(
         self, recorder: _SessionCostRecorder

--- a/libs/code/tests/unit_tests/test_cost_tracking.py
+++ b/libs/code/tests/unit_tests/test_cost_tracking.py
@@ -53,7 +53,7 @@ from deepagents_code.cost_tracking import (
     CostTrackingMiddleware,
     _ModelCallRecord,
     _SessionCostRecorder,
-    _set_configured_provider_metadata,
+    _set_configured_model_metadata,
     estimate_cost,
     resolve_message_model,
 )
@@ -3067,6 +3067,35 @@ class TestSessionCostRecorder:
             "child-1"
         ]
 
+    async def test_nested_event_uses_configured_model_when_response_omits_it(
+        self, recorder: _SessionCostRecorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        events: list[dict[str, Any]] = []
+        monkeypatch.setattr("langgraph.config.get_stream_writer", lambda: events.append)
+        configured_model = "explicit-nested-model"
+        model = _fake_model(
+            AIMessage(
+                content="response",
+                id="child-1",
+                usage_metadata=_usage(),  # ty: ignore[invalid-argument-type]
+            )
+        )
+        _set_configured_model_metadata(model, configured_model, KNOWN_PROVIDER)
+
+        await model.ainvoke(
+            "hello",
+            config={
+                "metadata": {
+                    "thread_id": THREAD_ID,
+                    "langgraph_checkpoint_ns": "tools:task|model:call",
+                }
+            },
+        )
+
+        assert events[0]["model_name"] == configured_model
+        assert events[0]["provider"] == KNOWN_PROVIDER
+        assert recorder.drain(THREAD_ID)[0].model_name == ""
+
     def test_root_or_unidentified_request_does_not_emit(
         self, recorder: _SessionCostRecorder, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -3140,7 +3169,7 @@ class TestSessionCostRecorder:
                 message_id="summary-1",
             )
         )
-        _set_configured_provider_metadata(model, "openai_codex")
+        _set_configured_model_metadata(model, "gpt-5.4", "openai_codex")
 
         await model.ainvoke(
             "summarize",

--- a/libs/code/tests/unit_tests/test_cost_tracking.py
+++ b/libs/code/tests/unit_tests/test_cost_tracking.py
@@ -3094,7 +3094,10 @@ class TestSessionCostRecorder:
 
         assert events[0]["model_name"] == configured_model
         assert events[0]["provider"] == KNOWN_PROVIDER
-        assert recorder.drain(THREAD_ID)[0].model_name == ""
+        # The durable record carries the same identity, so the graph prices the
+        # request as the model that served it rather than falling back to the
+        # parent graph's checkpointed spec.
+        assert recorder.drain(THREAD_ID)[0].model_name == configured_model
 
     def test_root_or_unidentified_request_does_not_emit(
         self, recorder: _SessionCostRecorder, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -43,6 +43,7 @@ from deepagents_code.client.non_interactive import (
     _process_ai_message,
     _process_hitl_interrupts,
     _process_message_chunk,
+    _process_stream_chunk,
     _record_usage_from_message,
     _run_agent_loop,
     _run_startup_command,
@@ -77,6 +78,34 @@ from deepagents_code.tool_display import format_tool_message_content
 def console() -> Console:
     """Console that captures output."""
     return Console(quiet=True)
+
+
+def test_nested_usage_event_updates_headless_stats(console: Console) -> None:
+    state = StreamState(thread_id="thread-1")
+    event = {
+        "type": "model_usage",
+        "version": 1,
+        "request_id": "child-1",
+        "usage_metadata": {
+            "input_tokens": 1_000,
+            "output_tokens": 100,
+            "total_tokens": 1_100,
+        },
+        "model_name": "gpt-5.5",
+        "provider": "openai",
+        "thread_id": "thread-1",
+        "scope": "tools:task",
+    }
+
+    _process_stream_chunk(
+        (("tools:task",), "custom", event),
+        state,
+        console,
+        FileOpTracker(assistant_id="assistant"),
+    )
+
+    assert state.stats.request_count == 1
+    assert state.stats.per_kind["subagent"].request_count == 1
 
 
 def test_subagent_summarization_does_not_signal_compaction() -> None:

--- a/libs/code/tests/unit_tests/test_session_stats.py
+++ b/libs/code/tests/unit_tests/test_session_stats.py
@@ -25,6 +25,7 @@ from deepagents_code._session_stats import (
     record_model_usage_event,
     usage_table_enabled,
 )
+from deepagents_code.cost_tracking import MODEL_USAGE_EVENT_VERSION
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -926,6 +927,7 @@ class TestRecordModelUsageEvent:
         "update",
         [
             {"version": True},
+            {"version": MODEL_USAGE_EVENT_VERSION + 1},
             {"request_id": ""},
             {"usage_metadata": "tokens"},
             {"scope": ""},

--- a/libs/code/tests/unit_tests/test_session_stats.py
+++ b/libs/code/tests/unit_tests/test_session_stats.py
@@ -22,6 +22,7 @@ from deepagents_code._session_stats import (
     format_token_count,
     print_usage_table,
     record_message_usage,
+    record_model_usage_event,
     usage_table_enabled,
 )
 
@@ -845,6 +846,118 @@ class TestRecordMessageUsage:
 
         assert record_message_usage(stats, SimpleNamespace(usage_metadata=None)) is None
         assert record_message_usage(stats, SimpleNamespace()) is None
+        assert stats.request_count == 0
+
+
+class TestRecordModelUsageEvent:
+    """Nested usage custom events share ordinary message accounting."""
+
+    @staticmethod
+    def _event() -> dict[str, object]:
+        return {
+            "type": "model_usage",
+            "version": 1,
+            "request_id": "child-1",
+            "usage_metadata": {
+                "input_tokens": 1_000,
+                "output_tokens": 100,
+                "total_tokens": 1_100,
+                "input_token_details": {"cache_read": 800},
+            },
+            "model_name": "gpt-5.5",
+            "provider": "openai",
+            "thread_id": "thread-1",
+            "scope": "tools:task",
+        }
+
+    def test_records_subagent_usage_once(self) -> None:
+        stats = SessionStats()
+        ledger: dict[str, RecordedRequest] = {}
+
+        first = record_model_usage_event(
+            stats,
+            self._event(),
+            active_thread_id="thread-1",
+            recorded_requests=ledger,
+        )
+        replay = record_model_usage_event(
+            stats,
+            self._event(),
+            active_thread_id="thread-1",
+            recorded_requests=ledger,
+        )
+
+        assert first is not None
+        assert replay is None
+        assert stats.request_count == 1
+        assert stats.per_kind["subagent"].request_count == 1
+        assert stats.cache_read_tokens == 800
+        assert ("openai", "gpt-5.5") in stats.per_model
+
+    def test_deduplicates_with_ordinary_message(self) -> None:
+        stats = SessionStats()
+        ledger: dict[str, RecordedRequest] = {}
+        message = AIMessage(
+            content="done",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 1_000,
+                "output_tokens": 100,
+                "total_tokens": 1_100,
+            },
+            response_metadata={
+                "model_name": "gpt-5.5",
+                "model_provider": "openai",
+            },
+        )
+
+        record_message_usage(stats, message, kind="subagent", recorded_requests=ledger)
+        replay = record_model_usage_event(
+            stats,
+            self._event(),
+            active_thread_id="thread-1",
+            recorded_requests=ledger,
+        )
+
+        assert replay is None
+        assert stats.request_count == 1
+
+    @pytest.mark.parametrize(
+        "update",
+        [
+            {"version": True},
+            {"request_id": ""},
+            {"usage_metadata": "tokens"},
+            {"scope": ""},
+        ],
+    )
+    def test_rejects_malformed_event(self, update: dict[str, object]) -> None:
+        event = self._event() | update
+        stats = SessionStats()
+
+        assert (
+            record_model_usage_event(
+                stats,
+                event,
+                active_thread_id="thread-1",
+                recorded_requests={},
+            )
+            is None
+        )
+        assert stats.request_count == 0
+
+    def test_rejects_another_thread(self) -> None:
+        stats = SessionStats()
+
+        assert (
+            record_model_usage_event(
+                stats,
+                self._event(),
+                active_thread_id="other-thread",
+                recorded_requests={},
+            )
+            is None
+        )
         assert stats.request_count == 0
 
 

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -3548,6 +3548,79 @@ class TestSessionCostEvents:
         assert updates[0] > 0
         assert turn_stats.per_kind["subagent"].request_count == 1
 
+    async def test_usage_already_counted_from_messages_is_not_added_twice(
+        self,
+    ) -> None:
+        """A nested request the message stream recorded stays a single charge.
+
+        The graph streams provisional usage for every nested call, including the
+        ones whose messages do reach this client. Both paths share one ledger, so
+        the second arrival must move neither the stats nor the displayed cost.
+        """
+        from langchain_core.messages import AIMessageChunk
+
+        async def mount_message(_: object) -> bool:
+            await asyncio.sleep(0)
+            return True
+
+        updates: list[float] = []
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+        adapter._on_provisional_cost = updates.append
+        usage = {
+            "input_tokens": 1_000,
+            "output_tokens": 100,
+            "total_tokens": 1_100,
+        }
+        chunks = [
+            (
+                ("tools:task",),
+                "messages",
+                (
+                    AIMessageChunk(content="", id="child-1", usage_metadata=usage),  # ty: ignore[invalid-argument-type]
+                    {},
+                ),
+            ),
+            (
+                ("tools:task",),
+                "custom",
+                {
+                    "type": "model_usage",
+                    "version": 1,
+                    "request_id": "child-1",
+                    "usage_metadata": usage,
+                    "model_name": "gpt-5.5",
+                    "provider": "openai",
+                    "thread_id": "thread-1",
+                    "scope": "tools:task",
+                },
+            ),
+            ((), "messages", (_text_message("Done."), {})),
+        ]
+        turn_stats = SessionStats()
+
+        with (
+            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.cost_tracking.estimate_cost", return_value=0.42),
+        ):
+            mock_settings.model_name = "gpt-5.5"
+            mock_settings.model_provider = "openai"
+            await execute_task_textual(
+                user_input="hello",
+                agent=_FakeAgent(chunks),
+                assistant_id="assistant",
+                session_state=_session_state(auto_approve=False),
+                adapter=adapter,
+                turn_stats=turn_stats,
+            )
+
+        assert updates == [pytest.approx(0.42)]
+        assert turn_stats.per_kind["subagent"].request_count == 1
+        assert turn_stats.total_cost_usd == pytest.approx(0.42)
+
     async def test_streamed_total_reaches_the_app(self) -> None:
         """A session-cost event is applied as the displayed lifetime total."""
 

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -3499,6 +3499,55 @@ class TestExecuteTaskTextualUsageStats:
 class TestSessionCostEvents:
     """The graph's absolute cost total drives the client display."""
 
+    async def test_nested_usage_updates_provisional_cost(self) -> None:
+        async def mount_message(_: object) -> bool:
+            await asyncio.sleep(0)
+            return True
+
+        updates: list[float] = []
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+        adapter._on_usage_update = lambda: None
+        adapter._on_provisional_cost = updates.append
+        chunks = [
+            (
+                ("tools:task",),
+                "custom",
+                {
+                    "type": "model_usage",
+                    "version": 1,
+                    "request_id": "child-1",
+                    "usage_metadata": {
+                        "input_tokens": 1_000,
+                        "output_tokens": 100,
+                        "total_tokens": 1_100,
+                    },
+                    "model_name": "gpt-5.5",
+                    "provider": "openai",
+                    "thread_id": "thread-1",
+                    "scope": "tools:task",
+                },
+            ),
+            ((), "messages", (_text_message("Done."), {})),
+        ]
+        turn_stats = SessionStats()
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=_FakeAgent(chunks),
+            assistant_id="assistant",
+            session_state=_session_state(auto_approve=False),
+            adapter=adapter,
+            turn_stats=turn_stats,
+        )
+
+        assert len(updates) == 1
+        assert updates[0] > 0
+        assert turn_stats.per_kind["subagent"].request_count == 1
+
     async def test_streamed_total_reaches_the_app(self) -> None:
         """A session-cost event is applied as the displayed lifetime total."""
 


### PR DESCRIPTION
Dynamic subagent model usage now appears in live dcode cost and usage statistics.

```mermaid
flowchart LR
  A[Dynamic subagent request] --> B[Session cost recorder]
  B -->|Versioned usage event| C[Live Textual and headless stats]
  B -->|Drain raw usage| D[Cost middleware]
  D -->|Checkpoint and authoritative total| C
```

Streams completed dynamic-subagent usage into existing provisional client accounting while preserving checkpointed graph cost as the durable authority. Events are minimized, thread-validated, deduplicated, and best-effort.

## References
- Plan: https://openswe.vercel.app/agents/4f3fc359-7153-5467-8164-33aa496b8a56/plan

Made by [Open SWE](https://openswe.vercel.app/agents/4f3fc359-7153-5467-8164-33aa496b8a56)