### PR TITLE
fix(acp): scope session cancellation to the requesting session

### DIFF
--- a/libs/acp/deepagents_acp/server.py
+++ b/libs/acp/deepagents_acp/server.py
@@ -267,7 +267,7 @@ class AgentServerACP(ACPAgent):
         self._session_modes: dict[str, str] = {}
         self._session_mode_states: dict[str, SessionModeState] = {}
         self._session_models: dict[str, str] = {}  # Track current model per session
-        self._cancelled = False
+        self._cancelled_sessions: set[str] = set()  # Per-session cancellation
         self._session_plans: dict[str, list[dict[str, Any]]] = {}
         self._session_cwds: dict[str, str] = {}
         self._session_mcp_servers: dict[str, list[McpServer]] = {}
@@ -506,8 +506,8 @@ class AgentServerACP(ACPAgent):
         return SetSessionConfigOptionResponse(config_options=config_options)
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:  # noqa: ARG002  # ACP protocol interface parameters
-        """Cancel the current execution."""
-        self._cancelled = True
+        """Cancel the current execution for the given session."""
+        self._cancelled_sessions.add(session_id)
 
     async def _log_text(self, session_id: str, text: str) -> None:
         """Send a text message update to the client."""
@@ -969,8 +969,8 @@ class AgentServerACP(ACPAgent):
             self._agent.checkpointer = MemorySaver()  # Guarded by getattr check above
         agent = self._agent
 
-        # Reset cancellation flag for new prompt
-        self._cancelled = False
+        # Reset cancellation flag for this session's new prompt
+        self._cancelled_sessions.discard(session_id)
 
         # Convert ACP content blocks to LangChain multimodal content format
         content_blocks = []
@@ -1000,8 +1000,8 @@ class AgentServerACP(ACPAgent):
 
         while current_state is None or current_state.interrupts:
             # Check for cancellation
-            if self._cancelled:
-                self._cancelled = False  # Reset for next prompt
+            if session_id in self._cancelled_sessions:
+                self._cancelled_sessions.discard(session_id)  # Reset for next prompt
                 return PromptResponse(stop_reason="cancelled")
 
             pending_interrupts: Sequence[Interrupt] = ()
@@ -1019,8 +1019,8 @@ class AgentServerACP(ACPAgent):
 
                 _namespace, stream_mode, data = stream_chunk
                 # Check for cancellation during streaming
-                if self._cancelled:
-                    self._cancelled = False  # Reset for next prompt
+                if session_id in self._cancelled_sessions:
+                    self._cancelled_sessions.discard(session_id)  # Reset for next prompt
                     return PromptResponse(stop_reason="cancelled")
 
                 if stream_mode == "updates":


### PR DESCRIPTION
fixes #5937 

AgentServerACP stores cancellation state as a single self._cancelled: bool (server.py:270), while every other per-session piece of mutable state uses a per-session dict keyed by session_id. When cancel(session_id="A") is called, it sets the shared flag to True and ignores the session_id entirely, causing any concurrent session's prompt() to observe the flag and abort its own stream with stop_reason="cancelled". A new prompt() call also unconditionally clears the flag, potentially swallowing a pending cancellation intended for a different in-flight session.

This fix replaces the shared bool with a set[str] of cancelled session IDs. cancel() adds the session, prompt() checks and discards only its own session_id. Zero other files are affected.

Root cause: self._cancelled was the sole exception to the per-session isolation pattern (_session_modes: dict[str, str], _session_plans: dict[str, list[...]], _session_cwds: dict[str, str], etc.).

Why this change:

ACP servers are multi-session by design — a single AgentServerACP instance serves concurrent clients, each with its own session_id. The shared _cancelled boolean meant that any session's cancellation would silently disrupt every other session's streaming. In practice this causes the ACP client to show stop_reason="cancelled" on a session that never requested cancellation, and a new prompt on an unrelated session can swallow a pending cancel before it takes effect.

Why this approach:

The codebase already establishes a clear per-session isolation pattern: every other piece of mutable session state (_session_modes, _session_plans, _session_cwds, _session_models, _session_mcp_servers, _allowed_command_types) is a dict keyed by session_id. The fix follows this exact convention — replacing the lone bool with a set[str] — so the cancellation state behaves consistently with everything around it. A set was chosen over a dict[str, bool] because only presence matters (no per-session metadata), and add/discard/in are the exact operations needed with no stale-state cleanup required. The reset-at-prompt semantics (discard at the top of prompt()) and reset-on-cancel semantics (discard after checking in the while-loop) are preserved from the original code, just scoped to the correct session.

Scope: libs/acp/deepagents_acp/server.py only — 5 edits, 9 insertions / 9 deletions.

Test Coverage / Reproduction Confirmation

Reproduction of the original bug (before fix):
The cancel() method set a shared self._cancelled = True boolean. A standalone script creating two sessions and calling cancel(session_id="A") confirmed that server._cancelled was True for both sessions — session B's streaming would observe it and abort.
Post-fix verification (all 7 assertions pass):
Per-Session Cancellation Isolation Test
[PASS] 1. Neither session cancelled initially
[PASS] 2. Only session A is in _cancelled_sessions after cancel(A)
[PASS] 3. discard(A) does not touch B
[PASS] 4. Both sessions in set after cancelling both
[PASS] 5. discard(A) leaves B still cancelled
[PASS] 6. Set empty after both discarded

[PASS] cancel() adds session_id to _cancelled_sessions set

ALL TESTS PASSED
Test logic:

Assertion What it proves
1 sid_a not in set and sid_b not in set after new_session() Fresh sessions start uncancelled
2 sid_a in set and sid_b not in set after cancel(sid_a) Cancel is scoped to the target session only
3 discard(sid_a) leaves sid_b untouched A prompt starting for session A clears only A's cancel
4 Both in set after cancelling both Multiple independent cancels compose correctly
5 discard(sid_a) leaves sid_b in set Clearing one session's cancel doesn't leak to another
6 Set empty after both discarded No stale state remains
7 isinstance(set) and len == 1 after single cancel cancel() writes to a set[str], not a bare bool