### PR TITLE
fix(code): recover stale pending work before compaction

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -18445,8 +18445,8 @@ class DeepAgentsApp(App):
                 collapsed.extend(group)
         return collapsed
 
-    async def _get_thread_state_values(self, thread_id: str) -> dict[str, Any]:
-        """Fetch thread state values for a thread.
+    async def _get_thread_state(self, thread_id: str) -> Any | None:  # noqa: ANN401
+        """Fetch the checkpoint state snapshot for a thread.
 
         In server mode the LangGraph dev server starts with an empty in-memory
         thread store, so `aget_state` returns empty state for any thread that
@@ -18459,20 +18459,29 @@ class DeepAgentsApp(App):
             thread_id: Thread ID to fetch from checkpoint storage.
 
         Returns:
+            The state snapshot, or `None` when no state is available.
+        """
+        if not self._agent:
+            return None
+
+        config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
+
+        if remote := self._remote_agent():
+            await remote.aensure_thread(dict(config))
+
+        return await self._agent.aget_state(config)
+
+    async def _get_thread_state_values(self, thread_id: str) -> dict[str, Any]:
+        """Fetch thread state values for a thread.
+
+        Args:
+            thread_id: Thread ID to fetch from checkpoint storage.
+
+        Returns:
             Thread state values keyed by channel name. Returns an empty dict
                 when no checkpointed values are available.
         """
-        if not self._agent:
-            return {}
-
-        config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
-        remote_config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
-
-        if remote := self._remote_agent():
-            await remote.aensure_thread(remote_config)
-
-        state = await self._agent.aget_state(config)
-
+        state = await self._get_thread_state(thread_id)
         if state and state.values:
             return dict(state.values)
         return {}
@@ -28227,17 +28236,19 @@ class DeepAgentsApp(App):
             self._on_tokens_update(tokens)
 
     async def _resumed_thread_has_pending_work(self) -> bool:
-        """Return whether the current checkpoint still contains unfinished work."""
-        if not self._lc_thread_id or not self._agent:
+        """Return whether the current checkpoint still contains unfinished work.
+
+        Returns `False` for local agents: recovery, like compaction, is a
+        server-mode operation, so there is no prompt to offer without a remote.
+
+        Returns:
+            Whether the resumed thread has a queued node, task, or interrupt.
+        """
+        from deepagents_code.client.remote_client import state_has_pending_work
+
+        if not self._lc_thread_id or self._remote_agent() is None:
             return False
-        config: RunnableConfig = {"configurable": {"thread_id": self._lc_thread_id}}
-        if remote := self._remote_agent():
-            remote_config: dict[str, Any] = {
-                "configurable": {"thread_id": self._lc_thread_id}
-            }
-            await remote.aensure_thread(remote_config)
-        state = await self._agent.aget_state(config)
-        return bool(state and (state.next or state.tasks or state.interrupts))
+        return state_has_pending_work(await self._get_thread_state(self._lc_thread_id))
 
     async def _cancel_pending_work_and_compact(self) -> None:
         """Discard a confirmed stale step, then compact the preserved thread."""
@@ -28251,9 +28262,7 @@ class DeepAgentsApp(App):
         """Perform recovery while the caller holds the agent-running reservation."""
         remote = self._remote_agent()
         if remote is None or not self._lc_thread_id:
-            await self._mount_message(
-                ErrorMessage("The interrupted operation could not be cancelled safely.")
-            )
+            # Unreachable: the prompt is only offered when both are present.
             return
         config: RunnableConfig = {"configurable": {"thread_id": self._lc_thread_id}}
         try:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -28226,6 +28226,54 @@ class DeepAgentsApp(App):
         if tokens > 0:
             self._on_tokens_update(tokens)
 
+    async def _resumed_thread_has_pending_work(self) -> bool:
+        """Return whether the current checkpoint still contains unfinished work."""
+        if not self._lc_thread_id or not self._agent:
+            return False
+        config: RunnableConfig = {"configurable": {"thread_id": self._lc_thread_id}}
+        if remote := self._remote_agent():
+            remote_config: dict[str, Any] = {
+                "configurable": {"thread_id": self._lc_thread_id}
+            }
+            await remote.aensure_thread(remote_config)
+        state = await self._agent.aget_state(config)
+        return bool(state and (state.next or state.tasks or state.interrupts))
+
+    async def _cancel_pending_work_and_compact(self) -> None:
+        """Discard a confirmed stale step, then compact the preserved thread."""
+        self._set_agent_running(True)
+        try:
+            await self._cancel_pending_work_and_compact_impl()
+        finally:
+            self._set_agent_running(False)
+
+    async def _cancel_pending_work_and_compact_impl(self) -> None:
+        """Perform recovery while the caller holds the agent-running reservation."""
+        remote = self._remote_agent()
+        if remote is None or not self._lc_thread_id:
+            await self._mount_message(
+                ErrorMessage("The interrupted operation could not be cancelled safely.")
+            )
+            return
+        config: RunnableConfig = {"configurable": {"thread_id": self._lc_thread_id}}
+        try:
+            await remote.aabandon_pending_work(config)
+        except Exception:
+            logger.exception("Failed to abandon pending graph work before compaction")
+            await self._mount_message(
+                ErrorMessage(
+                    "The interrupted operation could not be cancelled safely. "
+                    "The conversation was not compacted."
+                )
+            )
+            return
+        await self._mount_message(
+            AppMessage(
+                "Cancelled the interrupted operation. Files and chat were preserved."
+            )
+        )
+        await self._handle_offload(reserved=True)
+
     async def _maybe_compact_after_resume(self) -> None:
         """Offer to compact a just-resumed thread with an oversized context.
 
