### PR TITLE
fix(code): isolate parallel `task` failures

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 from langchain.agents.middleware import (
     HumanInTheLoopMiddleware,
     InterruptOnConfig,
+    ToolErrorMiddleware,
 )
 from langchain.agents.middleware.types import (
     AgentMiddleware,
@@ -143,6 +144,17 @@ from deepagents_code.unicode_security import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _format_task_error(error: Exception, request: ToolCallRequest) -> str | None:
+    from langgraph.errors import NodeCancelledError
+
+    if isinstance(error, NodeCancelledError):
+        return None
+    subagent_type = request.tool_call.get("args", {}).get("subagent_type")
+    subagent_name = subagent_type if isinstance(subagent_type, str) else "unknown"
+    logger.debug("Subagent %r failed", subagent_name, exc_info=error)
+    return f"Subagent {subagent_name!r} failed. You may retry this task."
 
 
 _MEMORY_READONLY_SYSTEM_PROMPT = (
@@ -3241,7 +3253,12 @@ def create_cli_agent(
     # with a non-zero request-time budget.
     from deepagents_code.model_retry import CodeModelRetryMiddleware
 
-    agent_middleware.append(CodeModelRetryMiddleware(max_retries=model_retries))
+    agent_middleware.extend(
+        [
+            CodeModelRetryMiddleware(max_retries=model_retries),
+            ToolErrorMiddleware(_format_task_error, tools=["task"]),
+        ]
+    )
 
     grader_context_tools = _normalize_rubric_grader_context_tools(
         rubric_grader_tools or ()

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -3373,20 +3373,115 @@ class TestEnableAskUser:
         middleware = self._capture_middleware(tmp_path, enable_ask_user=False)
         assert not any(isinstance(mw, AskUserMiddleware) for mw in middleware)
 
-    def test_no_tool_error_middleware(self, tmp_path: Path) -> None:
-        """The stack must not install `ToolErrorMiddleware` for `ask_user`.
-
-        Argument validation lives on the tool schema (pydantic), and `ToolNode`
-        already converts bad `ask_user` arguments to an error `ToolMessage`. A
-        `ToolErrorMiddleware` here would be dead weight — and, sitting outermost
-        in the stack, would risk reporting an internal `ValueError` (e.g.
-        `ServerHooksMiddleware`'s "client answered a different request") to the
-        model as its own bad tool input.
-        """
+    def test_tool_error_middleware_only_handles_task(self, tmp_path: Path) -> None:
         from langchain.agents.middleware import ToolErrorMiddleware
 
         middleware = self._capture_middleware(tmp_path, enable_ask_user=True)
-        assert not any(isinstance(mw, ToolErrorMiddleware) for mw in middleware)
+        handlers = [mw for mw in middleware if isinstance(mw, ToolErrorMiddleware)]
+        assert len(handlers) == 1
+        assert handlers[0]._tool_filter == ["task"]
+
+    def test_task_failure_is_sanitized(self, tmp_path: Path) -> None:
+        from langchain.agents.middleware import ToolErrorMiddleware
+        from langchain_core.messages import ToolMessage
+        from langgraph.prebuilt.tool_node import ToolCallRequest
+
+        middleware = self._capture_middleware(tmp_path, enable_ask_user=True)
+        handler = next(mw for mw in middleware if isinstance(mw, ToolErrorMiddleware))
+        request = ToolCallRequest(
+            tool_call={
+                "name": "task",
+                "args": {"subagent_type": "researcher"},
+                "id": "call-1",
+                "type": "tool_call",
+            },
+            tool=None,
+            state={},
+            runtime=Mock(),
+        )
+
+        def fail(_request: ToolCallRequest) -> ToolMessage:
+            msg = "secret provider detail"
+            raise RuntimeError(msg)
+
+        result = handler.wrap_tool_call(request, fail)
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert result.tool_call_id == "call-1"
+        assert result.content == (
+            "Subagent 'researcher' failed. You may retry this task."
+        )
+        assert "secret provider detail" not in result.content
+
+    async def test_parallel_task_failure_is_isolated(self, tmp_path: Path) -> None:
+        from langchain.agents.middleware import ToolErrorMiddleware
+        from langchain_core.messages import ToolMessage
+        from langgraph.prebuilt.tool_node import ToolCallRequest
+
+        middleware = self._capture_middleware(tmp_path, enable_ask_user=True)
+        error_handler = next(
+            mw for mw in middleware if isinstance(mw, ToolErrorMiddleware)
+        )
+
+        def request(call_id: str, subagent_type: str) -> ToolCallRequest:
+            return ToolCallRequest(
+                tool_call={
+                    "name": "task",
+                    "args": {"subagent_type": subagent_type},
+                    "id": call_id,
+                    "type": "tool_call",
+                },
+                tool=None,
+                state={},
+                runtime=Mock(),
+            )
+
+        async def run(call: ToolCallRequest) -> ToolMessage:
+            await asyncio.sleep(0)
+            if call.tool_call["id"] == "call-2":
+                msg = "provider failed"
+                raise RuntimeError(msg)
+            return ToolMessage("done", tool_call_id=call.tool_call["id"])
+
+        results = await asyncio.gather(
+            error_handler.awrap_tool_call(request("call-1", "researcher"), run),
+            error_handler.awrap_tool_call(request("call-2", "coder"), run),
+            error_handler.awrap_tool_call(request("call-3", "reviewer"), run),
+        )
+
+        assert [result.tool_call_id for result in results] == [
+            "call-1",
+            "call-2",
+            "call-3",
+        ]
+        assert [result.status for result in results] == ["success", "error", "success"]
+
+    def test_task_cancellation_propagates(self, tmp_path: Path) -> None:
+        from langchain.agents.middleware import ToolErrorMiddleware
+        from langchain_core.messages import ToolMessage
+        from langgraph.errors import NodeCancelledError
+        from langgraph.prebuilt.tool_node import ToolCallRequest
+
+        middleware = self._capture_middleware(tmp_path, enable_ask_user=True)
+        handler = next(mw for mw in middleware if isinstance(mw, ToolErrorMiddleware))
+        request = ToolCallRequest(
+            tool_call={
+                "name": "task",
+                "args": {"subagent_type": "researcher"},
+                "id": "call-1",
+                "type": "tool_call",
+            },
+            tool=None,
+            state={},
+            runtime=Mock(),
+        )
+
+        def cancel(_request: ToolCallRequest) -> ToolMessage:
+            node = "tools"
+            raise NodeCancelledError(node)
+
+        with pytest.raises(NodeCancelledError):
+            handler.wrap_tool_call(request, cancel)
 
 
 class TestLoadAsyncSubagents:


### PR DESCRIPTION
Fixes #5952

Failed subagents no longer discard successful sibling results from parallel `task` batches in dcode.

---

dcode now applies `ToolErrorMiddleware` only to the `task` tool. Ordinary subagent exceptions become sanitized error `ToolMessage` results for the original call, allowing the parent to retry without exposing provider details or losing completed siblings. LangGraph cancellation continues to propagate.

Made by [Open SWE](https://openswe.vercel.app/agents/33e7ba27-0024-5e67-822a-536cd46dd48c)