### PR TITLE
test(code): restore `runtime_state` in `TestDispatchModelSwitch`

### DIFF
--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -24505,6 +24505,28 @@ class TestRestartAfterInstall:
 class TestDispatchModelSwitch:
     """Tests for the defer-vs-immediate model switch dispatcher."""
 
+    @pytest.fixture(autouse=True)
+    def _restore_runtime_model(self) -> Iterator[None]:
+        """Undo the real-`runtime_state` writes these tests make.
+
+        Unlike the rest of this module, which patches
+        `deepagents_code.config.runtime_state`, the confirmation-threshold
+        tests below set the process-global directly so
+        `_dispatch_model_switch` reads a spec worth warning about. Leaving
+        those values behind poisons any later test whose own model shares the
+        name: `configurable_model._model_spec_from_model` prefers
+        `runtime_state` over the model's own `ls_provider` whenever
+        `runtime_state.model_name` matches, so the leaked provider silently
+        wins.
+        """
+        original_provider = runtime_state.model_provider
+        original_name = runtime_state.model_name
+        try:
+            yield
+        finally:
+            runtime_state.model_provider = original_provider
+            runtime_state.model_name = original_name
+
     @pytest.mark.parametrize(
         ("flag", "should_notify"),
         [


### PR DESCRIPTION
## Problem

Four tests in `TestDispatchModelSwitch` (`libs/code/tests/unit_tests/test_app.py`) write the process-global `runtime_state` directly, so `_dispatch_model_switch` sees a model spec worth warning about, and never restore it:

```python
runtime_state.model_provider = "anthropic"
runtime_state.model_name = "claude-opus-4-5"
```

`test_app.py:24617-24618`, `:24637-24638`, `:24694-24695`, `:24713-24714`

Everywhere else in that module patches `deepagents_code.config.runtime_state`, so these are the only writes that outlive their test.

The leak is not inert. `configurable_model._model_spec_from_model` prefers `runtime_state` over the model's own `ls_provider` whenever the names match:

```python
if settings_provider and settings_model and model_name == settings_model:
    return f"{settings_provider}:{settings_model}"
```

So any later test whose model happens to be named `claude-opus-4-5` silently resolves to the leaked `anthropic` provider.

`test_configurable_model.py::TestModelParams::test_reasoning_effort_reaches_model_settings` is exactly that test — its mock model returns `ls_provider: "openai"` and it asserts the checkpointed spec is `openai:claude-opus-4-5`.

## Reproduction

```
pytest "tests/unit_tests/test_app.py::TestDispatchModelSwitch" \
  "tests/unit_tests/test_configurable_model.py::TestModelParams::test_reasoning_effort_reaches_model_settings" \
  -q -p no:randomly
```

**Before:**
```
E       AssertionError: assert {'_model_spec...params': None} == {'_model_spec...params': None}
E         {'_model_spec': 'anthropic:claude-opus-4-5'} != {'_model_spec': 'openai:claude-opus-4-5'}
FAILED tests/unit_tests/test_configurable_model.py::TestModelParams::test_reasoning_effort_reaches_model_settings
1 failed, 11 passed in 1.72s
```

**After:**
```
12 passed in 8.65s
```

`pytest-randomly` shuffles file order by default, so this fires only when those two files land in that order — which is why it reads as an intermittent flake rather than a consistent failure. It is deterministic under `-p no:randomly`, where alphabetical order puts `test_app.py` first.

## Fix

A class-scoped autouse fixture that saves and restores the two fields, matching the pattern `test_config.py:1638-1655` and `test_model_switch.py:68-84` already use for the same global.