### PR TITLE
fix(sdk): prevent local shell commands from stealing TUI input

### DIFF
--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import uuid
 from typing import TYPE_CHECKING
 
@@ -310,6 +311,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 timeout=effective_timeout,
                 env=self._env,
                 cwd=str(self.cwd),  # Use the root_dir from FilesystemBackend
+                start_new_session=(sys.platform != "win32"),
             )
 
             # Combine stdout and stderr

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -1,5 +1,6 @@
 """Unit tests for LocalShellBackend."""
 
+import os
 import subprocess
 import sys
 import tempfile
@@ -13,6 +14,36 @@ from deepagents.backends.local_shell import LocalShellBackend
 from deepagents.backends.protocol import ExecuteResponse
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="LocalShellBackend requires sh, not available on Windows")
+
+
+def _execute_controlling_terminal_probe(directory: Path, result_file: Path) -> None:
+    """Run the backend probe after proving this process owns `/dev/tty`."""
+    descriptor = os.open("/dev/tty", os.O_RDONLY)
+    os.close(descriptor)
+    result = LocalShellBackend(root_dir=directory).execute(": </dev/tty")
+    result_file.write_text(f"{result.exit_code}\n{result.output}", encoding="utf-8")
+
+
+def _run_controlling_terminal_probe(directory: Path) -> tuple[int, str]:
+    """Run the backend inside a child that owns a real controlling terminal."""
+    pty = pytest.importorskip("pty")
+    result_file = directory / "tty-result"
+    child_id, terminal = pty.fork()
+    if child_id == 0:  # pragma: no cover - assertions run in the parent process
+        try:
+            _execute_controlling_terminal_probe(directory, result_file)
+        except BaseException as error:  # noqa: BLE001  # Report child setup failures to the parent.
+            result_file.write_text(f"harness error: {error}", encoding="utf-8")
+            os._exit(1)
+        os._exit(0)
+    try:
+        _, status = os.waitpid(child_id, 0)
+    finally:
+        os.close(terminal)
+    details = result_file.read_text(encoding="utf-8")
+    assert os.waitstatus_to_exitcode(status) == 0, details
+    exit_code, output = details.split("\n", 1)
+    return int(exit_code), output
 
 
 def test_local_shell_backend_initialization() -> None:
@@ -47,6 +78,13 @@ def test_local_shell_backend_execute_starts_new_session() -> None:
             backend.execute("echo hello")
 
     assert run.call_args.kwargs["start_new_session"] is True
+
+
+def test_local_shell_backend_cannot_open_parent_controlling_terminal(tmp_path: Path) -> None:
+    """Test a command cannot open the controlling terminal owned by its parent."""
+    exit_code, output = _run_controlling_terminal_probe(tmp_path)
+    assert exit_code != 0
+    assert "/dev/tty" in output
 
 
 def test_local_shell_backend_execute_with_error() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -1,9 +1,11 @@
 """Unit tests for LocalShellBackend."""
 
+import subprocess
 import sys
 import tempfile
 import warnings
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -34,6 +36,17 @@ def test_local_shell_backend_execute_simple_command() -> None:
         assert result.exit_code == 0
         assert "Hello World" in result.output
         assert result.truncated is False
+
+
+def test_local_shell_backend_execute_starts_new_session() -> None:
+    """Test that commands cannot access the parent's controlling terminal."""
+    completed = subprocess.CompletedProcess(args="echo hello", returncode=0, stdout="hello\n", stderr="")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        backend = LocalShellBackend(root_dir=tmpdir)
+        with patch("subprocess.run", return_value=completed) as run:
+            backend.execute("echo hello")
+
+    assert run.call_args.kwargs["start_new_session"] is True
 
 
 def test_local_shell_backend_execute_with_error() -> None:


### PR DESCRIPTION
Fixes #4329
Related: #5907

Local shell commands can no longer access the parent process's controlling terminal on POSIX systems, preventing credential prompts from stealing keyboard input from the dcode TUI.

---

The dcode agent routes `execute` through `LocalShellBackend`. Although that backend gives subprocesses `stdin=subprocess.DEVNULL`, programs such as Git and SSH can bypass standard input by opening `/dev/tty` directly. When they prompt for credentials, they then compete with Textual for the same terminal input, disrupting or effectively breaking the chat input until the process exits.

Start each local shell command in a new POSIX session so it no longer has access to dcode's controlling terminal. Interactive commands now fail cleanly through captured output rather than intercepting keystrokes. This also aligns the agent `execute` path with dcode's existing local `!` shell behavior.

Windows behavior is unchanged because `start_new_session` is enabled only on non-Windows platforms. Focused coverage runs the backend beneath a real controlling pseudo-terminal, proves the parent can open `/dev/tty`, and verifies the detached command cannot.

Made by [Open SWE](https://openswe.vercel.app/agents/58b7b723-1498-5094-af76-6ebd4bda4823)

Co-authored-by: Sumit Kumar <187615421+sumit1kr@users.noreply.github.com>