@@ -28251,6 +28299,18 @@ class DeepAgentsApp(App):
         if threshold <= 0 or self._context_tokens <= threshold:
             return
 
+        try:
+            pending_work = await self._resumed_thread_has_pending_work()
+        except Exception:
+            logger.exception("Failed to inspect resumed thread before compaction")
+            await self._mount_message(
+                ErrorMessage(
+                    "Could not check whether the previous operation finished. "
+                    "The conversation was not compacted."
+                )
+            )
+            return
+
         from deepagents_code.tui.modals.resume_compact import ResumeCompactPromptScreen
 
         try:
@@ -28258,12 +28318,17 @@ class DeepAgentsApp(App):
                 ResumeCompactPromptScreen(
                     context_tokens=self._context_tokens,
                     threshold=threshold,
+                    pending_work=pending_work,
                 )
             )
         except Exception:
             logger.exception("Failed to show the compact-on-resume prompt")
             return
-        if compact:
+        if not compact:
+            return
+        if pending_work:
+            await self._cancel_pending_work_and_compact()
+        else:
             await self._handle_offload()
 
     async def _offer_thread_cwd_switch(

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -28251,7 +28251,14 @@ class DeepAgentsApp(App):
         return state_has_pending_work(await self._get_thread_state(self._lc_thread_id))
 
     async def _cancel_pending_work_and_compact(self) -> None:
-        """Discard a confirmed stale step, then compact the preserved thread."""
+        """Discard a confirmed stale step, then compact the preserved thread.
+
+        Holds the agent-running reservation across the whole recovery so the
+        checkpoint cannot be written from under it, and hands the reservation
+        to `_handle_offload`, which releases it. Releasing here too is
+        redundant but harmless -- `_set_agent_running` is idempotent -- and it
+        is what covers the paths that never reach the offload.
+        """
         self._set_agent_running(True)
         try:
             await self._cancel_pending_work_and_compact_impl()

--- a/libs/code/deepagents_code/client/remote_client.py
+++ b/libs/code/deepagents_code/client/remote_client.py
@@ -166,6 +166,41 @@ def _require_thread_id(config: Mapping[str, Any] | None) -> str:
     return thread_id
 
 
+def _cancelled_tool_messages(values: object) -> list[Any]:
+    """Build terminal results for tool calls left unanswered by a lost run.
+
+    Returns:
+        Error results for every unanswered tool call in checkpoint history.
+    """
+    if not isinstance(values, dict):
+        return []
+    from langchain_core.messages import AIMessage, ToolMessage, convert_to_messages
+
+    raw_messages = values.get("messages")
+    if not isinstance(raw_messages, list):
+        return []
+    messages = convert_to_messages(cast("list[Any]", raw_messages))
+    answered = {
+        message.tool_call_id for message in messages if isinstance(message, ToolMessage)
+    }
+    calls = [
+        call
+        for message in messages
+        if isinstance(message, AIMessage)
+        for call in message.tool_calls
+        if call["id"] not in answered
+    ]
+    return [
+        ToolMessage(
+            content="Tool call cancelled because the previous session ended.",
+            name=call["name"],
+            tool_call_id=call["id"],
+            status="error",
+        )
+        for call in calls
+    ]
+
+
 def agent_error_type(exc: BaseException) -> str:
     """Best-effort error-type name for an exception from `RemoteAgent.astream`.
 
@@ -573,7 +608,7 @@ class RemoteAgent:
     async def aupdate_state(
         self,
         config: Mapping[str, Any],
-        values: dict[str, Any],
+        values: dict[str, Any] | None,
         *,
         as_node: str | None = None,
     ) -> None:
@@ -633,6 +668,28 @@ class RemoteAgent:
                 exc_info=True,
             )
             raise
+
+    async def aabandon_pending_work(self, config: Mapping[str, Any]) -> None:
+        """Cancel active runs and discard checkpointed work without replaying it.
+
+        Raises:
+            RuntimeError: If pending work remains after the state update.
+        """
+        thread_id = _require_thread_id(config)
+        prepared = _prepare_config(config)
+        graph = self._get_graph()
+        await _cancel_active_runs(graph, thread_id)
+        state = await graph.aget_state(prepared)
+        cancelled = _cancelled_tool_messages(getattr(state, "values", None))
+        if cancelled:
+            await graph.aupdate_state(
+                prepared, {"messages": cancelled}, as_node="tools"
+            )
+        await graph.aupdate_state(prepared, None, as_node="__end__")
+        state = await graph.aget_state(prepared)
+        if state and (state.next or state.tasks or state.interrupts):
+            msg = "The interrupted operation could not be cancelled safely."
+            raise RuntimeError(msg)
 
     async def aput_store_item(
         self,

--- a/libs/code/deepagents_code/client/remote_client.py
+++ b/libs/code/deepagents_code/client/remote_client.py
@@ -727,6 +727,11 @@ class RemoteAgent:
             _cancelled_tool_messages, getattr(state, "values", None)
         )
         if cancelled:
+            # `create_agent` names the tool step "tools", but only adds the node
+            # when the agent has tools. A toolless graph therefore rejects this
+            # update with `InvalidUpdateError` -- and could not have produced a
+            # dangling tool call in the first place, so the branch is dead
+            # there. The caller reports the failure rather than compacting.
             await self.aupdate_state(prepared, {"messages": cancelled}, as_node="tools")
         await self.aupdate_state(prepared, None, as_node="__end__")
         if state_has_pending_work(await self.aget_state(prepared)):

--- a/libs/code/deepagents_code/client/remote_client.py
+++ b/libs/code/deepagents_code/client/remote_client.py
@@ -166,8 +166,32 @@ def _require_thread_id(config: Mapping[str, Any] | None) -> str:
     return thread_id
 
 
+def state_has_pending_work(state: object) -> bool:
+    """Return whether a checkpoint snapshot still holds unfinished graph work.
+
+    Single definition of "pending" shared by the app-side detector and the
+    post-recovery verification, so the two cannot drift apart.
+
+    Args:
+        state: A `StateSnapshot`-shaped object, or `None`.
+
+    Returns:
+        Whether the snapshot has a queued node, task, or interrupt.
+    """
+    if state is None:
+        return False
+    return bool(
+        getattr(state, "next", None)
+        or getattr(state, "tasks", None)
+        or getattr(state, "interrupts", None)
+    )
+
+
 def _cancelled_tool_messages(values: object) -> list[Any]:
     """Build terminal results for tool calls left unanswered by a lost run.
+
+    Blocking and CPU-bound over the whole checkpoint history; async callers
+    must offload it with `asyncio.to_thread`.
 
     Returns:
         Error results for every unanswered tool call in checkpoint history.
@@ -183,13 +207,6 @@ def _cancelled_tool_messages(values: object) -> list[Any]:
     answered = {
         message.tool_call_id for message in messages if isinstance(message, ToolMessage)
     }
-    calls = [
-        call
-        for message in messages
-        if isinstance(message, AIMessage)
-        for call in message.tool_calls
-        if call["id"] not in answered
-    ]
     return [
         ToolMessage(
             content="Tool call cancelled because the previous session ended.",
@@ -197,7 +214,10 @@ def _cancelled_tool_messages(values: object) -> list[Any]:
             tool_call_id=call["id"],
             status="error",
         )
-        for call in calls
+        for message in messages
+        if isinstance(message, AIMessage)
+        for call in message.tool_calls
+        if call["id"] not in answered
     ]
 
 
@@ -672,23 +692,31 @@ class RemoteAgent:
     async def aabandon_pending_work(self, config: Mapping[str, Any]) -> None:
         """Cancel active runs and discard checkpointed work without replaying it.
 
+        The state writes go through `aupdate_state` so they inherit its HTTP
+        409 recovery: this method runs on exactly the threads whose run was
+        cancelled out from under the client, which is when 409s occur.
+
+        Args:
+            config: Config with `configurable.thread_id`.
+
         Raises:
             RuntimeError: If pending work remains after the state update.
         """
         thread_id = _require_thread_id(config)
         prepared = _prepare_config(config)
-        graph = self._get_graph()
-        await _cancel_active_runs(graph, thread_id)
-        state = await graph.aget_state(prepared)
-        cancelled = _cancelled_tool_messages(getattr(state, "values", None))
+        await _cancel_active_runs(self._get_graph(), thread_id)
+        state = await self.aget_state(prepared)
+        cancelled = await asyncio.to_thread(
+            _cancelled_tool_messages, getattr(state, "values", None)
+        )
         if cancelled:
-            await graph.aupdate_state(
-                prepared, {"messages": cancelled}, as_node="tools"
+            await self.aupdate_state(prepared, {"messages": cancelled}, as_node="tools")
+        await self.aupdate_state(prepared, None, as_node="__end__")
+        if state_has_pending_work(await self.aget_state(prepared)):
+            msg = (
+                f"Pending graph work remained on thread {thread_id} after "
+                "clearing checkpoint state"
             )
-        await graph.aupdate_state(prepared, None, as_node="__end__")
-        state = await graph.aget_state(prepared)
-        if state and (state.next or state.tasks or state.interrupts):
-            msg = "The interrupted operation could not be cancelled safely."
             raise RuntimeError(msg)
 
     async def aput_store_item(

--- a/libs/code/deepagents_code/client/remote_client.py
+++ b/libs/code/deepagents_code/client/remote_client.py
@@ -190,11 +190,22 @@ def state_has_pending_work(state: object) -> bool:
 def _cancelled_tool_messages(values: object) -> list[Any]:
     """Build terminal results for tool calls left unanswered by a lost run.
 
-    Blocking and CPU-bound over the whole checkpoint history; async callers
-    must offload it with `asyncio.to_thread`.
+    Only the trailing turn is considered. The queued `tools` step is triggered
+    by the final `AIMessage`, and a provider requires every `tool_result` to
+    sit immediately after the `tool_use` it answers. Earlier unanswered calls
+    are left alone on purpose: interrupt recovery writes a partial `AIMessage`
+    with its in-flight `tool_calls` and then closes the turn with a following
+    message (`_build_interrupted_ai_message` in the TUI adapter), so those
+    calls stay dangling by design. Answering them here would append their
+    results at the tail, far from their `tool_use`, and the next model call --
+    the compaction summarizer that runs right after recovery -- would be
+    rejected.
+
+    Blocking and CPU-bound over the checkpoint history; async callers must
+    offload it with `asyncio.to_thread`.
 
     Returns:
-        Error results for every unanswered tool call in checkpoint history.
+        Error results for the trailing turn's unanswered tool calls.
     """
     if not isinstance(values, dict):
         return []
@@ -204,21 +215,27 @@ def _cancelled_tool_messages(values: object) -> list[Any]:
     if not isinstance(raw_messages, list):
         return []
     messages = convert_to_messages(cast("list[Any]", raw_messages))
-    answered = {
-        message.tool_call_id for message in messages if isinstance(message, ToolMessage)
-    }
-    return [
-        ToolMessage(
-            content="Tool call cancelled because the previous session ended.",
-            name=call["name"],
-            tool_call_id=call["id"],
-            status="error",
-        )
-        for message in messages
-        if isinstance(message, AIMessage)
-        for call in message.tool_calls
-        if call["id"] not in answered
-    ]
+    # Walk back over the results the lost run did manage to write, then stop at
+    # the message that owns them. Anything but an `AIMessage` there means the
+    # turn was already closed out and nothing is dangling.
+    answered: set[str] = set()
+    for message in reversed(messages):
+        if isinstance(message, ToolMessage):
+            answered.add(message.tool_call_id)
+            continue
+        if not isinstance(message, AIMessage):
+            return []
+        return [
+            ToolMessage(
+                content="Tool call cancelled because the previous session ended.",
+                name=call["name"],
+                tool_call_id=call["id"],
+                status="error",
+            )
+            for call in message.tool_calls
+            if call["id"] not in answered
+        ]
+    return []
 
 
 def agent_error_type(exc: BaseException) -> str:

--- a/libs/code/deepagents_code/tui/modals/resume_compact.py
+++ b/libs/code/deepagents_code/tui/modals/resume_compact.py
@@ -69,16 +69,14 @@ class ResumeCompactPromptScreen(ModalScreen[bool]):
     }
     """
 
-    def __init__(self, *, context_tokens: int, threshold: int) -> None:
-        """Initialize the prompt.
-
-        Args:
-            context_tokens: Latest model-reported context size for the thread.
-            threshold: Configured token count that triggered the suggestion.
-        """
+    def __init__(
+        self, *, context_tokens: int, threshold: int, pending_work: bool = False
+    ) -> None:
+        """Initialize the prompt."""
         super().__init__()
         self._context_tokens = context_tokens
         self._threshold = threshold
+        self._pending_work = pending_work
 
     def compose(self) -> ComposeResult:
         """Compose the confirmation dialog.
@@ -88,21 +86,40 @@ class ResumeCompactPromptScreen(ModalScreen[bool]):
         """
         with Vertical():
             yield Static(
-                "Compact this thread?",
+                (
+                    "Cancel old operation and compact?"
+                    if self._pending_work
+                    else "Compact this thread?"
+                ),
                 classes="resume-compact-title",
                 markup=False,
             )
+            body = (
+                "This thread closed while an operation was unfinished. Nothing is "
+                "running now, but repeating the old operation could duplicate side "
+                "effects. Cancel its saved work, preserve the chat and files, and "
+                "shorten the conversation?"
+                if self._pending_work
+                else (
+                    f"This thread uses {format_token_count(self._context_tokens)} "
+                    "context tokens, above the configured "
+                    f"{format_token_count(self._threshold)} token threshold. "
+                    "Compacting summarizes older messages so later turns cost less."
+                )
+            )
             yield Static(
-                f"This thread uses {format_token_count(self._context_tokens)} context "
-                "tokens, above the configured "
-                f"{format_token_count(self._threshold)} token threshold. Compacting "
-                "summarizes older messages so later turns cost less.",
+                body,
                 classes="resume-compact-body",
                 markup=False,
             )
             yield Static(
                 f" {get_glyphs().bullet} ".join(
-                    ("Enter: compact now", "Esc: keep full context")
+                    (
+                        "Enter: cancel old operation and compact"
+                        if self._pending_work
+                        else "Enter: compact now",
+                        "Esc: keep full context",
+                    )
                 ),
                 classes="resume-compact-help",
                 markup=False,

--- a/libs/code/deepagents_code/tui/modals/resume_compact.py
+++ b/libs/code/deepagents_code/tui/modals/resume_compact.py
@@ -70,9 +70,16 @@ class ResumeCompactPromptScreen(ModalScreen[bool]):
     """
 
     def __init__(
-        self, *, context_tokens: int, threshold: int, pending_work: bool = False
+        self, *, context_tokens: int, threshold: int, pending_work: bool
     ) -> None:
-        """Initialize the prompt."""
+        """Initialize the prompt.
+
+        Args:
+            context_tokens: Latest model-reported context size for the thread.
+            threshold: Configured token count that triggered the suggestion.
+            pending_work: Whether the checkpoint still holds unfinished work,
+                which compacting must first cancel.
+        """
         super().__init__()
         self._context_tokens = context_tokens
         self._threshold = threshold
@@ -84,43 +91,30 @@ class ResumeCompactPromptScreen(ModalScreen[bool]):
         Yields:
             Title, explanation, and keyboard help.
         """
-        with Vertical():
-            yield Static(
-                (
-                    "Cancel old operation and compact?"
-                    if self._pending_work
-                    else "Compact this thread?"
-                ),
-                classes="resume-compact-title",
-                markup=False,
-            )
+        if self._pending_work:
+            title = "Cancel old operation and compact?"
             body = (
                 "This thread closed while an operation was unfinished. Nothing is "
                 "running now, but repeating the old operation could duplicate side "
                 "effects. Cancel its saved work, preserve the chat and files, and "
                 "shorten the conversation?"
-                if self._pending_work
-                else (
-                    f"This thread uses {format_token_count(self._context_tokens)} "
-                    "context tokens, above the configured "
-                    f"{format_token_count(self._threshold)} token threshold. "
-                    "Compacting summarizes older messages so later turns cost less."
-                )
             )
-            yield Static(
-                body,
-                classes="resume-compact-body",
-                markup=False,
+            enter_hint = "Enter: cancel old operation and compact"
+        else:
+            title = "Compact this thread?"
+            body = (
+                f"This thread uses {format_token_count(self._context_tokens)} "
+                "context tokens, above the configured "
+                f"{format_token_count(self._threshold)} token threshold. "
+                "Compacting summarizes older messages so later turns cost less."
             )
+            enter_hint = "Enter: compact now"
+
+        with Vertical():
+            yield Static(title, classes="resume-compact-title", markup=False)
+            yield Static(body, classes="resume-compact-body", markup=False)
             yield Static(
-                f" {get_glyphs().bullet} ".join(
-                    (
-                        "Enter: cancel old operation and compact"
-                        if self._pending_work
-                        else "Enter: compact now",
-                        "Esc: keep full context",
-                    )
-                ),
+                f" {get_glyphs().bullet} ".join((enter_hint, "Esc: keep full context")),
                 classes="resume-compact-help",
                 markup=False,
             )

--- a/libs/code/tests/integration_tests/test_pending_work_recovery.py
+++ b/libs/code/tests/integration_tests/test_pending_work_recovery.py
@@ -1,0 +1,81 @@
+"""Integration coverage for abandoning stale pending graph work."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, TypedDict, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from langchain_core.runnables import RunnableConfig
+
+from deepagents_code.client.remote_client import RemoteAgent
+
+
+class _State(TypedDict):
+    messages: list[Any]
+
+
+@pytest.mark.timeout(120)
+async def test_abandon_pending_tool_work_never_executes_tool(
+    tmp_path: Path,
+) -> None:
+    from langchain_core.messages import AIMessage
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.graph import END, START, StateGraph
+
+    calls: list[str] = []
+
+    def model(state: _State) -> dict[str, object]:
+        del state
+        return {}
+
+    def tools(state: _State) -> dict[str, object]:
+        del state
+        calls.append("executed")
+        (tmp_path / "side-effect").write_text("ran")
+        return {}
+
+    builder = StateGraph(cast("Any", _State))
+    builder.add_node("model", model)
+    builder.add_node("tools", tools)
+    builder.add_edge(START, "model")
+    builder.add_edge("model", "tools")
+    builder.add_edge("tools", END)
+    graph = builder.compile(checkpointer=MemorySaver())
+    config: RunnableConfig = {"configurable": {"thread_id": "pending-recovery"}}
+    await graph.aupdate_state(
+        config,
+        {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "shell", "args": {}, "id": "call-1"}],
+                )
+            ]
+        },
+        as_node="model",
+    )
+    before = await graph.aget_state(config)
+    assert before.next == ("tools",)
+
+    agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+    local_graph = cast("Any", graph)
+    local_graph._validate_client = lambda: SimpleNamespace(
+        runs=SimpleNamespace(list=AsyncMock(return_value=[]))
+    )
+    agent._graph = local_graph
+    await agent.aabandon_pending_work(config)
+
+    after = await graph.aget_state(config)
+    assert after.next == ()
+    assert after.tasks == ()
+    assert calls == []
+    assert not (tmp_path / "side-effect").exists()
+    cancelled = after.values["messages"][-1]
+    assert cancelled.tool_call_id == "call-1"
+    assert cancelled.status == "error"

