### PR TITLE
fix(acp): report failed tool calls as `failed` in streaming updates

### DIFF
--- a/libs/acp/deepagents_acp/server.py
+++ b/libs/acp/deepagents_acp/server.py
@@ -267,7 +267,7 @@ class AgentServerACP(ACPAgent):
         self._session_modes: dict[str, str] = {}
         self._session_mode_states: dict[str, SessionModeState] = {}
         self._session_models: dict[str, str] = {}  # Track current model per session
-        self._cancelled = False
+        self._cancelled_sessions: set[str] = set()  # Per-session cancellation
         self._session_plans: dict[str, list[dict[str, Any]]] = {}
         self._session_cwds: dict[str, str] = {}
         self._session_mcp_servers: dict[str, list[McpServer]] = {}
@@ -506,8 +506,8 @@ class AgentServerACP(ACPAgent):
         return SetSessionConfigOptionResponse(config_options=config_options)
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:  # noqa: ARG002  # ACP protocol interface parameters
-        """Cancel the current execution."""
-        self._cancelled = True
+        """Cancel the current execution for the given session."""
+        self._cancelled_sessions.add(session_id)
 
     async def _log_text(self, session_id: str, text: str) -> None:
         """Send a text message update to the client."""
@@ -969,8 +969,8 @@ class AgentServerACP(ACPAgent):
             self._agent.checkpointer = MemorySaver()  # Guarded by getattr check above
         agent = self._agent
 
-        # Reset cancellation flag for new prompt
-        self._cancelled = False
+        # Reset cancellation flag for this session's new prompt
+        self._cancelled_sessions.discard(session_id)
 
         # Convert ACP content blocks to LangChain multimodal content format
         content_blocks = []
@@ -1000,8 +1000,8 @@ class AgentServerACP(ACPAgent):
 
         while current_state is None or current_state.interrupts:
             # Check for cancellation
-            if self._cancelled:
-                self._cancelled = False  # Reset for next prompt
+            if session_id in self._cancelled_sessions:
+                self._cancelled_sessions.discard(session_id)  # Reset for next prompt
                 return PromptResponse(stop_reason="cancelled")
 
             pending_interrupts: Sequence[Interrupt] = ()
@@ -1019,8 +1019,8 @@ class AgentServerACP(ACPAgent):
 
                 _namespace, stream_mode, data = stream_chunk
                 # Check for cancellation during streaming
-                if self._cancelled:
-                    self._cancelled = False  # Reset for next prompt
+                if session_id in self._cancelled_sessions:
+                    self._cancelled_sessions.discard(session_id)  # Reset for next prompt
                     return PromptResponse(stop_reason="cancelled")
 
                 if stream_mode == "updates":

--- a/libs/acp/deepagents_acp/server.py
+++ b/libs/acp/deepagents_acp/server.py
@@ -1092,9 +1092,14 @@ class AgentServerACP(ACPAgent):
                             )
                         else:
                             formatted_content = str(content)
