### PR TITLE
fix(code): make debug log path click-to-copy

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -24093,17 +24093,26 @@ class DeepAgentsApp(App):
                 f"({store.visible_count} rendered), {turns} {turn_label}"
             )
 
-        def _log_path() -> str:
-            path = installed_debug_log_path()
+        def _log_field() -> SnapshotField:
+            try:
+                path = installed_debug_log_path()
+            except Exception as exc:
+                logger.warning("Debug snapshot field 'Debug log' failed", exc_info=True)
+                return SnapshotField(
+                    label="Debug log", value=f"(unavailable: {type(exc).__name__})"
+                )
             if path:
-                return str(path)
+                return SnapshotField(label="Debug log", value=str(path), copyable=True)
             # DEEPAGENTS_CODE_DEBUG can read truthy with no handler installed —
             # e.g. a bad path, or the var set after import via .env. Distinguish
             # that from the plain no-file-logging case so the console does not
             # imply a file exists (and hint that a request went unfulfilled).
-            if is_env_truthy(DEBUG):
-                return "in-memory only (file logging requested but unavailable)"
-            return "in-memory only"
+            value = (
+                "in-memory only (file logging requested but unavailable)"
+                if is_env_truthy(DEBUG)
+                else "in-memory only"
+            )
+            return SnapshotField(label="Debug log", value=value)
 
         return [
             _safe("Version", lambda: __version__, copyable=True),
@@ -24119,7 +24128,7 @@ class DeepAgentsApp(App):
             _safe("Sandbox", lambda: self._sandbox_type or "local"),
             _safe("MCP servers", _mcp),
             _safe("Tokens", _tokens),
-            _safe("Debug log", _log_path),
+            _log_field(),
         ]
 
     def _open_notification_center(self) -> None:

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -2036,6 +2036,41 @@ class TestDebugConsoleToggle:
             assert fields["CWD"].copyable is True
             assert fields["CWD"].value
 
+    async def test_build_snapshot_debug_log_path_is_copyable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import deepagents_code._debug as debug_mod
+
+        monkeypatch.setattr(
+            debug_mod, "installed_debug_log_path", lambda: "/tmp/custom-debug.log"
+        )
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        async with app.run_test():
+            field = next(
+                field
+                for field in app._build_debug_snapshot()
+                if field.label == "Debug log"
+            )
+            assert field.value == "/tmp/custom-debug.log"
+            assert field.copyable is True
+
+    async def test_build_snapshot_in_memory_log_is_not_copyable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import deepagents_code._debug as debug_mod
+
+        monkeypatch.setattr(debug_mod, "installed_debug_log_path", lambda: None)
+        monkeypatch.delenv("DEEPAGENTS_CODE_DEBUG", raising=False)
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        async with app.run_test():
+            field = next(
+                field
+                for field in app._build_debug_snapshot()
+                if field.label == "Debug log"
+            )
+            assert field.value == "in-memory only"
+            assert field.copyable is False
+
     async def test_build_snapshot_model_field_is_copyable_when_configured(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
The debugger's active debug log file path can now be copied by clicking it; in-memory fallback text remains non-interactive.

---

The snapshot reuses the existing safe copy-span behavior and preserves defensive fallback handling.

Made by [Open SWE](https://openswe.vercel.app/agents/ef160ebe-a941-5809-bc2f-77be98bb1105)