### PR TITLE
feat(sdk): add rubric grader integration hooks

### DIFF
--- a/libs/deepagents/deepagents/middleware/rubric.py
+++ b/libs/deepagents/deepagents/middleware/rubric.py
@@ -1004,7 +1004,7 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         grader_state = state
         if self._prepare_messages_for_grader:
             grader_state = cast("RubricState", dict(state))
-            grader_state["messages"] = self._prepare_messages_for_grader(state.get("messages", []))
+            grader_state["messages"] = self._prepare_messages_for_grader(list(state.get("messages", [])))
         payload = self._build_grader_payload(grader_state, iteration, correction)
         grader_input = dict(self._build_grader_state(grader_state, iteration)) if self._build_grader_state else {}
         if "messages" in grader_input:

--- a/libs/deepagents/deepagents/middleware/rubric.py
+++ b/libs/deepagents/deepagents/middleware/rubric.py
@@ -24,6 +24,7 @@ from typing import (
     Any,
     Literal,
     NotRequired,
+    cast,
 )
 
 from langchain.agents import create_agent
@@ -520,6 +521,15 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
             `GraderResponse`.
 
             With none, the grader reasons from the transcript alone.
+        grader_middleware: Middleware applied to the nested grader agent.
+        grader_context_schema: Runtime context schema for the nested grader.
+        grader_state_schema: State schema for the nested grader. Use this when
+            `build_grader_state` adds custom state fields.
+        prepare_messages_for_grader: Optional transform applied to the transcript
+            messages before the SDK builds the sanitized grader payload.
+        build_grader_state: Optional callback that adds custom fields to the
+            nested grader input. It cannot replace the SDK-owned `messages`
+            field.
         max_iterations: Maximum grader iterations per rubric attempt; must be a
             positive integer.
 
@@ -533,8 +543,10 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
             suppressed; do not use this callback to enforce control flow.
 
     Raises:
-        ValueError: If `max_iterations` is less than 1, or if `model` is falsy.
-        TypeError: If `max_iterations` is not an `int`.
+        ValueError: If `max_iterations` is less than 1, `model` is falsy, or
+            `build_grader_state` is provided without `grader_state_schema`.
+        TypeError: If `max_iterations` is not an `int`, or a provided callback
+            is not callable.
     """
 
     trace_policy = TracePolicy(process_inputs=omit_payload)
@@ -548,6 +560,11 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         model: str | BaseChatModel,
         system_prompt: str | None = None,
         tools: Sequence[BaseTool] | None = None,
+        grader_middleware: Sequence[AgentMiddleware[Any, Any, Any]] | None = None,
+        grader_context_schema: type[Any] | None = None,
+        grader_state_schema: type[AgentState[Any]] | None = None,
+        prepare_messages_for_grader: Callable[[list[AnyMessage]], list[AnyMessage]] | None = None,
+        build_grader_state: Callable[[RubricState, int], Mapping[str, Any]] | None = None,
         max_iterations: int = 3,
         on_evaluation: Callable[[RubricEvaluation], None] | None = None,
     ) -> None:
@@ -560,12 +577,27 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         if max_iterations < 1:
             msg = f"RubricMiddleware: `max_iterations` must be positive, got {max_iterations}."
             raise ValueError(msg)
+        if grader_state_schema is None and build_grader_state is not None:
+            msg = "RubricMiddleware: `grader_state_schema` is required with `build_grader_state`."
+            raise ValueError(msg)
+        for name, callback in (
+            ("prepare_messages_for_grader", prepare_messages_for_grader),
+            ("build_grader_state", build_grader_state),
+        ):
+            if callback is not None and not callable(callback):
+                msg = f"RubricMiddleware: `{name}` must be callable."
+                raise TypeError(msg)
 
         self.max_iterations = max_iterations
         self._model = model
         self._model_label = _configured_model_label(model)
         self._system_prompt = system_prompt or GRADER_SYSTEM_PROMPT
         self._tools: list[BaseTool] = list(tools) if tools else []
+        self._grader_middleware = list(grader_middleware or ())
+        self._grader_context_schema = grader_context_schema
+        self._grader_state_schema = grader_state_schema
+        self._prepare_messages_for_grader = prepare_messages_for_grader
+        self._build_grader_state = build_grader_state
         self._on_evaluation = on_evaluation
         # Built lazily so importing the middleware doesn't construct a model
         # client (which can trigger env-var lookups / API key validation).
@@ -789,8 +821,11 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
             model=resolved_model,
             system_prompt=self._system_prompt,
             tools=self._tools,
+            middleware=self._grader_middleware,
             name=RUBRIC_GRADER_MESSAGE_SOURCE,
             response_format=GraderResponse,
+            state_schema=self._grader_state_schema,
+            context_schema=self._grader_context_schema,
         )
         return self._grader
 
@@ -966,8 +1001,17 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         Returns:
             The nested grader's input state.
         """
