### PR TITLE
fix(code): flush traces before server shutdown

### DIFF
--- a/libs/code/deepagents_code/client/launch/server.py
+++ b/libs/code/deepagents_code/client/launch/server.py
@@ -55,13 +55,12 @@ _HEALTH_POLL_INTERVAL_REMOTE = 0.3
 
 _HEALTH_TIMEOUT = 60
 
-_SHUTDOWN_TIMEOUT = 3
+_SHUTDOWN_TIMEOUT = 5
 """Seconds to wait for a graceful exit before escalating to a hard kill.
 
-The server flushes buffered LangSmith traces inside this window, so
-`offload_api._TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE` must stay under it.
-Nothing imports across the two processes, so lowering this value would
-silently truncate that flush; `TestFlushBudget` asserts the inequality.
+The server spends up to two seconds flushing buffered LangSmith traces inside
+this window. The remaining margin lets LangGraph finish its own lifespan
+teardown before dcode escalates; `TestFlushBudget` guards that margin.
 """
 
 _SIGKILL_TIMEOUT = 2

--- a/libs/code/deepagents_code/client/launch/server.py
+++ b/libs/code/deepagents_code/client/launch/server.py
@@ -56,16 +56,33 @@ _HEALTH_POLL_INTERVAL_REMOTE = 0.3
 _HEALTH_TIMEOUT = 60
 
 _SHUTDOWN_TIMEOUT = 3
-"""Seconds to wait for a graceful SIGTERM exit before escalating to SIGKILL."""
+"""Seconds to wait for a graceful exit before escalating to a hard kill.
+
+The server flushes buffered LangSmith traces inside this window, so
+`offload_api._TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE` must stay under it.
+Nothing imports across the two processes, so lowering this value would
+silently truncate that flush; `TestFlushBudget` asserts the inequality.
+"""
 
 _SIGKILL_TIMEOUT = 2
 """Seconds to wait for the group/process to exit after SIGKILL."""
 
 _WINDOWS_CREATE_NEW_PROCESS_GROUP = 0x00000200
-"""Windows creation flag required for targeted console control signals."""
+"""Windows creation flag required for targeted console control signals.
+
+A literal because `subprocess.CREATE_NEW_PROCESS_GROUP` exists only on
+Windows. The flag also disables Ctrl+C handling for the new group, so
+`CTRL_C_EVENT` is inert against it and Ctrl+Break is the only graceful
+signal available.
+"""
 
 _WINDOWS_CTRL_BREAK_EVENT = 1
-"""Windows Ctrl+Break event handled as a graceful SIGBREAK by Uvicorn."""
+"""Windows Ctrl+Break event handled as a graceful SIGBREAK by Uvicorn.
+
+A literal because `signal.CTRL_BREAK_EVENT` exists only on Windows. The
+value is load-bearing: `subprocess.Popen.send_signal` dispatches on it
+exactly, and 0 would mean `CTRL_C_EVENT` instead.
+"""
 
 _PROCESS_GROUP_POLL_INTERVAL = 0.05
 
@@ -554,26 +571,38 @@ def _signal_windows_server(process: subprocess.Popen[Any]) -> None:
 def _terminate_server_process(process: subprocess.Popen[Any]) -> None:
     """Terminate the `langgraph dev` server and its descendants.
 
-    Sends SIGTERM, waits `_SHUTDOWN_TIMEOUT` for a graceful exit, then escalates
-    to SIGKILL. On POSIX the whole detached process group is signaled via
+    Signals the server for a graceful exit, waits `_SHUTDOWN_TIMEOUT`, then
+    escalates to a hard kill: SIGTERM then SIGKILL on POSIX, Ctrl+Break then
+    `TerminateProcess` on Windows.
+
+    On POSIX the whole detached process group is signaled via
     `os.killpg`, and teardown waits for the entire group to exit — not just the
     root — so a child that outlives the `langgraph dev` root is still escalated
     to SIGKILL rather than orphaned. On Windows, the server's console process
     group receives Ctrl+Break, which Uvicorn handles as a graceful SIGBREAK and
     runs the Starlette lifespan shutdown. If Ctrl+Break cannot be delivered,
     such as in a headless session without an attached console, the owned child
-    is terminated instead. If no dedicated group is available on POSIX, only
-    the root process is signaled. `_server_process_group` guarantees dcode's own
-    POSIX process group is never targeted.
+    is terminated instead. Note that the Windows escalation reaches only the
+    root handle, so a descendant that outlives it is orphaned; the POSIX group
+    path is the only one that escalates group-wide.
+
+    If no dedicated group is available on POSIX, only the root process is
+    signaled. `_server_process_group` guarantees dcode's own POSIX process
+    group is never targeted.
 
     Args:
         process: The running server subprocess to terminate.
     """
     pid = process.pid
     pgid = _server_process_group(pid)
