### PR TITLE
fix(code): wait for graph readiness after server restart

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -27641,6 +27641,13 @@ class DeepAgentsApp(App):
                     server_proc,
                     timeout=restart_timeout,
                 )
+                # `langgraph dev` lazily builds the agent graph. Wait for that
+                # build before reporting a completed restart so graph-bound
+                # extensions are registered and `/extensions` is accurate.
+                await server_proc.wait_for_graph_ready(
+                    "agent",
+                    timeout=restart_timeout,
+                )
             # `asyncio.CancelledError` is intentionally NOT caught here (it is a
             # `BaseException`): `_restart_server_process` raises it only when app
             # teardown has begun or a terminal `stop()` bumped the server's stop

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -36890,6 +36890,7 @@ class TestRespawnServer:
         proc = MagicMock()
         proc.url = "http://localhost:0/"
         proc.restart = AsyncMock()
+        proc.wait_for_graph_ready = AsyncMock()
         app._server_proc = proc
         app._server_kwargs = {}
         app._mcp_preload_kwargs = {}
@@ -37469,6 +37470,7 @@ class TestRespawnServer:
             # restart — the server came up; only metadata refresh degraded.
             assert result is True
             proc.restart.assert_awaited_once()
+            proc.wait_for_graph_ready.assert_awaited_once_with("agent", timeout=30.0)
             ready = [m for m in posted if isinstance(m, app.ServerReady)]
             assert len(ready) == 1
             assert ready[0].mcp_server_info is None


### PR DESCRIPTION
## Summary

Wait for the lazily built agent graph after restarting the local agent server. This ensures graph-bound extension registrations have completed before dcode reports the restart finished, so `/extensions` reflects the active graph.

## Testing

- Existing unit test updated to assert the graph-readiness wait.

## Review focus

- Confirm `agent` is the correct graph readiness target for the restart lifecycle.

AI assistance was used to prepare this PR.