### PR TITLE
refactor(code): resolve interpreter/shell/skills config at callsites

### DIFF
--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -190,16 +190,26 @@ def _resolve_enable_interpreter(
     Returns:
         The explicit `enable_interpreter` value when not `None`; `False` for
             remote-sandbox defaults; otherwise the configured local default
-            (`settings.enable_interpreter`).
+            from `interpreter.enable_interpreter`.
+
+    Raises:
+        RuntimeError: If the interpreter option is absent from the manifest.
     """
     if enable_interpreter is not None:
         return enable_interpreter
     if sandbox_type and sandbox_type != "none":
         return False
 
-    from deepagents_code.config import settings
+    from deepagents_code.config_manifest import _emit_ranked_diagnostics, get_option
+    from deepagents_code.configuration.resolver import get_config_resolver
 
-    return settings.enable_interpreter
+    option = get_option("interpreter.enable_interpreter")
+    if option is None:
+        msg = "interpreter.enable_interpreter is missing from the config manifest"
+        raise RuntimeError(msg)
+    resolved = get_config_resolver().get(option)
+    _emit_ranked_diagnostics(option, resolved)
+    return bool(resolved.value)
 
 
 def _interpreter_suppressed_by_sandbox(
@@ -223,7 +233,7 @@ def _interpreter_suppressed_by_sandbox(
             `True`, `--no-interpreter` → `False`, unset → `None`).
         sandbox_type: Sandbox backend identifier. Any falsy value (`None`, `""`)
             or `"none"` is treated as local execution.
-        local_default: The local-mode default (`settings.enable_interpreter`);
+        local_default: The resolver-backed local-mode default;
             gating on it keeps the advisory quiet for users who disabled the
             interpreter in config.
 
@@ -301,17 +311,16 @@ class ServerConfig:
     caller option via `_resolve_enable_interpreter` before constructing the
     config, so the `bool | None` "defer to default" sentinel never reaches this
     field. The `False` default here is only the bare-constructor/`from_env`
-    fallback; the user-facing default (on in local mode) lives in
-    `settings.enable_interpreter`.
+    fallback; the user-facing default (on in local mode) is resolver-backed.
 
     Local-mode only; the server graph raises if a sandbox is configured and
     this flag is `True`.
     """
 
     interpreter_ptc: str | list[str] | None = None
-    """Override for `settings.interpreter_ptc`.
+    """Invocation-scoped override for `interpreter.ptc`.
 
-    `None` means "fall through to whatever `settings.interpreter_ptc` resolves
+    `None` means "fall through to whatever `interpreter.ptc` resolves
     to from `~/.deepagents/config.toml`". A string is one of `"safe"`/`"all"`;
     a list is an explicit allowlist of tool names that may also include the
     `"safe"` preset (expanded at agent-build time); `"all"` is rejected inside
@@ -319,7 +328,7 @@ class ServerConfig:
     """
 
     interpreter_ptc_acknowledge_unsafe: bool = False
-    """Mirror of `settings.interpreter_ptc_acknowledge_unsafe` — required when
+    """Override for `interpreter.ptc_acknowledge_unsafe` — required when
     `interpreter_ptc="all"` is paired with non-`auto_approve` mode.
     """
 
@@ -635,9 +644,9 @@ class ServerConfig:
             enable_ask_user: Enable ask_user tool.
             enable_interpreter: Enable `CodeInterpreterMiddleware` on the main
                 agent. `None` uses the sandbox-aware default.
-            interpreter_ptc: Override for `settings.interpreter_ptc`.
-            interpreter_ptc_acknowledge_unsafe: Mirror of
-                `settings.interpreter_ptc_acknowledge_unsafe`.
+            interpreter_ptc: Invocation-scoped PTC allowlist override.
+            interpreter_ptc_acknowledge_unsafe: Explicit acknowledgement for
+                an invocation-scoped `interpreter_ptc="all"`.
             allow_fs_tools: Allowlist for `FilesystemMiddleware`'s `tools`
                 param to forward to the server subprocess. `None` leaves the
                 SDK default (all tools).

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -111,6 +111,7 @@ from deepagents_code.config import (
     settings,
 )
 from deepagents_code.configurable_model import ConfigurableModelMiddleware
+from deepagents_code.configuration.interpreter import InterpreterConfig
 from deepagents_code.integrations.sandbox_factory import get_default_working_dir
 from deepagents_code.local_context import (
     LocalContextMiddleware,
@@ -952,8 +953,8 @@ def _resolve_ptc_option(
         tools: Tools passed to `create_cli_agent`. Used only to enumerate
             `"all"`, which is therefore limited to these explicitly-passed
             tools (the SDK runtime built-ins cannot be enumerated here).
-        acknowledge_unsafe: Mirrors `settings.interpreter_ptc_acknowledge_unsafe`;
-            required when `ptc="all"` and `auto_approve` is `False`.
+        acknowledge_unsafe: Explicit acknowledgement required when `ptc="all"`
+            and `auto_approve` is `False`.
         auto_approve: Whether HITL approval is globally disabled. When `True`,
             `"all"` does not require `acknowledge_unsafe` because every host
             tool already runs without prompting.
@@ -1068,6 +1069,27 @@ def _resolve_ptc_option(
         f"got {type(ptc).__name__}."
     )
     raise ValueError(msg)
+
+
+def _resolve_shell_allow_list() -> list[str] | None:
+    """Resolve the shell allow-list for a direct agent-construction caller.
+
+    Returns:
+        The configured allow-list, or `None` when shell access is disabled.
+
+    Raises:
+        RuntimeError: If the option is absent from the manifest.
+    """
+    from deepagents_code.config_manifest import _emit_ranked_diagnostics, get_option
+    from deepagents_code.configuration.resolver import get_config_resolver
+
+    option = get_option("shell.allow_list")
+    if option is None:
+        msg = "shell.allow_list is missing from the configuration manifest"
+        raise RuntimeError(msg)
+    resolved = get_config_resolver().get(option)
+    _emit_ranked_diagnostics(option, resolved)
+    return cast("list[str] | None", resolved.value)
 
 
 def load_async_subagents(config_path: Path | None = None) -> list[AsyncSubAgent]:
@@ -2350,6 +2372,7 @@ def create_cli_agent(
     enable_skills: bool = True,
     enable_shell: bool = True,
     enable_interpreter: bool = False,
+    interpreter_config: InterpreterConfig | None = None,
     rubric_model: str | BaseChatModel | None = None,
     rubric_max_iterations: int | None = None,
     auto_classifier_model: str | BaseChatModel | None = None,
@@ -2424,8 +2447,8 @@ def create_cli_agent(
             disabled) or when `shell_allow_list` is `SHELL_ALLOW_ALL`.
         shell_allow_list: Explicit restrictive shell allow-list forwarded from
             the CLI process. When provided (and `interrupt_shell_only` is
-            `True`), used directly instead of reading `settings.shell_allow_list`
-            (which may not be set in the server subprocess environment).
+            `True`), used directly instead of resolving `shell.allow_list`
+            again in the server subprocess.
         fs_tools: Allowlist of filesystem tools to expose to the agent, from
             `--allow-fs-tools`. `None` (default; also what `--allow-fs-tools
             all` parses to) leaves `FilesystemMiddleware` at its SDK default
@@ -2462,7 +2485,7 @@ def create_cli_agent(
             receive the interpreter in v1.
 
             PTC (`tools.*` host bridge) calls bypass `interrupt_on`/HITL
-            approval, so `settings.interpreter_ptc` is the only effective
+            approval, so `InterpreterConfig.ptc` is the only effective
             control over which host tools can be invoked from inside the
             REPL. `js_eval` itself is intentionally not gated by HITL —
             per-call approval would be unusably noisy and would not block
@@ -2474,6 +2497,11 @@ def create_cli_agent(
             `interpreter_ptc_acknowledge_unsafe=True`.
 
             Requires the core `langchain-quickjs` dependency.
+        interpreter_config: Resolver-backed interpreter settings snapshot.
+
+            Direct callers may omit this to resolve one for the current
+            process. The server supplies a snapshot that incorporates its
+            invocation-scoped PTC overrides.
         rubric_model: Grader model for `RubricMiddleware`.
 
             A `'provider:model'` string or `BaseChatModel`.
@@ -2534,7 +2562,7 @@ def create_cli_agent(
 
     Raises:
         ValueError: When `enable_interpreter=True` is paired with a
-            non-`None` `sandbox`, when `settings.interpreter_ptc` contains
+            non-`None` `sandbox`, when `InterpreterConfig.ptc` contains
             unknown tool names, or when `interpreter_ptc="all"` is used
             without `auto_approve` or `interpreter_ptc_acknowledge_unsafe`.
         ModelNotAllowedError: When `model`, `auto_classifier_model`,
@@ -2567,6 +2595,7 @@ def create_cli_agent(
 
     # Load custom subagents from filesystem
     custom_subagents: list[SubAgent | CompiledSubAgent] = []
+    resolved_shell_allow_list = _resolve_shell_allow_list()
     restrictive_shell_allow_list: list[str] | None = None
     if interrupt_shell_only and not auto_approve:
         # Prefer the explicitly forwarded allow-list (set by the CLI process
@@ -2575,10 +2604,10 @@ def create_cli_agent(
         # the server subprocess path.
         if shell_allow_list:
             restrictive_shell_allow_list = list(shell_allow_list)
-        elif settings.shell_allow_list and not isinstance(
-            settings.shell_allow_list, _ShellAllowAll
+        elif resolved_shell_allow_list and not isinstance(
+            resolved_shell_allow_list, _ShellAllowAll
         ):
-            restrictive_shell_allow_list = list(settings.shell_allow_list)
+            restrictive_shell_allow_list = list(resolved_shell_allow_list)
         else:
             logger.warning(
                 "interrupt_shell_only=True but no restrictive shell allow-list "
@@ -2918,10 +2947,11 @@ def create_cli_agent(
         )
         from langchain_quickjs import CodeInterpreterMiddleware, PTCOption
 
+        interpreter = interpreter_config or InterpreterConfig.from_resolver()
         ptc_names = _resolve_ptc_option(
-            settings.interpreter_ptc,
+            interpreter.ptc,
             tools=tools,
-            acknowledge_unsafe=settings.interpreter_ptc_acknowledge_unsafe,
+            acknowledge_unsafe=interpreter.ptc_acknowledge_unsafe,
             auto_approve=auto_approve,
         )
         ptc_option: PTCOption | None = (
@@ -2934,10 +2964,10 @@ def create_cli_agent(
             agent_middleware.append(
                 CodeInterpreterMiddleware(
                     tool_name="js_eval",
-                    timeout=settings.interpreter_timeout_seconds,
-                    memory_limit=settings.interpreter_memory_limit_mb * 1024 * 1024,
-                    max_ptc_calls=settings.interpreter_max_ptc_calls,
-                    max_result_chars=settings.interpreter_max_result_chars,
+                    timeout=interpreter.timeout_seconds,
+                    memory_limit=interpreter.memory_limit_mb * 1024 * 1024,
+                    max_ptc_calls=interpreter.max_ptc_calls,
+                    max_result_chars=interpreter.max_result_chars,
                     ptc=ptc_option,
                 )
             )
@@ -2970,7 +3000,7 @@ def create_cli_agent(
     interrupt_on: dict[str, bool | InterruptOnConfig] = {}
     auto_mode_config: tuple[Path, list[str]] | None = None
     if resolved_interrupt_on is not None and auto_mode_enabled:
-        configured_allow_list = shell_allow_list or settings.shell_allow_list
+        configured_allow_list = shell_allow_list or resolved_shell_allow_list
         narrow_allow_list = (
             configured_allow_list if isinstance(configured_allow_list, list) else []
         )

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -404,6 +404,27 @@ def _load_non_negative_int_option(key: str, default: int, *, label: str) -> int:
     return value
 
 
+def _load_shell_allow_list() -> list[str] | None:
+    """Resolve the shell command allow-list from the shared resolver.
+
+    Returns:
+        The configured allow-list, or `None` when shell access is disabled.
+
+    Raises:
+        RuntimeError: If the option is absent from the manifest.
+    """
+    from deepagents_code.config_manifest import _emit_ranked_diagnostics, get_option
+    from deepagents_code.configuration.resolver import get_config_resolver
+
+    option = get_option("shell.allow_list")
+    if option is None:
+        msg = "shell.allow_list is missing from the configuration manifest"
+        raise RuntimeError(msg)
+    resolved = get_config_resolver().get(option)
+    _emit_ranked_diagnostics(option, resolved)
+    return cast("list[str] | None", resolved.value)
+
+
 def _load_float_option(
     key: str,
     default: float,
@@ -4806,17 +4827,25 @@ class DeepAgentsApp(App):
         in `main._warn_if_interpreter_disabled_by_sandbox`.
 
         Gated on the raw `--interpreter` tri-state (`self._interpreter_arg`) so an
-        explicit `--no-interpreter` opt-out stays quiet, and on the local default
-        from `settings` so users who disabled the interpreter in config are not
-        nagged.
+        explicit `--no-interpreter` opt-out stays quiet, and on the resolver-backed
+        local default so users who disabled the interpreter in config are not nagged.
         """
         from deepagents_code._server_config import _interpreter_suppressed_by_sandbox
-        from deepagents_code.config import settings
+        from deepagents_code.config_manifest import _emit_ranked_diagnostics, get_option
+        from deepagents_code.configuration.resolver import get_config_resolver
+
+        option = get_option("interpreter.enable_interpreter")
+        if option is None:
+            logger.error("Interpreter enable option is missing from the manifest")
+            return
+        resolved = get_config_resolver().get(option)
+        _emit_ranked_diagnostics(option, resolved)
+        local_default = bool(resolved.value)
 
         if not _interpreter_suppressed_by_sandbox(
             enable_interpreter=self._interpreter_arg,
             sandbox_type=self._sandbox_type,
-            local_default=settings.enable_interpreter,
+            local_default=local_default,
         ):
             return
         self.notify(
@@ -9366,7 +9395,6 @@ class DeepAgentsApp(App):
         """
         from deepagents_code.config import (
             is_shell_command_allowed,
-            settings,
         )
 
         loop = asyncio.get_running_loop()
@@ -9377,14 +9405,15 @@ class DeepAgentsApp(App):
             and request["description"].startswith("Auto human fallback")
             for request in action_requests or []
         )
-        if settings.shell_allow_list and action_requests and not is_auto_fallback:
+        shell_allow_list = _load_shell_allow_list()
+        if shell_allow_list and action_requests and not is_auto_fallback:
             all_auto_approved = True
             approved_commands = []
 
             for req in action_requests:
                 if req.get("name") == "execute":
                     command = req.get("args", {}).get("command", "")
-                    if is_shell_command_allowed(command, settings.shell_allow_list):
+                    if is_shell_command_allowed(command, shell_allow_list):
                         approved_commands.append(command)
                     else:
                         all_auto_approved = False

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5619,6 +5619,7 @@ class DeepAgentsApp(App):
             assistant_id,
             plugin_skill_sources=plugin_skill_sources,
             plugin_skill_roots=plugin_skill_roots,
+            path_base=Path(self._cwd),
         )
 
     def _discover_skills_and_roots_with_import_lock(

--- a/libs/code/deepagents_code/client/launch/server_manager.py
+++ b/libs/code/deepagents_code/client/launch/server_manager.py
@@ -342,7 +342,7 @@ async def start_server_and_get_agent(
         enable_ask_user: Enable ask_user tool.
         enable_interpreter: Enable the JS interpreter (`js_eval`) middleware on
             the main agent. `None` uses the sandbox-aware default.
-        interpreter_ptc: Override for `settings.interpreter_ptc` (PTC allowlist).
+        interpreter_ptc: Invocation-scoped PTC allowlist override.
         interpreter_ptc_acknowledge_unsafe: Explicit acknowledgement for
             `interpreter_ptc="all"` outside of `auto_approve`.
         allow_fs_tools: Allowlist for `FilesystemMiddleware`'s `tools` param.
@@ -522,7 +522,7 @@ async def server_session(
         enable_ask_user: Enable ask_user tool.
         enable_interpreter: Enable the JS interpreter (`js_eval`) middleware on
             the main agent. `None` uses the sandbox-aware default.
-        interpreter_ptc: Override for `settings.interpreter_ptc` (PTC allowlist).
+        interpreter_ptc: Invocation-scoped PTC allowlist override.
         interpreter_ptc_acknowledge_unsafe: Explicit acknowledgement for
             `interpreter_ptc="all"` outside of `auto_approve`.
         allow_fs_tools: Allowlist for `FilesystemMiddleware`'s `tools` param.

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -72,7 +72,6 @@ from deepagents_code.config import (
     create_model,
     is_shell_command_allowed,
     runtime_state,
-    settings,
 )
 from deepagents_code.file_ops import FileOpTracker, record_display_caveat
 from deepagents_code.hooks import (
@@ -1064,6 +1063,27 @@ def _process_stream_chunk(
         )
 
 
+def _resolve_shell_allow_list() -> list[str] | None:
+    """Resolve the non-interactive shell policy.
+
+    Returns:
+        The configured allow-list, or `None` when shell access is disabled.
+
+    Raises:
+        RuntimeError: If the option is absent from the manifest.
+    """
+    from deepagents_code.config_manifest import _emit_ranked_diagnostics, get_option
+    from deepagents_code.configuration.resolver import get_config_resolver
+
+    option = get_option("shell.allow_list")
+    if option is None:
+        msg = "shell.allow_list is missing from the configuration manifest"
+        raise RuntimeError(msg)
+    resolved = get_config_resolver().get(option)
+    _emit_ranked_diagnostics(option, resolved)
+    return cast("list[str] | None", resolved.value)
+
+
 def _make_hitl_decision(
     action_request: ActionRequest, console: Console
 ) -> dict[str, str]:
@@ -1095,7 +1115,8 @@ def _make_hitl_decision(
     action_name = action_request.get("name", "")
 
     if action_name == "execute":
-        if not settings.shell_allow_list:
+        shell_allow_list = _resolve_shell_allow_list()
+        if not shell_allow_list:
             command = action_request.get("args", {}).get("command", "")
             console.print(
                 f"\n[red]Shell command rejected (no allow-list configured): "
@@ -1112,11 +1133,11 @@ def _make_hitl_decision(
 
         command = action_request.get("args", {}).get("command", "")
 
-        if is_shell_command_allowed(command, settings.shell_allow_list):
+        if is_shell_command_allowed(command, shell_allow_list):
             console.print(f"[dim]✓ Auto-approved: {escape_markup(command)}[/dim]")
             return {"type": "approve"}
 
-        allowed_list_str = ", ".join(settings.shell_allow_list)
+        allowed_list_str = ", ".join(shell_allow_list)
         console.print(f"\n[red]Shell command rejected:[/red] {escape_markup(command)}")
         console.print(
             f"[yellow]Allowed commands:[/yellow] {escape_markup(allowed_list_str)}"
@@ -1970,8 +1991,7 @@ async def run_non_interactive(
             silently skipped.
         enable_interpreter: Enable the JS interpreter (`js_eval`) middleware
             on the main agent. `None` uses the sandbox-aware default.
-        interpreter_ptc: Override for `settings.interpreter_ptc` (PTC
-            allowlist for `js_eval`).
+        interpreter_ptc: Invocation-scoped PTC allowlist override for `js_eval`.
         interpreter_ptc_acknowledge_unsafe: Explicit acknowledgement for
             `interpreter_ptc="all"` outside of `auto_approve`.
         allow_fs_tools: Allowlist for `FilesystemMiddleware`'s `tools` param,
@@ -2158,10 +2178,9 @@ async def run_non_interactive(
         from deepagents_code.hooks.models.domain import HookEvent
         from deepagents_code.hooks.trust import WorkspaceTrust
 
-        enable_shell = bool(settings.shell_allow_list)
-        shell_is_unrestricted = isinstance(
-            settings.shell_allow_list, type(SHELL_ALLOW_ALL)
-        )
+        shell_allow_list = _resolve_shell_allow_list()
+        enable_shell = bool(shell_allow_list)
+        shell_is_unrestricted = isinstance(shell_allow_list, type(SHELL_ALLOW_ALL))
         # Currently, non-shell tools have no HITL handler in non-interactive
         # mode, so interrupting on them just fragments LangSmith traces
         # without adding value. Gate only shell execution via middleware.
@@ -2199,10 +2218,9 @@ async def run_non_interactive(
             enable_shell and not shell_is_unrestricted and not has_permission_hooks
         )
         # Extract the concrete allow-list to forward to the server subprocess.
-        # settings.shell_allow_list is already validated at this point.
         restrictive_allow_list: list[str] | None = (
-            list(settings.shell_allow_list)
-            if use_interrupt_shell_only and settings.shell_allow_list
+            list(shell_allow_list)
+            if use_interrupt_shell_only and shell_allow_list
             else None
         )
 

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -40,19 +40,17 @@ from deepagents_code._paths import (
     PATHS,
 )
 from deepagents_code._version import __version__
-from deepagents_code.config_manifest import (
-    INTERPRETER_ENABLE_DEFAULT,
-    INTERPRETER_MAX_PTC_CALLS_DEFAULT,
-    INTERPRETER_MAX_RESULT_CHARS_DEFAULT,
-    INTERPRETER_MEMORY_LIMIT_MB_DEFAULT,
-    INTERPRETER_PTC_ACKNOWLEDGE_UNSAFE_DEFAULT,
-    INTERPRETER_PTC_DEFAULT,
-    INTERPRETER_TIMEOUT_SECONDS_DEFAULT,
-    RECURSION_LIMIT_DEFAULT,
-)
+from deepagents_code.config_manifest import RECURSION_LIMIT_DEFAULT
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
+
+    from deepagents_code.config_manifest import ConfigOption
+    from deepagents_code.configuration.resolver import (
+        ConfigResolver,
+        RankedProviderValue,
+    )
+    from deepagents_code.configuration.types import ProviderStatus
 
 logger = logging.getLogger(__name__)
 
@@ -2885,8 +2883,6 @@ _RELOADABLE_FIELDS = (
     "google_cloud_location",
     "deepagents_langchain_project",
     "project_root",
-    "shell_allow_list",
-    "extra_skills_dirs",
 )
 """Fields refreshed on `/reload` and cwd switches.
 
@@ -2903,6 +2899,158 @@ _API_KEY_FIELDS = frozenset(
 Derived from `_RELOADABLE_FIELDS` so new `*_api_key` fields are picked up
 automatically.
 """
+
+_RESOLVER_RELOAD_FIELDS = (
+    "shell_allow_list",
+    "extra_skills_dirs",
+)
+"""Resolver-backed values included in reload previews and change reports."""
+
+_RELOAD_CHANGE_FIELDS = (*_RELOADABLE_FIELDS, *_RESOLVER_RELOAD_FIELDS)
+"""Stable display order for every reload-owned change report entry."""
+
+_resolver_reload_snapshot: dict[str, object] = {
+    "shell_allow_list": None,
+    "extra_skills_dirs": None,
+}
+_resolver_reload_snapshot_lock = threading.Lock()
+
+
+@dataclass(slots=True)
+class _ReloadOverrideProvider:
+    """Retain resolver values when one reload candidate cannot be applied."""
+
+    name: str = "retained reload value"
+    rank: int = 350
+    _values: dict[str, object] = dataclass_field(default_factory=dict)
+    _lock: threading.Lock = dataclass_field(default_factory=threading.Lock)
+
+    @property
+    def durable(self) -> bool:
+        """The retained generation exists only for this process lifetime."""
+        return False
+
+    def get(self, option: ConfigOption) -> RankedProviderValue[object]:
+        """Return a retained typed value or leave the option unset."""
+        from deepagents_code.configuration.resolver import RankedProviderValue
+        from deepagents_code.configuration.types import (
+            Found,
+            ProviderHealth,
+            ProviderStatus,
+            Unset,
+        )
+
+        with self._lock:
+            result = (
+                Found(self._values[option.key])
+                if option.key in self._values
+                else Unset()
+            )
+        return RankedProviderValue(
+            self.rank,
+            self.durable,
+            ProviderStatus(self.name, None, ProviderHealth.OK),
+            result,
+        )
+
+    def status(self) -> ProviderStatus:
+        """Return the health of the in-memory retained generation."""
+        from deepagents_code.configuration.types import ProviderHealth, ProviderStatus
+
+        return ProviderStatus(self.name, None, ProviderHealth.OK)
+
+    def reload(self) -> None:
+        """Keep the accepted in-memory generation unchanged."""
+
+    def replace(self, values: Mapping[str, object]) -> None:
+        """Atomically replace the options whose previous values stay in force."""
+        with self._lock:
+            self._values = dict(values)
+
+
+_reload_override_provider = _ReloadOverrideProvider()
+
+
+def _resolver_with_reload_overrides() -> ConfigResolver:
+    """Return the shared resolver with the reload-retention tier installed."""
+    from deepagents_code.configuration.resolver import (
+        RELOAD_RANK,
+        get_config_resolver,
+    )
+
+    resolver = get_config_resolver()
+    if RELOAD_RANK not in resolver.provider_statuses():
+        resolver.install_provider(_reload_override_provider)
+    return resolver
+
+
+def _sync_reload_overrides(
+    values: Mapping[str, object], *, path_base: Path | None
+) -> None:
+    """Retain values that the refreshed resolver generation cannot reproduce."""
+    from deepagents_code.config_manifest import get_option
+    from deepagents_code.configuration.resolver import RELOAD_RANK
+
+    resolver = _resolver_with_reload_overrides()
+    retained: dict[str, object] = {}
+    option_keys = {
+        "shell_allow_list": "shell.allow_list",
+        "extra_skills_dirs": "skills.extra_allowed_dirs",
+    }
+    with _use_extra_skills_path_base(path_base):
+        for field, key in option_keys.items():
+            option = get_option(key)
+            if option is None:
+                continue
+            try:
+                candidate = resolver.get_without_ranks(option, {RELOAD_RANK}).value
+            except (OSError, RuntimeError, ValueError):
+                candidate = object()
+            if candidate != values[field]:
+                retained[key] = values[field]
+    _reload_override_provider.replace(retained)
+
+
+def _remember_resolver_reload_values(values: Mapping[str, object]) -> None:
+    """Remember the accepted resolver generation for future change reports."""
+    with _resolver_reload_snapshot_lock:
+        for field in _RESOLVER_RELOAD_FIELDS:
+            _resolver_reload_snapshot[field] = values[field]
+
+
+def _remembered_resolver_reload_values() -> dict[str, object]:
+    """Return the resolver generation currently accepted by runtime reload."""
+    with _resolver_reload_snapshot_lock:
+        return dict(_resolver_reload_snapshot)
+
+
+def _current_resolver_reload_values(*, path_base: Path | None) -> dict[str, object]:
+    """Snapshot resolver-backed values before a preview or accepted reload.
+
+    Returns:
+        Resolver values keyed by their stable reload-report field names.
+
+    Raises:
+        RuntimeError: If either reload-owned option is absent from the manifest.
+    """
+    from deepagents_code.config_manifest import _emit_ranked_diagnostics, get_option
+
+    options = tuple(
+        option
+        for key in ("shell.allow_list", "skills.extra_allowed_dirs")
+        if (option := get_option(key)) is not None
+    )
+    if len(options) != len(_RESOLVER_RELOAD_FIELDS):
+        msg = "reload options are missing from the configuration manifest"
+        raise RuntimeError(msg)
+    with _use_extra_skills_path_base(path_base):
+        resolved = _resolver_with_reload_overrides().resolve_options(options)
+    for option in options:
+        _emit_ranked_diagnostics(option, resolved[option.key])
+    return {
+        "shell_allow_list": resolved["shell.allow_list"].value,
+        "extra_skills_dirs": resolved["skills.extra_allowed_dirs"].value,
+    }
 
 
 @dataclass
@@ -2963,76 +3111,6 @@ class Settings:
     project_root: Path | None = None
     """Current project root directory, or `None` if not in a git project."""
 
-    shell_allow_list: list[str] | None = None
-    """Shell commands that don't require user approval."""
-
-    extra_skills_dirs: list[Path] | None = None
-    """Extra directories added to the skill path containment allowlist.
-
-    These do NOT add new skill discovery locations — skills are still only
-    discovered from the standard directories. They exist so that symlinks inside
-    standard skill directories can point to targets in these additional
-    locations without being rejected by the containment check
-    in `load_skill_content`.
-
-    Set via `DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS` env var (colon-separated) or
-    `[skills].extra_allowed_dirs` in `~/.deepagents/config.toml`.
-    """
-
-    enable_interpreter: bool = INTERPRETER_ENABLE_DEFAULT
-    """Wire `CodeInterpreterMiddleware` from `langchain-quickjs` into the main
-    agent. Local-mode only; raises `ValueError` at agent-build time when a
-    remote sandbox is active. Subagents never receive the interpreter in v1.
-
-    `langchain-quickjs` is installed as a core dependency.
-
-    Defaults are owned by `config_manifest` (the canonical config surface) so
-    they are defined in exactly one place.
-    """
-
-    interpreter_timeout_seconds: float = INTERPRETER_TIMEOUT_SECONDS_DEFAULT
-    """Per-`js_eval`-call wall-clock timeout (seconds) for the QuickJS REPL."""
-
-    interpreter_memory_limit_mb: int = INTERPRETER_MEMORY_LIMIT_MB_DEFAULT
-    """QuickJS heap memory cap (MB), shared across all calls within a session."""
-
-    interpreter_max_ptc_calls: int = INTERPRETER_MAX_PTC_CALLS_DEFAULT
-    """Maximum `tools.*` host-bridge invocations allowed per `js_eval` call.
-
-    PTC calls bypass `interrupt_on`/HITL approval — this budget is the only
-    runtime limiter on bursty tool fan-out from inside the REPL.
-    """
-
-    interpreter_max_result_chars: int = INTERPRETER_MAX_RESULT_CHARS_DEFAULT
-    """Independent cap (chars) on `js_eval` result and stdout blocks before
-    truncation."""
-
-    interpreter_ptc: str | bool | list[str] = INTERPRETER_PTC_DEFAULT
-    """Programmatic tool calling allowlist for `js_eval`.
-
-    Accepted values:
-
-    - `False` or `[]`: pure REPL, no `tools.*` bridge.
-    - `"safe"`: expand to `INTERPRETER_PTC_SAFE_PRESET` (the default).
-    - `"all"`: every tool passed to `create_cli_agent` is exposed. Requires
-        `interpreter_ptc_acknowledge_unsafe=True` when `auto_approve` is `False`.
-    - `list[str]`: explicit tool names. The list may also include the `"safe"`
-        preset (expanded to `INTERPRETER_PTC_SAFE_PRESET`); `"all"` is rejected
-        inside a list. Names are matched against the live tool registry at
-        runtime, so names not present are simply not exposed.
-    """
-
-    interpreter_ptc_acknowledge_unsafe: bool = (
-        INTERPRETER_PTC_ACKNOWLEDGE_UNSAFE_DEFAULT
-    )
-    """Explicit acknowledgement required when `interpreter_ptc="all"` is set
-    without `auto_approve`.
-
-    `"all"` exposes every host tool to `tools.*` calls from inside the REPL,
-    bypassing HITL approval — this flag is a deliberate sanity gate, not a
-    feature toggle.
-    """
-
     @classmethod
     def from_environment(cls, *, start_path: Path | None = None) -> Settings:
         """Create settings by detecting the current environment.
@@ -3043,9 +3121,6 @@ class Settings:
         Returns:
             Settings instance with detected configuration
 
-        Raises:
-            RuntimeError: If the manifest is missing an enforced managed key, so
-                resolving it from the environment alone would bypass policy.
         """
         # Detect API keys (normalize empty strings to None).
         from deepagents_code.model_config import resolve_env_var
@@ -3079,70 +3154,10 @@ class Settings:
         from deepagents_code.project_utils import find_project_root
 
         project_root = find_project_root(start_path)
-
-        from deepagents_code.config_manifest import (
-            _emit_ranked_diagnostics,
-            get_config_options,
-            get_option,
+        _reload_override_provider.replace({})
+        _remember_resolver_reload_values(
+            _current_resolver_reload_values(path_base=start_path)
         )
-        from deepagents_code.configuration.resolver import get_config_resolver
-
-        # Resolve only the options this constructor reads. `resolve_all()`
-        # would also resolve `display.theme`, whose `THEME_DELEGATE` coercion
-        # reaches the theme registry and imports Textual (~470ms) — see
-        # `libs/code/AGENTS.md` on the startup hot path. Four CLI entry points
-        # in `skills/commands.py` build `Settings` without ever drawing a UI.
-        wanted = tuple(
-            option
-            for option in get_config_options()
-            if option.key in {"shell.allow_list", "skills.extra_allowed_dirs"}
-            or (option.group == "Interpreter" and option.settings_field is not None)
-        )
-        with _use_extra_skills_path_base(start_path):
-            resolved_config = get_config_resolver().resolve_options(wanted)
-
-        # No `is None` fallback for either enforced key below. The manifest is a
-        # module-level constant, so a missing option is a programming error, not
-        # a runtime condition — and resolving from the environment alone would
-        # bypass managed policy for a key that grants shell auto-approval or
-        # widens the skill-content allowlist. Failing loudly beats escalating
-        # quietly. `test_every_enforced_managed_key_resolves_to_a_manifest_option`
-        # keeps this unreachable.
-        shell_option = get_option("shell.allow_list")
-        if shell_option is None:
-            msg = "manifest is missing shell.allow_list; refusing to resolve it alone"
-            raise RuntimeError(msg)
-        shell_resolved = resolved_config[shell_option.key]
-        _emit_ranked_diagnostics(shell_option, shell_resolved)
-        # `parse_shell_allow_list_items` is the only producer for this
-        # option on every tier, and it yields `list[str] | None`.
-        shell_allow_list = cast("list[str] | None", shell_resolved.value)
-
-        # Parse extra skill containment roots from managed policy, the env
-        # var, or config.toml. These extend the path allowlist for
-        # load_skill_content but do not add new skill discovery locations.
-        skills_option = get_option("skills.extra_allowed_dirs")
-        if skills_option is None:
-            msg = (
-                "manifest is missing skills.extra_allowed_dirs; refusing to "
-                "resolve it alone"
-            )
-            raise RuntimeError(msg)
-        skills_resolved = resolved_config[skills_option.key]
-        _emit_ranked_diagnostics(skills_option, skills_resolved)
-        extra_skills_dirs = cast("list[Path] | None", skills_resolved.value)
-
-        # Only the Interpreter group is manifest-resolved here. Credentials,
-        # the shell allow-list, and the LangSmith project keep their dedicated
-        # loaders above: their empty-string-to-`None` and reload semantics do
-        # not fit the generic resolver.
-        interpreter_kwargs: dict[str, Any] = {}
-        for option in get_config_options():
-            if option.group != "Interpreter" or option.settings_field is None:
-                continue
-            resolved = resolved_config[option.key]
-            _emit_ranked_diagnostics(option, resolved)
-            interpreter_kwargs[option.settings_field] = resolved.value
 
         return cls(
             openai_api_key=openai_key,
@@ -3155,9 +3170,6 @@ class Settings:
             deepagents_langchain_project=deepagents_langchain_project,
             user_langchain_project=user_langchain_project,
             project_root=project_root,
-            shell_allow_list=shell_allow_list,
-            extra_skills_dirs=extra_skills_dirs,
-            **interpreter_kwargs,
         )
 
     @staticmethod
@@ -3230,6 +3242,7 @@ class Settings:
         )
         from deepagents_code.configuration.resolver import (
             CLI_RANK,
+            RELOAD_RANK,
             USER_RANK,
             get_config_resolver,
             resolver_from_snapshots,
@@ -3254,7 +3267,8 @@ class Settings:
         # `config.toml` the user just edited deserves the same treatment, and
         # more so -- they are staring at the edit that did not take.
         user_notice: str | None = None
-        user_status = resolver.provider_statuses().get(USER_RANK)
+        provider_statuses = resolver.provider_statuses()
+        user_status = provider_statuses.get(USER_RANK)
         if user_status is not None and not user_status.usable:
             detail = user_status.detail or user_status.health.value
             user_notice = f"Kept previous config.toml: {detail}"
@@ -3271,11 +3285,6 @@ class Settings:
 
         candidate_resolver = resolver
         if not refresh_managed:
-            # The shared resolver's cached user snapshot may predate the edit
-            # being previewed. Read the user file fresh when possible, but fall
-            # back to the retained snapshot when that read is unusable, matching
-            # the real reload. Keep the current managed snapshot because a
-            # preview must not refresh policy the process is enforcing.
             from deepagents_code.configuration.providers import TomlFileProvider
             from deepagents_code.model_config import DEFAULT_CONFIG_PATH
 
@@ -3287,9 +3296,6 @@ class Settings:
                 )
                 user_notice = None
             else:
-                # The preview's own read failed, so report that rather than
-                # the shared resolver's status: the file on disk right now is
-                # what the user would be accepting.
                 detail = (
                     user_candidate.status.detail or user_candidate.status.health.value
                 )
@@ -3297,17 +3303,10 @@ class Settings:
 
         shell_option = get_option("shell.allow_list")
         if shell_option is not None:
-            # Accepting an *env*-tier hit would defeat the `env` argument this
-            # method exists to honor: the resolver's env provider reads
-            # `os.environ` directly, so a preview of a `.env` edit reported the
-            # value live in the process instead of the one being previewed.
-            # Managed policy, the session CLI, and the user's file are safe to
-            # take from their resolvers; the env tier stays with the
-            # `env`-derived value computed above. Check the shared resolver
-            # first because the preview's candidate resolver -- built from the
-            # managed snapshot and a *freshly parsed* user file -- deliberately
-            # carries no process-local CLI provider.
-            shell_resolved = resolver.get(shell_option)
+            shell_resolved = resolver.get_without_ranks(
+                shell_option,
+                {RELOAD_RANK},
+            )
             _emit_ranked_diagnostics(shell_option, shell_resolved)
             shell_source = _ranked_source(shell_resolved)
             if (
@@ -3341,7 +3340,14 @@ class Settings:
                 resolved_skills: list[Path] | None = None
                 skills_managed = False
                 if skills_option is not None:
-                    skills_resolved = candidate_resolver.get(skills_option)
+                    skills_resolved = (
+                        candidate_resolver.get_without_ranks(
+                            skills_option,
+                            {RELOAD_RANK},
+                        )
+                        if candidate_resolver is resolver
+                        else candidate_resolver.get(skills_option)
+                    )
                     _emit_ranked_diagnostics(skills_option, skills_resolved)
                     if managed_decided(_ranked_source(skills_resolved)):
                         skills_managed = True
@@ -3360,11 +3366,7 @@ class Settings:
                     if skills_managed or not env_skills
                     else _parse_extra_skills_dirs(env_skills)
                 )
-        except (OSError, ValueError):
-            # Path resolution can fail (e.g. broken symlink loop). Keep the
-            # previous value rather than letting the failure escape reload --
-            # callers such as the cwd switch run this after `os.chdir`, where an
-            # uncaught error would strand the process in a half-applied cwd.
+        except (OSError, RuntimeError, ValueError):
             logger.warning(
                 "Could not resolve %s during reload; keeping previous value",
                 EXTRA_SKILLS_DIRS,
@@ -3407,7 +3409,7 @@ class Settings:
             return str(value)
 
         changes: list[str] = []
-        for field in _RELOADABLE_FIELDS:
+        for field in _RELOAD_CHANGE_FIELDS:
             old_value = previous[field]
             new_value = refreshed[field]
             if old_value != new_value:
@@ -3430,6 +3432,7 @@ class Settings:
             `reload_from_environment`.
         """
         previous = {field: getattr(self, field) for field in _RELOADABLE_FIELDS}
+        previous.update(_remembered_resolver_reload_values())
         env = _preview_dotenv_environ(start_path=start_path)
         refreshed, blocked = self._reload_values(
             start_path=start_path,
@@ -3444,8 +3447,9 @@ class Settings:
         """Reload selected settings from environment variables and project files.
 
         This refreshes only fields that are expected to change at runtime
-        (API keys, Google Cloud project, project root, shell allow-list, and
-        LangSmith tracing project).
+        (API keys, Google Cloud project, project root, and LangSmith tracing
+        project). Resolver-backed configuration is refreshed separately by the
+        shared `ConfigResolver` generation.
 
         Runtime model metadata lives in `RuntimeState` and is never touched by
         this method. The original user LangSmith project
@@ -3467,17 +3471,20 @@ class Settings:
             A list of human-readable change descriptions. Empty when nothing
             changed; a single notice when managed policy blocked the reload.
         """
-        _load_dotenv(start_path=start_path, refresh_loaded=True)
-
         previous = {field: getattr(self, field) for field in _RELOADABLE_FIELDS}
+        previous.update(_remembered_resolver_reload_values())
+        _resolver_with_reload_overrides()
+        _load_dotenv(start_path=start_path, refresh_loaded=True)
         refreshed, blocked = self._reload_values(
             start_path=start_path,
             env=dict(os.environ),
             previous=previous,
         )
 
-        for field, value in refreshed.items():
-            setattr(self, field, value)
+        for field in _RELOADABLE_FIELDS:
+            setattr(self, field, refreshed[field])
+        _remember_resolver_reload_values(refreshed)
+        _sync_reload_overrides(refreshed, path_base=start_path)
 
         # Sync the LANGSMITH_PROJECT env var so LangSmith tracing picks up
         # the change
@@ -3532,17 +3539,6 @@ class Settings:
     def has_tavily(self) -> bool:
         """Check if Tavily API key is configured."""
         return self.tavily_api_key is not None
-
-    def get_extra_skills_dirs(self) -> list[Path]:
-        """Get user-configured extra skill directories.
-
-        Set via `DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS` (colon-separated paths) or
-        `[skills].extra_allowed_dirs` in `~/.deepagents/config.toml`.
-
-        Returns:
-            List of extra skill directory paths, or empty list if not configured.
-        """
-        return self.extra_skills_dirs or []
 
 
 DANGEROUS_SHELL_PATTERNS = (

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -2458,7 +2458,6 @@ _STATIC_OPTIONS: tuple[ConfigOption[object], ...] = (
         toml_keys=("shell", "allow_list"),
         cli_flag="--shell-allow-list",
         cli=CliSpec("--shell-allow-list"),
-        settings_field="shell_allow_list",
     ),
     ConfigOption(
         key="skills.extra_allowed_dirs",
@@ -2470,7 +2469,6 @@ _STATIC_OPTIONS: tuple[ConfigOption[object], ...] = (
         kind=OptionKind.SKILLS_DIRS_DELEGATE,
         env_var=_env_vars.EXTRA_SKILLS_DIRS,
         toml_keys=("skills", "extra_allowed_dirs"),
-        settings_field="extra_skills_dirs",
     ),
     ConfigOption(
         key="models.ollama_discovery",
@@ -2562,7 +2560,6 @@ _STATIC_OPTIONS: tuple[ConfigOption[object], ...] = (
         toml_keys=("interpreter", "enable_interpreter"),
         cli_flag="--interpreter",
         cli=CliSpec("--interpreter"),
-        settings_field="enable_interpreter",
     ),
     ConfigOption(
         key="interpreter.timeout_seconds",
@@ -2571,7 +2568,6 @@ _STATIC_OPTIONS: tuple[ConfigOption[object], ...] = (
         kind=OptionKind.FLOAT,
         default=INTERPRETER_TIMEOUT_SECONDS_DEFAULT,
         toml_keys=("interpreter", "timeout_seconds"),
-        settings_field="interpreter_timeout_seconds",
     ),
     ConfigOption(
         key="interpreter.memory_limit_mb",
@@ -2580,7 +2576,6 @@ _STATIC_OPTIONS: tuple[ConfigOption[object], ...] = (
         kind=OptionKind.INT,
         default=INTERPRETER_MEMORY_LIMIT_MB_DEFAULT,
         toml_keys=("interpreter", "memory_limit_mb"),
-        settings_field="interpreter_memory_limit_mb",
     ),
     ConfigOption(
         key="interpreter.max_ptc_calls",
@@ -2589,7 +2584,6 @@ _STATIC_OPTIONS: tuple[ConfigOption[object], ...] = (
         kind=OptionKind.INT,
         default=INTERPRETER_MAX_PTC_CALLS_DEFAULT,
         toml_keys=("interpreter", "max_ptc_calls"),
-        settings_field="interpreter_max_ptc_calls",
     ),
     ConfigOption(
         key="interpreter.max_result_chars",
@@ -2598,7 +2592,6 @@ _STATIC_OPTIONS: tuple[ConfigOption[object], ...] = (
         kind=OptionKind.INT,
         default=INTERPRETER_MAX_RESULT_CHARS_DEFAULT,
         toml_keys=("interpreter", "max_result_chars"),
-        settings_field="interpreter_max_result_chars",
     ),
     ConfigOption(
         key="interpreter.ptc",
@@ -2609,7 +2602,6 @@ _STATIC_OPTIONS: tuple[ConfigOption[object], ...] = (
         toml_keys=("interpreter", "ptc"),
         cli_flag="--interpreter-tools",
         cli=CliSpec("--interpreter-tools"),
-        settings_field="interpreter_ptc",
     ),
     ConfigOption(
         key="interpreter.ptc_acknowledge_unsafe",
@@ -2618,7 +2610,6 @@ _STATIC_OPTIONS: tuple[ConfigOption[object], ...] = (
         kind=OptionKind.BOOL,
         default=INTERPRETER_PTC_ACKNOWLEDGE_UNSAFE_DEFAULT,
         toml_keys=("interpreter", "ptc_acknowledge_unsafe"),
-        settings_field="interpreter_ptc_acknowledge_unsafe",
     ),
     # --- Threads (config.toml-only; structured column table excepted) ---
     ConfigOption(

--- a/libs/code/deepagents_code/configuration/interpreter.py
+++ b/libs/code/deepagents_code/configuration/interpreter.py
@@ -1,0 +1,90 @@
+"""Resolver-backed interpreter configuration snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+from deepagents_code.config_manifest import _emit_ranked_diagnostics, get_option
+from deepagents_code.configuration.resolver import get_config_resolver
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from deepagents_code.config_manifest import ConfigOption
+    from deepagents_code.configuration.resolver import ConfigResolver, ResolvedValue
+
+_INTERPRETER_KEYS = (
+    "interpreter.timeout_seconds",
+    "interpreter.memory_limit_mb",
+    "interpreter.max_ptc_calls",
+    "interpreter.max_result_chars",
+    "interpreter.ptc",
+    "interpreter.ptc_acknowledge_unsafe",
+)
+
+
+def _resolved_values(
+    resolver: ConfigResolver,
+) -> Mapping[str, ResolvedValue[object]]:
+    """Resolve one consistent generation of interpreter options.
+
+    Returns:
+        Resolved values keyed by manifest option.
+
+    Raises:
+        RuntimeError: If an interpreter option is absent from the manifest.
+    """
+    options = tuple(get_option(key) for key in _INTERPRETER_KEYS)
+    if any(option is None for option in options):
+        msg = "interpreter options are missing from the configuration manifest"
+        raise RuntimeError(msg)
+    required = cast("tuple[ConfigOption, ...]", options)
+    resolved = resolver.resolve_options(required)
+    for option in required:
+        _emit_ranked_diagnostics(option, resolved[option.key])
+    return resolved
+
+
+@dataclass(frozen=True, slots=True)
+class InterpreterConfig:
+    """Configuration consumed by `CodeInterpreterMiddleware`."""
+
+    timeout_seconds: float
+    memory_limit_mb: int
+    max_ptc_calls: int
+    max_result_chars: int
+    ptc: str | bool | list[str]
+    ptc_acknowledge_unsafe: bool
+
+    @classmethod
+    def from_resolver(
+        cls,
+        resolver: ConfigResolver | None = None,
+        *,
+        ptc: str | list[str] | None = None,
+        ptc_acknowledge_unsafe: bool = False,
+    ) -> InterpreterConfig:
+        """Build a snapshot from the resolver and optional server overrides.
+
+        Args:
+            resolver: Resolver generation to read. Defaults to the process resolver.
+            ptc: Invocation-scoped PTC override forwarded by the server parent.
+            ptc_acknowledge_unsafe: Invocation-scoped unsafe-PTC acknowledgement.
+
+        Returns:
+            Resolved interpreter configuration for one agent build.
+        """
+        values = _resolved_values(resolver or get_config_resolver())
+        resolved_ptc = cast("str | bool | list[str]", values["interpreter.ptc"].value)
+        return cls(
+            timeout_seconds=cast("float", values["interpreter.timeout_seconds"].value),
+            memory_limit_mb=cast("int", values["interpreter.memory_limit_mb"].value),
+            max_ptc_calls=cast("int", values["interpreter.max_ptc_calls"].value),
+            max_result_chars=cast("int", values["interpreter.max_result_chars"].value),
+            ptc=resolved_ptc if ptc is None else ptc,
+            ptc_acknowledge_unsafe=(
+                ptc_acknowledge_unsafe
+                or bool(values["interpreter.ptc_acknowledge_unsafe"].value)
+            ),
+        )

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -207,7 +207,7 @@ def coerce_environment_value[T](
 
         try:
             return _found_for(option, _parse_extra_skills_dirs(raw, None))
-        except (ValueError, RuntimeError):
+        except (OSError, ValueError, RuntimeError):
             return Invalid(f"Ignoring {name} (could not resolve a path)")
     if kind is OptionKind.THEME_DELEGATE:
         # Theme names are resolved by the theme-aware provider path. Keep this

--- a/libs/code/deepagents_code/configuration/resolver.py
+++ b/libs/code/deepagents_code/configuration/resolver.py
@@ -35,6 +35,9 @@ MANAGED_RANK = 200
 CLI_RANK = 300
 """Parsed command-line argument rank."""
 
+RELOAD_RANK = 350
+"""Retained runtime-reload value rank."""
+
 ENVIRONMENT_RANK = 400
 """Process-environment rank."""
 

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1162,11 +1162,10 @@ def _resolve_interpreter_enabled(
     through would turn the redundant-but-harmless `enable_interpreter = true`
     into a launch failure for every remote-sandbox run.
 
-    Only the managed and CLI tiers are answered from `resolved`. When neither
-    decides, the value comes from `settings.enable_interpreter`, which resolves
-    the same manifest option through the same chain; the resolver read above
-    still runs for its diagnostics. `test_local_mode_uses_config_default` pins
-    the `settings` source, so the two are not interchangeable in tests.
+    Managed and CLI decisions are inspected separately so conflicts with a
+    remote sandbox can name the deciding tier. When neither decides, the same
+    resolved value already contains the environment, user-file, and default
+    tiers.
 
     Args:
         args: Parsed CLI arguments.
@@ -1214,9 +1213,7 @@ def _resolve_interpreter_enabled(
         return enabled
     if remote_sandbox:
         return False
-    from deepagents_code.config import settings
-
-    return settings.enable_interpreter
+    return bool(resolved.value)
 
 
 def _exit_interpreter_conflicts_with_sandbox(
@@ -1465,14 +1462,23 @@ def _warn_if_interpreter_disabled_by_sandbox(args: argparse.Namespace) -> None:
     Keyed on the raw `args.interpreter` tri-state so an explicit
     `--no-interpreter` opt-out stays silent (the predicate only fires for the
     unset default).
+
+    Raises:
+        RuntimeError: If the interpreter option is absent from the manifest.
     """
     from deepagents_code._server_config import _interpreter_suppressed_by_sandbox
-    from deepagents_code.config import settings
+    from deepagents_code.config_manifest import get_option
+
+    option = get_option("interpreter.enable_interpreter")
+    if option is None:
+        msg = "interpreter.enable_interpreter is missing from the config manifest"
+        raise RuntimeError(msg)
+    local_default = bool(_resolver_for_args(args).get(option).value)
 
     if not _interpreter_suppressed_by_sandbox(
         enable_interpreter=args.interpreter,
         sandbox_type=args.sandbox,
-        local_default=settings.enable_interpreter,
+        local_default=local_default,
     ):
         return
     from rich.console import Console as _Console
@@ -3109,8 +3115,7 @@ async def run_textual_cli_async(
             forwarded so the app can tell an explicit opt-out from a
             sandbox-suppressed default when surfacing the disabled-by-sandbox
             advisory.
-        interpreter_ptc: Override for `settings.interpreter_ptc` (PTC allowlist
-            for `js_eval`).
+        interpreter_ptc: Invocation-scoped PTC allowlist override for `js_eval`.
         interpreter_ptc_acknowledge_unsafe: Explicit acknowledgement for
             `interpreter_ptc="all"` outside of `auto_approve`.
         allow_fs_tools: Allowlist for `FilesystemMiddleware`'s `tools` param,

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -22,6 +22,8 @@ from deepagents_code._startup_error import (
     STARTUP_ERROR_MARKER as _STARTUP_ERROR_MARKER,
     emit_startup_failure,
 )
+from deepagents_code.configuration.interpreter import InterpreterConfig
+from deepagents_code.configuration.resolver import get_config_resolver
 from deepagents_code.project_utils import ProjectContext, get_server_project_context
 
 if TYPE_CHECKING:
@@ -240,7 +242,6 @@ async def _make_graphs() -> ServerRuntime:
         Any,
         Any,
         Any,
-        Any,
     ]:
         project_context = get_server_project_context()
 
@@ -260,7 +261,6 @@ async def _make_graphs() -> ServerRuntime:
             load_async_subagents,
             create_model,
             is_memory_auto_save_enabled,
-            settings,
             configure_langsmith_secret_redaction,
         )
 
@@ -270,7 +270,6 @@ async def _make_graphs() -> ServerRuntime:
         load_async_subagents,
         create_model,
         is_memory_auto_save_enabled,
-        settings,
         configure_langsmith_secret_redaction,
     ) = await asyncio.to_thread(_resolve_project_context_and_settings)
     configure_langsmith_secret_redaction()
@@ -348,14 +347,15 @@ async def _make_graphs() -> ServerRuntime:
         async_subagents = load_async_subagents() or None
         auto_mode_enabled = config.interactive and sandbox_backend is None
 
-        # These process-global settings writes are safe here because `make_graph`
-        # is lock-serialized and caches one graph for the server process lifetime.
-        if config.interpreter_ptc is not None:
-            settings.interpreter_ptc = config.interpreter_ptc
-        if config.interpreter_ptc_acknowledge_unsafe:
-            settings.interpreter_ptc_acknowledge_unsafe = True
-        if config.enable_interpreter:
-            settings.enable_interpreter = True
+        interpreter_config = (
+            InterpreterConfig.from_resolver(
+                get_config_resolver(),
+                ptc=config.interpreter_ptc,
+                ptc_acknowledge_unsafe=config.interpreter_ptc_acknowledge_unsafe,
+            )
+            if config.enable_interpreter
+            else None
+        )
 
         agent, composite_backend = create_cli_agent(
             model=result.model,
@@ -377,6 +377,7 @@ async def _make_graphs() -> ServerRuntime:
             enable_skills=config.enable_skills,
             enable_shell=config.enable_shell,
             enable_interpreter=config.enable_interpreter,
+            interpreter_config=interpreter_config,
             rubric_model=config.rubric_model,
             rubric_max_iterations=config.rubric_max_iterations,
             auto_classifier_model=config.auto_classifier_model,

--- a/libs/code/deepagents_code/skills/invocation.py
+++ b/libs/code/deepagents_code/skills/invocation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from deepagents_code._paths import (
     get_built_in_skills_dir,
@@ -51,8 +51,14 @@ def discover_skills_and_roots(
 
     Returns:
         Tuple of `(skill metadata list, pre-resolved containment roots)`.
+
+    Raises:
+        RuntimeError: If the extra skill-directory option is absent from the
+            manifest.
     """
-    from deepagents_code.config import settings
+    from deepagents_code.config import _use_extra_skills_path_base, settings
+    from deepagents_code.config_manifest import _emit_ranked_diagnostics, get_option
+    from deepagents_code.configuration.resolver import get_config_resolver
     from deepagents_code.skills.load import list_skills
     from deepagents_code.skills.trust import load_trusted_skill_dirs
 
@@ -80,7 +86,15 @@ def discover_skills_and_roots(
         )
         if path is not None
     ]
-    roots.extend(path.resolve() for path in settings.get_extra_skills_dirs())
+    option = get_option("skills.extra_allowed_dirs")
+    if option is None:
+        msg = "skills.extra_allowed_dirs is missing from the configuration manifest"
+        raise RuntimeError(msg)
+    with _use_extra_skills_path_base(settings.project_root):
+        resolved = get_config_resolver().get(option)
+    _emit_ranked_diagnostics(option, resolved)
+    extra_skills_dirs = cast("list[Path] | None", resolved.value)
+    roots.extend(path.resolve() for path in extra_skills_dirs or ())
     # Persisted in-the-moment approvals extend the containment allowlist just
     # like the declarative `extra_allowed_dirs`, but are managed by the trust
     # store rather than hand-edited config. These entries are already the

--- a/libs/code/deepagents_code/skills/invocation.py
+++ b/libs/code/deepagents_code/skills/invocation.py
@@ -40,6 +40,7 @@ def discover_skills_and_roots(
     *,
     plugin_skill_sources: tuple[tuple[Path, str], ...] = (),
     plugin_skill_roots: tuple[Path, ...] = (),
+    path_base: Path | None = None,
 ) -> tuple[list[ExtendedSkillMetadata], list[Path]]:
     """Discover skills and build pre-resolved containment roots.
 
@@ -48,6 +49,8 @@ def discover_skills_and_roots(
         plugin_skill_sources: Plugin-owned skill directories and namespaces,
             supplied by the plugin composition layer.
         plugin_skill_roots: Plugin-owned roots allowed for content loading.
+        path_base: User working directory for resolving relative skill roots.
+            Defaults to the process working directory.
 
     Returns:
         Tuple of `(skill metadata list, pre-resolved containment roots)`.
@@ -56,6 +59,8 @@ def discover_skills_and_roots(
         RuntimeError: If the extra skill-directory option is absent from the
             manifest.
     """
+    from pathlib import Path
+
     from deepagents_code.config import _use_extra_skills_path_base, settings
     from deepagents_code.config_manifest import _emit_ranked_diagnostics, get_option
     from deepagents_code.configuration.resolver import get_config_resolver
@@ -90,7 +95,7 @@ def discover_skills_and_roots(
     if option is None:
         msg = "skills.extra_allowed_dirs is missing from the configuration manifest"
         raise RuntimeError(msg)
-    with _use_extra_skills_path_base(settings.project_root):
+    with _use_extra_skills_path_base(path_base or Path.cwd()):
         resolved = get_config_resolver().get(option)
     _emit_ranked_diagnostics(option, resolved)
     extra_skills_dirs = cast("list[Path] | None", resolved.value)

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -58,6 +58,7 @@ from deepagents_code.agent import (
     load_async_subagents,
 )
 from deepagents_code.config import Settings, get_glyphs, runtime_state
+from deepagents_code.configuration.interpreter import InterpreterConfig
 from deepagents_code.managed_tools import BIN_DIR
 from deepagents_code.offload import (
     _FALLBACK_ARTIFACTS_ROOT,
@@ -85,6 +86,21 @@ def _restore_runtime_state() -> Iterator[None]:
         runtime_state.model_context_limit,
         runtime_state.model_unsupported_modalities,
     ) = previous
+
+
+@pytest.fixture(autouse=True)
+def _resolve_shell_policy_from_patched_settings() -> Iterator[None]:
+    """Translate legacy settings mocks into the resolver-backed shell reader."""
+    import deepagents_code.agent as agent_module
+
+    def resolve() -> list[str] | None:
+        return cast(
+            "list[str] | None",
+            getattr(agent_module.settings, "_test_shell_allow_list", None),
+        )
+
+    with patch.object(agent_module, "_resolve_shell_allow_list", resolve):
+        yield
 
 
 @dataclass
@@ -3511,7 +3527,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         runtime_state.model_unsupported_modalities = frozenset()
         runtime_state.model_context_limit = None
         mock_settings.project_root = None
-        mock_settings.shell_allow_list = ["ls", "cat"]
+        mock_settings._test_shell_allow_list = ["ls", "cat"]
         return mock_settings
 
     def test_interrupt_shell_only_adds_middleware_and_disables_interrupts(
@@ -3710,7 +3726,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         from deepagents_code.config import SHELL_ALLOW_ALL
 
         mock_settings = self._build_mock_settings(tmp_path)
-        mock_settings.shell_allow_list = SHELL_ALLOW_ALL
+        mock_settings._test_shell_allow_list = SHELL_ALLOW_ALL
         mock_agent = Mock()
         mock_agent.with_config.return_value = mock_agent
         fake_model = _make_fake_chat_model()
@@ -4271,7 +4287,7 @@ class TestCreateCliAgentFsToolsWiring:
         runtime_state.model_unsupported_modalities = frozenset()
         runtime_state.model_context_limit = None
         mock_settings.project_root = None
-        mock_settings.shell_allow_list = None
+        mock_settings._test_shell_allow_list = None
         return mock_settings
 
     @staticmethod
@@ -4894,7 +4910,7 @@ class TestAutoModeSubagentHITLWiring:
         runtime_state.model_unsupported_modalities = frozenset()
         runtime_state.model_context_limit = None
         mock_settings.project_root = None
-        mock_settings.shell_allow_list = ["ls", "cat"]
+        mock_settings._test_shell_allow_list = ["ls", "cat"]
         return mock_settings
 
     def _capture_create_deep_agent_kwargs(
@@ -5262,15 +5278,22 @@ class TestCreateCliAgentInterpreterWiring:
         runtime_state.model_unsupported_modalities = frozenset()
         runtime_state.model_context_limit = None
         mock_settings.project_root = None
-        mock_settings.shell_allow_list = None
+        mock_settings._test_shell_allow_list = None
         mock_settings.user_langchain_project = None
-        mock_settings.interpreter_timeout_seconds = 5.0
-        mock_settings.interpreter_memory_limit_mb = 64
-        mock_settings.interpreter_max_ptc_calls = 256
-        mock_settings.interpreter_max_result_chars = 4000
-        mock_settings.interpreter_ptc = False
-        mock_settings.interpreter_ptc_acknowledge_unsafe = False
         return mock_settings
+
+    @staticmethod
+    def _interpreter_config(
+        *, ptc: str | bool | list[str] = False, acknowledge: bool = False
+    ) -> InterpreterConfig:
+        return InterpreterConfig(
+            timeout_seconds=5.0,
+            memory_limit_mb=64,
+            max_ptc_calls=256,
+            max_result_chars=4000,
+            ptc=ptc,
+            ptc_acknowledge_unsafe=acknowledge,
+        )
 
     def _capture_middleware(
         self,
@@ -5292,6 +5315,7 @@ class TestCreateCliAgentInterpreterWiring:
         aimed at the subagent, classifier, or rubric spec pass vacuously.
         """
         mock_settings = self._build_mock_settings(tmp_path)
+        kwargs.setdefault("interpreter_config", self._interpreter_config())
         mock_agent = Mock()
         mock_agent.with_config.return_value = mock_agent
         fake_model = _make_fake_chat_model()
@@ -6597,6 +6621,7 @@ class TestCreateCliAgentInterpreterWiring:
                 enable_skills=False,
                 enable_shell=False,
                 enable_interpreter=True,
+                interpreter_config=self._interpreter_config(),
             )
 
         _, kwargs = mock_create.call_args
@@ -6672,7 +6697,6 @@ class TestCreateCliAgentInterpreterWiring:
         from langchain_quickjs import CodeInterpreterMiddleware
 
         mock_settings = self._build_mock_settings(tmp_path)
-        mock_settings.interpreter_ptc = ["nope", "grep"]
         fake_model = _make_fake_chat_model()
 
         @tool
@@ -6703,6 +6727,7 @@ class TestCreateCliAgentInterpreterWiring:
                 enable_skills=False,
                 enable_shell=False,
                 enable_interpreter=True,
+                interpreter_config=self._interpreter_config(ptc=["nope", "grep"]),
                 tools=[grep],
             )
 
@@ -6717,8 +6742,6 @@ class TestCreateCliAgentInterpreterWiring:
         from langchain_core.tools import tool
 
         mock_settings = self._build_mock_settings(tmp_path)
-        mock_settings.interpreter_ptc = "all"
-        mock_settings.interpreter_ptc_acknowledge_unsafe = False
         fake_model = _make_fake_chat_model()
 
         @tool
@@ -6744,6 +6767,7 @@ class TestCreateCliAgentInterpreterWiring:
                 enable_skills=False,
                 enable_shell=False,
                 enable_interpreter=True,
+                interpreter_config=self._interpreter_config(ptc="all"),
                 tools=[grep],
             )
 
@@ -6760,7 +6784,6 @@ class TestCreateCliAgentInterpreterWiring:
         from langchain_quickjs import CodeInterpreterMiddleware
 
         mock_settings = self._build_mock_settings(tmp_path)
-        mock_settings.interpreter_ptc = "safe"
         fake_model = _make_fake_chat_model()
 
         @tool
@@ -6796,6 +6819,7 @@ class TestCreateCliAgentInterpreterWiring:
                 enable_skills=False,
                 enable_shell=False,
                 enable_interpreter=True,
+                interpreter_config=self._interpreter_config(ptc="safe"),
                 tools=[grep, read_file],
             )
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -19232,8 +19232,6 @@ class TestRequestApprovalBranching:
     """_request_approval should show a placeholder when the user is typing."""
 
     async def test_auto_fallback_skips_shell_allow_list(self) -> None:
-        from deepagents_code.config import settings
-
         app = DeepAgentsApp(agent=MagicMock())
         app._last_typed_at = None
         action_requests = [
@@ -19245,7 +19243,7 @@ class TestRequestApprovalBranching:
         ]
 
         with (
-            patch.object(settings, "shell_allow_list", ["echo"]),
+            patch("deepagents_code.app._load_shell_allow_list", return_value=["echo"]),
             patch.object(app, "_mount_approval_widget", new=AsyncMock()) as mount,
             patch.object(app, "_reveal_pending_tool_calls"),
             patch.object(app, "_pause_loading_spinner_for_approval"),
@@ -39769,8 +39767,6 @@ class TestNotifyInterpreterDisabledBySandbox:
 
     def test_toasts_when_sandbox_suppresses_default(self) -> None:
         """A remote sandbox with the unset, default-on interpreter warns once."""
-        from deepagents_code.config import settings
-
         app = DeepAgentsApp(
             server_kwargs={
                 "assistant_id": "agent",
@@ -39783,8 +39779,7 @@ class TestNotifyInterpreterDisabledBySandbox:
         notify_mock = MagicMock()
         app.notify = notify_mock  # ty: ignore
 
-        with patch.object(settings, "enable_interpreter", True):
-            app._notify_interpreter_disabled_by_sandbox()
+        app._notify_interpreter_disabled_by_sandbox()
 
         notify_mock.assert_called_once()
         assert "unavailable under a remote sandbox" in notify_mock.call_args.args[0]
@@ -39793,8 +39788,6 @@ class TestNotifyInterpreterDisabledBySandbox:
 
     def test_no_toast_in_local_mode(self) -> None:
         """Local mode keeps the interpreter, so there is nothing to warn about."""
-        from deepagents_code.config import settings
-
         app = DeepAgentsApp(
             server_kwargs={
                 "assistant_id": "agent",
@@ -39806,15 +39799,12 @@ class TestNotifyInterpreterDisabledBySandbox:
         notify_mock = MagicMock()
         app.notify = notify_mock  # ty: ignore
 
-        with patch.object(settings, "enable_interpreter", True):
-            app._notify_interpreter_disabled_by_sandbox()
+        app._notify_interpreter_disabled_by_sandbox()
 
         notify_mock.assert_not_called()
 
     def test_no_toast_on_explicit_opt_out(self) -> None:
         """An explicit `--no-interpreter` opt-out under a sandbox is not announced."""
-        from deepagents_code.config import settings
-
         app = DeepAgentsApp(
             server_kwargs={
                 "assistant_id": "agent",
@@ -39827,15 +39817,18 @@ class TestNotifyInterpreterDisabledBySandbox:
         notify_mock = MagicMock()
         app.notify = notify_mock  # ty: ignore
 
-        with patch.object(settings, "enable_interpreter", True):
-            app._notify_interpreter_disabled_by_sandbox()
+        app._notify_interpreter_disabled_by_sandbox()
 
         notify_mock.assert_not_called()
 
-    def test_no_toast_when_config_default_off(self) -> None:
+    def test_no_toast_when_config_default_off(self, tmp_path: Path) -> None:
         """A user who disabled the interpreter in config is not nagged."""
-        from deepagents_code.config import settings
+        from deepagents_code.configuration import service
 
+        (tmp_path / "config.toml").write_text(
+            "[interpreter]\nenable_interpreter = false\n", encoding="utf-8"
+        )
+        service.invalidate_config_sources()
         app = DeepAgentsApp(
             server_kwargs={
                 "assistant_id": "agent",
@@ -39848,8 +39841,7 @@ class TestNotifyInterpreterDisabledBySandbox:
         notify_mock = MagicMock()
         app.notify = notify_mock  # ty: ignore
 
-        with patch.object(settings, "enable_interpreter", False):
-            app._notify_interpreter_disabled_by_sandbox()
+        app._notify_interpreter_disabled_by_sandbox()
 
         notify_mock.assert_not_called()
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -36629,9 +36629,11 @@ class TestRespawnServer:
                 AsyncMock(return_value=False),
             )
             handled: list[str] = []
+            message_handled = asyncio.Event()
 
             async def record(text: str) -> None:  # noqa: RUF029
                 handled.append(text)
+                message_handled.set()
 
             monkeypatch.setattr(app, "_handle_user_message", record)
 
@@ -36645,10 +36647,7 @@ class TestRespawnServer:
 
             gate.set()
             await app._reload_task
-            # The preserved message drains via call_after_refresh; run the
-            # scheduled callback before asserting on it.
-            await pilot.pause()
-            await asyncio.sleep(0)
+            await asyncio.wait_for(message_handled.wait(), timeout=5)
 
             assert not app._pending_messages
             assert handled == ["typed during reload"]

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -77,6 +77,7 @@ from deepagents_code.config import (
     settings,
     validate_model_capabilities,
 )
+from deepagents_code.configuration.interpreter import InterpreterConfig
 from deepagents_code.model_config import (
     ModelConfig,
     ModelConfigError,
@@ -7533,18 +7534,28 @@ class TestDetectModePrefix:
 class TestInterpreterSettings:
     """Tests for `[interpreter]` config.toml loading and validation."""
 
+    @staticmethod
+    def _resolve() -> tuple[bool, InterpreterConfig]:
+        from deepagents_code.config_manifest import get_option
+        from deepagents_code.configuration.resolver import get_config_resolver
+
+        option = get_option("interpreter.enable_interpreter")
+        assert option is not None
+        enabled = bool(get_config_resolver().get(option).value)
+        return enabled, InterpreterConfig.from_resolver()
+
     def test_defaults_when_config_absent(self, tmp_path: Path) -> None:
         config_path = tmp_path / "config.toml"  # does not exist
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
-            settings_obj = Settings.from_environment(start_path=tmp_path)
+            enabled, interpreter = self._resolve()
 
-        assert settings_obj.enable_interpreter is True
-        assert settings_obj.interpreter_timeout_seconds == pytest.approx(5.0)
-        assert settings_obj.interpreter_memory_limit_mb == 64
-        assert settings_obj.interpreter_max_ptc_calls == 256
-        assert settings_obj.interpreter_max_result_chars == 4000
-        assert settings_obj.interpreter_ptc == "safe"
-        assert settings_obj.interpreter_ptc_acknowledge_unsafe is False
+        assert enabled is True
+        assert interpreter.timeout_seconds == pytest.approx(5.0)
+        assert interpreter.memory_limit_mb == 64
+        assert interpreter.max_ptc_calls == 256
+        assert interpreter.max_result_chars == 4000
+        assert interpreter.ptc == "safe"
+        assert interpreter.ptc_acknowledge_unsafe is False
 
     def test_round_trip_through_toml(self, tmp_path: Path) -> None:
         config_path = tmp_path / "config.toml"
@@ -7561,15 +7572,15 @@ ptc_acknowledge_unsafe = true
 """
         )
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
-            settings_obj = Settings.from_environment(start_path=tmp_path)
+            enabled, interpreter = self._resolve()
 
-        assert settings_obj.enable_interpreter is True
-        assert settings_obj.interpreter_timeout_seconds == pytest.approx(12.5)
-        assert settings_obj.interpreter_memory_limit_mb == 128
-        assert settings_obj.interpreter_max_ptc_calls == 64
-        assert settings_obj.interpreter_max_result_chars == 8000
-        assert settings_obj.interpreter_ptc == "safe"
-        assert settings_obj.interpreter_ptc_acknowledge_unsafe is True
+        assert enabled is True
+        assert interpreter.timeout_seconds == pytest.approx(12.5)
+        assert interpreter.memory_limit_mb == 128
+        assert interpreter.max_ptc_calls == 64
+        assert interpreter.max_result_chars == 8000
+        assert interpreter.ptc == "safe"
+        assert interpreter.ptc_acknowledge_unsafe is True
 
     def test_ptc_explicit_list_round_trip(self, tmp_path: Path) -> None:
         config_path = tmp_path / "config.toml"
@@ -7580,9 +7591,9 @@ ptc = ["grep", "read_file"]
 """
         )
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
-            settings_obj = Settings.from_environment(start_path=tmp_path)
+            _, interpreter = self._resolve()
 
-        assert settings_obj.interpreter_ptc == ["grep", "read_file"]
+        assert interpreter.ptc == ["grep", "read_file"]
 
     def test_invalid_ptc_list_entry_falls_back(self, tmp_path: Path) -> None:
         config_path = tmp_path / "config.toml"
@@ -7593,9 +7604,9 @@ ptc = [""]
 """
         )
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
-            settings_obj = Settings.from_environment(start_path=tmp_path)
+            _, interpreter = self._resolve()
 
-        assert settings_obj.interpreter_ptc == "safe"
+        assert interpreter.ptc == "safe"
 
     def test_ptc_list_with_safe_preset_round_trip(self, tmp_path: Path) -> None:
         """`"safe"` is preserved as a list entry until agent-build expansion."""
@@ -7607,9 +7618,9 @@ ptc = ["safe", "task"]
 """
         )
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
-            settings_obj = Settings.from_environment(start_path=tmp_path)
+            _, interpreter = self._resolve()
 
-        assert settings_obj.interpreter_ptc == ["safe", "task"]
+        assert interpreter.ptc == ["safe", "task"]
 
     def test_ptc_list_with_all_falls_back(self, tmp_path: Path) -> None:
         """`"all"` inside a list is rejected, falling back to the default."""
@@ -7621,9 +7632,9 @@ ptc = ["all", "task"]
 """
         )
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
-            settings_obj = Settings.from_environment(start_path=tmp_path)
+            _, interpreter = self._resolve()
 
-        assert settings_obj.interpreter_ptc == "safe"
+        assert interpreter.ptc == "safe"
 
 
 class TestCreateModelCodex:

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -1669,19 +1669,27 @@ def test_charset_auto_display_value_includes_effective_glyph_mode() -> None:
 # --- Single-source defaults -------------------------------------------------
 
 
-def test_interpreter_defaults_match_settings() -> None:
-    """Manifest interpreter defaults are the same objects `Settings` uses.
+def test_interpreter_defaults_match_resolver_snapshot() -> None:
+    """The interpreter snapshot consumes the manifest-owned defaults."""
+    from deepagents_code.configuration.interpreter import InterpreterConfig
+    from deepagents_code.configuration.resolver import get_config_resolver
 
-    This is what makes the manifest the single source of truth: the dataclass
-    default and the manifest default cannot diverge because they are one value.
-    """
-    from deepagents_code.config import Settings
-
-    settings = Settings.from_environment()
-    for opt in get_config_options():
-        if opt.group != "Interpreter" or opt.settings_field is None:
-            continue
-        assert getattr(settings, opt.settings_field) == opt.default
+    interpreter = InterpreterConfig.from_resolver()
+    values = {
+        "interpreter.timeout_seconds": interpreter.timeout_seconds,
+        "interpreter.memory_limit_mb": interpreter.memory_limit_mb,
+        "interpreter.max_ptc_calls": interpreter.max_ptc_calls,
+        "interpreter.max_result_chars": interpreter.max_result_chars,
+        "interpreter.ptc": interpreter.ptc,
+        "interpreter.ptc_acknowledge_unsafe": interpreter.ptc_acknowledge_unsafe,
+    }
+    for key, value in values.items():
+        option = get_option(key)
+        assert option is not None
+        assert value == option.default
+    enabled = get_option("interpreter.enable_interpreter")
+    assert enabled is not None
+    assert get_config_resolver().get(enabled).value == enabled.default
 
 
 def test_every_settings_field_names_a_real_settings_attribute() -> None:

--- a/libs/code/tests/unit_tests/test_configuration.py
+++ b/libs/code/tests/unit_tests/test_configuration.py
@@ -1880,9 +1880,11 @@ def test_managed_skill_dirs_outrank_environment_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Managed skill containment roots cannot be replaced through the environment."""
-    from deepagents_code import config, model_config
+    from deepagents_code import model_config
     from deepagents_code._env_vars import EXTRA_SKILLS_DIRS
+    from deepagents_code.config_manifest import get_option
     from deepagents_code.configuration import service
+    from deepagents_code.configuration.resolver import get_config_resolver
 
     user = tmp_path / "config.toml"
     managed = tmp_path / "managed.toml"
@@ -1897,8 +1899,9 @@ def test_managed_skill_dirs_outrank_environment_override(
     monkeypatch.setenv(EXTRA_SKILLS_DIRS, str(env_dir))
     service.invalidate_config_sources()
     try:
-        settings = config.Settings.from_environment(start_path=tmp_path)
-        assert settings.extra_skills_dirs == [managed_dir]
+        option = get_option("skills.extra_allowed_dirs")
+        assert option is not None
+        assert get_config_resolver().get(option).value == [managed_dir]
     finally:
         service.invalidate_config_sources()
 
@@ -2639,7 +2642,9 @@ def test_reload_keeps_a_user_shell_allow_list(
     """
     from deepagents_code import model_config
     from deepagents_code.config import Settings
+    from deepagents_code.config_manifest import get_option
     from deepagents_code.configuration import service
+    from deepagents_code.configuration.resolver import get_config_resolver
 
     user = tmp_path / "config.toml"
     user.write_text('[shell]\nallow_list = ["git status"]\n', encoding="utf-8")
@@ -2651,10 +2656,12 @@ def test_reload_keeps_a_user_shell_allow_list(
     model_config.clear_caches()
     try:
         runtime = Settings.from_environment(start_path=tmp_path)
-        before = runtime.shell_allow_list
+        option = get_option("shell.allow_list")
+        assert option is not None
+        before = get_config_resolver().get(option).value
         assert before is not None
         runtime.reload_from_environment(start_path=tmp_path)
-        assert runtime.shell_allow_list == before
+        assert get_config_resolver().get(option).value == before
     finally:
         service.invalidate_config_sources()
 
@@ -2666,7 +2673,9 @@ def test_managed_shell_allow_list_still_wins_a_reload(
     """Reading the user layer on reload must not cost managed precedence."""
     from deepagents_code import model_config
     from deepagents_code.config import Settings
+    from deepagents_code.config_manifest import get_option
     from deepagents_code.configuration import service
+    from deepagents_code.configuration.resolver import get_config_resolver
 
     user = tmp_path / "config.toml"
     user.write_text('[shell]\nallow_list = ["git status"]\n', encoding="utf-8")
@@ -2679,7 +2688,9 @@ def test_managed_shell_allow_list_still_wins_a_reload(
     try:
         runtime = Settings.from_environment(start_path=tmp_path)
         runtime.reload_from_environment(start_path=tmp_path)
-        assert runtime.shell_allow_list == ["ls"]
+        option = get_option("shell.allow_list")
+        assert option is not None
+        assert get_config_resolver().get(option).value == ["ls"]
     finally:
         service.invalidate_config_sources()
 

--- a/libs/code/tests/unit_tests/test_configuration_resolver.py
+++ b/libs/code/tests/unit_tests/test_configuration_resolver.py
@@ -26,6 +26,7 @@ from deepagents_code.configuration.resolver import (
     DEFAULT_RANK,
     ENVIRONMENT_RANK,
     MANAGED_RANK,
+    RELOAD_RANK,
     USER_RANK,
     ConfigResolver,
     RankedProviderValue,
@@ -152,9 +153,9 @@ def test_deep_merge_provenance_uses_tuple_paths_and_numeric_ranks() -> None:
     assert resolved.provenance[USER_RANK] == frozenset({("a", "user"), ("sibling",)})
 
 
-def test_rank_space_reserves_but_does_not_require_a_cli_provider() -> None:
-    """The unwired CLI seam outranks environment and yields to managed policy."""
-    assert MANAGED_RANK < CLI_RANK < ENVIRONMENT_RANK < USER_RANK
+def test_rank_space_orders_invocation_and_reload_overrides() -> None:
+    """Invocation and retained reload values outrank the live environment."""
+    assert MANAGED_RANK < CLI_RANK < RELOAD_RANK < ENVIRONMENT_RANK < USER_RANK
 
     over_environment = resolve_ranked(
         (

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1316,19 +1316,13 @@ def test_cli_main_forwards_recursion_limit_to_headless_server() -> None:
 def test_cli_main_installs_the_shell_allow_list_before_dispatch() -> None:
     """`--shell-allow-list` must be resolvable by the time the agent is built.
 
-    This branch deleted the explicit application in `cli_main`
-    (`settings.shell_allow_list = parse_shell_allow_list(...)`). The flag's
-    whole effect now rests on an unwritten ordering invariant:
+    The flag's whole effect rests on an ordering invariant:
     `_install_cli_provider` must run before the work that reads the value.
     Nothing else fails if that ordering breaks -- the flag still parses, no
     warning fires, and shell auto-approval simply stops applying.
 
-    Asserted against the resolver and a freshly built `Settings`, not the
-    `deepagents_code.config.settings` singleton. `_get_settings` caches
-    permanently on first access, and under pytest `agent.py` is already
-    imported (it binds `settings` at module scope), so the singleton in this
-    process was built long before this test ran. Reading it here would assert
-    the import order of the test session rather than the order in `cli_main`.
+    Asserted against the resolver rather than the process singleton so the
+    test observes the CLI provider installed by this invocation.
 
     Scope, verified by mutation: this fails if the manifest binding names the
     wrong argparse destination, and it does *not* fail if the explicit
@@ -1337,7 +1331,6 @@ def test_cli_main_installs_the_shell_allow_list_before_dispatch() -> None:
     the flag survives; do not read a pass here as proof the explicit call is
     still in place.
     """
-    from deepagents_code.config import Settings
     from deepagents_code.config_manifest import get_option
     from deepagents_code.configuration.resolver import (
         CLI_RANK,
@@ -1353,7 +1346,6 @@ def test_cli_main_installs_the_shell_allow_list_before_dispatch() -> None:
         resolved = get_config_resolver().get(option)
         seen["value"] = resolved.value
         seen["ranks"] = resolved.ranks
-        seen["settings"] = Settings.from_environment().shell_allow_list
         return 0
 
     mock_stdin = MagicMock()
@@ -1381,7 +1373,6 @@ def test_cli_main_installs_the_shell_allow_list_before_dispatch() -> None:
     assert exc_info.value.code == 0
     assert seen["value"] == ["git status", "ls"]
     assert seen["ranks"] == (CLI_RANK,)
-    assert seen["settings"] == ["git status", "ls"]
 
 
 class TestTimeoutArgument:
@@ -3544,25 +3535,31 @@ class TestInterpreterFlagParsing:
 class TestResolveInterpreterEnabled:
     """Tests for `_resolve_interpreter_enabled`."""
 
-    def test_local_mode_uses_config_default(self, mock_argv: MockArgvType) -> None:
-        from deepagents_code.config import settings
+    def test_local_mode_uses_config_default(
+        self, mock_argv: MockArgvType, tmp_path: Path
+    ) -> None:
+        from deepagents_code.configuration import service
         from deepagents_code.main import _resolve_interpreter_enabled
 
         with mock_argv("-n", "task"):
             args = parse_args()
-        with patch.object(settings, "enable_interpreter", False):
-            assert _resolve_interpreter_enabled(args) is False
-        with patch.object(settings, "enable_interpreter", True):
-            assert _resolve_interpreter_enabled(args) is True
+        (tmp_path / "config.toml").write_text(
+            "[interpreter]\nenable_interpreter = false\n", encoding="utf-8"
+        )
+        service.invalidate_config_sources()
+        assert _resolve_interpreter_enabled(args) is False
+        (tmp_path / "config.toml").write_text(
+            "[interpreter]\nenable_interpreter = true\n", encoding="utf-8"
+        )
+        service.invalidate_config_sources()
+        assert _resolve_interpreter_enabled(args) is True
 
     def test_sandbox_defaults_disabled(self, mock_argv: MockArgvType) -> None:
-        from deepagents_code.config import settings
         from deepagents_code.main import _resolve_interpreter_enabled
 
         with mock_argv("-n", "task", "--sandbox", "daytona"):
             args = parse_args()
-        with patch.object(settings, "enable_interpreter", True):
-            assert _resolve_interpreter_enabled(args) is False
+        assert _resolve_interpreter_enabled(args) is False
 
     def test_explicit_flag_with_remote_sandbox_is_a_visible_error(
         self, mock_argv: MockArgvType, capsys: pytest.CaptureFixture[str]
@@ -3589,13 +3586,11 @@ class TestResolveInterpreterEnabled:
     def test_explicit_no_flag_overrides_local_default(
         self, mock_argv: MockArgvType
     ) -> None:
-        from deepagents_code.config import settings
         from deepagents_code.main import _resolve_interpreter_enabled
 
         with mock_argv("-n", "task", "--no-interpreter"):
             args = parse_args()
-        with patch.object(settings, "enable_interpreter", True):
-            assert _resolve_interpreter_enabled(args) is False
+        assert _resolve_interpreter_enabled(args) is False
 
     def test_empty_sandbox_treated_as_local(self) -> None:
         """An empty-string sandbox is falsy and must resolve as local mode.
@@ -3607,12 +3602,10 @@ class TestResolveInterpreterEnabled:
         """
         import argparse
 
-        from deepagents_code.config import settings
         from deepagents_code.main import _resolve_interpreter_enabled
 
         args = argparse.Namespace(interpreter=None, sandbox="")
-        with patch.object(settings, "enable_interpreter", True):
-            assert _resolve_interpreter_enabled(args) is True
+        assert _resolve_interpreter_enabled(args) is True
 
     def test_managed_false_revokes_an_explicit_interpreter_flag(
         self,
@@ -3766,7 +3759,6 @@ class TestResolveInterpreterEnabled:
         """With policy silent on the key, the sandbox default stands."""
         import argparse
 
-        from deepagents_code.config import settings
         from deepagents_code.configuration import service
         from deepagents_code.main import _resolve_interpreter_enabled
         from unit_tests.conftest import redirect_managed_config
@@ -3777,8 +3769,7 @@ class TestResolveInterpreterEnabled:
         service.invalidate_config_sources()
         try:
             args = argparse.Namespace(interpreter=None, sandbox="daytona")
-            with patch.object(settings, "enable_interpreter", True):
-                assert _resolve_interpreter_enabled(args) is False
+            assert _resolve_interpreter_enabled(args) is False
         finally:
             service.invalidate_config_sources()
 
@@ -3932,52 +3923,52 @@ class TestWarnInterpreterDisabledBySandbox:
         self, mock_argv: MockArgvType, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """A `--sandbox` run with the default-on interpreter warns on stderr."""
-        from deepagents_code.config import settings
         from deepagents_code.main import _warn_if_interpreter_disabled_by_sandbox
 
         with mock_argv("-n", "task", "--sandbox", "daytona"):
             args = parse_args()
-        with patch.object(settings, "enable_interpreter", True):
-            _warn_if_interpreter_disabled_by_sandbox(args)
+        _warn_if_interpreter_disabled_by_sandbox(args)
         assert "unavailable under a remote sandbox" in capsys.readouterr().err
 
     def test_silent_in_local_mode(
         self, mock_argv: MockArgvType, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """Local mode keeps the interpreter, so there is nothing to warn about."""
-        from deepagents_code.config import settings
         from deepagents_code.main import _warn_if_interpreter_disabled_by_sandbox
 
         with mock_argv("-n", "task"):
             args = parse_args()
-        with patch.object(settings, "enable_interpreter", True):
-            _warn_if_interpreter_disabled_by_sandbox(args)
+        _warn_if_interpreter_disabled_by_sandbox(args)
         assert capsys.readouterr().err == ""
 
     def test_silent_on_explicit_opt_out_under_sandbox(
         self, mock_argv: MockArgvType, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """An explicit `--no-interpreter` is the user's choice, not a drop."""
-        from deepagents_code.config import settings
         from deepagents_code.main import _warn_if_interpreter_disabled_by_sandbox
 
         with mock_argv("-n", "task", "--sandbox", "daytona", "--no-interpreter"):
             args = parse_args()
-        with patch.object(settings, "enable_interpreter", True):
-            _warn_if_interpreter_disabled_by_sandbox(args)
+        _warn_if_interpreter_disabled_by_sandbox(args)
         assert capsys.readouterr().err == ""
 
     def test_silent_when_config_default_off(
-        self, mock_argv: MockArgvType, capsys: pytest.CaptureFixture[str]
+        self,
+        mock_argv: MockArgvType,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
     ) -> None:
         """A user who disabled the interpreter in config is not nagged."""
-        from deepagents_code.config import settings
+        from deepagents_code.configuration import service
         from deepagents_code.main import _warn_if_interpreter_disabled_by_sandbox
 
+        (tmp_path / "config.toml").write_text(
+            "[interpreter]\nenable_interpreter = false\n", encoding="utf-8"
+        )
+        service.invalidate_config_sources()
         with mock_argv("-n", "task", "--sandbox", "daytona"):
             args = parse_args()
-        with patch.object(settings, "enable_interpreter", False):
-            _warn_if_interpreter_disabled_by_sandbox(args)
+        _warn_if_interpreter_disabled_by_sandbox(args)
         assert capsys.readouterr().err == ""
 
     def test_cli_main_forwards_enabled_interpreter_in_local_mode(self) -> None:
@@ -3986,7 +3977,6 @@ class TestWarnInterpreterDisabledBySandbox:
         Guards the `cli_main` -> `run_non_interactive` wiring: a dropped or
         reverted assignment (e.g. back to a hard-coded `False`) fails here.
         """
-        from deepagents_code.config import settings
         from deepagents_code.main import cli_main
 
         run_mock = AsyncMock(return_value=0)
@@ -4000,7 +3990,6 @@ class TestWarnInterpreterDisabledBySandbox:
                 "deepagents_code.main._should_ensure_managed_ripgrep",
                 return_value=False,
             ),
-            patch.object(settings, "enable_interpreter", True),
             patch(
                 "deepagents_code.client.non_interactive.run_non_interactive", run_mock
             ),
@@ -4015,7 +4004,6 @@ class TestWarnInterpreterDisabledBySandbox:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """End-to-end: `-n --sandbox` forwards the disabled interpreter and warns."""
-        from deepagents_code.config import settings
         from deepagents_code.main import cli_main
 
         run_mock = AsyncMock(return_value=0)
@@ -4034,7 +4022,6 @@ class TestWarnInterpreterDisabledBySandbox:
             patch(
                 "deepagents_code.integrations.sandbox_factory.verify_sandbox_deps",
             ),
-            patch.object(settings, "enable_interpreter", True),
             patch(
                 "deepagents_code.client.non_interactive.run_non_interactive", run_mock
             ),
@@ -4050,7 +4037,6 @@ class TestWarnInterpreterDisabledBySandbox:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """End-to-end: `-n --sandbox --no-interpreter` disables without an advisory."""
-        from deepagents_code.config import settings
         from deepagents_code.main import cli_main
 
         run_mock = AsyncMock(return_value=0)
@@ -4078,7 +4064,6 @@ class TestWarnInterpreterDisabledBySandbox:
             patch(
                 "deepagents_code.integrations.sandbox_factory.verify_sandbox_deps",
             ),
-            patch.object(settings, "enable_interpreter", True),
             patch(
                 "deepagents_code.client.non_interactive.run_non_interactive", run_mock
             ),

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -219,8 +219,10 @@ class TestMakeHitlDecision:
 
     def test_shell_without_allow_list_rejected(self, console: Console) -> None:
         """Shell commands should be rejected when no allow-list is configured."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.shell_allow_list = None
+        with patch(
+            "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+        ) as mock_settings:
+            mock_settings.return_value = None
             result = _make_hitl_decision(
                 {"name": "execute", "args": {"command": "rm -rf /"}}, console
             )
@@ -229,8 +231,10 @@ class TestMakeHitlDecision:
 
     def test_shell_allowed_command_approved(self, console: Console) -> None:
         """Shell commands in the allow-list should be approved."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.shell_allow_list = ["ls", "cat", "grep"]
+        with patch(
+            "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+        ) as mock_settings:
+            mock_settings.return_value = ["ls", "cat", "grep"]
             result = _make_hitl_decision(
                 {"name": "execute", "args": {"command": "ls -la"}}, console
             )
@@ -238,8 +242,10 @@ class TestMakeHitlDecision:
 
     def test_shell_disallowed_command_rejected(self, console: Console) -> None:
         """Shell commands not in the allow-list should be rejected."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.shell_allow_list = ["ls", "cat", "grep"]
+        with patch(
+            "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+        ) as mock_settings:
+            mock_settings.return_value = ["ls", "cat", "grep"]
             result = _make_hitl_decision(
                 {"name": "execute", "args": {"command": "rm -rf /"}}, console
             )
@@ -251,8 +257,10 @@ class TestMakeHitlDecision:
         self, console: Console
     ) -> None:
         """Rejection message should list the allowed commands."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.shell_allow_list = ["ls", "cat"]
+        with patch(
+            "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+        ) as mock_settings:
+            mock_settings.return_value = ["ls", "cat"]
             result = _make_hitl_decision(
                 {"name": "execute", "args": {"command": "whoami"}}, console
             )
@@ -266,8 +274,10 @@ class TestMakeHitlDecision:
 
     def test_shell_piped_command_allowed(self, console: Console) -> None:
         """Piped shell commands where all segments are allowed should pass."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.shell_allow_list = ["ls", "grep"]
+        with patch(
+            "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+        ) as mock_settings:
+            mock_settings.return_value = ["ls", "grep"]
             result = _make_hitl_decision(
                 {"name": "execute", "args": {"command": "ls | grep test"}}, console
             )
@@ -277,8 +287,10 @@ class TestMakeHitlDecision:
         self, console: Console
     ) -> None:
         """Piped commands with a disallowed segment should be rejected."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.shell_allow_list = ["ls"]
+        with patch(
+            "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+        ) as mock_settings:
+            mock_settings.return_value = ["ls"]
             result = _make_hitl_decision(
                 {"name": "execute", "args": {"command": "ls | rm file"}}, console
             )
@@ -286,8 +298,10 @@ class TestMakeHitlDecision:
 
     def test_shell_dangerous_pattern_rejected(self, console: Console) -> None:
         """Dangerous patterns rejected even if base command is allowed."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.shell_allow_list = ["ls"]
+        with patch(
+            "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+        ) as mock_settings:
+            mock_settings.return_value = ["ls"]
             result = _make_hitl_decision(
                 {"name": "execute", "args": {"command": "ls $(whoami)"}}, console
             )
@@ -295,8 +309,10 @@ class TestMakeHitlDecision:
 
     def test_shell_with_allow_all_approved(self, console: Console) -> None:
         """Shell commands should be approved when SHELL_ALLOW_ALL is set."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.shell_allow_list = SHELL_ALLOW_ALL
+        with patch(
+            "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+        ) as mock_settings:
+            mock_settings.return_value = SHELL_ALLOW_ALL
             result = _make_hitl_decision(
                 {"name": "execute", "args": {"command": "rm -rf /"}}, console
             )
@@ -304,8 +320,10 @@ class TestMakeHitlDecision:
 
     def test_execute_tool_gated_by_allow_list(self, console: Console) -> None:
         """The `execute` shell tool is gated by the allow-list."""
-        with patch("deepagents_code.client.non_interactive.settings") as mock_settings:
-            mock_settings.shell_allow_list = ["ls"]
+        with patch(
+            "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+        ) as mock_settings:
+            mock_settings.return_value = ["ls"]
             result = _make_hitl_decision(
                 {"name": "execute", "args": {"command": "rm -rf /"}}, console
             )
@@ -344,7 +362,7 @@ class TestBuildNonInteractiveHeader:
 
     def test_includes_agent_id(self) -> None:
         """Header should contain the agent identifier."""
-        with patch("deepagents_code.client.non_interactive.settings"):
+        with patch("deepagents_code.client.non_interactive._resolve_shell_allow_list"):
             runtime_state.model_name = None
             header = _build_non_interactive_header("my-agent", "abc123")
         assert "Agent: my-agent" in header.plain
@@ -353,28 +371,28 @@ class TestBuildNonInteractiveHeader:
 
     def test_default_agent_label(self) -> None:
         """Header should show '(default)' for the default agent name."""
-        with patch("deepagents_code.client.non_interactive.settings"):
+        with patch("deepagents_code.client.non_interactive._resolve_shell_allow_list"):
             runtime_state.model_name = None
             header = _build_non_interactive_header("agent", "abc123")
         assert "Agent: agent (default)" in header.plain
 
     def test_includes_model_name(self) -> None:
         """Header should display model name when available."""
-        with patch("deepagents_code.client.non_interactive.settings"):
+        with patch("deepagents_code.client.non_interactive._resolve_shell_allow_list"):
             runtime_state.model_name = "gpt-5"
             header = _build_non_interactive_header("agent", "abc123")
         assert "Model: gpt-5" in header.plain
 
     def test_omits_model_when_none(self) -> None:
         """Header should not include model section when model_name is None."""
-        with patch("deepagents_code.client.non_interactive.settings"):
+        with patch("deepagents_code.client.non_interactive._resolve_shell_allow_list"):
             runtime_state.model_name = None
             header = _build_non_interactive_header("agent", "abc123")
         assert "Model:" not in header.plain
 
     def test_includes_thread_id(self) -> None:
         """Header should contain the thread ID."""
-        with patch("deepagents_code.client.non_interactive.settings"):
+        with patch("deepagents_code.client.non_interactive._resolve_shell_allow_list"):
             runtime_state.model_name = None
             header = _build_non_interactive_header("agent", "deadbeef")
         assert "Thread: deadbeef" in header.plain
@@ -382,7 +400,7 @@ class TestBuildNonInteractiveHeader:
     def test_thread_clickable_when_url_available(self) -> None:
         """Thread ID should be a hyperlink when LangSmith URL is available."""
         url = "https://smith.langchain.com/o/org/projects/p/proj/t/abc123"
-        with patch("deepagents_code.client.non_interactive.settings"):
+        with patch("deepagents_code.client.non_interactive._resolve_shell_allow_list"):
             runtime_state.model_name = None
             with patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -404,7 +422,7 @@ class TestBuildNonInteractiveHeader:
 
     def test_default_header_does_not_lookup_langsmith(self) -> None:
         """Header should skip LangSmith lookup unless explicitly enabled."""
-        with patch("deepagents_code.client.non_interactive.settings"):
+        with patch("deepagents_code.client.non_interactive._resolve_shell_allow_list"):
             runtime_state.model_name = None
             with patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -437,7 +455,7 @@ class TestSandboxTypeForwarding:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -449,7 +467,7 @@ class TestSandboxTypeForwarding:
                 return_value=(mock_agent, mock_server_proc, None),
             ) as mock_start_server,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -486,7 +504,9 @@ class TestSandboxTypeForwarding:
                 "deepagents_code.client.non_interactive.generate_thread_id",
                 return_value="test-thread",
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
                 return_value=None,
@@ -505,7 +525,7 @@ class TestSandboxTypeForwarding:
                 return_value=(mock_agent, mock_server_proc, None),
             ) as mock_start_server,
         ):
-            mock_settings.shell_allow_list = SHELL_ALLOW_ALL
+            mock_settings.return_value = SHELL_ALLOW_ALL
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -539,7 +559,7 @@ class TestSandboxTypeForwarding:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -551,7 +571,7 @@ class TestSandboxTypeForwarding:
                 return_value=(mock_agent, mock_server_proc, None),
             ) as mock_start_server,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -593,7 +613,7 @@ class TestAllowFsToolsForwarding:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -605,7 +625,7 @@ class TestAllowFsToolsForwarding:
                 return_value=(mock_agent, mock_server_proc, None),
             ) as mock_start_server,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -655,7 +675,7 @@ class TestQuietMode:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -667,7 +687,7 @@ class TestQuietMode:
                 return_value=(mock_agent, mock_server_proc, None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -709,7 +729,7 @@ class TestQuietMode:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -723,7 +743,7 @@ class TestQuietMode:
             patch.object(sys, "stdout", stdout_buf),
             patch.object(sys, "stderr", stderr_buf),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -908,7 +928,7 @@ class TestNoStreamMode:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -921,7 +941,7 @@ class TestNoStreamMode:
             ),
             patch.object(sys, "stdout", stdout_buf),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -977,7 +997,7 @@ class TestNoStreamMode:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -990,7 +1010,7 @@ class TestNoStreamMode:
             ),
             patch.object(sys, "stdout", stdout_buf),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -1040,7 +1060,7 @@ class TestFastFollowLangsmithLink:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive._start_langsmith_thread_url_lookup",
@@ -1052,7 +1072,7 @@ class TestFastFollowLangsmithLink:
                 return_value=(mock_agent, mock_server_proc, None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -1093,7 +1113,7 @@ class TestFastFollowLangsmithLink:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive._start_langsmith_thread_url_lookup",
@@ -1105,7 +1125,7 @@ class TestFastFollowLangsmithLink:
                 return_value=(mock_agent, mock_server_proc, None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -1144,7 +1164,7 @@ class TestFastFollowLangsmithLink:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive._start_langsmith_thread_url_lookup",
@@ -1156,7 +1176,7 @@ class TestFastFollowLangsmithLink:
                 return_value=(mock_agent, mock_server_proc, None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -1191,7 +1211,7 @@ class TestFastFollowLangsmithLink:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive._start_langsmith_thread_url_lookup",
@@ -1202,7 +1222,7 @@ class TestFastFollowLangsmithLink:
                 return_value=(mock_agent, mock_server_proc, None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -1306,7 +1326,7 @@ class TestShellAllowListDecisionLogic:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -1318,7 +1338,7 @@ class TestShellAllowListDecisionLogic:
                 return_value=(mock_agent, mock_server_proc, None),
             ) as mock_start_server,
         ):
-            mock_settings.shell_allow_list = shell_allow_list
+            mock_settings.return_value = shell_allow_list
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -1362,7 +1382,7 @@ class TestNonInteractivePrompt:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -1374,7 +1394,7 @@ class TestNonInteractivePrompt:
                 return_value=(mock_agent, mock_server_proc, None),
             ) as mock_start_server,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -1413,7 +1433,7 @@ class TestNonInteractivePrompt:
                 return_value="test-thread",
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
@@ -1433,7 +1453,7 @@ class TestNonInteractivePrompt:
                 return_value=(mock_agent, mock_server_proc, None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -1464,7 +1484,7 @@ class TestNonInteractivePrompt:
                 ),
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.skills.invocation.discover_skills_and_roots",
@@ -1475,7 +1495,7 @@ class TestNonInteractivePrompt:
                 new_callable=AsyncMock,
             ) as mock_start_server,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -1515,7 +1535,7 @@ class TestNonInteractivePrompt:
                 ),
             ),
             patch(
-                "deepagents_code.client.non_interactive.settings",
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list",
             ) as mock_settings,
             patch(
                 "deepagents_code.skills.invocation.discover_skills_and_roots",
@@ -1533,7 +1553,7 @@ class TestNonInteractivePrompt:
                 new_callable=AsyncMock,
             ) as mock_start_server,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -1841,7 +1861,7 @@ class TestMaxTurns:
                 "deepagents_code.client.non_interactive.dispatch_hook",
                 new_callable=AsyncMock,
             ),
-            patch("deepagents_code.client.non_interactive.settings"),
+            patch("deepagents_code.client.non_interactive._resolve_shell_allow_list"),
         ):
             runtime_state.model_name = "test:model"
             runtime_state.model_provider = "test"
@@ -1987,12 +2007,14 @@ class TestMaxTurns:
             patch(
                 "deepagents_code.client.non_interactive.dispatch_hook_fire_and_forget"
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive._HITL_REQUEST_ADAPTER"
             ) as mock_adapter,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
@@ -2023,12 +2045,14 @@ class TestMaxTurns:
             patch(
                 "deepagents_code.client.non_interactive.dispatch_hook_fire_and_forget"
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive._HITL_REQUEST_ADAPTER"
             ) as mock_adapter,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
@@ -2065,13 +2089,15 @@ class TestMaxTurns:
             patch(
                 "deepagents_code.client.non_interactive.dispatch_hook_fire_and_forget"
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive._HITL_REQUEST_ADAPTER"
             ) as mock_adapter,
             patch("deepagents_code.client.non_interactive._MAX_HITL_ITERATIONS", 2),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
@@ -2106,13 +2132,15 @@ class TestMaxTurns:
             patch(
                 "deepagents_code.client.non_interactive.dispatch_hook_fire_and_forget"
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive._HITL_REQUEST_ADAPTER"
             ) as mock_adapter,
             patch("deepagents_code.client.non_interactive._MAX_HITL_ITERATIONS", 1),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
@@ -2147,7 +2175,9 @@ class TestMaxTurns:
                 "deepagents_code.client.non_interactive.generate_thread_id",
                 return_value="test-thread",
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
                 return_value=None,
@@ -2162,7 +2192,7 @@ class TestMaxTurns:
                 return_value=(mock_agent, mock_server_proc, None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -2190,7 +2220,9 @@ class TestMaxTurns:
                 "deepagents_code.client.non_interactive.generate_thread_id",
                 return_value="test-thread",
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
                 return_value=None,
@@ -2205,7 +2237,7 @@ class TestMaxTurns:
                 return_value=(mock_agent, mock_server_proc, None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -2235,12 +2267,14 @@ class TestMaxTurns:
             patch(
                 "deepagents_code.client.non_interactive.dispatch_hook_fire_and_forget"
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive._HITL_REQUEST_ADAPTER"
             ) as mock_adapter,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError):
@@ -2278,12 +2312,14 @@ class TestMaxTurns:
             patch(
                 "deepagents_code.client.non_interactive.dispatch_hook_fire_and_forget"
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive._HITL_REQUEST_ADAPTER"
             ) as mock_adapter,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             runtime_state.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError):
@@ -2331,7 +2367,9 @@ class TestMaxTurns:
                 "deepagents_code.client.non_interactive.generate_thread_id",
                 return_value="test-thread",
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
                 return_value=None,
@@ -2346,7 +2384,7 @@ class TestMaxTurns:
                 return_value=(looping_agent, mock_server_proc, None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -2576,7 +2614,7 @@ class TestRecordUsageFromMessageStats:
             },
         )
         with (
-            patch("deepagents_code.client.non_interactive.settings"),
+            patch("deepagents_code.client.non_interactive._resolve_shell_allow_list"),
             patch("deepagents_code.cost_tracking.estimate_cost", return_value=0.42),
         ):
             runtime_state.model_name = "gpt-5.5"
@@ -2600,7 +2638,7 @@ class TestRecordUsageFromMessageStats:
                 "total_tokens": 150,
             },
         )
-        with patch("deepagents_code.client.non_interactive.settings"):
+        with patch("deepagents_code.client.non_interactive._resolve_shell_allow_list"):
             runtime_state.model_name = "gpt-5.5"
             runtime_state.model_provider = "openai"
             _record_usage_from_message(message, state)
@@ -2775,7 +2813,9 @@ class TestMakeStdioEncodingSafe:
                 "deepagents_code.client.non_interactive.generate_thread_id",
                 return_value="test-thread",
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
                 return_value=None,
@@ -2786,7 +2826,7 @@ class TestMakeStdioEncodingSafe:
                 return_value=(mock_agent, mock_server_proc, None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -3967,7 +4007,9 @@ class TestDrainWiring:
                 "deepagents_code.client.non_interactive.generate_thread_id",
                 return_value="test-thread",
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
                 return_value=None,
@@ -3982,7 +4024,7 @@ class TestDrainWiring:
                 new_callable=AsyncMock,
             ) as mock_drain,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -4007,7 +4049,9 @@ class TestDrainWiring:
                 "deepagents_code.client.non_interactive.generate_thread_id",
                 return_value="test-thread",
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
                 return_value=None,
@@ -4027,7 +4071,7 @@ class TestDrainWiring:
                 new_callable=AsyncMock,
             ) as mock_drain,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -4057,7 +4101,9 @@ class TestDrainWiring:
                 "deepagents_code.client.non_interactive.generate_thread_id",
                 return_value="test-thread",
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
                 return_value=None,
@@ -4077,7 +4123,7 @@ class TestDrainWiring:
                 new_callable=AsyncMock,
             ) as mock_drain,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -4102,7 +4148,9 @@ class TestDrainWiring:
                 "deepagents_code.client.non_interactive.generate_thread_id",
                 return_value="test-thread",
             ),
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.non_interactive.build_langsmith_thread_url",
                 return_value=None,
@@ -4122,7 +4170,7 @@ class TestDrainWiring:
                 new_callable=AsyncMock,
             ) as mock_drain,
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 
@@ -4187,14 +4235,16 @@ class TestHeadlessUsageStats:
             patch(
                 "deepagents_code.client.non_interactive.print_usage_table"
             ) as mock_table,
-            patch("deepagents_code.client.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_code.client.non_interactive._resolve_shell_allow_list"
+            ) as mock_settings,
             patch(
                 "deepagents_code.client.launch.server_manager.start_server_and_get_agent",
                 new_callable=AsyncMock,
                 return_value=(mock_agent, MagicMock(), None),
             ),
         ):
-            mock_settings.shell_allow_list = None
+            mock_settings.return_value = None
             mock_settings.has_tavily = False
             runtime_state.model_name = None
 

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import os
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import dotenv as _dotenv_module
@@ -29,6 +29,28 @@ if TYPE_CHECKING:
 
 # Capture before any monkeypatching replaces it on the module.
 _real_load_dotenv = _dotenv_module.load_dotenv
+
+
+def _resolved_config_value(key: str, *, path_base: Path | None = None) -> object:
+    from deepagents_code.config import _use_extra_skills_path_base
+    from deepagents_code.config_manifest import get_option
+    from deepagents_code.configuration.resolver import get_config_resolver
+
+    option = get_option(key)
+    assert option is not None
+    with _use_extra_skills_path_base(path_base):
+        return get_config_resolver().get(option).value
+
+
+def _shell_allow_list() -> list[str] | None:
+    return cast("list[str] | None", _resolved_config_value("shell.allow_list"))
+
+
+def _extra_skills_dirs(*, path_base: Path | None = None) -> list[Path] | None:
+    return cast(
+        "list[Path] | None",
+        _resolved_config_value("skills.extra_allowed_dirs", path_base=path_base),
+    )
 
 
 def _test_plugin_fingerprint(version: str) -> _PluginFingerprint:
@@ -117,7 +139,7 @@ class TestReloadFromEnvironment:
         changes = settings.preview_reload_from_environment(start_path=target)
 
         assert any(change.startswith("shell_allow_list:") for change in changes)
-        assert settings.shell_allow_list is None
+        assert _shell_allow_list() is None
         assert "DEEPAGENTS_CODE_SHELL_ALLOW_LIST" not in os.environ
 
     def test_preview_reload_sees_shell_allow_list_toml_edit(
@@ -134,13 +156,13 @@ class TestReloadFromEnvironment:
 
         config_path = model_config.DEFAULT_CONFIG_PATH
         settings = Settings.from_environment(start_path=tmp_path)
-        assert settings.shell_allow_list is None
+        assert _shell_allow_list() is None
 
         config_path.write_text('[shell]\nallow_list = ["ls"]\n', encoding="utf-8")
         changes = settings.preview_reload_from_environment(start_path=tmp_path)
 
         assert any(change.startswith("shell_allow_list:") for change in changes)
-        assert settings.shell_allow_list is None
+        assert _shell_allow_list() is None
 
     def test_preview_reload_sees_extra_skill_roots_toml_edit(
         self, tmp_path: Path
@@ -152,7 +174,7 @@ class TestReloadFromEnvironment:
         skills_dir.mkdir()
         config_path = model_config.DEFAULT_CONFIG_PATH
         settings = Settings.from_environment(start_path=tmp_path)
-        assert settings.extra_skills_dirs is None
+        assert _extra_skills_dirs() is None
 
         config_path.write_text(
             f'[skills]\nextra_allowed_dirs = ["{skills_dir}"]\n',
@@ -163,7 +185,7 @@ class TestReloadFromEnvironment:
 
         assert any(change.startswith("extra_skills_dirs:") for change in preview)
         assert preview == applied
-        assert settings.extra_skills_dirs == [skills_dir]
+        assert _extra_skills_dirs() == [skills_dir]
 
     def test_reload_resolves_relative_skill_roots_from_target_cwd(
         self,
@@ -183,11 +205,11 @@ class TestReloadFromEnvironment:
             encoding="utf-8",
         )
         settings = Settings.from_environment(start_path=current)
-        assert settings.extra_skills_dirs == [current / "shared-skills"]
+        assert _extra_skills_dirs() == [current / "shared-skills"]
 
         settings.reload_from_environment(start_path=target)
 
-        assert settings.extra_skills_dirs == [target / "shared-skills"]
+        assert _extra_skills_dirs(path_base=target) == [target / "shared-skills"]
 
     def test_preview_reload_retains_shell_allow_list_on_corrupt_toml(
         self, tmp_path: Path
@@ -196,7 +218,7 @@ class TestReloadFromEnvironment:
         config_path = tmp_path / "config.toml"
         config_path.write_text('[shell]\nallow_list = ["ls"]\n', encoding="utf-8")
         settings = Settings.from_environment(start_path=tmp_path)
-        assert settings.shell_allow_list == ["ls"]
+        assert _shell_allow_list() == ["ls"]
 
         config_path.write_text("[shell\n", encoding="utf-8")
 
@@ -205,7 +227,7 @@ class TestReloadFromEnvironment:
 
         assert not any(change.startswith("shell_allow_list:") for change in preview)
         assert not any(change.startswith("shell_allow_list:") for change in applied)
-        assert settings.shell_allow_list == ["ls"]
+        assert _shell_allow_list() == ["ls"]
 
     def test_reload_reports_an_unparseable_user_config(self, tmp_path: Path) -> None:
         """A corrupt `config.toml` must not be reported as a clean reload.
@@ -221,7 +243,7 @@ class TestReloadFromEnvironment:
         config_path = model_config.DEFAULT_CONFIG_PATH
         config_path.write_text('[shell]\nallow_list = ["ls"]\n', encoding="utf-8")
         settings = Settings.from_environment(start_path=tmp_path)
-        assert settings.shell_allow_list == ["ls"]
+        assert _shell_allow_list() == ["ls"]
 
         config_path.write_text("[shell\n", encoding="utf-8")
         changes = settings.reload_from_environment(start_path=tmp_path)
@@ -230,7 +252,7 @@ class TestReloadFromEnvironment:
         assert changes[0].startswith("Kept previous config.toml:")
         # The retained value is still in force -- the notice reports the
         # rejection, it does not describe a rollback.
-        assert settings.shell_allow_list == ["ls"]
+        assert _shell_allow_list() == ["ls"]
 
     def test_preview_reports_an_unparseable_user_config(self, tmp_path: Path) -> None:
         """The preview reports its own read, so accept/decline agree with it."""
@@ -245,7 +267,7 @@ class TestReloadFromEnvironment:
 
         assert preview
         assert preview[0].startswith("Kept previous config.toml:")
-        assert settings.shell_allow_list == ["ls"]
+        assert _shell_allow_list() == ["ls"]
 
     def test_reload_reports_no_notice_for_a_readable_config(
         self, tmp_path: Path
@@ -265,7 +287,7 @@ class TestReloadFromEnvironment:
         assert not any(
             change.startswith("Kept previous config.toml:") for change in changes
         )
-        assert settings.shell_allow_list == ["ls", "cat"]
+        assert _shell_allow_list() == ["ls", "cat"]
 
     def test_reload_retains_extra_skill_roots_on_corrupt_toml(
         self, tmp_path: Path
@@ -279,14 +301,14 @@ class TestReloadFromEnvironment:
             encoding="utf-8",
         )
         settings = Settings.from_environment(start_path=tmp_path)
-        assert settings.extra_skills_dirs == [skills_dir]
+        assert _extra_skills_dirs() == [skills_dir]
 
         config_path.write_text("[skills\n", encoding="utf-8")
 
         changes = settings.reload_from_environment(start_path=tmp_path)
 
         assert not any(change.startswith("extra_skills_dirs:") for change in changes)
-        assert settings.extra_skills_dirs == [skills_dir]
+        assert _extra_skills_dirs() == [skills_dir]
 
     def test_reload_reads_managed_policy_once(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -381,12 +403,12 @@ class TestReloadFromEnvironment:
         """Reload should update parsed shell allow-list values."""
         monkeypatch.setenv("DEEPAGENTS_CODE_SHELL_ALLOW_LIST", "ls,cat")
         settings = Settings.from_environment(start_path=tmp_path)
-        assert settings.shell_allow_list == ["ls", "cat"]
+        assert _shell_allow_list() == ["ls", "cat"]
 
         monkeypatch.setenv("DEEPAGENTS_CODE_SHELL_ALLOW_LIST", "ls,grep")
         changes = settings.reload_from_environment(start_path=tmp_path)
 
-        assert settings.shell_allow_list == ["ls", "grep"]
+        assert _shell_allow_list() == ["ls", "grep"]
         assert any(change.startswith("shell_allow_list:") for change in changes)
 
     def test_reload_preserves_cli_shell_allow_list(
@@ -398,13 +420,13 @@ class TestReloadFromEnvironment:
 
         install_cli_provider(CliProvider({"shell_allow_list": "ls,cat"}))
         settings = Settings.from_environment(start_path=tmp_path)
-        assert settings.shell_allow_list == ["ls", "cat"]
+        assert _shell_allow_list() == ["ls", "cat"]
 
         monkeypatch.setenv("DEEPAGENTS_CODE_SHELL_ALLOW_LIST", "grep")
         preview = settings.preview_reload_from_environment(start_path=tmp_path)
         changes = settings.reload_from_environment(start_path=tmp_path)
 
-        assert settings.shell_allow_list == ["ls", "cat"]
+        assert _shell_allow_list() == ["ls", "cat"]
         assert not any(change.startswith("shell_allow_list:") for change in preview)
         assert not any(change.startswith("shell_allow_list:") for change in changes)
 
@@ -1313,12 +1335,12 @@ class TestReloadErrorPaths:
         """Malformed shell allow-list should fall back to previous value."""
         monkeypatch.setenv("DEEPAGENTS_CODE_SHELL_ALLOW_LIST", "ls,cat")
         settings = Settings.from_environment(start_path=tmp_path)
-        assert settings.shell_allow_list == ["ls", "cat"]
+        assert _shell_allow_list() == ["ls", "cat"]
 
         monkeypatch.setenv("DEEPAGENTS_CODE_SHELL_ALLOW_LIST", "all,ls")
         changes = settings.reload_from_environment(start_path=tmp_path)
 
-        assert settings.shell_allow_list == ["ls", "cat"]
+        assert _shell_allow_list() == ["ls", "cat"]
         assert not any(change.startswith("shell_allow_list:") for change in changes)
 
     def test_deleted_cwd_keeps_previous_project_root(
@@ -1354,7 +1376,7 @@ class TestReloadErrorPaths:
         changes = settings.reload_from_environment(start_path=tmp_path)
 
         assert settings.openai_api_key == "sk-updated"
-        assert settings.shell_allow_list == ["ls"]
+        assert _shell_allow_list() == ["ls"]
         assert any(c.startswith("openai_api_key:") for c in changes)
 
     def test_invalid_extra_skills_dirs_keeps_previous(
@@ -1368,10 +1390,10 @@ class TestReloadErrorPaths:
         """
         import deepagents_code.config as config_mod
 
-        settings = Settings.from_environment(start_path=tmp_path)
         sentinel = [tmp_path / "skills"]
-        settings.extra_skills_dirs = sentinel
         monkeypatch.setenv("DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS", str(sentinel[0]))
+        settings = Settings.from_environment(start_path=tmp_path)
+        assert _extra_skills_dirs() == sentinel
 
         def boom(*_args: object, **_kwargs: object) -> list[Path] | None:
             msg = "broken symlink loop"
@@ -1380,7 +1402,7 @@ class TestReloadErrorPaths:
         monkeypatch.setattr(config_mod, "_parse_extra_skills_dirs", boom)
         changes = settings.reload_from_environment(start_path=tmp_path)
 
-        assert settings.extra_skills_dirs == sentinel
+        assert _extra_skills_dirs() == sentinel
         assert not any(change.startswith("extra_skills_dirs:") for change in changes)
 
     def test_managed_skill_roots_are_validated_from_target_cwd(
@@ -1414,7 +1436,7 @@ class TestReloadErrorPaths:
         model_config.clear_caches()
         try:
             settings = Settings.from_environment(start_path=current)
-            previous = settings.extra_skills_dirs
+            previous = _extra_skills_dirs()
             assert previous == [current / "managed-skills"]
             original_resolve = config_mod._resolve_extra_skills_path
 
@@ -1433,8 +1455,8 @@ class TestReloadErrorPaths:
             changes = settings.reload_from_environment(start_path=target)
 
             assert config_mod.managed_reload_block(changes) is not None
-            assert settings.extra_skills_dirs == previous
-            assert settings.extra_skills_dirs != [user_skills]
+            assert _extra_skills_dirs() == previous
+            assert _extra_skills_dirs() != [user_skills]
         finally:
             service.invalidate_config_sources()
 
@@ -1912,7 +1934,6 @@ async def test_reload_notifies_when_managed_policy_newly_masks_cli(
     redirect_managed_config(monkeypatch, managed)
     service.invalidate_config_sources()
     install_cli_provider(CliProvider({"shell_allow_list": "ls"}))
-    original_allow_list = settings.shell_allow_list
     settings.reload_from_environment(start_path=tmp_path)
     notices: list[tuple[str, str | None]] = []
 
@@ -1930,7 +1951,6 @@ async def test_reload_notifies_when_managed_policy_newly_masks_cli(
             await reload_task
             await pilot.pause()
     finally:
-        settings.shell_allow_list = original_allow_list
         service.invalidate_config_sources()
 
     assert any(

--- a/libs/code/tests/unit_tests/test_server_config.py
+++ b/libs/code/tests/unit_tests/test_server_config.py
@@ -20,7 +20,6 @@ from deepagents_code._server_config import (
     _read_env_optional_bool,
     _read_env_str,
 )
-from deepagents_code.config import settings
 
 # ------------------------------------------------------------------
 # _read_env_bool
@@ -257,37 +256,44 @@ class TestServerConfigInterpreterDefault:
             interactive=True,
         )
 
-    def test_local_none_false_uses_settings_default(self) -> None:
-        with patch.object(settings, "enable_interpreter", False):
-            config = self._build(sandbox_type="none", enable_interpreter=None)
+    @staticmethod
+    def _write_default(tmp_path: Path, *, enabled: bool) -> None:
+        (tmp_path / "config.toml").write_text(
+            f"[interpreter]\nenable_interpreter = {str(enabled).lower()}\n",
+            encoding="utf-8",
+        )
+
+    def test_local_none_false_uses_resolver_default(self, tmp_path: Path) -> None:
+        self._write_default(tmp_path, enabled=False)
+        config = self._build(sandbox_type="none", enable_interpreter=None)
 
         assert config.enable_interpreter is False
 
-    def test_local_none_true_uses_settings_default(self) -> None:
-        with patch.object(settings, "enable_interpreter", True):
-            config = self._build(sandbox_type="none", enable_interpreter=None)
+    def test_local_none_true_uses_resolver_default(self, tmp_path: Path) -> None:
+        self._write_default(tmp_path, enabled=True)
+        config = self._build(sandbox_type="none", enable_interpreter=None)
 
         assert config.enable_interpreter is True
 
-    def test_local_explicit_false_is_preserved(self) -> None:
+    def test_local_explicit_false_is_preserved(self, tmp_path: Path) -> None:
         # An explicit `False` must win over a `True` config default rather than
         # falling through to the settings lookup.
-        with patch.object(settings, "enable_interpreter", True):
-            config = self._build(sandbox_type="none", enable_interpreter=False)
+        self._write_default(tmp_path, enabled=True)
+        config = self._build(sandbox_type="none", enable_interpreter=False)
 
         assert config.enable_interpreter is False
 
-    def test_empty_sandbox_is_treated_as_local(self) -> None:
+    def test_empty_sandbox_is_treated_as_local(self, tmp_path: Path) -> None:
         # An empty-string sandbox is falsy and must not be mistaken for a remote
         # backend, which would silently disable the interpreter.
-        with patch.object(settings, "enable_interpreter", True):
-            config = self._build(sandbox_type="", enable_interpreter=None)
+        self._write_default(tmp_path, enabled=True)
+        config = self._build(sandbox_type="", enable_interpreter=None)
 
         assert config.enable_interpreter is True
 
-    def test_remote_none_disables_interpreter(self) -> None:
-        with patch.object(settings, "enable_interpreter", True):
-            config = self._build(sandbox_type="daytona", enable_interpreter=None)
+    def test_remote_none_disables_interpreter(self, tmp_path: Path) -> None:
+        self._write_default(tmp_path, enabled=True)
+        config = self._build(sandbox_type="daytona", enable_interpreter=None)
 
         assert config.enable_interpreter is False
 

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -391,6 +391,7 @@ class TestServerGraph:
             enable_skills=True,
             enable_shell=True,
             enable_interpreter=False,
+            interpreter_config=None,
             rubric_model=None,
             rubric_max_iterations=None,
             auto_classifier_model=None,
@@ -445,25 +446,22 @@ class TestServerGraph:
         resolve_mcp_tools.assert_not_awaited()
 
     async def test_interpreter_settings_apply_before_agent_construction(self) -> None:
-        """Server config settings writes should be visible to `create_cli_agent`."""
+        """Server PTC overrides should reach the interpreter snapshot."""
         graph_obj = object()
         model_obj = object()
         observed: dict[str, object] = {}
 
-        def create_cli_agent_side_effect(**_: object) -> tuple[object, object]:
-            from deepagents_code.config import settings
+        def create_cli_agent_side_effect(**kwargs: object) -> tuple[object, object]:
+            from deepagents_code.configuration.interpreter import InterpreterConfig
 
-            observed["interpreter_ptc"] = settings.interpreter_ptc
-            observed["acknowledge"] = settings.interpreter_ptc_acknowledge_unsafe
-            observed["enable_interpreter"] = settings.enable_interpreter
+            interpreter = kwargs["interpreter_config"]
+            assert isinstance(interpreter, InterpreterConfig)
+            observed["interpreter_ptc"] = interpreter.ptc
+            observed["acknowledge"] = interpreter.ptc_acknowledge_unsafe
+            observed["enable_interpreter"] = kwargs["enable_interpreter"]
             return graph_obj, _backend_with_offload(object())
 
-        settings_obj = SimpleNamespace(
-            has_tavily=False,
-            interpreter_ptc=None,
-            interpreter_ptc_acknowledge_unsafe=False,
-            enable_interpreter=False,
-        )
+        settings_obj = SimpleNamespace(has_tavily=False)
         config_module = _module_with_attrs(
             "deepagents_code.config",
             configure_langsmith_secret_redaction=MagicMock(),

--- a/libs/code/tests/unit_tests/test_skill_invocation.py
+++ b/libs/code/tests/unit_tests/test_skill_invocation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -885,21 +886,6 @@ class TestDiscoverSkillsAndRoots:
     as-is, is caught.
     """
 
-    def _settings_with_no_builtin_roots(self, extra: list[Path]) -> MagicMock:
-        settings = MagicMock()
-        for getter in (
-            "get_built_in_skills_dir",
-            "get_user_skills_dir",
-            "get_project_skills_dir",
-            "get_user_agent_skills_dir",
-            "get_project_agent_skills_dir",
-            "get_user_claude_skills_dir",
-            "get_project_claude_skills_dir",
-        ):
-            getattr(settings, getter).return_value = None
-        settings.get_extra_skills_dirs.return_value = extra
-        return settings
-
     def test_persisted_trust_added_as_is_while_extra_dirs_resolved(
         self, tmp_path: Path
     ) -> None:
@@ -922,11 +908,15 @@ class TestDiscoverSkillsAndRoots:
         real_extra.mkdir()
         link_extra = tmp_path / "link_extra"
         link_extra.symlink_to(real_extra, target_is_directory=True)
+        (tmp_path / "config.toml").write_text(
+            f'[skills]\nextra_allowed_dirs = ["{link_extra}"]\n',
+            encoding="utf-8",
+        )
 
         with (
             patch(
                 "deepagents_code.config.settings",
-                self._settings_with_no_builtin_roots([link_extra]),
+                SimpleNamespace(project_root=tmp_path),
             ),
             patch("deepagents_code.skills.load.list_skills", return_value=[]),
             patch(

--- a/libs/code/tests/unit_tests/test_skill_invocation.py
+++ b/libs/code/tests/unit_tests/test_skill_invocation.py
@@ -312,6 +312,7 @@ def _make_app() -> MagicMock:
 
     app = MagicMock(spec=DeepAgentsApp)
     app._assistant_id = "agent"
+    app._cwd = str(Path.cwd())
     app._discovered_skills = []
     app._skill_allowed_roots = []
     app._skill_trust_denied = set()
@@ -931,6 +932,42 @@ class TestDiscoverSkillsAndRoots:
         assert real_trusted.resolve() not in roots
         # `extra_allowed_dirs` is the declarative allowlist and is resolved.
         assert real_extra.resolve() in roots
+
+    def test_relative_extra_dirs_use_user_cwd_not_project_root(
+        self, tmp_path: Path
+    ) -> None:
+        """Relative allowlist entries keep the cwd used by config loading."""
+        from deepagents_code.skills.invocation import discover_skills_and_roots
+
+        project_root = tmp_path / "project"
+        user_cwd = project_root / "subdir"
+        configured = user_cwd / "shared"
+        wrong = project_root / "shared"
+        configured.mkdir(parents=True)
+        wrong.mkdir()
+        (tmp_path / "config.toml").write_text(
+            '[skills]\nextra_allowed_dirs = ["shared"]\n',
+            encoding="utf-8",
+        )
+
+        with (
+            patch(
+                "deepagents_code.config.settings",
+                SimpleNamespace(project_root=project_root),
+            ),
+            patch("deepagents_code.skills.load.list_skills", return_value=[]),
+            patch(
+                "deepagents_code.skills.trust.load_trusted_skill_dirs",
+                return_value=[],
+            ),
+        ):
+            _skills, roots = discover_skills_and_roots(
+                "agent",
+                path_base=user_cwd,
+            )
+
+        assert configured.resolve() in roots
+        assert wrong.resolve() not in roots
 
 
 class TestResolveParentDir:


### PR DESCRIPTION
Interpreter, shell, and extra-skills options are already owned by the configuration manifest, so retaining copies on `Settings` duplicates resolver state. Consumers now resolve shell and skills options at use time, while `InterpreterConfig` provides a coherent snapshot for middleware construction. The server process builds its own snapshot from its resolver, and the obsolete `settings_field` mappings are removed.

Part 3 of 6 in the [`Settings` dissolution stack](https://github.com/langchain-ai/deepagents/pull/5859?stack=5864).
