### PR TITLE
fix(code): skip unchanged config writes

### DIFF
--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -3962,25 +3962,28 @@ def _save_toml_field(
                 data = {}
 
             existing_section = data.get(section)
-            if isinstance(existing_section, dict):
-                existing = existing_section.get(field)
-                if type(existing) is type(value) and existing == value:
-                    return True
-            if section not in data:
-                data[section] = {}
-            data[section][field] = value
+            existing = (
+                existing_section.get(field)
+                if isinstance(existing_section, dict)
+                else None
+            )
+            unchanged = type(existing) is type(value) and existing == value
+            if not unchanged:
+                if section not in data:
+                    data[section] = {}
+                data[section][field] = value
 
-            # Write to temp file then rename so an interrupted write can't corrupt
-            fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
-            try:
-                with os.fdopen(fd, "wb") as f:
-                    tomli_w.dump(data, f)
-                Path(tmp_path).replace(config_path)
-            except BaseException:
-                # Clean up temp file on any failure
-                with contextlib.suppress(OSError):
-                    Path(tmp_path).unlink()
-                raise
+                # Write to temp file then rename so an interrupted write can't corrupt
+                fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
+                try:
+                    with os.fdopen(fd, "wb") as f:
+                        tomli_w.dump(data, f)
+                    Path(tmp_path).replace(config_path)
+                except BaseException:
+                    # Clean up temp file on any failure
+                    with contextlib.suppress(OSError):
+                        Path(tmp_path).unlink()
+                    raise
     except (OSError, tomllib.TOMLDecodeError, TypeError, ValueError):
         # `TypeError` covers `tomli_w.dump` rejecting a non-serializable
         # payload; `ValueError` covers things like `os.fdopen` on a

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -3961,6 +3961,11 @@ def _save_toml_field(
             else:
                 data = {}
 
+            existing_section = data.get(section)
+            if isinstance(existing_section, dict):
+                existing = existing_section.get(field)
+                if type(existing) is type(value) and existing == value:
+                    return True
             if section not in data:
                 data[section] = {}
             data[section][field] = value

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -6308,6 +6308,17 @@ recent = "researcher"
         assert 'recent = "coder"' in content
         assert "researcher" not in content
 
+    def test_save_same_value_preserves_file_identity(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        content = b'[agents]\nrecent = "coder"\n'
+        config_path.write_bytes(content)
+        inode = config_path.stat().st_ino
+
+        assert save_recent_agent("coder", config_path) is True
+
+        assert config_path.stat().st_ino == inode
+        assert config_path.read_bytes() == content
+
     def test_load_returns_recent(self, tmp_path):
         config_path = tmp_path / "config.toml"
         save_recent_agent("coder", config_path)

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -9500,6 +9500,35 @@ class TestWritesReachTheSharedResolver:
 
         assert get_config_resolver().get(option).value == expected
 
+    def test_noop_save_refreshes_externally_changed_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An equal on-disk value still invalidates stale cached views."""
+        from deepagents_code.config_manifest import get_option
+        from deepagents_code.configuration.resolver import get_config_resolver
+
+        config_path = tmp_path / "config.toml"
+        monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+        config_path.write_text(
+            '[models]\nauto_classifier = "openai:old"\n', encoding="utf-8"
+        )
+        model_config.clear_caches()
+        option = get_option("models.auto_classifier")
+        assert option is not None
+        assert model_config.ModelConfig.load().auto_classifier_model == "openai:old"
+        assert get_config_resolver().get(option).value == "openai:old"
+
+        config_path.write_text(
+            '[models]\nauto_classifier = "openai:new"\n', encoding="utf-8"
+        )
+        inode = config_path.stat().st_ino
+
+        assert model_config.save_auto_classifier_model("openai:new") is True
+
+        assert config_path.stat().st_ino == inode
+        assert model_config.ModelConfig.load().auto_classifier_model == "openai:new"
+        assert get_config_resolver().get(option).value == "openai:new"
+
     def test_cleared_value_is_visible_to_the_next_resolver_read(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Launching another `dcode` session no longer makes editors report that `config.toml` changed when the persisted value was already current.

---

Startup persists the recent agent through `_save_toml_field`, which previously serialized and atomically replaced the config file on every call. Even with identical bytes, that replacement changed the file identity and triggered external-change warnings in editors such as nano.

Return successfully under the existing config lock when the stored scalar already has the same value and type. Actual changes retain the crash-safe atomic replacement path, and all saves still refresh cached config views so external edits become visible in-process.

Made by [Open SWE](https://openswe.vercel.app/agents/91004cf2-27d6-54fc-a961-3acb33d205cf)