+                        tool_status = (
+                            "failed"
+                            if getattr(message_chunk, "status", None) == "error"
+                            else "completed"
+                        )
                         update = update_tool_call(
                             tool_call_id=tool_call_id,
-                            status="completed",
+                            status=tool_status,
                             content=[tool_content(text_block(formatted_content))],
                         )
                         await self._conn.session_update(

--- a/libs/acp/tests/test_agent.py
+++ b/libs/acp/tests/test_agent.py
@@ -856,6 +856,127 @@ async def test_acp_agent_tool_result_completes_tool_call() -> None:
     assert tool_call_events
 
 
+def _tool_result_status_events(client: FakeACPClient, tool_call_id: str) -> list[Any]:
+    """Collect session_update events carrying a given tool's status."""
+    out: list[Any] = []
+    for e in client.events:
+        if e["type"] != "session_update":
+            continue
+        update = e["update"]
+        if getattr(update, "tool_call_id", None) != tool_call_id:
+            continue
+        status = getattr(update, "status", None)
+        if status is not None:
+            out.append((status, e))
+    return out
+
+
+async def test_acp_agent_tool_result_error_reports_failed_status() -> None:
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]), stream_delimiter=None)
+    graph = create_deep_agent(model=model, checkpointer=MemorySaver())
+
+    agent = AgentServerACP(agent=graph)
+    client = FakeACPClient()
+    agent.on_connect(client)  # type: ignore[arg-type]
+
+    session = await agent.new_session(cwd="/tmp", mcp_servers=[])
+
+    tool_start = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {
+                "id": "call_err",
+                "name": "execute",
+                "args": '{"command": "false"}',
+                "index": 0,
+            }
+        ],
+    )
+    tool_result = ToolMessage(
+        content="Command failed with exit code 1",
+        tool_call_id="call_err",
+        status="error",
+    )
+
+    class Graph:
+        @staticmethod
+        async def astream(*args: Any, **kwargs: Any):
+            yield ((), "messages", (tool_start, {}))
+            yield ((), "messages", (tool_result, {}))
+
+        async def aget_state(self, config: Any) -> Any:
+            class S:
+                next = ()
+                interrupts: list[Any] = []
+
+            return S()
+
+    agent._agent = Graph()  # type: ignore[assignment]
+
+    resp = await agent.prompt(
+        [TextContentBlock(type="text", text="hi")], session_id=session.session_id
+    )
+    assert resp.stop_reason == "end_turn"
+
+    tool_statuses = _tool_result_status_events(client, "call_err")
+    assert tool_statuses, "expected a status update for the failed tool call"
+    statuses = [status for status, _ in tool_statuses]
+    assert "failed" in statuses, f"expected 'failed' status, got {statuses}"
+
+
+async def test_acp_agent_tool_result_success_reports_completed_status() -> None:
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]), stream_delimiter=None)
+    graph = create_deep_agent(model=model, checkpointer=MemorySaver())
+
+    agent = AgentServerACP(agent=graph)
+    client = FakeACPClient()
+    agent.on_connect(client)  # type: ignore[arg-type]
+
+    session = await agent.new_session(cwd="/tmp", mcp_servers=[])
+
+    tool_start = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {
+                "id": "call_ok",
+                "name": "execute",
+                "args": '{"command": "echo hi"}',
+                "index": 0,
+            }
+        ],
+    )
+    tool_result = ToolMessage(
+        content="hi\n[Command succeeded with exit code 0]",
+        tool_call_id="call_ok",
+        status="success",
+    )
+
+    class Graph:
+        @staticmethod
+        async def astream(*args: Any, **kwargs: Any):
+            yield ((), "messages", (tool_start, {}))
+            yield ((), "messages", (tool_result, {}))
+
+        async def aget_state(self, config: Any) -> Any:
+            class S:
+                next = ()
+                interrupts: list[Any] = []
+
+            return S()
+
+    agent._agent = Graph()  # type: ignore[assignment]
+
+    resp = await agent.prompt(
+        [TextContentBlock(type="text", text="hi")], session_id=session.session_id
+    )
+    assert resp.stop_reason == "end_turn"
+
+    tool_statuses = _tool_result_status_events(client, "call_ok")
+    assert tool_statuses, "expected a status update for the successful tool call"
+    statuses = [status for status, _ in tool_statuses]
+    assert "completed" in statuses, f"expected 'completed' status, got {statuses}"
+
+
 async def test_acp_agent_multimodal_prompt_blocks_do_not_error() -> None:
     model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]), stream_delimiter=None)
     graph = create_deep_agent(model=model, checkpointer=MemorySaver())


### PR DESCRIPTION
closes #5938 

ACP clients now see failed instead of completed when a tool errors during live streaming, matching the existing session-replay behavior.

Why this change

During live streaming, AgentServerACP.prompt() reported every tool result to the client with a hardcoded status="completed", even when the underlying ToolMessage carried status="error" (LangGraph sets this on tool failure). The client's UI therefore rendered failed tools — permission-denied commands, crashed tools, etc. — as successful, which is misleading.
The session-replay path _replay_tool_message() already mapped status == "error" to "failed", so live streaming and replay disagreed about the same tool outcome depending on how the session was surfaced.

Why this approach

The streaming handler has access to the same ToolMessage.status field the replay path already relies on, so the fix is to compute the status from message_chunk.status instead of baking in "completed". This keeps exactly one semantic source of truth for tool outcome, makes the two paths converge, and requires no schema, protocol, or signature changes — the client-facing update_tool_call() call is byte-identical except for the status value.
The lookup uses getattr(message_chunk, "status", None), which is safe for ToolMessage objects that predate the field or omit it; those fall through to "completed", preserving the previous behavior for successful calls.

Test Coverage / Reproduction Confirmation

Reproduction of the original bug: a ToolMessage with status="error" streamed through prompt() produced update_tool_call(status="completed", ...) on the client connection, while the identical message replayed through _replay_tool_message() produced status="failed".
New tests (libs/acp/tests/test_agent.py):
- test_acp_agent_tool_result_error_reports_failed_status — streams a tool call followed by a ToolMessage(status="error") and asserts the client receives a ToolCallProgress update with status="failed".
- test_acp_agent_tool_result_success_reports_completed_status — same flow with status="success", asserting status="completed" is still reported so successful tools are unaffected.

The updates are captured through the existing FakeACPClient.session_update hook, exercising the exact update_tool_call() call the streaming handler sends.

Verification run:

$ uv run --group test pytest tests/ -q
96 passed in 7.06s
- uv run --group test ruff check deepagents_acp/ tests/ — clean
- uv run --group test ruff format deepagents_acp/ tests/ --diff — no changes
- uv run --group test ty check deepagents_acp — clean

grep server.ac — a scan for hardcoded status="completed" in the streaming handler confirms this was the only site that ignored the message status; the replay path already handled it correctly, so no other code needed to change.