### PR TITLE
feat(code): standardize external editor shortcut

### DIFF
--- a/libs/code/AGENTS.md
+++ b/libs/code/AGENTS.md
@@ -139,7 +139,7 @@ Hints that tell the user to run something (for example the teardown `-r <thread>
 
 ## Splash screen tips
 
-When adding a user-facing CLI feature (new slash command, keybinding, workflow), add a corresponding entry to the `_TIPS` dict in `deepagents_code/tui/widgets/startup_tip.py`, mapping the tip text to a relative selection weight (higher = shown more often). One tip is chosen at random above the input on startup to help users discover features. Keep tips short and action-oriented (e.g., `"Press ctrl+x to compose prompts in your external editor"`).
+When adding a user-facing CLI feature (new slash command, keybinding, workflow), add a corresponding entry to the `_TIPS` dict in `deepagents_code/tui/widgets/startup_tip.py`, mapping the tip text to a relative selection weight (higher = shown more often). One tip is chosen at random above the input on startup to help users discover features. Keep tips short and action-oriented (e.g., `"Press ctrl+g to compose prompts in your external editor"`).
 
 ## Slash commands
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3066,13 +3066,11 @@ class DeepAgentsApp(App):
             priority=True,
         ),
         Binding("ctrl+d", "quit_app", "Quit", show=False, priority=True),
-        Binding("ctrl+t", "toggle_auto_approve", "Toggle Approval Mode", show=False),
-        Binding("ctrl+g", "toggle_subagent_panel", "Toggle Subagents", show=False),
+        Binding("ctrl+t", "toggle_subagent_panel", "Toggle Subagents", show=False),
         # `check_action` steps this binding aside (returns `False`) while a
         # `DebugConsoleScreen` is active so the console's own `shift+tab`
         # reverse-focus traversal runs instead; keep the action name in sync
-        # there. That branch keys on the `toggle_auto_approve` action, so it also
-        # steps aside the `ctrl+t` binding above while the console is open.
+        # there.
         Binding(
             "shift+tab",
             "toggle_auto_approve",
@@ -3088,7 +3086,7 @@ class DeepAgentsApp(App):
             priority=True,
         ),
         Binding(
-            "ctrl+x",
+            "ctrl+g",
             "open_editor",
             "Open Editor",
             show=False,
@@ -15701,10 +15699,11 @@ class DeepAgentsApp(App):
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
                 f"  {newline_shortcut():<15} Insert newline\n"
-                f"  Ctrl+X          {editor_help}\n"
+                f"  Ctrl+G          {editor_help}\n"
                 "  Ctrl+R          Search and reuse submitted prompts\n"
                 "                  (press again for the full-screen view)\n"
                 "  Ctrl+N          Review pending notifications\n"
+                "  Ctrl+T          Toggle the subagent panel\n"
                 "  Ctrl+\\          Toggle the debug console\n"
                 "  Shift+Tab       Toggle auto-approve mode\n"
                 "  @filename       Auto-complete files and inject content\n"
@@ -17765,7 +17764,7 @@ class DeepAgentsApp(App):
             if self._approval_mode_blocked:
                 await self._mount_message(
                     ErrorMessage(
-                        "Manual approval mode has not been persisted. Press Ctrl+T "
+                        "Manual approval mode has not been persisted. Press Shift+Tab "
                         "to retry before starting another run."
                     )
                 )
@@ -22167,7 +22166,7 @@ class DeepAgentsApp(App):
         focused = self.focused
         # Ancestor (not identity) check: unlike goal-review's single `_edit_input`,
         # a menu owns two possible inputs (free-text vs "Other"), and this also
-        # rejects a stale menu's still-focused field from hijacking Ctrl+X.
+        # rejects a stale menu's still-focused field from hijacking Ctrl+G.
         if (
             not isinstance(focused, AskUserTextArea)
             or menu not in focused.ancestors
@@ -23886,9 +23885,7 @@ class DeepAgentsApp(App):
             cursor-style modals via `_SupportsReverseNav` and otherwise no-ops
             under a `ModalScreen` that lacks dedicated `shift+tab` handling
             (as `DebugConsoleScreen` does), so the key would be silently
-            swallowed. Note this keys on the action, and `toggle_auto_approve`
-            is also bound to `ctrl+t`, so that binding is stepped aside under
-            the console for either chord.
+            swallowed.
         - `quit_or_interrupt` (`ctrl+c`): the prompt clipboard owns this chord for
             copying the selected prompt rather than the focused search text.
         - `interrupt` (`escape`): while the prompt-search query has focus,

--- a/libs/code/deepagents_code/tui/widgets/ask_user.py
+++ b/libs/code/deepagents_code/tui/widgets/ask_user.py
@@ -254,7 +254,7 @@ class AskUserMenu(Container):
     def _render_help(self) -> str:
         """Build the footer hint text for the current menu state.
 
-        The `Ctrl+X external editor` hint is included only while one of this
+        The `Ctrl+G external editor` hint is included only while one of this
         menu's text areas holds focus, matching the routing in
         `App.action_open_editor`. Multi-select prompts add a Space-toggle tip.
 
@@ -275,9 +275,9 @@ class AskUserMenu(Container):
         if self._show_editor_hint():
             editor = editor_display_name()
             parts.append(
-                f"Ctrl+X edit in {editor}"
+                f"Ctrl+G edit in {editor}"
                 if editor is not None
-                else "Ctrl+X external editor"
+                else "Ctrl+G external editor"
             )
         if len(self._questions) > 1:
             parts.append("Tab/Shift+Tab switch question")
@@ -295,9 +295,9 @@ class AskUserMenu(Container):
         return question is not None and question.can_uncheck_other_input(focused)
 
     def _show_editor_hint(self) -> bool:
-        """Whether `ctrl+x` would currently open one of this menu's text areas.
+        """Whether `ctrl+g` would currently open one of this menu's text areas.
 
-        `App.action_open_editor` routes `ctrl+x` to an ask-user text area only
+        `App.action_open_editor` routes `ctrl+g` to an ask-user text area only
         when one is focused, and otherwise falls through to the chat input.
         A visible-but-unfocused field therefore must not advertise the
         shortcut: pressing it would open the user's chat draft instead. The
@@ -465,13 +465,13 @@ class AskUserMenu(Container):
             node = node.parent
         if node is not None and node._index != self._current_question:
             self._highlight_question(node._index)
-        # Every focus change inside the menu can flip whether ctrl+x routes
+        # Every focus change inside the menu can flip whether ctrl+g routes
         # here, including clicks that land on a question container rather than
         # its text area, so refresh regardless of which question is active.
         self._update_help()
 
     def on_descendant_blur(self, event: events.DescendantBlur) -> None:
-        """Retract the `Ctrl+X` hint when focus leaves a text area."""
+        """Retract the `Ctrl+G` hint when focus leaves a text area."""
         del event  # Unused: the hint is recomputed from current focus.
         self._update_help()
 

--- a/libs/code/deepagents_code/tui/widgets/goal_review.py
+++ b/libs/code/deepagents_code/tui/widgets/goal_review.py
@@ -48,7 +48,7 @@ def _editor_hint() -> str:
     """Return the current editor shortcut hint."""
     editor = editor_display_name()
     return (
-        f"Ctrl+X edit in {editor}" if editor is not None else "Ctrl+X external editor"
+        f"Ctrl+G edit in {editor}" if editor is not None else "Ctrl+G external editor"
     )
 
 
@@ -404,7 +404,7 @@ class GoalReviewMenu(Container):
             return
         glyphs = get_glyphs()
         self._help_widget.update(
-            f"{error} {glyphs.bullet} Ctrl+X external editor {glyphs.bullet} Esc back"
+            f"{error} {glyphs.bullet} Ctrl+G external editor {glyphs.bullet} Esc back"
         )
 
     def _submit(self, result: GoalReviewResult) -> None:

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -11,7 +11,7 @@ from textual.widgets import Static
 from deepagents_code._env_vars import HIDE_SPLASH_TIPS, is_env_truthy
 from deepagents_code.editor import editor_display_name
 
-_TIP_EXTERNAL_EDITOR = "Press ctrl+x to compose prompts in your external editor"
+_TIP_EXTERNAL_EDITOR = "Press ctrl+g to compose prompts in your external editor"
 """Generic editor tip replaced at construction when an editor is configured."""
 
 _TIP_SHIFT_TAB_WITH_YOLO = "Press Shift+Tab to cycle Manual, Auto, and YOLO modes"
@@ -86,7 +86,7 @@ def _active_tips(*, yolo_switcher_enabled: bool | None = None) -> dict[str, int]
     editor = editor_display_name()
     if editor is not None:
         weight = tips.pop(_TIP_EXTERNAL_EDITOR)
-        tips[f"Press ctrl+x to compose prompts in {editor}"] = weight
+        tips[f"Press ctrl+g to compose prompts in {editor}"] = weight
 
     if not yolo_switcher_enabled:
         # Replace the YOLO cycle tip with the Manual/Auto-only wording so the

--- a/libs/code/deepagents_code/tui/widgets/subagent_panel.py
+++ b/libs/code/deepagents_code/tui/widgets/subagent_panel.py
@@ -751,9 +751,9 @@ class SubagentPanel(Vertical):
             )
         self._update_cached("subagent-header-summary", Content.assemble(*parts))
         hint = (
-            "click or Ctrl+G to collapse"
+            "click or Ctrl+T to collapse"
             if self.expanded
-            else "click or Ctrl+G to expand"
+            else "click or Ctrl+T to expand"
         )
         self._update_cached("subagent-header-hint", Content.styled(hint, colors.muted))
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4838,6 +4838,20 @@ class TestMessageQueue:
         assert child_ids.index("subagent-panel") < child_ids.index("startup-tip")
         assert child_ids.index("startup-tip") < child_ids.index("input-area")
 
+    async def test_ctrl_t_toggles_subagent_panel(self) -> None:
+        from deepagents_code.tui.widgets.subagent_panel import SubagentPanel
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.query_one("#subagent-panel", SubagentPanel)
+            assert panel.expanded is True
+
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+
+            assert panel.expanded is False
+
     async def test_startup_tip_respects_hide_env_var(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -18960,7 +18974,7 @@ class TestInterruptApprovalPriority:
     async def test_approval_arriving_during_prompt_search_keeps_shift_tab(
         self,
     ) -> None:
-        """A focused approval should retain shift+tab/ctrl+t after search opened."""
+        """A focused approval should retain Shift+Tab after search opened."""
         from deepagents_code.tui.widgets.approval import ApprovalMenu
 
         app = DeepAgentsApp()
@@ -19709,8 +19723,32 @@ class TestActionOpenEditor:
         assert text_area.text == "edited"
         chat_input.focus_input.assert_called_once()
 
+    async def test_ctrl_g_opens_chat_input_in_editor(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat_input = app._chat_input
+            assert chat_input is not None
+            text_area = chat_input._text_area
+            assert text_area is not None
+            text_area.text = "original"
+
+            with (
+                patch.object(app, "suspend"),
+                patch(
+                    "deepagents_code.editor.open_in_editor", return_value="edited"
+                ) as open_editor,
+            ):
+                await pilot.press("ctrl+g")
+                await pilot.pause()
+
+            open_editor.assert_called_once_with(
+                "original", allow_empty=False, raise_on_error=False
+            )
+            assert text_area.text == "edited"
+
     async def test_prompt_search_cancel_preserves_external_editor_result(self) -> None:
-        """Escape after Ctrl+X should not restore the pre-editor draft."""
+        """Escape after Ctrl+G should not restore the pre-editor draft."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -19817,8 +19855,8 @@ class TestActionOpenEditor:
         # Focus is still restored via the `finally` clause before propagation.
         chat_input.focus_input.assert_called_once()
 
-    async def test_ctrl_x_edits_focused_goal_criteria_without_submitting(self) -> None:
-        """Ctrl+X should round-trip criteria through the focused goal editor."""
+    async def test_ctrl_g_edits_focused_goal_criteria_without_submitting(self) -> None:
+        """Ctrl+G should round-trip criteria through the focused goal editor."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -19831,7 +19869,7 @@ class TestActionOpenEditor:
                     return_value="- revised criterion",
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -19843,8 +19881,8 @@ class TestActionOpenEditor:
             assert menu._input_mode == "edit"
             assert future.done() is False
 
-    async def test_ctrl_x_edits_rejection_feedback_without_submitting(self) -> None:
-        """Ctrl+X should round-trip feedback without leaving rejection mode."""
+    async def test_ctrl_g_edits_rejection_feedback_without_submitting(self) -> None:
+        """Ctrl+G should round-trip feedback without leaving rejection mode."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -19861,7 +19899,7 @@ class TestActionOpenEditor:
                     return_value="add coverage and docs",
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -19873,7 +19911,7 @@ class TestActionOpenEditor:
             assert menu._input_mode == "reject"
             assert future.done() is False
 
-    async def test_ctrl_x_preserves_empty_goal_editor_result(self) -> None:
+    async def test_ctrl_g_preserves_empty_goal_editor_result(self) -> None:
         """An empty external edit should remain for normal goal validation."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
@@ -19886,7 +19924,7 @@ class TestActionOpenEditor:
                     "deepagents_code.editor.open_in_editor", return_value=""
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -19898,7 +19936,7 @@ class TestActionOpenEditor:
             assert menu._input_mode == "edit"
             assert future.done() is False
 
-    async def test_ctrl_x_expands_and_resets_goal_editor_paste_state(
+    async def test_ctrl_g_expands_and_resets_goal_editor_paste_state(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """External edits should use logical paste text and discard stale backing."""
@@ -19929,7 +19967,7 @@ class TestActionOpenEditor:
                     return_value="replacement",
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -19942,7 +19980,7 @@ class TestActionOpenEditor:
             assert app.focused is text_area
             assert future.done() is False
 
-    async def test_ctrl_x_cancel_preserves_goal_editor_and_paste_state(
+    async def test_ctrl_g_cancel_preserves_goal_editor_and_paste_state(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Cancelling the editor should preserve visible and stored paste text."""
@@ -19973,7 +20011,7 @@ class TestActionOpenEditor:
                     "deepagents_code.editor.open_in_editor", return_value=None
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -19985,7 +20023,7 @@ class TestActionOpenEditor:
             assert app.focused is text_area
             assert future.done() is False
 
-    async def test_ctrl_x_goal_editor_failure_preserves_text_and_focus(self) -> None:
+    async def test_ctrl_g_goal_editor_failure_preserves_text_and_focus(self) -> None:
         """Editor errors should notify without moving focus to the chat input."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
@@ -20005,7 +20043,7 @@ class TestActionOpenEditor:
                 ),
                 patch.object(app, "notify") as notify,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             notify.assert_called_once_with(
@@ -20018,10 +20056,10 @@ class TestActionOpenEditor:
             assert future.done() is False
 
     @pytest.mark.parametrize("state", ["hidden", "unfocused", "detached"])
-    async def test_inactive_goal_editor_does_not_intercept_chat_ctrl_x(
+    async def test_inactive_goal_editor_does_not_intercept_chat_ctrl_g(
         self, state: str
     ) -> None:
-        """Only the visible, attached, focused goal editor should capture Ctrl+X."""
+        """Only the visible, attached, focused goal editor should capture Ctrl+G."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -20047,7 +20085,7 @@ class TestActionOpenEditor:
                     return_value="edited chat draft",
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -20088,10 +20126,10 @@ class TestActionOpenEditor:
         assert app.focused is other_input
         return menu, other_input, future
 
-    async def test_ctrl_x_edits_focused_ask_user_other_without_submitting(
+    async def test_ctrl_g_edits_focused_ask_user_other_without_submitting(
         self,
     ) -> None:
-        """Ctrl+X should round-trip the 'Other' draft through the editor."""
+        """Ctrl+G should round-trip the 'Other' draft through the editor."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -20106,7 +20144,7 @@ class TestActionOpenEditor:
                     return_value="edited answer",
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -20117,7 +20155,7 @@ class TestActionOpenEditor:
             assert app.focused is other_input
             assert future.done() is False
 
-    async def test_ctrl_x_expands_and_resets_ask_user_other_paste_state(
+    async def test_ctrl_g_expands_and_resets_ask_user_other_paste_state(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """External edits should use logical paste text and discard stale backing."""
@@ -20147,7 +20185,7 @@ class TestActionOpenEditor:
                     return_value="replacement",
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -20160,7 +20198,7 @@ class TestActionOpenEditor:
             assert app.focused is other_input
             assert future.done() is False
 
-    async def test_ctrl_x_ask_user_other_failure_preserves_text_and_focus(
+    async def test_ctrl_g_ask_user_other_failure_preserves_text_and_focus(
         self,
     ) -> None:
         """Editor errors should notify without moving focus to the chat input."""
@@ -20183,7 +20221,7 @@ class TestActionOpenEditor:
                 ),
                 patch.object(app, "notify") as notify,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             notify.assert_called_once_with(
@@ -20196,10 +20234,10 @@ class TestActionOpenEditor:
             assert future.done() is False
 
     @pytest.mark.parametrize("state", ["hidden", "unfocused", "detached"])
-    async def test_inactive_ask_user_editor_does_not_intercept_chat_ctrl_x(
+    async def test_inactive_ask_user_editor_does_not_intercept_chat_ctrl_g(
         self, state: str
     ) -> None:
-        """Only the visible, attached, focused ask-user input should capture Ctrl+X."""
+        """Only the visible, attached, focused ask-user input should capture Ctrl+G."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -20228,7 +20266,7 @@ class TestActionOpenEditor:
                     return_value="edited chat draft",
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -20238,7 +20276,7 @@ class TestActionOpenEditor:
             assert app.focused is chat_input.input_widget
             assert future.done() is False
 
-    async def test_stale_ask_user_editor_does_not_intercept_chat_ctrl_x(
+    async def test_stale_ask_user_editor_does_not_intercept_chat_ctrl_g(
         self,
     ) -> None:
         """A focused field must belong to the currently pending ask-user menu."""
@@ -20274,7 +20312,7 @@ class TestActionOpenEditor:
                     return_value="edited chat draft",
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -20304,10 +20342,10 @@ class TestActionOpenEditor:
         assert app.focused is text_input
         return menu, text_input, future
 
-    async def test_ctrl_x_edits_focused_ask_user_text_without_submitting(
+    async def test_ctrl_g_edits_focused_ask_user_text_without_submitting(
         self,
     ) -> None:
-        """Ctrl+X should round-trip the always-visible free-text draft."""
+        """Ctrl+G should round-trip the always-visible free-text draft."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -20322,7 +20360,7 @@ class TestActionOpenEditor:
                     return_value="edited answer",
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -20333,7 +20371,7 @@ class TestActionOpenEditor:
             assert app.focused is text_input
             assert future.done() is False
 
-    async def test_ctrl_x_cancel_preserves_ask_user_other_and_paste_state(
+    async def test_ctrl_g_cancel_preserves_ask_user_other_and_paste_state(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Cancelling the editor must preserve text and NOT reset paste state."""
@@ -20363,7 +20401,7 @@ class TestActionOpenEditor:
                     "deepagents_code.editor.open_in_editor", return_value=None
                 ) as open_editor,
             ):
-                await pilot.press("ctrl+x")
+                await pilot.press("ctrl+g")
                 await pilot.pause()
 
             open_editor.assert_called_once_with(
@@ -20402,7 +20440,9 @@ class TestHelpEditorHint:
 
         assert mount_message.await_count == 2
         message = mount_message.await_args_list[-1].args[0]
-        assert "Ctrl+X          Open prompt in code" in str(message._content)
+        content = str(message._content)
+        assert "Ctrl+G          Open prompt in code" in content
+        assert "Ctrl+T          Toggle the subagent panel" in content
 
     async def test_uses_generic_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("VISUAL", raising=False)
@@ -20415,7 +20455,7 @@ class TestHelpEditorHint:
 
         assert mount_message.await_count == 2
         message = mount_message.await_args_list[-1].args[0]
-        assert "Ctrl+X          Open prompt in external editor" in str(message._content)
+        assert "Ctrl+G          Open prompt in external editor" in str(message._content)
 
 
 class TestApprovalModeSlashCommands:

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -1711,10 +1711,8 @@ class TestDebugConsoleToggle:
 
         Guards the enabled path the reverse-focus fix depends on: on the main
         screen `check_action` must leave `toggle_auto_approve` enabled (return
-        `True`) so shift+tab and ctrl+t still toggle auto-approve; the
+        `True`) so Shift+Tab still toggles auto-approve; the
         `test_shift_tab_reverses_focus_*` test only exercises the disabled path.
-        Branching on the action name (not the key) means the same gate covers
-        the `ctrl+t` binding, which also maps to `toggle_auto_approve`.
         """
         app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
         async with app.run_test() as pilot:

--- a/libs/code/tests/unit_tests/tui/widgets/test_ask_user.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_ask_user.py
@@ -2390,7 +2390,7 @@ class TestAskUserMenu:
             menu = app.query_one("#ask-user-menu", AskUserMenu)
             assert isinstance(app.focused, AskUserTextArea)
             help_text = menu.query_one(".ask-user-help").render()
-            assert "Ctrl+X edit in nvim" in str(help_text)
+            assert "Ctrl+G edit in nvim" in str(help_text)
 
     async def test_help_text_uses_generic_editor_hint_without_configuration(
         self, monkeypatch: pytest.MonkeyPatch
@@ -2403,7 +2403,7 @@ class TestAskUserMenu:
             await pilot.pause()
             menu = app.query_one("#ask-user-menu", AskUserMenu)
             help_text = menu.query_one(".ask-user-help").render()
-            assert "Ctrl+X external editor" in str(help_text)
+            assert "Ctrl+G external editor" in str(help_text)
 
     async def test_help_text_shows_editor_hint_for_choiceless_multiple_choice(
         self,
@@ -2417,10 +2417,10 @@ class TestAskUserMenu:
             await pilot.pause()
             menu = app.query_one("#ask-user-menu", AskUserMenu)
             help_text = menu.query_one(".ask-user-help").render()
-            assert "Ctrl+X" in str(help_text)
+            assert "Ctrl+G" in str(help_text)
 
     async def test_help_text_omits_editor_hint_for_multiple_choice(self) -> None:
-        """Footer omits Ctrl+X when only choices (no free-text field) are shown."""
+        """Footer omits Ctrl+G when only choices (no free-text field) are shown."""
         app = _AskUserTestApp(
             [
                 {
@@ -2435,10 +2435,10 @@ class TestAskUserMenu:
             await pilot.pause()
             menu = app.query_one("#ask-user-menu", AskUserMenu)
             help_text = menu.query_one(".ask-user-help").render()
-            assert "Ctrl+X" not in str(help_text)
+            assert "Ctrl+G" not in str(help_text)
 
     async def test_help_text_shows_editor_hint_when_other_selected(self) -> None:
-        """Landing on Other reveals and focuses its field, enabling Ctrl+X."""
+        """Landing on Other reveals and focuses its field, enabling Ctrl+G."""
         app = _AskUserTestApp(
             [
                 {
@@ -2463,10 +2463,10 @@ class TestAskUserMenu:
             assert other_input.display is True
             assert app.focused is other_input
             help_text = menu.query_one(".ask-user-help").render()
-            assert "Ctrl+X" in str(help_text)
+            assert "Ctrl+G" in str(help_text)
 
     async def test_help_text_hides_editor_hint_when_leaving_other(self) -> None:
-        """Moving off Other hides its field and retracts the Ctrl+X hint."""
+        """Moving off Other hides its field and retracts the Ctrl+G hint."""
         app = _AskUserTestApp(
             [
                 {
@@ -2484,7 +2484,7 @@ class TestAskUserMenu:
             await pilot.press("down")
             await pilot.press("down")
             await pilot.pause()
-            assert "Ctrl+X" in str(menu.query_one(".ask-user-help").render())
+            assert "Ctrl+G" in str(menu.query_one(".ask-user-help").render())
 
             # Back up to the last real choice: no free-text field is focused.
             await pilot.press("up")
@@ -2493,10 +2493,10 @@ class TestAskUserMenu:
             other_input = menu._question_widgets[0]._other_input
             assert other_input is not None
             assert other_input.display is False
-            assert "Ctrl+X" not in str(menu.query_one(".ask-user-help").render())
+            assert "Ctrl+G" not in str(menu.query_one(".ask-user-help").render())
 
     async def test_help_text_omits_editor_hint_when_other_field_unfocused(self) -> None:
-        """A visible but unfocused Other field must not advertise Ctrl+X.
+        """A visible but unfocused Other field must not advertise Ctrl+G.
 
         `App.action_open_editor` routes to an ask-user text area only while one
         is focused, and otherwise opens the chat draft, so the hint has to
@@ -2519,7 +2519,7 @@ class TestAskUserMenu:
             await pilot.press("down")
             await pilot.press("down")
             await pilot.pause()
-            assert "Ctrl+X" in str(menu.query_one(".ask-user-help").render())
+            assert "Ctrl+G" in str(menu.query_one(".ask-user-help").render())
 
             # Mirrors a click landing on the question container: the Other
             # field stays visible, but focus moves off it.
@@ -2530,21 +2530,21 @@ class TestAskUserMenu:
             assert other_input is not None
             assert other_input.display is True
             assert app.focused is not other_input
-            assert "Ctrl+X" not in str(menu.query_one(".ask-user-help").render())
+            assert "Ctrl+G" not in str(menu.query_one(".ask-user-help").render())
 
     async def test_help_text_hides_editor_hint_when_focus_leaves_menu(self) -> None:
-        """Focus moving off the menu entirely retracts the Ctrl+X hint."""
+        """Focus moving off the menu entirely retracts the Ctrl+G hint."""
         app = _AskUserTestApp([{"question": "Q1?", "type": "text"}])
 
         async with app.run_test() as pilot:
             await pilot.pause()
             menu = app.query_one("#ask-user-menu", AskUserMenu)
-            assert "Ctrl+X" in str(menu.query_one(".ask-user-help").render())
+            assert "Ctrl+G" in str(menu.query_one(".ask-user-help").render())
 
             app.set_focus(None)
             await pilot.pause()
 
-            assert "Ctrl+X" not in str(menu.query_one(".ask-user-help").render())
+            assert "Ctrl+G" not in str(menu.query_one(".ask-user-help").render())
 
     async def test_help_text_editor_hint_follows_clicked_question(self) -> None:
         """Clicking into another question's text field turns the hint on."""
@@ -2562,7 +2562,7 @@ class TestAskUserMenu:
         async with app.run_test() as pilot:
             await pilot.pause()
             menu = app.query_one("#ask-user-menu", AskUserMenu)
-            assert "Ctrl+X" not in str(menu.query_one(".ask-user-help").render())
+            assert "Ctrl+G" not in str(menu.query_one(".ask-user-help").render())
 
             text_input = menu._question_widgets[1]._text_input
             assert text_input is not None
@@ -2570,10 +2570,10 @@ class TestAskUserMenu:
             await pilot.pause()
 
             assert app.focused is text_input
-            assert "Ctrl+X" in str(menu.query_one(".ask-user-help").render())
+            assert "Ctrl+G" in str(menu.query_one(".ask-user-help").render())
 
     async def test_help_text_editor_hint_follows_active_question(self) -> None:
-        """Mixed prompts only advertise Ctrl+X for the active free-text field."""
+        """Mixed prompts only advertise Ctrl+G for the active free-text field."""
         app = _AskUserTestApp(
             [
                 {
@@ -2591,19 +2591,19 @@ class TestAskUserMenu:
 
             # Initial focus is the multiple-choice question: no free-text field.
             help_text = menu.query_one(".ask-user-help").render()
-            assert "Ctrl+X" not in str(help_text)
+            assert "Ctrl+G" not in str(help_text)
 
-            # Move to the text question: the focused field can use Ctrl+X.
+            # Move to the text question: the focused field can use Ctrl+G.
             menu.action_next_question()
             await pilot.pause()
             help_text = menu.query_one(".ask-user-help").render()
-            assert "Ctrl+X" in str(help_text)
+            assert "Ctrl+G" in str(help_text)
 
             # Move back: stop advertising the shortcut for the choice list.
             menu.action_previous_question()
             await pilot.pause()
             help_text = menu.query_one(".ask-user-help").render()
-            assert "Ctrl+X" not in str(help_text)
+            assert "Ctrl+G" not in str(help_text)
 
     async def test_single_question_hides_number_label(self) -> None:
         app = _AskUserTestApp([{"question": "Name?", "type": "text"}])

--- a/libs/code/tests/unit_tests/tui/widgets/test_goal_review.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_goal_review.py
@@ -210,11 +210,11 @@ class TestGoalReviewMenu:
             help_widget = menu.query_one(".goal-review-help", Static)
 
             menu.action_edit()
-            assert "Ctrl+X edit in nvim" in str(help_widget.content)
+            assert "Ctrl+G edit in nvim" in str(help_widget.content)
 
             menu.action_cancel()
             menu.action_reject_with_message()
-            assert "Ctrl+X edit in nvim" in str(help_widget.content)
+            assert "Ctrl+G edit in nvim" in str(help_widget.content)
 
     async def test_text_editor_help_uses_generic_fallback(
         self, monkeypatch: pytest.MonkeyPatch
@@ -229,7 +229,7 @@ class TestGoalReviewMenu:
             help_widget = menu.query_one(".goal-review-help", Static)
 
             menu.action_edit()
-            assert "Ctrl+X external editor" in str(help_widget.content)
+            assert "Ctrl+G external editor" in str(help_widget.content)
 
     async def test_newline_hint_uses_terminal_shortcut(
         self, monkeypatch: pytest.MonkeyPatch
@@ -537,7 +537,7 @@ class TestGoalReviewMenu:
             help_text = str(help_widget.content)
             assert "combined" in help_text
             assert "Remove at least" in help_text
-            assert "Ctrl+X external editor" in help_text
+            assert "Ctrl+G external editor" in help_text
 
     async def test_hint_without_a_help_widget_is_logged(
         self, caplog: pytest.LogCaptureFixture

--- a/libs/code/tests/unit_tests/tui/widgets/test_startup_tip.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_startup_tip.py
@@ -86,7 +86,7 @@ class TestStartupTip:
 
         tips = _active_tips(yolo_switcher_enabled=True)
 
-        assert "Press ctrl+x to compose prompts in code" in tips
+        assert "Press ctrl+g to compose prompts in code" in tips
         assert _TIP_EXTERNAL_EDITOR not in tips
 
     def test_active_tips_keeps_generic_editor_fallback(self) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_subagent_panel.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_subagent_panel.py
@@ -399,7 +399,7 @@ class TestHeaderToggle:
 
             summary = pilot.app.query_one("#subagent-header-summary", Static)
             hint = pilot.app.query_one("#subagent-header-hint", Static)
-            text = "click or Ctrl+G to collapse"
+            text = "click or Ctrl+T to collapse"
             # `_render` returns the unclipped content, so this is the "summary
             # really is overflowing" precondition; the ellipsis assertion below
             # reads the painted strip, which is where truncation happens.


### PR DESCRIPTION
Use `Ctrl+G` to open the prompt in an external editor and `Ctrl+T` to toggle the subagent panel.

---

This aligns external editing with Codex and Claude Code conventions while preserving `Shift+Tab` for approval-mode cycling. Help text, contextual hints, startup tips, and focused TUI coverage now reflect the new bindings.

Made by [Open SWE](https://openswe.vercel.app/agents/1a571726-3990-588f-a7f7-3dfcc5557092)