### PR TITLE
feat(code): open summarization model picker

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -29195,7 +29195,7 @@ class DeepAgentsApp(App):
         return (message, now)
 
     async def _handle_summarization_model_command(self, command: str) -> None:
-        """Set, clear, or display the session's summary-model override.
+        """Set, clear, or select the session's summary-model override.
 
         The override is session-scoped: unlike `/model --default` there is no
         persistent tier, so `[models].summarization_default` is the only way to
@@ -29208,10 +29208,7 @@ class DeepAgentsApp(App):
         await self._mount_message(UserMessage(command))
         argument = command.strip()[len("/summarization-model") :].strip()
         if not argument:
-            current = self._summarization_model_override
-            if current in {None, INHERIT_SUMMARIZATION_MODEL}:
-                current = "the main agent model"
-            await self._mount_message(AppMessage(f"Summarization model: {current}"))
+            await self._show_summarization_model_selector()
             return
         if argument.lower() in _CLEAR_TOKENS:
             self._summarization_model_override = INHERIT_SUMMARIZATION_MODEL
@@ -29225,11 +29222,62 @@ class DeepAgentsApp(App):
             )
             return
 
+        await self._set_summarization_model(argument)
+
+    async def _show_summarization_model_selector(self) -> None:
+        """Open the model selector for choosing the summarization model."""
+        from deepagents_code.model_config import ModelSpec
+        from deepagents_code.tui.widgets.model_selector import ModelSelectorScreen
+
+        current_spec = self._summarization_model_override
+        if current_spec in {None, INHERIT_SUMMARIZATION_MODEL}:
+            current_spec = self._effective_model_spec()
+        parsed = ModelSpec.try_parse(current_spec) if current_spec else None
+
+        def handle_result(result: tuple[str, str] | None) -> None:
+            if result is None:
+                if self._chat_input:
+                    self.call_after_refresh(self._chat_input.focus_input)
+                return
+            model_spec, _ = result
+            extra = screen.pending_install_extra
+
+            async def apply_selection() -> None:
+                if extra and not await self._install_extra(extra, auto_restart=True):
+                    return
+                await self._set_summarization_model(model_spec)
+
+            def start_selection_worker() -> None:
+                self.run_worker(
+                    apply_selection(),
+                    exclusive=False,
+                    group="summarization-model",
+                )
+                if self._chat_input:
+                    self._chat_input.focus_input()
+
+            self.call_after_refresh(start_selection_worker)
+
+        screen = ModelSelectorScreen(
+            current_model=parsed.model if parsed else None,
+            current_provider=parsed.provider if parsed else None,
+            cli_profile_override=self._profile_override,
+            title="Choose the summarization model",
+            description=(
+                "Pick the model used for context-compaction summaries. Clear it "
+                "with `/summarization-model clear` to follow the main agent model."
+            ),
+            default_scope=None,
+        )
+        self.push_screen(screen, handle_result)
+
+    async def _set_summarization_model(self, model_spec: str) -> None:
+        """Validate and set the session's summarization model."""
         if self._remote_agent() is not None and self._server_kwargs is None:
-            self._summarization_model_override = argument
+            self._summarization_model_override = model_spec
             await self._mount_message(
                 AppMessage(
-                    f"Summarization model requested: {argument}. The remote server "
+                    f"Summarization model requested: {model_spec}. The remote server "
                     "will validate it at compaction time and use the main agent "
                     "model if initialization fails."
                 )
@@ -29239,11 +29287,11 @@ class DeepAgentsApp(App):
         try:
             result = await asyncio.to_thread(
                 _create_model_with_deepagents_import_lock,
-                argument,
+                model_spec,
                 cli_max_retries=(self._server_kwargs or {}).get("cli_max_retries"),
             )
         except Exception as exc:
-            logger.exception("Failed to resolve summarization model %s", argument)
+            logger.exception("Failed to resolve summarization model %s", model_spec)
             await self._mount_message(ErrorMessage(_build_model_switch_error_body(exc)))
             return
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -29268,6 +29268,9 @@ class DeepAgentsApp(App):
                 "with `/summarization-model clear` to follow the main agent model."
             ),
             default_scope=None,
