### PR TITLE
fix(evals): use dcode runtime state in Harbor

### DIFF
--- a/libs/evals/deepagents_harbor/langgraph_project/langgraph_agent.py
+++ b/libs/evals/deepagents_harbor/langgraph_project/langgraph_agent.py
@@ -16,7 +16,7 @@ from deepagents import create_deep_agent
 from deepagents.backends import LocalShellBackend
 from deepagents_code._glm_5p2_profile import _GLM_5P2_MODEL_SPECS
 from deepagents_code.agent import create_cli_agent
-from deepagents_code.config import detect_provider, settings
+from deepagents_code.config import detect_provider, runtime_state
 from deepagents_code.model_config import ModelSpec
 from langchain.chat_models import init_chat_model
 from langchain_mcp_adapters.client import MultiServerMCPClient
@@ -202,13 +202,13 @@ def _harbor_assistant_id(session_id: str | None) -> str:
 
 
 def _apply_model_identity(model_spec: str, model: object) -> None:
-    """Populate dcode `settings` model identity from the selected model.
+    """Populate dcode runtime model identity from the selected model.
 
     `create_cli_agent` -> `get_system_prompt` builds the prompt's
-    `### Model Identity` section from the global dcode `settings` singleton
+    `### Model Identity` section from the global dcode `runtime_state` singleton
     (`model_name`, `model_provider`, `model_context_limit`,
     `model_unsupported_modalities`). Harbor builds the model itself via
-    `init_chat_model` and never touches those settings, so without this the
+    `init_chat_model` and never populates that state, so without this the
     identity section renders empty and the eval agent never learns which model
     it is. We set them here from Harbor's `configurable.model` spec plus the
     model's resolved profile, mirroring the extraction
@@ -229,10 +229,10 @@ def _apply_model_identity(model_spec: str, model: object) -> None:
         name = model_spec.lstrip(":")
         provider = detect_provider(name) or ""
 
-    settings.model_name = name
-    settings.model_provider = provider
-    settings.model_context_limit = None
-    settings.model_unsupported_modalities = frozenset()
+    runtime_state.model_name = name
+    runtime_state.model_provider = provider
+    runtime_state.model_context_limit = None
+    runtime_state.model_unsupported_modalities = frozenset()
 
     # Mirror create_model: pull context window + unsupported input modalities
     # from the model profile when the provider exposes one.
@@ -252,7 +252,7 @@ def _apply_model_identity(model_spec: str, model: object) -> None:
 
     max_input = profile.get("max_input_tokens")
     if isinstance(max_input, int):
-        settings.model_context_limit = max_input
+        runtime_state.model_context_limit = max_input
     else:
         # A profile that is present but lacks a usable context window is an
         # unexpected shape (e.g. a renamed key); surface it rather than silently
@@ -269,7 +269,7 @@ def _apply_model_identity(model_spec: str, model: object) -> None:
         "video_inputs": "video",
         "pdf_inputs": "pdf",
     }
