### PR TITLE
fix(code): point model switch warning to `/offload`

### DIFF
--- a/libs/code/deepagents_code/tui/modals/model_switch.py
+++ b/libs/code/deepagents_code/tui/modals/model_switch.py
@@ -91,7 +91,7 @@ class ModelSwitchWarningScreen(ModalScreen[bool]):
             f"{format_token_count(self._threshold)} warning threshold.\n\n"
             f"Switching from {self._current_model} to {self._target_model} keeps "
             "the conversation, but may discard prompt-cache savings and the new "
-            "model may have a different context limit. Run /compact first if you "
+            "model may have a different context limit. Run /offload first if you "
             "want to reduce the context."
         )
         glyphs = get_glyphs()

--- a/libs/code/tests/unit_tests/tui/modals/test_model_switch.py
+++ b/libs/code/tests/unit_tests/tui/modals/test_model_switch.py
@@ -62,3 +62,4 @@ async def test_dynamic_copy_renders_literally_and_marks_approximation() -> None:
         assert "approximately 124.0K" in rendered
         assert "anthropic:claude[old]" in rendered
         assert "openai:gpt[new]" in rendered
+        assert "/offload" in rendered


### PR DESCRIPTION
The large-context model-switch warning now points users to `/offload`, the command that summarizes older messages and frees context.

---

The modal still referenced the obsolete `/compact` spelling. Update the copy and cover the current command in the existing modal test.

Made by [Open SWE](https://openswe.vercel.app/agents/af86a6b6-3c48-56e5-ab94-6d4e70672aa2)