### PR TITLE
feat(code): attribute skill invocations in trace metadata

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -16316,6 +16316,7 @@ class DeepAgentsApp(App):
         await self._send_to_agent(
             envelope.prompt,
             message_kwargs=envelope.message_kwargs,
+            skill_name=envelope.skill_name,
         )
 
     async def _prompt_skill_trust_and_retry(
@@ -17280,6 +17281,7 @@ class DeepAgentsApp(App):
         message: str,
         *,
         message_kwargs: dict[str, Any] | None = None,
+        skill_name: str | None = None,
     ) -> None:
         """Send a message to the agent and start execution.
 
@@ -17291,6 +17293,7 @@ class DeepAgentsApp(App):
             message: The prompt to send to the agent.
             message_kwargs: Extra fields merged into the stream input message
                 dict (e.g., `additional_kwargs` for skill metadata).
+            skill_name: Invoked skill name for trace attribution, or `None`.
         """
         # Anchor to bottom so streaming response stays visible
         with suppress(NoMatches, ScreenStackError):
@@ -17355,6 +17358,7 @@ class DeepAgentsApp(App):
                     self._run_agent_task,
                     message,
                     message_kwargs=message_kwargs,
+                    skill_name=skill_name,
                     goal_notice_current=resuming_blocked,
                 )
                 # Cast because Textual's `WorkType` alias admits both a
@@ -17755,6 +17759,7 @@ class DeepAgentsApp(App):
         message: str,
         *,
         message_kwargs: dict[str, Any] | None = None,
+        skill_name: str | None = None,
         graph_input: dict[str, Any] | None = None,
         goal_notice_current: bool = False,
     ) -> None:
@@ -17766,6 +17771,7 @@ class DeepAgentsApp(App):
             message: The prompt to send to the agent.
             message_kwargs: Extra fields merged into the stream input message
                 dict (e.g., `additional_kwargs` for skill metadata).
+            skill_name: Invoked skill name for trace attribution, or `None`.
             graph_input: Prepared non-conversation input for a server operation.
             goal_notice_current: Whether the caller just persisted the current notice.
         """
@@ -17947,6 +17953,7 @@ class DeepAgentsApp(App):
                 image_tracker=self._image_tracker,
                 sandbox_type=self._sandbox_type,
                 message_kwargs=message_kwargs,
+                skill_name=skill_name,
                 graph_input=graph_input,
                 rubric=rubric,
                 goal_active=goal_backed_grading,

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -2037,6 +2037,7 @@ async def run_non_interactive(
         await _run_startup_command(startup_cmd.strip(), console, quiet=quiet)
 
     message_kwargs: dict[str, Any] | None = None
+    skill_name: str | None = None
     if initial_skill and initial_skill.strip():
         from deepagents_code.skills.invocation import (
             build_skill_invocation_envelope,
@@ -2131,6 +2132,7 @@ async def run_non_interactive(
         envelope = build_skill_invocation_envelope(skill, content, message)
         message = envelope.prompt
         message_kwargs = envelope.message_kwargs
+        skill_name = envelope.skill_name
 
     try:
         result = create_model(
@@ -2238,6 +2240,7 @@ async def run_non_interactive(
             turn_id=str(turn_id),
             turn_number=1,
             auto_approve=use_auto_approve,
+            skill_name=skill_name,
         )
 
         if not quiet:

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2119,6 +2119,7 @@ def build_stream_config(
     turn_id: str | None = None,
     turn_number: int | None = None,
     auto_approve: bool = False,
+    skill_name: str | None = None,
 ) -> RunnableConfig:
     """Build the LangGraph stream config dict.
 
