### PR TITLE
refactor(code): extract runtime model state into `RuntimeState`

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -92,6 +92,7 @@ from deepagents_code.config import (
     get_langsmith_project_name,
     restore_user_tracing_api_keys,
     restore_user_tracing_env,
+    runtime_state,
     settings,
 )
 from deepagents_code.configurable_model import ConfigurableModelMiddleware
@@ -1546,10 +1547,10 @@ def get_system_prompt(
         )
 
     model_identity_section = build_model_identity_section(
-        settings.model_name,
-        provider=settings.model_provider,
-        context_limit=settings.model_context_limit,
-        unsupported_modalities=settings.model_unsupported_modalities,
+        runtime_state.model_name,
+        provider=runtime_state.model_provider,
+        context_limit=runtime_state.model_context_limit,
+        unsupported_modalities=runtime_state.model_unsupported_modalities,
     )
     filesystem_tool_guidance = _build_fs_tool_prompt_guidance(fs_tools)
     web_search_tool_guidance = _WEB_SEARCH_TOOL_GUIDANCE if settings.has_tavily else ""

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4554,7 +4554,7 @@ class DeepAgentsApp(App):
             UI components for the main chat area and status bar.
         """
         from deepagents_code._env_vars import SHOW_HEADER, is_env_truthy
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
 
         if is_env_truthy(SHOW_HEADER) or self._installation_stale:
             yield _StaticHeader(id="app-header")
@@ -4563,8 +4563,8 @@ class DeepAgentsApp(App):
         # `_ChatScroll` keeps clicks on messages from stealing input focus.
         with _ChatScroll(id="chat"):
             yield WelcomeBanner(
-                model_provider=settings.model_provider or "",
-                model_name=settings.model_name or "",
+                model_provider=runtime_state.model_provider or "",
+                model_name=runtime_state.model_name or "",
                 cwd=self._cwd,
                 thread_id=self._lc_thread_id,
                 mcp_tool_count=self._mcp_tool_count,
@@ -5291,11 +5291,11 @@ class DeepAgentsApp(App):
         Returns:
             Whether the caller may continue.
         """
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
 
         outcome = await self._hooks.on_session_start(
             cause,
-            model=settings.model_name or None,
+            model=runtime_state.model_name or None,
         )
         if outcome.ok:
             return True
@@ -5762,7 +5762,7 @@ class DeepAgentsApp(App):
         if self._resume_thread_intent:
             await self._resolve_resume_thread()
 
-        # Run deferred model creation. settings.model_name / model_provider
+        # Run deferred model creation. runtime_state.model_name / model_provider
         # are already set eagerly for the status bar display; this call
         # does the heavy langchain import + SDK init and may refine them
         # (e.g., context_limit from the model profile).
@@ -5818,7 +5818,7 @@ class DeepAgentsApp(App):
             except ModelConfigError as exc:
                 self.post_message(self.ServerStartFailed(error=exc))
                 return
-            result.apply_to_settings()
+            result.apply_to_runtime_state()
             resolved_spec = f"{result.provider}:{result.model_name}"
             await self._restore_effort_override(resolved_spec)
             # Best-effort persistence. `resolved_spec` came out of `create_model`, so
@@ -5960,7 +5960,7 @@ class DeepAgentsApp(App):
         # startup (e.g. `/model` switching providers after `ModelConfigError`)
         # surfaces the now-active model. `StatusBar.on_mount` only runs once,
         # and `_retry_startup_with_model` updates `settings` via
-        # `apply_to_settings` without pushing into the widget.
+        # `apply_to_runtime_state` without pushing into the widget.
         if self._status_bar is None:
             logger.warning("Status bar not found during server ready transition")
         else:
@@ -15360,12 +15360,12 @@ class DeepAgentsApp(App):
         source: Literal["goal", "rubric"] = "rubric",
     ) -> None:
         """Open the model selector for choosing a grader model."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
         from deepagents_code.model_config import ModelSpec
         from deepagents_code.tui.widgets.model_selector import ModelSelectorScreen
 
-        current_provider = settings.model_provider
-        current_model = settings.model_name
+        current_provider = runtime_state.model_provider
+        current_model = runtime_state.model_name
         if self._rubric_model:
             parsed = ModelSpec.try_parse(self._rubric_model)
             if parsed:
@@ -15642,7 +15642,7 @@ class DeepAgentsApp(App):
         Args:
             command: The slash command (including /)
         """
-        from deepagents_code.config import newline_shortcut, settings
+        from deepagents_code.config import newline_shortcut, runtime_state
 
         cmd = command.lower().strip()
 
@@ -15894,8 +15894,8 @@ class DeepAgentsApp(App):
                 ContextUsageScreen(
                     context_tokens=context_tokens,
                     conversation_tokens=conversation_tokens,
-                    context_limit=settings.model_context_limit,
-                    model_spec=self._effective_model_spec() or settings.model_name,
+                    context_limit=runtime_state.model_context_limit,
+                    model_spec=self._effective_model_spec() or runtime_state.model_name,
                     approximate=approximate,
                 ),
                 lambda _result: self._focus_chat_input_after_refresh(),
@@ -15908,8 +15908,8 @@ class DeepAgentsApp(App):
                 count = self._context_tokens
                 formatted = format_token_count(count)
 
-                model_name = settings.model_name
-                context_limit = settings.model_context_limit
+                model_name = runtime_state.model_name
+                context_limit = runtime_state.model_context_limit
 
                 if context_limit is not None:
                     limit_str = format_token_count(context_limit)
@@ -16864,13 +16864,13 @@ class DeepAgentsApp(App):
         try:
             await self._set_spinner("Offloading")
             from deepagents_code._cli_context import CLIContext
