### PR TITLE
fix(code): skip uncorrelated-result warning for auto-mode policy denials

### DIFF
--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -88,6 +88,17 @@ AUTO_MODE_COUNTERS_NAMESPACE: tuple[str, str] = (
 )
 USER_PROMPT_METADATA_KEY = "deepagents_code_user_prompt"
 AUTO_MODE_EVENT_TYPE = "auto_mode"
+AUTO_DENIED_METADATA_KEY = "deepagents_code_auto_denied"
+"""`ToolMessage.additional_kwargs` flag set on a synthetic auto-mode denial.
+
+A policy denial (or classifier-unavailable fallback) synthesizes an error
+`ToolMessage` without the tool ever executing, so no `tool.use` fires and no
+widget mounts. The TUI's uncorrelated-result warning exists for the opposite
+case — a tool that *executed* but whose streamed args never parsed — so it
+must not fire for these. The flag travels in `additional_kwargs`, which
+survives the messages-mode stream, so the adapter can recognize the routine
+denial without string-matching the content.
+"""
 _CLASSIFIER_TIMEOUT_SECONDS = AUTO_CLASSIFIER_TIMEOUT_SECONDS_DEFAULT
 # Building a classifier is a different kind of wait than asking one for a
 # verdict: a cold provider-package import, profile resolution, and credential
@@ -3610,6 +3621,7 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
                     name=call["name"],
                     tool_call_id=_tool_call_id(call),
                     status="error",
+                    additional_kwargs={AUTO_DENIED_METADATA_KEY: True},
                 )
             )
             event_kind = "unavailable" if unavailable else "denial"

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -91,13 +91,20 @@ AUTO_MODE_EVENT_TYPE = "auto_mode"
 AUTO_DENIED_METADATA_KEY = "deepagents_code_auto_denied"
 """`ToolMessage.additional_kwargs` flag set on a synthetic auto-mode denial.
 
-A policy denial (or classifier-unavailable fallback) synthesizes an error
-`ToolMessage` without the tool ever executing, so no `tool.use` fires and no
-widget mounts. The TUI's uncorrelated-result warning exists for the opposite
-case — a tool that *executed* but whose streamed args never parsed — so it
-must not fire for these. The flag travels in `additional_kwargs`, which
-survives the messages-mode stream, so the adapter can recognize the routine
-denial without string-matching the content.
+Set on both dispositions that synthesize a result instead of executing the
+tool: `policy_deny` and the `classifier_unavailable` fallback.
+
+The flag lets the TUI skip its uncorrelated-result warning for these. A
+result reaches that warning when no widget mounted for the call, and a widget
+mounts only when the streamed args parse (see `ToolCallBuffer.parse_args`).
+A no-argument call streams no args, so it never mounts, and its denial result
+arrives uncorrelated. The denial is not the cause of the miss; it is the
+routine case in which the miss is expected.
+
+The flag is carried in `additional_kwargs` so the adapter does not
+string-match the content. `additional_kwargs` is dropped by the server
+message converters unless they forward it; `_convert_tool_message` in
+`client/remote_client.py` does, which is what the TUI depends on.
 """
 _CLASSIFIER_TIMEOUT_SECONDS = AUTO_CLASSIFIER_TIMEOUT_SECONDS_DEFAULT
 # Building a classifier is a different kind of wait than asking one for a

--- a/libs/code/deepagents_code/client/remote_client.py
+++ b/libs/code/deepagents_code/client/remote_client.py
@@ -969,6 +969,12 @@ def _convert_human_message(data: dict[str, Any]) -> Any:  # noqa: ANN401
 def _convert_tool_message(data: dict[str, Any]) -> Any:  # noqa: ANN401
     """Convert a server tool message dict to a `ToolMessage`.
 
+    `additional_kwargs` is forwarded. The TUI reads markers from it, such as
+    `AUTO_DENIED_METADATA_KEY` on a synthetic auto-mode denial. The TUI always
+    runs against a server, so a marker dropped here never reaches the client.
+    Guarded by `isinstance`: the server payload is JSON, and a non-dict value
+    would fail `ToolMessage` validation and discard the whole message.
+
     Args:
         data: Raw message dict from the server.
 
@@ -977,6 +983,7 @@ def _convert_tool_message(data: dict[str, Any]) -> Any:  # noqa: ANN401
     """
     from langchain_core.messages import ToolMessage
 
