### PR TITLE
chore(repo): bump openwiki to version 0.4.2

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: "26"
 
       - name: Install OpenWiki
-        run: npm install --global openwiki@0.4.1
+        run: npm install --global openwiki@0.4.2
 
       - name: Run OpenWiki
         run: openwiki code --update --print


### PR DESCRIPTION
## Summary

OpenWiki v0.4.1 introduced a regression that has been fixed in v0.4.2. Bumping OpenWiki update workflow to pick up the newest version.
