### PR TITLE
chore(ci): default manual raise-dependency-minimums runs to `all`

### DIFF
--- a/.github/workflows/raise_langchain_minimums.yml
+++ b/.github/workflows/raise_langchain_minimums.yml
@@ -62,7 +62,7 @@ on:
         description: "Release package whose dependency minimums to raise"
         required: true
         type: choice
-        default: "deepagents-code"
+        default: "all"
         options:
           - "deepagents-code"
           - "all"


### PR DESCRIPTION
The scheduled run of this workflow already bumps every release package (`package = all`), but a manual dispatch defaulted to `deepagents-code` — easy to miss in the Actions UI, and silently narrower than intended. Defaulting the `package` input to `all` makes the manual path match the cron behavior; dispatching against a single package is still an explicit choice in the dropdown.
