### PR TITLE
feat(code): copy current model from picker header

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -13,6 +13,7 @@ from textual.content import Content
 from textual.css.query import NoMatches
 from textual.events import (
     Click,  # noqa: TC002 - needed at runtime for Textual event dispatch
+    MouseMove,  # noqa: TC002 - needed at runtime for Textual event dispatch
 )
 from textual.fuzzy import Matcher
 from textual.message import Message
@@ -331,6 +332,16 @@ class CurrentModelTitle(Static):
             failure_noun="selection",
             success_message=f"{label} copied",
         )
+
+    def on_mouse_move(self, event: MouseMove) -> None:
+        """Show a pointer over the copyable model span."""
+        self.styles.pointer = (
+            "pointer" if copy_span_target(event.style) is not None else "default"
+        )
+
+    def on_leave(self) -> None:
+        """Reset the pointer when it leaves the title."""
+        self.styles.pointer = "default"
 
 
 class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):

--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -48,6 +48,7 @@ from deepagents_code.model_config import (
     save_auto_classifier_model,
     save_default_model,
 )
+from deepagents_code.tui.widgets._copy_spans import copy_span_style, copy_span_target
 
 logger = logging.getLogger(__name__)
 
@@ -310,6 +311,26 @@ class ModelOption(Static):
         """
         event.stop()
         self.post_message(self.Clicked(self.model_spec, self.provider, self.index))
+
+
+class CurrentModelTitle(Static):
+    """Selector title whose current-model span copies on click."""
+
+    def on_click(self, event: Click) -> None:
+        """Copy the current model when its title span is clicked."""
+        target = copy_span_target(event.style)
+        if target is None:
+            return
+        event.stop()
+        text, label = target
+        from deepagents_code.clipboard import copy_text_with_feedback
+
+        copy_text_with_feedback(
+            self.app,
+            text,
+            failure_noun="selection",
+            success_message=f"{label} copied",
+        )
 
 
 class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
@@ -659,17 +680,28 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             Widgets for the model selector UI.
         """
         with Vertical():
-            # Title with current model in provider:model format
             if self._title:
-                title = self._title
-            elif self._current_model and self._current_provider:
-                current_spec = f"{self._current_provider}:{self._current_model}"
-                title = f"Select Model (current: {current_spec})"
+                title: str | Content = self._title
+            elif self._current_spec:
+                title = Content.assemble(
+                    "Select Model (current: ",
+                    (self._current_spec, copy_span_style(self._current_spec, "Model")),
+                    ")",
+                )
             elif self._current_model:
-                title = f"Select Model (current: {self._current_model})"
+                title = Content.assemble(
+                    "Select Model (current: ",
+                    (
+                        self._current_model,
+                        copy_span_style(self._current_model, "Model"),
+                    ),
+                    ")",
+                )
             else:
                 title = "Select Model"
-            yield Static(title, classes="model-selector-title")
+            yield CurrentModelTitle(
+                title, classes="model-selector-title", id="model-selector-title"
+            )
             if self._description:
                 yield Static(
                     self._description,

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -11,9 +11,11 @@ import pytest
 from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical, VerticalScroll
+from textual.geometry import Offset
 from textual.screen import ModalScreen
 from textual.widgets import Input, Static
 
+from deepagents_code import clipboard as clipboard_module
 from deepagents_code._paths import PATHS
 from deepagents_code.config import get_glyphs
 from deepagents_code.model_config import (
@@ -250,6 +252,52 @@ class TestModelSelectorEscapeKey:
 
 class TestModelSelectorChrome:
     """Tests for model selector title and description chrome."""
+
+    async def test_current_model_title_copies_spec(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Clicking the current model in the title copies its canonical spec."""
+        copied: list[str] = []
+
+        def fake_copy(
+            _app: App[None],
+            text: str,
+            *,
+            failure_noun: str,
+            success_message: str | None = None,
+        ) -> bool:
+            copied.append(text)
+            assert failure_noun == "selection"
+            assert success_message == "Model copied"
+            _app.notify(success_message)
+            return True
+
+        monkeypatch.setattr(clipboard_module, "copy_text_with_feedback", fake_copy)
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            screen = ModelSelectorScreen(
+                current_model="claude-sonnet-4-5",
+                current_provider="anthropic",
+                default_scope=MAIN_MODEL_DEFAULT_SCOPE,
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+            await pilot.pause()
+            title = screen.query_one("#model-selector-title", Static)
+            x = title.content_region.x - title.region.x
+            offset = None
+            for segment in title.render_line(0):
+                if segment.style and segment.style.meta.get("copy_text"):
+                    offset = Offset(x, 0)
+                    break
+                x += segment.cell_length
+            assert offset is not None
+
+            await pilot.click(title, offset=offset)
+            await pilot.pause()
+
+            assert copied == ["anthropic:claude-sonnet-4-5"]
+            assert list(app._notifications)[-1].message == "Model copied"
 
     async def test_optional_title_and_description_render(self) -> None:
         """A custom title and description should render above the filter."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -285,15 +285,23 @@ class TestModelSelectorChrome:
             await pilot.pause()
             title = screen.query_one("#model-selector-title", Static)
             x = title.content_region.x - title.region.x
-            offset = None
+            model_offset = None
+            plain_offset = None
             for segment in title.render_line(0):
+                if segment.text.startswith("Select Model"):
+                    plain_offset = Offset(x, 0)
                 if segment.style and segment.style.meta.get("copy_text"):
-                    offset = Offset(x, 0)
+                    model_offset = Offset(x, 0)
                     break
                 x += segment.cell_length
-            assert offset is not None
+            assert model_offset is not None
+            assert plain_offset is not None
 
-            await pilot.click(title, offset=offset)
+            await pilot.hover(title, offset=model_offset)
+            assert title.styles.pointer == "pointer"
+            await pilot.hover(title, offset=plain_offset)
+            assert title.styles.pointer == "default"
+            await pilot.click(title, offset=model_offset)
             await pilot.pause()
 
             assert copied == ["anthropic:claude-sonnet-4-5"]


### PR DESCRIPTION
The current model name in the `/model` picker header can now be clicked to copy its canonical model spec.

---

The picker marks only the current-model span as copyable and reuses the existing clipboard fallback and notification flow. Custom picker titles remain unchanged. A focused Textual interaction test covers the click behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/b7314bfc-f358-5613-abbe-605583ea26da)