+            check_provider_requirements=(
+                self._remote_agent() is None or self._server_kwargs is not None
+            ),
         )
         self.push_screen(screen, handle_result)
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -29255,7 +29255,7 @@ class DeepAgentsApp(App):
             def start_selection_worker() -> None:
                 self.run_worker(
                     apply_selection(),
-                    exclusive=False,
+                    exclusive=True,
                     group="summarization-model",
                 )
                 if self._chat_input:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -29277,25 +29277,61 @@ class DeepAgentsApp(App):
         self, model_spec: str, extra: str | None
     ) -> None:
         """Install any provider extra, then apply a picker selection."""
-        from functools import partial
-
-        if extra and (self._agent_running or self._shell_running or self._connecting):
-            self._defer_action(
-                DeferredAction(
-                    kind="summarization_model_switch",
-                    execute=partial(
-                        self._apply_summarization_model_selection, model_spec, extra
-                    ),
-                )
-            )
-            self.notify(
-                "Summarization model will switch after current work finishes.",
-                markup=False,
-            )
+        if self._defer_summarization_model_install_if_busy(model_spec, extra):
             return
-        if extra and not await self._install_extra(extra, auto_restart=True):
+        if extra and not await self._install_summarization_model_extra(
+            extra, model_spec
+        ):
             return
         await self._set_summarization_model(model_spec)
+
+    def _defer_summarization_model_install_if_busy(
+        self, model_spec: str, extra: str | None
+    ) -> bool:
+        """Defer an install-backed summary selection while the app is busy.
+
+        Returns:
+            Whether the selection was deferred.
+        """
+        from functools import partial
+
+        if not extra or not (
+            self._agent_running or self._shell_running or self._connecting
+        ):
+            return False
+        self._defer_action(
+            DeferredAction(
+                kind="summarization_model_switch",
+                execute=partial(
+                    self._apply_summarization_model_selection, model_spec, extra
+                ),
+            )
+        )
+        self.notify(
+            "Summarization model will switch after current work finishes.",
+            markup=False,
+        )
+        return True
+
+    async def _install_summarization_model_extra(
+        self, extra: str, model_spec: str
+    ) -> bool:
+        """Install and authenticate a summary model provider.
+
+        Returns:
+            Whether model selection may continue.
+        """
+        if not await self._install_extra(extra, auto_restart=True):
+            return False
+        if await self._prompt_model_auth_if_needed(model_spec):
+            return True
+        await self._mount_message(
+            AppMessage(
+                f"Installed '{extra}'. Set {model_spec} after adding its "
+                "credentials with `/auth`."
+            )
+        )
+        return False
 
     async def _set_summarization_model(self, model_spec: str) -> None:
         """Validate and set the session's summarization model."""

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2103,6 +2103,7 @@ class ExternalInput(Message):
 
 DeferredActionKind = Literal[
     "model_switch",
+    "summarization_model_switch",
     "thread_switch",
     "chat_output",
     "agent_switch",
@@ -29243,9 +29244,7 @@ class DeepAgentsApp(App):
             extra = screen.pending_install_extra
 
             async def apply_selection() -> None:
-                if extra and not await self._install_extra(extra, auto_restart=True):
-                    return
-                await self._set_summarization_model(model_spec)
+                await self._apply_summarization_model_selection(model_spec, extra)
 
             def start_selection_worker() -> None:
                 self.run_worker(
@@ -29273,6 +29272,30 @@ class DeepAgentsApp(App):
             ),
         )
         self.push_screen(screen, handle_result)
+
+    async def _apply_summarization_model_selection(
+        self, model_spec: str, extra: str | None
+    ) -> None:
+        """Install any provider extra, then apply a picker selection."""
+        from functools import partial
+
+        if extra and (self._agent_running or self._shell_running or self._connecting):
+            self._defer_action(
+                DeferredAction(
+                    kind="summarization_model_switch",
+                    execute=partial(
+                        self._apply_summarization_model_selection, model_spec, extra
+                    ),
+                )
+            )
+            self.notify(
+                "Summarization model will switch after current work finishes.",
+                markup=False,
+            )
+            return
+        if extra and not await self._install_extra(extra, auto_restart=True):
+            return
+        await self._set_summarization_model(model_spec)
 
     async def _set_summarization_model(self, model_spec: str) -> None:
         """Validate and set the session's summarization model."""

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -29227,6 +29227,7 @@ class DeepAgentsApp(App):
 
     async def _show_summarization_model_selector(self) -> None:
         """Open the model selector for choosing the summarization model."""
