### PR TITLE
feat(code): add Baseten `zai-org/GLM-5.3-Flash` to model switcher

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -82,6 +82,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "baseten:nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": "Nemotron 3 Ultra 550B A55B",
     "baseten:zai-org/GLM-5.2": "GLM 5.2",
     "baseten:zai-org/GLM-5.2-Fast": "GLM 5.2 Fast",
+    "baseten:zai-org/GLM-5.3-Flash": "GLM 5.3 Flash",
     "fireworks:accounts/fireworks/models/deepseek-v4-flash-0731": (
         "DeepSeek V4 Flash 0731"
     ),


### PR DESCRIPTION
Adds Z.ai's GLM-5.3-Flash to the dcode model switcher for Baseten, so it can be picked from `/model` and the onboarding picker instead of typed in by hand.

---

Z.ai released [GLM-5.3-Flash](https://z.ai/blog/glm-5.3-flash) on 2026-08-26, its first natively multimodal model in the GLM-5 series (320B total / 18B active, hybrid linear and sparse attention, 1M context, MIT licensed). Baseten made it available through Model APIs the same day, per their [changelog](https://www.baseten.co/resources/changelog/glm-53-fast-available-on-baseten/) and [model page](https://www.baseten.co/library/glm-53-flash/).

The `baseten` provider is already wired into `PROVIDER_API_KEY_ENV`, and `_RECOMMENDED_MODELS` already carries `zai-org/GLM-5.2` and `zai-org/GLM-5.2-Fast`, so this only needs the new spec and its display name. The model ID `zai-org/GLM-5.3-Flash` is taken verbatim from Baseten's own model page rather than derived from another provider's naming scheme. The entry is placed alphabetically within the existing `baseten:` block, and the display name follows the sibling GLM entries.

Only the Baseten entry is added here. Other providers that may serve this model are intentionally out of scope for this PR.
