### PR TITLE
ci(ci): scope ripgrep setup to SDK tests

### DIFF
--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -86,6 +86,7 @@ def _starts_with(value: Any, prefix: str) -> bool:
 _CONTEXT_PATHS = sorted(
     (
         "github.event.pull_request.title",
+        "inputs.working-directory",
         "github.event_name",
         "github.head_ref",
         "runner.os",
@@ -118,11 +119,13 @@ def _context(
     head_ref: str | None = None,
     title: str | None = None,
     runner_os: str = "Linux",
+    working_directory: str = "libs/deepagents",
 ) -> dict[str, Any]:
     return {
         "github.event_name": event_name,
         "github.head_ref": head_ref,
         "github.event.pull_request.title": title,
+        "inputs.working-directory": working_directory,
         "runner.os": runner_os,
     }
 
@@ -166,6 +169,21 @@ SELECTION_CASES = [
             title="fix(code): tighten grep bounds",
             runner_os="Windows",
         ),
+        None,
+    ),
+    (
+        "non-SDK package PR",
+        _context(
+            event_name="pull_request",
+            head_ref="mdrxy/ci/soft-timeout-ripgrep",
+            title="fix(code): tighten grep bounds",
+            working_directory="libs/code",
+        ),
+        None,
+    ),
+    (
+        "non-SDK package push",
+        _context(event_name="push", working_directory="libs/code"),
         None,
     ),
 ]
@@ -225,7 +243,7 @@ def test_ci_success_runs_gate_script_from_trusted_base_ref() -> None:
 
     step = _find_step(workflow, job="ci_success", name="🎉 All Checks Passed")
     # The base copy is preferred; the PR copy is only a bootstrap fallback.
-    assert '.ci-gate-base' in step["run"]
+    assert ".ci-gate-base" in step["run"]
     assert step["run"].index(".ci-gate-base") < step["run"].index(".ci-gate-pr")
     # No step may execute the helper from the default (untrusted) checkout.
     for s in steps:
@@ -551,6 +569,7 @@ def test_ripgrep_bypass_step_runs_only_where_the_strict_step_does() -> None:
 
     condition = " ".join(resolve["if"].split())
     assert condition == (
+        "inputs.working-directory == 'libs/deepagents' && "
         "runner.os == 'Linux' && github.event_name == 'pull_request' && "
         "(startsWith(github.head_ref, 'release-please--') || "
         "startsWith(github.event.pull_request.title, 'release('))"

--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -558,10 +558,10 @@ def test_strict_ripgrep_install_bypass(
 def test_ripgrep_bypass_step_runs_only_where_the_strict_step_does() -> None:
     """The label step must not annotate legs that have no strict install.
 
-    Its `if:` is the intersection of `pull_request` and the strict step's own
-    condition. Widen it and every ordinary PR collects a per-leg `::error::`
-    about a check that is not enforced there; narrow it and a release PR
-    silently loses the bypass.
+    Its `if:` is the SDK package's `pull_request` intersection with the strict
+    step's own condition. Widen it and every ordinary PR collects a per-leg
+    `::error::` about a check that is not enforced there; narrow it and a release
+    PR silently loses the bypass.
     """
     workflow = _load_workflow(TEST_WORKFLOW)
     resolve = _find_step(workflow, job="build", name=RESOLVE_STEP)

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -122,10 +122,10 @@ jobs:
       # `github.event.pull_request.labels` because re-running a job replays the
       # original event payload, which would miss a label added after the fact.
       #
-      # The condition is the intersection of "this is a `pull_request`" and the
-      # strict step's own `if:` below. Running anywhere else would annotate legs
-      # that have no strict install to bypass -- an `::error::` about a check
-      # that is not enforced there, once per matrix leg. `push` and
+      # The condition is the intersection of "this is the SDK package", "this is
+      # a `pull_request`", and the strict step's own `if:` below. Running anywhere
+      # else would annotate legs that have no strict install to bypass -- an
+      # `::error::` about a check that is not enforced there, once per matrix leg. `push` and
       # `merge_group` carry no PR label context at all, so they skip this step
       # and the strict install always fails loudly for them.
       - name: "🏷️ Resolve ripgrep bypass"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -131,6 +131,7 @@ jobs:
       - name: "🏷️ Resolve ripgrep bypass"
         id: ripgrep-bypass
         if: >-
+          inputs.working-directory == 'libs/deepagents' &&
           runner.os == 'Linux' &&
           github.event_name == 'pull_request' &&
           (startsWith(github.head_ref, 'release-please--') ||
@@ -181,6 +182,7 @@ jobs:
       - name: "🔍 Install ripgrep (strict)"
         id: ripgrep-strict
         if: >-
+          inputs.working-directory == 'libs/deepagents' &&
           runner.os == 'Linux' &&
           (github.event_name != 'pull_request' ||
           startsWith(github.head_ref, 'release-please--') ||
@@ -237,6 +239,7 @@ jobs:
       - name: "🔍 Install ripgrep (non-release PR)"
         id: ripgrep-install
         if: >-
+          inputs.working-directory == 'libs/deepagents' &&
           runner.os == 'Linux' &&
           github.event_name == 'pull_request' &&
           !startsWith(github.head_ref, 'release-please--') &&


### PR DESCRIPTION
The reusable unit-test workflow installed ripgrep on every Linux package matrix leg even though only the SDK filesystem-backend tests enforce the real-binary contract.

Scope the bypass lookup and both install paths to `libs/deepagents`, preserving all four SDK Linux versions while skipping unnecessary `apt-get` work for the other 35 legs in a full run. Workflow contract tests now cover both non-SDK PR and push contexts.

Made by [Open SWE](https://openswe.vercel.app/agents/af842eab-5137-573e-9a91-381dddfe2437)