+        from deepagents_code.config import detect_provider
         from deepagents_code.model_config import ModelSpec
         from deepagents_code.tui.widgets.model_selector import ModelSelectorScreen
 
@@ -29234,6 +29235,11 @@ class DeepAgentsApp(App):
         if current_spec in {None, INHERIT_SUMMARIZATION_MODEL}:
             current_spec = self._effective_model_spec()
         parsed = ModelSpec.try_parse(current_spec) if current_spec else None
+        current_provider = parsed.provider if parsed else None
+        current_model = parsed.model if parsed else None
+        if current_spec and parsed is None:
+            current_provider = detect_provider(current_spec)
+            current_model = current_spec if current_provider else None
 
         def handle_result(result: tuple[str, str] | None) -> None:
             if result is None:
@@ -29258,8 +29264,8 @@ class DeepAgentsApp(App):
             self.call_after_refresh(start_selection_worker)
 
         screen = ModelSelectorScreen(
-            current_model=parsed.model if parsed else None,
-            current_provider=parsed.provider if parsed else None,
+            current_model=current_model,
+            current_provider=current_provider,
             cli_profile_override=self._profile_override,
             title="Choose the summarization model",
             description=(

--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -753,6 +753,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         include_uninstalled: bool = True,
         include_recent: bool = True,
         recommended_models: Mapping[str, str] | None = None,
+        current_spec: str | None = None,
         default_scope: DefaultModelScope | None,
     ) -> _ModelData:
         """Gather model discovery data synchronously.
@@ -776,6 +777,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 "Recent" entry the user never chose.
             recommended_models: Recommendation set whose missing provider models
                 should be surfaced. `None` uses the standard model shortlist.
+            current_spec: Active `provider:model` spec to keep in the list even
+                when discovery and recommendations do not include it.
             default_scope: Preference whose stored spec is read for the
                 `(default)` marker, stripped of surrounding whitespace so it can
                 match a row. `None` yields no marker.
@@ -848,6 +851,14 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             all_models.extend(installed_recommended)
             all_models.extend(uninstalled_recommended)
 
+        if (
+            current_spec
+            and config.is_model_allowed(current_spec)
+            and all(spec != current_spec for spec, _ in all_models)
+        ):
+            provider = current_spec.split(":", 1)[0]
+            all_models.append((current_spec, provider))
+
         profiles = get_model_profiles(cli_override=cli_override)
         recent_specs = load_recent_models() if include_recent else []
         stored_default = default_scope.load() if default_scope is not None else None
@@ -886,9 +897,10 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
     ) -> list[tuple[str, str]]:
         """Apply the active subset filter (onboarding or recommended-only).
 
-        Recently-used specs are unioned in even when the recommended-only
-        toggle is on, so personal usage always wins over curation. Onboarding
-        intentionally keeps a tight curated subset and skips this union.
+        Recently-used and currently active specs are unioned in even when the
+        recommended-only toggle is on, so personal usage always wins over
+        curation. Onboarding intentionally keeps a tight curated subset and
+        skips this union.
 
         Args:
             all_models: Full list of `(provider:model, provider)` pairs.
@@ -910,18 +922,19 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 recommended_models=self._recommended_models,
             )
             curated_specs = {spec for spec, _ in curated}
+            personal_specs = (
+                set(self._recent_specs) if self._include_recent_models else set()
+            )
+            if self._current_spec is not None:
+                personal_specs.add(self._current_spec)
             # Order follows all_models (insertion), not MRU; _update_display
             # rebuilds visual order by iterating self._recent_specs directly.
-            recent_extra = (
-                [
-                    (spec, provider)
-                    for spec, provider in all_models
-                    if spec in self._recent_specs and spec not in curated_specs
-                ]
-                if self._include_recent_models
-                else []
-            )
-            return [*recent_extra, *curated]
+            personal_extra = [
+                (spec, provider)
+                for spec, provider in all_models
+                if spec in personal_specs and spec not in curated_specs
+            ]
+            return [*personal_extra, *curated]
         return list(all_models)
 
     @staticmethod
@@ -977,6 +990,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 include_uninstalled=True,
                 include_recent=self._include_recent_models and not self._curated,
                 recommended_models=self._recommended_models,
+                current_spec=self._current_spec,
                 default_scope=self._default_scope,
             )
         except Exception:

--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -507,6 +507,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         title: str | None = None,
         description: str | Content | None = None,
         default_scope: DefaultModelScope | None,