-        payload = self._build_grader_payload(state, iteration, correction)
-        return {"messages": [HumanMessage(content=payload)]}
+        grader_state = state
+        if self._prepare_messages_for_grader:
+            grader_state = cast("RubricState", dict(state))
+            grader_state["messages"] = self._prepare_messages_for_grader(state.get("messages", []))
+        payload = self._build_grader_payload(grader_state, iteration, correction)
+        grader_input = dict(self._build_grader_state(grader_state, iteration)) if self._build_grader_state else {}
+        if "messages" in grader_input:
+            msg = "RubricMiddleware: `build_grader_state` cannot set `messages`."
+            raise ValueError(msg)
+        grader_input["messages"] = [HumanMessage(content=payload)]
+        return grader_input
 
     def _invoke_grader(
         self,

--- a/libs/deepagents/deepagents/middleware/rubric.py
+++ b/libs/deepagents/deepagents/middleware/rubric.py
@@ -24,7 +24,6 @@ from typing import (
     Any,
     Literal,
     NotRequired,
-    cast,
 )
 
 from langchain.agents import create_agent
@@ -593,7 +592,7 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         self._model_label = _configured_model_label(model)
         self._system_prompt = system_prompt or GRADER_SYSTEM_PROMPT
         self._tools: list[BaseTool] = list(tools) if tools else []
-        self._grader_middleware = list(grader_middleware or ())
+        self._grader_middleware = grader_middleware or ()
         self._grader_context_schema = grader_context_schema
         self._grader_state_schema = grader_state_schema
         self._prepare_messages_for_grader = prepare_messages_for_grader
@@ -1003,7 +1002,7 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         """
         grader_state = state
         if self._prepare_messages_for_grader:
-            grader_state = cast("RubricState", dict(state))
+            grader_state = RubricState(**state)
             grader_state["messages"] = self._prepare_messages_for_grader(list(state.get("messages", [])))
         payload = self._build_grader_payload(grader_state, iteration, correction)
         grader_input = dict(self._build_grader_state(grader_state, iteration)) if self._build_grader_state else {}

--- a/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
@@ -24,6 +24,7 @@ from typing import Any, ClassVar
 
 import pytest
 from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentMiddleware, AgentState
 from langchain.agents.structured_output import StructuredOutputValidationError
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.tools import tool
@@ -37,6 +38,7 @@ from deepagents.middleware.rubric import (
     GraderResponse,
     RubricEvaluation,
     RubricMiddleware,
+    RubricState,
     _build_grader_transcript,
     _sanitize_for_payload,
 )
@@ -203,6 +205,18 @@ class TestConstruction:
     def test_max_iterations_non_int_rejected(self) -> None:
         with pytest.raises(TypeError):
             RubricMiddleware(model=_STUB_MODEL, max_iterations="3")  # type: ignore[arg-type]
+
+    def test_build_grader_state_requires_a_state_schema(self) -> None:
+        with pytest.raises(ValueError, match="`grader_state_schema` is required"):
+            RubricMiddleware(model=_STUB_MODEL, build_grader_state=lambda _state, _iteration: {})
+
+    @pytest.mark.parametrize("name", ["prepare_messages_for_grader", "build_grader_state"])
+    def test_non_callable_grader_callback_rejected(self, name: str) -> None:
+        kwargs: dict[str, Any] = {name: "invalid"}
+        if name == "build_grader_state":
+            kwargs["grader_state_schema"] = AgentState
+        with pytest.raises(TypeError, match=f"`{name}` must be callable"):
+            RubricMiddleware(model=_STUB_MODEL, **kwargs)  # type: ignore[arg-type]
 
     def test_tools_default_to_empty(self) -> None:
         mw = RubricMiddleware(model=_STUB_MODEL)
@@ -514,7 +528,7 @@ class TestGraderPlumbing:
         """A grader with no tools is built only when first needed."""
         built: list[dict[str, Any]] = []
 
-        def fake_create_agent(*, model, system_prompt, tools, name, response_format):  # type: ignore[no-untyped-def]
+        def fake_create_agent(*, model, system_prompt, tools, name, response_format, **_kwargs: Any):  # type: ignore[no-untyped-def]
             built.append(
                 {
                     "model": model,
@@ -552,6 +566,35 @@ class TestGraderPlumbing:
         mw._ensure_grader()
         assert len(built) == 1
 
+    def test_nested_grader_configuration_passed_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: dict[str, Any] = {}
+        nested_middleware = AgentMiddleware()
+
+        class GraderContext:
+            pass
+
+        class GraderState(AgentState[GraderResponse]):
+            pass
+
+        def fake_create_agent(**kwargs: Any) -> SimpleNamespace:
+            seen.update(kwargs)
+            return SimpleNamespace()
+
+        monkeypatch.setattr("deepagents.middleware.rubric.create_agent", fake_create_agent)
+        monkeypatch.setattr("deepagents._models.resolve_model", lambda m: m)
+        mw = RubricMiddleware(
+            model=_STUB_MODEL,
+            grader_middleware=[nested_middleware],
+            grader_context_schema=GraderContext,
+            grader_state_schema=GraderState,
+        )
+
+        mw._ensure_grader()
+
+        assert seen["middleware"] == [nested_middleware]
+        assert seen["context_schema"] is GraderContext
+        assert seen["state_schema"] is GraderState
+
     def test_tools_passed_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
         @tool
         def shell(cmd: str) -> str:
@@ -560,7 +603,7 @@ class TestGraderPlumbing:
 
         seen: dict[str, Any] = {}
 
-        def fake_create_agent(*, model, system_prompt, tools, name, response_format):  # type: ignore[no-untyped-def]  # noqa: ARG001
+        def fake_create_agent(*, model, system_prompt, tools, name, response_format, **_kwargs: Any):  # type: ignore[no-untyped-def]  # noqa: ARG001
             seen["tools"] = list(tools)
             return SimpleNamespace()
 
@@ -573,7 +616,7 @@ class TestGraderPlumbing:
     def test_model_propagated(self, monkeypatch: pytest.MonkeyPatch) -> None:
         seen: dict[str, Any] = {}
 
-        def fake_create_agent(*, model, system_prompt, tools, name, response_format):  # type: ignore[no-untyped-def]  # noqa: ARG001
+        def fake_create_agent(*, model, system_prompt, tools, name, response_format, **_kwargs: Any):  # type: ignore[no-untyped-def]  # noqa: ARG001
             seen["model"] = model
             return SimpleNamespace()
 
@@ -836,7 +879,7 @@ class TestGraderPlumbing:
         """A user-supplied `system_prompt` replaces the default grader prompt."""
         seen: dict[str, Any] = {}
 
-        def fake_create_agent(*, model, system_prompt, tools, name, response_format):  # type: ignore[no-untyped-def]  # noqa: ARG001
+        def fake_create_agent(*, model, system_prompt, tools, name, response_format, **_kwargs: Any):  # type: ignore[no-untyped-def]  # noqa: ARG001
             seen["system_prompt"] = system_prompt
             return SimpleNamespace()
 
@@ -1931,6 +1974,47 @@ class TestGraderExtensionContract:
 
         assert captured["payload"]["operation_id"] == "op-1"
         assert "messages" in captured["payload"]
+
+    def test_prepare_messages_and_build_state_hooks(self) -> None:
+        class GraderState(AgentState[GraderResponse]):
+            pass
+
+        visible = HumanMessage(content="visible")
+        internal = HumanMessage(content="internal")
+        state = self._state(messages=[visible, internal])
+        seen: dict[str, Any] = {}
+
+        def build_grader_state(prepared: RubricState, iteration: int) -> dict[str, str]:
+            seen["messages"] = prepared["messages"]
+            return {"operation_id": f"op:{iteration}"}
+
+        mw = RubricMiddleware(
+            model=_STUB_MODEL,
+            grader_state_schema=GraderState,
+            prepare_messages_for_grader=lambda messages: [messages[0]],
+            build_grader_state=build_grader_state,
+        )
+
+        grader_input = mw._grader_input(state, 2)
+
+        assert grader_input["operation_id"] == "op:2"
+        assert "visible" in grader_input["messages"][0].content
+        assert "internal" not in grader_input["messages"][0].content
+        assert seen["messages"] == [visible]
+        assert state["messages"] == [visible, internal]
+
+    def test_build_grader_state_cannot_replace_messages(self) -> None:
+        class GraderState(AgentState[GraderResponse]):
+            pass
+
+        mw = RubricMiddleware(
+            model=_STUB_MODEL,
+            grader_state_schema=GraderState,
+            build_grader_state=lambda _state, _iteration: {"messages": []},
+        )
+
+        with pytest.raises(ValueError, match="cannot set `messages`"):
+            mw._grader_input(self._state(), 0)
 
     def test_per_call_wrapper_composes_with_coverage_retry(
         self,

--- a/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
@@ -1984,6 +1984,10 @@ class TestGraderExtensionContract:
         state = self._state(messages=[visible, internal])
         seen: dict[str, Any] = {}
 
+        def prepare_messages(messages: list[BaseMessage]) -> list[BaseMessage]:
+            messages.pop()
+            return messages
+
         def build_grader_state(prepared: RubricState, iteration: int) -> dict[str, str]:
             seen["messages"] = prepared["messages"]
             return {"operation_id": f"op:{iteration}"}
@@ -1991,7 +1995,7 @@ class TestGraderExtensionContract:
         mw = RubricMiddleware(
             model=_STUB_MODEL,
             grader_state_schema=GraderState,
-            prepare_messages_for_grader=lambda messages: [messages[0]],
+            prepare_messages_for_grader=prepare_messages,
             build_grader_state=build_grader_state,
         )
 


### PR DESCRIPTION
Related: #5030

`RubricMiddleware` now lets applications configure and prepare its nested grader agent without subclassing SDK internals.

---

`RubricMiddleware` grades the main agent by creating a second, nested agent. The existing API exposes that grader's model, prompt, and tools, but real applications also need the grader to participate in app-level policy:

- apply middleware such as tool-call budgets and path restrictions;
- receive typed runtime context used by those tools and middleware;
- remove app-internal control messages before they become grading evidence; and
- carry app-specific state, such as an operation ID used to scope a budget.

Without public hooks, consumers have to override private grader construction and input-building methods. That couples applications to SDK internals and makes transcript customization especially risky because the override must preserve the SDK's payload sanitization.

### Before

An application has to subclass `RubricMiddleware` and modify the nested grader input after delegating to private methods:

```python
class AppRubricMiddleware(RubricMiddleware):
    def _grader_input(self, state, iteration, correction=None):
        state = {
            **state,
            "messages": [
                message
                for message in state["messages"]
                if not is_internal_control_message(message)
            ],
        }
        grader_input = super()._grader_input(state, iteration, correction)
        grader_input["grading_operation_id"] = f"{state['_current_grading_run_id']}:{iteration}"
        return grader_input
```

It must also override nested-agent construction to install grader middleware, a context schema, and a state schema.

### After

The same integration is expressed through constructor options:

```python
rubric = RubricMiddleware(
    model=grader_model,
    tools=verification_tools,
    grader_middleware=[verification_budget, path_policy],
    grader_context_schema=AppContext,
    grader_state_schema=AppGraderState,
    prepare_messages_for_grader=lambda messages: [
        message
        for message in messages
        if not is_internal_control_message(message)
    ],
    build_grader_state=lambda state, iteration: {
        "grading_operation_id": (
            f"{state['_current_grading_run_id']}:{iteration}"
        )
    },
)
```

This keeps the responsibilities explicit:

- `grader_middleware`, `grader_context_schema`, and `grader_state_schema` configure the nested agent through the same `create_agent` surface used elsewhere.
- `prepare_messages_for_grader` filters a copy of the transcript before the SDK builds and sanitizes the grader payload; it does not mutate the outer agent state.
- `build_grader_state` adds schema-backed fields to the nested grader input, but cannot replace the SDK-owned `messages` field and bypass sanitization.

All new options are optional, so existing `RubricMiddleware` callers keep the same behavior. Invalid callbacks fail during construction, and custom grader state requires an explicit schema.

The follow-up in #5888 uses these hooks to remove Deep Agents Code's custom grader-input override while preserving its transcript filtering and verification-budget scoping.


Made by [Open SWE](https://openswe.vercel.app/agents/983cd60f-1eb6-57fd-9146-bb0078f08d1a)
