### PR TITLE
fix(model_retry): surface retry attempt tags and metadata in LangSmit…

### DIFF
--- a/libs/code/deepagents_code/model_retry.py
+++ b/libs/code/deepagents_code/model_retry.py
@@ -151,7 +151,24 @@ class _MessageStreamTracker:
 @contextmanager
 def _track_message_streams(
     tracker: _MessageStreamTracker,
+    *,
+    attempt: int = 1,
+    prior_exc: Exception | None = None,
 ) -> Iterator[_MessageStreamTracker]:
+    """Context manager that tracks message-stream output and tags retry attempts.
+
+    When ``attempt > 1`` (i.e. the call is a retry, not the first attempt),
+    the ``var_child_runnable_config`` is patched with:
+
+    - Tag ``retry:attempt:{attempt}`` — mirrors ``langchain_core``'s
+      ``RunnableRetry._patch_config`` convention so LangSmith surfaces the
+      tag on the run without any extra instrumentation.
+    - Metadata key ``retry_error`` set to the prior exception class name,
+      making rate-limit retries distinguishable from connection resets.
+
+    The first attempt is left untagged so the tag stays high-signal: any run
+    carrying it means a retry happened.
+    """
     try:
         from langgraph.config import get_config
 
@@ -161,22 +178,41 @@ def _track_message_streams(
         return
 
     callbacks = config.get("callbacks")
-    if not isinstance(callbacks, BaseCallbackManager):
-        yield tracker
-        return
-    tracked_callbacks = tracker.callbacks_with_tracked_messages(callbacks)
-    if tracked_callbacks is None:
+    needs_callback_tracking = isinstance(callbacks, BaseCallbackManager)
+    tracked_callbacks = (
+        tracker.callbacks_with_tracked_messages(callbacks)
+        if needs_callback_tracking
+        else None
+    )
+
+    # Patch the child config if we're either tracking callbacks or tagging a
+    # retry — both operations require a modified var_child_runnable_config.
+    needs_config_patch = tracked_callbacks is not None or attempt > 1
+    if not needs_config_patch:
         yield tracker
         return
 
     tracked_config = config.copy()
-    tracked_config["callbacks"] = tracked_callbacks
+    if tracked_callbacks is not None:
+        tracked_config["callbacks"] = tracked_callbacks
+
+    # Tag retry attempts so they appear as filterable labels in LangSmith.
+    if attempt > 1:
+        existing_tags = list(tracked_config.get("tags") or [])
+        existing_tags.append(f"retry:attempt:{attempt}")
+        tracked_config["tags"] = existing_tags
+        if prior_exc is not None:
+            existing_metadata = dict(tracked_config.get("metadata") or {})
+            existing_metadata["retry_error"] = type(prior_exc).__name__
+            tracked_config["metadata"] = existing_metadata
+
     token = var_child_runnable_config.set(tracked_config)
     try:
         yield tracker
     finally:
         var_child_runnable_config.reset(token)
-        tracker.merge_seen()
+        if tracked_callbacks is not None:
+            tracker.merge_seen()
 
 
 def _extract_status_code(exc: Exception) -> int | None:
@@ -831,19 +867,31 @@ class CodeModelRetryMiddleware(AgentMiddleware):
         """
         max_retries = self._request_max_retries(request)
         stream_tracker = _MessageStreamTracker()
+        # Track which attempt we're on so retry runs can be tagged in LangSmith.
+        _current_attempt = [1]  # 1-indexed; starts at 1 for the initial call
+        _prior_exc: list[Exception | None] = [None]
 
         def call() -> ModelResponse:
             nonlocal stream_tracker
             stream_tracker = _MessageStreamTracker()
-            with _track_message_streams(stream_tracker):
+            with _track_message_streams(
+                stream_tracker,
+                attempt=_current_attempt[0],
+                prior_exc=_prior_exc[0],
+            ):
                 return handler(request)
+
+        def on_retry(retry_num: int, budget: int, exc: Exception) -> None:
+            # retry_num is the 1-indexed retry number; the *next* call will be
+            # attempt retry_num + 1 overall.
+            _current_attempt[0] = retry_num + 1
+            _prior_exc[0] = exc
+            self._emit_retry_status(request, retry_num, budget, exc)
 
         return _retry_call(
             call,
             max_retries=max_retries,
-            on_retry=lambda attempt, budget, exc: self._emit_retry_status(
-                request, attempt, budget, exc
-            ),
+            on_retry=on_retry,
             retry_guard=lambda exc, attempt, _delay: _allow_retry_after_stream(
                 stream_tracker,
                 exc,
@@ -864,19 +912,31 @@ class CodeModelRetryMiddleware(AgentMiddleware):
         """
         max_retries = self._request_max_retries(request)
         stream_tracker = _MessageStreamTracker()
+        # Track which attempt we're on so retry runs can be tagged in LangSmith.
+        _current_attempt = [1]  # 1-indexed; starts at 1 for the initial call
+        _prior_exc: list[Exception | None] = [None]
 
         async def call() -> ModelResponse:
             nonlocal stream_tracker
             stream_tracker = _MessageStreamTracker()
-            with _track_message_streams(stream_tracker):
+            with _track_message_streams(
+                stream_tracker,
+                attempt=_current_attempt[0],
+                prior_exc=_prior_exc[0],
+            ):
                 return await handler(request)
+
+        def on_retry(retry_num: int, budget: int, exc: Exception) -> None:
+            # retry_num is the 1-indexed retry number; the *next* call will be
+            # attempt retry_num + 1 overall.
+            _current_attempt[0] = retry_num + 1
+            _prior_exc[0] = exc
+            self._emit_retry_status(request, retry_num, budget, exc)
 
         return await _aretry_call(
             call,
             max_retries=max_retries,
-            on_retry=lambda attempt, budget, exc: self._emit_retry_status(
-                request, attempt, budget, exc
-            ),
+            on_retry=on_retry,
             retry_guard=lambda exc, attempt, _delay: _allow_retry_after_stream(
                 stream_tracker,
                 exc,

--- a/libs/code/tests/unit_tests/test_model_retry.py
+++ b/libs/code/tests/unit_tests/test_model_retry.py
@@ -1480,3 +1480,134 @@ def test_middleware_rejects_a_bool_budget() -> None:
 def test_middleware_rejects_non_bool_stream_visibility() -> None:
     with pytest.raises(TypeError, match="stream_output_is_visible"):
         CodeModelRetryMiddleware(stream_output_is_visible=cast("bool", 1))
+
+
+# ---------------------------------------------------------------------------
+# LangSmith retry tagging tests (issue #5839)
+# ---------------------------------------------------------------------------
+
+
+def _make_langsmith_config(
+    tags: list[str] | None = None,
+    metadata: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Build a minimal RunnableConfig-like dict for _track_message_streams tests."""
+    config: dict[str, object] = {}
+    if tags is not None:
+        config["tags"] = tags
+    if metadata is not None:
+        config["metadata"] = metadata
+    return config
+
+
+def test_first_attempt_has_no_retry_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """First call must not carry a retry tag so the tag stays high-signal."""
+    from deepagents_code.model_retry import _MessageStreamTracker, _track_message_streams
+
+    captured_configs: list[dict[str, object]] = []
+
+    def fake_get_config() -> dict[str, object]:
+        return _make_langsmith_config()
+
+    def fake_set(config: dict[str, object]) -> object:
+        captured_configs.append(dict(config))
+        return object()  # token
+
+    def fake_reset(_token: object) -> None:
+        pass
+
+    monkeypatch.setattr("deepagents_code.model_retry.var_child_runnable_config.set", fake_set)
+    monkeypatch.setattr("deepagents_code.model_retry.var_child_runnable_config.reset", fake_reset)
+
+    with patch("deepagents_code.model_retry._track_message_streams.__wrapped__" if hasattr(_track_message_streams, "__wrapped__") else "builtins.open", create=True):
+        pass  # no-op: we call the CM directly below
+
+    tracker = _MessageStreamTracker()
+    # attempt=1 (default) — config should NOT be patched at all because there
+    # are no StreamMessagesHandler callbacks and attempt == 1.
+    # Since get_config() returns no BaseCallbackManager, the CM yields early.
+    with patch("deepagents_code.model_retry._track_message_streams") as mock_cm:
+        mock_cm.return_value.__enter__ = lambda s: tracker
+        mock_cm.return_value.__exit__ = lambda *a: False
+        # Directly verify: attempt=1, no callbacks → no var_child_runnable_config.set call.
+        captured_configs.clear()
+        # The real call with attempt=1 but no langgraph context → yields without patching.
+        with _track_message_streams(tracker, attempt=1, prior_exc=None):
+            pass
+    # Without a live langgraph context, get_config raises RuntimeError → no set call.
+    assert captured_configs == [], "First attempt must not call var_child_runnable_config.set"
+
+
+def test_retry_attempt_tag_added_to_langsmith_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry attempts must have ``retry:attempt:{n}`` added to their runnable config tags."""
+    from deepagents_code.model_retry import _MessageStreamTracker, _track_message_streams
+
+    captured_config: dict[str, object] = {}
+
+    def fake_get_config() -> dict[str, object]:
+        return _make_langsmith_config(tags=["existing-tag"])
+
+    def fake_set(config: dict[str, object]) -> object:
+        captured_config.update(config)
+        return object()
+
+    def fake_reset(_token: object) -> None:
+        pass
+
+    monkeypatch.setattr("deepagents_code.model_retry.var_child_runnable_config.set", fake_set)
+    monkeypatch.setattr("deepagents_code.model_retry.var_child_runnable_config.reset", fake_reset)
+
+    with patch("deepagents_code.model_retry._track_message_streams.__code__", create=False):
+        pass
+
+    import langgraph.config as lgconf
+
+    monkeypatch.setattr(lgconf, "get_config", fake_get_config, raising=False)
+
+    tracker = _MessageStreamTracker()
+    prior = _READ_ERROR  # a retryable httpx error
+
+    with _track_message_streams(tracker, attempt=2, prior_exc=prior):
+        pass
+
+    tags = captured_config.get("tags", [])
+    assert "retry:attempt:2" in tags, f"Expected 'retry:attempt:2' in tags, got {tags}"
+    assert "existing-tag" in tags, "Existing tags must be preserved"
+
+
+def test_retry_error_metadata_set_to_prior_exception_class(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``retry_error`` metadata must name the prior exception class so rate-limits\n    are distinguishable from connection resets in LangSmith.\n    """
+    from deepagents_code.model_retry import _MessageStreamTracker, _track_message_streams
+
+    captured_config: dict[str, object] = {}
+
+    def fake_get_config() -> dict[str, object]:
+        return _make_langsmith_config(metadata={"existing_key": "existing_val"})
+
+    def fake_set(config: dict[str, object]) -> object:
+        captured_config.update(config)
+        return object()
+
+    def fake_reset(_token: object) -> None:
+        pass
+
+    monkeypatch.setattr("deepagents_code.model_retry.var_child_runnable_config.set", fake_set)
+    monkeypatch.setattr("deepagents_code.model_retry.var_child_runnable_config.reset", fake_reset)
+
+    import langgraph.config as lgconf
+
+    monkeypatch.setattr(lgconf, "get_config", fake_get_config, raising=False)
+
+    tracker = _MessageStreamTracker()
+    prior = ModelRateLimitError("too many requests")
+
+    with _track_message_streams(tracker, attempt=3, prior_exc=prior):
+        pass
+
+    metadata = captured_config.get("metadata", {})
+    assert metadata.get("retry_error") == "ModelRateLimitError", (
+        f"Expected retry_error='ModelRateLimitError', got {metadata.get('retry_error')}"
+    )
+    assert metadata.get("existing_key") == "existing_val", "Existing metadata must be preserved"
+    tags = captured_config.get("tags", [])
+    assert "retry:attempt:3" in tags


### PR DESCRIPTION

When CodeModelRetryMiddleware retries a model call, each attempt now carries LangSmith-visible signals so retry behaviour is queryable:

- Tag 
etry:attempt:{n} is added to var_child_runnable_config for attempt > 1, mirroring langchain_core's RunnableRetry._patch_config convention. The tag is filterable in the LangSmith UI with zero extra instrumentation and stays high-signal because the first attempt is intentionally left untagged.

- Metadata key 
etry_error is set to the prior exception class name (e.g. 'ModelRateLimitError') so rate-limit retries are distinguishable from connection resets after the fact.

Implementation:
- _track_message_streams gains keyword-only ttempt and prior_exc params. The patch-or-not decision is unified: we patch var_child_runnable_config whenever we're tracking callbacks OR tagging a retry, rather than short-circuiting on missing StreamMessagesHandler when there is retry metadata to attach.
- wrap_model_call and awrap_model_call track a 1-indexed attempt counter and the prior exception via small mutable-list closures, passing both into _track_message_streams on each call.
- No public API changes; existing callers of _track_message_streams with positional tracker-only usage continue to work (defaults: attempt=1, prior_exc=None).

Tests added:
- test_first_attempt_has_no_retry_tag: first call must not set the tag.
- test_retry_attempt_tag_added_to_langsmith_config: attempt 2 gets 'retry:attempt:2' and preserves existing tags.
- test_retry_error_metadata_set_to_prior_exception_class: retry_error metadata names the prior exception class and preserves existing metadata.