+        check_provider_requirements: bool = True,
         result_callback: Callable[[tuple[str, str] | None], None] | None = None,
     ) -> None:
         """Initialize the ModelSelectorScreen.
@@ -537,6 +538,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 Ctrl+S and drop its footer hint — for pickers whose choice has
                 no persistent config key (the `/goal model` and `/rubric model`
                 graders) and for onboarding, which advertises no Ctrl+S.
+            check_provider_requirements: Whether to require local provider packages
+                and credentials before returning a selection.
             result_callback: Optional callback for selector results when the
                 screen is displayed without a `push_screen` result callback.
         """
@@ -554,6 +557,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         self._title = title
         self._description = description
         self._default_scope = default_scope
+        self._check_provider_requirements = check_provider_requirements
         self._result_callback = result_callback
         # Standard /model defaults to the curated recommended subset so users
         # face less decision fatigue; onboarding (`curated=True`) already
@@ -2022,7 +2026,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         on the selector and refresh the credential indicator so the user can
         try again or pick a different provider.
         """
-        if not provider:
+        if not provider or not self._check_provider_requirements:
             self._dismiss_with_result((model_spec, provider))
             return
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -26307,6 +26307,23 @@ class TestDeferredActions:
             assert len(app._pending_messages) == 1
             assert app._pending_messages[0].text == "/auto model openai:gpt-5.5-mini"
 
+    async def test_summarization_model_opens_selector_while_busy(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            with patch.object(
+                app,
+                "_show_summarization_model_selector",
+                new_callable=AsyncMock,
+            ) as show_selector:
+                app.post_message(ChatInput.Submitted("/summarization-model", "command"))
+                await pilot.pause()
+
+            show_selector.assert_awaited_once()
+            assert len(app._pending_messages) == 0
+
     async def test_side_effect_free_bypasses_queue(self) -> None:
         """SIDE_EFFECT_FREE commands bypass the queue."""
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_model_switch.py
+++ b/libs/code/tests/unit_tests/test_model_switch.py
@@ -1691,6 +1691,33 @@ class TestSummarizationModelCommand:
         assert screen._current_provider == "anthropic"
         assert screen._current_model == "claude-sonnet-4-5"
 
+    async def test_install_selection_waits_until_current_work_finishes(self) -> None:
+        """Provider installation must not race an active turn's server use."""
+        app = DeepAgentsApp()
+        app._agent_running = True
+        notify = Mock()
+        install = AsyncMock(return_value=True)
+        set_model = AsyncMock()
+        app.notify = notify  # ty: ignore[invalid-assignment]
+        app._install_extra = install  # ty: ignore[invalid-assignment]
+        app._set_summarization_model = set_model  # ty: ignore[invalid-assignment]
+
+        await app._apply_summarization_model_selection(
+            "baseten:moonshotai/Kimi-K3", "baseten"
+        )
+
+        install.assert_not_awaited()
+        set_model.assert_not_awaited()
+        assert len(app._deferred_actions) == 1
+        assert app._deferred_actions[0].kind == "summarization_model_switch"
+        notify.assert_called_once()
+
+        app._agent_running = False
+        await app._deferred_actions.pop().execute()
+
+        install.assert_awaited_once_with("baseten", auto_restart=True)
+        set_model.assert_awaited_once_with("baseten:moonshotai/Kimi-K3")
+
     async def test_multi_word_argument_is_rejected_without_resolving(self) -> None:
         """The grammar is a single bare spec -- no params, unlike `/model`."""
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_model_switch.py
+++ b/libs/code/tests/unit_tests/test_model_switch.py
@@ -1660,6 +1660,19 @@ class TestSummarizationModelCommand:
         assert screen._current_provider == "openai"
         assert screen._current_model == "gpt-5.4-mini"
         assert screen._default_scope is None
+        assert screen._check_provider_requirements is True
+
+    async def test_external_remote_selector_skips_local_provider_requirements(
+        self,
+    ) -> None:
+        app = DeepAgentsApp(summarization_model="server_provider:remote-model")
+        app._agent = _make_remote_agent()  # ty: ignore[invalid-assignment]
+
+        with patch.object(app, "push_screen") as push:
+            await app._show_summarization_model_selector()
+
+        screen = push.call_args.args[0]
+        assert screen._check_provider_requirements is False
 
     async def test_selector_falls_back_to_main_model_when_unset(self) -> None:
         app = DeepAgentsApp(summarization_model="")

