### PR TITLE
fix(code): hide inactive F2 tool hint

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/mcp_viewer.py
+++ b/libs/code/deepagents_code/tui/widgets/mcp_viewer.py
@@ -1299,7 +1299,13 @@ class MCPViewerScreen(ModalScreen[str | None]):
         enter_hint = self._selected_enter_hint()
         if enter_hint is not None:
             help_parts.append(enter_hint)
-        help_parts.extend(["F2 disable/enable", "Ctrl+E expand all"])
+        if (
+            self._row_widgets
+            and 0 <= self._selected_index < len(self._row_widgets)
+            and isinstance(self._row_widgets[self._selected_index], MCPServerHeaderItem)
+        ):
+            help_parts.append("F2 disable/enable")
+        help_parts.append("Ctrl+E expand all")
         if self._pending_reconnect:
             help_parts.append(f"{MCP_RECONNECT_KEY_LABEL} reconnect")
         help_parts.extend(["type to filter", "Esc close"])

--- a/libs/code/tests/unit_tests/tui/widgets/test_mcp_viewer.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_mcp_viewer.py
@@ -733,6 +733,23 @@ class TestMCPViewerScreen:
             assert isinstance(screen._row_widgets[screen._selected_index], MCPToolItem)
             assert toggled == []
 
+    async def test_f2_hint_only_shows_on_server_row(self) -> None:
+        """The footer only advertises F2 when it can toggle a server."""
+        app = MCPViewerTestApp()
+        async with app.run_test() as pilot:
+            screen = MCPViewerScreen(server_info=_sample_info())
+            app.push_screen(screen)
+            await pilot.pause()
+            help_text = screen.query_one(".mcp-viewer-help", Static)
+
+            assert "F2 disable/enable" in _widget_text(help_text)
+
+            await pilot.press("down")
+            assert "F2 disable/enable" not in _widget_text(help_text)
+
+            await pilot.press("up")
+            assert "F2 disable/enable" in _widget_text(help_text)
+
     async def test_single_server_singular_labels(self) -> None:
         """Title uses singular forms for 1 server and 1 tool."""
         info = [


### PR DESCRIPTION
The MCP viewer only shows `F2 disable/enable` when a server row is selected.

---

Individual tool rows do not support per-tool toggling, so advertising the shortcut there is misleading. The footer now follows the selected row while retaining the existing server-level control.

Made by [Open SWE](https://openswe.vercel.app/agents/da7bbf62-e320-58eb-a6c7-e05ad301d235)