### PR TITLE
fix(code): record Auto classifier deadline as a traced error

### DIFF
--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -2528,6 +2528,81 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         dispositions: Mapping[str, str],
         tools: Mapping[str, BaseTool],
     ) -> AutoDecisionBatch:
+        """Review one batch inside a span that outlives the review failing.
+
+        The inner `ainvoke` run is opened by LangChain callbacks and closed by
+        `on_llm_end` or `on_llm_error`. A deadline does not raise into that call
+        — `asyncio.timeout` *cancels* it, and `CancelledError` derives from
+        `BaseException`, which the callback error path does not catch. So a
+        timed-out review left its run with a null `end_time`, no outputs, and no
+        error: not a failure in tracing, just a run that never finished. Denials
+        that cost a full budget were invisible to any error rate or alert built
+        on the project.
+
+        Owning an outer span fixes that without touching the deadline: it is
+        closed on the way out, so both deadlines and construction faults are
+        recorded as real errors. The inner run stays orphaned, because nothing
+        here can close a run that was cancelled rather than failed.
+
+        Args:
+            request: Resolved primary-model request for the current batch.
+            calls: Tool calls this batch must review.
+            all_calls: Every tool call in the turn, for context.
+            dispositions: Dispositions already decided for this turn.
+            tools: Tool objects by name.
+
+        Returns:
+            Validated classifier verdict for the batch.
+        """
+        from langsmith import trace
+
+        # Names only. Arguments can carry file contents and secrets, and the
+        # inner run already records the prompt when tracing is on.
+        async with trace(
+            name="auto_classifier_review",
+            run_type="chain",
+            inputs={
+                "tool_count": len(calls),
+                "tools": [call["name"] for call in calls],
+                "classifier_model": self._classifier_model_label(request),
+            },
+            tags=["dcode:auto"],
+            metadata={"lc_source": "auto_mode_classifier"},
+        ) as span:
+            batch = await self._review_batch(
+                request, calls, all_calls, dispositions, tools
+            )
+            span.end(outputs={"decision_count": len(batch.decisions)})
+            return batch
+
+    async def _review_batch(
+        self,
+        request: ModelRequest,
+        calls: Sequence[ToolCall],
+        all_calls: Sequence[ToolCall],
+        dispositions: Mapping[str, str],
+        tools: Mapping[str, BaseTool],
+    ) -> AutoDecisionBatch:
+        """Build the classifier, ask it for a verdict, and validate the reply.
+
+        Args:
+            request: Resolved primary-model request for the current batch.
+            calls: Tool calls this batch must review.
+            all_calls: Every tool call in the turn, for context.
+            dispositions: Dispositions already decided for this turn.
+            tools: Tool objects by name.
+
+        Returns:
+            Validated classifier verdict for the batch.
+
+        Raises:
+            _ClassifierConstructionDeadlineExceededError: If the model could not
+                be built within its budget.
+            _ClassifierDeadlineExceededError: If the classifier did not answer
+                within its budget.
+            TimeoutError: If the provider raised its own timeout rather than one
+                of our wait budgets expiring.
+        """
         # Construction and inference get separate budgets: a cold provider
         # import must not eat the time reserved for the verdict, and the two
         # failures need different reasons. Constructor threads cannot be

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -2528,21 +2528,15 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         dispositions: Mapping[str, str],
         tools: Mapping[str, BaseTool],
     ) -> AutoDecisionBatch:
-        """Review one batch inside a span that outlives the review failing.
+        """Review one batch inside a span that survives the review failing.
 
-        The inner `ainvoke` run is opened by LangChain callbacks and closed by
-        `on_llm_end` or `on_llm_error`. A deadline does not raise into that call
-        — `asyncio.timeout` *cancels* it, and `CancelledError` derives from
-        `BaseException`, which the callback error path does not catch. So a
-        timed-out review left its run with a null `end_time`, no outputs, and no
-        error: not a failure in tracing, just a run that never finished. Denials
-        that cost a full budget were invisible to any error rate or alert built
-        on the project.
-
-        Owning an outer span fixes that without touching the deadline: it is
-        closed on the way out, so both deadlines and construction faults are
-        recorded as real errors. The inner run stays orphaned, because nothing
-        here can close a run that was cancelled rather than failed.
+        A deadline *cancels* the inner `ainvoke` rather than raising into it, and
+        LangChain closes its run from `on_llm_error`, which never sees a
+        `CancelledError`. Timed-out reviews therefore left a run with a null
+        `end_time` and no error — invisible to any error rate built on the
+        project. This span is closed on the way out, so deadlines and
+        construction faults land as real errors. The inner run stays orphaned:
+        nothing here can close a run that was cancelled rather than failed.
 
         Args:
             request: Resolved primary-model request for the current batch.