--- a/libs/code/tests/unit_tests/test_model_switch.py
+++ b/libs/code/tests/unit_tests/test_model_switch.py
@@ -1636,37 +1636,47 @@ class TestSummarizationModelCommand:
         create_model.assert_not_called()
         assert app._summarization_model_override == INHERIT_SUMMARIZATION_MODEL
 
-    async def test_no_argument_reports_the_current_value(self) -> None:
+    async def test_no_argument_opens_selector_without_changing_override(self) -> None:
         app = DeepAgentsApp(summarization_model="openai:gpt-5.4-mini")
         app._mount_message = AsyncMock()  # ty: ignore[invalid-assignment]
-        captured, capture_init = self._capture_app_messages()
 
-        with patch.object(AppMessage, "__init__", capture_init):
+        with patch.object(
+            app,
+            "_show_summarization_model_selector",
+            new_callable=AsyncMock,
+        ) as show_selector:
             await app._handle_command("/summarization-model")
 
-        assert any("openai:gpt-5.4-mini" in text for text in captured)
+        show_selector.assert_awaited_once()
         assert app._summarization_model_override == "openai:gpt-5.4-mini"
 
-    async def test_no_argument_names_the_fallback_when_unset(self) -> None:
-        app = DeepAgentsApp()
-        app._mount_message = AsyncMock()  # ty: ignore[invalid-assignment]
-        captured, capture_init = self._capture_app_messages()
+    async def test_selector_highlights_summarization_model(self) -> None:
+        app = DeepAgentsApp(summarization_model="openai:gpt-5.4-mini")
 
-        with patch.object(AppMessage, "__init__", capture_init):
-            await app._handle_command("/summarization-model")
+        with patch.object(app, "push_screen") as push:
+            await app._show_summarization_model_selector()
 
-        assert any("main agent model" in text for text in captured)
+        screen = push.call_args.args[0]
+        assert screen._current_provider == "openai"
+        assert screen._current_model == "gpt-5.4-mini"
+        assert screen._default_scope is None
 
-    async def test_blank_launch_override_names_the_main_model(self) -> None:
+    async def test_selector_falls_back_to_main_model_when_unset(self) -> None:
         app = DeepAgentsApp(summarization_model="")
-        app._mount_message = AsyncMock()  # ty: ignore[invalid-assignment]
-        captured, capture_init = self._capture_app_messages()
 
-        with patch.object(AppMessage, "__init__", capture_init):
-            await app._handle_command("/summarization-model")
+        with (
+            patch.object(
+                app,
+                "_effective_model_spec",
+                return_value="anthropic:claude-sonnet-4-5",
+            ),
+            patch.object(app, "push_screen") as push,
+        ):
+            await app._show_summarization_model_selector()
 
-        assert app._summarization_model_override == INHERIT_SUMMARIZATION_MODEL
-        assert any("main agent model" in text for text in captured)
+        screen = push.call_args.args[0]
+        assert screen._current_provider == "anthropic"
+        assert screen._current_model == "claude-sonnet-4-5"
 
     async def test_multi_word_argument_is_rejected_without_resolving(self) -> None:
         """The grammar is a single bare spec -- no params, unlike `/model`."""

--- a/libs/code/tests/unit_tests/test_model_switch.py
+++ b/libs/code/tests/unit_tests/test_model_switch.py
@@ -1673,6 +1673,35 @@ class TestSummarizationModelCommand:
         assert screen._current_provider == "openai"
         assert screen._current_model == "gpt-5.4-mini"
 
+    async def test_selector_replaces_in_flight_selection_worker(self) -> None:
+        """The latest picker result cancels an older validation worker."""
+        app = DeepAgentsApp()
+
+        with (
+            patch.object(app, "push_screen") as push,
+            patch.object(app, "run_worker") as run_worker,
+            patch.object(
+                app,
+                "call_after_refresh",
+                side_effect=lambda callback: callback(),
+            ),
+            patch.object(
+                app,
+                "_apply_summarization_model_selection",
+                new_callable=AsyncMock,
+            ) as apply_selection,
+        ):
+            await app._show_summarization_model_selector()
+            handle_result = push.call_args.args[1]
+            handle_result(("openai:gpt-5.6-sol", "openai"))
+
+            run_worker.assert_called_once()
+            assert run_worker.call_args.kwargs["exclusive"] is True
+            assert run_worker.call_args.kwargs["group"] == "summarization-model"
+            await run_worker.call_args.args[0]
+
+        apply_selection.assert_awaited_once_with("openai:gpt-5.6-sol", None)
+
     async def test_external_remote_selector_skips_local_provider_requirements(
         self,
     ) -> None:

