### PR TITLE
fix(code): hide MCP token path outside debug mode

### DIFF
--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -48,6 +48,7 @@ from mcp.shared.auth import (
 )
 from pydantic import BaseModel, ConfigDict, ValidationError
 
+from deepagents_code._env_vars import DEBUG, is_env_truthy
 from deepagents_code._paths import PATHS
 from deepagents_code.mcp_config import resolve_mcp_server_env
 
@@ -2187,9 +2188,9 @@ async def login(
         ui=ui,
     )
 
-    success_message = (
-        f"Logged in to MCP server '{server_name}'. Tokens saved to {storage.path}."
-    )
+    success_message = f"Logged in to MCP server '{server_name}'."
+    if is_env_truthy(DEBUG):
+        success_message += f" Tokens saved to {storage.path}."
 
     if result.completed:
         await ui.show_success(success_message)

--- a/libs/code/tests/unit_tests/test_mcp_oauth_ui.py
+++ b/libs/code/tests/unit_tests/test_mcp_oauth_ui.py
@@ -132,6 +132,7 @@ class TestLoginWithoutStdio:
 
         from deepagents_code.mcp_auth import login
 
+        monkeypatch.delenv(DEBUG, raising=False)
         monkeypatch.setattr("webbrowser.open", lambda _url: False)
 
         captured: list[str] = []

--- a/libs/code/tests/unit_tests/test_mcp_oauth_ui.py
+++ b/libs/code/tests/unit_tests/test_mcp_oauth_ui.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from deepagents_code._env_vars import DEBUG
 from deepagents_code.mcp_auth import FileTokenStorage
 
 if TYPE_CHECKING:
@@ -175,8 +176,39 @@ class TestLoginWithoutStdio:
         shown_url, opened = ui.authorize_urls[0]
         assert "team=T01234567" in shown_url
         assert opened is False
-        assert ui.successes, "login() must report success via the UI"
-        assert "Logged in to MCP server 'slack'" in ui.successes[-1]
+        assert ui.successes == ["Logged in to MCP server 'slack'."]
+
+    @pytest.mark.usefixtures("fake_home")
+    async def test_success_message_includes_token_location_in_debug_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Debug mode includes the token location in the success message."""
+        from deepagents_code.mcp_auth import login
+        from deepagents_code.mcp_providers import LoginResult
+
+        monkeypatch.setenv(DEBUG, "1")
+        ui = RecordingOAuthInteraction()
+
+        with patch(
+            "deepagents_code.mcp_providers.GenericProvider.run_login",
+            AsyncMock(return_value=LoginResult(completed=True)),
+        ):
+            await login(
+                server_name="langsmith",
+                server_config={
+                    "type": "http",
+                    "url": "https://api.smith.langchain.com/mcp",
+                    "auth": "oauth",
+                },
+                ui=ui,
+            )
+
+        token_path = FileTokenStorage(
+            "langsmith", server_url="https://api.smith.langchain.com/mcp"
+        ).path
+        assert ui.successes == [
+            f"Logged in to MCP server 'langsmith'. Tokens saved to {token_path}."
+        ]
 
     @pytest.mark.usefixtures("fake_home")
     async def test_github_device_flow_with_recording_ui(


### PR DESCRIPTION
MCP login success messages no longer expose the local token file location unless debug mode is enabled.

---

The token path is useful for troubleshooting but unnecessarily reveals local filesystem details in normal output. The success message now includes it only when `DEEPAGENTS_CODE_DEBUG` is truthy, with focused coverage for both modes.

Made by [Open SWE](https://openswe.vercel.app/agents/9d7c98e8-f252-5de1-acfa-08b78bf8eb70)