+    additional_kwargs = data.get("additional_kwargs")
     try:
         return ToolMessage(
             content=data.get("content", ""),
@@ -984,6 +991,9 @@ def _convert_tool_message(data: dict[str, Any]) -> Any:  # noqa: ANN401
             name=data.get("name", ""),
             id=data.get("id"),
             status=data.get("status", "success"),
+            additional_kwargs=(
+                additional_kwargs if isinstance(additional_kwargs, dict) else {}
+            ),
         )
     except (TypeError, ValueError, KeyError):
         logger.warning(

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -2400,19 +2400,39 @@ async def execute_task_textual(
                             # widget concept; see `non_interactive.py`. The
                             # parity contract is documented in `_tool_stream`.
                             if tool_id:
-                                # Warning, not info/debug: a real-id result with
-                                # no mounted widget (its args never parsed, so no
-                                # tool.use fired) means a hook consumer sees a
-                                # `tool.result` with empty args for a tool that
-                                # actually executed — degraded audit fidelity worth
-                                # surfacing at default log levels, matching the
-                                # headless path.
-                                logger.warning(
-                                    "ToolMessage tool_call_id=%s not in "
-                                    "_current_tool_messages; no correlated "
-                                    "tool.use, sending empty tool_args",
-                                    tool_id,
+                                # An auto-mode policy denial synthesizes an error
+                                # ToolMessage without the tool ever executing, so
+                                # no tool.use fires and no widget mounts — a
+                                # routine path, not degraded audit fidelity. Skip
+                                # the warning for it; the tool.result hook below
+                                # still fires as today. The marker is set at the
+                                # source in `auto_mode`, not string-matched on
+                                # content.
+                                from deepagents_code.auto_mode import (
+                                    AUTO_DENIED_METADATA_KEY,
                                 )
+
+                                is_synthetic_denial = bool(
+                                    (
+                                        getattr(message, "additional_kwargs", None)
+                                        or {}
+                                    ).get(AUTO_DENIED_METADATA_KEY)
+                                )
+                                if not is_synthetic_denial:
+                                    # Warning, not info/debug: a real-id result
+                                    # with no mounted widget (its args never
+                                    # parsed, so no tool.use fired) means a hook
+                                    # consumer sees a `tool.result` with empty
+                                    # args for a tool that actually executed —
+                                    # degraded audit fidelity worth surfacing at
+                                    # default log levels, matching the headless
+                                    # path.
+                                    logger.warning(
+                                        "ToolMessage tool_call_id=%s not in "
+                                        "_current_tool_messages; no correlated "
+                                        "tool.use, sending empty tool_args",
+                                        tool_id,
+                                    )
                             if tool_status == "error":
                                 _dispatch_tool_error_hook(tool_name)
                             _dispatch_tool_result_hook(

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -1499,7 +1499,11 @@ async def execute_task_textual(
     from pydantic import ValidationError
 
     from deepagents_code.approval_mode import ApprovalMode, awrite_approval_mode
-    from deepagents_code.auto_mode import USER_PROMPT_METADATA_KEY, user_prompt_metadata
+    from deepagents_code.auto_mode import (
+        AUTO_DENIED_METADATA_KEY,
+        USER_PROMPT_METADATA_KEY,
+        user_prompt_metadata,
+    )
     from deepagents_code.hooks.client_lifecycle import ClientHookStopError
     from deepagents_code.hooks.models.domain import HookEvent
 
@@ -2400,25 +2404,21 @@ async def execute_task_textual(
                             # widget concept; see `non_interactive.py`. The
                             # parity contract is documented in `_tool_stream`.
                             if tool_id:
-                                # An auto-mode policy denial synthesizes an error
-                                # ToolMessage without the tool ever executing, so
-                                # no tool.use fires and no widget mounts — a
-                                # routine path, not degraded audit fidelity. Skip
-                                # the warning for it; the tool.result hook below
-                                # still fires as today. The marker is set at the
-                                # source in `auto_mode`, not string-matched on
-                                # content.
-                                from deepagents_code.auto_mode import (
-                                    AUTO_DENIED_METADATA_KEY,
+                                # An auto-mode denial is stamped at the source in
+                                # `auto_mode`. For a no-argument call no widget
+                                # ever mounts, so the denial result lands here as
+                                # a matter of course. That is a routine path, not
+                                # degraded audit fidelity, so skip the warning.
+                                # The tool.result hook below still fires with
+                                # empty args. The headless twin in
+                                # `non_interactive.py` keeps its warning: auto
+                                # mode is never installed on that surface, so it
+                                # cannot see a denial.
+                                metadata = message.additional_kwargs
+                                is_auto_denied = isinstance(metadata, dict) and bool(
+                                    metadata.get(AUTO_DENIED_METADATA_KEY)
                                 )
-
-                                is_synthetic_denial = bool(
-                                    (
-                                        getattr(message, "additional_kwargs", None)
-                                        or {}
-                                    ).get(AUTO_DENIED_METADATA_KEY)
-                                )
-                                if not is_synthetic_denial:
+                                if not is_auto_denied:
                                     # Warning, not info/debug: a real-id result
                                     # with no mounted widget (its args never
                                     # parsed, so no tool.use fired) means a hook

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -5980,9 +5980,74 @@ async def test_policy_denial_becomes_error_tool_message(tmp_path: Path) -> None:
     assert denial.status == "error"
     assert denial.tool_call_id == "call-1"
     assert "destructive_action" in denial.content
-    # Stamped so the TUI can recognize a synthetic denial (no tool executed, no
-    # widget mounted) and skip its uncorrelated-result warning.
+    # Stamped so the TUI can recognize a synthetic denial and skip its
+    # uncorrelated-result warning.
     assert denial.additional_kwargs[AUTO_DENIED_METADATA_KEY] is True
+
+
+async def test_policy_denial_marker_survives_server_round_trip(
+    tmp_path: Path,
+) -> None:
+    """The stamp reaches the TUI, not just the middleware return value.
+
+    The TUI always runs against a server, so the denial is serialized and
+    rebuilt by `_convert_tool_message` before the adapter sees it. This links
+    the producer to the consumer: a stamp the converter drops is invisible to
+    `test_auto_denied_tool_result_skips_uncorrelated_warning`, which builds its
+    own message.
+    """
+    from deepagents_code.client.remote_client import _convert_message_data
+
+    middleware = _middleware(tmp_path)
+    call = {
+        "name": "delete",
+        "args": {"file_path": "old.py"},
+        "id": "call-1",
+        "type": "tool_call",
+    }
+    ai_message = AIMessage(content="", tool_calls=[call])
+    key = approval_mode_key("thread-1")
+    store = _Store()
+    store.put(APPROVAL_MODE_NAMESPACE, key, {"mode": "auto"})
+    runtime = SimpleNamespace(
+        context={"approval_mode_key": key, "thread_id": "thread-1"},
+        store=store,
+        stream_writer=lambda _event: None,
+    )
+    plan = {
+        "batch_id": __import__("hashlib").sha256(b"call-1").hexdigest(),
+        "thread_key": key,
+        "mode_at_proposal": "auto",
+        "phase": "planned",
+        "manual_gated_ids": ["call-1"],
+        "decisions": [
+            {
+                "tool_call_id": "call-1",
+                "disposition": "policy_deny",
+                "category": "destructive_action",
+                "reason": "not authorized",
+                "path": "classifier",
+            }
+        ],
+        "pending_result_ids": [],
+        "processed_result_ids": [],
+        "counters_applied": True,
+        "fallback_reason": None,
+    }
+    state = {"messages": [ai_message], "_auto_decision_plan": plan}
+
+    update = await middleware.aafter_model(
+        cast("AgentState[Any]", state), cast("Runtime[Any]", runtime)
+    )
+
+    assert update is not None
+    denial = next(
+        message for message in update["messages"] if isinstance(message, ToolMessage)
+    )
+    # Serialize as the server does, then rebuild as the client does.
+    rebuilt = _convert_message_data(denial.model_dump())
+    assert isinstance(rebuilt, ToolMessage)
+    assert rebuilt.additional_kwargs[AUTO_DENIED_METADATA_KEY] is True
 
 
 async def test_classifier_unavailable_emits_single_event_for_batch(
@@ -6047,6 +6112,12 @@ async def test_classifier_unavailable_emits_single_event_for_batch(
     ]
     assert {message.tool_call_id for message in denials} == {"call-1", "call-2"}
     assert all(message.status == "error" for message in denials)
+    # The classifier-unavailable fallback is stamped like a policy denial: the
+    # tool did not execute, so the TUI must not warn about the missing widget.
+    assert all(
+        message.additional_kwargs[AUTO_DENIED_METADATA_KEY] is True
+        for message in denials
+    )
     unavailable_events = [
         event for event in events if event.get("event") == "unavailable"
     ]

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -60,6 +60,7 @@ from deepagents_code.auto_mode import (
     _MAX_CLASSIFIER_MODEL_CACHE,
     _MAX_EMITTED_EVENT_SCOPES,
     _MAX_PENDING_EVENT_SCOPES,
+    AUTO_DENIED_METADATA_KEY,
     AUTO_MODE_COUNTERS_NAMESPACE,
     USER_PROMPT_METADATA_KEY,
     AutoDecision,
@@ -5979,6 +5980,9 @@ async def test_policy_denial_becomes_error_tool_message(tmp_path: Path) -> None:
     assert denial.status == "error"
     assert denial.tool_call_id == "call-1"
     assert "destructive_action" in denial.content
+    # Stamped so the TUI can recognize a synthetic denial (no tool executed, no
+    # widget mounted) and skip its uncorrelated-result warning.
+    assert denial.additional_kwargs[AUTO_DENIED_METADATA_KEY] is True
 
 
 async def test_classifier_unavailable_emits_single_event_for_batch(

--- a/libs/code/tests/unit_tests/test_remote_client.py
+++ b/libs/code/tests/unit_tests/test_remote_client.py
@@ -207,6 +207,40 @@ class TestConvertMessageData:
         assert msg.name == ""
         assert msg.status == "success"
 
+    def test_tool_message_forwards_additional_kwargs(self) -> None:
+        """Markers set server-side survive the conversion.
+
+        The TUI always runs against a server, so a marker dropped here never
+        reaches the adapter. `AUTO_DENIED_METADATA_KEY` is the live consumer.
+        """
+        from deepagents_code.auto_mode import AUTO_DENIED_METADATA_KEY
+
+        msg = _convert_message_data(
+            {
+                "type": "tool",
+                "content": "Auto denied [credential_access]: not authorized",
+                "tool_call_id": "tc1",
+                "name": "onepassword_authenticate",
+                "status": "error",
+                "id": "m4",
+                "additional_kwargs": {AUTO_DENIED_METADATA_KEY: True},
+            }
+        )
+        assert isinstance(msg, ToolMessage)
+        assert msg.additional_kwargs[AUTO_DENIED_METADATA_KEY] is True
+
+    def test_tool_message_additional_kwargs_defaults_to_empty(self) -> None:
+        """A missing or non-dict `additional_kwargs` does not discard the message."""
+        msg = _convert_message_data({"type": "tool", "id": "m1"})
+        assert isinstance(msg, ToolMessage)
+        assert msg.additional_kwargs == {}
+
+        msg = _convert_message_data(
+            {"type": "tool", "id": "m1", "additional_kwargs": "not-a-dict"}
+        )
+        assert isinstance(msg, ToolMessage)
+        assert msg.additional_kwargs == {}
+
     def test_unknown_type_returns_none(self) -> None:
         assert _convert_message_data({"type": "unknown"}) is None
 

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -8798,10 +8798,14 @@ class TestToolHooksTextual:
     ) -> None:
         """A synthetic auto-mode denial does not log the uncorrelated warning.
 
-        The denial ToolMessage is synthesized without the tool executing, so no
-        tool.use fires and no widget mounts — a routine path. The marker set in
-        `auto_mode` must suppress the warning while the tool.result hook still
-        fires with empty args.
+        Covers the adapter branch given an already-marked message. A no-argument
+        call such as `onepassword_authenticate` streams no args, so no widget
+        mounts and its denial result arrives uncorrelated. The marker must
+        suppress the warning while the tool.result hook still fires with empty
+        args.
+
+        That the marker reaches this point is covered separately by
+        `test_policy_denial_marker_survives_server_round_trip`.
         """
         from deepagents_code.auto_mode import AUTO_DENIED_METADATA_KEY
 

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -8793,6 +8793,67 @@ class TestToolHooksTextual:
             for record in caplog.records
         )
 
+    async def test_auto_denied_tool_result_skips_uncorrelated_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A synthetic auto-mode denial does not log the uncorrelated warning.
+
+        The denial ToolMessage is synthesized without the tool executing, so no
+        tool.use fires and no widget mounts — a routine path. The marker set in
+        `auto_mode` must suppress the warning while the tool.result hook still
+        fires with empty args.
+        """
+        from deepagents_code.auto_mode import AUTO_DENIED_METADATA_KEY
+
+        chunks = [
+            (
+                (),
+                "messages",
+                (
+                    ToolMessage(
+                        content="Auto denied [credential_access]: not authorized",
+                        tool_call_id="call-1",
+                        name="onepassword_authenticate",
+                        status="error",
+                        additional_kwargs={AUTO_DENIED_METADATA_KEY: True},
+                    ),
+                    {},
+                ),
+            ),
+        ]
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        with (
+            caplog.at_level("WARNING", logger="deepagents_code.tui.textual_adapter"),
+            patch(
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
+            ) as mock_dispatch,
+        ):
+            await execute_task_textual(
+                user_input="hello",
+                agent=_FakeAgent(chunks),
+                assistant_id="assistant",
+                session_state=_session_state(auto_approve=False),
+                adapter=adapter,
+            )
+
+        result_payloads = [
+            c[0][1] for c in mock_dispatch.call_args_list if c[0][0] == "tool.result"
+        ]
+        assert len(result_payloads) == 1
+        assert result_payloads[0]["tool_id"] == "call-1"
+        assert result_payloads[0]["tool_args"] == {}
+        assert not any(
+            "call-1" in record.message
+            and "no correlated" in record.message
+            and record.levelname == "WARNING"
+            for record in caplog.records
+        )
+
     async def test_ask_user_interrupt_dispatches_tool_hooks(self) -> None:
         """ask_user interrupt rows emit tool.use and tool.result hooks."""
         future: asyncio.Future[AskUserWidgetResult] = asyncio.Future()


### PR DESCRIPTION
When auto-mode policy-denies a tool call (e.g. the credential-access policy blocking `onepassword_authenticate`), the TUI logged a false-positive warning:

```
WARNING deepagents_code.tui.textual_adapter ToolMessage tool_call_id=<id> not in _current_tool_messages; no correlated tool.use, sending empty tool_args
```

The warning exists to flag degraded audit fidelity — a tool that *executed* but whose streamed args never parsed, so no `tool.use` fired and the audit hook sees a `tool.result` with empty args. A policy denial instead synthesizes an *error* `ToolMessage` without the tool ever executing, so no widget mounts — an expected, routine path, not degraded fidelity. The warning added noise to debug logs and risked training users to ignore it.

The fix marks the denial at the source rather than string-matching in the adapter:

- `auto_mode.py`: the synthesized denial `ToolMessage` is stamped with `additional_kwargs={"deepagents_code_auto_denied": True}` (a new `AUTO_DENIED_METADATA_KEY` constant). `additional_kwargs` survives the messages-mode stream, verified by a probe.
- `textual_adapter.py`: the uncorrelated-result branch checks the marker and skips the warning when present. The `tool.result` hook still fires exactly as before; only the log line is suppressed. The real warning case — a tool that executed with unparsed args — still warns.

Manual HITL rejections were checked and do not need the same treatment: they are synthesized in the base middleware's `after_model` state update (not streamed) and are consumed through the adapter's interrupt-resolution path (`completed_tool_result_ids`), so they never reach the uncorrelated warning branch.
