### PR TITLE
fix(code): reap temp artifacts left by a finished turn

### DIFF
--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -935,6 +935,58 @@ def _current_temp_artifacts(
     }
 
 
+def _stale_temp_artifacts(
+    state: Mapping[str, object], runtime: object, messages: Sequence[object]
+) -> dict[str, AutoTempArtifact]:
+    """Return this thread's artifacts allocated by an already-finished turn.
+
+    Args:
+        state: Agent state carrying the private artifact ledger.
+        runtime: Runtime carrying the trusted thread identity.
+        messages: Messages carrying the trusted turn identity.
+
+    Returns:
+        Artifacts owned by this thread whose allocating turn is over. The result
+        is empty when either trusted identity is missing, so an unidentifiable
+        turn never reaps a live allocation.
+    """
+    thread_key = _thread_key(runtime)
+    turn_id = _latest_turn_id(messages)
+    if thread_key is None or turn_id is None:
+        return {}
+    return {
+        file_path: artifact
+        for file_path, artifact in _active_temp_artifacts(state).items()
+        if artifact["thread_key"] == thread_key and artifact["turn_id"] != turn_id
+    }
+
+
+def _reap_temp_artifacts(
+    artifacts: Mapping[str, AutoTempArtifact],
+) -> dict[str, AutoTempArtifactMutation]:
+    """Delete finished-turn artifact files and build their ledger removals.
+
+    Args:
+        artifacts: Stale artifacts keyed by their allocated path.
+
+    Returns:
+        A ledger mutation per artifact, clearing the entry. Entries are cleared
+        even when the file is already gone or its identity changed, because the
+        allocating turn no longer owns the path either way.
+    """
+    mutations: dict[str, AutoTempArtifactMutation] = {}
+    for file_path, artifact in artifacts.items():
+        try:
+            _delete_temp_artifact_file(artifact)
+        except OSError as exc:
+            logger.debug("Could not reap temporary artifact %s: %s", file_path, exc)
+        mutations[file_path] = AutoTempArtifactMutation(
+            allocation_id=artifact["allocation_id"],
+            artifact=None,
+        )
+    return mutations
+
+
 def _validate_temp_artifact_suffix(suffix: str) -> str:
     if not _TEMP_ARTIFACT_SUFFIX_RE.fullmatch(suffix):
         msg = "suffix must be empty or a short extension such as .md"
@@ -2221,6 +2273,35 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
 
         self.tools = [create_temp_artifact, delete_temp_artifact]
         self._temp_tools_by_name = {item.name: item for item in self.tools}
+
+    async def abefore_model(  # noqa: PLR6301
+        self, state: AutoModeState, runtime: Runtime[Any]
+    ) -> dict[str, Any] | None:
+        """Reap temporary artifacts the model left behind on earlier turns.
+
+        `delete_temp_artifact` only accepts paths allocated by the current turn,
+        so an artifact the model forgets to delete before the turn ends can never
+        be deleted by the model afterwards. Reaping here keeps that strict
+        ownership check while bounding how long an orphan survives to a single
+        turn, instead of leaving it for the OS temp sweeper.
+
+        Args:
+            state: Agent state carrying the private artifact ledger.
+            runtime: LangGraph runtime carrying the trusted thread identity.
+
+        Returns:
+            A ledger update clearing the reaped entries, or `None` when nothing
+            is stale.
+        """
+        stale = _stale_temp_artifacts(
+            cast("Mapping[str, object]", state),
+            runtime,
+            state.get("messages", []),
+        )
+        if not stale:
+            return None
+        mutations = await asyncio.to_thread(_reap_temp_artifacts, stale)
+        return {_TEMP_ARTIFACT_STATE_KEY: mutations}
 
     def _managed_temp_rejection(self, request: ToolCallRequest) -> ToolMessage | None:
         tool_name = request.tool_call["name"]

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -6872,3 +6872,88 @@ def test_classifier_policy_section_order_and_references() -> None:
 
     # A missing space between adjacent literals would silently join two words.
     assert "  " not in _CLASSIFIER_POLICY
