### PR TITLE
fix(code): guard path expansion in the Auto approval gate

### DIFF
--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -1689,6 +1689,18 @@ def _resolve_path(root: Path, raw: object) -> Path | None:
         return None
 
 
+def _path_error_reason(error: Exception, raw: str) -> str:
+    """Return a reason describing why a model-authored path failed to resolve.
+
+    The path is echoed back so the model can see which argument to correct, and
+    it is untrusted: it carries whatever length and bytes the model produced.
+    `sanitize_auto_reason` strips control characters and caps the result at
+    `_REASON_LIMIT`, which keeps an oversized path from failing plan validation
+    and discarding the decisions for every other call in the batch.
+    """
+    return sanitize_auto_reason(f"{type(error).__name__}: {error} (path: {raw})")
+
+
 _WRITE_PATH_TOOLS = frozenset({"write_file", "edit_file", "delete"})
 
 
@@ -1708,7 +1720,7 @@ def _unresolvable_write_path_reason(root: Path, raw: object) -> str | None:
             candidate = root / candidate
         candidate.resolve(strict=False)
     except (OSError, RuntimeError, ValueError) as error:
-        return f"{type(error).__name__}: {error} (path: {raw})"
+        return _path_error_reason(error, raw)
     return None
 
 
@@ -2285,7 +2297,7 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             # resolver's error instead, which the model can act on. Reached in
             # approval modes that do not consult the Auto gate.
             return ToolMessage(
-                content=f"{type(error).__name__}: {error} (path: {raw_path})",
+                content=_path_error_reason(error, raw_path),
                 name=tool_name,
                 tool_call_id=_tool_call_id(request.tool_call),
                 status="error",

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -1667,14 +1667,25 @@ def _resolved_tools(request: ModelRequest) -> dict[str, BaseTool]:
 
 
 def _resolve_path(root: Path, raw: object) -> Path | None:
+    """Return the absolute path a model-authored path argument names.
+
+    The argument is untrusted model output, so expansion is part of what can
+    fail: `Path.expanduser` raises `RuntimeError` for a `~name` prefix that
+    names no account on this host. Expansion runs inside the guard for that
+    reason, and every failure yields `None`.
+
+    Callers treat `None` as "not deterministically safe" and route the call to
+    model review, so an unresolvable path costs one review instead of raising
+    through the approval gate.
+    """
     if not isinstance(raw, str) or not raw:
         return None
-    candidate = Path(raw).expanduser()
-    if not candidate.is_absolute():
-        candidate = root / candidate
     try:
+        candidate = Path(raw).expanduser()
+        if not candidate.is_absolute():
+            candidate = root / candidate
         return candidate.resolve(strict=False)
-    except (OSError, RuntimeError):
+    except (OSError, RuntimeError, ValueError):
         return None
 
 
@@ -2240,10 +2251,15 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         raw_path = request.tool_call.get("args", {}).get("file_path")
         if not isinstance(raw_path, str):
             return None
-        candidate = Path(raw_path).expanduser()
-        if not candidate.is_absolute():
-            candidate = self._worktree_root / candidate
-        normalized_path = os.path.normcase(str(candidate.absolute()))
+        try:
+            candidate = Path(raw_path).expanduser()
+            if not candidate.is_absolute():
+                candidate = self._worktree_root / candidate
+            normalized_path = os.path.normcase(str(candidate.absolute()))
+        except (OSError, RuntimeError, ValueError):
+            # An unresolvable path names no managed artifact, so there is
+            # nothing to protect here. The write tool reports its own error.
+            return None
         artifacts = _active_temp_artifacts(cast("Mapping[str, object]", request.state))
         protected_paths = {
             os.path.normcase(str(Path(artifact["file_path"]).absolute()))

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -1689,6 +1689,29 @@ def _resolve_path(root: Path, raw: object) -> Path | None:
         return None
 
 
+_WRITE_PATH_TOOLS = frozenset({"write_file", "edit_file", "delete"})
+
+
+def _unresolvable_write_path_reason(root: Path, raw: object) -> str | None:
+    """Return why a write path cannot be resolved, or `None` when it resolves.
+
+    A `file_path` argument is unambiguously a path, so a path this host cannot
+    resolve at all — a `~name` prefix naming no account, an embedded NUL — can
+    only fail. Reporting the resolver's own error tells the model what to
+    correct, which a silent denial or a review pass does not.
+    """
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        candidate = Path(raw).expanduser()
+        if not candidate.is_absolute():
+            candidate = root / candidate
+        candidate.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError) as error:
+        return f"{type(error).__name__}: {error} (path: {raw})"
+    return None
+
+
 def _is_within(root: Path, path: Path) -> bool:
     try:
         path.relative_to(root)
@@ -2246,7 +2269,7 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
                 tool_call_id=_tool_call_id(request.tool_call),
                 status="error",
             )