-            from deepagents_code.config import settings
+            from deepagents_code.config import runtime_state
 
             context = CLIContext(
                 model=self._effective_model_spec(),
                 model_params=self._model_params_override or {},
                 profile_overrides=self._profile_override or {},
-                model_context_limit=settings.model_context_limit,
+                model_context_limit=runtime_state.model_context_limit,
                 thread_id=self._lc_thread_id,
                 # The operation runs the agent's `PreCompact` and `PreToolUse`
                 # hooks, and the server defaults a missing mode to `manual`.
@@ -17330,10 +17330,10 @@ class DeepAgentsApp(App):
         """
         if self._model_override:
             return self._model_override
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
 
-        provider = settings.model_provider or ""
-        model = settings.model_name or ""
+        provider = runtime_state.model_provider or ""
+        model = runtime_state.model_name or ""
         if provider and model:
             return f"{provider}:{model}"
         return None
@@ -17342,27 +17342,27 @@ class DeepAgentsApp(App):
         """Return the provider name in effect for the next invocation.
 
         Derives the provider from the effective `provider:model` spec, falling
-        back to `settings.model_provider`. Used to diagnose gateway/key
+        back to `runtime_state.model_provider`. Used to diagnose gateway/key
         mismatches when an error is rendered.
         """
         spec = self._effective_model_spec()
         if spec and ":" in spec:
             return spec.split(":", 1)[0] or None
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
 
-        return settings.model_provider or None
+        return runtime_state.model_provider or None
 
     def _sync_status_model(self) -> None:
         """Update model displays and the `/effort` hint for the active model."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
         from deepagents_code.reasoning_effort import (
             current_effort_from_model_params,
             default_effort_for_model,
             supported_efforts_for_model,
         )
 
-        provider = settings.model_provider or ""
-        model = settings.model_name or ""
+        provider = runtime_state.model_provider or ""
+        model = runtime_state.model_name or ""
         spec = self._effective_model_spec()
         if self._chat_input is not None:
             try:
@@ -17390,10 +17390,10 @@ class DeepAgentsApp(App):
             logger.debug("Screen stack empty during model sync", exc_info=True)
         if self._status_bar is None:
             return
-        self._status_bar.set_context_limit(settings.model_context_limit)
+        self._status_bar.set_context_limit(runtime_state.model_context_limit)
         if not provider or not model:
             logger.warning(
-                "Settings missing model identity at status sync "
+                "Runtime state missing model identity at status sync "
                 "(provider=%r, model=%r); status bar will render blank",
                 provider,
                 model,
@@ -17667,7 +17667,7 @@ class DeepAgentsApp(App):
         # `_agent_turn_started`.
         self._agent_turn_started = True
 
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
         from deepagents_code.hooks.client_lifecycle import ClientHookStopError
         from deepagents_code.resume_state import RUBRIC_RESULT_VALUES
         from deepagents_code.tui.textual_adapter import (
@@ -17850,7 +17850,7 @@ class DeepAgentsApp(App):
                     model=self._model_override,
                     model_params=self._model_params_override or {},
                     profile_overrides=self._profile_override or {},
-                    model_context_limit=settings.model_context_limit,
+                    model_context_limit=runtime_state.model_context_limit,
                     classifier_model=self._auto_classifier_context_value(),
                 ),
                 turn_stats=turn_stats,
@@ -21525,15 +21525,15 @@ class DeepAgentsApp(App):
 
     async def _show_auto_classifier_model_selector(self) -> None:
         """Open the model selector for choosing the Auto classifier model."""
-        from deepagents_code.config import detect_provider, settings
+        from deepagents_code.config import detect_provider, runtime_state
         from deepagents_code.model_config import ModelSpec
         from deepagents_code.tui.widgets.model_selector import (
             AUTO_CLASSIFIER_DEFAULT_SCOPE,
             ModelSelectorScreen,
         )
 
-        current_provider = settings.model_provider
-        current_model = settings.model_name
+        current_provider = runtime_state.model_provider
+        current_model = runtime_state.model_name
         if display := self._auto_classifier_display_spec():
             parsed = ModelSpec.try_parse(display)
             if parsed:
@@ -22496,15 +22496,15 @@ class DeepAgentsApp(App):
         Returns:
             Configured model selector modal.
         """
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
         from deepagents_code.tui.widgets.model_selector import (
             MAIN_MODEL_DEFAULT_SCOPE,
             ModelSelectorScreen,
         )
 
         return ModelSelectorScreen(
-            current_model=settings.model_name,
-            current_provider=settings.model_provider,
+            current_model=runtime_state.model_name,
+            current_provider=runtime_state.model_provider,
             cli_profile_override=self._profile_override,
             curated=curated,
             title="Choose a Recommended Model" if curated else None,
@@ -22681,15 +22681,15 @@ class DeepAgentsApp(App):
         callers reach it through `_schedule_off_message_pump` because their
         continuation starts on the App message pump.
         """
-        from deepagents_code.config import detect_provider, settings
+        from deepagents_code.config import detect_provider, runtime_state
         from deepagents_code.model_config import ModelSpec
 
         target = model_spec.removeprefix(":")
         parsed = ModelSpec.try_parse(target)
         provider = parsed.provider if parsed else detect_provider(target)
         model_name = parsed.model if parsed else target
-        if model_name == settings.model_name and (
-            not provider or provider == settings.model_provider
+        if model_name == runtime_state.model_name and (
+            not provider or provider == runtime_state.model_provider
         ):
             await self._switch_model(target, extra_kwargs=extra_kwargs)
             return
@@ -22703,7 +22703,7 @@ class DeepAgentsApp(App):
                 ModelSwitchWarningScreen,
             )
 
-            current = f"{settings.model_provider}:{settings.model_name}"
+            current = f"{runtime_state.model_provider}:{runtime_state.model_name}"
             display = f"{provider}:{model_name}" if provider and not parsed else target
             screen = ModelSwitchWarningScreen(
                 current_model=current,
@@ -28718,7 +28718,7 @@ class DeepAgentsApp(App):
                 messaging (which model couldn't be restored and what the session
                 is falling back to) rather than the interactive `/model` errors.
         """
-        from deepagents_code.config import detect_provider, settings
+        from deepagents_code.config import detect_provider, runtime_state
         from deepagents_code.model_config import (
             ModelSpec,
             ProviderAuthState,
@@ -28815,10 +28815,10 @@ class DeepAgentsApp(App):
                 )
 
             # Check if already using this exact model
-            if model_name == settings.model_name and (
-                not provider or provider == settings.model_provider
+            if model_name == runtime_state.model_name and (
+                not provider or provider == runtime_state.model_provider
             ):
-                current = f"{settings.model_provider}:{settings.model_name}"
+                current = f"{runtime_state.model_provider}:{runtime_state.model_name}"
                 # Mirror the regular-switch path so `--model-params` semantics
                 # are consistent across same-model and different-model cases:
                 # passing params applies them, omitting params clears any
@@ -28858,7 +28858,7 @@ class DeepAgentsApp(App):
                     extra_kwargs=extra_kwargs,
                     profile_overrides=self._profile_override,
                 )
-                result.apply_to_settings()
+                result.apply_to_runtime_state()
             except Exception as exc:
                 logger.exception("Failed to resolve model metadata for %s", display)
                 if from_resume:

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -71,6 +71,7 @@ from deepagents_code.config import (
     build_langsmith_thread_url,
     create_model,
     is_shell_command_allowed,
+    runtime_state,
     settings,
 )
 from deepagents_code.file_ops import FileOpTracker, record_display_caveat
@@ -597,8 +598,8 @@ def _record_usage_from_message(
     record_message_usage(
         state.stats,
         message_obj,
-        fallback_model=settings.model_name or "",
-        fallback_provider=settings.model_provider or "",
+        fallback_model=runtime_state.model_name or "",
+        fallback_provider=runtime_state.model_provider or "",
         request_metadata=metadata,
         kind=usage_kind,
         recorded_requests=state.recorded_usage_requests,
@@ -1011,8 +1012,8 @@ def _process_stream_chunk(
                 state.stats,
                 data,
                 active_thread_id=state.thread_id,
-                fallback_model=settings.model_name or "",
-                fallback_provider=settings.model_provider or "",
+                fallback_model=runtime_state.model_name or "",
+                fallback_provider=runtime_state.model_provider or "",
                 recorded_requests=state.recorded_usage_requests,
             )
         elif (
@@ -1575,12 +1576,12 @@ async def _run_agent_loop(
     state.hooks.apply_graph_context(context)
     context["approval_mode"] = resolved_approval_mode.value
     context["auto_approve"] = resolved_approval_mode is ApprovalMode.YOLO
-    state.active_model = settings.model_name or None
+    state.active_model = runtime_state.model_name or None
     state.transcript = state.hooks.recorder(thread_id)
 
     start_outcome = await state.hooks.on_session_start(
         SessionStartCause.STARTUP,
-        model=settings.model_name or None,
+        model=runtime_state.model_name or None,
     )
     if not start_outcome.ok:
         await _end_headless_session(state, SessionEndCause.OTHER)
@@ -1787,8 +1788,8 @@ def _build_non_interactive_header(
         (f"Agent: {assistant_id}{default_label}", "dim"),
     ]
 
-    if settings.model_name:
-        parts.extend([(" | ", "dim"), (f"Model: {settings.model_name}", "dim")])
+    if runtime_state.model_name:
+        parts.extend([(" | ", "dim"), (f"Model: {runtime_state.model_name}", "dim")])
 
     parts.append((" | ", "dim"))
 
@@ -2115,7 +2116,7 @@ async def run_non_interactive(
         console.print(f"[bold red]Error:[/bold red] {e}")
         return 1
 
-    result.apply_to_settings()
+    result.apply_to_runtime_state()
 
     thread_id = generate_thread_id()
 

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -103,7 +103,7 @@ _bootstrap_lock = threading.Lock()
 and the prewarm worker thread."""
 
 _singleton_lock = threading.Lock()
-"""Guards lazy singleton construction in `_get_console` / `_get_settings`."""
+"""Guards lazy construction of process-wide config, runtime, and console state."""
 
 _dotenv_loaded_values: dict[str, str] = {}
 """Environment values injected by our dotenv loader and safe to refresh later."""
@@ -1432,9 +1432,10 @@ if TYPE_CHECKING:
     from deepagents_code._git import RepositoryMetadata
 
     # Static type stubs for lazy module attributes resolved by __getattr__.
-    # At runtime these are created on first access by _get_settings() /
-    # _get_console() and cached in globals().
+    # At runtime these are created on first access by the singleton helpers and
+    # cached in globals().
     settings: Settings
+    runtime_state: RuntimeState
     console: Console
 
 MODE_PREFIXES: dict[str, str] = {
@@ -2889,9 +2890,9 @@ _RELOADABLE_FIELDS = (
 )
 """Fields refreshed on `/reload` and cwd switches.
 
-Runtime model state (`model_name`, `model_provider`, `model_context_limit`) and
-the original user LangSmith project are intentionally excluded -- they are set
-once and should not change across reloads.
+Runtime model metadata lives in `RuntimeState` and cannot be touched by a config
+reload. The original user LangSmith project is intentionally excluded because it
+is captured once at bootstrap.
 """
 
 _API_KEY_FIELDS = frozenset(
@@ -2902,6 +2903,23 @@ _API_KEY_FIELDS = frozenset(
 Derived from `_RELOADABLE_FIELDS` so new `*_api_key` fields are picked up
 automatically.
 """
+
+
+@dataclass
+class RuntimeState:
+    """Mutable metadata for the model active in this process."""
+
+    model_name: str | None = None
+    """Currently active model name, set after model creation."""
+
+    model_provider: str | None = None
+    """Provider identifier (e.g., `openai`, `anthropic`, `google_genai`)."""
+
+    model_context_limit: int | None = None
+    """Maximum input token count from the model profile."""
+
+    model_unsupported_modalities: frozenset[str] = frozenset()
+    """Input modalities not indicated as supported by the model profile."""
 
 
 @dataclass
@@ -2941,18 +2959,6 @@ class Settings:
 
     user_langchain_project: str | None
     """Original `LANGSMITH_PROJECT` from environment (for user code)."""
-
-    model_name: str | None = None
-    """Currently active model name, set after model creation."""
-
-    model_provider: str | None = None
-    """Provider identifier (e.g., `openai`, `anthropic`, `google_genai`)."""
-
-    model_context_limit: int | None = None
-    """Maximum input token count from the model profile."""
-
-    model_unsupported_modalities: frozenset[str] = frozenset()
-    """Input modalities not indicated as supported by the model profile."""
 
     project_root: Path | None = None
     """Current project root directory, or `None` if not in a git project."""
@@ -3441,10 +3447,10 @@ class Settings:
         (API keys, Google Cloud project, project root, shell allow-list, and
         LangSmith tracing project).
 
-        Runtime model state (`model_name`, `model_provider`,
-        `model_context_limit`) and the original user LangSmith project
-        (`user_langchain_project`) are intentionally preserved -- they are
-        not in `_RELOADABLE_FIELDS` and are never touched by this method.
+        Runtime model metadata lives in `RuntimeState` and is never touched by
+        this method. The original user LangSmith project
+        (`user_langchain_project`) is also intentionally preserved because it is
+        not in `_RELOADABLE_FIELDS`.
 
         !!! note
 
@@ -5666,8 +5672,8 @@ def _create_model_via_init(
 class ModelResult:
     """Result of creating a chat model, bundling the model with its metadata.
 
-    This separates model creation from settings mutation so callers can decide
-    when to commit the metadata to global settings.
+    This separates model creation from runtime-state mutation so callers can
+    decide when to commit the metadata to process-wide state.
 
     Attributes:
         model: The instantiated chat model.
@@ -5729,13 +5735,13 @@ class ModelResult:
             msg = f"cli_max_retries must be >= 0, got {self.cli_max_retries}"
             raise ValueError(msg)
 
-    def apply_to_settings(self) -> None:
-        """Commit this result's metadata to global `settings`."""
-        s = _get_settings()
-        s.model_name = self.model_name
-        s.model_provider = self.provider
-        s.model_context_limit = self.context_limit
-        s.model_unsupported_modalities = self.unsupported_modalities
+    def apply_to_runtime_state(self) -> None:
+        """Commit this result's metadata to global `runtime_state`."""
+        state = _get_runtime_state()
+        state.model_name = self.model_name
+        state.model_provider = self.provider
+        state.model_context_limit = self.context_limit
+        state.model_unsupported_modalities = self.unsupported_modalities
 
 
 def _apply_profile_overrides(
@@ -6248,8 +6254,22 @@ def _get_settings() -> Settings:
         return inst
 
 
-def __getattr__(name: str) -> Settings | Console:
-    """Lazy module attributes for `settings` and `console`.
+def _get_runtime_state() -> RuntimeState:
+    """Return the lazily initialized process-wide `RuntimeState` instance."""
+    cached = globals().get("runtime_state")
+    if cached is not None:
+        return cached
+    with _singleton_lock:
+        cached = globals().get("runtime_state")
+        if cached is not None:
+            return cached
+        state = RuntimeState()
+        globals()["runtime_state"] = state
+        return state
+
+
+def __getattr__(name: str) -> Settings | RuntimeState | Console:
+    """Lazy module attributes for process-wide state and the console.
 
     Defers heavy initialization until first access. Subsequent accesses hit
     the module-level attribute directly (no `__getattr__` overhead).
@@ -6262,6 +6282,8 @@ def __getattr__(name: str) -> Settings | Console:
     """
     if name == "settings":
         return _get_settings()
+    if name == "runtime_state":
+        return _get_runtime_state()
     if name == "console":
         return _get_console()
     msg = f"module {__name__!r} has no attribute {name!r}"

--- a/libs/code/deepagents_code/configurable_model.py
+++ b/libs/code/deepagents_code/configurable_model.py
@@ -369,10 +369,10 @@ def _get_context(request: ModelRequest) -> CLIContextSchema | None:
 def _model_spec_from_model(model: BaseChatModel) -> str | None:
     """Return a resumable `provider:model` spec for a model object."""
     model_name = get_model_identifier(model)
-    from deepagents_code.config import settings
+    from deepagents_code.config import runtime_state
 
-    settings_provider = settings.model_provider or ""
-    settings_model = settings.model_name or ""
+    settings_provider = runtime_state.model_provider or ""
+    settings_model = runtime_state.model_name or ""
     if settings_provider and settings_model and model_name == settings_model:
         return f"{settings_provider}:{settings_model}"
     provider = _get_ls_provider(model)

--- a/libs/code/deepagents_code/cost_tracking.py
+++ b/libs/code/deepagents_code/cost_tracking.py
@@ -2254,10 +2254,10 @@ def _pricing_target(
     resolved_model = model_name or fallback[0]
     resolved_provider = provider or fallback[1]
     if not resolved_model:
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
 
-        resolved_model = settings.model_name or ""
-        resolved_provider = resolved_provider or settings.model_provider or ""
+        resolved_model = runtime_state.model_name or ""
+        resolved_provider = resolved_provider or runtime_state.model_provider or ""
     return resolved_model, resolved_provider
 
 

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -3138,7 +3138,7 @@ async def run_textual_cli_async(
         _get_default_model_spec,
         detect_provider,
         resolve_auto_classifier_model_with_problem,
-        settings,
+        runtime_state,
     )
     from deepagents_code.model_config import (
         ModelConfigError,
@@ -3174,14 +3174,14 @@ async def run_textual_cli_async(
     if resolved_spec:
         parsed = ModelSpec.try_parse(resolved_spec)
         if parsed:
-            settings.model_provider = parsed.provider
-            settings.model_name = parsed.model
+            runtime_state.model_provider = parsed.provider
+            runtime_state.model_name = parsed.model
         else:
-            settings.model_name = resolved_spec
-            settings.model_provider = detect_provider(resolved_spec) or ""
+            runtime_state.model_name = resolved_spec
+            runtime_state.model_provider = detect_provider(resolved_spec) or ""
     else:
-        settings.model_provider = ""
-        settings.model_name = ""
+        runtime_state.model_provider = ""
+        runtime_state.model_name = ""
 
     # Distinguish "flag absent" from "flag explicitly blank": `--auto-classifier-
     # model ""` is the "inherit the main agent model" instruction and overrides
@@ -3381,7 +3381,7 @@ async def _run_acp_cli_async(
         sys.stderr.write(f"Error: {exc}\n")
         sys.stderr.flush()
         return 1
-    model_result.apply_to_settings()
+    model_result.apply_to_runtime_state()
 
     try:
         project_context = ProjectContext.from_user_cwd(Path.cwd())
@@ -3477,7 +3477,7 @@ async def _run_acp_cli_async(
                         cli_max_retries=cli_max_retries,
                     )
                 )
-                session_model.apply_to_settings()
+                session_model.apply_to_runtime_state()
                 agent_graph, _backend = create_cli_agent(
                     model=session_model.model,
                     assistant_id=assistant_id,

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -286,7 +286,7 @@ async def _make_graphs() -> ServerRuntime:
         profile_overrides=config.profile_overrides,
         cli_max_retries=config.cli_max_retries,
     )
-    result.apply_to_settings()
+    result.apply_to_runtime_state()
 
     tools, mcp_server_info, mcp_tools = await _build_tools(config, project_context)
     read_only_context_tools = _criteria_context_tools(tools, mcp_tools)

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -1719,13 +1719,13 @@ async def execute_task_textual(
     completed_compaction_ids: set[str] = set()
 
     async def _after_automatic_compact() -> None:
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
         from deepagents_code.hooks.client_lifecycle import ClientHookStopError
         from deepagents_code.hooks.models.domain import SessionStartCause
 
         outcome = await hooks.on_session_start(
             SessionStartCause.COMPACT,
-            model=settings.model_name or None,
+            model=runtime_state.model_name or None,
         )
         if not outcome.ok:
             raise ClientHookStopError(
@@ -1857,14 +1857,14 @@ async def execute_task_textual(
                     # recorded is still ours, not input for the handlers below.
                     if not is_main_agent and _session_stats.is_model_usage_event(data):
                         try:
-                            from deepagents_code.config import settings
+                            from deepagents_code.config import runtime_state
 
                             recorded_usage = _session_stats.record_model_usage_event(
                                 turn_stats,
                                 data,
                                 active_thread_id=thread_id,
-                                fallback_model=settings.model_name or "",
-                                fallback_provider=settings.model_provider or "",
+                                fallback_model=runtime_state.model_name or "",
+                                fallback_provider=runtime_state.model_provider or "",
                                 recorded_requests=recorded_usage_requests,
                             )
                         except Exception:
@@ -2157,13 +2157,13 @@ async def execute_task_textual(
                     # spend money even though their text stays out of the chat.
                     recorded_usage = None
                     if getattr(message, "usage_metadata", None):
-                        from deepagents_code.config import settings
+                        from deepagents_code.config import runtime_state
 
                         recorded_usage = _session_stats.record_message_usage(
                             turn_stats,
                             message,
-                            fallback_model=settings.model_name or "",
-                            fallback_provider=settings.model_provider or "",
+                            fallback_model=runtime_state.model_name or "",
+                            fallback_provider=runtime_state.model_provider or "",
                             request_metadata=(
                                 metadata if isinstance(metadata, dict) else None
                             ),

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -658,7 +658,7 @@ class StatusBar(Vertical):
 
     def on_mount(self) -> None:
         """Set reactive values after mount to trigger watchers safely."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
 
         self.cwd = self._initial_cwd
         if self._hide_cwd:
@@ -668,9 +668,9 @@ class StatusBar(Vertical):
                 self.query_one("#branch-display", BranchLabel).display = False
         # Set initial model display
         label = self.query_one("#model-display", ModelLabel)
-        label.provider = settings.model_provider or ""
-        label.model = settings.model_name or ""
-        self.set_context_limit(settings.model_context_limit)
+        label.provider = runtime_state.model_provider or ""
+        label.model = runtime_state.model_name or ""
+        self.set_context_limit(runtime_state.model_context_limit)
         with suppress(NoMatches):
             self.query_one("#rubric-display", Static).display = False
         # Reactives are `init=False`, so the connection watcher never fires on

--- a/libs/code/tests/integration_tests/test_auto_approve_remote.py
+++ b/libs/code/tests/integration_tests/test_auto_approve_remote.py
@@ -115,7 +115,7 @@ async def _run_auto_approve_write(
 
     model_config.clear_caches()
     try:
-        create_model("itest:fake").apply_to_settings()
+        create_model("itest:fake").apply_to_runtime_state()
         thread_id = generate_thread_id()
         target = project_dir / f"auto-approved-{suffix}.txt"
 

--- a/libs/code/tests/integration_tests/test_compact_resume.py
+++ b/libs/code/tests/integration_tests/test_compact_resume.py
@@ -156,7 +156,7 @@ async def test_compact_resumed_thread_uses_persisted_history(
 
     model_config.clear_caches()
     try:
-        create_model("itest:fake").apply_to_settings()
+        create_model("itest:fake").apply_to_runtime_state()
         thread_id = generate_thread_id()
 
         # Server 1: create a real persisted thread with enough content to

--- a/libs/code/tests/integration_tests/test_offload_server_side.py
+++ b/libs/code/tests/integration_tests/test_offload_server_side.py
@@ -77,7 +77,7 @@ def _build_long_prompt(turn: int) -> str:
 
 async def _run_turn(agent, *, thread_id: str, assistant_id: str, prompt: str) -> None:
     """Execute one real remote agent turn and drain the stream to completion."""
-    from deepagents_code.config import build_stream_config, settings
+    from deepagents_code.config import build_stream_config, runtime_state
 
     config = build_stream_config(thread_id, assistant_id)
     stream_input = {"messages": [{"role": "user", "content": prompt}]}
@@ -89,7 +89,7 @@ async def _run_turn(agent, *, thread_id: str, assistant_id: str, prompt: str) ->
         stream_mode=["messages", "updates"],
         subgraphs=True,
         config=config,
-        context={"model_context_limit": settings.model_context_limit},
+        context={"model_context_limit": runtime_state.model_context_limit},
         durability="exit",
     ):
         pass
@@ -210,7 +210,7 @@ async def test_offload_runs_server_side_and_is_agent_readable(
 
     model_config.clear_caches()
     try:
-        create_model("itest:fake").apply_to_settings()
+        create_model("itest:fake").apply_to_runtime_state()
         thread_id = generate_thread_id()
 
         async with server_session(
@@ -415,7 +415,7 @@ async def test_concurrent_run_during_offload_preserves_messages(
 
     model_config.clear_caches()
     try:
-        create_model("itest:fake").apply_to_settings()
+        create_model("itest:fake").apply_to_runtime_state()
         thread_id = generate_thread_id()
 
         async with server_session(
@@ -578,7 +578,7 @@ async def test_offload_route_respects_configured_auth(
     model_config.clear_caches()
     server: ServerProcess | None = None
     try:
-        create_model("itest:fake").apply_to_settings()
+        create_model("itest:fake").apply_to_runtime_state()
 
         # The auth module lives in the server work dir (the subprocess's cwd,
         # which `langgraph dev` puts on `sys.path`) so its import path stays
@@ -713,7 +713,7 @@ async def test_server_shutdown_flushes_existing_tracers(
     model_config.clear_caches()
     server: ServerProcess | None = None
     try:
-        create_model("itest:fake").apply_to_settings()
+        create_model("itest:fake").apply_to_runtime_state()
         (work_dir / "itest_flush_app.py").write_text(_TEST_FLUSH_APP)
         generated = generate_langgraph_json(work_dir)
         config = json.loads(generated.read_text())

--- a/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -100,7 +100,7 @@ def _assert_snapshot(
 
 @contextmanager
 def _mock_settings(tmp_path: Path) -> Generator[None, None, None]:
-    """Patch ``settings`` with temporary directories and fixed model identity.
+    """Patch filesystem settings and fixed runtime model identity.
 
     Mirrors the ``mock_settings`` pattern from ``test_end_to_end.py`` but
     fixes ``model_name``/``model_provider``/``model_context_limit`` so the
@@ -113,7 +113,10 @@ def _mock_settings(tmp_path: Path) -> Generator[None, None, None]:
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir(parents=True)
 
-    with patch("deepagents_code.agent.settings") as mock_s:
+    with (
+        patch("deepagents_code.agent.settings") as mock_s,
+        patch("deepagents_code.agent.runtime_state") as mock_runtime_state,
+    ):
         mock_s.ensure_agent_dir.return_value = agent_dir
         mock_s.ensure_user_skills_dir.return_value = skills_dir
         mock_s.get_project_skills_dir.return_value = None
@@ -126,10 +129,10 @@ def _mock_settings(tmp_path: Path) -> Generator[None, None, None]:
         mock_s.get_project_agent_skills_dir.return_value = None
         mock_s.get_user_claude_skills_dir.return_value = tmp_path / "claude_skills"
         mock_s.get_project_claude_skills_dir.return_value = None
-        mock_s.model_name = _FIXED_MODEL_NAME
-        mock_s.model_provider = _FIXED_MODEL_PROVIDER
-        mock_s.model_context_limit = _FIXED_CONTEXT_LIMIT
-        mock_s.model_unsupported_modalities = frozenset()
+        mock_runtime_state.model_name = _FIXED_MODEL_NAME
+        mock_runtime_state.model_provider = _FIXED_MODEL_PROVIDER
+        mock_runtime_state.model_context_limit = _FIXED_CONTEXT_LIMIT
+        mock_runtime_state.model_unsupported_modalities = frozenset()
         mock_s.has_tavily = False
         mock_s.project_root = None
         mock_s.user_langchain_project = None

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -57,7 +57,7 @@ from deepagents_code.agent import (
     list_agents,
     load_async_subagents,
 )
-from deepagents_code.config import Settings, get_glyphs
+from deepagents_code.config import Settings, get_glyphs, runtime_state
 from deepagents_code.managed_tools import BIN_DIR
 from deepagents_code.offload import (
     _FALLBACK_ARTIFACTS_ROOT,
@@ -67,6 +67,24 @@ from deepagents_code.offload import (
 )
 from deepagents_code.plugins.store import DEFAULT_PLUGIN_DIRNAME
 from deepagents_code.project_utils import ProjectContext
+
+
+@pytest.fixture(autouse=True)
+def _restore_runtime_state() -> Iterator[None]:
+    """Keep process-wide model metadata isolated between tests."""
+    previous = (
+        runtime_state.model_name,
+        runtime_state.model_provider,
+        runtime_state.model_context_limit,
+        runtime_state.model_unsupported_modalities,
+    )
+    yield
+    (
+        runtime_state.model_name,
+        runtime_state.model_provider,
+        runtime_state.model_context_limit,
+        runtime_state.model_unsupported_modalities,
+    ) = previous
 
 
 @dataclass
@@ -1443,10 +1461,10 @@ class TestGetSystemPromptModelIdentity:
     def test_includes_model_identity_when_all_settings_present(self) -> None:
         """Test that model identity section is included when all settings are set."""
         mock_settings = Mock()
-        mock_settings.model_name = "claude-sonnet-4-6"
-        mock_settings.model_provider = "anthropic"
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = 200000
+        runtime_state.model_name = "claude-sonnet-4-6"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = 200000
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1459,10 +1477,10 @@ class TestGetSystemPromptModelIdentity:
     def test_excludes_model_identity_when_model_name_is_none(self) -> None:
         """Test that model identity section is excluded when model_name is None."""
         mock_settings = Mock()
-        mock_settings.model_name = None
-        mock_settings.model_provider = "anthropic"
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = 200000
+        runtime_state.model_name = None
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = 200000
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1472,7 +1490,7 @@ class TestGetSystemPromptModelIdentity:
     def test_skills_path_uses_launch_profile(self) -> None:
         """Agent-facing instructions name the effective configured skills root."""
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
         mock_settings.has_tavily = False
 
         with patch("deepagents_code.agent.settings", mock_settings):
@@ -1485,10 +1503,10 @@ class TestGetSystemPromptModelIdentity:
     def test_excludes_provider_when_not_set(self) -> None:
         """Test that provider is excluded when model_provider is None."""
         mock_settings = Mock()
-        mock_settings.model_name = "gpt-4"
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = 128000
+        runtime_state.model_name = "gpt-4"
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = 128000
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1501,10 +1519,10 @@ class TestGetSystemPromptModelIdentity:
     def test_excludes_context_limit_when_not_set(self) -> None:
         """Test that context limit is excluded when model_context_limit is None."""
         mock_settings = Mock()
-        mock_settings.model_name = "gemini-3-pro"
-        mock_settings.model_provider = "google"
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = "gemini-3-pro"
+        runtime_state.model_provider = "google"
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1517,10 +1535,10 @@ class TestGetSystemPromptModelIdentity:
     def test_model_identity_with_only_model_name(self) -> None:
         """Test model identity section with only model_name set."""
         mock_settings = Mock()
-        mock_settings.model_name = "test-model"
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = "test-model"
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1533,12 +1551,12 @@ class TestGetSystemPromptModelIdentity:
     def test_includes_unsupported_modalities_warning(self) -> None:
         """Test that unsupported modalities are surfaced in the prompt."""
         mock_settings = Mock()
-        mock_settings.model_name = "deepseek-r1"
-        mock_settings.model_provider = "deepseek"
-        mock_settings.model_unsupported_modalities = frozenset(
+        runtime_state.model_name = "deepseek-r1"
+        runtime_state.model_provider = "deepseek"
+        runtime_state.model_unsupported_modalities = frozenset(
             {"image", "audio", "video", "pdf"}
         )
-        mock_settings.model_context_limit = 64000
+        runtime_state.model_context_limit = 64000
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1548,10 +1566,10 @@ class TestGetSystemPromptModelIdentity:
     def test_single_unsupported_modality(self) -> None:
         """Test warning with a single unsupported modality."""
         mock_settings = Mock()
-        mock_settings.model_name = "test-model"
-        mock_settings.model_provider = "test"
-        mock_settings.model_unsupported_modalities = frozenset({"audio"})
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = "test-model"
+        runtime_state.model_provider = "test"
+        runtime_state.model_unsupported_modalities = frozenset({"audio"})
+        runtime_state.model_context_limit = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1561,10 +1579,10 @@ class TestGetSystemPromptModelIdentity:
     def test_no_modality_warning_when_all_supported(self) -> None:
         """Test that no modality warning appears when all modalities supported."""
         mock_settings = Mock()
-        mock_settings.model_name = "claude-opus-4-6"
-        mock_settings.model_provider = "anthropic"
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = 200000
+        runtime_state.model_name = "claude-opus-4-6"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = 200000
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1577,7 +1595,7 @@ class TestGetSystemPromptWebSearch:
 
     def test_omits_guidance_without_tavily(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
         mock_settings.has_tavily = False
 
         with patch("deepagents_code.agent.settings", mock_settings):
@@ -1588,7 +1606,7 @@ class TestGetSystemPromptWebSearch:
 
     def test_includes_guidance_with_tavily(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
         mock_settings.has_tavily = True
 
         with patch("deepagents_code.agent.settings", mock_settings):
@@ -1603,7 +1621,7 @@ class TestGetSystemPromptNonInteractive:
 
     def test_interactive_prompt_mentions_interactive_tui(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=True)
@@ -1613,7 +1631,7 @@ class TestGetSystemPromptNonInteractive:
 
     def test_non_interactive_prompt_mentions_headless(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
@@ -1623,7 +1641,7 @@ class TestGetSystemPromptNonInteractive:
 
     def test_non_interactive_prompt_does_not_ask_questions(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
@@ -1632,7 +1650,7 @@ class TestGetSystemPromptNonInteractive:
 
     def test_non_interactive_prompt_instructs_autonomous_execution(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
@@ -1642,7 +1660,7 @@ class TestGetSystemPromptNonInteractive:
 
     def test_non_interactive_prompt_requires_non_interactive_commands(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
@@ -1652,7 +1670,7 @@ class TestGetSystemPromptNonInteractive:
 
     def test_default_is_interactive(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1666,7 +1684,7 @@ class TestGetSystemPromptNonInteractive:
         `{todo_list_section}`/`{todo_guidance}` wiring is gone.
         """
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         for interactive in (True, False):
             with patch("deepagents_code.agent.settings", mock_settings):
@@ -1684,7 +1702,7 @@ class TestGetSystemPromptCwdOSError:
     def test_falls_back_on_cwd_oserror(self) -> None:
         """get_system_prompt should not crash when Path.cwd() raises OSError."""
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with (
             patch("deepagents_code.agent.settings", mock_settings),
@@ -1700,7 +1718,7 @@ class TestGetSystemPromptSandbox:
 
     def test_sandbox_includes_no_local_filesystem_warning(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", sandbox_type="modal")
@@ -1709,7 +1727,7 @@ class TestGetSystemPromptSandbox:
 
     def test_sandbox_includes_working_dir_constraint(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", sandbox_type="modal")
@@ -1719,7 +1737,7 @@ class TestGetSystemPromptSandbox:
 
     def test_sandbox_warns_about_subagent_paths(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", sandbox_type="daytona")
@@ -1729,7 +1747,7 @@ class TestGetSystemPromptSandbox:
 
     def test_local_mode_omits_sandbox_warnings(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1743,7 +1761,7 @@ class TestGetSystemPromptFilesystemTools:
 
     def test_restricted_prompt_omits_unavailable_mutation_tools(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt(
@@ -1757,7 +1775,7 @@ class TestGetSystemPromptFilesystemTools:
 
     def test_restricted_prompt_keeps_enabled_mutation_tool(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt(
@@ -1771,7 +1789,7 @@ class TestGetSystemPromptFilesystemTools:
 
     def test_unrestricted_prompt_keeps_all_mutation_tool_guidance(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1785,7 +1803,7 @@ class TestGetSystemPromptPlaceholderValidation:
 
     def test_no_unreplaced_placeholders_in_interactive(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=True)
@@ -1797,7 +1815,7 @@ class TestGetSystemPromptPlaceholderValidation:
 
     def test_no_unreplaced_placeholders_in_non_interactive(self) -> None:
         mock_settings = Mock()
-        mock_settings.model_name = None
+        runtime_state.model_name = None
 
         with patch("deepagents_code.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
@@ -1830,10 +1848,10 @@ class TestCreateCliAgentInteractiveForwarding:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
 
         mock_agent = Mock()
@@ -1903,10 +1921,10 @@ class TestCreateCliAgentInteractiveForwarding:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
 
         mock_agent = Mock()
@@ -2207,10 +2225,10 @@ class TestCreateCliAgentSkillsSources:
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
         # Needed by get_system_prompt() which formats model identity
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
 
         captured_sources: list[list[str]] = []
@@ -2305,10 +2323,10 @@ class TestCreateCliAgentSkillsSources:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
 
         captured_sources: list[list[str]] = []
@@ -2372,10 +2390,10 @@ class TestCreateCliAgentMemorySources:
         ]
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = tmp_path
 
         captured: list[list[str]] = []
@@ -2438,10 +2456,10 @@ class TestCreateCliAgentMemorySources:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
 
         captured: list[list[str]] = []
@@ -2504,10 +2522,10 @@ class TestCreateCliAgentMemoryAutoSave:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
         return mock_settings
 
@@ -2615,10 +2633,10 @@ class TestCreateCliAgentProjectContext:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.user_langchain_project = None
 
@@ -2695,10 +2713,10 @@ class TestCreateCliAgentProjectContext:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.user_langchain_project = None
 
@@ -2775,10 +2793,10 @@ class TestCreateCliAgentProjectContext:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.user_langchain_project = user_langchain_project
 
@@ -2906,10 +2924,10 @@ class TestCreateCliAgentProjectContext:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
 
         mock_agent = Mock()
@@ -2968,10 +2986,10 @@ class TestMiddlewareStackConformance:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
 
         captured_middleware: list[list[Any]] = []
@@ -3056,10 +3074,10 @@ class TestEnableAskUser:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
 
         captured: list[list[Any]] = []
@@ -3400,10 +3418,10 @@ class TestCreateCliAgentShellMiddlewareWiring:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.shell_allow_list = ["ls", "cat"]
         return mock_settings
@@ -4162,10 +4180,10 @@ class TestCreateCliAgentFsToolsWiring:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.shell_allow_list = None
         return mock_settings
@@ -4787,10 +4805,10 @@ class TestAutoModeSubagentHITLWiring:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.shell_allow_list = ["ls", "cat"]
         return mock_settings
@@ -5127,10 +5145,10 @@ class TestCreateCliAgentInterpreterWiring:
         mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
-        mock_settings.model_name = None
-        mock_settings.model_provider = None
-        mock_settings.model_unsupported_modalities = frozenset()
-        mock_settings.model_context_limit = None
+        runtime_state.model_name = None
+        runtime_state.model_provider = None
+        runtime_state.model_unsupported_modalities = frozenset()
+        runtime_state.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.shell_allow_list = None
         mock_settings.user_langchain_project = None

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -98,6 +98,7 @@ from deepagents_code.cold_cache import (
     PromptCachePolicy,
     RewarmEstimate,
 )
+from deepagents_code.config import runtime_state
 from deepagents_code.event_bus import ExternalEvent
 from deepagents_code.goal_state_limits import (
     GOAL_APPLICATION_CHAR_LIMIT,
@@ -226,11 +227,11 @@ async def test_context_prefers_checkpoint_total_after_offload(
 
     with (
         patch("deepagents_code.app.ContextUsageScreen") as screen_type,
-        patch("deepagents_code.config.settings") as settings,
+        patch("deepagents_code.config.runtime_state") as mock_runtime_state,
     ):
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-sonnet"
-        settings.model_context_limit = 2_000
+        mock_runtime_state.model_provider = "anthropic"
+        mock_runtime_state.model_name = "claude-sonnet"
+        mock_runtime_state.model_context_limit = 2_000
         await app._handle_command("/context")
 
     assert screen_type.call_args.kwargs["context_tokens"] == 1_000
@@ -446,11 +447,11 @@ class TestInitialPromptOnMount:
         app.run_worker = MagicMock(side_effect=_closing_run_worker_mock)  # ty: ignore
 
         with (
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.runtime_state") as mock_runtime_state,
             patch("asyncio.create_task", side_effect=_closing_run_worker_mock),
         ):
-            mock_settings.model_provider = "openai"
-            mock_settings.model_name = "gpt-5.5"
+            mock_runtime_state.model_provider = "openai"
+            mock_runtime_state.model_name = "gpt-5.5"
             await app.on_mount()
 
         status_bar.set_model.assert_called_once_with(
@@ -475,9 +476,9 @@ class TestInitialPromptOnMount:
         status_bar = MagicMock(spec=StatusBar)
         app._status_bar = status_bar
 
-        with patch("deepagents_code.config.settings") as mock_settings:
-            mock_settings.model_provider = "anthropic"
-            mock_settings.model_name = "claude-opus-4-7"
+        with patch("deepagents_code.config.runtime_state") as mock_runtime_state:
+            mock_runtime_state.model_provider = "anthropic"
+            mock_runtime_state.model_name = "claude-opus-4-7"
             app.on_deep_agents_app_server_ready(
                 app.ServerReady(
                     agent=MagicMock(),
@@ -536,11 +537,11 @@ class TestInitialPromptOnMount:
         app._status_bar = status_bar
 
         with (
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.runtime_state") as mock_runtime_state,
             caplog.at_level(logging.WARNING, logger="deepagents_code.app"),
         ):
-            mock_settings.model_provider = None
-            mock_settings.model_name = None
+            mock_runtime_state.model_provider = None
+            mock_runtime_state.model_name = None
             app.on_deep_agents_app_server_ready(
                 app.ServerReady(
                     agent=MagicMock(),
@@ -556,7 +557,7 @@ class TestInitialPromptOnMount:
         # isn't invisible.
         status_bar.set_model.assert_called_once_with(provider="", model="", effort="")
         assert any(
-            "Settings missing model identity" in record.message
+            "Runtime state missing model identity" in record.message
             for record in caplog.records
         )
 
@@ -15648,10 +15649,10 @@ class TestActiveProvider:
 
         app = DeepAgentsApp(agent=MagicMock())
         app._model_override = None
-        # No model name → no full spec, so the settings fallback supplies the
+        # No model name → no full spec, so runtime state supplies the
         # provider directly.
-        monkeypatch.setattr(config.settings, "model_provider", "anthropic")
-        monkeypatch.setattr(config.settings, "model_name", "")
+        monkeypatch.setattr(config.runtime_state, "model_provider", "anthropic")
+        monkeypatch.setattr(config.runtime_state, "model_name", "")
         assert app._active_provider() == "anthropic"
 
     def test_none_when_unconfigured(self, monkeypatch) -> None:
@@ -15659,8 +15660,8 @@ class TestActiveProvider:
 
         app = DeepAgentsApp(agent=MagicMock())
         app._model_override = None
-        monkeypatch.setattr(config.settings, "model_provider", "")
-        monkeypatch.setattr(config.settings, "model_name", "")
+        monkeypatch.setattr(config.runtime_state, "model_provider", "")
+        monkeypatch.setattr(config.runtime_state, "model_name", "")
         assert app._active_provider() is None
 
 
@@ -24607,8 +24608,8 @@ class TestDispatchModelSwitch:
         app.notify = MagicMock()  # ty: ignore
         from deepagents_code.config import settings
 
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
         app._dispatch_model_switch("openai:gpt-5.5")
         action = app._deferred_actions[0]
         app._context_tokens = 150_000
@@ -24629,8 +24630,8 @@ class TestDispatchModelSwitch:
         app.notify = MagicMock()  # ty: ignore
         from deepagents_code.config import settings
 
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
 
         prompt_open = asyncio.Event()
         answer_prompt = asyncio.Event()
@@ -24688,8 +24689,8 @@ class TestDispatchModelSwitch:
         app._switch_model = AsyncMock()  # ty: ignore
         from deepagents_code.config import settings
 
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
 
         async with app.run_test():
             await app._confirm_and_switch_model("openai:gpt-5.5")
@@ -24709,8 +24710,8 @@ class TestDispatchModelSwitch:
         app._switch_model = AsyncMock()  # ty: ignore
         from deepagents_code.config import settings
 
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
 
         async with app.run_test():
             await app._confirm_and_switch_model("openai:gpt-5.5")
@@ -30383,7 +30384,7 @@ class TestPrewarmAwait:
             call_order.append("create_model")
             create_model_kwargs.update(kwargs)
             result = MagicMock()
-            result.apply_to_settings = MagicMock()
+            result.apply_to_runtime_state = MagicMock()
             result.provider = "anthropic"
             result.model_name = "claude-opus-4-7"
             return result
@@ -30429,7 +30430,7 @@ class TestPrewarmAwait:
 
         def fake_create_model(*_: Any, **__: Any) -> MagicMock:
             result = MagicMock()
-            result.apply_to_settings = MagicMock()
+            result.apply_to_runtime_state = MagicMock()
             result.provider = "anthropic"
             result.model_name = "claude-opus-4-7"
             return result
@@ -30525,7 +30526,7 @@ class TestPrewarmAwait:
 
         def fake_create_model(*_: Any, **__: Any) -> MagicMock:
             result = MagicMock()
-            result.apply_to_settings = MagicMock()
+            result.apply_to_runtime_state = MagicMock()
             result.provider = "anthropic"
             result.model_name = "claude-opus-4-7"
             return result
@@ -30674,7 +30675,7 @@ class TestPrewarmAwait:
 
         def fake_create_model(*_: Any, **__: Any) -> MagicMock:
             result = MagicMock()
-            result.apply_to_settings = MagicMock()
+            result.apply_to_runtime_state = MagicMock()
             result.provider = "anthropic"
             result.model_name = "claude-opus-4-8"
             return result
@@ -37644,9 +37645,11 @@ class TestWelcomeBannerLiveUpdates:
         with patch.dict(os.environ, {SPLASH_SHOW_MODEL: "1"}):
             app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
             async with app.run_test() as pilot:
-                with patch("deepagents_code.config.settings") as mock_settings:
-                    mock_settings.model_provider = "openai"
-                    mock_settings.model_name = "gpt-5.5"
+                with patch(
+                    "deepagents_code.config.runtime_state"
+                ) as mock_runtime_state:
+                    mock_runtime_state.model_provider = "openai"
+                    mock_runtime_state.model_name = "gpt-5.5"
                     app._sync_status_model()
                 await pilot.pause()
                 banner = app.query_one("#welcome-banner", WelcomeBanner)
@@ -37673,7 +37676,7 @@ class TestWelcomeBannerLiveUpdates:
         async with app.run_test() as pilot:
             await pilot.pause()
             with (
-                patch("deepagents_code.config.settings") as mock_settings,
+                patch("deepagents_code.config.runtime_state") as mock_runtime_state,
                 patch.object(
                     app,
                     "query_one",
@@ -37681,8 +37684,8 @@ class TestWelcomeBannerLiveUpdates:
                 ),
                 caplog.at_level(logging.DEBUG, logger="deepagents_code.app"),
             ):
-                mock_settings.model_provider = "openai"
-                mock_settings.model_name = "gpt-5.5"
+                mock_runtime_state.model_provider = "openai"
+                mock_runtime_state.model_name = "gpt-5.5"
                 # Must not propagate — the guard exists precisely for this.
                 app._sync_status_model()
         assert "Screen stack empty during model sync" in caplog.text
@@ -37695,7 +37698,7 @@ class TestWelcomeBannerLiveUpdates:
         async with app.run_test() as pilot:
             await pilot.pause()
             with (
-                patch("deepagents_code.config.settings") as mock_settings,
+                patch("deepagents_code.config.runtime_state") as mock_runtime_state,
                 patch.object(
                     app,
                     "query_one",
@@ -37703,8 +37706,8 @@ class TestWelcomeBannerLiveUpdates:
                 ),
                 caplog.at_level(logging.WARNING, logger="deepagents_code.app"),
             ):
-                mock_settings.model_provider = "openai"
-                mock_settings.model_name = "gpt-5.5"
+                mock_runtime_state.model_provider = "openai"
+                mock_runtime_state.model_name = "gpt-5.5"
                 app._sync_status_model()
         assert "Welcome banner not found during model sync" in caplog.text
 

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -62,6 +62,7 @@ from deepagents_code.config import (
     normalize_langsmith_endpoint,
     parse_shell_allow_list,
     reset_langsmith_url_cache,
+    runtime_state,
     settings,
     validate_model_capabilities,
 )
@@ -1633,11 +1634,11 @@ class TestCreateModelSplitCredentialWiring:
         assert ordered == ["warn", "apply"]
 
 
-class TestModelResultApplyToSettings:
-    """Tests for ModelResult.apply_to_settings propagation."""
+class TestModelResultApplyToRuntimeState:
+    """Tests for `ModelResult.apply_to_runtime_state` propagation."""
 
     def test_propagates_unsupported_modalities(self) -> None:
-        """Test that apply_to_settings writes unsupported_modalities to settings."""
+        """Test model results update all process-wide runtime metadata."""
         model_result = ModelResult(
             model=Mock(),
             model_name="deepseek-r1",
@@ -1645,21 +1646,24 @@ class TestModelResultApplyToSettings:
             context_limit=64000,
             unsupported_modalities=frozenset({"image", "audio"}),
         )
-        # `apply_to_settings` writes four fields to the process-global settings;
+        # The method writes four fields to process-global runtime state;
         # restore all of them or the values leak into every later test.
-        original_name = settings.model_name
-        original_provider = settings.model_provider
-        original_limit = settings.model_context_limit
-        original_modalities = settings.model_unsupported_modalities
+        original_name = runtime_state.model_name
+        original_provider = runtime_state.model_provider
+        original_limit = runtime_state.model_context_limit
+        original_modalities = runtime_state.model_unsupported_modalities
         try:
-            model_result.apply_to_settings()
+            model_result.apply_to_runtime_state()
             expected = frozenset({"image", "audio"})
-            assert settings.model_unsupported_modalities == expected
+            assert runtime_state.model_name == "deepseek-r1"
+            assert runtime_state.model_provider == "deepseek"
+            assert runtime_state.model_context_limit == 64000
+            assert runtime_state.model_unsupported_modalities == expected
         finally:
-            settings.model_name = original_name
-            settings.model_provider = original_provider
-            settings.model_context_limit = original_limit
-            settings.model_unsupported_modalities = original_modalities
+            runtime_state.model_name = original_name
+            runtime_state.model_provider = original_provider
+            runtime_state.model_context_limit = original_limit
+            runtime_state.model_unsupported_modalities = original_modalities
 
 
 class TestRetriesConfig:

--- a/libs/code/tests/unit_tests/test_configurable_model.py
+++ b/libs/code/tests/unit_tests/test_configurable_model.py
@@ -116,15 +116,15 @@ class TestCheckpointPersistence:
 
     def test_startup_custom_provider_uses_configured_spec(self) -> None:
         """Custom classes must checkpoint their configured provider alias."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
 
         model = _make_model("fake")
         model._get_ls_params.return_value = {
             "ls_provider": "deterministicintegrationchatmodel"
         }
         with (
-            patch.object(settings, "model_provider", "itest"),
-            patch.object(settings, "model_name", "fake"),
+            patch.object(runtime_state, "model_provider", "itest"),
+            patch.object(runtime_state, "model_name", "fake"),
         ):
             assert _model_spec_from_model(model) == "itest:fake"
 

--- a/libs/code/tests/unit_tests/test_end_to_end.py
+++ b/libs/code/tests/unit_tests/test_end_to_end.py
@@ -90,6 +90,7 @@ def mock_settings(
     # Patch settings
     with (
         patch("deepagents_code.agent.settings") as mock_settings_obj,
+        patch("deepagents_code.agent.runtime_state") as mock_runtime_state,
         patch(
             "deepagents_code.agent._offload_fallback_root",
             return_value=tmp_path / ".deepagents",
@@ -114,10 +115,11 @@ def mock_settings(
         mock_settings_obj.get_agent_dir = get_agent_dir
         mock_settings_obj.project_root = None
 
-        # Model identity settings (used in system prompt generation)
-        mock_settings_obj.model_name = None
-        mock_settings_obj.model_provider = None
-        mock_settings_obj.model_context_limit = None
+        # Model identity state (used in system prompt generation)
+        mock_runtime_state.model_name = None
+        mock_runtime_state.model_provider = None
+        mock_runtime_state.model_context_limit = None
+        mock_runtime_state.model_unsupported_modalities = frozenset()
 
         yield agent_dir
 

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -163,7 +163,7 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server(
         model=model_obj,
         provider="anthropic",
         model_name="claude-sonnet-4-6",
-        apply_to_settings=MagicMock(),
+        apply_to_runtime_state=MagicMock(),
         model_retries=5,
         cli_max_retries=None,
     )
@@ -266,7 +266,7 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server(
         additional_configs=plugin_configs,
     )
     discover_plugin_mcp.assert_called_once_with(project_dir=acp_project_root)
-    assert model_result.apply_to_settings.call_count == 2
+    assert model_result.apply_to_runtime_state.call_count == 2
     mock_create_agent.assert_called_once()
     call_kwargs = mock_create_agent.call_args.kwargs
     assert call_kwargs["model"] is model_obj
@@ -299,7 +299,7 @@ def test_acp_mode_auto_forwards_classifier_and_store() -> None:
         model=object(),
         provider="openai",
         model_name="gpt-5.5",
-        apply_to_settings=MagicMock(),
+        apply_to_runtime_state=MagicMock(),
         model_retries=5,
         cli_max_retries=None,
     )
@@ -355,7 +355,7 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
         model=model_obj,
         provider="anthropic",
         model_name="claude-sonnet-4-6",
-        apply_to_settings=MagicMock(),
+        apply_to_runtime_state=MagicMock(),
         model_retries=5,
         cli_max_retries=None,
     )
@@ -412,7 +412,7 @@ def test_acp_mode_forwards_allow_fs_tools() -> None:
         model=model_obj,
         provider="anthropic",
         model_name="claude-sonnet-4-6",
-        apply_to_settings=MagicMock(),
+        apply_to_runtime_state=MagicMock(),
         model_retries=5,
         cli_max_retries=None,
     )
@@ -460,7 +460,7 @@ def test_acp_mode_forwards_none_allow_fs_tools_by_default() -> None:
         model=object(),
         provider="anthropic",
         model_name="claude-sonnet-4-6",
-        apply_to_settings=MagicMock(),
+        apply_to_runtime_state=MagicMock(),
         model_retries=5,
         cli_max_retries=None,
     )
@@ -512,7 +512,7 @@ def test_acp_mode_forwards_recursion_limit() -> None:
         model=object(),
         provider="anthropic",
         model_name="claude-sonnet-4-6",
-        apply_to_settings=MagicMock(),
+        apply_to_runtime_state=MagicMock(),
         model_retries=5,
         cli_max_retries=None,
     )

--- a/libs/code/tests/unit_tests/test_model_switch.py
+++ b/libs/code/tests/unit_tests/test_model_switch.py
@@ -16,7 +16,7 @@ from deepagents_code.app import (
     _format_model_params,
 )
 from deepagents_code.client.remote_client import RemoteAgent
-from deepagents_code.config import settings
+from deepagents_code.config import runtime_state
 from deepagents_code.model_config import (
     ModelSpec,
     ProviderAuthSource,
@@ -57,30 +57,30 @@ class _FakeModelResult:
         self.context_limit = context_limit
         self.unsupported_modalities = unsupported_modalities
 
-    def apply_to_settings(self) -> None:
-        """Mirror `ModelResult.apply_to_settings()` for test isolation."""
-        settings.model_name = self.model_name
-        settings.model_provider = self.provider
-        settings.model_context_limit = self.context_limit
-        settings.model_unsupported_modalities = self.unsupported_modalities
+    def apply_to_runtime_state(self) -> None:
+        """Mirror `ModelResult.apply_to_runtime_state()` for test isolation."""
+        runtime_state.model_name = self.model_name
+        runtime_state.model_provider = self.provider
+        runtime_state.model_context_limit = self.context_limit
+        runtime_state.model_unsupported_modalities = self.unsupported_modalities
 
 
 @pytest.fixture(autouse=True)
-def _restore_settings(
+def _restore_runtime_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> Iterator[None]:
-    """Save and restore global settings mutated by tests."""
-    original_name = settings.model_name
-    original_provider = settings.model_provider
-    original_context_limit = settings.model_context_limit
-    original_modalities = settings.model_unsupported_modalities
+    """Save and restore global runtime state mutated by tests."""
+    original_name = runtime_state.model_name
+    original_provider = runtime_state.model_provider
+    original_context_limit = runtime_state.model_context_limit
+    original_modalities = runtime_state.model_unsupported_modalities
     monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", tmp_path / "config.toml")
     yield
-    settings.model_name = original_name
-    settings.model_provider = original_provider
-    settings.model_context_limit = original_context_limit
-    settings.model_unsupported_modalities = original_modalities
+    runtime_state.model_name = original_name
+    runtime_state.model_provider = original_provider
+    runtime_state.model_context_limit = original_context_limit
+    runtime_state.model_unsupported_modalities = original_modalities
 
 
 @pytest.fixture(autouse=True)
@@ -171,8 +171,8 @@ class TestModelSwitchWarning:
         app._model_switch_warning_threshold = 100_000
         app._push_screen_wait = AsyncMock()  # ty: ignore
         app._switch_model = AsyncMock()  # ty: ignore
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
 
         await app._confirm_and_switch_model("openai:gpt-5.5")
 
@@ -186,8 +186,8 @@ class TestModelSwitchWarning:
         app._model_switch_warning_threshold = 100_000
         app._push_screen_wait = AsyncMock(return_value=True)  # ty: ignore
         app._switch_model = AsyncMock()  # ty: ignore
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
 
         await app._confirm_and_switch_model("openai:gpt-5.5")
 
@@ -205,8 +205,8 @@ class TestModelSwitchWarning:
         app._model_switch_warning_threshold = 100_000
         app._push_screen_wait = AsyncMock(return_value=result)  # ty: ignore
         app._switch_model = AsyncMock()  # ty: ignore
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
 
         await app._confirm_and_switch_model("openai:gpt-5.5")
 
@@ -219,8 +219,8 @@ class TestModelSwitchWarning:
         app._push_screen_wait = AsyncMock(side_effect=RuntimeError("boom"))  # ty: ignore
         app._switch_model = AsyncMock()  # ty: ignore
         app._mount_message = AsyncMock()  # ty: ignore
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
 
         await app._confirm_and_switch_model("openai:gpt-5.5")
 
@@ -235,8 +235,8 @@ class TestModelSwitchWarning:
         app._model_switch_warning_threshold = 0
         app._push_screen_wait = AsyncMock()  # ty: ignore
         app._switch_model = AsyncMock()  # ty: ignore
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
 
         await app._confirm_and_switch_model("openai:gpt-5.5")
 
@@ -249,8 +249,8 @@ class TestModelSwitchWarning:
         app._model_switch_warning_threshold = 100_000
         app._push_screen_wait = AsyncMock()  # ty: ignore
         app._switch_model = AsyncMock()  # ty: ignore
-        settings.model_provider = "anthropic"
-        settings.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
 
         await app._confirm_and_switch_model("anthropic:claude-opus-4-5")
 
@@ -278,8 +278,8 @@ class TestModelSwitchNoOp:
         app._agent = _make_remote_agent()
 
         # Set current model
-        settings.model_name = "claude-opus-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
 
         with patch(
             "deepagents_code.model_config.get_provider_auth_status",
@@ -308,8 +308,8 @@ class TestModelSwitchNoOp:
         app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-opus-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
 
         # Pin the clock inside the toast lifetime so suppression is asserted
         # deterministically rather than relying on real elapsed time.
@@ -345,8 +345,8 @@ class TestModelSwitchNoOp:
         app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-opus-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
 
         # Advance past NOTIFICATION_TIMEOUT between the two no-ops so the
         # second selection re-toasts instead of staying suppressed forever.
@@ -385,8 +385,8 @@ class TestModelSwitchNoOp:
         app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-opus-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
 
         clock = {"now": 100.0}
 
@@ -415,8 +415,8 @@ class TestModelSwitchNoOp:
         app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-opus-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
 
         with patch(
             "deepagents_code.model_config.get_provider_auth_status",
@@ -451,8 +451,8 @@ class TestModelSwitchNoOp:
         app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-opus-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
 
         # Hold the clock still so a second toast is attributable to the reset
         # rather than to the toast lifetime quietly expiring.
@@ -492,8 +492,8 @@ class TestModelSwitchNoOp:
         app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-opus-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
 
         with patch(
             "deepagents_code.model_config.get_provider_auth_status",
@@ -524,8 +524,8 @@ class TestModelSwitchNoOp:
         app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-opus-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
 
         with patch(
             "deepagents_code.model_config.get_provider_auth_status",
@@ -554,8 +554,8 @@ class TestModelSwitchNoOp:
         app._status_bar = Mock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         with patch(
             "deepagents_code.model_config.get_provider_auth_status",
@@ -588,8 +588,8 @@ class TestModelSwitchNoOp:
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-opus-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-opus-4-5"
+        runtime_state.model_provider = "anthropic"
 
         # Simulate a prior `/model <current> --model-params {...}` call.
         app._model_override = "anthropic:claude-opus-4-5"
@@ -608,8 +608,8 @@ class TestModelSwitchNoOp:
         app = DeepAgentsApp()
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
         model_config.save_effort_for_model(
             "anthropic:claude-opus-4-5",
             "high",
@@ -627,8 +627,8 @@ class TestModelSwitchNoOp:
         app = DeepAgentsApp()
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
         model_config.save_effort_for_model("openai:gpt-5.5", "high")
 
         with patch(
@@ -659,8 +659,8 @@ class TestModelSwitchErrorHandling:
         app._agent = _make_remote_agent()
 
         # Set a different current model
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         captured_errors: list[str] = []
         original_init = ErrorMessage.__init__
@@ -694,8 +694,8 @@ class TestModelSwitchErrorHandling:
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         captured_errors: list[str] = []
         original_err_init = ErrorMessage.__init__
@@ -737,8 +737,8 @@ class TestModelSwitchErrorHandling:
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         captured_messages: list[str] = []
         original_init = AppMessage.__init__
@@ -762,8 +762,8 @@ class TestModelSwitchErrorHandling:
         assert app._model_override == "anthropic:claude-sonnet-4-5"
         assert app._model_params_override is None
         mock_save.assert_called_once()
-        assert settings.model_name == "claude-sonnet-4-5"
-        assert settings.model_provider == "anthropic"
+        assert runtime_state.model_name == "claude-sonnet-4-5"
+        assert runtime_state.model_provider == "anthropic"
         assert any("Switched to" in m for m in captured_messages)
 
     async def test_remote_agent_refreshes_model_metadata(
@@ -775,9 +775,9 @@ class TestModelSwitchErrorHandling:
         app._agent = _make_remote_agent()
         app._profile_override = {"max_input_tokens": 180_000}
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
-        settings.model_context_limit = 128_000
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
+        runtime_state.model_context_limit = 128_000
 
         with (
             patch(
@@ -791,9 +791,9 @@ class TestModelSwitchErrorHandling:
                 extra_kwargs={"temperature": 0.7},
             )
 
-        assert settings.model_name == "claude-sonnet-4-5"
-        assert settings.model_provider == "anthropic"
-        assert settings.model_context_limit == 200_000
+        assert runtime_state.model_name == "claude-sonnet-4-5"
+        assert runtime_state.model_provider == "anthropic"
+        assert runtime_state.model_context_limit == 200_000
         mock_create_model.assert_called_once_with(
             "anthropic:claude-sonnet-4-5",
             extra_kwargs={"temperature": 0.7},
@@ -807,8 +807,8 @@ class TestModelSwitchErrorHandling:
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         with (
             patch(
@@ -834,8 +834,8 @@ class TestModelSwitchErrorHandling:
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         captured_messages: list[str] = []
         original_init = AppMessage.__init__
@@ -893,8 +893,8 @@ class TestModelSwitchConcurrencyGuard:
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         with (
             patch(
@@ -962,8 +962,8 @@ class TestModelSwitchSessionReadiness:
         app._agent = None
         app._connecting = True
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         with (
             patch(
@@ -983,8 +983,8 @@ class TestModelSwitchSessionReadiness:
 
         assert app._deferred_actions == []
         assert app._model_override == "anthropic:claude-sonnet-4-5"
-        assert settings.model_name == "claude-sonnet-4-5"
-        assert settings.model_provider == "anthropic"
+        assert runtime_state.model_name == "claude-sonnet-4-5"
+        assert runtime_state.model_provider == "anthropic"
         assert app._model_switching is False
 
 
@@ -1148,8 +1148,8 @@ api_key_env = "FIREWORKS_API_KEY"
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         captured_messages: list[str] = []
         original_app_init = AppMessage.__init__
@@ -1170,8 +1170,8 @@ api_key_env = "FIREWORKS_API_KEY"
 
         mock_save.assert_called_once_with("fireworks:llama-v3p1-70b")
         assert app._model_override == "fireworks:llama-v3p1-70b"
-        assert settings.model_name == "llama-v3p1-70b"
-        assert settings.model_provider == "fireworks"
+        assert runtime_state.model_name == "llama-v3p1-70b"
+        assert runtime_state.model_provider == "fireworks"
         # Should succeed, not show "Unknown provider"
         assert any(
             "Switched to fireworks:llama-v3p1-70b" in m for m in captured_messages
@@ -1190,8 +1190,8 @@ api_key_env = "FIREWORKS_API_KEY"
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         captured_errors: list[str] = []
         original_err_init = ErrorMessage.__init__
@@ -1223,8 +1223,8 @@ models = ["llama3"]
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         captured_messages: list[str] = []
         original_app_init = AppMessage.__init__
@@ -1244,8 +1244,8 @@ models = ["llama3"]
 
         mock_save.assert_called_once_with("ollama:llama3")
         assert app._model_override == "ollama:llama3"
-        assert settings.model_name == "llama3"
-        assert settings.model_provider == "ollama"
+        assert runtime_state.model_name == "llama3"
+        assert runtime_state.model_provider == "ollama"
         assert any("Switched to ollama:llama3" in m for m in captured_messages)
 
 
@@ -1258,8 +1258,8 @@ class TestModelSwitchBareModelName:
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-sonnet-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-sonnet-4-5"
+        runtime_state.model_provider = "anthropic"
 
         captured_messages: list[str] = []
         original_init = AppMessage.__init__
@@ -1283,8 +1283,8 @@ class TestModelSwitchBareModelName:
 
         mock_save.assert_called_once_with("openai:gpt-5.5")
         assert app._model_override == "openai:gpt-5.5"
-        assert settings.model_name == "gpt-5.5"
-        assert settings.model_provider == "openai"
+        assert runtime_state.model_name == "gpt-5.5"
+        assert runtime_state.model_provider == "openai"
         assert any("Switched to openai:gpt-5.5" in m for m in captured_messages)
 
     async def test_fireworks_qualified_id_gets_provider_prefix(self) -> None:
@@ -1292,15 +1292,15 @@ class TestModelSwitchBareModelName:
 
         Without provider inference the raw ID would surface unprefixed in the
         confirmation message and the status bar (which reads
-        `settings.model_provider`). `detect_provider` recognizes the
+        `runtime_state.model_provider`). `detect_provider` recognizes the
         fully-qualified Fireworks ID so both reflect the `fireworks` provider.
         """
         app = DeepAgentsApp()
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-sonnet-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-sonnet-4-5"
+        runtime_state.model_provider = "anthropic"
 
         captured_messages: list[str] = []
         original_init = AppMessage.__init__
@@ -1324,8 +1324,8 @@ class TestModelSwitchBareModelName:
 
         mock_save.assert_called_once_with(f"fireworks:{model_id}")
         assert app._model_override == f"fireworks:{model_id}"
-        assert settings.model_name == model_id
-        assert settings.model_provider == "fireworks"
+        assert runtime_state.model_name == model_id
+        assert runtime_state.model_provider == "fireworks"
         assert any(f"Switched to fireworks:{model_id}" in m for m in captured_messages)
 
     async def test_bare_model_name_missing_credentials(self) -> None:
@@ -1334,8 +1334,8 @@ class TestModelSwitchBareModelName:
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "claude-sonnet-4-5"
-        settings.model_provider = "anthropic"
+        runtime_state.model_name = "claude-sonnet-4-5"
+        runtime_state.model_provider = "anthropic"
 
         captured_errors: list[str] = []
         original_init = ErrorMessage.__init__
@@ -1372,8 +1372,8 @@ class TestModelSwitchBareModelName:
         app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         with (
             patch("deepagents_code.config.detect_provider", return_value="openai"),
@@ -1558,8 +1558,8 @@ class TestModelSwitchBusyIndicator:
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         async with _StatusBarHarness().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
@@ -1614,8 +1614,8 @@ class TestModelSwitchBusyIndicator:
         app._mount_message = AsyncMock()  # ty: ignore
         app._agent = _make_remote_agent()
 
-        settings.model_name = "gpt-5.5"
-        settings.model_provider = "openai"
+        runtime_state.model_name = "gpt-5.5"
+        runtime_state.model_provider = "openai"
 
         async with _StatusBarHarness().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -51,7 +51,7 @@ from deepagents_code.client.non_interactive import (
     _summarization_stream_status,
     run_non_interactive,
 )
-from deepagents_code.config import SHELL_ALLOW_ALL, ModelResult
+from deepagents_code.config import SHELL_ALLOW_ALL, ModelResult, runtime_state
 from deepagents_code.file_ops import (
     DiffOutcome,
     FileOperationRecord,
@@ -73,6 +73,24 @@ from deepagents_code.hooks.models.domain import (
 )
 from deepagents_code.hooks.transcript import TranscriptRecorder, TranscriptStore
 from deepagents_code.tool_display import format_tool_message_content
+
+
+@pytest.fixture(autouse=True)
+def _restore_runtime_state() -> Iterator[None]:
+    """Keep process-wide model metadata isolated between tests."""
+    previous = (
+        runtime_state.model_name,
+        runtime_state.model_provider,
+        runtime_state.model_context_limit,
+        runtime_state.model_unsupported_modalities,
+    )
+    yield
+    (
+        runtime_state.model_name,
+        runtime_state.model_provider,
+        runtime_state.model_context_limit,
+        runtime_state.model_unsupported_modalities,
+    ) = previous
 
 
 @pytest.fixture
@@ -326,8 +344,8 @@ class TestBuildNonInteractiveHeader:
 
     def test_includes_agent_id(self) -> None:
         """Header should contain the agent identifier."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.model_name = None
+        with patch("deepagents_code.client.non_interactive.settings"):
+            runtime_state.model_name = None
             header = _build_non_interactive_header("my-agent", "abc123")
         assert "Agent: my-agent" in header.plain
         # Non-default agent should not have "(default)" label
@@ -335,37 +353,37 @@ class TestBuildNonInteractiveHeader:
 
     def test_default_agent_label(self) -> None:
         """Header should show '(default)' for the default agent name."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.model_name = None
+        with patch("deepagents_code.client.non_interactive.settings"):
+            runtime_state.model_name = None
             header = _build_non_interactive_header("agent", "abc123")
         assert "Agent: agent (default)" in header.plain
 
     def test_includes_model_name(self) -> None:
         """Header should display model name when available."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.model_name = "gpt-5"
+        with patch("deepagents_code.client.non_interactive.settings"):
+            runtime_state.model_name = "gpt-5"
             header = _build_non_interactive_header("agent", "abc123")
         assert "Model: gpt-5" in header.plain
 
     def test_omits_model_when_none(self) -> None:
         """Header should not include model section when model_name is None."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.model_name = None
+        with patch("deepagents_code.client.non_interactive.settings"):
+            runtime_state.model_name = None
             header = _build_non_interactive_header("agent", "abc123")
         assert "Model:" not in header.plain
 
     def test_includes_thread_id(self) -> None:
         """Header should contain the thread ID."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.model_name = None
+        with patch("deepagents_code.client.non_interactive.settings"):
+            runtime_state.model_name = None
             header = _build_non_interactive_header("agent", "deadbeef")
         assert "Thread: deadbeef" in header.plain
 
     def test_thread_clickable_when_url_available(self) -> None:
         """Thread ID should be a hyperlink when LangSmith URL is available."""
         url = "https://smith.langchain.com/o/org/projects/p/proj/t/abc123"
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.model_name = None
+        with patch("deepagents_code.client.non_interactive.settings"):
+            runtime_state.model_name = None
             with patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
                 return_value=url,
@@ -386,8 +404,8 @@ class TestBuildNonInteractiveHeader:
 
     def test_default_header_does_not_lookup_langsmith(self) -> None:
         """Header should skip LangSmith lookup unless explicitly enabled."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.model_name = None
+        with patch("deepagents_code.client.non_interactive.settings"):
+            runtime_state.model_name = None
             with patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
             ) as mock_build_url:
@@ -433,7 +451,7 @@ class TestSandboxTypeForwarding:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(
                 message="test task",
@@ -489,7 +507,7 @@ class TestSandboxTypeForwarding:
         ):
             mock_settings.shell_allow_list = SHELL_ALLOW_ALL
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test task")
 
@@ -535,7 +553,7 @@ class TestSandboxTypeForwarding:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(
                 message="test task",
@@ -589,7 +607,7 @@ class TestAllowFsToolsForwarding:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(
                 message="test task",
@@ -651,7 +669,7 @@ class TestQuietMode:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=quiet)
 
@@ -707,7 +725,7 @@ class TestQuietMode:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=True)
 
@@ -905,7 +923,7 @@ class TestNoStreamMode:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=True, stream=False)
 
@@ -974,7 +992,7 @@ class TestNoStreamMode:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=True, stream=True)
 
@@ -1036,7 +1054,7 @@ class TestFastFollowLangsmithLink:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=False)
 
@@ -1089,7 +1107,7 @@ class TestFastFollowLangsmithLink:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=False)
 
@@ -1140,7 +1158,7 @@ class TestFastFollowLangsmithLink:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=False)
 
@@ -1186,7 +1204,7 @@ class TestFastFollowLangsmithLink:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=True)
 
@@ -1302,7 +1320,7 @@ class TestShellAllowListDecisionLogic:
         ):
             mock_settings.shell_allow_list = shell_allow_list
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test task")
 
@@ -1358,7 +1376,7 @@ class TestNonInteractivePrompt:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="do the thing")
 
@@ -1417,7 +1435,7 @@ class TestNonInteractivePrompt:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(
                 message="review this patch",
@@ -1459,7 +1477,7 @@ class TestNonInteractivePrompt:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             result = await run_non_interactive(
                 message="review this patch",
@@ -1517,7 +1535,7 @@ class TestNonInteractivePrompt:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             result = await run_non_interactive(
                 message="review this patch",
@@ -1823,10 +1841,10 @@ class TestMaxTurns:
                 "deepagents_code.client.non_interactive.dispatch_hook",
                 new_callable=AsyncMock,
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch("deepagents_code.client.non_interactive.settings"),
         ):
-            mock_settings.model_name = "test:model"
-            mock_settings.model_provider = "test"
+            runtime_state.model_name = "test:model"
+            runtime_state.model_provider = "test"
             await _run_agent_loop(
                 agent,
                 "question",
@@ -1975,7 +1993,7 @@ class TestMaxTurns:
             ) as mock_adapter,
         ):
             mock_settings.shell_allow_list = None
-            mock_settings.model_name = ""
+            runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
                 await _run_agent_loop(
@@ -2011,7 +2029,7 @@ class TestMaxTurns:
             ) as mock_adapter,
         ):
             mock_settings.shell_allow_list = None
-            mock_settings.model_name = ""
+            runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
                 await _run_agent_loop(
@@ -2054,7 +2072,7 @@ class TestMaxTurns:
             patch("deepagents_code.client.non_interactive._MAX_HITL_ITERATIONS", 2),
         ):
             mock_settings.shell_allow_list = None
-            mock_settings.model_name = ""
+            runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
                 await _run_agent_loop(
@@ -2095,7 +2113,7 @@ class TestMaxTurns:
             patch("deepagents_code.client.non_interactive._MAX_HITL_ITERATIONS", 1),
         ):
             mock_settings.shell_allow_list = None
-            mock_settings.model_name = ""
+            runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
                 await _run_agent_loop(
@@ -2146,7 +2164,7 @@ class TestMaxTurns:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="task", max_turns=7)
 
@@ -2189,7 +2207,7 @@ class TestMaxTurns:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="task")
 
@@ -2223,7 +2241,7 @@ class TestMaxTurns:
             ) as mock_adapter,
         ):
             mock_settings.shell_allow_list = None
-            mock_settings.model_name = ""
+            runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError):
                 await _run_agent_loop(
@@ -2266,7 +2284,7 @@ class TestMaxTurns:
             ) as mock_adapter,
         ):
             mock_settings.shell_allow_list = None
-            mock_settings.model_name = ""
+            runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError):
                 await _run_agent_loop(
@@ -2330,7 +2348,7 @@ class TestMaxTurns:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             result = await run_non_interactive(message="task", max_turns=1)
 
@@ -2540,7 +2558,7 @@ class TestRunStartupCommand:
 class TestRecordUsageFromMessageStats:
     """`_record_usage_from_message` threads the active provider into usage stats.
 
-    Guards the wiring between `settings.model_provider` and
+    Guards the wiring between `runtime_state.model_provider` and
     `SessionStats.record_request` — the per-model API is unit-tested in
     isolation elsewhere, but these confirm the call site actually forwards the
     configured provider.
@@ -2558,11 +2576,11 @@ class TestRecordUsageFromMessageStats:
             },
         )
         with (
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch("deepagents_code.client.non_interactive.settings"),
             patch("deepagents_code.cost_tracking.estimate_cost", return_value=0.42),
         ):
-            mock_settings.model_name = "gpt-5.5"
-            mock_settings.model_provider = "openai"
+            runtime_state.model_name = "gpt-5.5"
+            runtime_state.model_provider = "openai"
             _record_usage_from_message(message, state)
 
         model_stats = state.stats.per_model["openai", "gpt-5.5"]
@@ -2582,9 +2600,9 @@ class TestRecordUsageFromMessageStats:
                 "total_tokens": 150,
             },
         )
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.model_name = "gpt-5.5"
-            mock_settings.model_provider = "openai"
+        with patch("deepagents_code.client.non_interactive.settings"):
+            runtime_state.model_name = "gpt-5.5"
+            runtime_state.model_provider = "openai"
             _record_usage_from_message(message, state)
 
         assert state.stats.per_model["openai", "gpt-5.5"].input_tokens == 150
@@ -2770,7 +2788,7 @@ class TestMakeStdioEncodingSafe:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             await run_non_interactive(message="test task")
 
@@ -3966,7 +3984,7 @@ class TestDrainWiring:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             result = await run_non_interactive(message="test", quiet=True)
 
@@ -4011,7 +4029,7 @@ class TestDrainWiring:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             result = await run_non_interactive(message="test", quiet=True)
 
@@ -4061,7 +4079,7 @@ class TestDrainWiring:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             result = await run_non_interactive(message="test", quiet=True)
 
@@ -4106,7 +4124,7 @@ class TestDrainWiring:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             result = await run_non_interactive(message="test", quiet=True)
 
@@ -4178,7 +4196,7 @@ class TestHeadlessUsageStats:
         ):
             mock_settings.shell_allow_list = None
             mock_settings.has_tavily = False
-            mock_settings.model_name = None
+            runtime_state.model_name = None
 
             return_code = await run_non_interactive(message="test", quiet=quiet)
 

--- a/libs/code/tests/unit_tests/test_reasoning_effort.py
+++ b/libs/code/tests/unit_tests/test_reasoning_effort.py
@@ -17,7 +17,7 @@ from textual.widgets import OptionList
 from deepagents_code import model_config, reasoning_effort
 from deepagents_code.app import DeepAgentsApp
 from deepagents_code.command_registry import COMMANDS
-from deepagents_code.config import settings
+from deepagents_code.config import runtime_state
 from deepagents_code.model_config import ModelProfileEntry
 from deepagents_code.reasoning_effort import (
     current_effort_from_model_params,
@@ -33,17 +33,17 @@ from deepagents_code.tui.widgets.messages import ErrorMessage
 
 
 @pytest.fixture(autouse=True)
-def _restore_settings(
+def _restore_runtime_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> Iterator[None]:
-    original_name = settings.model_name
-    original_provider = settings.model_provider
+    original_name = runtime_state.model_name
+    original_provider = runtime_state.model_provider
     monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", tmp_path / "config.toml")
     model_config.clear_caches()
     yield
-    settings.model_name = original_name
-    settings.model_provider = original_provider
+    runtime_state.model_name = original_name
+    runtime_state.model_provider = original_provider
     model_config.clear_caches()
 
 
@@ -646,8 +646,8 @@ def test_effort_argument_hint_is_profile_agnostic() -> None:
 async def test_effort_command_sets_current_model_params() -> None:
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort high")
 
@@ -662,8 +662,8 @@ async def test_effort_command_replaces_native_effort_and_preserves_summary() -> 
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
     app._model_params_override = {"reasoning": {"effort": "low", "summary": "auto"}}
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort high")
 
@@ -676,8 +676,8 @@ async def test_effort_command_replaces_native_effort_and_preserves_summary() -> 
 async def test_effort_command_matches_levels_case_insensitively() -> None:
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort HIGH")
 
@@ -694,8 +694,8 @@ async def test_profile_override_controls_selector_and_validation() -> None:
     app = DeepAgentsApp(profile_override=override)
     app._mount_message = AsyncMock()  # ty: ignore
     app.push_screen = Mock()  # ty: ignore
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort")
 
@@ -713,8 +713,8 @@ def test_sync_status_model_refreshes_profile_argument_hint() -> None:
     """Switching models re-derives the `/effort` hint from the live profile."""
     app = DeepAgentsApp()
     app._chat_input = Mock()  # ty: ignore
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     # Real profile data drives the hint: gpt-5.5 exposes effort levels, while
     # plain-chat-model does not, so switching to it must clear the hint.
@@ -728,7 +728,7 @@ def test_sync_status_model_refreshes_profile_argument_hint() -> None:
         }
     ):
         app._sync_status_model()
-        settings.model_name = "plain-chat-model"
+        runtime_state.model_name = "plain-chat-model"
         app._sync_status_model()
 
     assert app._chat_input.set_argument_hint_override.call_args_list == [  # ty: ignore[unresolved-attribute]
@@ -743,8 +743,8 @@ def test_sync_status_model_hint_failure_does_not_break_status_bar() -> None:
     app._chat_input = Mock()  # ty: ignore
     app._chat_input.set_argument_hint_override.side_effect = RuntimeError("boom")  # ty: ignore[unresolved-attribute]
     app._status_bar = Mock()  # ty: ignore
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     # Must not raise even though the hint refresh blows up.
     app._sync_status_model()
@@ -776,8 +776,8 @@ def test_profile_override_controls_status_default() -> None:
         }
     )
     app._status_bar = Mock()  # ty: ignore
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     app._sync_status_model()
 
@@ -796,8 +796,8 @@ async def test_empty_profile_override_levels_disable_effort() -> None:
         }
     )
     app._mount_message = AsyncMock()  # ty: ignore
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort high")
 
@@ -908,8 +908,8 @@ async def test_effort_command_without_args_opens_selector() -> None:
     app._mount_message = AsyncMock()  # ty: ignore
     app.push_screen = Mock()  # ty: ignore
     app._model_params_override = {"reasoning_effort": "medium"}
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort")
 
@@ -927,8 +927,8 @@ async def test_gemini_36_selector_offers_minimal_with_medium_default() -> None:
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
     app.push_screen = Mock()  # ty: ignore
-    settings.model_provider = "google_genai"
-    settings.model_name = "gemini-3.6-flash"
+    runtime_state.model_provider = "google_genai"
+    runtime_state.model_name = "gemini-3.6-flash"
 
     await app._handle_effort_command("/effort")
 
@@ -945,8 +945,8 @@ async def test_effort_command_clear_removes_only_effort_params() -> None:
         "reasoning_effort": "high",
         "reasoning": {"effort": "low", "summary": "auto"},
     }
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
     model_config.save_effort_for_model("openai:gpt-5.5", "high")
 
     await app._handle_effort_command("/effort clear")
@@ -963,8 +963,8 @@ async def test_effort_command_save_failure_reports_error(
 ) -> None:
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
     monkeypatch.setattr(
         model_config, "save_effort_for_model", lambda *_args, **_kwargs: False
     )
@@ -988,8 +988,8 @@ async def test_effort_command_clear_failure_reports_error(
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
     app._model_params_override = {"reasoning_effort": "high"}
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
     monkeypatch.setattr(
         model_config, "clear_effort_for_model", lambda *_args, **_kwargs: False
     )
@@ -1010,8 +1010,8 @@ async def test_effort_command_updates_status_bar_effort() -> None:
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
     app._status_bar = Mock()  # ty: ignore
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort xhigh")
 
@@ -1028,8 +1028,8 @@ async def test_effort_command_clear_refreshes_status_bar_to_default() -> None:
     app._mount_message = AsyncMock()  # ty: ignore
     app._status_bar = Mock()  # ty: ignore
     app._model_params_override = {"reasoning_effort": "high"}
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort clear")
 
@@ -1046,8 +1046,8 @@ async def test_effort_command_clear_refreshes_status_bar_to_default() -> None:
 async def test_effort_command_rejects_unsupported_effort() -> None:
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
-    settings.model_provider = "anthropic"
-    settings.model_name = "claude-opus-4-5"
+    runtime_state.model_provider = "anthropic"
+    runtime_state.model_name = "claude-opus-4-5"
 
     # Opus 4.5 supports up to `high`; `xhigh` postdates it (Opus 4.7+ only).
     await app._handle_effort_command("/effort xhigh")
@@ -1064,8 +1064,8 @@ async def test_effort_command_clear_aliases(token: str) -> None:
         "temperature": 0.2,
         "reasoning_effort": "high",
     }
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command(f"/effort {token}")
 
@@ -1076,8 +1076,8 @@ async def test_effort_selector_reports_no_model_configured() -> None:
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
     app.push_screen = Mock()  # ty: ignore
-    settings.model_provider = None
-    settings.model_name = None
+    runtime_state.model_provider = None
+    runtime_state.model_name = None
 
     await app._handle_effort_command("/effort")
 
@@ -1088,8 +1088,8 @@ async def test_effort_selector_reports_no_model_configured() -> None:
 async def test_effort_command_reports_not_configurable_model() -> None:
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
-    settings.model_provider = "anthropic"
-    settings.model_name = "claude-sonnet-4-5"
+    runtime_state.model_provider = "anthropic"
+    runtime_state.model_name = "claude-sonnet-4-5"
 
     await app._handle_effort_command("/effort high")
 
@@ -1101,8 +1101,8 @@ async def test_effort_clear_works_when_profile_is_not_configurable() -> None:
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
     app._model_params_override = {"output_config": {"effort": "low", "format": "json"}}
-    settings.model_provider = "anthropic"
-    settings.model_name = "claude-sonnet-4-5"
+    runtime_state.model_provider = "anthropic"
+    runtime_state.model_name = "claude-sonnet-4-5"
 
     await app._handle_effort_command("/effort clear")
 
@@ -1118,8 +1118,8 @@ async def test_effort_selector_not_configurable_model_skips_screen() -> None:
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
     app.push_screen = Mock()  # ty: ignore
-    settings.model_provider = "anthropic"
-    settings.model_name = "claude-sonnet-4-5"
+    runtime_state.model_provider = "anthropic"
+    runtime_state.model_name = "claude-sonnet-4-5"
 
     await app._handle_effort_command("/effort")
 
@@ -1137,8 +1137,8 @@ async def test_set_effort_override_guards_non_configurable_model() -> None:
     """
     app = DeepAgentsApp()
     app._mount_message = AsyncMock()  # ty: ignore
-    settings.model_provider = "anthropic"
-    settings.model_name = "claude-sonnet-4-5"
+    runtime_state.model_provider = "anthropic"
+    runtime_state.model_name = "claude-sonnet-4-5"
 
     await app._set_effort_override("high")
 
@@ -1158,8 +1158,8 @@ async def test_effort_selector_result_applies_and_refocuses() -> None:
     app.run_worker = Mock(  # ty: ignore
         side_effect=lambda coro, **kwargs: scheduled.append((coro, kwargs))
     )
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort")
     handle_result = app.push_screen.call_args.args[1]  # ty: ignore[unresolved-attribute]
@@ -1183,8 +1183,8 @@ async def test_effort_selector_cancel_refocuses_without_applying() -> None:
     app.push_screen = Mock()  # ty: ignore
     app._chat_input = Mock()  # ty: ignore
     app.run_worker = Mock()  # ty: ignore
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort")
     handle_result = app.push_screen.call_args.args[1]  # ty: ignore[unresolved-attribute]
@@ -1215,8 +1215,8 @@ async def test_effort_selector_apply_failure_reports_error(
     app.run_worker = Mock(  # ty: ignore
         side_effect=lambda coro, **_kwargs: scheduled.append(coro)
     )
-    settings.model_provider = "openai"
-    settings.model_name = "gpt-5.5"
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-5.5"
 
     await app._handle_effort_command("/effort")
     handle_result = app.push_screen.call_args.args[1]  # ty: ignore[unresolved-attribute]

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -14,7 +14,7 @@ import pytest
 
 from deepagents_code import _env_vars
 from deepagents_code.command_registry import get_slash_commands
-from deepagents_code.config import Settings
+from deepagents_code.config import Settings, runtime_state
 from deepagents_code.skills.load import ExtendedSkillMetadata
 
 if TYPE_CHECKING:
@@ -309,22 +309,22 @@ class TestReloadFromEnvironment:
 
         assert loads == 1
 
-    def test_preserves_model_state(
+    def test_does_not_touch_runtime_model_state(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """Reload should preserve runtime model fields and user project."""
+        """Reload should not touch separate runtime model state or user project."""
         settings = Settings.from_environment(start_path=tmp_path)
-        settings.model_name = "gpt-5"
-        settings.model_provider = "openai"
-        settings.model_context_limit = 200_000
+        runtime_state.model_name = "gpt-5"
+        runtime_state.model_provider = "openai"
+        runtime_state.model_context_limit = 200_000
         settings.user_langchain_project = "my-project"
 
         monkeypatch.setenv("OPENAI_API_KEY", "sk-reloaded")
         settings.reload_from_environment(start_path=tmp_path)
 
-        assert settings.model_name == "gpt-5"
-        assert settings.model_provider == "openai"
-        assert settings.model_context_limit == 200_000
+        assert runtime_state.model_name == "gpt-5"
+        assert runtime_state.model_provider == "openai"
+        assert runtime_state.model_context_limit == 200_000
         assert settings.user_langchain_project == "my-project"
 
     def test_no_changes_returns_empty(self, tmp_path: Path) -> None:
@@ -1706,7 +1706,6 @@ class TestReloadModelProfileHints:
         """Client-only sessions should resync after profile caches are cleared."""
         from deepagents_code import model_config
         from deepagents_code.app import DeepAgentsApp
-        from deepagents_code.config import settings
         from deepagents_code.plugins.models import PluginDiscoveryResult
 
         config_path = tmp_path / "config.toml"
@@ -1723,8 +1722,8 @@ reasoning_effort_levels = ["{level}"]
         write_config("old")
         monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
         monkeypatch.setattr(model_config, "_get_provider_profile_modules", list)
-        monkeypatch.setattr(settings, "model_provider", "acme")
-        monkeypatch.setattr(settings, "model_name", "foo")
+        monkeypatch.setattr(runtime_state, "model_provider", "acme")
+        monkeypatch.setattr(runtime_state, "model_name", "foo")
         model_config.clear_caches()
 
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -251,7 +251,7 @@ class TestServerGraph:
 
         model_result = SimpleNamespace(
             model=model_obj,
-            apply_to_settings=MagicMock(),
+            apply_to_runtime_state=MagicMock(),
             model_retries=5,
             cli_max_retries=3,
         )
@@ -470,7 +470,7 @@ class TestServerGraph:
             create_model=MagicMock(
                 return_value=SimpleNamespace(
                     model=model_obj,
-                    apply_to_settings=MagicMock(),
+                    apply_to_runtime_state=MagicMock(),
                     model_retries=5,
                     cli_max_retries=None,
                 ),

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -3229,7 +3229,7 @@ class TestExecuteTaskTextualUsageStats:
     """`execute_task_textual` forwards the active provider into usage stats.
 
     The per-model recording API is unit-tested directly elsewhere; this guards
-    the call site actually reading `settings.model_provider` and threading it
+    the call site actually reading `runtime_state.model_provider` and threading it
     through `record_request`.
     """
 
@@ -3254,11 +3254,11 @@ class TestExecuteTaskTextualUsageStats:
         adapter._on_provisional_cost = record_cost
 
         with (
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.runtime_state") as mock_runtime_state,
             patch("deepagents_code.cost_tracking.estimate_cost", return_value=0.42),
         ):
-            mock_settings.model_name = "gpt-5.5"
-            mock_settings.model_provider = "openai"
+            mock_runtime_state.model_name = "gpt-5.5"
+            mock_runtime_state.model_provider = "openai"
             await execute_task_textual(
                 user_input="hello",
                 agent=_FakeAgent([_usage_chunk(input_tokens=100, output_tokens=50)]),
@@ -3307,11 +3307,11 @@ class TestExecuteTaskTextualUsageStats:
         )
 
         with (
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.runtime_state") as mock_runtime_state,
             patch("deepagents_code.cost_tracking.estimate_cost", return_value=0.42),
         ):
-            mock_settings.model_name = "gpt-5.5"
-            mock_settings.model_provider = "openai"
+            mock_runtime_state.model_name = "gpt-5.5"
+            mock_runtime_state.model_provider = "openai"
             stats = await execute_task_textual(
                 user_input="hello",
                 agent=agent,
@@ -3375,11 +3375,11 @@ class TestExecuteTaskTextualUsageStats:
         ]
 
         with (
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.runtime_state") as mock_runtime_state,
             patch("deepagents_code.cost_tracking.estimate_cost", return_value=0.1),
         ):
-            mock_settings.model_name = "gpt-5.5"
-            mock_settings.model_provider = "openai"
+            mock_runtime_state.model_name = "gpt-5.5"
+            mock_runtime_state.model_provider = "openai"
             await execute_task_textual(
                 user_input="hello",
                 agent=_FakeAgent(chunks),
@@ -3451,11 +3451,11 @@ class TestExecuteTaskTextualUsageStats:
         turn_stats = SessionStats()
 
         with (
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.runtime_state") as mock_runtime_state,
             patch("deepagents_code.cost_tracking.estimate_cost", return_value=0.1),
         ):
-            mock_settings.model_name = "gpt-5.5"
-            mock_settings.model_provider = "openai"
+            mock_runtime_state.model_name = "gpt-5.5"
+            mock_runtime_state.model_provider = "openai"
             await execute_task_textual(
                 user_input="hello",
                 agent=agent,
@@ -3508,11 +3508,11 @@ class TestExecuteTaskTextualUsageStats:
         turn_stats = SessionStats()
 
         with (
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.runtime_state") as mock_runtime_state,
             patch("deepagents_code.cost_tracking.estimate_cost", return_value=0.1),
         ):
-            mock_settings.model_name = "configured-model"
-            mock_settings.model_provider = "google_genai"
+            mock_runtime_state.model_name = "configured-model"
+            mock_runtime_state.model_provider = "google_genai"
             await execute_task_textual(
                 user_input="hello",
                 agent=agent,
@@ -3639,11 +3639,11 @@ class TestSessionCostEvents:
         turn_stats = SessionStats()
 
         with (
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.runtime_state") as mock_runtime_state,
             patch("deepagents_code.cost_tracking.estimate_cost", return_value=0.42),
         ):
-            mock_settings.model_name = "gpt-5.5"
-            mock_settings.model_provider = "openai"
+            mock_runtime_state.model_name = "gpt-5.5"
+            mock_runtime_state.model_provider = "openai"
             await execute_task_textual(
                 user_input="hello",
                 agent=_FakeAgent(chunks),

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -688,7 +688,7 @@ class TestCostDisplay:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             # A `None` limit renders `--` only once tokens are non-zero, so pin
-            # the limit rather than inheriting `settings.model_context_limit`.
+            # the limit rather than inheriting `runtime_state.model_context_limit`.
             bar.set_context_limit(None)
             bar.set_tokens(5000)
             bar.set_cost(0.0)

--- a/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
@@ -4626,7 +4626,7 @@ class TestResumeAdoptionFailureMessage:
 
     async def test_omits_fallback_when_no_current_model(self) -> None:
         """With no resolvable current model, the fallback clause is dropped."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
 
         app = DeepAgentsApp()
         app._model_override = None
@@ -4636,8 +4636,8 @@ class TestResumeAdoptionFailureMessage:
         )
 
         with (
-            patch.object(settings, "model_provider", ""),
-            patch.object(settings, "model_name", ""),
+            patch.object(runtime_state, "model_provider", ""),
+            patch.object(runtime_state, "model_name", ""),
         ):
             await app._mount_resume_adoption_failure(
                 "anthropic:claude-opus-4-8", "the model could not be initialized"
@@ -4652,38 +4652,38 @@ class TestEffectiveModelSpec:
     """Tests for DeepAgentsApp._effective_model_spec."""
 
     async def test_prefers_session_override(self) -> None:
-        """A `/model` override wins over the startup default in `settings`."""
-        from deepagents_code.config import settings
+        """A `/model` override wins over process-wide runtime model state."""
+        from deepagents_code.config import runtime_state
 
         app = DeepAgentsApp()
         app._model_override = "openai:gpt-5.1"
         with (
-            patch.object(settings, "model_provider", "anthropic"),
-            patch.object(settings, "model_name", "claude-sonnet-4-5"),
+            patch.object(runtime_state, "model_provider", "anthropic"),
+            patch.object(runtime_state, "model_name", "claude-sonnet-4-5"),
         ):
             assert app._effective_model_spec() == "openai:gpt-5.1"
 
     async def test_falls_back_to_settings_spec(self) -> None:
-        """With no override, the resolved `provider:model` from settings is used."""
-        from deepagents_code.config import settings
+        """With no override, the resolved runtime `provider:model` is used."""
+        from deepagents_code.config import runtime_state
 
         app = DeepAgentsApp()
         app._model_override = None
         with (
-            patch.object(settings, "model_provider", "anthropic"),
-            patch.object(settings, "model_name", "claude-sonnet-4-5"),
+            patch.object(runtime_state, "model_provider", "anthropic"),
+            patch.object(runtime_state, "model_name", "claude-sonnet-4-5"),
         ):
             assert app._effective_model_spec() == "anthropic:claude-sonnet-4-5"
 
     async def test_none_when_spec_incomplete(self) -> None:
         """No override and a blank model yields `None` (no malformed spec)."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import runtime_state
 
         app = DeepAgentsApp()
         app._model_override = None
         with (
-            patch.object(settings, "model_provider", "anthropic"),
-            patch.object(settings, "model_name", ""),
+            patch.object(runtime_state, "model_provider", "anthropic"),
+            patch.object(runtime_state, "model_name", ""),
         ):
             assert app._effective_model_spec() is None
 


### PR DESCRIPTION
`Settings` currently owns model metadata that is only known after model creation and changes at runtime, so treating it as configuration obscures its ownership. This extracts those fields into a small mutable `RuntimeState`, preserves lazy initialization, and routes `ModelResult.apply_to_runtime_state()` and readers through that state without changing model selection behavior.

Part 1 of 6 in the [`Settings` dissolution stack](https://github.com/langchain-ai/deepagents/pull/5859?stack=5864).
