### PR TITLE
feat(code): list MCP servers needing login

### DIFF
--- a/libs/code/deepagents_code/client/commands/mcp.py
+++ b/libs/code/deepagents_code/client/commands/mcp.py
@@ -118,6 +118,7 @@ async def run_mcp_login_list(*, config_path: str | None) -> int:
 
     _print_resolution_notices(resolution)
     from deepagents_code.mcp_auth import FileTokenStorage, format_login_failure
+    from deepagents_code.mcp_config import resolve_mcp_server_env
     from deepagents_code.mcp_tools import _drop_invalid_mcp_config_servers
 
     valid_config, errors = _drop_invalid_mcp_config_servers(resolution.config)
@@ -131,7 +132,16 @@ async def run_mcp_login_list(*, config_path: str | None) -> int:
     for server_name, server_config in valid_config["mcpServers"].items():
         if server_config.get("auth") != "oauth":
             continue
-        storage = FileTokenStorage(server_name, server_url=server_config["url"])
+        try:
+            resolved_config = resolve_mcp_server_env(server_name, server_config)
+        except (RuntimeError, TypeError) as exc:
+            print(  # noqa: T201
+                f"Invalid MCP server config for {server_name!r}: {exc}",
+                file=sys.stderr,
+            )
+            unreadable += 1
+            continue
+        storage = FileTokenStorage(server_name, server_url=resolved_config["url"])
         try:
             tokens = await storage.get_tokens()
         except (OSError, RuntimeError, ValueError) as exc:

--- a/libs/code/deepagents_code/client/commands/mcp.py
+++ b/libs/code/deepagents_code/client/commands/mcp.py
@@ -9,7 +9,10 @@ if TYPE_CHECKING:
     import argparse
     from collections.abc import Callable
 
-    from deepagents_code.mcp_login_service import ConfigResolutionError
+    from deepagents_code.mcp_login_service import (
+        ConfigResolution,
+        ConfigResolutionError,
+    )
 
 
 def _lazy_ui_help(fn_name: str) -> Callable[[], None]:
@@ -52,10 +55,14 @@ def setup_mcp_parsers(
 
     login_parser = mcp_sub.add_parser(
         "login",
-        help="Run the OAuth login flow for an MCP server",
+        help="List servers needing login or run an OAuth login flow",
         add_help=False,
     )
-    login_parser.add_argument("server", help="Server name from mcpServers config")
+    login_parser.add_argument(
+        "server",
+        nargs="?",
+        help="Server name from mcpServers config; omit to list servers needing login",
+    )
     login_parser.add_argument(
         "--mcp-config",
         dest="config_path",
@@ -79,6 +86,75 @@ def setup_mcp_parsers(
         "--help",
         action=make_help_action(_lazy_ui_help("show_mcp_config_help")),
     )
+
+
+async def run_mcp_login_list(*, config_path: str | None) -> int:
+    """List configured OAuth servers without stored tokens.
+
+    Returns:
+        Process exit code: 0 on success, 1 on config failure, or 2 when no
+            config file was found.
+    """
+    from deepagents_code._invocation import invoked_name
+    from deepagents_code.mcp_login_service import (
+        ConfigErrorKind,
+        ConfigResolution,
+        ConfigResolutionError,
+        resolve_mcp_config,
+    )
+    from deepagents_code.ui import console
+
+    resolution = resolve_mcp_config(config_path)
+    if isinstance(resolution, ConfigResolutionError):
+        _print_resolution_error(resolution)
+        return 2 if resolution.kind is ConfigErrorKind.NO_CONFIG_FOUND else 1
+    if not isinstance(resolution, ConfigResolution):  # pragma: no cover - safety
+        print(  # noqa: T201
+            "Internal error: unexpected result from resolve_mcp_config. "
+            "Please report this bug.",
+            file=sys.stderr,
+        )
+        return 1
+
+    _print_resolution_notices(resolution)
+    from deepagents_code.mcp_auth import FileTokenStorage, format_login_failure
+    from deepagents_code.mcp_tools import _drop_invalid_mcp_config_servers
+
+    valid_config, errors = _drop_invalid_mcp_config_servers(resolution.config)
+    for server_name, error in errors.items():
+        print(  # noqa: T201
+            f"Invalid MCP server config for {server_name!r}: {error}", file=sys.stderr
+        )
+
+    needs_login: list[str] = []
+    for server_name, server_config in valid_config["mcpServers"].items():
+        if server_config.get("auth") != "oauth":
+            continue
+        storage = FileTokenStorage(server_name, server_url=server_config["url"])
+        try:
+            tokens = await storage.get_tokens()
+        except (OSError, RuntimeError, ValueError) as exc:
+            print(  # noqa: T201
+                f"Could not read login state for {server_name!r}: "
+                f"{format_login_failure(exc)}",
+                file=sys.stderr,
+            )
+            continue
+        if tokens is None:
+            needs_login.append(server_name)
+
+    if not needs_login:
+        console.print("No MCP servers need login.")
+        return 0
+    console.print("MCP servers needing login:")
+    for server_name in needs_login:
+        console.print(f"  {server_name}", markup=False)
+    console.print()
+    console.print(
+        f"Run `{invoked_name()} mcp login <server>` to authenticate.",
+        markup=False,
+    )
+    return 0
 
 
 # Maintainer note: `deepagents-talon` dynamically imports `run_mcp_login` from
@@ -112,12 +188,6 @@ async def run_mcp_login(*, server: str, config_path: str | None) -> int:
         ConfigErrorKind,
         ConfigResolution,
         ConfigResolutionError,
-        format_legacy_env_ignored_notice,
-        format_legacy_ignored_notice,
-        format_load_errors_notice,
-        format_malformed_approvals_notice,
-        format_policy_error_notice,
-        format_untrusted_project_notice,
         resolve_mcp_config,
         select_server,
     )
@@ -136,31 +206,7 @@ async def run_mcp_login(*, server: str, config_path: str | None) -> int:
         )
         return 1
 