@@ -2184,6 +2185,7 @@ def build_stream_config(
         turn_number: 1-based per-thread turn index, or `None`.
         auto_approve: Whether auto-approve ("YOLO") mode is active for this turn.
             When `True`, `dcode_auto_approve=True` is recorded in trace metadata.
+        skill_name: Invoked skill name to record in trace metadata, or `None`.
 
     Returns:
         Config dict with `configurable` and `metadata` keys, plus
@@ -2216,6 +2218,9 @@ def build_stream_config(
     # Mark auto-approve ("YOLO") runs so they are filterable in trace metadata.
     if auto_approve:
         metadata["dcode_auto_approve"] = True
+
+    if skill_name:
+        metadata["ls_skill_name"] = skill_name
 
     # Record the launch environment so traces are groupable by terminal.
     # Blank is treated as unset, matching the other readers. Not a contract key.

--- a/libs/code/deepagents_code/skills/invocation.py
+++ b/libs/code/deepagents_code/skills/invocation.py
@@ -29,10 +29,12 @@ class SkillInvocationEnvelope:
         prompt: Composed prompt that wraps `SKILL.md` content with
             invocation instructions.
         message_kwargs: Extra fields merged into the initial HumanMessage.
+        skill_name: Invoked skill name for trace attribution.
     """
 
     prompt: str
     message_kwargs: dict[str, Any]
+    skill_name: str
 
 
 def discover_skills_and_roots(
@@ -148,4 +150,8 @@ def build_skill_invocation_envelope(
             },
         },
     }
-    return SkillInvocationEnvelope(prompt=prompt, message_kwargs=message_kwargs)
+    return SkillInvocationEnvelope(
+        prompt=prompt,
+        message_kwargs=message_kwargs,
+        skill_name=skill["name"],
+    )

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -1438,6 +1438,7 @@ async def execute_task_textual(
     *,
     sandbox_type: str | None = None,
     message_kwargs: dict[str, Any] | None = None,
+    skill_name: str | None = None,
     graph_input: dict[str, Any] | None = None,
     rubric: str | None = None,
     goal_active: bool = False,
@@ -1465,6 +1466,7 @@ async def execute_task_textual(
         message_kwargs: Extra fields merged into the stream input message
             dict (e.g., `additional_kwargs` for persisting skill metadata
             in the checkpoint).
+        skill_name: Invoked skill name for trace attribution, or `None`.
         graph_input: Prepared non-conversation input for a server-side graph
             operation. When provided, no user message or media is constructed.
         rubric: Acceptance criteria supplied to `RubricMiddleware` via graph
@@ -1572,6 +1574,7 @@ async def execute_task_textual(
         turn_id=turn_id,
         turn_number=turn_number,
         auto_approve=bool(session_state.auto_approve),
+        skill_name=skill_name,
     )
 
     captured_input_tokens = 0

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -1469,6 +1469,10 @@ class TestNonInteractivePrompt:
         assert "**User request:** review this patch" in user_msg["content"]
         assert user_msg["additional_kwargs"]["__skill"]["name"] == "code-review"
         assert user_msg["additional_kwargs"]["__skill"]["args"] == "review this patch"
+        assert (
+            mock_agent.astream.call_args.kwargs["config"]["metadata"]["ls_skill_name"]
+            == "code-review"
+        )
 
     async def test_initial_skill_missing_returns_error_without_starting_server(
         self,

--- a/libs/code/tests/unit_tests/test_skill_invocation.py
+++ b/libs/code/tests/unit_tests/test_skill_invocation.py
@@ -393,6 +393,7 @@ class TestBuildSkillInvocationEnvelope:
         assert meta["description"] == "Review code changes"
         assert meta["source"] == "user"
         assert meta["args"] == "review this patch"
+        assert envelope.skill_name == "code-review"
 
     def test_empty_args_omits_user_request(self) -> None:
         """No `**User request:**` line when args is empty."""
@@ -514,6 +515,7 @@ class TestHandleSkillCommand:
 
         app._send_to_agent.assert_awaited_once()
         prompt = app._send_to_agent.call_args[0][0]
+        assert app._send_to_agent.call_args.kwargs["skill_name"] == "test-skill"
         assert "test-skill" in prompt
         assert "# Instructions" in prompt
         # Verify SkillMessage was mounted instead of UserMessage

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -1351,6 +1351,18 @@ class TestBuildStreamConfig:
         config = build_stream_config("t-yolo", assistant_id=None, auto_approve=True)
         assert config["metadata"]["dcode_auto_approve"] is True
 
+    def test_skill_name_included_when_invoked(self) -> None:
+        """Skill invocations should be identifiable in trace metadata."""
+        config = build_stream_config(
+            "t-skill", assistant_id=None, skill_name="code-review"
+        )
+        assert config["metadata"]["ls_skill_name"] == "code-review"
+
+    def test_skill_name_absent_by_default(self) -> None:
+        """Ordinary turns should not carry skill attribution."""
+        config = build_stream_config("t-no-skill", assistant_id=None)
+        assert "ls_skill_name" not in config["metadata"]
+
     def test_auto_approve_absent_when_inactive(self) -> None:
         """Manual-approval runs should not carry the auto-approve label."""
         config = build_stream_config("t-manual", assistant_id=None, auto_approve=False)
@@ -2860,6 +2872,29 @@ class TestExecuteTaskTextualTurnMarkers:
         assert second_meta["dcode_auto_approve"] is True
         # The session state itself reflects the latest turn.
         assert session_state.turn_number == 2
+
+    async def test_skill_name_reaches_stream_config(self) -> None:
+        """The TUI should attribute a skill invocation to the streamed trace."""
+        from deepagents_code.app import TextualSessionState
+
+        session_state = TextualSessionState(thread_id="thread-1", auto_approve=False)
+        agent = _SequencedAgent([[]])
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        await execute_task_textual(
+            user_input="review this",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=session_state,
+            adapter=adapter,
+            skill_name="code-review",
+        )
+
+        assert agent.configs[0]["metadata"]["ls_skill_name"] == "code-review"
 
     async def test_auto_approve_absent_from_stream_config_when_disabled(self) -> None:
         """A manual-approval session must not label its trace as auto-approve.


### PR DESCRIPTION
Skill invocations now include `ls_skill_name` in LangSmith trace metadata across interactive and headless dcode runs.

---

The closed #4826 parsed the persisted `__skill` message envelope independently in each stream adapter. This keeps the change within `libs/code` while making trace attribution an explicit value on `SkillInvocationEnvelope`, propagated through both execution paths into the centralized `build_stream_config` metadata builder.

Made by [Open SWE](https://openswe.vercel.app/agents/e3e3c743-7dfd-50b9-8683-268d3ff1be1a)