### PR TITLE
fix(code): clarify clear command descriptions

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -17,7 +17,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/auto` |  | Switch to Auto approval mode or manage its classifier model |
 | `/auto-update` |  | Turn automatic updates on or off |
 | `/changelog` |  | Open the changelog in a browser |
-| `/clear` |  | Clear the chat and start a new thread |
+| `/clear` |  | Start a fresh thread |
 | `/context` |  | Show current context window usage |
 | `/context-doctor` |  | Audit what a session injects and its estimated token cost |
 | `/copy` |  | Copy the latest assistant message to clipboard |
@@ -26,7 +26,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/editor` |  | Open prompt in an external editor ($EDITOR) |
 | `/effort` |  | Set reasoning effort for the current model |
 | `/feedback` |  | Send feedback or report an issue |
-| `/force-clear` |  | Stop active work, clear the chat, and start a new thread |
+| `/force-clear` |  | Recover a stuck session with a fresh thread |
 | `/goal` |  | Set and manage a persistent objective with acceptance criteria |
 | `/help` |  | Show help and available commands |
 | `/install` |  | Install an optional integration |

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -115,7 +115,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         name="/clear",
-        description="Clear the chat and start a new thread",
+        description="Start a fresh thread",
         bypass_tier=BypassTier.QUEUED,
         hidden_keywords="reset",
     ),
@@ -144,7 +144,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         name="/force-clear",
-        description="Stop active work, clear the chat, and start a new thread",
+        description="Recover a stuck session with a fresh thread",
         bypass_tier=BypassTier.ALWAYS,
         hidden_keywords="reset interrupt",
     ),

--- a/libs/code/tests/unit_tests/tui/widgets/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_autocomplete.py
@@ -264,9 +264,9 @@ class TestSlashCommandController:
         suggestions = mock_view.render_completion_suggestions.call_args[0][0]
         assert any("/quit" in s[0] for s in suggestions)
 
-    def test_substring_description_match_new(self, controller, mock_view):
-        """Typing 'new' surfaces /clear via substring on 'start new thread'."""
-        controller.on_text_changed("/new", 4)
+    def test_substring_description_match_fresh(self, controller, mock_view):
+        """Typing 'fresh' surfaces /clear via substring on 'Start a fresh thread'."""
+        controller.on_text_changed("/fresh", 6)
 
         mock_view.render_completion_suggestions.assert_called()
         suggestions = mock_view.render_completion_suggestions.call_args[0][0]


### PR DESCRIPTION
`/clear` now emphasizes starting fresh, while `/force-clear` is framed as recovery for a stuck session.

---

The previous descriptions focused on implementation details and made the intended use cases hard to distinguish. The generated command catalog is updated from the registry.

Made by [Open SWE](https://openswe.vercel.app/agents/e6814be2-5315-55be-aca4-e8542b57afb0)