--- a/libs/code/tests/integration_tests/test_pending_work_recovery.py
+++ b/libs/code/tests/integration_tests/test_pending_work_recovery.py
@@ -25,7 +25,7 @@ async def test_abandon_pending_tool_work_never_executes_tool(
     tmp_path: Path,
 ) -> None:
     from langchain_core.messages import AIMessage
-    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.checkpoint.memory import InMemorySaver
     from langgraph.graph import END, START, StateGraph
 
     calls: list[str] = []
@@ -46,7 +46,7 @@ async def test_abandon_pending_tool_work_never_executes_tool(
     builder.add_edge(START, "model")
     builder.add_edge("model", "tools")
     builder.add_edge("tools", END)
-    graph = builder.compile(checkpointer=MemorySaver())
+    graph = builder.compile(checkpointer=InMemorySaver())
     config: RunnableConfig = {"configurable": {"thread_id": "pending-recovery"}}
     await graph.aupdate_state(
         config,

--- a/libs/code/tests/unit_tests/test_remote_client.py
+++ b/libs/code/tests/unit_tests/test_remote_client.py
@@ -934,6 +934,50 @@ class TestCancelledToolMessages:
     def test_ignores_state_without_a_message_list(self, values: object) -> None:
         assert _cancelled_tool_messages(values) == []
 
+    def test_leaves_earlier_interrupted_turns_dangling(self) -> None:
+        """Only the trailing turn is answered.
+
+        Interrupt recovery persists a partial `AIMessage` carrying its
+        in-flight `tool_calls` and then closes the turn with a cancellation
+        notice, so history routinely holds calls that are unanswered by
+        design. Answering one here would append its `tool_result` after
+        unrelated messages, which the provider rejects.
+        """
+        values = {
+            "messages": [
+                {
+                    "type": "ai",
+                    "content": "",
+                    "tool_calls": [{"name": "shell", "args": {}, "id": "interrupted"}],
+                },
+                {"type": "human", "content": "Task interrupted by user."},
+                {"type": "human", "content": "try again"},
+                {
+                    "type": "ai",
+                    "content": "",
+                    "tool_calls": [{"name": "shell", "args": {}, "id": "pending"}],
+                },
+            ]
+        }
+
+        cancelled = _cancelled_tool_messages(values)
+
+        assert [message.tool_call_id for message in cancelled] == ["pending"]
+
+    def test_ignores_a_turn_that_already_closed(self) -> None:
+        values = {
+            "messages": [
+                {
+                    "type": "ai",
+                    "content": "",
+                    "tool_calls": [{"name": "shell", "args": {}, "id": "interrupted"}],
+                },
+                {"type": "human", "content": "Task interrupted by user."},
+            ]
+        }
+
+        assert _cancelled_tool_messages(values) == []
+
 
 def _pending_state(values: dict[str, Any]) -> SimpleNamespace:
     """Snapshot stub for a thread with a queued `tools` step."""

--- a/libs/code/tests/unit_tests/test_remote_client.py
+++ b/libs/code/tests/unit_tests/test_remote_client.py
@@ -15,6 +15,7 @@ from langchain_core.messages import AIMessageChunk, HumanMessage, ToolMessage
 from deepagents_code._env_vars import LANGSMITH_REPLICA_PROJECTS
 from deepagents_code.client.remote_client import (
     RemoteAgent,
+    _cancelled_tool_messages,
     _convert_ai_message,
     _convert_human_message,
     _convert_interrupts,
@@ -902,6 +903,138 @@ class TestRemoteAgentUpdateStateConflictRecovery:
         assert mock_graph.aupdate_state.await_count == 1
         runs_list.assert_not_called()
         runs_cancel.assert_not_called()
+
+
+class TestCancelledToolMessages:
+    def test_supports_serialized_messages_and_ignores_answered_calls(self) -> None:
+        values = {
+            "messages": [
+                {
+                    "type": "ai",
+                    "content": "",
+                    "tool_calls": [
+                        {"name": "shell", "args": {}, "id": "answered"},
+                        {"name": "shell", "args": {}, "id": "pending"},
+                    ],
+                },
+                {
+                    "type": "tool",
+                    "content": "done",
+                    "tool_call_id": "answered",
+                },
+            ]
+        }
+
+        cancelled = _cancelled_tool_messages(values)
+
+        assert [message.tool_call_id for message in cancelled] == ["pending"]
+        assert cancelled[0].status == "error"
+
+    @pytest.mark.parametrize("values", [None, [], {}, {"messages": "invalid"}])
+    def test_ignores_state_without_a_message_list(self, values: object) -> None:
+        assert _cancelled_tool_messages(values) == []
+
+
+class TestRemoteAgentAbandonPendingWork:
+    async def test_cancels_runs_clears_checkpoint_and_verifies(self) -> None:
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        runs_list = AsyncMock(return_value=[])
+        mock_client = MagicMock()
+        mock_client.runs.list = runs_list
+        mock_graph = MagicMock()
+        mock_graph._validate_client.return_value = mock_client
+        mock_graph.aupdate_state = AsyncMock()
+        mock_graph.aget_state = AsyncMock(
+            side_effect=[
+                SimpleNamespace(
+                    values={"messages": []},
+                    next=("tools",),
+                    tasks=(object(),),
+                    interrupts=(),
+                ),
+                SimpleNamespace(values={}, next=(), tasks=(), interrupts=()),
+            ]
+        )
+        agent._graph = mock_graph
+
+        await agent.aabandon_pending_work(_config())
+
+        assert runs_list.await_count == 2
+        mock_graph.aupdate_state.assert_awaited_once()
+        state_update = mock_graph.aupdate_state.await_args
+        assert state_update is not None
+        assert state_update.args[1] is None
+        assert state_update.kwargs == {"as_node": "__end__"}
+        assert mock_graph.aget_state.await_count == 2
+
+    async def test_terminalizes_dangling_tool_call_before_clearing(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        mock_client = MagicMock()
+        mock_client.runs.list = AsyncMock(return_value=[])
+        mock_graph = MagicMock()
+        mock_graph._validate_client.return_value = mock_client
+        mock_graph.aupdate_state = AsyncMock()
+        mock_graph.aget_state = AsyncMock(
+            side_effect=[
+                SimpleNamespace(
+                    values={
+                        "messages": [
+                            AIMessage(
+                                content="",
+                                tool_calls=[
+                                    {"name": "shell", "args": {}, "id": "call-1"}
+                                ],
+                            )
+                        ]
+                    },
+                    next=("tools",),
+                    tasks=(object(),),
+                    interrupts=(),
+                ),
+                SimpleNamespace(values={}, next=(), tasks=(), interrupts=()),
+            ]
+        )
+        agent._graph = mock_graph
+
+        await agent.aabandon_pending_work(_config())
+
+        assert mock_graph.aupdate_state.await_count == 2
+        message_update = mock_graph.aupdate_state.await_args_list[0]
+        assert message_update.kwargs == {"as_node": "tools"}
+        cancelled = message_update.args[1]["messages"][0]
+        assert cancelled.tool_call_id == "call-1"
+        assert cancelled.status == "error"
+        assert mock_graph.aupdate_state.await_args_list[1].args[1] is None
+
+    async def test_raises_when_pending_work_remains(self) -> None:
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        mock_client = MagicMock()
+        mock_client.runs.list = AsyncMock(return_value=[])
+        mock_graph = MagicMock()
+        mock_graph._validate_client.return_value = mock_client
+        mock_graph.aupdate_state = AsyncMock()
+        mock_graph.aget_state = AsyncMock(
+            side_effect=[
+                SimpleNamespace(
+                    values={"messages": []},
+                    next=("tools",),
+                    tasks=(object(),),
+                    interrupts=(),
+                ),
+                SimpleNamespace(
+                    values={"messages": []},
+                    next=("tools",),
+                    tasks=(object(),),
+                    interrupts=(),
+                ),
+            ]
+        )
+        agent._graph = mock_graph
+
+        with pytest.raises(RuntimeError, match="could not be cancelled safely"):
+            await agent.aabandon_pending_work(_config())
 
 
 class TestRemoteAgentStore:

--- a/libs/code/tests/unit_tests/test_remote_client.py
+++ b/libs/code/tests/unit_tests/test_remote_client.py
@@ -935,31 +935,39 @@ class TestCancelledToolMessages:
         assert _cancelled_tool_messages(values) == []
 
 
+def _pending_state(values: dict[str, Any]) -> SimpleNamespace:
+    """Snapshot stub for a thread with a queued `tools` step."""
+    return SimpleNamespace(
+        values=values, next=("tools",), tasks=(object(),), interrupts=()
+    )
+
+
+def _idle_state() -> SimpleNamespace:
+    """Snapshot stub for a thread with nothing left to run."""
+    return SimpleNamespace(values={}, next=(), tasks=(), interrupts=())
+
+
 class TestRemoteAgentAbandonPendingWork:
-    async def test_cancels_runs_clears_checkpoint_and_verifies(self) -> None:
+    def _agent_with_states(self, *states: Any) -> tuple[RemoteAgent, MagicMock]:
+        """RemoteAgent whose mock graph returns `states` from successive reads."""
         agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
-        runs_list = AsyncMock(return_value=[])
         mock_client = MagicMock()
-        mock_client.runs.list = runs_list
+        mock_client.runs.list = AsyncMock(return_value=[])
         mock_graph = MagicMock()
         mock_graph._validate_client.return_value = mock_client
         mock_graph.aupdate_state = AsyncMock()
-        mock_graph.aget_state = AsyncMock(
-            side_effect=[
-                SimpleNamespace(
-                    values={"messages": []},
-                    next=("tools",),
-                    tasks=(object(),),
-                    interrupts=(),
-                ),
-                SimpleNamespace(values={}, next=(), tasks=(), interrupts=()),
-            ]
-        )
+        mock_graph.aget_state = AsyncMock(side_effect=list(states))
         agent._graph = mock_graph
+        return agent, mock_graph
+
+    async def test_cancels_runs_clears_checkpoint_and_verifies(self) -> None:
+        agent, mock_graph = self._agent_with_states(
+            _pending_state({"messages": []}), _idle_state()
+        )
 
         await agent.aabandon_pending_work(_config())
 
-        assert runs_list.await_count == 2
+        assert mock_graph._validate_client.return_value.runs.list.await_count == 2
         mock_graph.aupdate_state.assert_awaited_once()
         state_update = mock_graph.aupdate_state.await_args
         assert state_update is not None
@@ -970,33 +978,19 @@ class TestRemoteAgentAbandonPendingWork:
     async def test_terminalizes_dangling_tool_call_before_clearing(self) -> None:
         from langchain_core.messages import AIMessage
 
-        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
-        mock_client = MagicMock()
-        mock_client.runs.list = AsyncMock(return_value=[])
-        mock_graph = MagicMock()
-        mock_graph._validate_client.return_value = mock_client
-        mock_graph.aupdate_state = AsyncMock()
-        mock_graph.aget_state = AsyncMock(
-            side_effect=[
-                SimpleNamespace(
-                    values={
-                        "messages": [
-                            AIMessage(
-                                content="",
-                                tool_calls=[
-                                    {"name": "shell", "args": {}, "id": "call-1"}
-                                ],
-                            )
-                        ]
-                    },
-                    next=("tools",),
-                    tasks=(object(),),
-                    interrupts=(),
-                ),
-                SimpleNamespace(values={}, next=(), tasks=(), interrupts=()),
-            ]
+        agent, mock_graph = self._agent_with_states(
+            _pending_state(
+                {
+                    "messages": [
+                        AIMessage(
+                            content="",
+                            tool_calls=[{"name": "shell", "args": {}, "id": "call-1"}],
+                        )
+                    ]
+                }
+            ),
+            _idle_state(),
         )
-        agent._graph = mock_graph
 
         await agent.aabandon_pending_work(_config())
 
@@ -1009,31 +1003,11 @@ class TestRemoteAgentAbandonPendingWork:
         assert mock_graph.aupdate_state.await_args_list[1].args[1] is None
 
     async def test_raises_when_pending_work_remains(self) -> None:
-        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
-        mock_client = MagicMock()
-        mock_client.runs.list = AsyncMock(return_value=[])
-        mock_graph = MagicMock()
-        mock_graph._validate_client.return_value = mock_client
-        mock_graph.aupdate_state = AsyncMock()
-        mock_graph.aget_state = AsyncMock(
-            side_effect=[
-                SimpleNamespace(
-                    values={"messages": []},
-                    next=("tools",),
-                    tasks=(object(),),
-                    interrupts=(),
-                ),
-                SimpleNamespace(
-                    values={"messages": []},
-                    next=("tools",),
-                    tasks=(object(),),
-                    interrupts=(),
-                ),
-            ]
+        agent, _ = self._agent_with_states(
+            _pending_state({"messages": []}), _pending_state({"messages": []})
         )
-        agent._graph = mock_graph
 
-        with pytest.raises(RuntimeError, match="could not be cancelled safely"):
+        with pytest.raises(RuntimeError, match="Pending graph work remained"):
             await agent.aabandon_pending_work(_config())
 
 

--- a/libs/code/tests/unit_tests/test_resume_compaction_recovery.py
+++ b/libs/code/tests/unit_tests/test_resume_compaction_recovery.py
@@ -1,0 +1,75 @@
+"""Unit coverage for compacting resumed threads with unfinished graph work."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+from deepagents_code.app import DeepAgentsApp
+from deepagents_code.client.remote_client import RemoteAgent
+from deepagents_code.tui.widgets.messages import ErrorMessage
+
+
+def _app_with_remote() -> tuple[Any, Any]:
+    remote = cast("Any", RemoteAgent(url="http://localhost:8123", graph_name="agent"))
+    app = cast("Any", DeepAgentsApp(agent=remote, thread_id="thread-1"))
+    app._context_tokens = 500_000
+    app._push_screen_wait = AsyncMock(return_value=True)  # ty: ignore[invalid-assignment]
+    app._handle_offload = AsyncMock()
+    app._mount_message = AsyncMock(return_value=True)
+    remote.aensure_thread = AsyncMock()
+    remote.aget_state = AsyncMock(
+        return_value=SimpleNamespace(
+            values={}, next=("tools",), tasks=(object(),), interrupts=()
+        )
+    )
+    remote.aabandon_pending_work = AsyncMock()
+    return app, remote
+
+
+async def test_confirmed_recovery_discards_pending_work_before_compaction() -> None:
+    app, remote = _app_with_remote()
+
+    await app._maybe_compact_after_resume()
+
+    screen = app._push_screen_wait.await_args.args[0]
+    assert screen._pending_work is True
+    remote.aabandon_pending_work.assert_awaited_once()
+    app._handle_offload.assert_awaited_once_with(reserved=True)
+
+
+async def test_declined_recovery_preserves_pending_work_and_context() -> None:
+    app, remote = _app_with_remote()
+    app._push_screen_wait.return_value = False
+
+    await app._maybe_compact_after_resume()
+
+    remote.aabandon_pending_work.assert_not_awaited()
+    app._handle_offload.assert_not_awaited()
+
+
+async def test_idle_thread_uses_normal_compaction_path() -> None:
+    app, remote = _app_with_remote()
+    remote.aget_state.return_value = SimpleNamespace(
+        values={}, next=(), tasks=(), interrupts=()
+    )
+
+    await app._maybe_compact_after_resume()
+
+    screen = app._push_screen_wait.await_args.args[0]
+    assert screen._pending_work is False
+    remote.aabandon_pending_work.assert_not_awaited()
+    app._handle_offload.assert_awaited_once()
+
+
+async def test_failed_recovery_does_not_compact() -> None:
+    app, remote = _app_with_remote()
+    remote.aabandon_pending_work.side_effect = RuntimeError("still pending")
+
+    await app._cancel_pending_work_and_compact()
+
+    app._handle_offload.assert_not_awaited()
+    mounted = app._mount_message.await_args.args[0]
+    assert isinstance(mounted, ErrorMessage)
+    assert "not compacted" in str(mounted._content)


### PR DESCRIPTION
- detect stale pending LangGraph work before offering resume compaction
- require explicit confirmation to cancel the saved operation without replaying it
- terminalize dangling tool calls, clear pending tasks, verify the checkpoint, then compact while preserving files and chat
- add focused unit and integration coverage proving abandoned tool work is not executed

### Notes

- The existing `test_compact_resume.py` integration test reaches successful server-side offload but currently fails its pre-existing archive filename assertion because the runtime now emits `session_<id>.md` instead of `<thread_id>.md`.

Made by [Open SWE](https://openswe.vercel.app/agents/7379d6bc-f404-58be-813d-ff66cf0fad4a)