+
+
+async def test_temp_artifact_from_a_finished_turn_is_reaped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    middleware = _middleware(worktree)
+    request, _store, _key = _request(
+        worktree,
+        model=_FailIfClassifiedModel(),
+        tool_name="create_temp_artifact",
+        args={},
+    )
+    state, artifact = _create_test_temp_artifact(middleware, request)
+    artifact_path = Path(cast("str", artifact["file_path"]))
+
+    same_turn = await middleware.abefore_model(
+        cast("Any", state), cast("Any", request.runtime)
+    )
+
+    assert same_turn is None
+    assert await asyncio.to_thread(artifact_path.exists)
+
+    state["messages"] = [
+        HumanMessage(
+            content="another request",
+            additional_kwargs={
+                USER_PROMPT_METADATA_KEY: user_prompt_metadata(
+                    "another request", [], turn_id="turn-2"
+                )
+            },
+        )
+    ]
+
+    update = await middleware.abefore_model(
+        cast("Any", state), cast("Any", request.runtime)
+    )
+
+    assert update is not None
+    assert not await asyncio.to_thread(artifact_path.exists)
+    merged = _merge_temp_artifacts(
+        cast("dict[str, Any]", state["_auto_temp_artifacts"]),
+        cast("dict[str, Any]", update["_auto_temp_artifacts"]),
+    )
+    assert merged == {}
+
+
+async def test_reaping_tolerates_a_temp_artifact_file_already_gone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    middleware = _middleware(worktree)
+    request, _store, _key = _request(
+        worktree,
+        model=_FailIfClassifiedModel(),
+        tool_name="create_temp_artifact",
+        args={},
+    )
+    state, artifact = _create_test_temp_artifact(middleware, request)
+    await asyncio.to_thread(Path(cast("str", artifact["file_path"])).unlink)
+    state["messages"] = [
+        HumanMessage(
+            content="another request",
+            additional_kwargs={
+                USER_PROMPT_METADATA_KEY: user_prompt_metadata(
+                    "another request", [], turn_id="turn-2"
+                )
+            },
+        )
+    ]
+
+    update = await middleware.abefore_model(
+        cast("Any", state), cast("Any", request.runtime)
+    )
+
+    assert update is not None
+    merged = _merge_temp_artifacts(
+        cast("dict[str, Any]", state["_auto_temp_artifacts"]),
+        cast("dict[str, Any]", update["_auto_temp_artifacts"]),
+    )
+    assert merged == {}


### PR DESCRIPTION
## What a user sees

The model creates a scratch file on one turn — say a pull-request body for `gh pr create --body-file` — and does not clean it up before that turn ends. On a later turn it tries to, and the tool refuses:

```
Denied temporary artifact cleanup: the exact path is not owned by this request.
```

Nothing else can remove the file either (`write_file`/`edit_file`/`delete` on a managed artifact path are rejected), so it sits in OS temp until the platform sweeps it — days on macOS. The model sees a failed cleanup it cannot retry, and the user sees a growing pile of `dcode-scratch-*` files. Observed with an artifact created on turn 4 and denied on turn 6.

## Why the denial is correct

`create_temp_artifact` tags each allocation with `thread_key` and `turn_id`; `delete_temp_artifact` resolves the caller's path through `_current_temp_artifacts`, which keeps only the current turn's. That narrow scope is what lets the tool act on a model-supplied `/tmp` path at all, verified by prefix and device/inode at `_delete_temp_artifact_file`. Widening it to thread scope would trade that containment away.

So this PR keeps the check and removes the leftovers instead.

## Change

`AutoModeHITLMiddleware.abefore_model` reaps, once per model step, this thread's artifacts whose allocating turn is over:

- `_stale_temp_artifacts` selects entries with a matching `thread_key` and a `turn_id` other than the latest human message's. It returns nothing when either trusted identity is missing, so an unidentifiable turn never reaps a live allocation. Within a turn the set is empty and the hook is a no-op.
- `_reap_temp_artifacts` deletes through the existing `_delete_temp_artifact_file`, so the identity checks are unchanged. An `OSError` (file already gone, identity changed) is logged at debug and the ledger entry is still cleared — the finished turn no longer owns the path either way, and a changed identity is never deleted.
- Filesystem work runs under `asyncio.to_thread`; the hook executes on the blockbuster-guarded server loop.

On the case above, the turn-4 artifact is deleted at the first model step of turn 5. A turn-6 delete attempt is still denied, and nothing is orphaned.