-    # A policy read failure and an "untrusted project" skip are mutually
-    # exclusive reasons for the same dropped servers; surface the policy error
-    # (the real, actionable cause) instead of nudging the user to re-approve.
-    policy_notice = format_policy_error_notice(resolution.policy_error)
-    if policy_notice:
-        print(policy_notice, file=sys.stderr)  # noqa: T201
-    else:
-        notice = format_untrusted_project_notice(resolution.untrusted_project_paths)
-        if notice:
-            print(notice, file=sys.stderr)  # noqa: T201
-    legacy_notice = format_legacy_ignored_notice(resolution.legacy_ignored)
-    if legacy_notice:
-        print(legacy_notice, file=sys.stderr)  # noqa: T201
-    legacy_env_notice = format_legacy_env_ignored_notice(resolution.legacy_env_ignored)
-    if legacy_env_notice:
-        print(legacy_env_notice, file=sys.stderr)  # noqa: T201
-    malformed_notice = format_malformed_approvals_notice(resolution.malformed_approvals)
-    if malformed_notice:
-        print(malformed_notice, file=sys.stderr)  # noqa: T201
-    # Report configs that failed to parse/validate but were dropped while
-    # another config still loaded — otherwise a broken .mcp.json is invisible on
-    # this surface (the runtime loader reports the same failures as error rows).
-    load_errors_notice = format_load_errors_notice(resolution.load_errors)
-    if load_errors_notice:
-        print(load_errors_notice, file=sys.stderr)  # noqa: T201
+    _print_resolution_notices(resolution)
 
     selection = select_server(resolution, server)
     if isinstance(selection, ConfigResolutionError):
@@ -265,6 +311,35 @@ def run_mcp_config() -> int:
         highlight=False,
     )
     return 0
+
+
+def _print_resolution_notices(resolution: ConfigResolution) -> None:
+    """Print notices attached to a successful config resolution."""
+    from deepagents_code.mcp_login_service import (
+        format_legacy_env_ignored_notice,
+        format_legacy_ignored_notice,
+        format_load_errors_notice,
+        format_malformed_approvals_notice,
+        format_policy_error_notice,
+        format_untrusted_project_notice,
+    )
+
+    policy_notice = format_policy_error_notice(resolution.policy_error)
+    if policy_notice:
+        print(policy_notice, file=sys.stderr)  # noqa: T201
+    else:
+        notice = format_untrusted_project_notice(resolution.untrusted_project_paths)
+        if notice:
+            print(notice, file=sys.stderr)  # noqa: T201
+    notices = (
+        format_legacy_ignored_notice(resolution.legacy_ignored),
+        format_legacy_env_ignored_notice(resolution.legacy_env_ignored),
+        format_malformed_approvals_notice(resolution.malformed_approvals),
+        format_load_errors_notice(resolution.load_errors),
+    )
+    for notice in notices:
+        if notice:
+            print(notice, file=sys.stderr)  # noqa: T201
 
 
 def _print_resolution_error(error: ConfigResolutionError) -> None:

--- a/libs/code/deepagents_code/client/commands/mcp.py
+++ b/libs/code/deepagents_code/client/commands/mcp.py
@@ -91,9 +91,20 @@ def setup_mcp_parsers(
 async def run_mcp_login_list(*, config_path: str | None) -> int:
     """List configured OAuth servers without stored tokens.
 
+    Servers are drawn from the same trust-gated resolution as `run_mcp_login`,
+    so untrusted project-level entries are excluded from the scan.
+
+    A server counts as needing login when it opted into OAuth and has no
+    stored token at all. Expiry is deliberately not consulted, matching the
+    runtime's upfront gate in `resolve_and_load_mcp_tools`.
+
     Returns:
-        Process exit code: 0 on success, 1 on config failure or unreadable
-            token state, or 2 when no config file was found.
+        Process exit code: 0 when every configured server's login state was
+            determined — including when some of them need login, which is
+            informational rather than a failure; 1 when the config could not
+            be resolved or any server's state is unknown (unreadable token
+            state, unresolvable config, or a config file that failed to
+            load); or 2 when no config file was found.
     """
     from deepagents_code._invocation import invoked_name
     from deepagents_code.mcp_login_service import (
@@ -121,6 +132,10 @@ async def run_mcp_login_list(*, config_path: str | None) -> int:
     from deepagents_code.mcp_config import resolve_mcp_server_env
     from deepagents_code.mcp_tools import _drop_invalid_mcp_config_servers
 
+    # Defense in depth: `resolve_mcp_config` already validates every source, so
+    # `errors` is expected to stay empty. Keep the call anyway — it is what
+    # guarantees the `resolved_config["url"]` index and `FileTokenStorage`'s
+    # server-name regex below cannot raise, and those run outside the `try`.
     valid_config, errors = _drop_invalid_mcp_config_servers(resolution.config)
     for server_name, error in errors.items():
         print(  # noqa: T201
@@ -128,7 +143,10 @@ async def run_mcp_login_list(*, config_path: str | None) -> int:
         )
 
     needs_login: list[str] = []
-    unreadable = 0
+    # Servers whose login state could not be determined. A config file that
+    # failed to load counts too: it may have held an OAuth server that never
+    # reached the scan, so the picture is incomplete before the loop starts.
+    unreadable = len(errors) + len(resolution.load_errors)
     for server_name, server_config in valid_config["mcpServers"].items():
         if server_config.get("auth") != "oauth":
             continue
@@ -145,9 +163,19 @@ async def run_mcp_login_list(*, config_path: str | None) -> int:
         try:
             tokens = await storage.get_tokens()
         except (OSError, RuntimeError, ValueError) as exc:
+            # `FileTokenStorage` raises `OSError`/`RuntimeError` from its own
+            # file read, and those messages carry the token path and the
+            # "delete it and re-login" remedy — render them verbatim.
+            # `format_login_failure` is for exceptions that may embed an
+            # `OAuthToken`, which here is only the pydantic `ValidationError`
+            # from parsing the stored payload.
+            detail = (
+                str(exc)
+                if isinstance(exc, OSError | RuntimeError)
+                else format_login_failure(exc)
+            )
             print(  # noqa: T201
-                f"Could not read login state for {server_name!r}: "
-                f"{format_login_failure(exc)}",
+                f"Could not read login state for {server_name!r}: {detail}",
                 file=sys.stderr,
             )
             unreadable += 1
@@ -155,22 +183,28 @@ async def run_mcp_login_list(*, config_path: str | None) -> int:
         if tokens is None:
             needs_login.append(server_name)
 
-    if not needs_login:
-        # Unreadable token state is not an all-clear: the server's login state
-        # is unknown, so reporting "no servers need login" would be false.
-        if unreadable:
-            return 1
+    if needs_login:
+        console.print("MCP servers needing login:")
+        for server_name in needs_login:
+            console.print(f"  {server_name}", markup=False)
+        console.print()
+        console.print(
+            f"Run `{invoked_name()} mcp login <server>` to authenticate.",
+            markup=False,
+        )
+    elif not unreadable:
         console.print("No MCP servers need login.")
-        return 0
-    console.print("MCP servers needing login:")
-    for server_name in needs_login:
-        console.print(f"  {server_name}", markup=False)
-    console.print()
-    console.print(
-        f"Run `{invoked_name()} mcp login <server>` to authenticate.",
-        markup=False,
-    )
-    return 1 if unreadable else 0
+
+    # An undetermined server is not an all-clear: its login state is unknown,
+    # so both "no servers need login" and a bare list would overstate what was
+    # actually checked. Say so on stdout — the per-server reasons went to
+    # stderr, which is easily lost when only stdout is read or piped.
+    if unreadable:
+        if needs_login:
+            console.print()
+        console.print(f"{unreadable} server(s) could not be checked; see errors above.")
+        return 1
+    return 0
 
 
 # Maintainer note: `deepagents-talon` dynamically imports `run_mcp_login` from
@@ -340,6 +374,9 @@ def _print_resolution_notices(resolution: ConfigResolution) -> None:
         format_untrusted_project_notice,
     )
 
+    # A policy read failure and an "untrusted project" skip are mutually
+    # exclusive reasons for the same dropped servers; surface the policy error
+    # (the real, actionable cause) instead of nudging the user to re-approve.
     policy_notice = format_policy_error_notice(resolution.policy_error)
     if policy_notice:
         print(policy_notice, file=sys.stderr)  # noqa: T201
@@ -347,6 +384,10 @@ def _print_resolution_notices(resolution: ConfigResolution) -> None:
         notice = format_untrusted_project_notice(resolution.untrusted_project_paths)
         if notice:
             print(notice, file=sys.stderr)  # noqa: T201
+    # `format_load_errors_notice` reports configs that failed to parse/validate
+    # but were dropped while another config still loaded — otherwise a broken
+    # .mcp.json is invisible on this surface (the runtime loader reports the
+    # same failures as error rows).
     notices = (
         format_legacy_ignored_notice(resolution.legacy_ignored),
         format_legacy_env_ignored_notice(resolution.legacy_env_ignored),
@@ -365,7 +406,7 @@ def _print_resolution_error(error: ConfigResolutionError) -> None:
     explains the drop), then the legacy-key, legacy-env, and malformed-approval
     notices. Per-path load errors are not printed here because `error.message`
     already embeds them for `NO_USABLE_CONFIG`. These notices are also surfaced
-    independently for successful resolutions in `run_mcp_login`.
+    independently for successful resolutions by `_print_resolution_notices`.
     """
     from deepagents_code.mcp_login_service import (
         format_legacy_env_ignored_notice,

--- a/libs/code/deepagents_code/client/commands/mcp.py
+++ b/libs/code/deepagents_code/client/commands/mcp.py
@@ -92,8 +92,8 @@ async def run_mcp_login_list(*, config_path: str | None) -> int:
     """List configured OAuth servers without stored tokens.
 
     Returns:
-        Process exit code: 0 on success, 1 on config failure, or 2 when no
-            config file was found.
+        Process exit code: 0 on success, 1 on config failure or unreadable
+            token state, or 2 when no config file was found.
     """
     from deepagents_code._invocation import invoked_name
     from deepagents_code.mcp_login_service import (
@@ -127,6 +127,7 @@ async def run_mcp_login_list(*, config_path: str | None) -> int:
         )
 
     needs_login: list[str] = []
+    unreadable = 0
     for server_name, server_config in valid_config["mcpServers"].items():
         if server_config.get("auth") != "oauth":
             continue
@@ -139,11 +140,16 @@ async def run_mcp_login_list(*, config_path: str | None) -> int:
                 f"{format_login_failure(exc)}",
                 file=sys.stderr,
             )
+            unreadable += 1
             continue
         if tokens is None:
             needs_login.append(server_name)
 
     if not needs_login:
+        # Unreadable token state is not an all-clear: the server's login state
+        # is unknown, so reporting "no servers need login" would be false.
+        if unreadable:
+            return 1
         console.print("No MCP servers need login.")
         return 0
     console.print("MCP servers needing login:")
@@ -154,7 +160,7 @@ async def run_mcp_login_list(*, config_path: str | None) -> int:
         f"Run `{invoked_name()} mcp login <server>` to authenticate.",
         markup=False,
     )
-    return 0
+    return 1 if unreadable else 0
 
 
 # Maintainer note: `deepagents-talon` dynamically imports `run_mcp_login` from

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -5829,6 +5829,7 @@ def cli_main() -> None:
             from deepagents_code.client.commands.mcp import (
                 run_mcp_config,
                 run_mcp_login,
+                run_mcp_login_list,
             )
             from deepagents_code.ui import show_mcp_help
 
@@ -5839,14 +5840,15 @@ def cli_main() -> None:
                         f"Using --mcp-config from top-level: {config_path}",
                         file=sys.stderr,
                     )
-                sys.exit(
-                    asyncio.run(
-                        run_mcp_login(
-                            server=args.server,
-                            config_path=config_path,
-                        )
+                command = (
+                    run_mcp_login(
+                        server=args.server,
+                        config_path=config_path,
                     )
+                    if args.server is not None
+                    else run_mcp_login_list(config_path=config_path)
                 )
+                sys.exit(asyncio.run(command))
             if args.mcp_command == "config":
                 sys.exit(run_mcp_config())
             show_mcp_help()

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -696,13 +696,30 @@ class FileTokenStorage(TokenStorage):
         try:
             raw = path.read_text(encoding="utf-8")
             data = json.loads(raw)
-        except (OSError, json.JSONDecodeError) as exc:
+        # `UnicodeDecodeError` is a `ValueError`, not an `OSError`, so it needs
+        # its own entry — otherwise an undecodable file escapes without the
+        # remedy text that every other corruption mode gets.
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
             msg = (
                 f"Failed to read MCP token file {path}: {exc}. "
                 f"Delete the file and run `/mcp login {self._server_name}` "
                 f"in the TUI (or `dcode mcp login {self._server_name}`)."
             )
             raise RuntimeError(msg) from exc
+        # `json.loads` yields a `dict` only for object literals; `null`, a list,
+        # or a bare scalar would make the `.get` below raise `AttributeError`,
+        # which callers do not catch. Fail as a normal corrupt-file error.
+        if not isinstance(data, dict):
+            msg = (
+                f"MCP token file {path} is not a JSON object (found "
+                f"{type(data).__name__}). Delete it and run "
+                f"`/mcp login {self._server_name}` in the TUI (or "
+                f"`dcode mcp login {self._server_name}`)."
+            )
+            # Not `TypeError` (TRY004): this is a corrupt-file report, not a
+            # caller type error, and callers catch the same `RuntimeError` the
+            # other corruption modes raise. `TypeError` would escape them.
+            raise RuntimeError(msg)  # noqa: TRY004
         if data.get("version") != _STORAGE_VERSION:
             msg = (
                 f"MCP token file {path} has unsupported version "

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -721,10 +721,15 @@ class FileTokenStorage(TokenStorage):
             # other corruption modes raise. `TypeError` would escape them.
             raise RuntimeError(msg)  # noqa: TRY004
         if data.get("version") != _STORAGE_VERSION:
+            # Render only the value's type, never the value itself: callers
+            # print this message verbatim (e.g. `mcp login` list on stderr),
+            # and the version field is attacker-controlled file content that
+            # could carry credential material planted by a malformed write.
             msg = (
                 f"MCP token file {path} has unsupported version "
-                f"{data.get('version')!r} (expected {_STORAGE_VERSION}). "
-                f"Delete it and run `/mcp login {self._server_name}` in the "
+                f"({type(data.get('version')).__name__}; expected "
+                f"{_STORAGE_VERSION!r}). Delete it and run "
+                f"`/mcp login {self._server_name}` in the "
                 f"TUI (or `dcode mcp login {self._server_name}`)."
             )
             raise RuntimeError(msg)

--- a/libs/code/deepagents_code/mcp_login_service.py
+++ b/libs/code/deepagents_code/mcp_login_service.py
@@ -27,9 +27,9 @@ if TYPE_CHECKING:
 class ConfigErrorKind(StrEnum):
     """Discriminator for `ConfigResolutionError` reasons.
 
-    Only `NO_CONFIG_FOUND` maps to exit code 2 in `run_mcp_login`; all
-    other kinds map to exit code 1. The TUI surface translates them into
-    in-app status messages.
+    Only `NO_CONFIG_FOUND` maps to exit code 2 in the `mcp login` CLI
+    handlers (`run_mcp_login`, `run_mcp_login_list`); all other kinds map to
+    exit code 1. The TUI surface translates them into in-app status messages.
     """
 
     EXPLICIT_LOAD_FAILED = "explicit_load_failed"

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -778,7 +778,7 @@ def show_mcp_help() -> None:
     console.print("  dcode mcp <command> [options]")
     console.print()
     console.print("[bold]Commands:[/bold]", style=theme.PRIMARY)
-    console.print("  login <server>    Run the OAuth login flow for an MCP server")
+    console.print("  login [server]    List servers needing login or authenticate one")
     console.print("  config            Show MCP config discovery paths")
     console.print()
     _print_option_section()
@@ -801,7 +801,11 @@ def show_mcp_login_help() -> None:
     """Show help information for the `mcp login` subcommand."""
     console.print()
     console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
-    console.print("  dcode mcp login <server> [--mcp-config PATH]")
+    console.print("  dcode mcp login [server] [--mcp-config PATH]")
+    console.print()
+    console.print(
+        "With no server, lists configured OAuth servers that have no stored login."
+    )
     console.print()
     _print_option_section(
         "  --mcp-config PATH       Path to an MCP config JSON file "
@@ -814,6 +818,7 @@ def show_mcp_login_help() -> None:
     console.print(_MCP_CONFIG_FORMAT_EXAMPLE, style=theme.MUTED)
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode mcp login")
     console.print("  dcode mcp login notion")
     console.print("  dcode mcp login linear --mcp-config ./mcp-config.json")
     console.print()

--- a/libs/code/tests/unit_tests/client/commands/test_mcp.py
+++ b/libs/code/tests/unit_tests/client/commands/test_mcp.py
@@ -65,7 +65,7 @@ class TestSetupMCPParsers:
         assert ns.server == "notion"
 
     def test_mcp_login_allows_omitted_server(self) -> None:
-        """Bare `dcode mcp login` selects discovery mode."""
+        """The parser accepts `dcode mcp login` with no server."""
         ns = _build_parser().parse_args(["mcp", "login"])
         assert ns.mcp_command == "login"
         assert ns.server is None
@@ -77,12 +77,15 @@ class TestRunMCPLoginList:
     async def test_lists_oauth_servers_without_tokens(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
+        """Only OAuth servers lacking a stored token are listed."""
         from deepagents_code.client.commands.mcp import run_mcp_login_list
 
         config_path = tmp_path / "mcp.json"
         config_path.write_text(
             '{"mcpServers":{'
             '"notion":{"transport":"http","url":"https://notion.test/mcp",'
+            '"auth":"oauth"},'
+            '"linear":{"transport":"http","url":"https://linear.test/mcp",'
             '"auth":"oauth"},'
             '"public":{"transport":"http","url":"https://public.test/mcp"}}}'
         )
@@ -93,11 +96,16 @@ class TestRunMCPLoginList:
         output = capsys.readouterr().out
         assert "MCP servers needing login:" in output
         assert "notion" in output
+        assert "linear" in output
         assert "public" not in output
+        # The remediation hint is the point of the command; without it the
+        # user is told what is wrong but not what to do.
+        assert "mcp login <server>` to authenticate." in output
 
     async def test_omits_oauth_servers_with_tokens(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
+        """A server with a stored token is not reported as needing login."""
         from mcp.shared.auth import OAuthToken
 
         from deepagents_code.client.commands.mcp import run_mcp_login_list
@@ -191,6 +199,168 @@ class TestRunMCPLoginList:
         assert exit_code == 1
         assert "Could not read login state for 'notion'" in captured.err
         assert "No MCP servers need login." not in captured.out
+
+    async def test_unreadable_alongside_needs_login_returns_nonzero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An unreadable server taints a non-empty list too, not just an empty one."""
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+        from deepagents_code.mcp_auth import FileTokenStorage
+
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(
+            '{"mcpServers":{'
+            '"notion":{"transport":"http","url":"https://notion.test/mcp",'
+            '"auth":"oauth"},'
+            '"linear":{"transport":"http","url":"https://linear.test/mcp",'
+            '"auth":"oauth"}}}'
+        )
+
+        async def _get_tokens(self: FileTokenStorage) -> None:
+            """Stub storage: `linear` is unreadable, `notion` has no tokens."""
+            if self._server_name == "linear":
+                msg = "corrupt"
+                raise ValueError(msg)
+
+        with (
+            patch("deepagents_code.mcp_auth.token_store_dir", return_value=tmp_path),
+            patch.object(FileTokenStorage, "get_tokens", _get_tokens),
+        ):
+            exit_code = await run_mcp_login_list(config_path=str(config_path))
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "notion" in captured.out
+        # The unchecked server must not silently vanish from a confident list.
+        assert "1 server(s) could not be checked" in captured.out
+        assert "Could not read login state for 'linear'" in captured.err
+
+    async def test_token_read_error_keeps_the_remedy_text(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A corrupt token file reports its path and how to fix it."""
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+        from deepagents_code.mcp_auth import FileTokenStorage
+
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(
+            '{"mcpServers":{"notion":{"transport":"http",'
+            '"url":"https://notion.test/mcp","auth":"oauth"}}}'
+        )
+        with patch("deepagents_code.mcp_auth.token_store_dir", return_value=tmp_path):
+            token_path = FileTokenStorage(
+                "notion", server_url="https://notion.test/mcp"
+            ).path
+            token_path.parent.mkdir(parents=True, exist_ok=True)
+            token_path.write_text("{ not json")
+            exit_code = await run_mcp_login_list(config_path=str(config_path))
+
+        err = capsys.readouterr().err
+        assert exit_code == 1
+        assert str(token_path) in err
+        assert "Delete the file and run" in err
+
+    async def test_non_object_token_file_is_reported_not_raised(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Valid JSON that is not an object must not escape as `AttributeError`."""
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+        from deepagents_code.mcp_auth import FileTokenStorage
+
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(
+            '{"mcpServers":{"notion":{"transport":"http",'
+            '"url":"https://notion.test/mcp","auth":"oauth"}}}'
+        )
+        with patch("deepagents_code.mcp_auth.token_store_dir", return_value=tmp_path):
+            token_path = FileTokenStorage(
+                "notion", server_url="https://notion.test/mcp"
+            ).path
+            token_path.parent.mkdir(parents=True, exist_ok=True)
+            token_path.write_text("null")
+            exit_code = await run_mcp_login_list(config_path=str(config_path))
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "is not a JSON object" in captured.err
+        assert "No MCP servers need login." not in captured.out
+
+    async def test_no_config_found_returns_2(self) -> None:
+        """No discovered config files yields exit code 2."""
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+
+        with patch(
+            "deepagents_code.mcp_tools.discover_mcp_config_sources",
+            return_value=[],
+        ):
+            exit_code = await run_mcp_login_list(config_path=None)
+
+        assert exit_code == 2
+
+    async def test_unloadable_explicit_config_returns_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An explicit config that cannot be loaded is exit 1, not exit 2."""
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+
+        missing = tmp_path / "nope.json"
+
+        exit_code = await run_mcp_login_list(config_path=str(missing))
+
+        assert exit_code == 1
+        assert "Failed to load MCP config" in capsys.readouterr().err
+
+    async def test_prints_trust_hint_for_untrusted_project_config(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Trust-gated servers are explained, not silently absent from the list."""
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+
+        project_cfg = tmp_path / "project.json"
+        project_cfg.write_text(
+            '{"mcpServers":{"notion":{"transport":"http",'
+            '"url":"https://mcp.notion.com/mcp","auth":"oauth"}}}'
+        )
+
+        with patch(
+            "deepagents_code.mcp_tools.discover_mcp_config_sources",
+            return_value=[
+                DiscoveredMCPConfig(project_cfg, MCPConfigScope.PROJECT, tmp_path)
+            ],
+        ):
+            exit_code = await run_mcp_login_list(config_path=None)
+
+        err = capsys.readouterr().err
+        assert exit_code != 0
+        assert "Skipping untrusted project MCP server entries" in err
+
+    async def test_unloadable_discovered_config_is_not_an_all_clear(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A config file that failed to load leaves the picture incomplete."""
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+
+        good = tmp_path / "good.json"
+        good.write_text(
+            '{"mcpServers":{"public":{"transport":"http",'
+            '"url":"https://public.test/mcp"}}}'
+        )
+        broken = tmp_path / "broken.json"
+        broken.write_text("{ not json")
+
+        with patch(
+            "deepagents_code.mcp_tools.discover_mcp_config_sources",
+            return_value=[
+                DiscoveredMCPConfig(good, MCPConfigScope.USER, None),
+                DiscoveredMCPConfig(broken, MCPConfigScope.USER, None),
+            ],
+        ):
+            exit_code = await run_mcp_login_list(config_path=None)
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "No MCP servers need login." not in captured.out
+        assert "could not be checked" in captured.out
 
 
 class TestRunMCPLogin:

--- a/libs/code/tests/unit_tests/client/commands/test_mcp.py
+++ b/libs/code/tests/unit_tests/client/commands/test_mcp.py
@@ -64,6 +64,60 @@ class TestSetupMCPParsers:
         assert ns.mcp_command == "login"
         assert ns.server == "notion"
 
+    def test_mcp_login_allows_omitted_server(self) -> None:
+        """Bare `dcode mcp login` selects discovery mode."""
+        ns = _build_parser().parse_args(["mcp", "login"])
+        assert ns.mcp_command == "login"
+        assert ns.server is None
+
+
+class TestRunMCPLoginList:
+    """Behavior of bare `dcode mcp login`."""
+
+    async def test_lists_oauth_servers_without_tokens(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(
+            '{"mcpServers":{'
+            '"notion":{"transport":"http","url":"https://notion.test/mcp",'
+            '"auth":"oauth"},'
+            '"public":{"transport":"http","url":"https://public.test/mcp"}}}'
+        )
+
+        exit_code = await run_mcp_login_list(config_path=str(config_path))
+
+        assert exit_code == 0
+        output = capsys.readouterr().out
+        assert "MCP servers needing login:" in output
+        assert "notion" in output
+        assert "public" not in output
+
+    async def test_omits_oauth_servers_with_tokens(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from mcp.shared.auth import OAuthToken
+
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+        from deepagents_code.mcp_auth import FileTokenStorage
+
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(
+            '{"mcpServers":{"notion":{"transport":"http",'
+            '"url":"https://notion.test/mcp","auth":"oauth"}}}'
+        )
+        with patch("deepagents_code.mcp_auth.token_store_dir", return_value=tmp_path):
+            storage = FileTokenStorage("notion", server_url="https://notion.test/mcp")
+            await storage.set_tokens(
+                OAuthToken(access_token="secret", token_type="Bearer")
+            )
+            exit_code = await run_mcp_login_list(config_path=str(config_path))
+
+        assert exit_code == 0
+        assert capsys.readouterr().out.strip() == "No MCP servers need login."
+
 
 class TestRunMCPLogin:
     """Behavior of the `mcp login` command handler."""

--- a/libs/code/tests/unit_tests/client/commands/test_mcp.py
+++ b/libs/code/tests/unit_tests/client/commands/test_mcp.py
@@ -118,6 +118,55 @@ class TestRunMCPLoginList:
         assert exit_code == 0
         assert capsys.readouterr().out.strip() == "No MCP servers need login."
 
+    async def test_resolves_url_before_looking_up_tokens(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Token identity uses the interpolated URL, matching login and runtime."""
+        from mcp.shared.auth import OAuthToken
+
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+        from deepagents_code.mcp_auth import FileTokenStorage
+
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(
+            '{"mcpServers":{"notion":{"transport":"http",'
+            '"url":"${MCP_TEST_URL}","auth":"oauth"}}}'
+        )
+        resolved_url = "https://notion.test/mcp"
+        monkeypatch.setenv("MCP_TEST_URL", resolved_url)
+
+        with patch("deepagents_code.mcp_auth.token_store_dir", return_value=tmp_path):
+            storage = FileTokenStorage("notion", server_url=resolved_url)
+            await storage.set_tokens(
+                OAuthToken(access_token="secret", token_type="Bearer")
+            )
+            exit_code = await run_mcp_login_list(config_path=str(config_path))
+
+        assert exit_code == 0
+        assert capsys.readouterr().out.strip() == "No MCP servers need login."
+
+    async def test_invalid_url_type_is_reported(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A non-string OAuth URL is a config error, not a storage crash."""
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(
+            '{"mcpServers":{"notion":{"transport":"http","url":123,"auth":"oauth"}}}'
+        )
+
+        exit_code = await run_mcp_login_list(config_path=str(config_path))
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "Invalid MCP server config for 'notion'" in captured.err
+        assert "mcpServers.notion.url must be a string" in captured.err
+        assert "No MCP servers need login." not in captured.out
+
     async def test_unreadable_token_state_returns_nonzero(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/libs/code/tests/unit_tests/client/commands/test_mcp.py
+++ b/libs/code/tests/unit_tests/client/commands/test_mcp.py
@@ -118,6 +118,31 @@ class TestRunMCPLoginList:
         assert exit_code == 0
         assert capsys.readouterr().out.strip() == "No MCP servers need login."
 
+    async def test_unreadable_token_state_returns_nonzero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A server whose token file cannot be read must not get an all-clear."""
+        from deepagents_code.client.commands.mcp import run_mcp_login_list
+        from deepagents_code.mcp_auth import FileTokenStorage
+
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(
+            '{"mcpServers":{"notion":{"transport":"http",'
+            '"url":"https://notion.test/mcp","auth":"oauth"}}}'
+        )
+        with (
+            patch("deepagents_code.mcp_auth.token_store_dir", return_value=tmp_path),
+            patch.object(
+                FileTokenStorage, "get_tokens", side_effect=ValueError("corrupt")
+            ),
+        ):
+            exit_code = await run_mcp_login_list(config_path=str(config_path))
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "Could not read login state for 'notion'" in captured.err
+        assert "No MCP servers need login." not in captured.out
+
 
 class TestRunMCPLogin:
     """Behavior of the `mcp login` command handler."""

--- a/libs/code/tests/unit_tests/test_args.py
+++ b/libs/code/tests/unit_tests/test_args.py
@@ -569,7 +569,9 @@ class TestMcpCommandDispatch:
 
         assert exc_info.value.code == 0
         mock_list.assert_awaited_once_with(config_path=None)
-        mock_login.assert_not_awaited()
+        # `assert_not_called`, not `assert_not_awaited`: building both
+        # coroutines and awaiting one would still pass the latter.
+        mock_login.assert_not_called()
 
     def test_mcp_login_uses_top_level_mcp_config_as_fallback(self) -> None:
         """`dcode --mcp-config PATH mcp login NAME` propagates PATH to login."""

--- a/libs/code/tests/unit_tests/test_args.py
+++ b/libs/code/tests/unit_tests/test_args.py
@@ -547,6 +547,30 @@ class TestConfigCommandDispatch:
 class TestMcpCommandDispatch:
     """Tests for `cli_main()` dispatch of `dcode mcp` subcommands."""
 
+    def test_bare_mcp_login_lists_servers(self) -> None:
+        """`dcode mcp login` dispatches to login discovery."""
+        from deepagents_code.main import cli_main
+
+        with (
+            patch.object(sys, "argv", ["deepagents", "mcp", "login"]),
+            patch("deepagents_code.main.check_cli_dependencies"),
+            patch("deepagents_code.main.apply_stdin_pipe"),
+            patch(
+                "deepagents_code.client.commands.mcp.run_mcp_login_list",
+                new=AsyncMock(return_value=0),
+            ) as mock_list,
+            patch(
+                "deepagents_code.client.commands.mcp.run_mcp_login",
+                new=AsyncMock(return_value=0),
+            ) as mock_login,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+
+        assert exc_info.value.code == 0
+        mock_list.assert_awaited_once_with(config_path=None)
+        mock_login.assert_not_awaited()
+
     def test_mcp_login_uses_top_level_mcp_config_as_fallback(self) -> None:
         """`dcode --mcp-config PATH mcp login NAME` propagates PATH to login."""
         from deepagents_code.main import cli_main


### PR DESCRIPTION
Bare `dcode mcp login` now lists configured OAuth MCP servers that do not have stored credentials.

---

This makes the login command useful without requiring users to already know a server name. Discovery uses the existing trust-gated merged configuration and reads only local URL-scoped token state; `dcode mcp login <server>` keeps its current behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/71c1477d-fbb0-5259-b93e-8eea055a8d81)