### PR TITLE
fix(code): reject stale successful updates

### DIFF
--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -2456,10 +2456,11 @@ async def perform_upgrade(
         stdout/stderr. *installed_version* is the version the successful
         install actually resolved to, read back from the tool environment on
         disk, or `None` when the upgrade failed or the installed version
-        could not be determined. Callers should report *installed_version*
-        rather than the version their update check observed: the install
-        command is unpinned, so a release published between check and install
-        is what lands on disk.
+        could not be determined. A successful installer exit is reported as a
+        failure when the installed version remains below `target_version`.
+        Callers should report *installed_version* rather than the version their
+        update check observed: the install command is unpinned, so a release
+        published between check and install is what lands on disk.
 
     Raises:
         OSError: Propagated from building the upgrade command or running the
@@ -2621,9 +2622,21 @@ async def perform_upgrade(
             # distribution back rather than reporting the earlier check's
             # version; when the readback is indeterminate, the caller's
             # checked version is still the best available answer.
-            installed_version = (
-                await asyncio.to_thread(read_installed_distribution_version)
-            ) or target_version
+            installed_version = await asyncio.to_thread(
+                read_installed_distribution_version
+            )
+            if (
+                installed_version is not None
+                and target_version is not None
+                and _parse_version(installed_version) < _parse_version(target_version)
+            ):
+                detail = (
+                    "Installer completed, but deepagents-code remains at "
+                    f"v{installed_version}; v{target_version} may not have reached "
+                    "the package index yet. Try again shortly."
+                )
+                return False, f"{detail}\n{output}".rstrip(), None
+            installed_version = installed_version or target_version
     return success, output, installed_version
 
 

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -2456,8 +2456,8 @@ async def perform_upgrade(
         stdout/stderr. *installed_version* is the version the successful
         install actually resolved to, read back from the tool environment on
         disk, or `None` when the upgrade failed or the installed version
-        could not be determined. A successful installer exit is reported as a
-        failure when the installed version remains below `target_version`.
+        could not be determined. A successful uv installer exit is reported
+        as a failure when the installed version remains below `target_version`.
         Callers should report *installed_version* rather than the version their
         update check observed: the install command is unpinned, so a release
         published between check and install is what lands on disk.
@@ -2615,13 +2615,11 @@ async def perform_upgrade(
             # The install was pinned to the exact target version, so that is
             # what landed on disk; skip the filesystem readback.
             installed_version = pin_target_version
-        else:
-            # The install command is unpinned (`uv tool install -U` / `brew
-            # upgrade`), so a release published between the update check and
-            # the install is what actually landed. Read the installed
-            # distribution back rather than reporting the earlier check's
-            # version; when the readback is indeterminate, the caller's
-            # checked version is still the best available answer.
+        elif method == "uv":
+            # uv updates the running tool environment in place, so its dist-info
+            # reflects what the resolver actually installed. Homebrew replaces
+            # and relinks a Cellar keg instead; this process still sees the old
+            # prefix and cannot verify the new formula this way.
             installed_version = await asyncio.to_thread(
                 read_installed_distribution_version
             )
@@ -2631,12 +2629,14 @@ async def perform_upgrade(
                 and _parse_version(installed_version) < _parse_version(target_version)
             ):
                 detail = (
-                    "Installer completed, but deepagents-code remains at "
-                    f"v{installed_version}; v{target_version} may not have reached "
-                    "the package index yet. Try again shortly."
+                    f"v{target_version} is still propagating to the package index; "
+                    f"dcode remains on v{installed_version}. "
+                    "Try again in a few minutes."
                 )
-                return False, f"{detail}\n{output}".rstrip(), None
+                return False, detail, None
             installed_version = installed_version or target_version
+        else:
+            installed_version = target_version
     return success, output, installed_version
 
 

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -3160,9 +3160,35 @@ class TestUpdateLogs:
 
         assert success is False
         assert installed is None
-        assert "remains at v1.0.0" in output
-        assert "v1.1.0 may not have reached the package index yet" in output
-        assert "Updated dependencies only" in output
+        assert output == (
+            "v1.1.0 is still propagating to the package index; "
+            "dcode remains on v1.0.0. Try again in a few minutes."
+        )
+
+    async def test_perform_upgrade_brew_skips_running_prefix_readback(self) -> None:
+        """Homebrew's running process cannot verify the newly relinked Cellar."""
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="brew",
+            ),
+            patch(
+                "deepagents_code.update_check.shutil.which", return_value="/opt/brew"
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "deepagents_code.update_check.read_installed_distribution_version",
+            ) as readback_mock,
+        ):
+            success, _output, installed = await perform_upgrade(target_version="1.1.0")
+
+        assert success is True
+        assert installed == "1.1.0"
+        readback_mock.assert_not_called()
 
     async def test_perform_upgrade_falls_back_to_target_when_readback_fails(
         self, cache_file

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -3120,6 +3120,50 @@ class TestUpdateLogs:
         assert success is True
         assert installed == "1.2.0"
 
+    async def test_perform_upgrade_rejects_stale_successful_install(
+        self, cache_file
+    ) -> None:
+        """A successful installer exit is not success when the app stays stale."""
+        cache_file.write_text(
+            json.dumps({"release_prerelease_pins": {"1.1.0": []}}),
+            encoding="utf-8",
+        )
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset(),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=(),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, "Updated dependencies only"),
+            ),
+            patch(
+                "deepagents_code.update_check.read_installed_distribution_version",
+                return_value="1.0.0",
+            ),
+        ):
+            success, output, installed = await perform_upgrade(target_version="1.1.0")
+
+        assert success is False
+        assert installed is None
+        assert "remains at v1.0.0" in output
+        assert "v1.1.0 may not have reached the package index yet" in output
+        assert "Updated dependencies only" in output
+
     async def test_perform_upgrade_falls_back_to_target_when_readback_fails(
         self, cache_file
     ) -> None:


### PR DESCRIPTION
`dcode update` now reports when a newly published release is still propagating instead of falsely claiming that version was installed.

---

The motivating case was the `0.1.63` release: PyPI’s release metadata advertised `0.1.63`, so `dcode update` offered it, but the first `uv tool install -U` resolution only upgraded `click`, `langchain-protocol`, and `openai` while leaving `deepagents-code==0.1.62`. Because uv exited successfully, dcode printed `Updated to v0.1.63`; the next launch correctly detected `0.1.62`, repeated the update, and then installed `0.1.63`.

`perform_upgrade` already reads the uv tool environment after installation. This change compares that readback with the update target and returns a concise propagation message when uv resolved an older app version. The check is uv-only: Homebrew replaces and relinks a Cellar keg, so the running process’s prefix can still report the old version after a successful formula upgrade.

Tests cover the stale uv resolution, newer-version and indeterminate readbacks, and the Homebrew relink case.

<details><summary>Test plan</summary>

- `make -C libs/code format`
- `make -C libs/code lint`
- `uv run --directory libs/code pytest -q --disable-warnings tests/unit_tests/test_update_check.py -k 'perform_upgrade'

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/459d7ee6-a016-5fc2-8e03-3d8b2354d23a)