-    settings.model_unsupported_modalities = frozenset(
+    runtime_state.model_unsupported_modalities = frozenset(
         label for key, label in modality_keys.items() if profile.get(key) is False
     )
 
@@ -296,7 +296,7 @@ def make_graph(config: dict[str, object] | None = None) -> object:
     configurable = _configurable(config)
     model = _build_model(configurable)
     # Feed the selected model into dcode's system-prompt `### Model Identity`
-    # section (create_cli_agent -> get_system_prompt reads it from `settings`).
+    # section (create_cli_agent -> get_system_prompt reads it from `runtime_state`).
     _apply_model_identity(_model_name(configurable), model)
     assistant_id = _harbor_assistant_id(os.environ.get("HARBOR_SESSION_ID"))
     with _scrub_shell_env():

--- a/libs/evals/tests/unit_tests/test_harbor_langgraph_agent.py
+++ b/libs/evals/tests/unit_tests/test_harbor_langgraph_agent.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from deepagents_code.config import settings
+from deepagents_code.config import runtime_state
 
 from deepagents_harbor.langgraph_project import langgraph_agent
 
@@ -25,19 +25,19 @@ _MODEL_IDENTITY_FIELDS = (
 
 
 @pytest.fixture(autouse=True)
-def _restore_model_identity_settings() -> Iterator[None]:
-    """Snapshot/restore dcode's `settings` model-identity fields.
+def _restore_model_identity_state() -> Iterator[None]:
+    """Snapshot and restore dcode's process-wide model identity.
 
     `make_graph` writes these process-level singleton fields (so the system
     prompt's Model Identity section is populated). Without restoring them, a
     test that runs `make_graph` would leak the model identity into later tests.
     """
-    saved = {field: getattr(settings, field) for field in _MODEL_IDENTITY_FIELDS}
+    saved = {field: getattr(runtime_state, field) for field in _MODEL_IDENTITY_FIELDS}
     try:
         yield
     finally:
         for field, value in saved.items():
-            setattr(settings, field, value)
+            setattr(runtime_state, field, value)
 
 
 def test_langgraph_config_points_to_deepagent_factory() -> None:
@@ -328,13 +328,13 @@ def test_make_graph_builds_headless_local_deepagent(
     assert "system_prompt" not in captured_create[0]
 
 
-def test_make_graph_populates_model_identity_settings(
+def test_make_graph_populates_runtime_model_identity(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """`make_graph` must feed `configurable.model` into dcode `settings`.
+    """`make_graph` feeds `configurable.model` into dcode runtime state.
 
     create_cli_agent -> get_system_prompt renders the prompt's Model Identity
-    section from these settings, so without this wiring the eval agent's prompt
+    section from this state, so without this wiring the eval agent's prompt
     would omit which model it is running as.
     """
 
@@ -365,17 +365,17 @@ def test_make_graph_populates_model_identity_settings(
         }
     )
 
-    assert settings.model_name == "claude-sonnet-4-5"
-    assert settings.model_provider == "anthropic"
-    assert settings.model_context_limit == 200_000
-    assert settings.model_unsupported_modalities == frozenset({"audio", "video"})
+    assert runtime_state.model_name == "claude-sonnet-4-5"
+    assert runtime_state.model_provider == "anthropic"
+    assert runtime_state.model_context_limit == 200_000
+    assert runtime_state.model_unsupported_modalities == frozenset({"audio", "video"})
 
 
 def test_make_graph_resets_model_identity_for_model_without_profile(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    settings.model_context_limit = 200_000
-    settings.model_unsupported_modalities = frozenset({"audio", "video"})
+    runtime_state.model_context_limit = 200_000
+    runtime_state.model_unsupported_modalities = frozenset({"audio", "video"})
 
     monkeypatch.setattr(langgraph_agent, "init_chat_model", lambda *_a, **_k: object())
     monkeypatch.setattr(
@@ -394,8 +394,8 @@ def test_make_graph_resets_model_identity_for_model_without_profile(
         }
     )
 
-    assert settings.model_context_limit is None
-    assert settings.model_unsupported_modalities == frozenset()
+    assert runtime_state.model_context_limit is None
+    assert runtime_state.model_unsupported_modalities == frozenset()
 
 
 @pytest.mark.parametrize(
@@ -435,8 +435,8 @@ def test_make_graph_derives_identity_for_bare_model_name(
         }
     )
 
-    assert settings.model_name == expected_name
-    assert settings.model_provider == expected_provider
+    assert runtime_state.model_name == expected_name
+    assert runtime_state.model_provider == expected_provider
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Harbor's dcode graph now initializes model identity through the supported runtime-state API.

---

The `Settings` dissolution removes `config.settings`, but the Harbor LangGraph agent still imported it to populate the model identity used by the dcode system prompt. This migrates that consumer and its isolation fixture to `runtime_state`, preserving the existing identity derivation and profile behavior.

Part 6 of 6 in the [`Settings` dissolution stack](https://github.com/langchain-ai/deepagents/pull/5859?stack=5864). This is the evals fan-out and depends on #5863.
