### PR TITLE
feat(code): link doctor commit hash to GitHub

### DIFF
--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import platform
+import re
 import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -28,6 +29,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+_REPOSITORY_URL = "https://github.com/langchain-ai/deepagents"
+
 
 @dataclass
 class DiagnosticItem:
@@ -40,6 +44,7 @@ class DiagnosticItem:
     label: str
     value: str
     ok: bool = True
+    url: str | None = None
 
 
 @dataclass
@@ -185,12 +190,17 @@ def _collect_diagnostics() -> DiagnosticSection:
         method = detect_install_method()
         path = sys.prefix
 
+    commit = _commit_hash(path)
+    commit_url = (
+        f"{_REPOSITORY_URL}/commit/{commit}" if _COMMIT_RE.fullmatch(commit) else None
+    )
+
     return DiagnosticSection(
         title="Diagnostics",
         items=[
             DiagnosticItem("deepagents-code", cli_value),
             DiagnosticItem("deepagents (SDK)", sdk_version, ok=sdk_ok),
-            DiagnosticItem("Commit hash", _commit_hash(path)),
+            DiagnosticItem("Commit hash", commit, url=commit_url),
             DiagnosticItem("Python", platform.python_version()),
             DiagnosticItem("Platform", _platform_tag()),
             DiagnosticItem("Install method", method),
@@ -774,6 +784,8 @@ def _tree_connectors() -> tuple[str, str]:
 def _render_text(sections: list[DiagnosticSection]) -> None:
     """Print the diagnostic sections as a styled tree to the console."""
     from rich.markup import escape
+    from rich.style import Style
+    from rich.text import Text
 
     from deepagents_code import theme
     from deepagents_code.config import console, get_glyphs
@@ -792,11 +804,11 @@ def _render_text(sections: list[DiagnosticSection]) -> None:
         for index, item in enumerate(section.items):
             connector = corner if index == len(section.items) - 1 else tee
             value_color = theme.MUTED if item.ok else "red"
-            console.print(
-                f"  {connector} {escape(item.label)}: "
-                f"[{value_color}]{escape(item.value)}[/{value_color}]",
-                highlight=False,
+            line = Text.assemble(
+                f"  {connector} {item.label}: ",
+                (item.value, Style(color=value_color, link=item.url)),
             )
+            console.print(line, highlight=False)
         console.print()
 
     console.print(

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import platform
+import re
 import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -796,7 +797,8 @@ def _render_text(sections: list[DiagnosticSection]) -> None:
             value_color = theme.MUTED if item.ok else "red"
             url = (
                 f"https://github.com/langchain-ai/deepagents/commit/{item.value}"
-                if item.label == "Commit hash" and item.value != "unknown"
+                if item.label == "Commit hash"
+                and re.fullmatch(r"[0-9a-fA-F]{7,40}", item.value)
                 else None
             )
             console.print(

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import logging
 import platform
-import re
 import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -29,9 +28,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
-_REPOSITORY_URL = "https://github.com/langchain-ai/deepagents"
-
 
 @dataclass
 class DiagnosticItem:
@@ -44,7 +40,6 @@ class DiagnosticItem:
     label: str
     value: str
     ok: bool = True
-    url: str | None = None
 
 
 @dataclass
@@ -190,17 +185,12 @@ def _collect_diagnostics() -> DiagnosticSection:
         method = detect_install_method()
         path = sys.prefix
 
-    commit = _commit_hash(path)
-    commit_url = (
-        f"{_REPOSITORY_URL}/commit/{commit}" if _COMMIT_RE.fullmatch(commit) else None
-    )
-
     return DiagnosticSection(
         title="Diagnostics",
         items=[
             DiagnosticItem("deepagents-code", cli_value),
             DiagnosticItem("deepagents (SDK)", sdk_version, ok=sdk_ok),
-            DiagnosticItem("Commit hash", commit, url=commit_url),
+            DiagnosticItem("Commit hash", _commit_hash(path)),
             DiagnosticItem("Python", platform.python_version()),
             DiagnosticItem("Platform", _platform_tag()),
             DiagnosticItem("Install method", method),
@@ -804,11 +794,17 @@ def _render_text(sections: list[DiagnosticSection]) -> None:
         for index, item in enumerate(section.items):
             connector = corner if index == len(section.items) - 1 else tee
             value_color = theme.MUTED if item.ok else "red"
-            line = Text.assemble(
-                f"  {connector} {item.label}: ",
-                (item.value, Style(color=value_color, link=item.url)),
+            url = (
+                f"https://github.com/langchain-ai/deepagents/commit/{item.value}"
+                if item.label == "Commit hash" and item.value != "unknown"
+                else None
             )
-            console.print(line, highlight=False)
+            console.print(
+                f"  {connector} {escape(item.label)}: ",
+                Text(item.value, style=Style(color=value_color, link=url)),
+                sep="",
+                highlight=False,
+            )
         console.print()
 
     console.print(

--- a/libs/code/tests/unit_tests/test_doctor.py
+++ b/libs/code/tests/unit_tests/test_doctor.py
@@ -92,29 +92,6 @@ class TestCollectSections:
         assert "Platform" in labels
         assert "Install method" in labels
 
-    @pytest.mark.parametrize(
-        ("commit", "url"),
-        [
-            ("abc1234", "https://github.com/langchain-ai/deepagents/commit/abc1234"),
-            ("unknown", None),
-        ],
-    )
-    def test_commit_hash_link(self, commit: str, url: str | None) -> None:
-        """A resolved commit links to GitHub while an unknown value stays plain."""
-        from deepagents_code.doctor import _collect_diagnostics
-
-        with (
-            patch("deepagents_code.doctor._commit_hash", return_value=commit),
-            patch(
-                "deepagents_code.extras_info._sdk_requirement_for_cli",
-                return_value=None,
-            ),
-        ):
-            diagnostics = _collect_diagnostics()
-
-        item = next(item for item in diagnostics.items if item.label == "Commit hash")
-        assert item.url == url
-
 
 class TestDiagnosticsVersionReport:
     """Tests for how the Diagnostics section renders version-report facts."""
@@ -784,9 +761,11 @@ class TestConfigurationSection:
 class TestRunDoctorCommand:
     """Tests for the text and JSON rendering paths."""
 
-    def _run_text(self) -> tuple[int, str]:
+    def _run_text(self, *, force_terminal: bool = False) -> tuple[int, str]:
         buf = io.StringIO()
-        test_console = Console(file=buf, highlight=False, width=200)
+        test_console = Console(
+            file=buf, force_terminal=force_terminal, highlight=False, width=200
+        )
         args = argparse.Namespace(output_format="text")
         with patch("deepagents_code.config.console", test_console):
             code = run_doctor_command(args)
@@ -815,38 +794,11 @@ class TestRunDoctorCommand:
         assert "dcode -v" in output
 
     def test_commit_hash_renders_as_link(self) -> None:
-        """Text output links the hash without changing its visible text."""
-        sections = [
-            DiagnosticSection(
-                title="Diagnostics",
-                items=[
-                    DiagnosticItem(
-                        "Commit hash",
-                        "abc1234",
-                        url="https://github.com/langchain-ai/deepagents/commit/abc1234",
-                    )
-                ],
-            )
-        ]
-        buf = io.StringIO()
-        test_console = Console(
-            file=buf,
-            force_terminal=True,
-            color_system="standard",
-            highlight=False,
-            width=200,
-        )
+        """Text output links the hash to GitHub."""
+        with patch("deepagents_code.doctor._commit_hash", return_value="abc1234"):
+            _, output = self._run_text(force_terminal=True)
 
-        with (
-            patch("deepagents_code.doctor.collect_sections", return_value=sections),
-            patch("deepagents_code.config.console", test_console),
-        ):
-            code = run_doctor_command(argparse.Namespace(output_format="text"))
-
-        output = buf.getvalue()
-        assert code == 0
         assert "https://github.com/langchain-ai/deepagents/commit/abc1234" in output
-        assert "abc1234" in output
 
     def test_json_output_envelope(self, capsys) -> None:
         """JSON output is a stable envelope with section data."""
@@ -869,7 +821,6 @@ class TestRunDoctorCommand:
         assert data["healthy"] is True
         titles = [section["title"] for section in data["sections"]]
         assert titles == ["Diagnostics", "Updates", "Tracing", "Configuration"]
-        assert set(data["sections"][0]["items"][0]) == {"label", "value", "ok"}
 
     def test_unhealthy_returns_nonzero(self) -> None:
         """An unhealthy section yields a non-zero exit code."""

--- a/libs/code/tests/unit_tests/test_doctor.py
+++ b/libs/code/tests/unit_tests/test_doctor.py
@@ -800,6 +800,14 @@ class TestRunDoctorCommand:
 
         assert "https://github.com/langchain-ai/deepagents/commit/abc1234" in output
 
+    def test_invalid_commit_hash_renders_without_link(self) -> None:
+        """Text output leaves an invalid hash unlinked."""
+        with patch("deepagents_code.doctor._commit_hash", return_value="not-a-sha"):
+            _, output = self._run_text(force_terminal=True)
+
+        assert "not-a-sha" in output
+        assert "https://github.com/langchain-ai/deepagents/commit/" not in output
+
     def test_json_output_envelope(self, capsys) -> None:
         """JSON output is a stable envelope with section data."""
         args = argparse.Namespace(output_format="json")

--- a/libs/code/tests/unit_tests/test_doctor.py
+++ b/libs/code/tests/unit_tests/test_doctor.py
@@ -92,6 +92,29 @@ class TestCollectSections:
         assert "Platform" in labels
         assert "Install method" in labels
 
+    @pytest.mark.parametrize(
+        ("commit", "url"),
+        [
+            ("abc1234", "https://github.com/langchain-ai/deepagents/commit/abc1234"),
+            ("unknown", None),
+        ],
+    )
+    def test_commit_hash_link(self, commit: str, url: str | None) -> None:
+        """A resolved commit links to GitHub while an unknown value stays plain."""
+        from deepagents_code.doctor import _collect_diagnostics
+
+        with (
+            patch("deepagents_code.doctor._commit_hash", return_value=commit),
+            patch(
+                "deepagents_code.extras_info._sdk_requirement_for_cli",
+                return_value=None,
+            ),
+        ):
+            diagnostics = _collect_diagnostics()
+
+        item = next(item for item in diagnostics.items if item.label == "Commit hash")
+        assert item.url == url
+
 
 class TestDiagnosticsVersionReport:
     """Tests for how the Diagnostics section renders version-report facts."""
@@ -791,6 +814,40 @@ class TestRunDoctorCommand:
         assert "dcode --version" in output
         assert "dcode -v" in output
 
+    def test_commit_hash_renders_as_link(self) -> None:
+        """Text output links the hash without changing its visible text."""
+        sections = [
+            DiagnosticSection(
+                title="Diagnostics",
+                items=[
+                    DiagnosticItem(
+                        "Commit hash",
+                        "abc1234",
+                        url="https://github.com/langchain-ai/deepagents/commit/abc1234",
+                    )
+                ],
+            )
+        ]
+        buf = io.StringIO()
+        test_console = Console(
+            file=buf,
+            force_terminal=True,
+            color_system="standard",
+            highlight=False,
+            width=200,
+        )
+
+        with (
+            patch("deepagents_code.doctor.collect_sections", return_value=sections),
+            patch("deepagents_code.config.console", test_console),
+        ):
+            code = run_doctor_command(argparse.Namespace(output_format="text"))
+
+        output = buf.getvalue()
+        assert code == 0
+        assert "https://github.com/langchain-ai/deepagents/commit/abc1234" in output
+        assert "abc1234" in output
+
     def test_json_output_envelope(self, capsys) -> None:
         """JSON output is a stable envelope with section data."""
         args = argparse.Namespace(output_format="json")
@@ -812,6 +869,7 @@ class TestRunDoctorCommand:
         assert data["healthy"] is True
         titles = [section["title"] for section in data["sections"]]
         assert titles == ["Diagnostics", "Updates", "Tracing", "Configuration"]
+        assert set(data["sections"][0]["items"][0]) == {"label", "value", "ok"}
 
     def test_unhealthy_returns_nonzero(self) -> None:
         """An unhealthy section yields a non-zero exit code."""


### PR DESCRIPTION
The commit hash in `dcode doctor` now links directly to that commit on GitHub in terminals that support hyperlinks.

---

Render the resolved commit hash with Rich's terminal hyperlink support while preserving the existing visible and JSON output. Unknown or invalid hash values remain plain text.

Made by [Open SWE](https://openswe.vercel.app/agents/25553271-f2f1-5cd8-b89e-1c1ff4e31786)