-        if tool_name not in {"write_file", "edit_file", "delete"}:
+        if tool_name not in _WRITE_PATH_TOOLS:
             return None
         raw_path = request.tool_call.get("args", {}).get("file_path")
         if not isinstance(raw_path, str):
@@ -2256,10 +2279,17 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             if not candidate.is_absolute():
                 candidate = self._worktree_root / candidate
             normalized_path = os.path.normcase(str(candidate.absolute()))
-        except (OSError, RuntimeError, ValueError):
-            # An unresolvable path names no managed artifact, so there is
-            # nothing to protect here. The write tool reports its own error.
-            return None
+        except (OSError, RuntimeError, ValueError) as error:
+            # The backend does not expand `~`, so letting this through writes to
+            # a literal `~name` directory and reports success. Report the
+            # resolver's error instead, which the model can act on. Reached in
+            # approval modes that do not consult the Auto gate.
+            return ToolMessage(
+                content=f"{type(error).__name__}: {error} (path: {raw_path})",
+                name=tool_name,
+                tool_call_id=_tool_call_id(request.tool_call),
+                status="error",
+            )
         artifacts = _active_temp_artifacts(cast("Mapping[str, object]", request.state))
         protected_paths = {
             os.path.normcase(str(Path(artifact["file_path"]).absolute()))
@@ -2700,6 +2730,26 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
                 and tool is not None
                 and tool is self._trusted_compaction_tool
             )
