### PR TITLE
feat(sdk): add Anthropic harness profiles for Claude 5

### DIFF
--- a/libs/deepagents/deepagents/profiles/_builtin_profiles.py
+++ b/libs/deepagents/deepagents/profiles/_builtin_profiles.py
@@ -27,6 +27,7 @@ import warnings
 from importlib.metadata import EntryPoint, entry_points
 
 from deepagents.profiles.harness import (
+    _anthropic_fable_mythos_5,
     _anthropic_haiku_4_5,
     _anthropic_opus_4_7,
     _anthropic_sonnet_4_6,
@@ -149,6 +150,7 @@ def _ensure_builtin_profiles_loaded() -> None:
         _nvidia.register()
         _openai.register()
         _openrouter.register()
+        _anthropic_fable_mythos_5.register()
         _anthropic_opus_4_7.register()
         _anthropic_sonnet_4_6.register()
         _anthropic_haiku_4_5.register()

--- a/libs/deepagents/deepagents/profiles/harness/_anthropic_fable_mythos_5.py
+++ b/libs/deepagents/deepagents/profiles/harness/_anthropic_fable_mythos_5.py
@@ -1,0 +1,58 @@
+"""Built-in Claude Fable 5 and Mythos 5 harness profile.
+
+Layers Anthropic's universal Claude guidance onto
+`anthropic:claude-fable-5` and `anthropic:claude-mythos-5`, plus shared
+guidance for long-horizon completion, context continuity, and reader-oriented
+final summaries.
+
+The profile intentionally omits unconditional memory and asynchronous
+delegation instructions because those capabilities depend on the middleware
+and subagents configured by the caller. Refusal and provider fallback handling
+also remain runtime concerns rather than prompt policy.
+
+Sources:
+
+- https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices
+- https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5
+"""
+
+# ruff: noqa: E501
+# The universal sections mirror Anthropic's published samples verbatim so they
+# stay auditable against the other model-specific Claude profile modules.
+
+from deepagents.profiles.harness.harness_profiles import (
+    HarnessProfile,
+    _register_harness_profile_impl,
+)
+
+_SYSTEM_PROMPT_SUFFIX = """\
+<use_parallel_tool_calls>
+If you intend to call multiple tools and there are no dependencies between the tool calls, make all of the independent tool calls in parallel. Prioritize calling tools simultaneously whenever the actions can be done in parallel rather than sequentially. For example, when reading 3 files, run 3 tool calls in parallel to read all 3 files into context at the same time. Maximize use of parallel tool calls where possible to increase speed and efficiency. However, if some tool calls depend on previous calls to inform dependent values like the parameters, do NOT call these tools in parallel and instead call them sequentially. Never use placeholders or guess missing parameters in tool calls.
+</use_parallel_tool_calls>
+
+<investigate_before_answering>
+Never speculate about code you have not opened. If the user references a specific file, you MUST read the file before answering. Make sure to investigate and read relevant files BEFORE answering questions about the codebase. Never make any claims about code before investigating unless you are certain of the correct answer - give grounded and hallucination-free answers.
+</investigate_before_answering>
+
+<tool_result_reflection>
+After receiving tool results, carefully reflect on their quality and determine optimal next steps before proceeding. Use your thinking to plan and iterate based on this new information, and then take the best next action.
+</tool_result_reflection>
+
+<long_horizon_completion>
+For long-running work, continue until the task is complete or you are blocked on information only the user can provide. Do not stop, propose a new session, or hand work off merely because the conversation has become long or you perceive context pressure. Let the harness manage context and keep making concrete progress.
+</long_horizon_completion>
+
+<final_summary_readability>
+After an extended tool-driven run, write the final answer for a reader who may not have followed the working process. Lead with the outcome, use complete sentences, and explain important files, identifiers, decisions, and remaining blockers in plain language. Prefer clarity over terse working shorthand.
+</final_summary_readability>"""
+"""Text appended to the assembled base system prompt."""
+
+
+def register() -> None:
+    """Register the built-in Claude Fable 5 and Mythos 5 harness profile."""
+    profile = HarnessProfile(system_prompt_suffix=_SYSTEM_PROMPT_SUFFIX)
+    for model_spec in (
+        "anthropic:claude-fable-5",
+        "anthropic:claude-mythos-5",
+    ):
+        _register_harness_profile_impl(model_spec, profile)

--- a/libs/deepagents/deepagents/profiles/harness/_anthropic_fable_mythos_5.py
+++ b/libs/deepagents/deepagents/profiles/harness/_anthropic_fable_mythos_5.py
@@ -39,7 +39,7 @@ After receiving tool results, carefully reflect on their quality and determine o
 </tool_result_reflection>
 
 <long_horizon_completion>
-For long-running work, continue until the task is complete or you are blocked on information only the user can provide. Do not stop, propose a new session, or hand work off merely because the conversation has become long or you perceive context pressure. Let the harness manage context and keep making concrete progress.
+Do not stop, propose a new session, or hand work off merely because the conversation has become long or you perceive context pressure. Continue making concrete progress until complete or blocked on required user input.
 </long_horizon_completion>
 
 <final_summary_readability>

--- a/libs/deepagents/deepagents/profiles/harness/_anthropic_fable_mythos_5.py
+++ b/libs/deepagents/deepagents/profiles/harness/_anthropic_fable_mythos_5.py
@@ -39,7 +39,7 @@ After receiving tool results, carefully reflect on their quality and determine o
 </tool_result_reflection>
 
 <long_horizon_completion>
-Do not stop, propose a new session, or hand work off merely because the conversation has become long or you perceive context pressure. Continue making concrete progress until complete or blocked on required user input.
+Do not stop, propose a new session, or hand work off merely because the conversation has become long or you perceive context pressure. Continue making concrete progress until the task is complete or blocked on required user input.
 </long_horizon_completion>
 
 <final_summary_readability>

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -1209,10 +1209,11 @@ class TestBuiltInProfiles:
         mythos = _get_harness_profile("anthropic:claude-mythos-5")
         assert fable is not None
         assert mythos is not None
-        assert fable == mythos
+        assert fable.system_prompt_suffix == mythos.system_prompt_suffix
         assert "<long_horizon_completion>" in fable.system_prompt_suffix
         assert "<final_summary_readability>" in fable.system_prompt_suffix
         assert not fable.materialize_extra_middleware()
+        assert not mythos.materialize_extra_middleware()
 
     @pytest.mark.parametrize(
         "model_key",

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -1180,6 +1180,8 @@ class TestBuiltInProfiles:
     @pytest.mark.parametrize(
         "model_key",
         [
+            "anthropic:claude-fable-5",
+            "anthropic:claude-mythos-5",
             "anthropic:claude-opus-4-7",
             "anthropic:claude-sonnet-4-6",
             "anthropic:claude-haiku-4-5",
@@ -1200,6 +1202,17 @@ class TestBuiltInProfiles:
         assert profile is not None
         assert "<tool_usage>" in profile.system_prompt_suffix
         assert "<subagent_usage>" in profile.system_prompt_suffix
+
+    def test_fable_and_mythos_5_share_model_specific_overlays(self) -> None:
+        """Fable 5 and Mythos 5 share long-horizon and final-summary overlays."""
+        fable = _get_harness_profile("anthropic:claude-fable-5")
+        mythos = _get_harness_profile("anthropic:claude-mythos-5")
+        assert fable is not None
+        assert mythos is not None
+        assert fable == mythos
+        assert "<long_horizon_completion>" in fable.system_prompt_suffix
+        assert "<final_summary_readability>" in fable.system_prompt_suffix
+        assert not fable.materialize_extra_middleware()
 
     @pytest.mark.parametrize(
         "model_key",
@@ -1227,12 +1240,18 @@ class TestBuiltInProfiles:
         the text, the others must follow or this test will flag it.
         """
         opus = _get_harness_profile("anthropic:claude-opus-4-7")
+        fable = _get_harness_profile("anthropic:claude-fable-5")
+        mythos = _get_harness_profile("anthropic:claude-mythos-5")
         sonnet = _get_harness_profile("anthropic:claude-sonnet-4-6")
         haiku = _get_harness_profile("anthropic:claude-haiku-4-5")
         assert opus is not None
+        assert fable is not None
+        assert mythos is not None
         assert sonnet is not None
         assert haiku is not None
         assert opus.system_prompt_suffix.startswith(sonnet.system_prompt_suffix)
+        assert fable.system_prompt_suffix.startswith(sonnet.system_prompt_suffix)
+        assert mythos.system_prompt_suffix.startswith(sonnet.system_prompt_suffix)
         assert sonnet.system_prompt_suffix == haiku.system_prompt_suffix
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #5891

Deep Agents now applies docs-aligned built-in harness guidance to Claude Fable 5, Mythos 5, Opus 5, and Sonnet 5.

---

The Anthropic harness profile registry previously covered Claude Opus 4.7, Sonnet 4.6, and Haiku 4.5, while the corresponding Claude 5 model specs resolved without exact built-in guidance.

This change centralizes the universal Claude prompt sections and registers prompt-only profiles for these exact keys:

- `anthropic:claude-fable-5`
- `anthropic:claude-mythos-5`
- `anthropic:claude-opus-5`
- `anthropic:claude-sonnet-5`

Fable 5 and Mythos 5 share Anthropic's documented overlay for task scope, evidence-backed progress, and autonomous completion. Opus 5 receives separate response, scope, and synchronous-delegation guidance, while Sonnet 5 receives a minimal instruction-scope overlay for its more literal behavior.

The profiles reuse the existing registry and lazy bootstrap. They do not add middleware, a provider-wide Anthropic fallback, persistent-memory promises, asynchronous-subagent requirements, or provider-level refusal handling. Other Anthropic variants, including Fable/Mythos 5.1 and Opus 4.8, remain outside this change.

Focused unit coverage verifies exact-key resolution, model-specific guidance, universal-guidance ordering, unchanged middleware behavior, and isolation from unrelated Anthropic identifiers.

Validation:

- `uv run ruff check ...`
- `uv run ruff format ... --diff`
- `uv run --group test pytest tests/unit_tests/test_models.py::TestBuiltInProfiles -q` (36 passed)

No dependencies or lockfiles are changed.