### PR TITLE
refactor(code): route credentials and reload through env provider + auth store

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -102,13 +102,13 @@ from deepagents_code.config import (
     _ShellAllowAll,
     config,
     console,
+    credentials,
     get_default_coding_instructions,
     get_glyphs,
     get_langsmith_project_name,
     restore_user_tracing_api_keys,
     restore_user_tracing_env,
     runtime_state,
-    settings,
 )
 from deepagents_code.configurable_model import ConfigurableModelMiddleware
 from deepagents_code.configuration.interpreter import InterpreterConfig
@@ -1590,7 +1590,9 @@ def get_system_prompt(
         unsupported_modalities=runtime_state.model_unsupported_modalities,
     )
     filesystem_tool_guidance = _build_fs_tool_prompt_guidance(fs_tools)
-    web_search_tool_guidance = _WEB_SEARCH_TOOL_GUIDANCE if settings.has_tavily else ""
+    web_search_tool_guidance = (
+        _WEB_SEARCH_TOOL_GUIDANCE if credentials.has_tavily else ""
+    )
 
     # Build working directory section (local vs sandbox)
     if sandbox_type:
@@ -2312,12 +2314,12 @@ def get_skill_sources(
     project_skills_dir = (
         project_context.project_skills_dir()
         if project_context is not None
-        else get_project_skills_dir(settings.project_root)
+        else get_project_skills_dir(credentials.project_root)
     )
     project_agent_skills_dir = (
         project_context.project_agent_skills_dir()
         if project_context is not None
-        else get_project_agent_skills_dir(settings.project_root)
+        else get_project_agent_skills_dir(credentials.project_root)
     )
     sources: list[CodeSkillSource] = [
         (str(get_built_in_skills_dir()), "Built-in"),
@@ -2344,7 +2346,7 @@ def get_skill_sources(
     user_claude_skills_dir = get_user_claude_skills_dir()
     if user_claude_skills_dir is not None and user_claude_skills_dir.exists():
         sources.append((str(user_claude_skills_dir), "User Claude"))
-    project_claude_skills_dir = get_project_claude_skills_dir(settings.project_root)
+    project_claude_skills_dir = get_project_claude_skills_dir(credentials.project_root)
     if project_claude_skills_dir:
         sources.append((str(project_claude_skills_dir), "Project Claude"))
 
@@ -2628,7 +2630,7 @@ def create_cli_agent(
     project_agents_dir = (
         project_context.project_agents_dir()
         if project_context is not None
-        else get_project_agents_dir(settings.project_root)
+        else get_project_agents_dir(credentials.project_root)
     )
 
     def _subagent_cli_middleware(
@@ -2846,7 +2848,7 @@ def create_cli_agent(
         project_agent_md_paths = (
             project_context.project_agent_md_paths()
             if project_context is not None
-            else get_project_agent_md_path(settings.project_root)
+            else get_project_agent_md_path(credentials.project_root)
         )
         memory_sources.extend(str(p) for p in project_agent_md_paths)
 
@@ -2899,8 +2901,8 @@ def create_cli_agent(
             # `deepagents-code` default applied at bootstrap) entirely so shell
             # commands don't inherit it.
             shell_env = os.environ.copy()
-            if settings.user_langchain_project is not None:
-                shell_env["LANGSMITH_PROJECT"] = settings.user_langchain_project
+            if credentials.user_langchain_project is not None:
+                shell_env["LANGSMITH_PROJECT"] = credentials.user_langchain_project
             else:
                 shell_env.pop("LANGSMITH_PROJECT", None)
             restore_user_tracing_env(shell_env)
@@ -2979,7 +2981,7 @@ def create_cli_agent(
                 backend=backend,
                 mcp_server_info=mcp_server_info,
                 tracing_project=get_langsmith_project_name(),
-                user_tracing_project=settings.user_langchain_project,
+                user_tracing_project=credentials.user_langchain_project,
             )
         )
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6281,7 +6281,7 @@ class DeepAgentsApp(App):
             copy_selection_to_clipboard,  # noqa: F401
         )
         from deepagents_code.command_registry import ALWAYS_IMMEDIATE  # noqa: F401
-        from deepagents_code.config import settings  # noqa: F401
+        from deepagents_code.config import credentials  # noqa: F401
         from deepagents_code.hooks import dispatch_hook  # noqa: F401
         from deepagents_code.model_config import ModelSpec  # noqa: F401
         from deepagents_code.tui.textual_adapter import TextualUIAdapter  # noqa: F401
@@ -10961,9 +10961,9 @@ class DeepAgentsApp(App):
         spawn-time tools, so web search takes full effect on the next launch (or
         after a restart).
         """
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        if settings.has_tavily:
+        if credentials.has_tavily:
             return
 
         from deepagents_code.tui.widgets.auth import AuthPromptScreen, AuthResult
@@ -12741,7 +12741,7 @@ class DeepAgentsApp(App):
             get_skill_sources,
             get_system_prompt,
         )
-        from deepagents_code.config import is_memory_auto_save_enabled, settings
+        from deepagents_code.config import credentials, is_memory_auto_save_enabled
         from deepagents_code.context_doctor import (
             build_context_doctor_report,
             format_memory_prompt,
@@ -12774,7 +12774,7 @@ class DeepAgentsApp(App):
                 logger.exception("Failed to build base prompt for /context-doctor")
             memory_paths = [
                 get_user_agent_md_path(self._assistant_id or DEFAULT_AGENT_NAME),
-                *get_project_agent_md_path(settings.project_root),
+                *get_project_agent_md_path(credentials.project_root),
             ]
             for path in memory_paths:
                 try:
@@ -16474,13 +16474,13 @@ class DeepAgentsApp(App):
         Raises:
             asyncio.CancelledError: After any active reload thread has settled.
         """
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
         if start_path is None:
-            reload_work = asyncio.to_thread(settings.reload_from_environment)
+            reload_work = asyncio.to_thread(credentials.reload_from_environment)
         else:
             reload_work = asyncio.to_thread(
-                settings.reload_from_environment,
+                credentials.reload_from_environment,
                 start_path=start_path,
             )
         reload_task = asyncio.create_task(reload_work, name="settings-reload")
@@ -23069,9 +23069,9 @@ class DeepAgentsApp(App):
 
         if provider != TAVILY_SERVICE:
             return
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        if settings.has_tavily:
+        if credentials.has_tavily:
             return
         if self._server_proc is None or self._server_kwargs is None:
             return
@@ -26515,9 +26515,9 @@ class DeepAgentsApp(App):
         post-install offer: same guards, watchdog, and fallback messaging, with
         web-search-specific copy.
         """
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        if settings.has_tavily:
+        if credentials.has_tavily:
             # A respawn happened between arming the offer and now — e.g. an
             # install-on-select in the same `/auth` session auto-restarted the
             # server, which reloaded config and rebound `web_search`. The
@@ -28183,11 +28183,11 @@ class DeepAgentsApp(App):
     @staticmethod
     async def _preview_project_settings_change(cwd: Path) -> bool:
         """Return whether switching cwd would refresh project settings."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
         try:
             changes = await asyncio.to_thread(
-                settings.preview_reload_from_environment,
+                credentials.preview_reload_from_environment,
                 start_path=cwd,
             )
         except (OSError, ValueError):

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -15,7 +15,11 @@ import sys
 import threading
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass, field as dataclass_field
+from dataclasses import (
+    dataclass,
+    field as dataclass_field,
+    replace as dataclass_replace,
+)
 from enum import StrEnum
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
@@ -3070,14 +3074,9 @@ class RuntimeState:
     """Input modalities not indicated as supported by the model profile."""
 
 
-@dataclass
-class Credentials:
-    """Environment-backed credentials and reloadable project context.
-
-    This mutable snapshot owns the environment values that can change after
-    login, `/reload`, or a cwd switch. Resolver-backed configuration and model
-    runtime metadata live in their dedicated holders.
-    """
+@dataclass(frozen=True, slots=True)
+class CredentialsSnapshot:
+    """One complete generation of credentials and project context."""
 
     openai_api_key: str | None
     """OpenAI API key if available."""
@@ -3108,6 +3107,81 @@ class Credentials:
 
     project_root: Path | None = None
     """Current project root directory, or `None` if not in a git project."""
+
+    @property
+    def has_anthropic(self) -> bool:
+        """Check if Anthropic API key is configured."""
+        return self.anthropic_api_key is not None
+
+    @property
+    def has_google(self) -> bool:
+        """Check if Google API key is configured."""
+        return self.google_api_key is not None
+
+    @property
+    def has_vertex_ai(self) -> bool:
+        """Check if VertexAI is available (Google Cloud project set, no API key)."""
+        return self.google_cloud_project is not None and self.google_api_key is None
+
+    @property
+    def has_tavily(self) -> bool:
+        """Check if Tavily API key is configured."""
+        return self.tavily_api_key is not None
+
+
+_CREDENTIAL_FIELDS = frozenset(CredentialsSnapshot.__dataclass_fields__)
+
+
+class Credentials:
+    """Stable owner of the active credential and project-context snapshot.
+
+    Reloads construct a complete immutable `CredentialsSnapshot` and publish it
+    with one reference assignment. Callers that need a consistent multi-field
+    view can retain `active` while ordinary field reads remain source compatible.
+    """
+
+    __slots__ = ("_active",)
+
+    openai_api_key: str | None
+    anthropic_api_key: str | None
+    google_api_key: str | None
+    nvidia_api_key: str | None
+    tavily_api_key: str | None
+    google_cloud_project: str | None
+    google_cloud_location: str | None
+    deepagents_langchain_project: str | None
+    user_langchain_project: str | None
+    project_root: Path | None
+
+    def __init__(self, active: CredentialsSnapshot) -> None:
+        """Create a stable owner for one complete credential generation."""
+        self._active = active
+
+    @property
+    def active(self) -> CredentialsSnapshot:
+        """Complete credential generation currently in force."""
+        return self._active
+
+    def __getattr__(self, name: str) -> object:
+        """Forward credential field reads to the active immutable snapshot.
+
+        Returns:
+            The requested credential field value.
+
+        Raises:
+            AttributeError: If `name` is not a credential field.
+        """
+        if name in _CREDENTIAL_FIELDS:
+            return getattr(self._active, name)
+        msg = f"{type(self).__name__!s} has no attribute {name!r}"
+        raise AttributeError(msg)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Publish a replacement snapshot for compatibility field mutations."""
+        if name in _CREDENTIAL_FIELDS:
+            self._active = dataclass_replace(self._active, **{name: value})
+            return
+        object.__setattr__(self, name, value)
 
     @classmethod
     def from_environment(cls, *, start_path: Path | None = None) -> Credentials:
@@ -3158,16 +3232,18 @@ class Credentials:
         )
 
         return cls(
-            openai_api_key=openai_key,
-            anthropic_api_key=anthropic_key,
-            google_api_key=google_key,
-            nvidia_api_key=nvidia_key,
-            tavily_api_key=tavily_key,
-            google_cloud_project=google_cloud_project,
-            google_cloud_location=google_cloud_location,
-            deepagents_langchain_project=deepagents_langchain_project,
-            user_langchain_project=user_langchain_project,
-            project_root=project_root,
+            CredentialsSnapshot(
+                openai_api_key=openai_key,
+                anthropic_api_key=anthropic_key,
+                google_api_key=google_key,
+                nvidia_api_key=nvidia_key,
+                tavily_api_key=tavily_key,
+                google_cloud_project=google_cloud_project,
+                google_cloud_location=google_cloud_location,
+                deepagents_langchain_project=deepagents_langchain_project,
+                user_langchain_project=user_langchain_project,
+                project_root=project_root,
+            )
         )
 
     @staticmethod
@@ -3429,7 +3505,8 @@ class Credentials:
             A list of human-readable change descriptions that would be produced by
             `reload_from_environment`.
         """
-        previous = {field: getattr(self, field) for field in _RELOADABLE_FIELDS}
+        active = self.active
+        previous = {field: getattr(active, field) for field in _RELOADABLE_FIELDS}
         previous.update(_remembered_resolver_reload_values())
         env = _preview_dotenv_environ(start_path=start_path)
         refreshed, blocked = self._reload_values(
@@ -3469,7 +3546,8 @@ class Credentials:
             A list of human-readable change descriptions. Empty when nothing
             changed; a single notice when managed policy blocked the reload.
         """
-        previous = {field: getattr(self, field) for field in _RELOADABLE_FIELDS}
+        active = self.active
+        previous = {field: getattr(active, field) for field in _RELOADABLE_FIELDS}
         previous.update(_remembered_resolver_reload_values())
         _resolver_with_reload_overrides()
         _load_dotenv(start_path=start_path, refresh_loaded=True)
@@ -3479,8 +3557,10 @@ class Credentials:
             previous=previous,
         )
 
-        for field in _RELOADABLE_FIELDS:
-            setattr(self, field, refreshed[field])
+        replacement = dataclass_replace(
+            active,
+            **{field: refreshed[field] for field in _RELOADABLE_FIELDS},
+        )
         _remember_resolver_reload_values(refreshed)
         _sync_reload_overrides(refreshed, path_base=start_path)
 
@@ -3511,17 +3591,19 @@ class Credentials:
 
         reset_env_resolution_log()
         changes = self._format_reload_changes(previous, refreshed)
+        if managed_reload_block([blocked] if blocked else []) is None:
+            self._active = replacement
         return [blocked, *changes] if blocked else changes
 
     @property
     def has_anthropic(self) -> bool:
         """Check if Anthropic API key is configured."""
-        return self.anthropic_api_key is not None
+        return self.active.has_anthropic
 
     @property
     def has_google(self) -> bool:
         """Check if Google API key is configured."""
-        return self.google_api_key is not None
+        return self.active.has_google
 
     @property
     def has_vertex_ai(self) -> bool:
@@ -3531,12 +3613,12 @@ class Credentials:
         so if GOOGLE_CLOUD_PROJECT is set and GOOGLE_API_KEY is not, we assume
         VertexAI.
         """
-        return self.google_cloud_project is not None and self.google_api_key is None
+        return self.active.has_vertex_ai
 
     @property
     def has_tavily(self) -> bool:
         """Check if Tavily API key is configured."""
-        return self.tavily_api_key is not None
+        return self.active.has_tavily
 
 
 class Settings(Credentials):

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3140,8 +3140,6 @@ class Credentials:
     view can retain `active` while ordinary field reads remain source compatible.
     """
 
-    __slots__ = ("_active",)
-
     openai_api_key: str | None
     anthropic_api_key: str | None
     google_api_key: str | None

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3622,6 +3622,59 @@ class Credentials:
 class Settings(Credentials):
     """Compatibility surface retained until the final dissolution layer."""
 
+    def __init__(
+        self,
+        openai_api_key: str | None,
+        anthropic_api_key: str | None,
+        google_api_key: str | None,
+        nvidia_api_key: str | None,
+        tavily_api_key: str | None,
+        google_cloud_project: str | None,
+        google_cloud_location: str | None,
+        deepagents_langchain_project: str | None,
+        user_langchain_project: str | None,
+        project_root: Path | None = None,
+    ) -> None:
+        """Preserve the legacy dataclass constructor during the migration."""
+        super().__init__(
+            CredentialsSnapshot(
+                openai_api_key=openai_api_key,
+                anthropic_api_key=anthropic_api_key,
+                google_api_key=google_api_key,
+                nvidia_api_key=nvidia_api_key,
+                tavily_api_key=tavily_api_key,
+                google_cloud_project=google_cloud_project,
+                google_cloud_location=google_cloud_location,
+                deepagents_langchain_project=deepagents_langchain_project,
+                user_langchain_project=user_langchain_project,
+                project_root=project_root,
+            )
+        )
+
+    @classmethod
+    def from_environment(cls, *, start_path: Path | None = None) -> Settings:
+        """Build the compatibility owner from the environment.
+
+        Args:
+            start_path: Directory to start project detection from.
+
+        Returns:
+            A compatibility owner containing the resolved snapshot.
+        """
+        active = Credentials.from_environment(start_path=start_path).active
+        return cls(
+            openai_api_key=active.openai_api_key,
+            anthropic_api_key=active.anthropic_api_key,
+            google_api_key=active.google_api_key,
+            nvidia_api_key=active.nvidia_api_key,
+            tavily_api_key=active.tavily_api_key,
+            google_cloud_project=active.google_cloud_project,
+            google_cloud_location=active.google_cloud_location,
+            deepagents_langchain_project=active.deepagents_langchain_project,
+            user_langchain_project=active.user_langchain_project,
+            project_root=active.project_root,
+        )
+
 
 credentials: Credentials
 """Lazily initialized process-wide credential and project snapshot."""

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -56,9 +56,9 @@ logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Lazy bootstrap: dotenv loading, LANGSMITH_PROJECT override, and start-path
-# detection are deferred until first access of `settings` (via module
+# detection are deferred until first access of `credentials` (via module
 # `__getattr__`).  This avoids disk I/O and path traversal during import for
-# callers that never touch `settings` (e.g. `deepagents --help`).
+# callers that never touch credentials (e.g. `deepagents --help`).
 # ---------------------------------------------------------------------------
 
 
@@ -1309,7 +1309,7 @@ def _ensure_bootstrap() -> None:
     """Run one-time bootstrap: dotenv loading and `LANGSMITH_PROJECT` override.
 
     Idempotent and thread-safe — subsequent calls are no-ops. Called
-    automatically by `_get_settings()` when `settings` is first accessed.
+    automatically by `_get_credentials()` when `credentials` is first accessed.
 
     The flag is set in `finally` so that partial failures (e.g. a
     malformed `.env`) still mark bootstrap as done — preventing infinite retry
@@ -3071,14 +3071,12 @@ class RuntimeState:
 
 
 @dataclass
-class Settings:
-    """Global settings and environment detection for deepagents-code.
+class Credentials:
+    """Environment-backed credentials and reloadable project context.
 
-    This class is initialized once at startup and provides access to:
-    - Available models and API keys
-    - Current project information
-    - Tool availability (e.g., Tavily)
-    - File system paths
+    This mutable snapshot owns the environment values that can change after
+    login, `/reload`, or a cwd switch. Resolver-backed configuration and model
+    runtime metadata live in their dedicated holders.
     """
 
     openai_api_key: str | None
@@ -3112,14 +3110,14 @@ class Settings:
     """Current project root directory, or `None` if not in a git project."""
 
     @classmethod
-    def from_environment(cls, *, start_path: Path | None = None) -> Settings:
-        """Create settings by detecting the current environment.
+    def from_environment(cls, *, start_path: Path | None = None) -> Credentials:
+        """Create credentials by detecting the current environment.
 
         Args:
             start_path: Directory to start project detection from (defaults to cwd)
 
         Returns:
-            Settings instance with detected configuration
+            Credentials instance with detected configuration.
 
         """
         # Detect API keys (normalize empty strings to None).
@@ -3541,6 +3539,14 @@ class Settings:
         return self.tavily_api_key is not None
 
 
+class Settings(Credentials):
+    """Compatibility surface retained until the final dissolution layer."""
+
+
+credentials: Credentials
+"""Lazily initialized process-wide credential and project snapshot."""
+
+
 DANGEROUS_SHELL_PATTERNS = (
     "$(",  # Command substitution
     "`",  # Backtick command substitution
@@ -3708,7 +3714,7 @@ def get_langsmith_project_name() -> str | None:
 
     Checks for the required API key and tracing environment variables.
     When both are present, resolves the project name with priority:
-    `settings.deepagents_langchain_project` (from
+    `credentials.deepagents_langchain_project` (from
     `DEEPAGENTS_CODE_LANGSMITH_PROJECT`), then `LANGSMITH_PROJECT` from the
     environment (note: this may already have been overridden at bootstrap time
     to match `DEEPAGENTS_CODE_LANGSMITH_PROJECT`), then `'deepagents-code'`.
@@ -3726,7 +3732,7 @@ def get_langsmith_project_name() -> str | None:
         return None
 
     return (
-        _get_settings().deepagents_langchain_project
+        _get_credentials().deepagents_langchain_project
         or os.environ.get("LANGSMITH_PROJECT")
         or LANGSMITH_PROJECT_DEFAULT
     )
@@ -4867,14 +4873,14 @@ def detect_provider(model_name: str) -> str | None:
         return "perplexity"
 
     if model_lower.startswith("claude"):
-        s = _get_settings()
-        if not s.has_anthropic and s.has_vertex_ai:
+        credentials = _get_credentials()
+        if not credentials.has_anthropic and credentials.has_vertex_ai:
             return "google_anthropic_vertex"
         return "anthropic"
 
     if model_lower.startswith("gemini"):
-        s = _get_settings()
-        if s.has_vertex_ai and not s.has_google:
+        credentials = _get_credentials()
+        if credentials.has_vertex_ai and not credentials.has_google:
             return "google_vertexai"
         return "google_genai"
 
@@ -5183,11 +5189,11 @@ def _apply_google_anthropic_vertex_kwargs(
     """
     if provider != "google_anthropic_vertex":
         return
-    settings = _get_settings()
-    if settings.google_cloud_project:
-        kwargs.setdefault("project", settings.google_cloud_project)
-    if settings.google_cloud_location:
-        kwargs.setdefault("location", settings.google_cloud_location)
+    credentials = _get_credentials()
+    if credentials.google_cloud_project:
+        kwargs.setdefault("project", credentials.google_cloud_project)
+    if credentials.google_cloud_location:
+        kwargs.setdefault("location", credentials.google_cloud_location)
     if not kwargs.get("location"):
         from deepagents_code.model_config import ModelConfigError
 
@@ -5959,21 +5965,21 @@ def _get_console() -> Console:
         return inst
 
 
-def _get_settings() -> Settings:
-    """Return the lazily-initialized global `Settings` instance.
+def _get_credentials() -> Credentials:
+    """Return the lazily initialized process-wide `Credentials` instance.
 
-    Ensures bootstrap has run before constructing settings. The result is cached
-    in `globals()["settings"]` so subsequent access — including
-    `from config import settings` in other modules — resolves instantly.
+    Bootstrap runs before credentials are read. During the stacked migration,
+    the instance uses the empty `Settings` compatibility subclass and is also
+    cached under the legacy `settings` name.
 
     Returns:
-        The global `Settings` singleton.
+        The global credentials singleton.
     """
-    cached = globals().get("settings")
+    cached = globals().get("credentials")
     if cached is not None:
         return cached
     with _singleton_lock:
-        cached = globals().get("settings")
+        cached = globals().get("credentials")
         if cached is not None:
             return cached
         _ensure_bootstrap()
@@ -5981,12 +5987,23 @@ def _get_settings() -> Settings:
             inst = Settings.from_environment(start_path=_bootstrap_state.start_path)
         except Exception:
             logger.exception(
-                "Failed to initialize settings from environment (start_path=%s)",
+                "Failed to initialize credentials from environment (start_path=%s)",
                 _bootstrap_state.start_path,
             )
             raise
+        globals()["credentials"] = inst
         globals()["settings"] = inst
         return inst
+
+
+def _get_settings() -> Settings:
+    """Return the legacy alias for the process-wide credentials singleton."""
+    cached = globals().get("settings")
+    if cached is not None:
+        return cast("Settings", cached)
+    inst = _get_credentials()
+    globals()["settings"] = inst
+    return cast("Settings", inst)
 
 
 def _get_runtime_state() -> RuntimeState:
@@ -6003,7 +6020,7 @@ def _get_runtime_state() -> RuntimeState:
         return state
 
 
-def __getattr__(name: str) -> Settings | RuntimeState | Console:
+def __getattr__(name: str) -> Credentials | RuntimeState | Console:
     """Lazy module attributes for process-wide state and the console.
 
     Defers heavy initialization until first access. Subsequent accesses hit
@@ -6017,6 +6034,8 @@ def __getattr__(name: str) -> Settings | RuntimeState | Console:
     """
     if name == "settings":
         return _get_settings()
+    if name == "credentials":
+        return _get_credentials()
     if name == "runtime_state":
         return _get_runtime_state()
     if name == "console":

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -7,7 +7,7 @@ locations. The typed defaults for config-file-only options (notably the
 its dataclass defaults from them — so a default is defined in exactly one place.
 
 Resolution runs through the shared `ConfigResolver` (see
-`configuration.resolver`): the runtime (`Settings.from_environment`) reads the
+`configuration.resolver`): the runtime (`Credentials.from_environment`) reads the
 shared process resolver and the `config` CLI command builds one from the
 generation it snapshots, so introspection can never drift from what the app
 actually reads. Resolution precedence mirrors the loaders: managed TOML beats

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1825,9 +1825,9 @@ def check_optional_tools(*, config_path: Path | None = None) -> list[str]:
     ):
         missing.append("ripgrep")
 
-    from deepagents_code.config import settings
+    from deepagents_code.config import credentials
 
-    if not settings.has_tavily and not is_warning_suppressed("tavily", config_path):
+    if not credentials.has_tavily and not is_warning_suppressed("tavily", config_path):
         missing.append("tavily")
 
     return missing
@@ -3361,8 +3361,8 @@ async def _run_acp_cli_async(
     from deepagents_code.agent import create_cli_agent, load_async_subagents
     from deepagents_code.config import (
         create_model,
+        credentials,
         is_memory_auto_save_enabled,
-        settings,
     )
     from deepagents_code.model_config import (
         ModelConfigError,
@@ -3422,7 +3422,7 @@ async def _run_acp_cli_async(
     ]
 
     tools: list[Any] = [fetch_url, get_current_thread_id]
-    if settings.has_tavily:
+    if credentials.has_tavily:
         tools.append(web_search)
 
     mcp_session_manager = None
@@ -5070,14 +5070,14 @@ def cli_main() -> None:
                 exc_info=True,
             )
 
-        # Import console/settings AFTER arg parsing and after the bare-help
+        # Import console/credentials AFTER arg parsing and after the bare-help
         # fast path so neither argparse's `--help`/`-h` exit nor
-        # `deepagents <group>` pays the settings bootstrap cost. `settings`
+        # `deepagents <group>` pays the credentials bootstrap cost. `credentials`
         # must be named here even though this scope does not read it: the
         # import is what triggers `_ensure_bootstrap()` (dotenv loading), and
         # commands dispatched below — notably `auth status` — resolve
         # credentials from the environment expecting `.env` to be loaded.
-        from deepagents_code.config import console, settings  # noqa: F401
+        from deepagents_code.config import console, credentials  # noqa: F401
 
         if command is None:
             # The health gate already ran above, for every command, so the

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -101,11 +101,11 @@ async def _build_tools(
         FileNotFoundError: If the MCP config file is not found.
         RuntimeError: If MCP tool loading fails.
     """
-    from deepagents_code.config import settings
+    from deepagents_code.config import credentials
     from deepagents_code.tools import fetch_url, get_current_thread_id, web_search
 
     tools: list[Any] = [fetch_url, get_current_thread_id]
-    if settings.has_tavily:
+    if credentials.has_tavily:
         tools.append(web_search)
 
     mcp_server_info: list[Any] | None = None
@@ -249,12 +249,12 @@ async def _make_graphs() -> ServerRuntime:
         from deepagents_code.config import (
             configure_langsmith_secret_redaction,
             create_model,
+            credentials,
             is_memory_auto_save_enabled,
-            settings,
         )
 
         if project_context is not None:
-            settings.reload_from_environment(start_path=project_context.user_cwd)
+            credentials.reload_from_environment(start_path=project_context.user_cwd)
         return (
             project_context,
             create_cli_agent,

--- a/libs/code/deepagents_code/skills/commands.py
+++ b/libs/code/deepagents_code/skills/commands.py
@@ -156,14 +156,14 @@ def _list(
     """
     from rich.markup import escape as escape_markup
 
-    from deepagents_code.config import Settings, console, get_glyphs
+    from deepagents_code.config import Credentials, console, get_glyphs
     from deepagents_code.skills.load import list_skills
 
-    settings = Settings.from_environment()
+    credentials = Credentials.from_environment()
     user_skills_dir = get_user_skills_dir(agent)
-    project_skills_dir = get_project_skills_dir(settings.project_root)
+    project_skills_dir = get_project_skills_dir(credentials.project_root)
     user_agent_skills_dir = get_user_agent_skills_dir()
-    project_agent_skills_dir = get_project_agent_skills_dir(settings.project_root)
+    project_agent_skills_dir = get_project_agent_skills_dir(credentials.project_root)
 
     # If --project flag is used, only show project skills
     if project:
@@ -421,7 +421,7 @@ def _create(
     """
     from rich.markup import escape as escape_markup
 
-    from deepagents_code.config import Settings, console, get_glyphs
+    from deepagents_code.config import Credentials, console, get_glyphs
 
     # Validate skill name first (per Agent Skills spec)
     is_valid, error_msg = _validate_name(skill_name)
@@ -436,9 +436,9 @@ def _create(
         raise SystemExit(1)
 
     # Determine target directory
-    settings = Settings.from_environment()
+    credentials = Credentials.from_environment()
     if project:
-        if not settings.project_root:
+        if not credentials.project_root:
             console.print("[bold red]Error:[/bold red] Not in a project directory.")
             console.print(
                 "[dim]Project skills require a .git directory "
@@ -446,7 +446,7 @@ def _create(
                 style=theme.MUTED,
             )
             raise SystemExit(1)
-        skills_dir = ensure_project_skills_dir(settings.project_root)
+        skills_dir = ensure_project_skills_dir(credentials.project_root)
         if skills_dir is None:
             console.print(
                 "[bold red]Error:[/bold red] Could not create project skills directory."
@@ -551,14 +551,14 @@ def _info(
     """
     from rich.markup import escape as escape_markup
 
-    from deepagents_code.config import Settings, console
+    from deepagents_code.config import Credentials, console
     from deepagents_code.skills.load import list_skills
 
-    settings = Settings.from_environment()
+    credentials = Credentials.from_environment()
     user_skills_dir = get_user_skills_dir(agent)
-    project_skills_dir = get_project_skills_dir(settings.project_root)
+    project_skills_dir = get_project_skills_dir(credentials.project_root)
     user_agent_skills_dir = get_user_agent_skills_dir()
-    project_agent_skills_dir = get_project_agent_skills_dir(settings.project_root)
+    project_agent_skills_dir = get_project_agent_skills_dir(credentials.project_root)
 
     # Load skills based on --project flag
     if project:
@@ -697,7 +697,7 @@ def _delete(
     """
     from rich.markup import escape as escape_markup
 
-    from deepagents_code.config import Settings, console, get_glyphs
+    from deepagents_code.config import Credentials, console, get_glyphs
     from deepagents_code.skills.load import list_skills
 
     # Validate skill name first (per Agent Skills spec)
@@ -706,11 +706,11 @@ def _delete(
         console.print(f"[bold red]Error:[/bold red] Invalid skill name: {error_msg}")
         raise SystemExit(1)
 
-    settings = Settings.from_environment()
+    credentials = Credentials.from_environment()
     user_skills_dir = get_user_skills_dir(agent)
-    project_skills_dir = get_project_skills_dir(settings.project_root)
+    project_skills_dir = get_project_skills_dir(credentials.project_root)
     user_agent_skills_dir = get_user_agent_skills_dir()
-    project_agent_skills_dir = get_project_agent_skills_dir(settings.project_root)
+    project_agent_skills_dir = get_project_agent_skills_dir(credentials.project_root)
 
     # Load skills based on --project flag
     if project:

--- a/libs/code/deepagents_code/skills/invocation.py
+++ b/libs/code/deepagents_code/skills/invocation.py
@@ -61,7 +61,7 @@ def discover_skills_and_roots(
     """
     from pathlib import Path
 
-    from deepagents_code.config import _use_extra_skills_path_base, settings
+    from deepagents_code.config import _use_extra_skills_path_base, credentials
     from deepagents_code.config_manifest import _emit_ranked_diagnostics, get_option
     from deepagents_code.configuration.resolver import get_config_resolver
     from deepagents_code.skills.load import list_skills
@@ -71,11 +71,13 @@ def discover_skills_and_roots(
         built_in_skills_dir=get_built_in_skills_dir(),
         plugin_skill_sources=plugin_skill_sources,
         user_skills_dir=get_user_skills_dir(assistant_id),
-        project_skills_dir=get_project_skills_dir(settings.project_root),
+        project_skills_dir=get_project_skills_dir(credentials.project_root),
         user_agent_skills_dir=get_user_agent_skills_dir(),
-        project_agent_skills_dir=get_project_agent_skills_dir(settings.project_root),
+        project_agent_skills_dir=get_project_agent_skills_dir(credentials.project_root),
         user_claude_skills_dir=get_user_claude_skills_dir(),
-        project_claude_skills_dir=get_project_claude_skills_dir(settings.project_root),
+        project_claude_skills_dir=get_project_claude_skills_dir(
+            credentials.project_root
+        ),
     )
     roots = [
         path.resolve()
@@ -83,11 +85,11 @@ def discover_skills_and_roots(
             get_built_in_skills_dir(),
             *plugin_skill_roots,
             get_user_skills_dir(assistant_id),
-            get_project_skills_dir(settings.project_root),
+            get_project_skills_dir(credentials.project_root),
             get_user_agent_skills_dir(),
-            get_project_agent_skills_dir(settings.project_root),
+            get_project_agent_skills_dir(credentials.project_root),
             get_user_claude_skills_dir(),
-            get_project_claude_skills_dir(settings.project_root),
+            get_project_claude_skills_dir(credentials.project_root),
         )
         if path is not None
     ]

--- a/libs/code/deepagents_code/tool_catalog.py
+++ b/libs/code/deepagents_code/tool_catalog.py
@@ -228,13 +228,13 @@ def collect_built_in_tools(
         RuntimeError: If the compiled graph does not expose its bound tools.
     """
     from deepagents_code.agent import create_cli_agent
-    from deepagents_code.config import settings
+    from deepagents_code.config import credentials
     from deepagents_code.tools import fetch_url, get_current_thread_id, web_search
 
     # Keep in sync with `server_graph._build_tools`: web_search is bound only
     # when Tavily is configured, so it appears here only under the same gate.
     custom_tools: list[Any] = [fetch_url, get_current_thread_id]
-    if settings.has_tavily:
+    if credentials.has_tavily:
         custom_tools.append(web_search)
 
     agent, _backend = create_cli_agent(

--- a/libs/code/deepagents_code/tools.py
+++ b/libs/code/deepagents_code/tools.py
@@ -292,12 +292,12 @@ def _get_tavily_client() -> TavilyClient | None:
     if _tavily_client is not _UNSET:
         return _tavily_client  # ty: ignore[invalid-return-type]  # narrowed by sentinel check
 
-    from deepagents_code.config import settings
+    from deepagents_code.config import credentials
 
-    if settings.has_tavily:
+    if credentials.has_tavily:
         from tavily import TavilyClient as _TavilyClient
 
-        _tavily_client = _TavilyClient(api_key=settings.tavily_api_key)
+        _tavily_client = _TavilyClient(api_key=credentials.tavily_api_key)
     else:
         _tavily_client = None
     return _tavily_client

--- a/libs/code/tests/unit_tests/skills/test_commands.py
+++ b/libs/code/tests/unit_tests/skills/test_commands.py
@@ -980,7 +980,7 @@ class TestDeleteSkill:
         mock_settings.get_project_agent_skills_dir.return_value = None
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_skills_dir, project=None),
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
@@ -1005,7 +1005,7 @@ class TestDeleteSkill:
             output.append(" ".join(str(a) for a in args))
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_skills_dir, project=None),
             patch("deepagents_code.config.console") as mock_console,
         ):
@@ -1034,7 +1034,7 @@ class TestDeleteSkill:
         mock_settings.get_project_agent_skills_dir.return_value = None
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_skills_dir, project=None),
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
@@ -1056,7 +1056,7 @@ class TestDeleteSkill:
         mock_settings.get_project_agent_skills_dir.return_value = None
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_skills_dir, project=None),
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
@@ -1078,7 +1078,7 @@ class TestDeleteSkill:
         mock_settings.get_project_agent_skills_dir.return_value = None
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_skills_dir, project=None),
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
@@ -1100,7 +1100,7 @@ class TestDeleteSkill:
         mock_settings.get_project_agent_skills_dir.return_value = None
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_skills_dir, project=None),
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
@@ -1122,7 +1122,7 @@ class TestDeleteSkill:
         mock_settings.get_project_agent_skills_dir.return_value = None
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_skills_dir, project=None),
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
@@ -1156,7 +1156,7 @@ class TestDeleteSkill:
             output.clear()
 
             with (
-                patch("deepagents_code.config.Settings") as mock_settings_cls,
+                patch("deepagents_code.config.Credentials") as mock_settings_cls,
                 _patch_skill_paths(user=user_skills_dir, project=None),
                 patch("deepagents_code.config.console") as mock_console,
             ):
@@ -1185,7 +1185,7 @@ class TestDeleteSkill:
         mock_settings.get_project_agent_skills_dir.return_value = None
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_dir, project=project_skills_dir),
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
@@ -1206,7 +1206,7 @@ class TestDeleteSkill:
             output.append(" ".join(str(a) for a in args))
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_dir, project=None),
             patch("deepagents_code.config.console") as mock_console,
         ):
@@ -1240,7 +1240,7 @@ class TestDeleteSkill:
         mock_settings.get_project_agent_skills_dir.return_value = None
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_skills_dir, project=None),
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
@@ -1266,7 +1266,7 @@ class TestDeleteSkill:
         mock_settings.get_project_agent_skills_dir.return_value = None
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=agent1_skills_dir, project=None),
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
@@ -1293,7 +1293,7 @@ class TestDeleteSkill:
             output.append(" ".join(str(a) for a in args))
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(user=user_skills_dir, project=None),
             patch("deepagents_code.config.console") as mock_console,
             patch("shutil.rmtree", side_effect=OSError("Permission denied")),
@@ -1327,7 +1327,7 @@ class TestDeleteSkill:
             output.append(" ".join(str(a) for a in args))
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             _patch_skill_paths(
                 user=None,
                 project=None,
@@ -1414,7 +1414,7 @@ class TestDeleteArgparsing:
             output.append(" ".join(str(a) for a in args_p))
 
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             patch("deepagents_code.config.console") as mock_console,
         ):
             mock_settings_cls.from_environment.return_value = mock_settings

--- a/libs/code/tests/unit_tests/skills/test_skills_json.py
+++ b/libs/code/tests/unit_tests/skills/test_skills_json.py
@@ -23,7 +23,7 @@ class TestSkillsListJson:
         ]
         buf = StringIO()
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             patch(
                 "deepagents_code.skills.commands.get_user_skills_dir",
                 return_value=tmp_path / "skills",
@@ -56,7 +56,7 @@ class TestSkillsListJson:
         """JSON mode returns empty array when no skills found."""
         buf = StringIO()
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             patch(
                 "deepagents_code.skills.commands.get_user_skills_dir",
                 return_value=tmp_path / "skills",
@@ -99,7 +99,7 @@ class TestSkillsInfoJson:
         ]
         buf = StringIO()
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             patch(
                 "deepagents_code.skills.commands.get_user_skills_dir",
                 return_value=tmp_path / "skills",
@@ -138,7 +138,7 @@ class TestSkillsCreateJson:
 
         buf = StringIO()
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             patch(
                 "deepagents_code.skills.commands.ensure_user_skills_dir",
                 return_value=skills_dir,
@@ -177,7 +177,7 @@ class TestSkillsDeleteJson:
         ]
         buf = StringIO()
         with (
-            patch("deepagents_code.config.Settings") as mock_settings_cls,
+            patch("deepagents_code.config.Credentials") as mock_settings_cls,
             patch(
                 "deepagents_code.skills.commands.get_user_skills_dir",
                 return_value=skills_dir,

--- a/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -113,7 +113,7 @@ def _mock_settings(tmp_path: Path) -> Generator[None, None, None]:
     skills_dir.mkdir(parents=True)
 
     with (
-        patch("deepagents_code.agent.settings") as mock_s,
+        patch("deepagents_code.agent.credentials") as mock_s,
         patch("deepagents_code.agent.runtime_state") as mock_runtime_state,
         patch("deepagents_code.agent.ensure_agent_dir", return_value=agent_dir),
         patch(

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -96,7 +96,7 @@ def _resolve_shell_policy_from_patched_settings() -> Iterator[None]:
     def resolve() -> list[str] | None:
         return cast(
             "list[str] | None",
-            getattr(agent_module.settings, "_test_shell_allow_list", None),
+            getattr(agent_module.credentials, "_test_shell_allow_list", None),
         )
 
     with patch.object(agent_module, "_resolve_shell_allow_list", resolve):
@@ -1543,7 +1543,7 @@ class TestGetSystemPromptModelIdentity:
         runtime_state.model_unsupported_modalities = frozenset()
         runtime_state.model_context_limit = 200000
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "### Model Identity" in prompt
@@ -1559,7 +1559,7 @@ class TestGetSystemPromptModelIdentity:
         runtime_state.model_unsupported_modalities = frozenset()
         runtime_state.model_context_limit = 200000
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "### Model Identity" not in prompt
@@ -1570,7 +1570,7 @@ class TestGetSystemPromptModelIdentity:
         runtime_state.model_name = None
         mock_settings.has_tavily = False
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         expected = PATHS.display(PATHS.profile.agent_skills_dir("test-agent"))
@@ -1585,7 +1585,7 @@ class TestGetSystemPromptModelIdentity:
         runtime_state.model_unsupported_modalities = frozenset()
         runtime_state.model_context_limit = 128000
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "### Model Identity" in prompt
@@ -1601,7 +1601,7 @@ class TestGetSystemPromptModelIdentity:
         runtime_state.model_unsupported_modalities = frozenset()
         runtime_state.model_context_limit = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "### Model Identity" in prompt
@@ -1617,7 +1617,7 @@ class TestGetSystemPromptModelIdentity:
         runtime_state.model_unsupported_modalities = frozenset()
         runtime_state.model_context_limit = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "### Model Identity" in prompt
@@ -1635,7 +1635,7 @@ class TestGetSystemPromptModelIdentity:
         )
         runtime_state.model_context_limit = 64000
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "Audio, image, pdf, and video input may not be available" in prompt
@@ -1648,7 +1648,7 @@ class TestGetSystemPromptModelIdentity:
         runtime_state.model_unsupported_modalities = frozenset({"audio"})
         runtime_state.model_context_limit = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "Audio input may not be available" in prompt
@@ -1661,7 +1661,7 @@ class TestGetSystemPromptModelIdentity:
         runtime_state.model_unsupported_modalities = frozenset()
         runtime_state.model_context_limit = 200000
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "may not be available" not in prompt
@@ -1675,7 +1675,7 @@ class TestGetSystemPromptWebSearch:
         runtime_state.model_name = None
         mock_settings.has_tavily = False
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "### Web Search Tool Usage" not in prompt
@@ -1686,7 +1686,7 @@ class TestGetSystemPromptWebSearch:
         runtime_state.model_name = None
         mock_settings.has_tavily = True
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "### Web Search Tool Usage" in prompt
@@ -1700,7 +1700,7 @@ class TestGetSystemPromptNonInteractive:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=True)
 
         assert "interactive TUI" in prompt
@@ -1710,7 +1710,7 @@ class TestGetSystemPromptNonInteractive:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
 
         assert "non-interactive" in prompt
@@ -1720,7 +1720,7 @@ class TestGetSystemPromptNonInteractive:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
 
         assert "ask questions before acting" not in prompt
@@ -1729,7 +1729,7 @@ class TestGetSystemPromptNonInteractive:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
 
         assert "Do NOT ask clarifying questions" in prompt
@@ -1739,7 +1739,7 @@ class TestGetSystemPromptNonInteractive:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
 
         assert "non-interactive command variants" in prompt
@@ -1749,7 +1749,7 @@ class TestGetSystemPromptNonInteractive:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "interactive TUI" in prompt
@@ -1764,7 +1764,7 @@ class TestGetSystemPromptNonInteractive:
         runtime_state.model_name = None
 
         for interactive in (True, False):
-            with patch("deepagents_code.agent.settings", mock_settings):
+            with patch("deepagents_code.agent.credentials", mock_settings):
                 prompt = get_system_prompt("test-agent", interactive=interactive)
 
             assert "Todo List Management" not in prompt
@@ -1782,7 +1782,7 @@ class TestGetSystemPromptCwdOSError:
         runtime_state.model_name = None
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.Path.cwd", side_effect=OSError("deleted")),
         ):
             prompt = get_system_prompt("test-agent")
@@ -1797,7 +1797,7 @@ class TestGetSystemPromptSandbox:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", sandbox_type="modal")
 
         assert "do NOT have access to the user's local filesystem" in prompt
@@ -1806,7 +1806,7 @@ class TestGetSystemPromptSandbox:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", sandbox_type="modal")
 
         assert "/workspace" in prompt
@@ -1816,7 +1816,7 @@ class TestGetSystemPromptSandbox:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", sandbox_type="daytona")
 
         assert "subagents" in prompt
@@ -1826,7 +1826,7 @@ class TestGetSystemPromptSandbox:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "do NOT have access to the user's local filesystem" not in prompt
@@ -1840,7 +1840,7 @@ class TestGetSystemPromptFilesystemTools:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt(
                 "test-agent",
                 fs_tools=["read_file", "execute"],
@@ -1854,7 +1854,7 @@ class TestGetSystemPromptFilesystemTools:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt(
                 "test-agent",
                 fs_tools=["read_file", "edit_file"],
@@ -1868,7 +1868,7 @@ class TestGetSystemPromptFilesystemTools:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
 
         assert "`edit_file` over" in prompt
@@ -1882,7 +1882,7 @@ class TestGetSystemPromptPlaceholderValidation:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=True)
 
         # No raw {placeholder} patterns should remain
@@ -1894,7 +1894,7 @@ class TestGetSystemPromptPlaceholderValidation:
         mock_settings = Mock()
         runtime_state.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
+        with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
 
         import re
@@ -1939,7 +1939,7 @@ class TestCreateCliAgentInteractiveForwarding:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -2005,7 +2005,7 @@ class TestCreateCliAgentInteractiveForwarding:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch("deepagents_code.agent.create_deep_agent", return_value=mock_agent),
@@ -2057,7 +2057,7 @@ class TestListAgents:
             output.append(" ".join(str(a) for a in args))
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch(
                 "deepagents_code.agent.user_deepagents_dir",
                 return_value=agents_dir,
@@ -2098,7 +2098,7 @@ class TestListAgents:
             output.append(" ".join(str(a) for a in args))
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.console") as mock_console,
         ):
             mock_console.print = capture_print
@@ -2135,7 +2135,7 @@ class TestListAgentsJson:
 
         buf = StringIO()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch(
                 "deepagents_code.agent.user_deepagents_dir",
                 return_value=agents_dir,
@@ -2171,7 +2171,7 @@ class TestListAgentsJson:
 
         buf = StringIO()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch(
                 "deepagents_code.agent.user_deepagents_dir",
                 return_value=agents_dir,
@@ -2200,7 +2200,7 @@ class TestListAgentsJson:
 
         buf = StringIO()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch(
                 "deepagents_code.agent.user_deepagents_dir",
                 return_value=agents_dir,
@@ -2232,7 +2232,7 @@ class TestListAgentsJson:
             output.append(" ".join(str(a) for a in args))
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.console") as mock_console,
         ):
             mock_console.print = capture_print
@@ -2258,7 +2258,7 @@ class TestResetAgentJson:
 
         buf = StringIO()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("sys.stdout", buf),
         ):
             from deepagents_code.agent import reset_agent
@@ -2333,7 +2333,7 @@ class TestCreateCliAgentSkillsSources:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             _patch_agent_paths(
                 agent_dir=agent_dir,
                 skills_dir=skills_dir,
@@ -2435,7 +2435,7 @@ class TestCreateCliAgentSkillsSources:
         mock_agent = Mock()
         mock_agent.with_config.return_value = mock_agent
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             _patch_agent_paths(
                 agent_dir=agent_dir,
                 skills_dir=skills_dir,
@@ -2509,7 +2509,7 @@ class TestCreateCliAgentMemorySources:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             _patch_agent_paths(
                 agent_dir=agent_dir,
                 skills_dir=skills_dir,
@@ -2579,7 +2579,7 @@ class TestCreateCliAgentMemorySources:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             _patch_agent_paths(
                 agent_dir=agent_dir,
                 skills_dir=skills_dir,
@@ -2653,7 +2653,7 @@ class TestCreateCliAgentMemoryAutoSave:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware", FakeMemoryMiddleware),
             patch(
@@ -2758,7 +2758,7 @@ class TestCreateCliAgentProjectContext:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             _patch_agent_paths(
                 agent_dir=agent_dir,
                 skills_dir=user_skills_dir,
@@ -2842,7 +2842,7 @@ class TestCreateCliAgentProjectContext:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             _patch_agent_paths(
                 agent_dir=agent_dir,
                 skills_dir=user_skills_dir,
@@ -2919,7 +2919,7 @@ class TestCreateCliAgentProjectContext:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch(
@@ -3045,7 +3045,7 @@ class TestCreateCliAgentProjectContext:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.create_deep_agent", return_value=mock_agent),
@@ -3110,7 +3110,7 @@ class TestMiddlewareStackConformance:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch(
                 "deepagents_code.agent.create_deep_agent",
                 side_effect=capture_create_agent,
@@ -3196,7 +3196,7 @@ class TestEnableAskUser:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch(
                 "deepagents_code.agent.create_deep_agent",
                 side_effect=capture,
@@ -3543,7 +3543,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -3582,7 +3582,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -3628,7 +3628,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         }
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -3686,7 +3686,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         }
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -3739,7 +3739,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         }
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -3792,7 +3792,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         }
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -3850,7 +3850,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         fake_model = _make_fake_chat_model()
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -3949,7 +3949,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         ]
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4062,7 +4062,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         }
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4115,7 +4115,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         }
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4165,7 +4165,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         }
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4219,7 +4219,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         }
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4363,7 +4363,7 @@ class TestCreateCliAgentFsToolsWiring:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4401,7 +4401,7 @@ class TestCreateCliAgentFsToolsWiring:
         fs_calls, fs_factory = self._fs_middleware_spy()
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4457,7 +4457,7 @@ class TestCreateCliAgentFsToolsWiring:
         fake_model = _make_fake_chat_model()
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4532,7 +4532,7 @@ class TestCreateCliAgentFsToolsWiring:
         fake_model = _make_fake_chat_model()
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4592,7 +4592,7 @@ class TestCreateCliAgentFsToolsWiring:
         fs_calls, fs_factory = self._fs_middleware_spy()
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4668,7 +4668,7 @@ class TestCreateCliAgentFsToolsWiring:
         fs_calls, fs_factory = self._fs_middleware_spy()
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4751,7 +4751,7 @@ class TestCreateCliAgentFsToolsWiring:
         }
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4846,7 +4846,7 @@ class TestCreateCliAgentFsToolsWiring:
 
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -4940,7 +4940,7 @@ class TestAutoModeSubagentHITLWiring:
         }
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -5320,7 +5320,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent.with_config.return_value = mock_agent
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -5867,7 +5867,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent.with_config.return_value = mock_agent
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -5939,7 +5939,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent = Mock()
         mock_agent.with_config.return_value = mock_agent
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -5988,7 +5988,7 @@ class TestCreateCliAgentInterpreterWiring:
             FilesystemBackend(root_dir=tmp_path, virtual_mode=False),
         )
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -6037,7 +6037,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent.with_config.return_value = mock_agent
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -6089,7 +6089,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent.with_config.return_value = mock_agent
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -6148,7 +6148,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent.with_config.return_value = mock_agent
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -6192,7 +6192,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent.with_config.return_value = mock_agent
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch("deepagents_code.agent.ReliableRubricMiddleware") as mock_rubric,
@@ -6601,7 +6601,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent.with_config.return_value = mock_agent
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -6636,7 +6636,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent.with_config.return_value = mock_agent
         fake_model = _make_fake_chat_model()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -6666,7 +6666,7 @@ class TestCreateCliAgentInterpreterWiring:
         fake_model = _make_fake_chat_model()
         fake_sandbox = Mock()
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -6707,7 +6707,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent = Mock()
         mock_agent.with_config.return_value = mock_agent
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -6750,7 +6750,7 @@ class TestCreateCliAgentInterpreterWiring:
             return ""
 
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
@@ -6799,7 +6799,7 @@ class TestCreateCliAgentInterpreterWiring:
         mock_agent = Mock()
         mock_agent.with_config.return_value = mock_agent
         with (
-            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.credentials", mock_settings),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(

--- a/libs/code/tests/unit_tests/test_agent_friendly.py
+++ b/libs/code/tests/unit_tests/test_agent_friendly.py
@@ -114,7 +114,7 @@ class TestResetDryRun:
         buf = io.StringIO()
         test_console = Console(file=buf, highlight=False, width=200)
         with (
-            patch("deepagents_code.agent.settings") as mock_settings,
+            patch("deepagents_code.agent.credentials") as mock_settings,
             patch("deepagents_code.agent.console", test_console),
             patch(
                 "deepagents_code.agent.get_default_coding_instructions",
@@ -140,7 +140,7 @@ class TestResetDryRun:
 
         stdout_buf = io.StringIO()
         with (
-            patch("deepagents_code.agent.settings") as mock_settings,
+            patch("deepagents_code.agent.credentials") as mock_settings,
             patch("deepagents_code.agent.console"),
             patch(
                 "deepagents_code.agent.get_default_coding_instructions",
@@ -363,7 +363,7 @@ class TestSkillsCreateIdempotency:
         mock_settings.project_root = None
         mock_settings.ensure_user_skills_dir.return_value = tmp_path
         with (
-            patch("deepagents_code.config.Settings") as settings_cls,
+            patch("deepagents_code.config.Credentials") as settings_cls,
             patch(
                 "deepagents_code.skills.commands.ensure_user_skills_dir",
                 return_value=tmp_path,
@@ -390,7 +390,7 @@ class TestSkillsCreateIdempotency:
         mock_settings.project_root = None
         mock_settings.ensure_user_skills_dir.return_value = tmp_path
         with (
-            patch("deepagents_code.config.Settings") as settings_cls,
+            patch("deepagents_code.config.Credentials") as settings_cls,
             patch(
                 "deepagents_code.skills.commands.ensure_user_skills_dir",
                 return_value=tmp_path,
@@ -542,7 +542,7 @@ class TestErrorMessageHints:
         buf = io.StringIO()
         test_console = Console(file=buf, highlight=False, width=200)
         with (  # separate to satisfy PT012
-            patch("deepagents_code.agent.settings") as mock_settings,
+            patch("deepagents_code.agent.credentials") as mock_settings,
             patch("deepagents_code.agent.console", test_console),
         ):
             mock_settings.user_deepagents_dir = tmp_path

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2308,7 +2308,9 @@ class TestStartupSequence:
         app._push_screen_wait = AsyncMock(side_effect=capture_prompt)  # ty: ignore
 
         with (
-            patch("deepagents_code.config.settings", SimpleNamespace(has_tavily=False)),
+            patch(
+                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=False)
+            ),
             patch(
                 "deepagents_code.model_config.apply_stored_service_credentials"
             ) as apply_credentials,
@@ -2340,7 +2342,9 @@ class TestStartupSequence:
         app._push_screen_wait = AsyncMock(return_value=AuthResult.CANCELLED)  # ty: ignore
 
         with (
-            patch("deepagents_code.config.settings", SimpleNamespace(has_tavily=False)),
+            patch(
+                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=False)
+            ),
             patch(
                 "deepagents_code.model_config.apply_stored_service_credentials"
             ) as apply_credentials,
@@ -2356,7 +2360,9 @@ class TestStartupSequence:
         app._push_screen_wait = push_screen_wait  # ty: ignore
 
         with (
-            patch("deepagents_code.config.settings", SimpleNamespace(has_tavily=True)),
+            patch(
+                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=True)
+            ),
             patch("deepagents_code.auth_store.set_stored_key") as set_stored_key,
         ):
             await app._prompt_launch_tavily()
@@ -2381,7 +2387,9 @@ class TestStartupSequence:
             monkeypatch.setenv("TAVILY_API_KEY", "tvly-real-key")
 
         with (
-            patch("deepagents_code.config.settings", SimpleNamespace(has_tavily=False)),
+            patch(
+                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=False)
+            ),
             patch(
                 "deepagents_code.model_config.apply_stored_service_credentials",
                 side_effect=export_key,
@@ -2408,7 +2416,9 @@ class TestStartupSequence:
         app.notify = notify_mock  # ty: ignore
 
         with (
-            patch("deepagents_code.config.settings", SimpleNamespace(has_tavily=False)),
+            patch(
+                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=False)
+            ),
             # No side_effect: the export is a no-op, so `TAVILY_API_KEY` stays
             # unset (the autouse `_clear_tavily_env` fixture cleared it).
             patch(
@@ -26531,7 +26541,7 @@ class TestSwitchAgentGuards:
         (tmp_path / "coder").mkdir()
         async with app.run_test():
             with (
-                patch("deepagents_code.config.settings") as mock_settings,
+                patch("deepagents_code.config.credentials") as mock_settings,
                 patch(
                     "deepagents_code.app.user_deepagents_dir",
                     return_value=tmp_path,
@@ -26554,7 +26564,7 @@ class TestSwitchAgentGuards:
         (tmp_path / "researcher").mkdir()
         async with app.run_test():
             with (
-                patch("deepagents_code.config.settings") as mock_settings,
+                patch("deepagents_code.config.credentials") as mock_settings,
                 patch(
                     "deepagents_code.app.user_deepagents_dir",
                     return_value=tmp_path,

--- a/libs/code/tests/unit_tests/test_auth_web_search_restart.py
+++ b/libs/code/tests/unit_tests/test_auth_web_search_restart.py
@@ -35,10 +35,10 @@ class TestNoteWebSearchRestart:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A saved Tavily key on a Tavily-less running server arms the offer."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         _fake_tavily_export(monkeypatch)
 
         app = DeepAgentsApp()
@@ -51,9 +51,9 @@ class TestNoteWebSearchRestart:
 
     def test_ignores_non_tavily_service(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Model-provider keys don't gate a spawn-time tool, so no offer."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         _fake_tavily_export(monkeypatch)
 
         app = DeepAgentsApp()
@@ -68,9 +68,9 @@ class TestNoteWebSearchRestart:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A server spawned with Tavily already bound `web_search`."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", "tvly-existing")
+        monkeypatch.setattr(credentials, "tavily_api_key", "tvly-existing")
 
         app = DeepAgentsApp()
         app._server_proc = MagicMock()
@@ -82,9 +82,9 @@ class TestNoteWebSearchRestart:
 
     def test_skips_when_no_owned_server(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """With no owned subprocess there is nothing to respawn."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         _fake_tavily_export(monkeypatch)
 
         app = DeepAgentsApp()
@@ -104,10 +104,10 @@ class TestNoteWebSearchRestart:
         `apply_stored_service_credentials` exports nothing; without an env key
         a respawn couldn't bind `web_search`, so there is nothing to offer.
         """
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         monkeypatch.setattr(
             "deepagents_code.model_config.apply_stored_service_credentials",
             lambda: None,
@@ -141,10 +141,10 @@ class TestNoteWebSearchRestart:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Deleting Tavily still removes `/auth` export after prompt scheduling."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         _fake_tavily_export(monkeypatch)
 
         app = DeepAgentsApp()
@@ -162,10 +162,10 @@ class TestNoteWebSearchRestart:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Deleting Tavily restores a shell key that `/auth` temporarily replaced."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
         monkeypatch.setenv("TAVILY_API_KEY", "tvly-from-shell")
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         _fake_tavily_export(monkeypatch)
 
         app = DeepAgentsApp()
@@ -225,7 +225,7 @@ class TestNoteWebSearchRestart:
 class TestOfferRestartForWebSearch:
     """`_offer_restart_for_web_search` messaging and restart dispatch.
 
-    Each test pins `settings.tavily_api_key` to `None` so the idempotent
+    Each test pins `credentials.tavily_api_key` to `None` so the idempotent
     "already configured" guard never short-circuits the offer under test; the
     guard itself is covered by `test_skips_offer_when_tavily_already_configured`.
     """
@@ -234,9 +234,9 @@ class TestOfferRestartForWebSearch:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A remote/not-owned server can't be `/restart`ed — recommend relaunch."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         app = DeepAgentsApp()
         app._server_proc = None
         app._server_kwargs = None
@@ -256,9 +256,9 @@ class TestOfferRestartForWebSearch:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """An owned-but-busy server points at `/restart`, never a relaunch."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         app = DeepAgentsApp()
         app._server_proc = MagicMock()
         app._server_kwargs = {"model_name": "anthropic:fake"}
@@ -279,9 +279,9 @@ class TestOfferRestartForWebSearch:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Choosing restart respawns the owned server via `_restart_after_install`."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         app = DeepAgentsApp()
         app._server_proc = MagicMock()
         app._server_kwargs = {"model_name": "anthropic:fake"}
@@ -301,9 +301,9 @@ class TestOfferRestartForWebSearch:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A chosen restart that can't run surfaces a web-search fallback hint."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         app = DeepAgentsApp()
         app._server_proc = MagicMock()
         app._server_kwargs = {"model_name": "anthropic:fake"}
@@ -330,9 +330,9 @@ class TestOfferRestartForWebSearch:
         auto-restarted the server (reloading config and rebinding `web_search`),
         so by the time the reopened manager closes there is nothing left to do.
         """
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", "tvly-now-configured")
+        monkeypatch.setattr(credentials, "tavily_api_key", "tvly-now-configured")
         app = DeepAgentsApp()
         app._server_proc = MagicMock()
         app._server_kwargs = {"model_name": "anthropic:fake"}
@@ -357,9 +357,9 @@ class TestOfferRestartForWebSearch:
         stays silent (neither restarts nor mounts a `/restart` hint) when the
         user picks "later".
         """
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         app = DeepAgentsApp()
         app._server_proc = MagicMock()
         app._server_kwargs = {"model_name": "anthropic:fake"}
@@ -378,9 +378,9 @@ class TestOfferRestartForWebSearch:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A prompt that never resolves is bounded by the watchdog → manual hint."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         app = DeepAgentsApp()
         app._server_proc = MagicMock()
         app._server_kwargs = {"model_name": "anthropic:fake"}
@@ -404,9 +404,9 @@ class TestOfferRestartForWebSearch:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """If the modal can't be mounted at all, degrade to the manual hint."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
 
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         app = DeepAgentsApp()
         app._server_proc = MagicMock()
         app._server_kwargs = {"model_name": "anthropic:fake"}
@@ -436,11 +436,11 @@ class TestCredentialSavedHandler:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Saving Tavily flags the offer without waiting for the manager to close."""
-        from deepagents_code.config import settings
+        from deepagents_code.config import credentials
         from deepagents_code.tui.widgets.auth import AuthManagerScreen
 
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
-        monkeypatch.setattr(settings, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
         _fake_tavily_export(monkeypatch)
 
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -37,6 +37,7 @@ from deepagents_code.config import (
     MODEL_RETRIES_ATTR,
     RECOMMENDED_SAFE_SHELL_COMMANDS,
     SHELL_ALLOW_ALL,
+    Credentials,
     LangSmithApiError,
     LangSmithProjectNotFoundError,
     LangsmithShadowResult,
@@ -2517,7 +2518,7 @@ class TestGetLangsmithProjectName:
         }
         with (
             patch.dict("os.environ", env, clear=False),
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.credentials") as mock_settings,
         ):
             mock_settings.deepagents_langchain_project = "settings-project"
             assert get_langsmith_project_name() == "settings-project"
@@ -2531,7 +2532,7 @@ class TestGetLangsmithProjectName:
         }
         with (
             patch.dict("os.environ", env, clear=False),
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.credentials") as mock_settings,
         ):
             mock_settings.deepagents_langchain_project = None
             assert get_langsmith_project_name() == "env-project"
@@ -2546,7 +2547,7 @@ class TestGetLangsmithProjectName:
         }
         with (
             patch.dict("os.environ", env, clear=False),
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.credentials") as mock_settings,
         ):
             mock_settings.deepagents_langchain_project = None
             assert get_langsmith_project_name() == LANGSMITH_PROJECT_DEFAULT
@@ -2562,7 +2563,7 @@ class TestGetLangsmithProjectName:
         }
         with (
             patch.dict("os.environ", env, clear=False),
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.credentials") as mock_settings,
         ):
             mock_settings.deepagents_langchain_project = None
             assert get_langsmith_project_name() == LANGSMITH_PROJECT_DEFAULT
@@ -2614,7 +2615,7 @@ class TestGetLangsmithProjectName:
         }
         with (
             patch.dict("os.environ", bare_env, clear=False),
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.credentials") as mock_settings,
         ):
             mock_settings.deepagents_langchain_project = None
             manifest_value = resolve()
@@ -2629,7 +2630,7 @@ class TestGetLangsmithProjectName:
         }
         with (
             patch.dict("os.environ", default_env, clear=False),
-            patch("deepagents_code.config.settings") as mock_settings,
+            patch("deepagents_code.config.credentials") as mock_settings,
         ):
             mock_settings.deepagents_langchain_project = None
             manifest_value = resolve()
@@ -6576,7 +6577,15 @@ class TestDetectProvider:
 
 
 class TestLazyModuleAttributes:
-    """Tests for lazy `__getattr__` resolution of `settings` and `console`."""
+    """Tests for lazy process-wide state and console resolution."""
+
+    def test_getattr_returns_credentials(self) -> None:
+        """The credentials accessor shares the compatibility singleton."""
+        from deepagents_code.config import _get_credentials, _get_settings
+
+        result = _get_credentials()
+        assert isinstance(result, Credentials)
+        assert result is _get_settings()
 
     def test_getattr_returns_settings(self) -> None:
         """Module __getattr__ resolves 'settings' to a Settings instance."""

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -7,6 +7,7 @@ import textwrap
 import time
 import warnings
 from collections.abc import Iterator
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, ClassVar
 from unittest.mock import Mock, patch
@@ -6031,10 +6032,13 @@ max_tokens = 1024
     ) -> None:
         """Explicit model params outrank Google Cloud environment defaults."""
         mock_init_chat_model.return_value = _make_init_chat_model_mock()
-        with (
-            patch.object(settings, "google_cloud_project", "env-project"),
-            patch.object(settings, "google_cloud_location", "us-east5"),
-        ):
+        owner = config_module._get_credentials()
+        replacement = replace(
+            owner.active,
+            google_cloud_project="env-project",
+            google_cloud_location="us-east5",
+        )
+        with patch.object(owner, "_active", replacement):
             create_model(
                 "google_anthropic_vertex:claude-sonnet-4-6",
                 extra_kwargs={"project": "param-project", "location": "europe-west1"},
@@ -6045,9 +6049,14 @@ max_tokens = 1024
 
     def test_google_anthropic_vertex_requires_location(self) -> None:
         """Missing Claude-on-Vertex location produces an actionable error."""
+        owner = config_module._get_credentials()
+        replacement = replace(
+            owner.active,
+            google_cloud_project="test-project",
+            google_cloud_location=None,
+        )
         with (
-            patch.object(settings, "google_cloud_project", "test-project"),
-            patch.object(settings, "google_cloud_location", None),
+            patch.object(owner, "_active", replacement),
             pytest.raises(
                 ModelConfigError,
                 match=r"GOOGLE_CLOUD_LOCATION.*DEEPAGENTS_CODE_GOOGLE_CLOUD_LOCATION",
@@ -6586,6 +6595,8 @@ class TestLazyModuleAttributes:
         result = _get_credentials()
         assert isinstance(result, Credentials)
         assert result is _get_settings()
+        assert result is _get_credentials()
+        assert result.active is result.active
 
     def test_getattr_returns_settings(self) -> None:
         """Module __getattr__ resolves 'settings' to a Settings instance."""

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -1692,24 +1692,22 @@ def test_interpreter_defaults_match_resolver_snapshot() -> None:
     assert get_config_resolver().get(enabled).value == enabled.default
 
 
-def test_every_settings_field_names_a_real_settings_attribute() -> None:
-    """Catch a typo'd `settings_field` on any option, not just interpreter ones.
+def test_every_settings_field_names_a_credential_field() -> None:
+    """Catch a typo'd credential `settings_field` on any option.
 
     `settings_field` is a free-form string with no compile-time link to the
-    `Settings` dataclass, so a misspelling would only surface at runtime
-    `getattr`. This locks the mapping across the whole catalog.
+    credential snapshot, so a misspelling would only surface at runtime. This
+    locks the remaining mapping across the whole catalog.
     """
-    from dataclasses import fields
+    from deepagents_code.config import _CREDENTIAL_FIELDS
 
-    from deepagents_code.config import Settings
-
-    valid = {f.name for f in fields(Settings)}
     bad = {
         opt.key: opt.settings_field
         for opt in get_config_options()
-        if opt.settings_field is not None and opt.settings_field not in valid
+        if opt.settings_field is not None
+        and opt.settings_field not in _CREDENTIAL_FIELDS
     }
-    assert not bad, f"options reference unknown Settings fields: {bad}"
+    assert not bad, f"options reference unknown credential fields: {bad}"
 
 
 # --- Resolution -------------------------------------------------------------

--- a/libs/code/tests/unit_tests/test_end_to_end.py
+++ b/libs/code/tests/unit_tests/test_end_to_end.py
@@ -89,7 +89,7 @@ def mock_settings(
 
     # Patch settings
     with (
-        patch("deepagents_code.agent.settings") as mock_settings_obj,
+        patch("deepagents_code.agent.credentials") as mock_settings_obj,
         patch("deepagents_code.agent.runtime_state") as mock_runtime_state,
         patch(
             "deepagents_code.agent._offload_fallback_root",

--- a/libs/code/tests/unit_tests/test_install_command.py
+++ b/libs/code/tests/unit_tests/test_install_command.py
@@ -889,7 +889,9 @@ async def test_install_restart_capable_extra_offers_restart_when_idle() -> None:
             patch.object(
                 app, "_push_screen_wait", new=AsyncMock(return_value="restart")
             ) as prompt,
-            patch("deepagents_code.config.settings.reload_from_environment", _reload),
+            patch(
+                "deepagents_code.config.credentials.reload_from_environment", _reload
+            ),
             patch("deepagents_code.model_config.clear_caches", _clear),
             patch.object(
                 app,
@@ -1034,7 +1036,9 @@ async def test_install_package_offers_restart_when_idle() -> None:
             patch.object(
                 app, "_push_screen_wait", new=AsyncMock(return_value="restart")
             ) as prompt,
-            patch("deepagents_code.config.settings.reload_from_environment", _reload),
+            patch(
+                "deepagents_code.config.credentials.reload_from_environment", _reload
+            ),
             patch("deepagents_code.model_config.clear_caches", _clear),
             patch.object(
                 app,
@@ -1153,7 +1157,7 @@ async def test_install_restart_failure_omits_complete_message() -> None:
             patch.object(
                 app, "_push_screen_wait", new=AsyncMock(return_value="restart")
             ) as prompt,
-            patch("deepagents_code.config.settings.reload_from_environment", list),
+            patch("deepagents_code.config.credentials.reload_from_environment", list),
             patch("deepagents_code.model_config.clear_caches", lambda: None),
             patch.object(
                 app, "_restart_server_manual", new=AsyncMock(return_value=False)
@@ -1186,7 +1190,7 @@ async def test_install_restart_raising_removes_transient_and_propagates() -> Non
         app._server_kwargs = {"model_name": "fireworks:fake"}
 
         with (
-            patch("deepagents_code.config.settings.reload_from_environment", list),
+            patch("deepagents_code.config.credentials.reload_from_environment", list),
             patch("deepagents_code.model_config.clear_caches", lambda: None),
             patch.object(
                 app,

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -3206,7 +3206,7 @@ class TestCheckOptionalTools:
     def _tavily_available(self) -> Iterator[None]:
         """Patch settings.has_tavily to True so ripgrep-only tests stay isolated."""
         with patch(
-            "deepagents_code.config.settings",
+            "deepagents_code.config.credentials",
             SimpleNamespace(has_tavily=True),
         ):
             yield
@@ -3286,7 +3286,7 @@ class TestCheckOptionalTools:
         with (
             patch("deepagents_code.main.shutil.which", return_value="/usr/bin/rg"),
             patch(
-                "deepagents_code.config.settings",
+                "deepagents_code.config.credentials",
                 SimpleNamespace(has_tavily=False),
             ),
         ):
@@ -3309,7 +3309,7 @@ class TestCheckOptionalTools:
         with (
             patch("deepagents_code.main.shutil.which", return_value="/usr/bin/rg"),
             patch(
-                "deepagents_code.config.settings",
+                "deepagents_code.config.credentials",
                 SimpleNamespace(has_tavily=False),
             ),
         ):

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -217,7 +217,9 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server(
             side_effect=AssertionError("check_cli_dependencies should be skipped"),
         ),
         patch("deepagents_code.main.parse_args", return_value=args),
-        patch("deepagents_code.config.settings", new=SimpleNamespace(has_tavily=True)),
+        patch(
+            "deepagents_code.config.credentials", new=SimpleNamespace(has_tavily=True)
+        ),
         patch(
             "deepagents_code.config.is_memory_auto_save_enabled", return_value=False
         ) as mock_memory_auto_save,
@@ -317,7 +319,9 @@ def test_acp_mode_auto_forwards_classifier_and_store() -> None:
     with (
         patch.object(sys, "argv", ["deepagents", "--acp", "--auto-approve"]),
         patch("deepagents_code.main.parse_args", return_value=args),
-        patch("deepagents_code.config.settings", new=SimpleNamespace(has_tavily=False)),
+        patch(
+            "deepagents_code.config.credentials", new=SimpleNamespace(has_tavily=False)
+        ),
         patch("deepagents_code.model_config.save_recent_model", return_value=True),
         patch("deepagents_code.config.create_model", return_value=model_result),
         patch(
@@ -373,7 +377,9 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
             side_effect=AssertionError("check_cli_dependencies should be skipped"),
         ),
         patch("deepagents_code.main.parse_args", return_value=args),
-        patch("deepagents_code.config.settings", new=SimpleNamespace(has_tavily=False)),
+        patch(
+            "deepagents_code.config.credentials", new=SimpleNamespace(has_tavily=False)
+        ),
         patch("deepagents_code.model_config.save_recent_model", return_value=True),
         patch("deepagents_code.config.create_model", return_value=model_result),
         patch(
@@ -427,7 +433,9 @@ def test_acp_mode_forwards_allow_fs_tools() -> None:
             side_effect=AssertionError("check_cli_dependencies should be skipped"),
         ),
         patch("deepagents_code.main.parse_args", return_value=args),
-        patch("deepagents_code.config.settings", new=SimpleNamespace(has_tavily=False)),
+        patch(
+            "deepagents_code.config.credentials", new=SimpleNamespace(has_tavily=False)
+        ),
         patch("deepagents_code.model_config.save_recent_model", return_value=True),
         patch("deepagents_code.config.create_model", return_value=model_result),
         patch(
@@ -474,7 +482,9 @@ def test_acp_mode_forwards_none_allow_fs_tools_by_default() -> None:
             side_effect=AssertionError("check_cli_dependencies should be skipped"),
         ),
         patch("deepagents_code.main.parse_args", return_value=args),
-        patch("deepagents_code.config.settings", new=SimpleNamespace(has_tavily=False)),
+        patch(
+            "deepagents_code.config.credentials", new=SimpleNamespace(has_tavily=False)
+        ),
         patch("deepagents_code.model_config.save_recent_model", return_value=True),
         patch("deepagents_code.config.create_model", return_value=model_result),
         patch(
@@ -526,7 +536,9 @@ def test_acp_mode_forwards_recursion_limit() -> None:
             side_effect=AssertionError("check_cli_dependencies should be skipped"),
         ),
         patch("deepagents_code.main.parse_args", return_value=args),
-        patch("deepagents_code.config.settings", new=SimpleNamespace(has_tavily=False)),
+        patch(
+            "deepagents_code.config.credentials", new=SimpleNamespace(has_tavily=False)
+        ),
         patch("deepagents_code.model_config.save_recent_model", return_value=True),
         patch("deepagents_code.config.create_model", return_value=model_result),
         patch(

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -7,6 +7,7 @@ import threading
 import tomllib
 from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager, suppress
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, ClassVar, cast
 from unittest.mock import MagicMock, patch
@@ -6718,16 +6719,21 @@ recent = "openai:gpt-5.2"
 
     def test_env_used_when_neither_set(self, tmp_path):
         """Falls back to env var auto-detection when neither default nor recent set."""
-        from deepagents_code.config import _get_default_model_spec, settings
+        from deepagents_code.config import _get_credentials, _get_default_model_spec
 
         config_path = tmp_path / "config.toml"
         config_path.write_text("")
 
+        owner = _get_credentials()
+        replacement = replace(
+            owner.active,
+            openai_api_key=None,
+            anthropic_api_key="test-key",
+        )
         with (
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
             patch("deepagents_code.auth_store.get_stored_key", return_value=None),
-            patch.object(settings, "openai_api_key", None),
-            patch.object(settings, "anthropic_api_key", "test-key"),
+            patch.object(owner, "_active", replacement),
             patch.dict(
                 "os.environ",
                 {"ANTHROPIC_API_KEY": "test-key"},
@@ -6759,42 +6765,52 @@ recent = "openai:gpt-5.2"
 
     def test_vertex_project_does_not_drive_env_default(self, tmp_path):
         """Vertex project alone should not select an automatic default model."""
-        from deepagents_code.config import _get_default_model_spec, settings
+        from deepagents_code.config import _get_credentials, _get_default_model_spec
         from deepagents_code.model_config import ModelConfigError
 
         config_path = tmp_path / "config.toml"
         config_path.write_text("")
 
+        owner = _get_credentials()
+        replacement = replace(
+            owner.active,
+            openai_api_key=None,
+            anthropic_api_key=None,
+            google_api_key=None,
+            google_cloud_project="test-project",
+            nvidia_api_key=None,
+        )
         with (
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
             patch("deepagents_code.auth_store.get_stored_key", return_value=None),
             patch.dict("os.environ", {}, clear=True),
-            patch.object(settings, "openai_api_key", None),
-            patch.object(settings, "anthropic_api_key", None),
-            patch.object(settings, "google_api_key", None),
-            patch.object(settings, "google_cloud_project", "test-project"),
-            patch.object(settings, "nvidia_api_key", None),
+            patch.object(owner, "_active", replacement),
             pytest.raises(ModelConfigError),
         ):
             _get_default_model_spec()
 
     def test_nvidia_key_does_not_drive_env_default(self, tmp_path):
         """NVIDIA key alone should not select an automatic default model."""
-        from deepagents_code.config import _get_default_model_spec, settings
+        from deepagents_code.config import _get_credentials, _get_default_model_spec
         from deepagents_code.model_config import ModelConfigError
 
         config_path = tmp_path / "config.toml"
         config_path.write_text("")
 
+        owner = _get_credentials()
+        replacement = replace(
+            owner.active,
+            openai_api_key=None,
+            anthropic_api_key=None,
+            google_api_key=None,
+            google_cloud_project=None,
+            nvidia_api_key="test-key",
+        )
         with (
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
             patch("deepagents_code.auth_store.get_stored_key", return_value=None),
             patch.dict("os.environ", {}, clear=True),
-            patch.object(settings, "openai_api_key", None),
-            patch.object(settings, "anthropic_api_key", None),
-            patch.object(settings, "google_api_key", None),
-            patch.object(settings, "google_cloud_project", None),
-            patch.object(settings, "nvidia_api_key", "test-key"),
+            patch.object(owner, "_active", replacement),
             pytest.raises(ModelConfigError),
         ):
             _get_default_model_spec()

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -125,6 +125,67 @@ class TestReloadFromEnvironment:
         assert settings.openai_api_key == "sk-new-key"
         assert "openai_api_key: unset -> set" in changes
 
+    def test_reload_publishes_one_complete_replacement(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Readers retain the old generation until one complete swap."""
+        import deepagents_code.config as config_mod
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-old")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic-old")
+        owner = Settings.from_environment(start_path=tmp_path)
+        previous = owner.active
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-new")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic-new")
+        observed: list[object] = []
+
+        def observe_before_publication(
+            _values: object, *, path_base: Path | None
+        ) -> None:
+            assert path_base == tmp_path
+            observed.append(owner.active)
+
+        monkeypatch.setattr(
+            config_mod, "_sync_reload_overrides", observe_before_publication
+        )
+
+        owner.reload_from_environment(start_path=tmp_path)
+
+        current = owner.active
+        assert observed == [previous]
+        assert current is not previous
+        assert previous.openai_api_key == "sk-openai-old"
+        assert previous.anthropic_api_key == "sk-anthropic-old"
+        assert current.openai_api_key == "sk-openai-new"
+        assert current.anthropic_api_key == "sk-anthropic-new"
+
+    def test_reload_failure_keeps_previous_snapshot(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A failure after candidate construction cannot publish it."""
+        import deepagents_code.config as config_mod
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-old")
+        owner = Settings.from_environment(start_path=tmp_path)
+        previous = owner.active
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-new")
+
+        def fail_before_publication(_values: object, *, path_base: Path | None) -> None:
+            del path_base
+            msg = "resolver publication failed"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(
+            config_mod, "_sync_reload_overrides", fail_before_publication
+        )
+
+        with pytest.raises(RuntimeError, match="resolver publication failed"):
+            owner.reload_from_environment(start_path=tmp_path)
+
+        assert owner.active is previous
+        assert owner.openai_api_key == "sk-old"
+
     def test_preview_reload_reports_changes_without_mutating(
         self, tmp_path: Path
     ) -> None:
@@ -1436,6 +1497,7 @@ class TestReloadErrorPaths:
         model_config.clear_caches()
         try:
             settings = Settings.from_environment(start_path=current)
+            previous_credentials = settings.active
             previous = _extra_skills_dirs()
             assert previous == [current / "managed-skills"]
             original_resolve = config_mod._resolve_extra_skills_path
@@ -1455,6 +1517,7 @@ class TestReloadErrorPaths:
             changes = settings.reload_from_environment(start_path=target)
 
             assert config_mod.managed_reload_block(changes) is not None
+            assert settings.active is previous_credentials
             assert _extra_skills_dirs() == previous
             assert _extra_skills_dirs() != [user_skills]
         finally:

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -84,6 +84,35 @@ _RELOAD_ENV_KEYS = (
 )
 
 
+def test_settings_constructor_preserves_legacy_credential_fields(
+    tmp_path: Path,
+) -> None:
+    """The intermediate compatibility class keeps its dataclass signature."""
+    settings = Settings(
+        openai_api_key="openai",
+        anthropic_api_key="anthropic",
+        google_api_key="google",
+        nvidia_api_key="nvidia",
+        tavily_api_key="tavily",
+        google_cloud_project="project",
+        google_cloud_location="location",
+        deepagents_langchain_project="agent-project",
+        user_langchain_project="user-project",
+        project_root=tmp_path,
+    )
+
+    assert settings.openai_api_key == "openai"
+    assert settings.anthropic_api_key == "anthropic"
+    assert settings.google_api_key == "google"
+    assert settings.nvidia_api_key == "nvidia"
+    assert settings.tavily_api_key == "tavily"
+    assert settings.google_cloud_project == "project"
+    assert settings.google_cloud_location == "location"
+    assert settings.deepagents_langchain_project == "agent-project"
+    assert settings.user_langchain_project == "user-project"
+    assert settings.project_root == tmp_path
+
+
 class TestReloadFromEnvironment:
     """Tests for `Settings.reload_from_environment`."""
 

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -262,7 +262,7 @@ class TestServerGraph:
             configure_langsmith_secret_redaction=configure_redaction,
             create_model=create_model,
             is_memory_auto_save_enabled=MagicMock(return_value=True),
-            settings=SimpleNamespace(
+            credentials=SimpleNamespace(
                 has_tavily=True,
                 reload_from_environment=reload_from_environment,
             ),
@@ -413,7 +413,7 @@ class TestServerGraph:
         resolve_mcp_tools = AsyncMock()
         config_module = _module_with_attrs(
             "deepagents_code.config",
-            settings=SimpleNamespace(has_tavily=False),
+            credentials=SimpleNamespace(has_tavily=False),
         )
         tools_module = _module_with_attrs(
             "deepagents_code.tools",
@@ -474,7 +474,7 @@ class TestServerGraph:
                 ),
             ),
             is_memory_auto_save_enabled=MagicMock(return_value=True),
-            settings=settings_obj,
+            credentials=settings_obj,
         )
         agent_module = _module_with_attrs(
             "deepagents_code.agent",
@@ -540,7 +540,7 @@ class TestServerGraph:
         resolve_mcp_tools = AsyncMock(return_value=(discovered_mcp_tools, None, []))
         config_module = _module_with_attrs(
             "deepagents_code.config",
-            settings=SimpleNamespace(has_tavily=False),
+            credentials=SimpleNamespace(has_tavily=False),
         )
         tools_module = _module_with_attrs(
             "deepagents_code.tools",
@@ -605,7 +605,7 @@ class TestServerGraph:
 
         config_module = _module_with_attrs(
             "deepagents_code.config",
-            settings=SimpleNamespace(has_tavily=False),
+            credentials=SimpleNamespace(has_tavily=False),
         )
         tools_module = _module_with_attrs(
             "deepagents_code.tools",

--- a/libs/code/tests/unit_tests/test_skill_invocation.py
+++ b/libs/code/tests/unit_tests/test_skill_invocation.py
@@ -441,7 +441,7 @@ class TestHandleSkillCommand:
         app = _make_app()
         with (
             patch("deepagents_code.skills.load.list_skills", return_value=[]),
-            patch("deepagents_code.config.settings"),
+            patch("deepagents_code.config.credentials"),
         ):
             await app._handle_skill_command("/skill:nonexistent")
 
@@ -455,7 +455,7 @@ class TestHandleSkillCommand:
         with (
             patch("deepagents_code.skills.load.list_skills", return_value=[skill]),
             patch("deepagents_code.skills.load.load_skill_content", return_value=None),
-            patch("deepagents_code.config.settings"),
+            patch("deepagents_code.config.credentials"),
         ):
             await app._handle_skill_command("/skill:test-skill")
 
@@ -475,7 +475,7 @@ class TestHandleSkillCommand:
                     "all allowed skill directories."
                 ),
             ),
-            patch("deepagents_code.config.settings"),
+            patch("deepagents_code.config.credentials"),
         ):
             await app._handle_skill_command("/skill:test-skill")
 
@@ -489,7 +489,7 @@ class TestHandleSkillCommand:
         with (
             patch("deepagents_code.skills.load.list_skills", return_value=[skill]),
             patch("deepagents_code.skills.load.load_skill_content", return_value=""),
-            patch("deepagents_code.config.settings"),
+            patch("deepagents_code.config.credentials"),
         ):
             await app._handle_skill_command("/skill:test-skill")
 
@@ -508,7 +508,7 @@ class TestHandleSkillCommand:
                 "deepagents_code.skills.load.load_skill_content",
                 return_value="# Instructions\nDo stuff",
             ),
-            patch("deepagents_code.config.settings"),
+            patch("deepagents_code.config.credentials"),
         ):
             await app._handle_skill_command("/skill:test-skill")
 
@@ -532,7 +532,7 @@ class TestHandleSkillCommand:
                 "deepagents_code.skills.load.load_skill_content",
                 return_value="# Instructions\nDo stuff",
             ),
-            patch("deepagents_code.config.settings"),
+            patch("deepagents_code.config.credentials"),
         ):
             await app._handle_skill_command("/skill:test-skill find quantum")
 
@@ -553,7 +553,7 @@ class TestHandleSkillCommand:
                 "deepagents_code.skills.load.load_skill_content",
                 return_value="# Instructions\nDo stuff",
             ),
-            patch("deepagents_code.config.settings"),
+            patch("deepagents_code.config.credentials"),
         ):
             await app._invoke_skill("test-skill", "  keep leading whitespace")
 
@@ -572,7 +572,7 @@ class TestHandleSkillCommand:
                 "deepagents_code.skills.load.list_skills",
                 side_effect=PermissionError("access denied"),
             ),
-            patch("deepagents_code.config.settings"),
+            patch("deepagents_code.config.credentials"),
         ):
             await app._handle_skill_command("/skill:test-skill")
 
@@ -587,7 +587,7 @@ class TestHandleSkillCommand:
                 "deepagents_code.skills.load.list_skills",
                 side_effect=TypeError("bad argument"),
             ),
-            patch("deepagents_code.config.settings"),
+            patch("deepagents_code.config.credentials"),
         ):
             await app._handle_skill_command("/skill:test-skill")
 
@@ -640,7 +640,7 @@ class TestHandleSkillCommand:
                 "deepagents_code.skills.load.load_skill_content",
                 return_value="# Fresh\nContent",
             ),
-            patch("deepagents_code.config.settings"),
+            patch("deepagents_code.config.credentials"),
         ):
             await app._handle_skill_command("/skill:new-skill")
 
@@ -916,7 +916,7 @@ class TestDiscoverSkillsAndRoots:
 
         with (
             patch(
-                "deepagents_code.config.settings",
+                "deepagents_code.config.credentials",
                 SimpleNamespace(project_root=tmp_path),
             ),
             patch("deepagents_code.skills.load.list_skills", return_value=[]),

--- a/libs/code/tests/unit_tests/test_skill_invocation.py
+++ b/libs/code/tests/unit_tests/test_skill_invocation.py
@@ -952,7 +952,7 @@ class TestDiscoverSkillsAndRoots:
 
         with (
             patch(
-                "deepagents_code.config.settings",
+                "deepagents_code.config.credentials",
                 SimpleNamespace(project_root=project_root),
             ),
             patch("deepagents_code.skills.load.list_skills", return_value=[]),

--- a/libs/code/tests/unit_tests/test_threads_resume.py
+++ b/libs/code/tests/unit_tests/test_threads_resume.py
@@ -397,7 +397,7 @@ class TestCrossAgentResume:
         app._restart_server_for_agent_swap = AsyncMock(return_value=True)  # ty: ignore
 
         with (
-            patch("deepagents_code.config.settings") as settings,
+            patch("deepagents_code.config.credentials") as settings,
             patch(
                 "deepagents_code.app.user_deepagents_dir",
                 return_value=tmp_path,
@@ -432,7 +432,7 @@ class TestCrossAgentResume:
         app._fetch_thread_history_data = fetch  # ty: ignore
 
         with (
-            patch("deepagents_code.config.settings") as settings,
+            patch("deepagents_code.config.credentials") as settings,
             patch(
                 "deepagents_code.app.user_deepagents_dir",
                 return_value=tmp_path,

--- a/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
@@ -1378,7 +1378,7 @@ api_key_url = "javascript:alert(1)"
             return []
 
         monkeypatch.setattr(
-            "deepagents_code.config.settings.reload_from_environment",
+            "deepagents_code.config.credentials.reload_from_environment",
             blocked_reload,
         )
         app = _AuthHostApp()
@@ -1407,7 +1407,7 @@ api_key_url = "javascript:alert(1)"
             return []
 
         monkeypatch.setattr(
-            "deepagents_code.config.settings.reload_from_environment",
+            "deepagents_code.config.credentials.reload_from_environment",
             reload_from_environment,
         )
         app = _AuthHostApp()
@@ -1441,7 +1441,7 @@ api_key_url = "javascript:alert(1)"
             notices.append((str(message), severity))
 
         monkeypatch.setattr(
-            "deepagents_code.config.settings.reload_from_environment",
+            "deepagents_code.config.credentials.reload_from_environment",
             lambda: [blocked],
         )
         cache_cleared = False
@@ -1534,7 +1534,7 @@ api_key_url = "javascript:alert(1)"
                 raise ValueError(msg)
 
             monkeypatch.setattr(
-                "deepagents_code.config.settings.reload_from_environment", _boom
+                "deepagents_code.config.credentials.reload_from_environment", _boom
             )
             await pilot.press("ctrl+r")
             await pilot.pause()


### PR DESCRIPTION
Credentials and environment-derived project context have a reload lifecycle separate from tiered configuration. `Credentials` now owns API keys, provider/project metadata, capability checks, and `project_root`, including preview and reload behavior. Reloads construct a replacement before swapping it into use, preserve policy on failure, mask key changes, retain the bootstrap-owned user project, and keep `LANGSMITH_PROJECT` synchronized.

Part 4 of 6 in the [`Settings` dissolution stack](https://github.com/langchain-ai/deepagents/pull/5859?stack=5864).