+            if call["name"] in _WRITE_PATH_TOOLS:
+                # `resolve` touches the filesystem, so it stays off the event
+                # loop like the deterministic check below.
+                unresolvable = await asyncio.to_thread(
+                    _unresolvable_write_path_reason,
+                    self._worktree_root,
+                    call.get("args", {}).get("file_path"),
+                )
+                if unresolvable is not None:
+                    deterministic_dispositions[_tool_call_id(call)] = "deny"
+                    plan["decisions"].append(
+                        {
+                            "tool_call_id": _tool_call_id(call),
+                            "disposition": "policy_deny",
+                            "category": AutoDecisionCategory.OTHER_POLICY.value,
+                            "reason": unresolvable,
+                            "path": "deterministic",
+                        }
+                    )
+                    continue
             if is_trusted_compaction and trusted_compaction_seen:
                 deterministic_dispositions[_tool_call_id(call)] = "deny"
                 plan["decisions"].append(

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -61,6 +61,7 @@ from deepagents_code.auto_mode import (
     _MAX_CLASSIFIER_MODEL_CACHE,
     _MAX_EMITTED_EVENT_SCOPES,
     _MAX_PENDING_EVENT_SCOPES,
+    _REASON_LIMIT,
     AUTO_DENIED_METADATA_KEY,
     AUTO_MODE_COUNTERS_NAMESPACE,
     USER_PROMPT_METADATA_KEY,
@@ -80,6 +81,7 @@ from deepagents_code.auto_mode import (
     _fixed_repo_command_allowed,
     _merge_temp_artifacts,
     _routine_write_allowed,
+    _unresolvable_write_path_reason,
     classifier_unavailable_reason,
     gated_mcp_tool_names,
     mcp_tool_is_coherently_read_only,
@@ -1403,6 +1405,56 @@ async def test_unresolvable_home_write_is_denied_with_a_reason(
     assert prefix in decision["reason"]
     # Denied on the path itself, so the classifier is never consulted.
     assert not model.calls
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        pytest.param("a" * 600, id="over-reason-limit"),
+        pytest.param("\x00\x1b[31m", id="control-characters"),
+    ],
+)
+def test_unresolvable_write_path_reason_stays_plan_safe(
+    tmp_path: Path, suffix: str
+) -> None:
+    """The echoed path is untrusted, so the reason must survive plan validation.
+
+    An oversized reason fails `_validated_plan`, which discards the decisions
+    for every call in the batch and drops the whole turn to Manual.
+    """
+    prefix = _unresolvable_home_prefix()
+
+    reason = _unresolvable_write_path_reason(tmp_path, f"{prefix}{suffix}/f.txt")
+
+    assert reason is not None
+    assert len(reason) <= _REASON_LIMIT
+    assert "\x00" not in reason
+    assert "\x1b" not in reason
+
+
+async def test_oversized_unresolvable_write_path_keeps_the_plan_valid(
+    tmp_path: Path,
+) -> None:
+    """A long malformed path denies its own call without voiding the batch."""
+    prefix = _unresolvable_home_prefix()
+    model = _StructuredModel(_deny_result(call_id="write-call"))
+    middleware = _middleware(tmp_path)
+    args: dict[str, object] = {
+        "file_path": f"{prefix}{'a' * 600}/f.txt",
+        "content": "x",
+    }
+    request, _store, _key = _request(
+        tmp_path,
+        model=model,
+        tool_name="write_file",
+        args=args,
+    )
+
+    plan = await _plan(middleware, request, tool_name="write_file", args=args)
+
+    decision = plan["decisions"][0]
+    assert decision["disposition"] == "policy_deny"
+    assert len(decision["reason"]) <= _REASON_LIMIT
 
 
 def test_classifier_schema_requires_every_object_property() -> None:

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Literal, cast, get_type_hints
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 from langchain.agents.middleware.types import (
@@ -78,6 +79,7 @@ from deepagents_code.auto_mode import (
     _default_counters,
     _fixed_repo_command_allowed,
     _merge_temp_artifacts,
+    _routine_write_allowed,
     classifier_unavailable_reason,
     gated_mcp_tool_names,
     mcp_tool_is_coherently_read_only,
@@ -1302,6 +1304,76 @@ def test_fixed_repo_commands_allow_only_read_only_git_operations(
     assert not _fixed_repo_command_allowed("git diff ../other", tmp_path)
     assert not _fixed_repo_command_allowed("git status && rm -rf .", tmp_path)
     assert not _fixed_repo_command_allowed("git status & rm -rf .", tmp_path)
+
+
+def _unresolvable_home_prefix() -> str:
+    """Return a `~name` prefix that names no account on this host.
+
+    Generated instead of hardcoded so the test cannot pass by accident on a
+    host that has an account with the chosen name.
+    """
+    name = f"dcode-absent-{uuid4().hex}"
+    prefix = f"~{name}"
+    if not os.path.expanduser(prefix).startswith("~"):  # noqa: PTH111
+        pytest.skip(f"host unexpectedly resolves {prefix}")
+    return prefix
+
+
+def test_unresolvable_home_path_is_reviewed_not_raised(tmp_path: Path) -> None:
+    """An unknown `~name` denies the shortcut instead of failing the gate.
+
+    `Path.expanduser` raises `RuntimeError` for a home directory it cannot
+    determine. The path arguments here are model output, so that raise must not
+    escape: it would abort the model node and end the turn.
+    """
+    prefix = _unresolvable_home_prefix()
+
+    assert not _fixed_repo_command_allowed(f"git diff -- {prefix}/f.txt", tmp_path)
+    assert not _routine_write_allowed(
+        tmp_path,
+        {
+            "name": "write_file",
+            "args": {"file_path": f"{prefix}/f.txt"},
+            "id": "call-1",
+            "type": "tool_call",
+        },
+    )
+
+
+async def test_unresolvable_home_write_passes_the_managed_temp_guard(
+    tmp_path: Path,
+) -> None:
+    """The artifact guard also expands an untrusted path, so it needs the guard.
+
+    An unresolvable path names no managed artifact. The write tool runs and
+    reports its own error, which lets the model correct the path and retry.
+    """
+    prefix = _unresolvable_home_prefix()
+    middleware = _middleware(tmp_path)
+    executed = False
+    request = ToolCallRequest(
+        tool_call={
+            "name": "write_file",
+            "args": {"file_path": f"{prefix}/f.txt", "content": "x"},
+            "id": "write-call",
+            "type": "tool_call",
+        },
+        tool=_tool("write_file"),
+        state={"messages": []},
+        runtime=cast("Any", SimpleNamespace()),
+    )
+
+    async def handler(_request: ToolCallRequest) -> ToolMessage:
+        nonlocal executed
+        await asyncio.sleep(0)
+        executed = True
+        return ToolMessage(content="ran", tool_call_id="write-call")
+
+    result = await middleware.awrap_tool_call(request, handler)
+
+    assert executed
+    assert isinstance(result, ToolMessage)
+    assert result.status != "error"
 
 
 def test_classifier_schema_requires_every_object_property() -> None:

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -1340,13 +1340,14 @@ def test_unresolvable_home_path_is_reviewed_not_raised(tmp_path: Path) -> None:
     )
 
 
-async def test_unresolvable_home_write_passes_the_managed_temp_guard(
+async def test_unresolvable_home_write_is_reported_to_the_model(
     tmp_path: Path,
 ) -> None:
-    """The artifact guard also expands an untrusted path, so it needs the guard.
+    """An unresolvable write path is refused with the resolver's own error.
 
-    An unresolvable path names no managed artifact. The write tool runs and
-    reports its own error, which lets the model correct the path and retry.
+    The backend does not expand `~`, so letting the write through creates a
+    literal `~name` directory and reports success. The model needs the error to
+    correct the path, and this guard runs in every approval mode.
     """
     prefix = _unresolvable_home_prefix()
     middleware = _middleware(tmp_path)
@@ -1371,9 +1372,37 @@ async def test_unresolvable_home_write_passes_the_managed_temp_guard(
 
     result = await middleware.awrap_tool_call(request, handler)
 
-    assert executed
+    assert not executed
     assert isinstance(result, ToolMessage)
-    assert result.status != "error"
+    assert result.status == "error"
+    content = cast("str", result.content)
+    assert "Could not determine home directory" in content
+    assert prefix in content
+
+
+async def test_unresolvable_home_write_is_denied_with_a_reason(
+    tmp_path: Path,
+) -> None:
+    """The Auto gate denies the write and hands the model the resolver error."""
+    prefix = _unresolvable_home_prefix()
+    model = _StructuredModel(_deny_result(call_id="write-call"))
+    middleware = _middleware(tmp_path)
+    args: dict[str, object] = {"file_path": f"{prefix}/f.txt", "content": "x"}
+    request, _store, _key = _request(
+        tmp_path,
+        model=model,
+        tool_name="write_file",
+        args=args,
+    )
+
+    plan = await _plan(middleware, request, tool_name="write_file", args=args)
+
+    decision = plan["decisions"][0]
+    assert decision["disposition"] == "policy_deny"
+    assert "Could not determine home directory" in decision["reason"]
+    assert prefix in decision["reason"]
+    # Denied on the path itself, so the classifier is never consulted.
+    assert not model.calls
 
 
 def test_classifier_schema_requires_every_object_property() -> None:


### PR DESCRIPTION
A tool call with a `~name` path for an account that does not exist on this machine no longer ends the turn. The agent gets the error and corrects the path itself.

---

`Path.expanduser` raises `RuntimeError` when it cannot determine a home directory. `~deploy/config.yml` does this on a machine with no `deploy` account. Two sites expanded a path outside their guard: `_resolve_path`, whose `try` began one line too late, and `_managed_temp_rejection`, which had no guard. `_managed_temp_rejection` runs in every approval mode, not only Auto.

Path arguments are model output, and a model writes such a path after a copied README line or a typo. The raise reached a caller with no handler and ended the turn with error status and no output. The agent could not recover, because the failure came before its call ran.

Both sites now expand inside the guard.

```
execute, cat ~deploy/config.yml
  before   RuntimeError -> turn ends, no output
  after    shell reports no such file -> agent retries with a valid path

write_file, ~deploy/config.yml
  before   RuntimeError -> turn ends, no output
  after    RuntimeError: Could not determine home directory. (path: ~deploy/config.yml)
```

`execute` goes through a shell, which leaves `~deploy` as text and fails to open it, so an error already reaches the agent. `write_file` goes to the backend, which does not expand `~` and treats `~deploy` as a directory name. It would create a literal `~deploy` directory and report success, so the agent learns nothing and the developer finds a stray directory later. An unresolvable `file_path` is therefore refused with the resolver's own message: the Auto gate denies before the classifier runs, and the tool guard returns the same text for modes that skip the gate.

Only `file_path` gets this treatment, because only `file_path` is certainly a path. An `execute` argument can start with `~` and still be a search string, so `grep -r "~deploy" .` still goes to review.

`_resolve_path` still returns `None` for an unresolvable path, which both callers read as "send to review". `ValueError` joins the caught set, because `Path` raises it for a NUL byte, which is the same class of input.
