### PR TITLE
test(code): pin Unicode charset in diff rendering tests

### DIFF
--- a/libs/code/tests/unit_tests/test_charset.py
+++ b/libs/code/tests/unit_tests/test_charset.py
@@ -1,11 +1,17 @@
 """Tests for charset mode configuration and glyph selection."""
 
+from __future__ import annotations
+
 import os
 import sys
 from dataclasses import fields
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 from deepagents_code._env_vars import HIDE_SPLASH_VERSION
 from deepagents_code.config import (
@@ -22,6 +28,20 @@ from deepagents_code.config import (
     is_ascii_mode,
     reset_glyphs_cache,
 )
+
+
+@pytest.fixture(autouse=True)
+def _restore_glyphs_cache() -> Iterator[None]:
+    """Keep the process-global glyph cache from leaking across tests.
+
+    Several tests force the charset to ASCII or Unicode and leave the detected
+    mode in `config`'s module-level caches; xdist scheduling then decides which
+    unrelated test inherits that state. Reset before *and* after each test so
+    the ambient mode is always recomputed from the environment.
+    """
+    reset_glyphs_cache()
+    yield
+    reset_glyphs_cache()
 
 
 class TestCharsetMode:
@@ -133,10 +153,6 @@ class TestGlyphs:
 class TestDetectCharsetMode:
     """Tests for _detect_charset_mode function."""
 
-    def setup_method(self) -> None:
-        """Reset glyphs cache before each test."""
-        reset_glyphs_cache()
-
     @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
     def test_explicit_unicode_mode(self) -> None:
         """Test explicit unicode mode via env var."""
@@ -209,10 +225,6 @@ class TestDetectCharsetMode:
 class TestGetGlyphs:
     """Tests for get_glyphs function."""
 
-    def setup_method(self) -> None:
-        """Reset glyphs cache before each test."""
-        reset_glyphs_cache()
-
     @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
     def test_get_glyphs_returns_unicode_for_unicode_mode(self) -> None:
         """Test get_glyphs returns UNICODE_GLYPHS for unicode mode."""
@@ -283,10 +295,6 @@ class TestGlyphUsability:
 class TestGetBanner:
     """Tests for get_banner function."""
 
-    def setup_method(self) -> None:
-        """Reset glyphs cache before each test."""
-        reset_glyphs_cache()
-
     @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
     def test_get_banner_returns_unicode_for_unicode_mode(self) -> None:
         """Test get_banner returns Unicode banner for unicode mode."""
@@ -344,10 +352,6 @@ class TestGetBanner:
 
 class TestIsAsciiMode:
     """Tests for is_ascii_mode helper."""
-
-    def setup_method(self) -> None:
-        """Reset glyphs cache before each test."""
-        reset_glyphs_cache()
 
     @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
     def test_false_in_unicode_mode(self) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_diff.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_diff.py
@@ -13,7 +13,7 @@ from textual.style import Color, Style
 from textual.visual import RenderOptions
 from textual.widgets import Static
 
-from deepagents_code.config import ASCII_GLYPHS, get_glyphs
+from deepagents_code.config import ASCII_GLYPHS, get_glyphs, reset_glyphs_cache
 from deepagents_code.diff_utils import (
     DiffStats,
     count_diff_change_lines,
@@ -48,6 +48,22 @@ def _clear_highlight_cache() -> Iterator[None]:
     diff_module._highlight_lines_cached.cache_clear()
     yield
     diff_module._highlight_lines_cached.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _unicode_glyphs(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Render every diff row with the Unicode glyph set, regardless of ambient state.
+
+    The diff renderer reads `get_glyphs()`, which is cached process-wide from the
+    terminal charset detection. An unrelated test that forces ASCII mode (e.g. in
+    `test_charset.py`) would otherwise leave `.` as the continuation glyph and
+    break the `…` expectations below, with xdist scheduling deciding which run
+    order exposes the leak.
+    """
+    monkeypatch.setenv("UI_CHARSET_MODE", "unicode")
+    reset_glyphs_cache()
+    yield
+    reset_glyphs_cache()
 
 
 def _rendered(diff: str, max_lines: int | None = 100) -> list[Static]:


### PR DESCRIPTION
Fixes #5843

---

The `deepagents-code` Python 3.12 unit-test leg failed three `test_diff.py` assertions that expected the Unicode line-continuation glyph `…` but rendered the ASCII fallback `.`. The same tests passed on 3.13 and 3.14, and the PR that hit the failure did not touch the diff renderer.

The diff widget reads `get_glyphs()`, which caches the detected charset mode in a process-wide module variable. Several tests in `test_charset.py` patch `UI_CHARSET_MODE` to force ASCII or Unicode and reset that cache in `setup_method` — before each test — but never reset it afterward. `TestIsAsciiMode::test_true_in_ascii_mode` therefore leaves the cache pinned to ASCII. Whether any later test in the same pytest-xdist worker inherits that state depends entirely on how tests are distributed across workers, which is why the failure surfaced only on the 3.12 leg and disappeared under other run orders.

Two changes make the intended behavior deterministic across the matrix:

- `test_charset.py` now uses an autouse fixture that resets the glyph cache both before and after each test, so a forced charset cannot leak into unrelated tests.
- `test_diff.py` now sets `UI_CHARSET_MODE=unicode` and resets the cache around every test, so the rendering expectations no longer depend on ambient process state.