@@ -2556,8 +2550,7 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         """
         from langsmith import trace
 
-        # Names only. Arguments can carry file contents and secrets, and the
-        # inner run already records the prompt when tracing is on.
+        # Names only: arguments can carry file contents and secrets.
         async with trace(
             name="auto_classifier_review",
             run_type="chain",
@@ -2600,8 +2593,7 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
                 be built within its budget.
             _ClassifierDeadlineExceededError: If the classifier did not answer
                 within its budget.
-            TimeoutError: If the provider raised its own timeout rather than one
-                of our wait budgets expiring.
+            TimeoutError: If the provider raised a timeout of its own.
         """
         # Construction and inference get separate budgets: a cold provider
         # import must not eat the time reserved for the verdict, and the two

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -39,6 +39,7 @@ from langgraph.errors import GraphInterrupt
 from langgraph.graph import StateGraph
 from langgraph.runtime import ExecutionInfo
 from langgraph.types import Command
+from langsmith import tracing_context
 from pydantic import BaseModel, Field
 
 from deepagents_code._ask_user_types import (
@@ -4545,6 +4546,113 @@ async def test_classifier_timeout_reports_configured_limit(tmp_path: Path) -> No
         "review_started",
         "review_completed",
     ]
+
+
+class _RecordingTracingClient:
+    """Stand-in for `langsmith.Client` that records what a run posts."""
+
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+        self.updated: list[dict[str, Any]] = []
+
+    def create_run(self, **kwargs: Any) -> None:
+        self.created.append(kwargs)
+
+    def update_run(self, **kwargs: Any) -> None:
+        self.updated.append(kwargs)
+
+
+def _review_span(client: _RecordingTracingClient) -> dict[str, Any]:
+    """Return the single closed `auto_classifier_review` run."""
+    spans = [
+        run for run in client.updated if run.get("name") == "auto_classifier_review"
+    ]
+    assert len(spans) == 1
+    return spans[0]
+
+
+def _review_span_inputs(client: _RecordingTracingClient) -> dict[str, Any]:
+    """Return the opening payload of the review run.
+
+    Inputs travel on the create, not the close: `patch` drops them unless
+    `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` is off.
+    """
+    opens = [
+        run for run in client.created if run.get("name") == "auto_classifier_review"
+    ]
+    assert len(opens) == 1
+    return cast("dict[str, Any]", opens[0]["inputs"])
+
+
+async def test_classifier_timeout_closes_review_span_with_error(tmp_path: Path) -> None:
+    """A deadline reaches tracing as a failed span, not one that never ended.
+
+    `asyncio.timeout` cancels the classifier call, and `CancelledError` bypasses
+    the LangChain callback that would close the inner run. Without a span of our
+    own, a 20s denial left no error for an alert or error rate to see.
+    """
+
+    class _SlowModel(_StructuredModel):
+        async def ainvoke(self, messages: list[object], **kwargs: object) -> object:
+            self.calls.append(messages)
+            self.call_kwargs.append(kwargs)
+            await asyncio.sleep(5)
+            return self.result
+
+    middleware = _middleware(tmp_path, classifier_timeout_seconds=0.05)
+    request, _store, _key = _request(
+        tmp_path,
+        model=_SlowModel(),
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+    client = _RecordingTracingClient()
+
+    with tracing_context(enabled=True, client=cast("Any", client)):
+        plan = await _plan(
+            middleware,
+            request,
+            tool_name="delete",
+            args={"file_path": "old.py"},
+        )
+
+    assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
+    span = _review_span(client)
+    assert span["end_time"] is not None
+    assert "_ClassifierDeadlineExceededError" in span["error"]
+    # No verdict was reached, so the span must not claim one.
+    assert not span["outputs"]
+
+
+async def test_classifier_review_span_records_verdict(tmp_path: Path) -> None:
+    """A completed review closes the span with no error and a decision count."""
+    middleware = _middleware(tmp_path)
+    request, _store, _key = _request(
+        tmp_path,
+        model=_StructuredModel(_allow_result()),
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+    client = _RecordingTracingClient()
+
+    with tracing_context(enabled=True, client=cast("Any", client)):
+        plan = await _plan(
+            middleware,
+            request,
+            tool_name="delete",
+            args={"file_path": "old.py"},
+        )
+
+    assert plan["decisions"][0]["disposition"] == "classifier_allow"
+    span = _review_span(client)
+    assert span["error"] is None
+    assert span["outputs"] == {"decision_count": 1}
+    # Names identify the batch; arguments can carry secrets and stay out.
+    assert _review_span_inputs(client) == {
+        "tool_count": 1,
+        "tools": ["delete"],
+        "classifier_model": "inherited",
+    }
 
 
 @pytest.mark.parametrize("budget", [0, -1.0, float("nan"), float("inf")])

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -4572,11 +4572,7 @@ def _review_span(client: _RecordingTracingClient) -> dict[str, Any]:
 
 
 def _review_span_inputs(client: _RecordingTracingClient) -> dict[str, Any]:
-    """Return the opening payload of the review run.
-
-    Inputs travel on the create, not the close: `patch` drops them unless
-    `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` is off.
-    """
+    """Return the review run's inputs, which travel on the create, not the close."""
     opens = [
         run for run in client.created if run.get("name") == "auto_classifier_review"
     ]
@@ -4585,12 +4581,7 @@ def _review_span_inputs(client: _RecordingTracingClient) -> dict[str, Any]:
 
 
 async def test_classifier_timeout_closes_review_span_with_error(tmp_path: Path) -> None:
-    """A deadline reaches tracing as a failed span, not one that never ended.
-
-    `asyncio.timeout` cancels the classifier call, and `CancelledError` bypasses
-    the LangChain callback that would close the inner run. Without a span of our
-    own, a 20s denial left no error for an alert or error rate to see.
-    """
+    """A deadline reaches tracing as a failed span, not one that never ended."""
 
     class _SlowModel(_StructuredModel):
         async def ainvoke(self, messages: list[object], **kwargs: object) -> object:


### PR DESCRIPTION
<!-- langsmith-issue {"id":"bf299f3a-6ef4-4175-beb2-4fb53a3444fe"} -->

## The problem

In Auto mode a second model — the classifier — reviews each batch of tool calls before it runs, within a (default) 20 second budget. If it does not answer in time, Auto denies the batch. That is correct: an unreviewed action must not run. But the denial left no record in tracing.

The budget is enforced with `asyncio.timeout`, which does not raise into the classifier call — it **cancels** it. Cancellation arrives as `CancelledError`, a `BaseException`. LangChain closes the `dcode_auto_classifier` run from `on_llm_end` or `on_llm_error`, and the error path catches `Exception`, so it never sees a cancellation. Nothing closed the run.

The result is a run that looks like it is still in progress, permanently:

<img width="629" height="229" alt="Screenshot" src="https://github.com/user-attachments/assets/0be6cc34-5a70-4b7a-8db0-6c245c9ced54" />

A null `end_time` with no error is not counted as a failure. It cannot be filtered for, alerted on, or graphed — while each occurrence costs a full 20 seconds and an extra model round-trip.

This was not fully silent: `auto_mode.py` already logs the denial with its latency and underlying error. The hole is in tracing only, which is where error rates and alerts are built.

## The change

`_classify` opens a span it owns, `auto_classifier_review`, around the whole review; the build-and-ask logic moves to `_review_batch` unchanged. The span is closed on the way out, so the exception is recorded as the run's error. Construction deadlines and model faults had the same gap and are now covered too.

After, on a deadline:

```
auto_classifier_review     start=T  end_time=T+20s  error="_ClassifierDeadlineExceededError: local classifier deadline exceeded after 20s"
└─ dcode_auto_classifier   start=T  end_time=null  outputs={}
```

After, on a completed review:

```
auto_classifier_review     start=T  end_time=T+1.4s  error=null
                           inputs={"tool_count": 1, "tools": ["delete"], "classifier_model": "inherited"}
                           outputs={"decision_count": 1}
```

The inner run stays orphaned — nothing here can close a run that was cancelled rather than failed. The parent span is what makes the failure countable.

Span inputs carry tool **names** only, since arguments can hold file contents and secrets.