### PR TITLE
fix(code): respect ASCII mode in splash border

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/welcome.py
+++ b/libs/code/deepagents_code/tui/widgets/welcome.py
@@ -264,14 +264,19 @@ class WelcomeBanner(Static):
     def on_mount(self) -> None:
         """Watch for theme changes and start the LangSmith project-URL fetch."""
         self.watch(self.app, "theme", self._on_theme_change, init=False)
-        if is_ascii_mode():
-            self.styles.border = ("ascii", theme.get_theme_colors(self).primary)
+        self._update_border()
         if self._project_name:
             self.run_worker(self._fetch_and_update, exclusive=True)
 
     def _on_theme_change(self) -> None:
         """Re-render the banner when the app theme changes."""
+        self._update_border()
         self.update(self._build_banner())
+
+    def _update_border(self) -> None:
+        """Apply the current theme color to the ASCII border."""
+        if is_ascii_mode():
+            self.styles.border = ("ascii", theme.get_theme_colors(self).primary)
 
     async def _fetch_and_update(self) -> None:
         """Fetch the LangSmith URL in a thread and update the banner."""

--- a/libs/code/deepagents_code/tui/widgets/welcome.py
+++ b/libs/code/deepagents_code/tui/widgets/welcome.py
@@ -35,6 +35,7 @@ from deepagents_code.config import (
     get_glyphs,
     get_langsmith_project_name,
     get_langsmith_replica_project,
+    is_ascii_mode,
 )
 from deepagents_code.tui.widgets._copy_spans import copy_span_style, copy_span_target
 from deepagents_code.tui.widgets._links import open_style_link
@@ -263,6 +264,8 @@ class WelcomeBanner(Static):
     def on_mount(self) -> None:
         """Watch for theme changes and start the LangSmith project-URL fetch."""
         self.watch(self.app, "theme", self._on_theme_change, init=False)
+        if is_ascii_mode():
+            self.styles.border = ("ascii", theme.get_theme_colors(self).primary)
         if self._project_name:
             self.run_worker(self._fetch_and_update, exclusive=True)
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
@@ -867,6 +867,19 @@ class _BannerApp(App[None]):
         yield self._banner
 
 
+class TestBorder:
+    """Tests for the charset-aware banner border."""
+
+    async def test_ascii_mode_uses_ascii_border(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ASCII mode replaces the default rounded border."""
+        monkeypatch.setattr(welcome_module, "is_ascii_mode", lambda: True)
+        banner = _make_banner(show_model=False)
+        async with _BannerApp(banner).run_test(size=(80, 24)):
+            assert banner.styles.border_top[0] == "ascii"
+
+
 def _click_offset(banner: WelcomeBanner, needle: str) -> tuple[int, int]:
     """Return a click offset inside the rendered span containing `needle`.
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from textual.app import App, ComposeResult
+from textual.color import Color as TColor
 from textual.content import Content
 from textual.style import Style as TStyle
 
@@ -876,8 +877,19 @@ class TestBorder:
         """ASCII mode replaces the default rounded border."""
         monkeypatch.setattr(welcome_module, "is_ascii_mode", lambda: True)
         banner = _make_banner(show_model=False)
-        async with _BannerApp(banner).run_test(size=(80, 24)):
+        app = _BannerApp(banner)
+        async with app.run_test(size=(80, 24)) as pilot:
             assert banner.styles.border_top[0] == "ascii"
+
+            original_color = banner.styles.border_top[1]
+            app.theme = "textual-light"
+            await pilot.pause()
+
+            assert banner.styles.border_top[0] == "ascii"
+            assert banner.styles.border_top[1] == TColor.parse(
+                welcome_module.theme.get_theme_colors(banner).primary
+            )
+            assert banner.styles.border_top[1] != original_color
 
 
 def _click_offset(banner: WelcomeBanner, needle: str) -> tuple[int, int]:


### PR DESCRIPTION
The startup splash banner now uses an ASCII-safe border when ASCII charset mode is active.

---

The splash banner kept Textual's rounded Unicode border even after its content glyphs switched to ASCII. Apply the same charset-aware border selection already used by the chat input and cover it with a focused mounted-widget regression test.

Made by [Open SWE](https://openswe.vercel.app/agents/7e5df730-093d-507b-b255-30a35d856a55)