-    scope = (
+    # Windows resolves no pgid, but Ctrl+Break still reaches the whole console
+    # group — while the escalation below only ever kills the root handle. The
+    # two scopes are tracked separately so neither log line overstates what
+    # actually happened.
+    signal_scope = (
         "process group" if pgid is not None or sys.platform == "win32" else "process"
     )
+    kill_scope = "process group" if pgid is not None else "process"
 
     logger.info("Stopping langgraph dev server (pid=%d)", pid)
     try:
@@ -592,30 +621,43 @@ def _terminate_server_process(process: subprocess.Popen[Any]) -> None:
             else:
                 stopped = True
     except ProcessLookupError:
-        # The server exited before the SIGTERM landed; nothing left to reap.
-        logger.debug("Server %s pid=%d already exited before SIGTERM", scope, pid)
+        # The server exited before the graceful signal landed; nothing to reap.
+        logger.debug(
+            "Server %s pid=%d already exited before the graceful signal",
+            signal_scope,
+            pid,
+        )
         return
     except OSError:
-        # SIGTERM could not be delivered (e.g. EPERM). We never reach the SIGKILL
-        # escalation, so the server is left running — report it with the same
-        # fidelity as a failed SIGKILL rather than a bare "error stopping".
+        # The graceful signal could not be delivered (e.g. EPERM). We never
+        # reach the hard-kill escalation, so the server is left running —
+        # report it with the same fidelity as a failed SIGKILL rather than a
+        # bare "error stopping".
         logger.exception(
-            "Failed to signal server %s pid=%d; it may be orphaned", scope, pid
+            "Failed to signal server %s pid=%d; it may be orphaned",
+            signal_scope,
+            pid,
         )
         return
 
     if stopped:
         return
 
-    logger.warning("Server did not stop gracefully, killing %s", scope)
+    logger.warning("Server did not stop gracefully, killing %s", kill_scope)
+    if sys.platform == "win32":
+        logger.warning(
+            "Windows escalation reaches only the server root; any surviving "
+            "`langgraph dev` descendant is left orphaned"
+        )
     # Guard escalation explicitly: `ProcessLookupError` means the group exited
-    # just before SIGKILL, while any other `OSError` means it may be orphaned.
+    # just before the hard kill, while any other `OSError` means it may be
+    # orphaned.
     try:
         if pgid is not None:
             os.killpg(pgid, signal.SIGKILL)
             if not _wait_for_process_group_exit(process, pgid, _SIGKILL_TIMEOUT):
                 logger.warning(
-                    "Server %s pid=%d did not exit after SIGKILL", scope, pid
+                    "Server %s pid=%d did not exit after the hard kill", kill_scope, pid
                 )
         else:
             process.kill()
@@ -623,14 +665,18 @@ def _terminate_server_process(process: subprocess.Popen[Any]) -> None:
                 process.wait(timeout=_SIGKILL_TIMEOUT)
             except subprocess.TimeoutExpired:
                 logger.warning(
-                    "Server %s pid=%d did not exit after SIGKILL", scope, pid
+                    "Server %s pid=%d did not exit after the hard kill", kill_scope, pid
                 )
     except ProcessLookupError:
-        logger.debug("Server %s pid=%d already exited before SIGKILL", scope, pid)
+        logger.debug(
+            "Server %s pid=%d already exited before the hard kill",
+            kill_scope,
+            pid,
+        )
     except OSError:
         logger.exception(
-            "Failed to SIGKILL server %s pid=%d; it may be orphaned",
-            scope,
+            "Hard kill failed for server %s pid=%d; it may be orphaned",
+            kill_scope,
             pid,
         )
 

--- a/libs/code/deepagents_code/client/launch/server.py
+++ b/libs/code/deepagents_code/client/launch/server.py
@@ -529,6 +529,28 @@ def _wait_for_process_group_exit(
         time.sleep(min(_PROCESS_GROUP_POLL_INTERVAL, remaining))
 
 
+def _signal_windows_server(process: subprocess.Popen[Any]) -> None:
+    """Request graceful Windows shutdown, terminating when no console exists.
+
+    Args:
+        process: The owned server process to signal.
+
+    Raises:
+        ProcessLookupError: The server exited before the signal landed.
+    """
+    try:
+        process.send_signal(_WINDOWS_CTRL_BREAK_EVENT)
+    except ProcessLookupError:
+        raise
+    except OSError:
+        logger.warning(
+            "Failed to send Ctrl+Break to server process pid=%d; "
+            "falling back to terminate",
+            process.pid,
+        )
+        process.terminate()
+
+
 def _terminate_server_process(process: subprocess.Popen[Any]) -> None:
     """Terminate the `langgraph dev` server and its descendants.
 
@@ -538,9 +560,11 @@ def _terminate_server_process(process: subprocess.Popen[Any]) -> None:
     root — so a child that outlives the `langgraph dev` root is still escalated
     to SIGKILL rather than orphaned. On Windows, the server's console process
     group receives Ctrl+Break, which Uvicorn handles as a graceful SIGBREAK and
-    runs the Starlette lifespan shutdown. If no dedicated group is available on
-    POSIX, only the root process is signaled. `_server_process_group` guarantees
-    dcode's own POSIX process group is never targeted.
+    runs the Starlette lifespan shutdown. If Ctrl+Break cannot be delivered,
+    such as in a headless session without an attached console, the owned child
+    is terminated instead. If no dedicated group is available on POSIX, only
+    the root process is signaled. `_server_process_group` guarantees dcode's own
+    POSIX process group is never targeted.
 
     Args:
         process: The running server subprocess to terminate.
@@ -557,10 +581,10 @@ def _terminate_server_process(process: subprocess.Popen[Any]) -> None:
             os.killpg(pgid, signal.SIGTERM)
             stopped = _wait_for_process_group_exit(process, pgid, _SHUTDOWN_TIMEOUT)
         else:
-            graceful_signal = (
-                _WINDOWS_CTRL_BREAK_EVENT if sys.platform == "win32" else signal.SIGTERM
-            )
-            process.send_signal(graceful_signal)
+            if sys.platform == "win32":
+                _signal_windows_server(process)
+            else:
+                process.send_signal(signal.SIGTERM)
             try:
                 process.wait(timeout=_SHUTDOWN_TIMEOUT)
             except subprocess.TimeoutExpired:

--- a/libs/code/deepagents_code/client/launch/server.py
+++ b/libs/code/deepagents_code/client/launch/server.py
@@ -61,6 +61,12 @@ _SHUTDOWN_TIMEOUT = 3
 _SIGKILL_TIMEOUT = 2
 """Seconds to wait for the group/process to exit after SIGKILL."""
 
+_WINDOWS_CREATE_NEW_PROCESS_GROUP = 0x00000200
+"""Windows creation flag required for targeted console control signals."""
+
+_WINDOWS_CTRL_BREAK_EVENT = 1
+"""Windows Ctrl+Break event handled as a graceful SIGBREAK by Uvicorn."""
+
 _PROCESS_GROUP_POLL_INTERVAL = 0.05
 
 _LOG_TAIL_CHARS = 3000
@@ -449,11 +455,11 @@ def _server_process_group(pid: int) -> int | None:
     the same shutdown signals as the root rather than being left running when
     only the root is signaled.
 
-    Returns `None` — meaning "signal only the root process" — on Windows (no
-    POSIX process groups) and whenever the server is not the leader of its own
-    dedicated group. As a defensive check, the `pgid == os.getpgid(0)` clause
-    also refuses to return dcode's own group, so the group handed back can never
-    be the one whose termination would take down the TUI.
+    Returns `None` on Windows (which uses a console process group instead) and
+    whenever the server is not the leader of its own dedicated POSIX group. As
+    a defensive check, the `pgid == os.getpgid(0)` clause also refuses to return
+    dcode's own group, so the group handed back can never be the one whose
+    termination would take down the TUI.
 
     Args:
         pid: Process id of the server subprocess.
@@ -530,16 +536,20 @@ def _terminate_server_process(process: subprocess.Popen[Any]) -> None:
     to SIGKILL. On POSIX the whole detached process group is signaled via
     `os.killpg`, and teardown waits for the entire group to exit — not just the
     root — so a child that outlives the `langgraph dev` root is still escalated
-    to SIGKILL rather than orphaned. On Windows (or if the server is not its own
-    group leader) only the root process is signaled. `_server_process_group`
-    guarantees dcode's own process group is never targeted.
+    to SIGKILL rather than orphaned. On Windows, the server's console process
+    group receives Ctrl+Break, which Uvicorn handles as a graceful SIGBREAK and
+    runs the Starlette lifespan shutdown. If no dedicated group is available on
+    POSIX, only the root process is signaled. `_server_process_group` guarantees
+    dcode's own POSIX process group is never targeted.
 
     Args:
         process: The running server subprocess to terminate.
     """
     pid = process.pid
     pgid = _server_process_group(pid)
-    scope = "process group" if pgid is not None else "process"
+    scope = (
+        "process group" if pgid is not None or sys.platform == "win32" else "process"
+    )
 
     logger.info("Stopping langgraph dev server (pid=%d)", pid)
     try:
@@ -547,7 +557,10 @@ def _terminate_server_process(process: subprocess.Popen[Any]) -> None:
             os.killpg(pgid, signal.SIGTERM)
             stopped = _wait_for_process_group_exit(process, pgid, _SHUTDOWN_TIMEOUT)
         else:
-            process.send_signal(signal.SIGTERM)
+            graceful_signal = (
+                _WINDOWS_CTRL_BREAK_EVENT if sys.platform == "win32" else signal.SIGTERM
+            )
+            process.send_signal(graceful_signal)
             try:
                 process.wait(timeout=_SHUTDOWN_TIMEOUT)
             except subprocess.TimeoutExpired:
@@ -896,6 +909,9 @@ class ServerProcess:
                 stdout=self._log_file,
                 stderr=subprocess.STDOUT,
                 start_new_session=(sys.platform != "win32"),
+                creationflags=(
+                    _WINDOWS_CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0
+                ),
             )
             return self._process
 

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-import time
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
@@ -35,10 +34,7 @@ from deepagents_code.offload_middleware import (
 from deepagents_code.server_graph import get_server_runtime
 
 if TYPE_CHECKING:
-    from collections.abc import Sized
-
     from langchain_core.runnables import RunnableConfig
-    from langsmith import Client
     from starlette.requests import Request
 
     from deepagents_code.cost_tracking import PreparedOperationCost
@@ -76,249 +72,68 @@ _operation_outcomes: OrderedDict[_OperationKey, _OperationOutcome] = OrderedDict
 _MAX_OPERATION_OUTCOMES = 1024
 """Bound completed/cancelled ids retained to close request/cancel races."""
 _TRACE_FLUSH_TIMEOUT = 2.0
-"""Seconds allowed for the shutdown trace flush.
-
-Worst case the flush holds `_TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE` of
-`client.launch.server._SHUTDOWN_TIMEOUT`, the SIGTERM grace period before dcode
-escalates to SIGKILL. It also runs before LangGraph's own teardown, so the
-budget left for the rest of shutdown is thin by design. Raising either constant
-makes shutdown strictly worse: the process is killed with the traces still
-queued. `TestFlushBudget` enforces the inequality, which no import can.
-"""
-_TRACE_FLUSH_GRACE = 0.5
-"""Extra seconds before the flush thread is abandoned.
-
-`Client.flush` honors its timeout for the tracing-queue drain and for the
-compressed-send wait. It does not honor it for `_flush_run_ops_buffer`, nor for
-the drain-and-submit prologue of `flush_compressed_traces` -- including a
-retrying inline send when the client thread pool is already shut down. The
-outer deadline is the hard ceiling for those unbounded segments.
-"""
-
-_MISSING = object()
-"""Sentinel separating "attribute absent" from a legitimate `None` value."""
+"""Seconds allowed for the shutdown trace flush."""
+_TRACE_FLUSH_POLL_INTERVAL = 0.05
+"""Seconds between completion checks while the daemon flush thread runs."""
 
 
-class _FlushDeadlineError(Exception):
-    """The shutdown flush thread outlived its hard deadline.
-
-    A private type rather than `TimeoutError`, which is an `OSError` subclass
-    that langsmith's inline retry raises on a socket timeout. Borrowing the
-    builtin would report a fast network failure as a slow deadline overrun.
-    """
-
-
-def _pending_trace_work(client: Client) -> int | None:
-    """Count trace work still unsent after a flush.
-
-    `Client.flush` returns silently when its deadline expires, so a truncated
-    flush is indistinguishable from a complete one unless the leftovers are
-    inspected directly.
-
-    Args:
-        client: The LangSmith client that was just flushed.
-
-    Returns:
-        The sum of queued run operations (`tracing_queue.unfinished_tasks`) and
-        in-flight send batches (`_futures`), or `None` when the client exposes
-        neither -- "cannot tell" rather than "nothing pending". Those are two
-        different units, so read the number as a signal that work was dropped
-        rather than as an exact batch count.
-    """
-    queue = getattr(client, "tracing_queue", _MISSING)
-    futures = getattr(client, "_futures", _MISSING)
-    if queue is _MISSING and futures is _MISSING:
-        # Returning 0 here would make the truncation warning a permanently
-        # silent no-op after a langsmith rename, which is the exact failure
-        # this function exists to report.
-        logger.warning(
-            "Cannot verify the LangSmith trace flush: the client exposes "
-            "neither `tracing_queue` nor `_futures`; a truncated flush will go "
-            "unreported until this is updated"
-        )
-        return None
-
-    pending = 0
-    if queue is not _MISSING and queue is not None:
-        pending += getattr(queue, "unfinished_tasks", 0)
-    if futures is not _MISSING and futures:
-        pending += len(cast("Sized", futures))
-    return pending
-
-
-def _describe_pending(client: Client) -> str:
-    """Render the unsent trace count for an operator-facing log line.
-
-    Args:
-        client: The LangSmith client that was just flushed.
-
-    Returns:
-        A noun phrase naming how much trace work is being dropped.
-    """
-    pending = _pending_trace_work(client)
-    if pending is None:
-        return "an unknown number of queued trace items"
-    return f"{pending} queued trace item(s)"
-
-
-async def _await_flush_thread(client: Client) -> float:
-    """Run `client.flush` on a daemon thread and wait, with a hard deadline.
-
-    `asyncio.to_thread` is unusable here. A timeout cancels only the awaitable,
-    not the default-executor thread running `flush`. And the `asyncio.run`
-    runner joins default-executor threads during loop shutdown, for up to five
-    minutes. A hung flush would therefore still delay process exit past the
-    SIGKILL escalation, which is the exact case the deadline exists for. The
-    daemon thread is never joined, so a wedged flush is simply left behind and
-    dies with the process.
-
-    The deadline is a plain `call_later` handle instead of `asyncio.wait_for`
-    for the same reason: cancellation does not stop the thread, so the future
-    is discarded rather than cancelled.
-
-    Args:
-        client: The LangSmith client to flush.
-
-    Returns:
-        Seconds spent waiting on the flush.
-
-    Raises:
-        _FlushDeadlineError: The flush did not finish within
-            `_TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE`.
-    """
-    loop = asyncio.get_running_loop()
-    done = loop.create_future()
-    dispatched = threading.Event()
-
-    def complete(error: Exception | None) -> None:
-        if done.done():
-            if error is not None:
-                # Log rather than drop. "The flush ran out of time" and "the
-                # flush failed on a rotated API key" call for opposite
-                # responses, and only one of them is already reported.
-                logger.warning(
-                    "LangSmith flush failed after the shutdown deadline: %r", error
-                )
-            return
-        if error is None:
-            done.set_result(False)
-        else:
-            done.set_exception(error)
-
-    def dispatch_completion(error: Exception | None) -> None:
-        try:
-            loop.call_soon_threadsafe(complete, error)
-        except RuntimeError:
-            if not loop.is_closed():
-                raise
-            # The deadline fired, the loop is gone, and the traces are already
-            # reported as dropped. This must never escape: an unhandled error
-            # in an unjoined thread prints a bare traceback into the server log
-            # that dcode tails on failure, which reads as a crash.
-            logger.debug("LangSmith flush finished after the shutdown deadline")
-
-    def flush() -> None:
-        outcome: Exception | None = None
-        try:
-            client.flush(timeout=_TRACE_FLUSH_TIMEOUT)
-        except Exception as exc:  # noqa: BLE001  # relayed to the waiter below
-            outcome = exc
-        except BaseException as exc:  # noqa: BLE001  # see comment below
-            # A `SystemExit`, or a `KeyboardInterrupt` delivered to this
-            # thread, would otherwise leave the waiter with no outcome at all.
-            # Re-raising it past the lifespan would replace whatever error was
-            # already propagating, so relay it as a plain `Exception`.
-            outcome = RuntimeError(f"LangSmith flush raised {exc!r}")
-        finally:
-            dispatch_completion(outcome)
-            # Announce only after the completion is queued, so the `call_soon`
-            # in `give_up` lands behind it. A result already in flight is then
-            # never misreported as a deadline overrun.
-            dispatched.set()
-
-    def resolve_deadline() -> None:
-        if not done.done():
-            done.set_result(True)
-
-    def give_up() -> None:
-        # Resolve rather than raise so the deadline surfaces at the `await` in
-        # the coroutine body; cancellation alone could not stop the thread
-        # anyway. The deadline is unconditional -- an unreachable deadline is
-        # the one failure this whole design exists to prevent -- so the retry
-        # below happens at most once.
-        if done.done():
-            return
-        if dispatched.is_set():
-            # The thread's completion is already queued ahead of this
-            # callback. Give it one loop turn to land.
-            loop.call_soon(resolve_deadline)
-            return
-        done.set_result(True)
-
-    thread = threading.Thread(
-        target=flush, daemon=True, name="langsmith-shutdown-flush"
-    )
-    timer = loop.call_later(_TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE, give_up)
-    started = time.monotonic()
+def _run_trace_flush(done: threading.Event, failures: list[BaseException]) -> None:
+    """Flush existing LangSmith tracers and record completion for the event loop."""
     try:
-        thread.start()
-        if await done:
-            raise _FlushDeadlineError
+        from langchain_core.tracers.langchain import wait_for_all_tracers
+
+        wait_for_all_tracers()
+    except BaseException as exc:  # noqa: BLE001  # telemetry cannot break shutdown
+        failures.append(exc)
     finally:
-        timer.cancel()
-    return time.monotonic() - started
+        done.set()
 
 
 async def _flush_traces() -> None:
     """Flush the child process's existing LangSmith tracing client.
 
-    Reads `run_trees._CLIENT` directly rather than calling the public
-    `get_cached_client()`, which would *construct* a client when tracing is
-    off. `langchain_core.tracers.langchain.wait_for_all_tracers` reads the
-    same private global for the same reason; it is unusable here only because
-    it accepts no timeout, and an unbounded flush would outlive the SIGTERM
-    grace period.
-
-    This is best effort: every failure is logged and swallowed so a telemetry
-    problem can never turn into a failed shutdown.
+    `wait_for_all_tracers` does not construct a client when tracing is off. It
+    has no timeout, so it runs on an unjoined daemon thread and this coroutine
+    abandons the wait at `_TRACE_FLUSH_TIMEOUT`. Polling a `threading.Event`
+    avoids scheduling a late completion onto an event loop that may be closed.
 
     This runs before LangGraph's own lifespan teardown, because an
     `AsyncExitStack` unwinds last-entered first. Traces emitted while the
     runtime cancels in-flight runs are therefore still lost. Covering those
     would need a second flush after the runtime is down.
     """
+    done = threading.Event()
+    failures: list[BaseException] = []
+    thread = threading.Thread(
+        target=_run_trace_flush,
+        args=(done, failures),
+        daemon=True,
+        name="langsmith-shutdown-flush",
+    )
     try:
-        from langsmith import run_trees
-
-        client = getattr(run_trees, "_CLIENT", None)
-        if client is None:
-            logger.debug("No LangSmith client to flush during shutdown")
-            return
-
-        try:
-            elapsed = await _await_flush_thread(client)
-        except _FlushDeadlineError:
-            logger.warning(
-                "LangSmith trace flush exceeded %.1fs; dropping %s",
-                _TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE,
-                _describe_pending(client),
-            )
-            return
-
-        if pending := _pending_trace_work(client):
-            logger.warning(
-                "LangSmith trace flush incomplete after %.1fs; "
-                "dropping %d queued trace item(s)",
-                elapsed,
-                pending,
-            )
+        thread.start()
     except Exception:
-        # Broad by design: this runs in a `finally` during shutdown, so an
-        # escaping error would replace whatever was already propagating.
-        # `exception` (not `warning`) so a broken langsmith integration --
-        # a renamed `_CLIENT`, a dropped `timeout` kwarg -- is loud rather
-        # than a silently permanent no-op.
-        logger.exception("Failed to flush LangSmith traces during shutdown")
+        logger.exception("Failed to start the LangSmith shutdown flush")
+        return
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _TRACE_FLUSH_TIMEOUT
+    while not done.is_set():
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            logger.warning(
+                "LangSmith trace flush exceeded %.1fs; some traces may be lost",
+                _TRACE_FLUSH_TIMEOUT,
+            )
+            return
+        await asyncio.sleep(min(_TRACE_FLUSH_POLL_INTERVAL, remaining))
+
+    if failures:
+        failure = failures[0]
+        logger.error(
+            "Failed to flush LangSmith traces during shutdown",
+            exc_info=(type(failure), failure, failure.__traceback__),
+        )
 
 
 @asynccontextmanager

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -34,6 +34,7 @@ from deepagents_code.server_graph import get_server_runtime
 
 if TYPE_CHECKING:
     from langchain_core.runnables import RunnableConfig
+    from langsmith import Client
     from starlette.requests import Request
 
     from deepagents_code.cost_tracking import PreparedOperationCost
@@ -71,25 +72,108 @@ _operation_outcomes: OrderedDict[_OperationKey, _OperationOutcome] = OrderedDict
 _MAX_OPERATION_OUTCOMES = 1024
 """Bound completed/cancelled ids retained to close request/cancel races."""
 _TRACE_FLUSH_TIMEOUT = 2.0
+"""Seconds allowed for the shutdown trace flush.
+
+Held below `client.launch.server._SHUTDOWN_TIMEOUT` (3s), the SIGTERM grace
+period before dcode escalates to SIGKILL, so the flush completes inside the
+window instead of being killed mid-send. Raising this past that budget makes
+shutdown strictly worse: the process is killed with the traces still queued.
+"""
+_TRACE_FLUSH_GRACE = 0.5
+"""Extra seconds before the flush thread is abandoned.
+
+`Client.flush` bounds only the wait on already-submitted sends; its
+synchronous drain and submit steps -- including a retrying inline send when
+the client thread pool is already shut down -- ignore the timeout. The outer
+`asyncio.wait_for` supplies the hard ceiling that `flush` itself does not.
+"""
+
+
+def _pending_trace_batches(client: Client) -> int:
+    """Count trace batches still unsent after a flush.
+
+    `Client.flush` returns silently when its deadline expires, so a truncated
+    flush is indistinguishable from a complete one unless the leftovers are
+    inspected directly.
+
+    Args:
+        client: The LangSmith client that was just flushed.
+
+    Returns:
+        Number of queued or in-flight batches, or 0 if the client does not
+        expose the internals this reads.
+    """
+    queue = getattr(client, "tracing_queue", None)
+    pending = getattr(queue, "unfinished_tasks", 0) if queue is not None else 0
+    return pending + len(getattr(client, "_futures", None) or ())
 
 
 async def _flush_traces() -> None:
-    """Flush the child process's existing LangSmith tracing client."""
-    from langsmith import run_trees
+    """Flush the child process's existing LangSmith tracing client.
 
-    client = run_trees._CLIENT
-    if client is None:
-        return
+    Reads `run_trees._CLIENT` directly rather than calling the public
+    `get_cached_client()`, which would *construct* a client when tracing is
+    off. `langchain_core.tracers.langchain.wait_for_all_tracers` reads the
+    same private global for the same reason; it is unusable here only because
+    it accepts no timeout, and an unbounded flush would outlive the SIGTERM
+    grace period.
+
+    Best effort by contract: every failure is logged and swallowed so a
+    telemetry problem can never turn into a failed shutdown.
+
+    Note that this runs before LangGraph's own lifespan teardown (an
+    `AsyncExitStack` unwinds last-entered first), so traces emitted while the
+    runtime cancels in-flight runs are still lost. Covering those would need a
+    second flush after the runtime is down.
+    """
     try:
-        await asyncio.to_thread(client.flush, timeout=_TRACE_FLUSH_TIMEOUT)
-    except Exception:
-        logger.warning(
-            "Failed to flush LangSmith traces during shutdown", exc_info=True
+        from langsmith import run_trees
+
+        client = getattr(run_trees, "_CLIENT", None)
+        if client is None:
+            logger.debug("No LangSmith client to flush during shutdown")
+            return
+
+        await asyncio.wait_for(
+            asyncio.to_thread(client.flush, timeout=_TRACE_FLUSH_TIMEOUT),
+            timeout=_TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE,
         )
+
+        if pending := _pending_trace_batches(client):
+            logger.warning(
+                "LangSmith trace flush incomplete after %.1fs; dropping %d batch(es)",
+                _TRACE_FLUSH_TIMEOUT,
+                pending,
+            )
+    except TimeoutError:
+        logger.warning(
+            "LangSmith trace flush exceeded %.1fs; dropping queued traces",
+            _TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE,
+        )
+    except Exception:
+        # Broad by design: this runs in a `finally` during shutdown, so an
+        # escaping error would replace whatever was already propagating.
+        # `exception` (not `warning`) so a broken langsmith integration --
+        # a renamed `_CLIENT`, a dropped `timeout` kwarg -- is loud rather
+        # than a silently permanent no-op.
+        logger.exception("Failed to flush LangSmith traces during shutdown")
 
 
 @asynccontextmanager
 async def _lifespan(_app: Starlette) -> AsyncIterator[None]:
+    """Flush buffered traces once the server stops serving.
+
+    `Client` registers an `atexit` handler that only closes its session, never
+    flushes, so without this hook anything still queued when dcode signals the
+    server is lost. The flush is in a `finally` so it also runs when the app
+    body raises -- the crash case where the buffered traces matter most.
+
+    Args:
+        _app: The Starlette app, required by the lifespan protocol.
+
+    Yields:
+        Control for the lifetime of the application.
+    """
     try:
         yield
     finally:

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Literal, cast
 from weakref import WeakValueDictionary
 
@@ -69,6 +70,31 @@ _active_operations: dict[_OperationKey, asyncio.Task[object]] = {}
 _operation_outcomes: OrderedDict[_OperationKey, _OperationOutcome] = OrderedDict()
 _MAX_OPERATION_OUTCOMES = 1024
 """Bound completed/cancelled ids retained to close request/cancel races."""
+_TRACE_FLUSH_TIMEOUT = 2.0
+
+
+async def _flush_traces() -> None:
+    """Flush the child process's existing LangSmith tracing client."""
+    from langsmith import run_trees
+
+    client = run_trees._CLIENT
+    if client is None:
+        return
+    try:
+        await asyncio.to_thread(client.flush, timeout=_TRACE_FLUSH_TIMEOUT)
+    except Exception:
+        logger.warning(
+            "Failed to flush LangSmith traces during shutdown", exc_info=True
+        )
+
+
+@asynccontextmanager
+async def _lifespan(_app: Starlette) -> AsyncIterator[None]:
+    try:
+        yield
+    finally:
+        await _flush_traces()
+
 
 # One client for the process. `get_client` builds a fresh `httpx.AsyncClient`
 # (with its own connection pool) per call and exposes no close hook we own, so
@@ -917,6 +943,7 @@ async def cancel_offload(request: Request) -> JSONResponse:
 
 
 app = Starlette(
+    lifespan=_lifespan,
     routes=[
         Route(
             "/dcode/threads/{thread_id:str}/offload",
@@ -928,5 +955,5 @@ app = Starlette(
             cancel_offload,
             methods=["POST"],
         ),
-    ]
+    ],
 )

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -135,14 +135,28 @@ async def _await_flush_thread(client: Client) -> None:
     done = loop.create_future()
     event = threading.Event()
 
+    def complete(error: Exception | None = None) -> None:
+        if done.done():
+            return
+        if error is None:
+            done.set_result(False)
+        else:
+            done.set_exception(error)
+
+    def dispatch_completion(error: Exception | None = None) -> None:
+        try:
+            loop.call_soon_threadsafe(complete, error)
+        except RuntimeError:
+            if not loop.is_closed():
+                raise
+
     def flush() -> None:
         try:
             client.flush(timeout=_TRACE_FLUSH_TIMEOUT)
         except Exception as exc:  # noqa: BLE001  # relayed to the waiter below
-            if not done.done():
-                loop.call_soon_threadsafe(done.set_exception, exc)
+            dispatch_completion(exc)
         else:
-            loop.call_soon_threadsafe(done.set_result, False)
+            dispatch_completion()
         finally:
             event.set()
 

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
@@ -85,7 +86,7 @@ _TRACE_FLUSH_GRACE = 0.5
 `Client.flush` bounds only the wait on already-submitted sends; its
 synchronous drain and submit steps -- including a retrying inline send when
 the client thread pool is already shut down -- ignore the timeout. The outer
-`asyncio.wait_for` supplies the hard ceiling that `flush` itself does not.
+deadline supplies the hard ceiling that `flush` itself does not.
 """
 
 
@@ -106,6 +107,62 @@ def _pending_trace_batches(client: Client) -> int:
     queue = getattr(client, "tracing_queue", None)
     pending = getattr(queue, "unfinished_tasks", 0) if queue is not None else 0
     return pending + len(getattr(client, "_futures", None) or ())
+
+
+async def _await_flush_thread(client: Client) -> None:
+    """Run `client.flush` on a daemon thread and wait, with a hard deadline.
+
+    `asyncio.to_thread` is unusable here: a timeout cancels only the
+    awaitable, not the default-executor thread running `flush`, and the
+    `asyncio.run` runner joins default-executor threads during loop shutdown
+    (up to five minutes). A hung flush would therefore still delay process
+    exit past the SIGKILL escalation, which is the exact case the deadline
+    exists for. The daemon thread is never joined, so a wedged flush is
+    simply left behind and dies with the process.
+
+    The deadline is a plain `call_later` handle instead of `asyncio.wait_for`
+    for the same reason: cancellation does not stop the thread, so the future
+    is discarded rather than cancelled.
+
+    Args:
+        client: The LangSmith client to flush.
+
+    Raises:
+        TimeoutError: The flush did not finish within
+            `_TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE`.
+    """
+    loop = asyncio.get_running_loop()
+    done = loop.create_future()
+    event = threading.Event()
+
+    def flush() -> None:
+        try:
+            client.flush(timeout=_TRACE_FLUSH_TIMEOUT)
+        except Exception as exc:  # noqa: BLE001  # relayed to the waiter below
+            if not done.done():
+                loop.call_soon_threadsafe(done.set_exception, exc)
+        else:
+            loop.call_soon_threadsafe(done.set_result, False)
+        finally:
+            event.set()
+
+    def give_up() -> None:
+        # Resolve rather than raise so the `TimeoutError` surfaces at the
+        # `await` in the coroutine body; cancellation alone could not stop
+        # the thread anyway.
+        if not event.is_set() and not done.done():
+            done.set_result(True)
+
+    thread = threading.Thread(
+        target=flush, daemon=True, name="langsmith-shutdown-flush"
+    )
+    timer = loop.call_later(_TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE, give_up)
+    try:
+        thread.start()
+        if await done:
+            raise TimeoutError
+    finally:
+        timer.cancel()
 
 
 async def _flush_traces() -> None:
@@ -134,10 +191,7 @@ async def _flush_traces() -> None:
             logger.debug("No LangSmith client to flush during shutdown")
             return
 
-        await asyncio.wait_for(
-            asyncio.to_thread(client.flush, timeout=_TRACE_FLUSH_TIMEOUT),
-            timeout=_TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE,
-        )
+        await _await_flush_thread(client)
 
         if pending := _pending_trace_batches(client):
             logger.warning(

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+import time
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
@@ -34,6 +35,8 @@ from deepagents_code.offload_middleware import (
 from deepagents_code.server_graph import get_server_runtime
 
 if TYPE_CHECKING:
+    from collections.abc import Sized
+
     from langchain_core.runnables import RunnableConfig
     from langsmith import Client
     from starlette.requests import Request
@@ -75,23 +78,38 @@ _MAX_OPERATION_OUTCOMES = 1024
 _TRACE_FLUSH_TIMEOUT = 2.0
 """Seconds allowed for the shutdown trace flush.
 
-Held below `client.launch.server._SHUTDOWN_TIMEOUT` (3s), the SIGTERM grace
-period before dcode escalates to SIGKILL, so the flush completes inside the
-window instead of being killed mid-send. Raising this past that budget makes
-shutdown strictly worse: the process is killed with the traces still queued.
+Worst case the flush holds `_TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE` of
+`client.launch.server._SHUTDOWN_TIMEOUT`, the SIGTERM grace period before dcode
+escalates to SIGKILL. It also runs before LangGraph's own teardown, so the
+budget left for the rest of shutdown is thin by design. Raising either constant
+makes shutdown strictly worse: the process is killed with the traces still
+queued. `TestFlushBudget` enforces the inequality, which no import can.
 """
 _TRACE_FLUSH_GRACE = 0.5
 """Extra seconds before the flush thread is abandoned.
 
-`Client.flush` bounds only the wait on already-submitted sends; its
-synchronous drain and submit steps -- including a retrying inline send when
-the client thread pool is already shut down -- ignore the timeout. The outer
-deadline supplies the hard ceiling that `flush` itself does not.
+`Client.flush` honors its timeout for the tracing-queue drain and for the
+compressed-send wait. It does not honor it for `_flush_run_ops_buffer`, nor for
+the drain-and-submit prologue of `flush_compressed_traces` -- including a
+retrying inline send when the client thread pool is already shut down. The
+outer deadline is the hard ceiling for those unbounded segments.
 """
 
+_MISSING = object()
+"""Sentinel separating "attribute absent" from a legitimate `None` value."""
 
-def _pending_trace_batches(client: Client) -> int:
-    """Count trace batches still unsent after a flush.
+
+class _FlushDeadlineError(Exception):
+    """The shutdown flush thread outlived its hard deadline.
+
+    A private type rather than `TimeoutError`, which is an `OSError` subclass
+    that langsmith's inline retry raises on a socket timeout. Borrowing the
+    builtin would report a fast network failure as a slow deadline overrun.
+    """
+
+
+def _pending_trace_work(client: Client) -> int | None:
+    """Count trace work still unsent after a flush.
 
     `Client.flush` returns silently when its deadline expires, so a truncated
     flush is indistinguishable from a complete one unless the leftovers are
@@ -101,24 +119,58 @@ def _pending_trace_batches(client: Client) -> int:
         client: The LangSmith client that was just flushed.
 
     Returns:
-        Number of queued or in-flight batches, or 0 if the client does not
-        expose the internals this reads.
+        The sum of queued run operations (`tracing_queue.unfinished_tasks`) and
+        in-flight send batches (`_futures`), or `None` when the client exposes
+        neither -- "cannot tell" rather than "nothing pending". Those are two
+        different units, so read the number as a signal that work was dropped
+        rather than as an exact batch count.
     """
-    queue = getattr(client, "tracing_queue", None)
-    pending = getattr(queue, "unfinished_tasks", 0) if queue is not None else 0
-    return pending + len(getattr(client, "_futures", None) or ())
+    queue = getattr(client, "tracing_queue", _MISSING)
+    futures = getattr(client, "_futures", _MISSING)
+    if queue is _MISSING and futures is _MISSING:
+        # Returning 0 here would make the truncation warning a permanently
+        # silent no-op after a langsmith rename, which is the exact failure
+        # this function exists to report.
+        logger.warning(
+            "Cannot verify the LangSmith trace flush: the client exposes "
+            "neither `tracing_queue` nor `_futures`; a truncated flush will go "
+            "unreported until this is updated"
+        )
+        return None
+
+    pending = 0
+    if queue is not _MISSING and queue is not None:
+        pending += getattr(queue, "unfinished_tasks", 0)
+    if futures is not _MISSING and futures:
+        pending += len(cast("Sized", futures))
+    return pending
 
 
-async def _await_flush_thread(client: Client) -> None:
+def _describe_pending(client: Client) -> str:
+    """Render the unsent trace count for an operator-facing log line.
+
+    Args:
+        client: The LangSmith client that was just flushed.
+
+    Returns:
+        A noun phrase naming how much trace work is being dropped.
+    """
+    pending = _pending_trace_work(client)
+    if pending is None:
+        return "an unknown number of queued trace items"
+    return f"{pending} queued trace item(s)"
+
+
+async def _await_flush_thread(client: Client) -> float:
     """Run `client.flush` on a daemon thread and wait, with a hard deadline.
 
-    `asyncio.to_thread` is unusable here: a timeout cancels only the
-    awaitable, not the default-executor thread running `flush`, and the
-    `asyncio.run` runner joins default-executor threads during loop shutdown
-    (up to five minutes). A hung flush would therefore still delay process
-    exit past the SIGKILL escalation, which is the exact case the deadline
-    exists for. The daemon thread is never joined, so a wedged flush is
-    simply left behind and dies with the process.
+    `asyncio.to_thread` is unusable here. A timeout cancels only the awaitable,
+    not the default-executor thread running `flush`. And the `asyncio.run`
+    runner joins default-executor threads during loop shutdown, for up to five
+    minutes. A hung flush would therefore still delay process exit past the
+    SIGKILL escalation, which is the exact case the deadline exists for. The
+    daemon thread is never joined, so a wedged flush is simply left behind and
+    dies with the process.
 
     The deadline is a plain `call_later` handle instead of `asyncio.wait_for`
     for the same reason: cancellation does not stop the thread, so the future
@@ -127,56 +179,94 @@ async def _await_flush_thread(client: Client) -> None:
     Args:
         client: The LangSmith client to flush.
 
+    Returns:
+        Seconds spent waiting on the flush.
+
     Raises:
-        TimeoutError: The flush did not finish within
+        _FlushDeadlineError: The flush did not finish within
             `_TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE`.
     """
     loop = asyncio.get_running_loop()
     done = loop.create_future()
-    event = threading.Event()
+    dispatched = threading.Event()
 
-    def complete(error: Exception | None = None) -> None:
+    def complete(error: Exception | None) -> None:
         if done.done():
+            if error is not None:
+                # Log rather than drop. "The flush ran out of time" and "the
+                # flush failed on a rotated API key" call for opposite
+                # responses, and only one of them is already reported.
+                logger.warning(
+                    "LangSmith flush failed after the shutdown deadline: %r", error
+                )
             return
         if error is None:
             done.set_result(False)
         else:
             done.set_exception(error)
 
-    def dispatch_completion(error: Exception | None = None) -> None:
+    def dispatch_completion(error: Exception | None) -> None:
         try:
             loop.call_soon_threadsafe(complete, error)
         except RuntimeError:
             if not loop.is_closed():
                 raise
+            # The deadline fired, the loop is gone, and the traces are already
+            # reported as dropped. This must never escape: an unhandled error
+            # in an unjoined thread prints a bare traceback into the server log
+            # that dcode tails on failure, which reads as a crash.
+            logger.debug("LangSmith flush finished after the shutdown deadline")
 
     def flush() -> None:
+        outcome: Exception | None = None
         try:
             client.flush(timeout=_TRACE_FLUSH_TIMEOUT)
         except Exception as exc:  # noqa: BLE001  # relayed to the waiter below
-            dispatch_completion(exc)
-        else:
-            dispatch_completion()
+            outcome = exc
+        except BaseException as exc:  # noqa: BLE001  # see comment below
+            # A `SystemExit`, or a `KeyboardInterrupt` delivered to this
+            # thread, would otherwise leave the waiter with no outcome at all.
+            # Re-raising it past the lifespan would replace whatever error was
+            # already propagating, so relay it as a plain `Exception`.
+            outcome = RuntimeError(f"LangSmith flush raised {exc!r}")
         finally:
-            event.set()
+            dispatch_completion(outcome)
+            # Announce only after the completion is queued, so the `call_soon`
+            # in `give_up` lands behind it. A result already in flight is then
+            # never misreported as a deadline overrun.
+            dispatched.set()
+
+    def resolve_deadline() -> None:
+        if not done.done():
+            done.set_result(True)
 
     def give_up() -> None:
-        # Resolve rather than raise so the `TimeoutError` surfaces at the
-        # `await` in the coroutine body; cancellation alone could not stop
-        # the thread anyway.
-        if not event.is_set() and not done.done():
-            done.set_result(True)
+        # Resolve rather than raise so the deadline surfaces at the `await` in
+        # the coroutine body; cancellation alone could not stop the thread
+        # anyway. The deadline is unconditional -- an unreachable deadline is
+        # the one failure this whole design exists to prevent -- so the retry
+        # below happens at most once.
+        if done.done():
+            return
+        if dispatched.is_set():
+            # The thread's completion is already queued ahead of this
+            # callback. Give it one loop turn to land.
+            loop.call_soon(resolve_deadline)
+            return
+        done.set_result(True)
 
     thread = threading.Thread(
         target=flush, daemon=True, name="langsmith-shutdown-flush"
     )
     timer = loop.call_later(_TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE, give_up)
+    started = time.monotonic()
     try:
         thread.start()
         if await done:
-            raise TimeoutError
+            raise _FlushDeadlineError
     finally:
         timer.cancel()
+    return time.monotonic() - started
 
 
 async def _flush_traces() -> None:
@@ -189,13 +279,13 @@ async def _flush_traces() -> None:
     it accepts no timeout, and an unbounded flush would outlive the SIGTERM
     grace period.
 
-    Best effort by contract: every failure is logged and swallowed so a
-    telemetry problem can never turn into a failed shutdown.
+    This is best effort: every failure is logged and swallowed so a telemetry
+    problem can never turn into a failed shutdown.
 
-    Note that this runs before LangGraph's own lifespan teardown (an
-    `AsyncExitStack` unwinds last-entered first), so traces emitted while the
-    runtime cancels in-flight runs are still lost. Covering those would need a
-    second flush after the runtime is down.
+    This runs before LangGraph's own lifespan teardown, because an
+    `AsyncExitStack` unwinds last-entered first. Traces emitted while the
+    runtime cancels in-flight runs are therefore still lost. Covering those
+    would need a second flush after the runtime is down.
     """
     try:
         from langsmith import run_trees
@@ -205,19 +295,23 @@ async def _flush_traces() -> None:
             logger.debug("No LangSmith client to flush during shutdown")
             return
 
-        await _await_flush_thread(client)
-
-        if pending := _pending_trace_batches(client):
+        try:
+            elapsed = await _await_flush_thread(client)
+        except _FlushDeadlineError:
             logger.warning(
-                "LangSmith trace flush incomplete after %.1fs; dropping %d batch(es)",
-                _TRACE_FLUSH_TIMEOUT,
+                "LangSmith trace flush exceeded %.1fs; dropping %s",
+                _TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE,
+                _describe_pending(client),
+            )
+            return
+
+        if pending := _pending_trace_work(client):
+            logger.warning(
+                "LangSmith trace flush incomplete after %.1fs; "
+                "dropping %d queued trace item(s)",
+                elapsed,
                 pending,
             )
-    except TimeoutError:
-        logger.warning(
-            "LangSmith trace flush exceeded %.1fs; dropping queued traces",
-            _TRACE_FLUSH_TIMEOUT + _TRACE_FLUSH_GRACE,
-        )
     except Exception:
         # Broad by design: this runs in a `finally` during shutdown, so an
         # escaping error would replace whatever was already propagating.

--- a/libs/code/tests/integration_tests/test_offload_server_side.py
+++ b/libs/code/tests/integration_tests/test_offload_server_side.py
@@ -10,6 +10,7 @@ and prove the archive is readable *through the agent*.
 
 from __future__ import annotations
 
+import json
 import re
 import uuid
 from typing import TYPE_CHECKING
@@ -638,6 +639,92 @@ async def test_offload_route_respects_configured_auth(
                 malformed.text,
             )
             assert "context.model" in malformed.text
+    finally:
+        if server is not None:
+            server.stop()
+        model_config.clear_caches()
+
+
+_TEST_FLUSH_APP = """
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from langsmith import run_trees
+
+from deepagents_code.offload_api import app
+
+
+class _MarkerClient:
+    def flush(self) -> None:
+        Path(os.environ["ITEST_TRACE_FLUSH_MARKER"]).write_text("flushed")
+
+
+_original_lifespan = app.router.lifespan_context
+
+
+@asynccontextmanager
+async def _marker_lifespan(starlette_app):
+    previous = getattr(run_trees, "_CLIENT", None)
+    run_trees._CLIENT = _MarkerClient()
+    try:
+        async with _original_lifespan(starlette_app):
+            yield
+    finally:
+        run_trees._CLIENT = previous
+
+
+app.router.lifespan_context = _marker_lifespan
+"""
+
+
+@pytest.mark.timeout(60)
+async def test_server_shutdown_flushes_existing_tracers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real `langgraph dev` shutdown runs the custom app's flush lifespan."""
+    home_dir = tmp_path / "home"
+    project_dir = tmp_path / "project"
+    work_dir = tmp_path / "server_work"
+    marker = tmp_path / "trace-flushed"
+    home_dir.mkdir()
+    project_dir.mkdir()
+    work_dir.mkdir()
+
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("DEEPAGENTS_CODE_NO_UPDATE_CHECK", "1")
+    monkeypatch.setenv("LANGSMITH_TRACING", "false")
+    monkeypatch.setenv("LANGCHAIN_TRACING_V2", "false")
+    monkeypatch.setenv("ITEST_TRACE_FLUSH_MARKER", str(marker))
+    monkeypatch.chdir(project_dir)
+    _write_model_config(home_dir)
+
+    from deepagents_code import model_config
+    from deepagents_code.client.launch.server import (
+        ServerProcess,
+        generate_langgraph_json,
+    )
+    from deepagents_code.config import create_model
+
+    config_path = home_dir / ".deepagents" / "config.toml"
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_DIR", config_path.parent)
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+
+    model_config.clear_caches()
+    server: ServerProcess | None = None
+    try:
+        create_model("itest:fake").apply_to_settings()
+        (work_dir / "itest_flush_app.py").write_text(_TEST_FLUSH_APP)
+        generated = generate_langgraph_json(work_dir)
+        config = json.loads(generated.read_text())
+        config["http"]["app"] = "./itest_flush_app.py:app"
+        generated.write_text(json.dumps(config, indent=2))
+
+        server = ServerProcess(config_dir=work_dir, scaffold=None)
+        await server.start()
+        server.stop()
+
+        assert marker.read_text() == "flushed"
     finally:
         if server is not None:
             server.stop()

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import threading
+import time
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1348,19 +1350,82 @@ def test_validated_context_fields_exist_on_the_schema() -> None:
 
 
 class TestLifespan:
+    """Shutdown flushes buffered LangSmith traces.
+
+    `langsmith.Client` only closes its session at exit and never flushes, so
+    without the lifespan hook anything still queued when dcode signals the
+    server is dropped.
+    """
+
+    @staticmethod
+    def _client() -> MagicMock:
+        """Build a flushed-clean client that rejects calls the real one rejects.
+
+        `spec` matters: a bare `MagicMock` accepts any keyword, so the suite
+        would keep passing after langsmith drops the `timeout` parameter --
+        the exact break that would silently disable this flush.
+        """
+        from langsmith import Client
+
+        client = MagicMock(spec=Client)
+        client.tracing_queue = None
+        client._futures = None
+        return client
+
     async def test_flushes_existing_tracing_client(self) -> None:
+        """The flush happens on shutdown, not on startup."""
         from langsmith import run_trees
 
         from deepagents_code import offload_api
 
-        client = MagicMock()
+        client = self._client()
+        with patch.object(run_trees, "_CLIENT", client):
+            async with offload_api.app.router.lifespan_context(offload_api.app):
+                client.flush.assert_not_called()
+
+        client.flush.assert_called_once_with(timeout=offload_api._TRACE_FLUSH_TIMEOUT)
+
+    async def test_flushes_when_the_app_body_raises(self) -> None:
+        """A crashing app still flushes -- that is what the `finally` buys."""
+        from langsmith import run_trees
+
+        from deepagents_code import offload_api
+
+        client = self._client()
+        boom = RuntimeError("app exploded")
+
+        async def run_and_raise() -> None:
+            async with offload_api.app.router.lifespan_context(offload_api.app):
+                raise boom
+
+        with (
+            patch.object(run_trees, "_CLIENT", client),
+            pytest.raises(RuntimeError, match="app exploded"),
+        ):
+            await run_and_raise()
+
+        client.flush.assert_called_once()
+
+    async def test_flushes_off_the_event_loop(self) -> None:
+        """The blocking flush runs in a thread so shutdown stays responsive."""
+        from langsmith import run_trees
+
+        from deepagents_code import offload_api
+
+        flush_thread: list[int] = []
+        client = self._client()
+        client.flush.side_effect = lambda **_: flush_thread.append(
+            threading.get_ident()
+        )
         with patch.object(run_trees, "_CLIENT", client):
             async with offload_api.app.router.lifespan_context(offload_api.app):
                 pass
 
-        client.flush.assert_called_once_with(timeout=offload_api._TRACE_FLUSH_TIMEOUT)
+        assert flush_thread == [flush_thread[0]]
+        assert flush_thread[0] != threading.get_ident()
 
     async def test_does_not_create_tracing_client(self) -> None:
+        """Tracing stays off: shutdown never constructs a client to flush."""
         from langsmith import run_trees
 
         from deepagents_code import offload_api
@@ -1374,15 +1439,16 @@ class TestLifespan:
 
         get_cached_client.assert_not_called()
 
-    async def test_flush_failure_does_not_block_shutdown(
+    async def test_warns_when_the_flush_leaves_traces_behind(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
+        """`Client.flush` truncates silently on timeout, so leftovers are read."""
         from langsmith import run_trees
 
         from deepagents_code import offload_api
 
-        client = MagicMock()
-        client.flush.side_effect = RuntimeError("flush failed")
+        client = self._client()
+        client.tracing_queue = SimpleNamespace(unfinished_tasks=3)
         with (
             patch.object(run_trees, "_CLIENT", client),
             caplog.at_level(logging.WARNING, logger=offload_api.__name__),
@@ -1390,7 +1456,76 @@ class TestLifespan:
             async with offload_api.app.router.lifespan_context(offload_api.app):
                 pass
 
+        assert "dropping 3 batch(es)" in caplog.text
+
+    async def test_hung_flush_does_not_block_shutdown(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A flush ignoring its own timeout is abandoned rather than waited on.
+
+        `Client.flush` bounds only the wait on submitted sends, so its
+        synchronous drain can overrun the SIGTERM grace period; the outer
+        `wait_for` is the ceiling that actually holds.
+        """
+        from langsmith import run_trees
+
+        from deepagents_code import offload_api
+
+        client = self._client()
+        client.flush.side_effect = lambda **_: time.sleep(0.5)
+        with (
+            patch.object(run_trees, "_CLIENT", client),
+            patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
+            patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.01),
+            caplog.at_level(logging.WARNING, logger=offload_api.__name__),
+        ):
+            async with offload_api.app.router.lifespan_context(offload_api.app):
+                pass
+
+        assert "exceeded" in caplog.text
+
+    async def test_flush_failure_does_not_block_shutdown(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A raising flush is logged with a traceback, never re-raised.
+
+        Logged at `exception` so a broken langsmith integration is loud; a
+        renamed `_CLIENT` or a dropped `timeout` kwarg would otherwise turn
+        this hook into a permanent silent no-op.
+        """
+        from langsmith import run_trees
+
+        from deepagents_code import offload_api
+
+        client = self._client()
+        client.flush.side_effect = RuntimeError("flush failed")
+        with (
+            patch.object(run_trees, "_CLIENT", client),
+            caplog.at_level(logging.ERROR, logger=offload_api.__name__),
+        ):
+            async with offload_api.app.router.lifespan_context(offload_api.app):
+                pass
+
         assert "Failed to flush LangSmith traces" in caplog.text
+        assert "flush failed" in caplog.text
+
+    async def test_missing_private_client_attribute_is_survivable(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A langsmith rename of `_CLIENT` degrades instead of failing shutdown."""
+        from langsmith import run_trees
+
+        from deepagents_code import offload_api
+
+        with (
+            patch.object(run_trees, "_CLIENT", None),
+            caplog.at_level(logging.DEBUG, logger=offload_api.__name__),
+        ):
+            del run_trees._CLIENT
+            async with offload_api.app.router.lifespan_context(offload_api.app):
+                pass
+
+        assert "No LangSmith client to flush" in caplog.text
 
 
 class TestRouteRegistration:

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1344,6 +1345,52 @@ def test_validated_context_fields_exist_on_the_schema() -> None:
     }
 
     assert validated <= declared, validated - declared
+
+
+class TestLifespan:
+    async def test_flushes_existing_tracing_client(self) -> None:
+        from langsmith import run_trees
+
+        from deepagents_code import offload_api
+
+        client = MagicMock()
+        with patch.object(run_trees, "_CLIENT", client):
+            async with offload_api.app.router.lifespan_context(offload_api.app):
+                pass
+
+        client.flush.assert_called_once_with(timeout=offload_api._TRACE_FLUSH_TIMEOUT)
+
+    async def test_does_not_create_tracing_client(self) -> None:
+        from langsmith import run_trees
+
+        from deepagents_code import offload_api
+
+        with (
+            patch.object(run_trees, "_CLIENT", None),
+            patch.object(run_trees, "get_cached_client") as get_cached_client,
+        ):
+            async with offload_api.app.router.lifespan_context(offload_api.app):
+                pass
+
+        get_cached_client.assert_not_called()
+
+    async def test_flush_failure_does_not_block_shutdown(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from langsmith import run_trees
+
+        from deepagents_code import offload_api
+
+        client = MagicMock()
+        client.flush.side_effect = RuntimeError("flush failed")
+        with (
+            patch.object(run_trees, "_CLIENT", client),
+            caplog.at_level(logging.WARNING, logger=offload_api.__name__),
+        ):
+            async with offload_api.app.router.lifespan_context(offload_api.app):
+                pass
+
+        assert "Failed to flush LangSmith traces" in caplog.text
 
 
 class TestRouteRegistration:

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -9,7 +9,7 @@ import threading
 import time
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 
@@ -1349,6 +1349,50 @@ def test_validated_context_fields_exist_on_the_schema() -> None:
     assert validated <= declared, validated - declared
 
 
+_ORPHAN_JOIN_TIMEOUT = 5.0
+"""Seconds a test waits on an abandoned flush thread before giving up.
+
+Generous on purpose: it only bounds a hang, so a slow CI machine must never
+trip it.
+"""
+
+
+def _new_flush_thread(existing: set[threading.Thread]) -> threading.Thread:
+    """Return the flush thread this test started.
+
+    Matched against a pre-test snapshot rather than by name alone, so a
+    leftover thread from another test cannot be mistaken for this one.
+
+    Args:
+        existing: Threads alive before the code under test ran.
+
+    Returns:
+        The single new `langsmith-shutdown-flush` thread.
+    """
+    started = [
+        thread
+        for thread in threading.enumerate()
+        if thread not in existing and thread.name == "langsmith-shutdown-flush"
+    ]
+    assert len(started) == 1, started
+    return started[0]
+
+
+def _join_flush_threads(existing: set[threading.Thread]) -> None:
+    """Wait for flush threads this test started, so none outlive it.
+
+    A thread that outlives its test surfaces as a
+    `PytestUnhandledThreadExceptionWarning` attributed to whichever test is
+    running when it wakes.
+
+    Args:
+        existing: Threads alive before the code under test ran.
+    """
+    for thread in threading.enumerate():
+        if thread not in existing and thread.name == "langsmith-shutdown-flush":
+            thread.join(_ORPHAN_JOIN_TIMEOUT)
+
+
 class TestLifespan:
     """Shutdown flushes buffered LangSmith traces.
 
@@ -1361,13 +1405,15 @@ class TestLifespan:
     def _client() -> MagicMock:
         """Build a flushed-clean client that rejects calls the real one rejects.
 
-        `spec` matters: a bare `MagicMock` accepts any keyword, so the suite
-        would keep passing after langsmith drops the `timeout` parameter --
-        the exact break that would silently disable this flush.
+        `create_autospec` rather than `MagicMock(spec=Client)`: `spec` checks
+        attribute *names* only and does not signature-check calls on child
+        mocks, so the suite would keep passing after langsmith drops the
+        `timeout` parameter -- the exact break that silently disables this
+        flush. `create_autospec` validates the call itself.
         """
         from langsmith import Client
 
-        client = MagicMock(spec=Client)
+        client = create_autospec(Client, instance=True)
         client.tracing_queue = None
         client._futures = None
         return client
@@ -1421,23 +1467,32 @@ class TestLifespan:
             async with offload_api.app.router.lifespan_context(offload_api.app):
                 pass
 
-        assert flush_thread == [flush_thread[0]]
+        assert len(flush_thread) == 1
         assert flush_thread[0] != threading.get_ident()
 
     async def test_does_not_create_tracing_client(self) -> None:
-        """Tracing stays off: shutdown never constructs a client to flush."""
+        """Tracing stays off: shutdown never constructs a client to flush.
+
+        Asserted against `Client.__init__` rather than `get_cached_client`,
+        which the shutdown path does not reference at all -- so an assertion
+        on that name could never fail. Any route to a new client, including a
+        bare `Client()`, trips this.
+        """
+        import langsmith
         from langsmith import run_trees
 
         from deepagents_code import offload_api
 
+        def forbidden(*_args: object, **_kwargs: object) -> None:
+            msg = "shutdown must not construct a LangSmith client"
+            raise AssertionError(msg)
+
         with (
             patch.object(run_trees, "_CLIENT", None),
-            patch.object(run_trees, "get_cached_client") as get_cached_client,
+            patch.object(langsmith.Client, "__init__", forbidden),
         ):
             async with offload_api.app.router.lifespan_context(offload_api.app):
                 pass
-
-        get_cached_client.assert_not_called()
 
     async def test_warns_when_the_flush_leaves_traces_behind(
         self, caplog: pytest.LogCaptureFixture
@@ -1456,7 +1511,7 @@ class TestLifespan:
             async with offload_api.app.router.lifespan_context(offload_api.app):
                 pass
 
-        assert "dropping 3 batch(es)" in caplog.text
+        assert "dropping 3 queued trace item(s)" in caplog.text
 
     async def test_hung_flush_does_not_block_shutdown(
         self, caplog: pytest.LogCaptureFixture
@@ -1472,29 +1527,36 @@ class TestLifespan:
 
         from deepagents_code import offload_api
 
+        release = threading.Event()
         client = self._client()
-        client.flush.side_effect = lambda **_: time.sleep(1.0)
-        with (
-            patch.object(run_trees, "_CLIENT", client),
-            patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
-            patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.01),
-            caplog.at_level(logging.WARNING, logger=offload_api.__name__),
-        ):
-            started = time.monotonic()
-            async with offload_api.app.router.lifespan_context(offload_api.app):
-                pass
-            elapsed = time.monotonic() - started
+        client.flush.side_effect = lambda **_: release.wait(_ORPHAN_JOIN_TIMEOUT)
+        existing = set(threading.enumerate())
+        try:
+            with (
+                patch.object(run_trees, "_CLIENT", client),
+                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
+                patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.01),
+                caplog.at_level(logging.WARNING, logger=offload_api.__name__),
+            ):
+                started = time.monotonic()
+                async with offload_api.app.router.lifespan_context(offload_api.app):
+                    pass
+                elapsed = time.monotonic() - started
 
-        assert "exceeded" in caplog.text
-        assert elapsed < 0.5
+            assert "exceeded" in caplog.text
+            assert elapsed < 0.5
 
-        # The abandoned thread is a daemon, so nothing -- not even the
-        # `asyncio.run` runner's executor join -- waits on it at teardown.
-        orphan = next(
-            t for t in threading.enumerate() if t.name == "langsmith-shutdown-flush"
-        )
-        assert orphan.daemon
-        assert orphan.is_alive()
+            # The abandoned thread is a daemon, so nothing -- not even the
+            # `asyncio.run` runner's executor join -- waits on it at teardown.
+            orphan = _new_flush_thread(existing)
+            assert orphan.daemon
+            assert orphan.is_alive()
+        finally:
+            # Released rather than left sleeping: a thread that outlives its
+            # test surfaces as a `PytestUnhandledThreadExceptionWarning`
+            # against whichever test happens to be running when it wakes.
+            release.set()
+            _join_flush_threads(existing)
 
     @pytest.mark.parametrize("cancel_waiter", [False, True])
     async def test_late_flush_completion_is_ignored(self, cancel_waiter: bool) -> None:
@@ -1539,7 +1601,7 @@ class TestLifespan:
                     with pytest.raises(asyncio.CancelledError):
                         await waiter
                 else:
-                    with pytest.raises(TimeoutError):
+                    with pytest.raises(offload_api._FlushDeadlineError):
                         await waiter
 
                 release.set()
@@ -1596,6 +1658,299 @@ class TestLifespan:
                 pass
 
         assert "No LangSmith client to flush" in caplog.text
+
+    async def test_base_exception_in_the_flush_still_releases_the_waiter(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A non-`Exception` failure must not strand the waiter forever.
+
+        The worker records its outcome in a `finally`, so the deadline stays
+        reachable. Were the outcome recorded only on the `Exception` path, a
+        `SystemExit` from `flush` would leave `await done` unresolved and hang
+        shutdown until dcode escalated to SIGKILL, with nothing logged.
+        """
+        from langsmith import run_trees
+
+        from deepagents_code import offload_api
+
+        client = self._client()
+        client.flush.side_effect = SystemExit(1)
+        with (
+            patch.object(run_trees, "_CLIENT", client),
+            caplog.at_level(logging.ERROR, logger=offload_api.__name__),
+        ):
+            started = time.monotonic()
+            async with offload_api.app.router.lifespan_context(offload_api.app):
+                pass
+            elapsed = time.monotonic() - started
+
+        # Relayed as a plain `Exception`: re-raising `SystemExit` past the
+        # lifespan would replace whatever error was already propagating.
+        assert elapsed < offload_api._TRACE_FLUSH_TIMEOUT
+        assert "Failed to flush LangSmith traces" in caplog.text
+        assert "SystemExit" in caplog.text
+
+    async def test_flush_failure_after_the_deadline_is_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A cause that arrives late is reported, not discarded.
+
+        "The flush ran out of time" and "the flush failed on a rotated API
+        key" call for opposite responses, and only the first is already in the
+        log by the time the late result lands.
+        """
+        from deepagents_code import offload_api
+
+        release = threading.Event()
+        client = self._client()
+
+        def flush(**_kwargs: object) -> None:
+            release.wait(_ORPHAN_JOIN_TIMEOUT)
+            msg = "credentials rejected"
+            raise RuntimeError(msg)
+
+        client.flush.side_effect = flush
+        existing = set(threading.enumerate())
+        try:
+            with (
+                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
+                patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.0),
+                caplog.at_level(logging.WARNING, logger=offload_api.__name__),
+                pytest.raises(offload_api._FlushDeadlineError),
+            ):
+                await offload_api._await_flush_thread(client)
+
+            with caplog.at_level(logging.WARNING, logger=offload_api.__name__):
+                release.set()
+                _join_flush_threads(existing)
+                # One turn for the thread's queued completion to run.
+                await asyncio.sleep(0)
+        finally:
+            release.set()
+            _join_flush_threads(existing)
+
+        assert "failed after the shutdown deadline" in caplog.text
+        assert "credentials rejected" in caplog.text
+
+    async def test_completion_racing_the_deadline_is_not_misreported(self) -> None:
+        """A flush that finishes as the timer fires is not called an overrun.
+
+        The worker announces itself only *after* queueing its completion, so a
+        `give_up` that observes the announcement knows the result is already
+        ahead of it in the ready queue and can yield one loop turn. Drop that
+        check and a successful flush is reported as "exceeded ...; dropping
+        queued traces" whenever the timer wins the race.
+
+        Driven by hand rather than by real timing: the window is microseconds
+        wide, so a wall-clock test would assert nothing most of the time.
+        """
+        from deepagents_code import offload_api
+
+        loop = asyncio.get_running_loop()
+        real_call_soon_threadsafe = loop.call_soon_threadsafe
+        client = self._client()
+        deferred: list[tuple[Callable[..., object], tuple[object, ...]]] = []
+        give_ups: list[Callable[[], object]] = []
+
+        def defer_completion(
+            callback: Callable[..., object], *args: object
+        ) -> MagicMock:
+            deferred.append((callback, args))
+            return MagicMock()
+
+        def capture_timer(
+            _delay: float, callback: Callable[[], object], *_args: object
+        ) -> MagicMock:
+            give_ups.append(callback)
+            return MagicMock()
+
+        with patch.object(loop, "call_soon_threadsafe", defer_completion):
+            # `call_later` is unpatched again as soon as the deadline handle is
+            # captured, because `asyncio.sleep` needs it too.
+            with patch.object(loop, "call_later", capture_timer):
+                waiter = asyncio.create_task(offload_api._await_flush_thread(client))
+                # A bare yield: enough for the coroutine to start the worker
+                # and reach its `await`, and it needs no timer of its own.
+                await asyncio.sleep(0)
+            assert len(give_ups) == 1
+
+            # The stub flush returns at once; this waits for the worker to
+            # dispatch its completion and then announce itself.
+            await asyncio.sleep(0.05)
+            assert len(deferred) == 1
+
+        # Queue the completion first, exactly as the worker's ordering
+        # guarantees, then fire the deadline in the same loop turn.
+        callback, args = deferred.pop()
+        real_call_soon_threadsafe(callback, *args)
+        give_ups.pop()()
+
+        assert await waiter >= 0
+
+    def test_abandoned_flush_thread_raises_no_unhandled_exception(self) -> None:
+        """The orphan wakes into a closed loop without printing a traceback.
+
+        `call_soon_threadsafe` raises `RuntimeError` once the loop is gone. An
+        unhandled error there prints a bare traceback from an unjoined thread
+        into the server log dcode tails on failure, which reads as a crash on
+        the deliberately-degraded path.
+
+        Driven through `asyncio.run` rather than the ambient test loop because
+        the loop has to actually close for the race to exist.
+        """
+        from deepagents_code import offload_api
+
+        release = threading.Event()
+        client = self._client()
+        client.flush.side_effect = lambda **_: release.wait(_ORPHAN_JOIN_TIMEOUT)
+        unhandled: list[object] = []
+
+        async def main() -> None:
+            with (
+                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
+                patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.0),
+                pytest.raises(offload_api._FlushDeadlineError),
+            ):
+                await offload_api._await_flush_thread(client)
+
+        existing = set(threading.enumerate())
+        original_hook = threading.excepthook
+        threading.excepthook = unhandled.append
+        try:
+            asyncio.run(main())
+            orphan = _new_flush_thread(existing)
+            release.set()
+            orphan.join(_ORPHAN_JOIN_TIMEOUT)
+            assert not orphan.is_alive()
+        finally:
+            threading.excepthook = original_hook
+            release.set()
+            _join_flush_threads(existing)
+
+        assert unhandled == []
+
+
+class TestPendingTraceWork:
+    """Leftover counting after a flush that returned early.
+
+    `Client.flush` truncates silently, so this is the only signal that traces
+    were dropped -- and the only place a langsmith rename can turn the warning
+    into a permanent no-op.
+    """
+
+    @staticmethod
+    def _client(**attributes: object) -> MagicMock:
+        """Build a client exposing only the named attributes.
+
+        The unnamed ones are `del`d rather than left at their autospec
+        defaults, so `getattr` raises `AttributeError` the way it would after
+        langsmith renamed them.
+
+        Args:
+            **attributes: Attributes to expose, and their values.
+
+        Returns:
+            A `Client` autospec narrowed to `attributes`.
+        """
+        from langsmith import Client
+
+        client = create_autospec(Client, instance=True)
+        for name in ("tracing_queue", "_futures"):
+            if name in attributes:
+                setattr(client, name, attributes[name])
+            else:
+                delattr(client, name)
+        return client
+
+    def test_counts_in_flight_send_batches(self) -> None:
+        """Batches already handed to the client's pool live in `_futures`.
+
+        This is the limb that matters after a truncated flush: the queue is
+        drained but the sends are not yet acknowledged.
+        """
+        from deepagents_code import offload_api
+
+        client = self._client(tracing_queue=None, _futures=[object(), object()])
+        assert offload_api._pending_trace_work(client) == 2
+
+    def test_sums_both_sources(self) -> None:
+        """Queued operations and in-flight batches add rather than shadow."""
+        from deepagents_code import offload_api
+
+        client = self._client(
+            tracing_queue=SimpleNamespace(unfinished_tasks=3),
+            _futures=[object()],
+        )
+        assert offload_api._pending_trace_work(client) == 4
+
+    def test_queue_without_a_task_counter_is_survivable(self) -> None:
+        """A renamed `unfinished_tasks` degrades to "nothing queued"."""
+        from deepagents_code import offload_api
+
+        client = self._client(tracing_queue=SimpleNamespace(), _futures=None)
+        assert offload_api._pending_trace_work(client) == 0
+
+    def test_reports_that_it_cannot_tell(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Neither attribute present is "unknown", not "nothing pending".
+
+        Returning 0 here is what would make the truncation warning a silently
+        permanent no-op after langsmith renames its internals -- the exact
+        failure the warning exists to report.
+        """
+        from deepagents_code import offload_api
+
+        client = self._client()
+        with caplog.at_level(logging.WARNING, logger=offload_api.__name__):
+            assert offload_api._pending_trace_work(client) is None
+
+        assert "Cannot verify the LangSmith trace flush" in caplog.text
+
+    async def test_unverifiable_deadline_says_so(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The deadline warning names the count, or admits it has none."""
+        from langsmith import run_trees
+
+        from deepagents_code import offload_api
+
+        release = threading.Event()
+        client = self._client()
+        client.flush.side_effect = lambda **_: release.wait(_ORPHAN_JOIN_TIMEOUT)
+        existing = set(threading.enumerate())
+        try:
+            with (
+                patch.object(run_trees, "_CLIENT", client),
+                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
+                patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.0),
+                caplog.at_level(logging.WARNING, logger=offload_api.__name__),
+            ):
+                async with offload_api.app.router.lifespan_context(offload_api.app):
+                    pass
+        finally:
+            release.set()
+            _join_flush_threads(existing)
+
+        assert "an unknown number of queued trace items" in caplog.text
+
+
+class TestFlushBudget:
+    """The trace flush has to fit inside dcode's shutdown grace period.
+
+    `offload_api` runs in the server child process and `client.launch.server`
+    in the dcode TUI, so no import couples the two constants. Without this
+    assertion, raising the flush budget past the SIGTERM grace period leaves
+    the suite green while guaranteeing the process is SIGKILLed with the
+    traces still queued -- the precise harm the docstrings warn about.
+    """
+
+    def test_flush_budget_fits_the_shutdown_grace_period(self) -> None:
+        from deepagents_code import offload_api
+        from deepagents_code.client.launch import server
+
+        budget = offload_api._TRACE_FLUSH_TIMEOUT + offload_api._TRACE_FLUSH_GRACE
+        assert budget < server._SHUTDOWN_TIMEOUT
 
 
 class TestRouteRegistration:

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -16,7 +16,7 @@ import pytest
 from deepagents_code.offload_middleware import OffloadExecution, OffloadResult
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Iterator
 
     from deepagents_code.offload_middleware import _PendingArchive
 
@@ -1350,25 +1350,18 @@ def test_validated_context_fields_exist_on_the_schema() -> None:
 
 
 _ORPHAN_JOIN_TIMEOUT = 5.0
-"""Seconds a test waits on an abandoned flush thread before giving up.
+"""Seconds a test waits for a released flush thread before giving up."""
 
-Generous on purpose: it only bounds a hang, so a slow CI machine must never
-trip it.
-"""
+
+def _flush_client() -> MagicMock:
+    """Build an autospecced LangSmith client for shutdown tests."""
+    from langsmith import Client
+
+    return create_autospec(Client, instance=True)
 
 
 def _new_flush_thread(existing: set[threading.Thread]) -> threading.Thread:
-    """Return the flush thread this test started.
-
-    Matched against a pre-test snapshot rather than by name alone, so a
-    leftover thread from another test cannot be mistaken for this one.
-
-    Args:
-        existing: Threads alive before the code under test ran.
-
-    Returns:
-        The single new `langsmith-shutdown-flush` thread.
-    """
+    """Return the flush thread started after the supplied snapshot."""
     started = [
         thread
         for thread in threading.enumerate()
@@ -1379,44 +1372,14 @@ def _new_flush_thread(existing: set[threading.Thread]) -> threading.Thread:
 
 
 def _join_flush_threads(existing: set[threading.Thread]) -> None:
-    """Wait for flush threads this test started, so none outlive it.
-
-    A thread that outlives its test surfaces as a
-    `PytestUnhandledThreadExceptionWarning` attributed to whichever test is
-    running when it wakes.
-
-    Args:
-        existing: Threads alive before the code under test ran.
-    """
+    """Wait for flush threads started after the supplied snapshot."""
     for thread in threading.enumerate():
         if thread not in existing and thread.name == "langsmith-shutdown-flush":
             thread.join(_ORPHAN_JOIN_TIMEOUT)
 
 
 class TestLifespan:
-    """Shutdown flushes buffered LangSmith traces.
-
-    `langsmith.Client` only closes its session at exit and never flushes, so
-    without the lifespan hook anything still queued when dcode signals the
-    server is dropped.
-    """
-
-    @staticmethod
-    def _client() -> MagicMock:
-        """Build a flushed-clean client that rejects calls the real one rejects.
-
-        `create_autospec` rather than `MagicMock(spec=Client)`: `spec` checks
-        attribute *names* only and does not signature-check calls on child
-        mocks, so the suite would keep passing after langsmith drops the
-        `timeout` parameter -- the exact break that silently disables this
-        flush. `create_autospec` validates the call itself.
-        """
-        from langsmith import Client
-
-        client = create_autospec(Client, instance=True)
-        client.tracing_queue = None
-        client._futures = None
-        return client
+    """Shutdown flushes buffered LangSmith traces."""
 
     async def test_flushes_existing_tracing_client(self) -> None:
         """The flush happens on shutdown, not on startup."""
@@ -1424,25 +1387,25 @@ class TestLifespan:
 
         from deepagents_code import offload_api
 
-        client = self._client()
+        client = _flush_client()
         with patch.object(run_trees, "_CLIENT", client):
             async with offload_api.app.router.lifespan_context(offload_api.app):
                 client.flush.assert_not_called()
 
-        client.flush.assert_called_once_with(timeout=offload_api._TRACE_FLUSH_TIMEOUT)
+        client.flush.assert_called_once_with()
 
     async def test_flushes_when_the_app_body_raises(self) -> None:
-        """A crashing app still flushes -- that is what the `finally` buys."""
+        """A crashing app still flushes without replacing its exception."""
         from langsmith import run_trees
 
         from deepagents_code import offload_api
 
-        client = self._client()
-        boom = RuntimeError("app exploded")
+        client = _flush_client()
 
         async def run_and_raise() -> None:
             async with offload_api.app.router.lifespan_context(offload_api.app):
-                raise boom
+                msg = "app exploded"
+                raise RuntimeError(msg)
 
         with (
             patch.object(run_trees, "_CLIENT", client),
@@ -1450,34 +1413,27 @@ class TestLifespan:
         ):
             await run_and_raise()
 
-        client.flush.assert_called_once()
+        client.flush.assert_called_once_with()
 
     async def test_flushes_off_the_event_loop(self) -> None:
-        """The blocking flush runs in a thread so shutdown stays responsive."""
+        """The blocking flush runs on a daemon worker, not the event loop."""
         from langsmith import run_trees
 
         from deepagents_code import offload_api
 
-        flush_thread: list[int] = []
-        client = self._client()
-        client.flush.side_effect = lambda **_: flush_thread.append(
-            threading.get_ident()
-        )
+        flush_threads: list[int] = []
+        client = _flush_client()
+        client.flush.side_effect = lambda: flush_threads.append(threading.get_ident())
+
         with patch.object(run_trees, "_CLIENT", client):
             async with offload_api.app.router.lifespan_context(offload_api.app):
                 pass
 
-        assert len(flush_thread) == 1
-        assert flush_thread[0] != threading.get_ident()
+        assert len(flush_threads) == 1
+        assert flush_threads[0] != threading.get_ident()
 
     async def test_does_not_create_tracing_client(self) -> None:
-        """Tracing stays off: shutdown never constructs a client to flush.
-
-        Asserted against `Client.__init__` rather than `get_cached_client`,
-        which the shutdown path does not reference at all -- so an assertion
-        on that name could never fail. Any route to a new client, including a
-        bare `Client()`, trips this.
-        """
+        """Tracing disabled remains a no-op rather than constructing a client."""
         import langsmith
         from langsmith import run_trees
 
@@ -1494,48 +1450,23 @@ class TestLifespan:
             async with offload_api.app.router.lifespan_context(offload_api.app):
                 pass
 
-    async def test_warns_when_the_flush_leaves_traces_behind(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """`Client.flush` truncates silently on timeout, so leftovers are read."""
-        from langsmith import run_trees
-
-        from deepagents_code import offload_api
-
-        client = self._client()
-        client.tracing_queue = SimpleNamespace(unfinished_tasks=3)
-        with (
-            patch.object(run_trees, "_CLIENT", client),
-            caplog.at_level(logging.WARNING, logger=offload_api.__name__),
-        ):
-            async with offload_api.app.router.lifespan_context(offload_api.app):
-                pass
-
-        assert "dropping 3 queued trace item(s)" in caplog.text
-
     async def test_hung_flush_does_not_block_shutdown(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A flush ignoring its own timeout is abandoned rather than waited on.
-
-        `Client.flush` bounds only the wait on submitted sends, so its
-        synchronous drain can overrun the SIGTERM grace period; the flush runs
-        on an unjoined daemon thread so even that overrun cannot stall the
-        event loop's own shutdown.
-        """
+        """A hung flush is abandoned after the external deadline."""
         from langsmith import run_trees
 
         from deepagents_code import offload_api
 
         release = threading.Event()
-        client = self._client()
-        client.flush.side_effect = lambda **_: release.wait(_ORPHAN_JOIN_TIMEOUT)
+        client = _flush_client()
+        client.flush.side_effect = release.wait
         existing = set(threading.enumerate())
         try:
             with (
                 patch.object(run_trees, "_CLIENT", client),
-                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
-                patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.01),
+                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.01),
+                patch.object(offload_api, "_TRACE_FLUSH_POLL_INTERVAL", 0.001),
                 caplog.at_level(logging.WARNING, logger=offload_api.__name__),
             ):
                 started = time.monotonic()
@@ -1543,93 +1474,24 @@ class TestLifespan:
                     pass
                 elapsed = time.monotonic() - started
 
-            assert "exceeded" in caplog.text
+            assert "some traces may be lost" in caplog.text
             assert elapsed < 0.5
-
-            # The abandoned thread is a daemon, so nothing -- not even the
-            # `asyncio.run` runner's executor join -- waits on it at teardown.
             orphan = _new_flush_thread(existing)
             assert orphan.daemon
             assert orphan.is_alive()
         finally:
-            # Released rather than left sleeping: a thread that outlives its
-            # test surfaces as a `PytestUnhandledThreadExceptionWarning`
-            # against whichever test happens to be running when it wakes.
             release.set()
             _join_flush_threads(existing)
 
-    @pytest.mark.parametrize("cancel_waiter", [False, True])
-    async def test_late_flush_completion_is_ignored(self, cancel_waiter: bool) -> None:
-        """A late thread result cannot complete a timed-out or cancelled future."""
-        from deepagents_code import offload_api
-
-        loop = asyncio.get_running_loop()
-        call_soon_threadsafe = loop.call_soon_threadsafe
-        started = asyncio.Event()
-        completion_deferred = asyncio.Event()
-        release = threading.Event()
-        deferred: list[tuple[Callable[..., object], tuple[object, ...]]] = []
-
-        def flush(**_kwargs: object) -> None:
-            call_soon_threadsafe(started.set)
-            release.wait()
-
-        def defer_completion(
-            callback: Callable[..., object], *args: object, **_kwargs: object
-        ) -> None:
-            deferred.append((callback, args))
-            call_soon_threadsafe(completion_deferred.set)
-
-        client = self._client()
-        client.flush.side_effect = flush
-        errors: list[dict[str, object]] = []
-        previous_handler = loop.get_exception_handler()
-        loop.set_exception_handler(lambda _loop, context: errors.append(context))
-
-        try:
-            with (
-                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
-                patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.0),
-                patch.object(
-                    loop, "call_soon_threadsafe", side_effect=defer_completion
-                ),
-            ):
-                waiter = asyncio.create_task(offload_api._await_flush_thread(client))
-                await started.wait()
-                if cancel_waiter:
-                    waiter.cancel()
-                    with pytest.raises(asyncio.CancelledError):
-                        await waiter
-                else:
-                    with pytest.raises(offload_api._FlushDeadlineError):
-                        await waiter
-
-                release.set()
-                await completion_deferred.wait()
-
-            callback, args = deferred.pop()
-            loop.call_soon(callback, *args)
-            await asyncio.sleep(0)
-        finally:
-            release.set()
-            loop.set_exception_handler(previous_handler)
-
-        assert errors == []
-
-    async def test_flush_failure_does_not_block_shutdown(
+    async def test_flush_failure_is_logged_and_swallowed(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A raising flush is logged with a traceback, never re-raised.
-
-        Logged at `exception` so a broken langsmith integration is loud; a
-        renamed `_CLIENT` or a dropped `timeout` kwarg would otherwise turn
-        this hook into a permanent silent no-op.
-        """
+        """A telemetry failure cannot turn into a failed shutdown."""
         from langsmith import run_trees
 
         from deepagents_code import offload_api
 
-        client = self._client()
+        client = _flush_client()
         client.flush.side_effect = RuntimeError("flush failed")
         with (
             patch.object(run_trees, "_CLIENT", client),
@@ -1641,316 +1503,36 @@ class TestLifespan:
         assert "Failed to flush LangSmith traces" in caplog.text
         assert "flush failed" in caplog.text
 
-    async def test_missing_private_client_attribute_is_survivable(
+    async def test_base_exception_is_logged_and_swallowed(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A langsmith rename of `_CLIENT` degrades instead of failing shutdown."""
+        """A non-Exception failure still releases the shutdown waiter."""
         from langsmith import run_trees
 
         from deepagents_code import offload_api
 
-        with (
-            patch.object(run_trees, "_CLIENT", None),
-            caplog.at_level(logging.DEBUG, logger=offload_api.__name__),
-        ):
-            del run_trees._CLIENT
-            async with offload_api.app.router.lifespan_context(offload_api.app):
-                pass
-
-        assert "No LangSmith client to flush" in caplog.text
-
-    async def test_base_exception_in_the_flush_still_releases_the_waiter(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A non-`Exception` failure must not strand the waiter forever.
-
-        The worker records its outcome in a `finally`, so the deadline stays
-        reachable. Were the outcome recorded only on the `Exception` path, a
-        `SystemExit` from `flush` would leave `await done` unresolved and hang
-        shutdown until dcode escalated to SIGKILL, with nothing logged.
-        """
-        from langsmith import run_trees
-
-        from deepagents_code import offload_api
-
-        client = self._client()
+        client = _flush_client()
         client.flush.side_effect = SystemExit(1)
         with (
             patch.object(run_trees, "_CLIENT", client),
             caplog.at_level(logging.ERROR, logger=offload_api.__name__),
         ):
-            started = time.monotonic()
             async with offload_api.app.router.lifespan_context(offload_api.app):
                 pass
-            elapsed = time.monotonic() - started
 
-        # Relayed as a plain `Exception`: re-raising `SystemExit` past the
-        # lifespan would replace whatever error was already propagating.
-        assert elapsed < offload_api._TRACE_FLUSH_TIMEOUT
         assert "Failed to flush LangSmith traces" in caplog.text
         assert "SystemExit" in caplog.text
 
-    async def test_flush_failure_after_the_deadline_is_logged(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A cause that arrives late is reported, not discarded.
-
-        "The flush ran out of time" and "the flush failed on a rotated API
-        key" call for opposite responses, and only the first is already in the
-        log by the time the late result lands.
-        """
-        from deepagents_code import offload_api
-
-        release = threading.Event()
-        client = self._client()
-
-        def flush(**_kwargs: object) -> None:
-            release.wait(_ORPHAN_JOIN_TIMEOUT)
-            msg = "credentials rejected"
-            raise RuntimeError(msg)
-
-        client.flush.side_effect = flush
-        existing = set(threading.enumerate())
-        try:
-            with (
-                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
-                patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.0),
-                caplog.at_level(logging.WARNING, logger=offload_api.__name__),
-                pytest.raises(offload_api._FlushDeadlineError),
-            ):
-                await offload_api._await_flush_thread(client)
-
-            with caplog.at_level(logging.WARNING, logger=offload_api.__name__):
-                release.set()
-                _join_flush_threads(existing)
-                # One turn for the thread's queued completion to run.
-                await asyncio.sleep(0)
-        finally:
-            release.set()
-            _join_flush_threads(existing)
-
-        assert "failed after the shutdown deadline" in caplog.text
-        assert "credentials rejected" in caplog.text
-
-    async def test_completion_racing_the_deadline_is_not_misreported(self) -> None:
-        """A flush that finishes as the timer fires is not called an overrun.
-
-        The worker announces itself only *after* queueing its completion, so a
-        `give_up` that observes the announcement knows the result is already
-        ahead of it in the ready queue and can yield one loop turn. Drop that
-        check and a successful flush is reported as "exceeded ...; dropping
-        queued traces" whenever the timer wins the race.
-
-        Driven by hand rather than by real timing: the window is microseconds
-        wide, so a wall-clock test would assert nothing most of the time.
-        """
-        from deepagents_code import offload_api
-
-        loop = asyncio.get_running_loop()
-        real_call_soon_threadsafe = loop.call_soon_threadsafe
-        client = self._client()
-        deferred: list[tuple[Callable[..., object], tuple[object, ...]]] = []
-        give_ups: list[Callable[[], object]] = []
-
-        def defer_completion(
-            callback: Callable[..., object], *args: object
-        ) -> MagicMock:
-            deferred.append((callback, args))
-            return MagicMock()
-
-        def capture_timer(
-            _delay: float, callback: Callable[[], object], *_args: object
-        ) -> MagicMock:
-            give_ups.append(callback)
-            return MagicMock()
-
-        with patch.object(loop, "call_soon_threadsafe", defer_completion):
-            # `call_later` is unpatched again as soon as the deadline handle is
-            # captured, because `asyncio.sleep` needs it too.
-            with patch.object(loop, "call_later", capture_timer):
-                waiter = asyncio.create_task(offload_api._await_flush_thread(client))
-                # A bare yield: enough for the coroutine to start the worker
-                # and reach its `await`, and it needs no timer of its own.
-                await asyncio.sleep(0)
-            assert len(give_ups) == 1
-
-            # The stub flush returns at once; this waits for the worker to
-            # dispatch its completion and then announce itself.
-            await asyncio.sleep(0.05)
-            assert len(deferred) == 1
-
-        # Queue the completion first, exactly as the worker's ordering
-        # guarantees, then fire the deadline in the same loop turn.
-        callback, args = deferred.pop()
-        real_call_soon_threadsafe(callback, *args)
-        give_ups.pop()()
-
-        assert await waiter >= 0
-
-    def test_abandoned_flush_thread_raises_no_unhandled_exception(self) -> None:
-        """The orphan wakes into a closed loop without printing a traceback.
-
-        `call_soon_threadsafe` raises `RuntimeError` once the loop is gone. An
-        unhandled error there prints a bare traceback from an unjoined thread
-        into the server log dcode tails on failure, which reads as a crash on
-        the deliberately-degraded path.
-
-        Driven through `asyncio.run` rather than the ambient test loop because
-        the loop has to actually close for the race to exist.
-        """
-        from deepagents_code import offload_api
-
-        release = threading.Event()
-        client = self._client()
-        client.flush.side_effect = lambda **_: release.wait(_ORPHAN_JOIN_TIMEOUT)
-        unhandled: list[object] = []
-
-        async def main() -> None:
-            with (
-                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
-                patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.0),
-                pytest.raises(offload_api._FlushDeadlineError),
-            ):
-                await offload_api._await_flush_thread(client)
-
-        existing = set(threading.enumerate())
-        original_hook = threading.excepthook
-        threading.excepthook = unhandled.append
-        try:
-            asyncio.run(main())
-            orphan = _new_flush_thread(existing)
-            release.set()
-            orphan.join(_ORPHAN_JOIN_TIMEOUT)
-            assert not orphan.is_alive()
-        finally:
-            threading.excepthook = original_hook
-            release.set()
-            _join_flush_threads(existing)
-
-        assert unhandled == []
-
-
-class TestPendingTraceWork:
-    """Leftover counting after a flush that returned early.
-
-    `Client.flush` truncates silently, so this is the only signal that traces
-    were dropped -- and the only place a langsmith rename can turn the warning
-    into a permanent no-op.
-    """
-
-    @staticmethod
-    def _client(**attributes: object) -> MagicMock:
-        """Build a client exposing only the named attributes.
-
-        The unnamed ones are `del`d rather than left at their autospec
-        defaults, so `getattr` raises `AttributeError` the way it would after
-        langsmith renamed them.
-
-        Args:
-            **attributes: Attributes to expose, and their values.
-
-        Returns:
-            A `Client` autospec narrowed to `attributes`.
-        """
-        from langsmith import Client
-
-        client = create_autospec(Client, instance=True)
-        for name in ("tracing_queue", "_futures"):
-            if name in attributes:
-                setattr(client, name, attributes[name])
-            else:
-                delattr(client, name)
-        return client
-
-    def test_counts_in_flight_send_batches(self) -> None:
-        """Batches already handed to the client's pool live in `_futures`.
-
-        This is the limb that matters after a truncated flush: the queue is
-        drained but the sends are not yet acknowledged.
-        """
-        from deepagents_code import offload_api
-
-        client = self._client(tracing_queue=None, _futures=[object(), object()])
-        assert offload_api._pending_trace_work(client) == 2
-
-    def test_sums_both_sources(self) -> None:
-        """Queued operations and in-flight batches add rather than shadow."""
-        from deepagents_code import offload_api
-
-        client = self._client(
-            tracing_queue=SimpleNamespace(unfinished_tasks=3),
-            _futures=[object()],
-        )
-        assert offload_api._pending_trace_work(client) == 4
-
-    def test_queue_without_a_task_counter_is_survivable(self) -> None:
-        """A renamed `unfinished_tasks` degrades to "nothing queued"."""
-        from deepagents_code import offload_api
-
-        client = self._client(tracing_queue=SimpleNamespace(), _futures=None)
-        assert offload_api._pending_trace_work(client) == 0
-
-    def test_reports_that_it_cannot_tell(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Neither attribute present is "unknown", not "nothing pending".
-
-        Returning 0 here is what would make the truncation warning a silently
-        permanent no-op after langsmith renames its internals -- the exact
-        failure the warning exists to report.
-        """
-        from deepagents_code import offload_api
-
-        client = self._client()
-        with caplog.at_level(logging.WARNING, logger=offload_api.__name__):
-            assert offload_api._pending_trace_work(client) is None
-
-        assert "Cannot verify the LangSmith trace flush" in caplog.text
-
-    async def test_unverifiable_deadline_says_so(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """The deadline warning names the count, or admits it has none."""
-        from langsmith import run_trees
-
-        from deepagents_code import offload_api
-
-        release = threading.Event()
-        client = self._client()
-        client.flush.side_effect = lambda **_: release.wait(_ORPHAN_JOIN_TIMEOUT)
-        existing = set(threading.enumerate())
-        try:
-            with (
-                patch.object(run_trees, "_CLIENT", client),
-                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
-                patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.0),
-                caplog.at_level(logging.WARNING, logger=offload_api.__name__),
-            ):
-                async with offload_api.app.router.lifespan_context(offload_api.app):
-                    pass
-        finally:
-            release.set()
-            _join_flush_threads(existing)
-
-        assert "an unknown number of queued trace items" in caplog.text
-
 
 class TestFlushBudget:
-    """The trace flush has to fit inside dcode's shutdown grace period.
+    """The flush leaves time for LangGraph's own lifespan teardown."""
 
-    `offload_api` runs in the server child process and `client.launch.server`
-    in the dcode TUI, so no import couples the two constants. Without this
-    assertion, raising the flush budget past the SIGTERM grace period leaves
-    the suite green while guaranteeing the process is SIGKILLed with the
-    traces still queued -- the precise harm the docstrings warn about.
-    """
-
-    def test_flush_budget_fits_the_shutdown_grace_period(self) -> None:
+    def test_flush_budget_leaves_teardown_margin(self) -> None:
         from deepagents_code import offload_api
         from deepagents_code.client.launch import server
 
-        budget = offload_api._TRACE_FLUSH_TIMEOUT + offload_api._TRACE_FLUSH_GRACE
-        assert budget < server._SHUTDOWN_TIMEOUT
+        remaining = server._SHUTDOWN_TIMEOUT - offload_api._TRACE_FLUSH_TIMEOUT
+        assert remaining >= 2.0
 
 
 class TestRouteRegistration:

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -1464,25 +1464,37 @@ class TestLifespan:
         """A flush ignoring its own timeout is abandoned rather than waited on.
 
         `Client.flush` bounds only the wait on submitted sends, so its
-        synchronous drain can overrun the SIGTERM grace period; the outer
-        `wait_for` is the ceiling that actually holds.
+        synchronous drain can overrun the SIGTERM grace period; the flush runs
+        on an unjoined daemon thread so even that overrun cannot stall the
+        event loop's own shutdown.
         """
         from langsmith import run_trees
 
         from deepagents_code import offload_api
 
         client = self._client()
-        client.flush.side_effect = lambda **_: time.sleep(0.5)
+        client.flush.side_effect = lambda **_: time.sleep(1.0)
         with (
             patch.object(run_trees, "_CLIENT", client),
             patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
             patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.01),
             caplog.at_level(logging.WARNING, logger=offload_api.__name__),
         ):
+            started = time.monotonic()
             async with offload_api.app.router.lifespan_context(offload_api.app):
                 pass
+            elapsed = time.monotonic() - started
 
         assert "exceeded" in caplog.text
+        assert elapsed < 0.5
+
+        # The abandoned thread is a daemon, so nothing -- not even the
+        # `asyncio.run` runner's executor join -- waits on it at teardown.
+        orphan = next(
+            t for t in threading.enumerate() if t.name == "langsmith-shutdown-flush"
+        )
+        assert orphan.daemon
+        assert orphan.is_alive()
 
     async def test_flush_failure_does_not_block_shutdown(
         self, caplog: pytest.LogCaptureFixture

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -16,7 +16,7 @@ import pytest
 from deepagents_code.offload_middleware import OffloadExecution, OffloadResult
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
     from deepagents_code.offload_middleware import _PendingArchive
 
@@ -1495,6 +1495,64 @@ class TestLifespan:
         )
         assert orphan.daemon
         assert orphan.is_alive()
+
+    @pytest.mark.parametrize("cancel_waiter", [False, True])
+    async def test_late_flush_completion_is_ignored(self, cancel_waiter: bool) -> None:
+        """A late thread result cannot complete a timed-out or cancelled future."""
+        from deepagents_code import offload_api
+
+        loop = asyncio.get_running_loop()
+        call_soon_threadsafe = loop.call_soon_threadsafe
+        started = asyncio.Event()
+        completion_deferred = asyncio.Event()
+        release = threading.Event()
+        deferred: list[tuple[Callable[..., object], tuple[object, ...]]] = []
+
+        def flush(**_kwargs: object) -> None:
+            call_soon_threadsafe(started.set)
+            release.wait()
+
+        def defer_completion(
+            callback: Callable[..., object], *args: object, **_kwargs: object
+        ) -> None:
+            deferred.append((callback, args))
+            call_soon_threadsafe(completion_deferred.set)
+
+        client = self._client()
+        client.flush.side_effect = flush
+        errors: list[dict[str, object]] = []
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: errors.append(context))
+
+        try:
+            with (
+                patch.object(offload_api, "_TRACE_FLUSH_TIMEOUT", 0.0),
+                patch.object(offload_api, "_TRACE_FLUSH_GRACE", 0.0),
+                patch.object(
+                    loop, "call_soon_threadsafe", side_effect=defer_completion
+                ),
+            ):
+                waiter = asyncio.create_task(offload_api._await_flush_thread(client))
+                await started.wait()
+                if cancel_waiter:
+                    waiter.cancel()
+                    with pytest.raises(asyncio.CancelledError):
+                        await waiter
+                else:
+                    with pytest.raises(TimeoutError):
+                        await waiter
+
+                release.set()
+                await completion_deferred.wait()
+
+            callback, args = deferred.pop()
+            loop.call_soon(callback, *args)
+            await asyncio.sleep(0)
+        finally:
+            release.set()
+            loop.set_exception_handler(previous_handler)
+
+        assert errors == []
 
     async def test_flush_failure_does_not_block_shutdown(
         self, caplog: pytest.LogCaptureFixture

--- a/libs/code/tests/unit_tests/test_server.py
+++ b/libs/code/tests/unit_tests/test_server.py
@@ -2023,24 +2023,26 @@ class TestTerminateServerProcess:
         )
         process.kill.assert_not_called()
 
-    def test_windows_ctrl_break_oserror_reports_orphan(
+    def test_windows_ctrl_break_oserror_falls_back_to_terminate(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """An undeliverable Windows Ctrl+Break reports the orphan risk."""
+        """A headless Windows child is terminated when Ctrl+Break is unavailable."""
         monkeypatch.setattr(
             "deepagents_code.client.launch.server.sys.platform", "win32"
         )
         process = self._own_group_process()
-        process.send_signal.side_effect = PermissionError
+        process.send_signal.side_effect = OSError("no console")
 
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.WARNING):
             _terminate_server_process(process)
 
         process.send_signal.assert_called_once_with(
             server_module._WINDOWS_CTRL_BREAK_EVENT
         )
+        process.terminate.assert_called_once_with()
+        process.wait.assert_called_once_with(timeout=server_module._SHUTDOWN_TIMEOUT)
         process.kill.assert_not_called()
-        assert "may be orphaned" in caplog.text
+        assert "falling back to terminate" in caplog.text
 
     def test_windows_sigkill_oserror_reports_orphan(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture

--- a/libs/code/tests/unit_tests/test_server.py
+++ b/libs/code/tests/unit_tests/test_server.py
@@ -1512,20 +1512,25 @@ class TestServerSessionIsolation:
         """On POSIX the server is spawned in its own session/process group."""
         popen = await self._spawn_and_capture(tmp_path, "linux", monkeypatch)
         assert popen.call_args.kwargs["start_new_session"] is True
+        assert popen.call_args.kwargs["creationflags"] == 0
 
-    async def test_windows_spawn_without_new_session(
+    async def test_windows_spawn_starts_new_process_group(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """On Windows the unsupported `setsid()` call is not requested."""
+        """On Windows a console group enables targeted Ctrl+Break shutdown."""
         popen = await self._spawn_and_capture(tmp_path, "win32", monkeypatch)
         assert popen.call_args.kwargs["start_new_session"] is False
+        assert (
+            popen.call_args.kwargs["creationflags"]
+            == server_module._WINDOWS_CREATE_NEW_PROCESS_GROUP
+        )
 
 
 class TestServerProcessGroup:
     """Tests for `_server_process_group` targeting logic."""
 
     def test_returns_none_on_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Windows has no POSIX process groups, so signaling targets the root."""
+        """Windows uses console groups instead of POSIX process groups."""
         monkeypatch.setattr(
             "deepagents_code.client.launch.server.sys.platform", "win32"
         )
@@ -1770,10 +1775,10 @@ class TestTerminateServerProcess:
         killpg.assert_not_called()
         process.send_signal.assert_called_once_with(signal.SIGTERM)
 
-    def test_windows_signals_root_process_only(
+    def test_windows_ctrl_break_timeout_escalates(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """On Windows only the root process is signaled (no `killpg`)."""
+        """On Windows Ctrl+Break permits graceful shutdown before escalation."""
         monkeypatch.setattr(
             "deepagents_code.client.launch.server.sys.platform", "win32"
         )
@@ -1785,8 +1790,27 @@ class TestTerminateServerProcess:
 
         _terminate_server_process(process)
 
-        process.send_signal.assert_called_once_with(signal.SIGTERM)
+        process.send_signal.assert_called_once_with(
+            server_module._WINDOWS_CTRL_BREAK_EVENT
+        )
         process.kill.assert_called_once_with()
+
+    def test_windows_ctrl_break_shutdown_is_graceful(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A responsive Windows server exits through Uvicorn's SIGBREAK path."""
+        monkeypatch.setattr(
+            "deepagents_code.client.launch.server.sys.platform", "win32"
+        )
+        process = self._own_group_process()
+
+        _terminate_server_process(process)
+
+        process.send_signal.assert_called_once_with(
+            server_module._WINDOWS_CTRL_BREAK_EVENT
+        )
+        process.wait.assert_called_once_with(timeout=server_module._SHUTDOWN_TIMEOUT)
+        process.kill.assert_not_called()
 
     def test_initial_sigterm_process_lookup_is_benign(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1982,10 +2006,10 @@ class TestTerminateServerProcess:
         start_mock.assert_awaited_once()
         assert server._process is None
 
-    def test_root_sigterm_process_lookup_is_benign(
+    def test_windows_ctrl_break_process_lookup_is_benign(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """On the root-only path a vanished process is not escalated to SIGKILL."""
+        """A Windows process that vanishes before Ctrl+Break needs no SIGKILL."""
         monkeypatch.setattr(
             "deepagents_code.client.launch.server.sys.platform", "win32"
         )
@@ -1994,13 +2018,15 @@ class TestTerminateServerProcess:
 
         _terminate_server_process(process)
 
-        process.send_signal.assert_called_once_with(signal.SIGTERM)
+        process.send_signal.assert_called_once_with(
+            server_module._WINDOWS_CTRL_BREAK_EVENT
+        )
         process.kill.assert_not_called()
 
-    def test_root_sigterm_oserror_reports_orphan(
+    def test_windows_ctrl_break_oserror_reports_orphan(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """On the root-only path an undeliverable SIGTERM reports the orphan."""
+        """An undeliverable Windows Ctrl+Break reports the orphan risk."""
         monkeypatch.setattr(
             "deepagents_code.client.launch.server.sys.platform", "win32"
         )
@@ -2010,14 +2036,16 @@ class TestTerminateServerProcess:
         with caplog.at_level(logging.ERROR):
             _terminate_server_process(process)
 
-        process.send_signal.assert_called_once_with(signal.SIGTERM)
+        process.send_signal.assert_called_once_with(
+            server_module._WINDOWS_CTRL_BREAK_EVENT
+        )
         process.kill.assert_not_called()
         assert "may be orphaned" in caplog.text
 
-    def test_root_sigkill_oserror_reports_orphan(
+    def test_windows_sigkill_oserror_reports_orphan(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """On the root-only path a failed escalation SIGKILL reports the orphan."""
+        """On Windows a failed escalation SIGKILL reports the orphan risk."""
         monkeypatch.setattr(
             "deepagents_code.client.launch.server.sys.platform", "win32"
         )

--- a/libs/code/tests/unit_tests/test_server.py
+++ b/libs/code/tests/unit_tests/test_server.py
@@ -9,6 +9,7 @@ import os
 import signal
 import socket
 import subprocess
+import sys
 import threading
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Self
@@ -1514,6 +1515,37 @@ class TestServerSessionIsolation:
         assert popen.call_args.kwargs["start_new_session"] is True
         assert popen.call_args.kwargs["creationflags"] == 0
 
+    @pytest.mark.skipif(
+        sys.platform != "win32", reason="the stdlib names exist only on Windows"
+    )
+    def test_windows_constants_match_the_stdlib(self) -> None:
+        """The literals are the real ABI values, not just self-consistent.
+
+        Every other Windows assertion in this file runs on Linux behind a
+        patched `sys.platform`, comparing the constants to themselves. A wrong
+        value would pass all of them: `_WINDOWS_CTRL_BREAK_EVENT = 0` is
+        `CTRL_C_EVENT`, which `Popen.send_signal` dispatches differently, so
+        Windows shutdown would break silently.
+        """
+        # Both stdlib names are Windows-only, so they do not resolve for the
+        # type checker on the platform this file is checked on.
+        assert (
+            server_module._WINDOWS_CREATE_NEW_PROCESS_GROUP
+            == subprocess.CREATE_NEW_PROCESS_GROUP  # ty: ignore[unresolved-attribute]
+        )
+        assert (
+            server_module._WINDOWS_CTRL_BREAK_EVENT == signal.CTRL_BREAK_EVENT  # ty: ignore[unresolved-attribute]
+        )
+
+    def test_windows_constants_match_the_documented_literals(self) -> None:
+        """Guards the values on the platforms CI actually runs.
+
+        `libs/code` has no Windows CI leg, so without this the constants are
+        unverified everywhere.
+        """
+        assert server_module._WINDOWS_CREATE_NEW_PROCESS_GROUP == 0x00000200
+        assert server_module._WINDOWS_CTRL_BREAK_EVENT == 1
+
     async def test_windows_spawn_starts_new_process_group(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1795,6 +1827,50 @@ class TestTerminateServerProcess:
         )
         process.kill.assert_called_once_with()
 
+    def test_windows_logs_the_group_scope_for_the_graceful_signal(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Ctrl+Break reaches the console group even with no POSIX pgid.
+
+        The word in the log line is the only observable effect of the win32
+        clause in `signal_scope`, so nothing else can catch its removal.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.client.launch.server.sys.platform", "win32"
+        )
+        process = self._own_group_process()
+        process.send_signal.side_effect = ProcessLookupError
+
+        with caplog.at_level(logging.DEBUG, logger=server_module.__name__):
+            _terminate_server_process(process)
+
+        assert "process group" in caplog.text
+
+    def test_windows_escalation_reports_root_only_kill(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The hard kill reaches the root handle, and says so.
+
+        Ctrl+Break is group-wide but `TerminateProcess` is not, so reusing the
+        graceful signal's scope here would claim a group kill that never
+        happened and hide the orphaned descendants.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.client.launch.server.sys.platform", "win32"
+        )
+        process = self._own_group_process()
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="langgraph", timeout=3),
+            0,
+        ]
+
+        with caplog.at_level(logging.WARNING):
+            _terminate_server_process(process)
+
+        assert "killing process" in caplog.text
+        assert "killing process group" not in caplog.text
+        assert "left orphaned" in caplog.text
+
     def test_windows_ctrl_break_shutdown_is_graceful(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1914,7 +1990,7 @@ class TestTerminateServerProcess:
             ((4321, signal.SIGKILL),),
             ((4321, 0),),
         ]
-        assert "did not exit after SIGKILL" in caplog.text
+        assert "did not exit after the hard kill" in caplog.text
 
     def test_windows_sigkill_timeout_warns(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -1933,7 +2009,7 @@ class TestTerminateServerProcess:
             _terminate_server_process(process)
 
         process.kill.assert_called_once_with()
-        assert "did not exit after SIGKILL" in caplog.text
+        assert "did not exit after the hard kill" in caplog.text
 
     async def test_startup_failure_terminates_group(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
`dcode -x` now drains pending LangSmith traces before its child server exits.

---

The child `langgraph dev` process could terminate before final trace updates left the SDK queue. The custom HTTP app now flushes existing tracers during lifespan shutdown on a bounded daemon worker, so a stuck telemetry call cannot delay exit.

The parent uses graceful process-group signaling on POSIX and Ctrl+Break for a dedicated Windows process group, with enough shutdown margin for both the trace flush and LangGraph teardown. No tracing client is created when tracing is disabled.

<details>
<summary>Test plan</summary>

- Unit coverage for successful, failed, disabled, and timed-out flushes
- Cross-platform server termination unit coverage
- Real `langgraph dev` subprocess shutdown test
- `make lint`

</details>