--- a/libs/code/tests/unit_tests/test_model_switch.py
+++ b/libs/code/tests/unit_tests/test_model_switch.py
@@ -1697,9 +1697,13 @@ class TestSummarizationModelCommand:
         app._agent_running = True
         notify = Mock()
         install = AsyncMock(return_value=True)
+        authenticate = AsyncMock(return_value=True)
         set_model = AsyncMock()
         app.notify = notify  # ty: ignore[invalid-assignment]
         app._install_extra = install  # ty: ignore[invalid-assignment]
+        app._prompt_model_auth_if_needed = (  # ty: ignore[invalid-assignment]
+            authenticate
+        )
         app._set_summarization_model = set_model  # ty: ignore[invalid-assignment]
 
         await app._apply_summarization_model_selection(
@@ -1716,7 +1720,55 @@ class TestSummarizationModelCommand:
         await app._deferred_actions.pop().execute()
 
         install.assert_awaited_once_with("baseten", auto_restart=True)
+        authenticate.assert_awaited_once_with("baseten:moonshotai/Kimi-K3")
         set_model.assert_awaited_once_with("baseten:moonshotai/Kimi-K3")
+
+    async def test_install_selection_prompts_for_credentials_before_setting(
+        self,
+    ) -> None:
+        """A newly installed provider must be authenticated before validation."""
+        app = DeepAgentsApp()
+        install = AsyncMock(return_value=True)
+        authenticate = AsyncMock(return_value=True)
+        set_model = AsyncMock()
+        app._install_extra = install  # ty: ignore[invalid-assignment]
+        app._prompt_model_auth_if_needed = (  # ty: ignore[invalid-assignment]
+            authenticate
+        )
+        app._set_summarization_model = set_model  # ty: ignore[invalid-assignment]
+
+        await app._apply_summarization_model_selection(
+            "baseten:moonshotai/Kimi-K3", "baseten"
+        )
+
+        install.assert_awaited_once_with("baseten", auto_restart=True)
+        authenticate.assert_awaited_once_with("baseten:moonshotai/Kimi-K3")
+        set_model.assert_awaited_once_with("baseten:moonshotai/Kimi-K3")
+
+    async def test_cancelled_post_install_auth_keeps_summary_model(self) -> None:
+        """Dismissing auth leaves the installed provider unapplied."""
+        app = DeepAgentsApp(summarization_model="openai:gpt-5.4-mini")
+        install = AsyncMock(return_value=True)
+        authenticate = AsyncMock(return_value=False)
+        set_model = AsyncMock()
+        mount_message = AsyncMock()
+        app._install_extra = install  # ty: ignore[invalid-assignment]
+        app._prompt_model_auth_if_needed = (  # ty: ignore[invalid-assignment]
+            authenticate
+        )
+        app._set_summarization_model = set_model  # ty: ignore[invalid-assignment]
+        app._mount_message = mount_message  # ty: ignore[invalid-assignment]
+
+        await app._apply_summarization_model_selection(
+            "baseten:moonshotai/Kimi-K3", "baseten"
+        )
+
+        set_model.assert_not_awaited()
+        assert app._summarization_model_override == "openai:gpt-5.4-mini"
+        assert mount_message.await_args is not None
+        mounted = str(mount_message.await_args.args[0]._content)
+        assert "Installed 'baseten'" in mounted
+        assert "/auth" in mounted
 
     async def test_multi_word_argument_is_rejected_without_resolving(self) -> None:
         """The grammar is a single bare spec -- no params, unlike `/model`."""

--- a/libs/code/tests/unit_tests/test_model_switch.py
+++ b/libs/code/tests/unit_tests/test_model_switch.py
@@ -1662,6 +1662,17 @@ class TestSummarizationModelCommand:
         assert screen._default_scope is None
         assert screen._check_provider_requirements is True
 
+    async def test_selector_resolves_bare_summarization_model_provider(self) -> None:
+        """Bare startup specs still identify the active picker row."""
+        app = DeepAgentsApp(summarization_model="gpt-5.4-mini")
+
+        with patch.object(app, "push_screen") as push:
+            await app._show_summarization_model_selector()
+
+        screen = push.call_args.args[0]
+        assert screen._current_provider == "openai"
+        assert screen._current_model == "gpt-5.4-mini"
+
     async def test_external_remote_selector_skips_local_provider_requirements(
         self,
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -4282,6 +4282,37 @@ enabled = false
         assert results == [("baseten:zai-org/GLM-5.2", "baseten")]
         dismiss.assert_called_once_with(("baseten:zai-org/GLM-5.2", "baseten"))
 
+    async def test_remote_selection_skips_local_provider_requirements(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_code.tui.widgets import model_selector
+
+        results: list[tuple[str, str] | None] = []
+        screen = ModelSelectorScreen(
+            check_provider_requirements=False,
+            default_scope=None,
+            result_callback=results.append,
+        )
+        dismiss = MagicMock()
+        screen.dismiss = dismiss  # ty: ignore
+        monkeypatch.setattr(
+            "deepagents_code.config_manifest.provider_install_extra",
+            lambda _provider: pytest.fail("local install should not be checked"),
+        )
+        monkeypatch.setattr(
+            model_selector,
+            "get_provider_auth_status",
+            lambda _provider: pytest.fail("local credentials should not be checked"),
+        )
+
+        screen._select_with_auth_check(
+            "server_provider:remote-model", "server_provider"
+        )
+
+        result = ("server_provider:remote-model", "server_provider")
+        assert results == [result]
+        dismiss.assert_called_once_with(result)
+
     async def test_select_uninstalled_provider_prompts_install(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -2478,6 +2478,45 @@ class TestModelSelectorFiltering:
 class TestModelSelectorCurrentModelPreselection:
     """Tests for pre-selecting the current model when opening the selector."""
 
+    async def test_non_discovered_current_model_is_visible_and_preselected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A remote-only current model survives the recommended-only subset."""
+        from deepagents_code.tui.widgets import model_selector
+
+        monkeypatch.setattr(
+            model_selector,
+            "get_available_models",
+            lambda: {"openai": ["gpt-5.6-sol"]},
+        )
+        monkeypatch.setattr(model_selector, "get_model_profiles", lambda **_kwargs: {})
+        monkeypatch.setattr(model_selector, "load_recent_models", list)
+        monkeypatch.setattr(
+            model_selector,
+            "get_provider_auth_status",
+            lambda provider: ProviderAuthStatus(
+                state=ProviderAuthState.CONFIGURED,
+                provider=provider,
+                source=ProviderAuthSource.ENV,
+            ),
+        )
+
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            screen = ModelSelectorScreen(
+                current_model="remote-model",
+                current_provider="server_provider",
+                recommended_models={"openai:gpt-5.6-sol": "GPT-5.6 Sol"},
+                default_scope=None,
+                check_provider_requirements=False,
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            current = ("server_provider:remote-model", "server_provider")
+            assert current in screen._filtered_models
+            assert screen._filtered_models[screen._selected_index] == current
+
     async def test_current_model_is_preselected(self) -> None:
         """Opening the selector should pre-select the current model, not first."""
         app = ModelSelectorTestApp()
@@ -3948,11 +3987,12 @@ class TestModelSelectorInstallRouting:
             include_uninstalled: bool = True,
             include_recent: bool = True,
             recommended_models: Mapping[str, str] | None = None,
+            current_spec: str | None = None,
             # Mirrors production: required and nullable, so the stub cannot
             # outlive the contract it fakes.
             default_scope: model_selector.DefaultModelScope | None,
         ) -> model_selector._ModelData:
-            del recommended_models, default_scope
+            del recommended_models, current_spec, default_scope
             captured["include_uninstalled"] = include_uninstalled
             captured["include_recent"] = include_recent
             return model_selector._ModelData(


### PR DESCRIPTION
Running `/summarization-model` without arguments now opens the model switcher and highlights the active summarization model.

---

The bare command previously only printed the current value. This reuses the existing model selector with summarization-specific selection handling while preserving direct `<spec>` and `clear` forms. The selector disables default persistence so it cannot retarget the main agent model. External remote-agent selections defer provider installation and credential validation to the remote server.

Tests cover selector routing, current-model highlighting, main-model fallback, remote provider handling, and opening while the agent is busy.

Made by [Open SWE](https://openswe.vercel.app/agents/20022a3d-28fa-5163-87db-5a91bd164666)