### PR TITLE
feat(ci): require acknowledgment for new Markdown files

### DIFF
--- a/.github/LAYOUT.md
+++ b/.github/LAYOUT.md
@@ -43,9 +43,10 @@ bypass label is applied. They consume labels rather than apply them.
 
 - `pr_scope_file_check.yml` — fails when the PR title's package scope does not cover the package dirs it changes; bypass with `allow-scope-mismatch`.
 - `markdown_file_check.yml` — fails non-`docs` PRs that add Markdown files; bypass with `markdown-added: acknowledged`.
+- `project_readme_check.yml` — fails non-`docs` PRs that edit a project README; bypass with `readme: acknowledged`.
 
-Neither gates merges on its own — each must be added to the branch's required
-status checks.
+None of these gate merges on their own — each must be added to the branch's
+required status checks.
 
 ## Local composite actions (`actions/`)
 

--- a/.github/LAYOUT.md
+++ b/.github/LAYOUT.md
@@ -31,11 +31,21 @@ Credential placement rules are in [`SECRETS.md`](./SECRETS.md). Release wiring i
 
 - `pr_labeler.yml` — unified PR labeler: size, file, title, external/internal, contributor tier.
 - `pr_labeler_backfill.yml` — manual backfill of those labels on open PRs.
-- `markdown_file_check.yml` — blocks non-`docs` PRs that add Markdown files until `markdown-added: acknowledged` is applied.
 - `auto-label-by-package.yml` — labels issues by the package they name.
 - `tag-external-issues.yml` — classifies issues as external or internal and applies the contributor tier.
 
 The two PR labelers also appear in [`RELEASING.md`](./RELEASING.md#ci-guardrails-around-releases) because the release guardrails section lists every check a PR may hit; the labelers' output does not drive release gating. The two issue labelers are not release-gated either.
+
+### PR gate workflows
+
+Blocking pre-merge checks that read PR metadata and fail until it is fixed or a
+bypass label is applied. They consume labels rather than apply them.
+
+- `pr_scope_file_check.yml` — fails when the PR title's package scope does not cover the package dirs it changes; bypass with `allow-scope-mismatch`.
+- `markdown_file_check.yml` — fails non-`docs` PRs that add Markdown files; bypass with `markdown-added: acknowledged`.
+
+Neither gates merges on its own — each must be added to the branch's required
+status checks.
 
 ## Local composite actions (`actions/`)
 

--- a/.github/LAYOUT.md
+++ b/.github/LAYOUT.md
@@ -31,6 +31,7 @@ Credential placement rules are in [`SECRETS.md`](./SECRETS.md). Release wiring i
 
 - `pr_labeler.yml` — unified PR labeler: size, file, title, external/internal, contributor tier.
 - `pr_labeler_backfill.yml` — manual backfill of those labels on open PRs.
+- `markdown_file_check.yml` — blocks non-`docs` PRs that add Markdown files until `markdown-added: acknowledged` is applied.
 - `auto-label-by-package.yml` — labels issues by the package they name.
 - `tag-external-issues.yml` — classifies issues as external or internal and applies the contributor tier.
 

--- a/.github/scripts/checks/markdown_file_check.js
+++ b/.github/scripts/checks/markdown_file_check.js
@@ -1,0 +1,33 @@
+"use strict";
+
+function isDocsTitle(title) {
+  return /^docs(?:\([^)]*\))?!?:\s/.test(title || "");
+}
+
+function addedMarkdownFiles(files) {
+  return files
+    .filter(
+      (file) =>
+        file.status === "added" && file.filename.toLowerCase().endsWith(".md"),
+    )
+    .map((file) => file.filename);
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function fileLines(files, limit = 50) {
+  const lines = files
+    .slice(0, limit)
+    .map((file) => `- <code>${escapeHtml(file)}</code>`);
+  if (files.length > limit) {
+    lines.push(`- _and ${files.length - limit} more_`);
+  }
+  return lines;
+}
+
+module.exports = { addedMarkdownFiles, fileLines, isDocsTitle };

--- a/.github/scripts/checks/markdown_file_check.js
+++ b/.github/scripts/checks/markdown_file_check.js
@@ -261,12 +261,35 @@ async function run({ github, context, core }) {
     return;
   }
 
-  const { number, title } = pullRequest;
+  const { number } = pullRequest;
 
-  // The title comes from the event payload while files and labels are read
-  // live. A title edited between event delivery and this run is therefore
-  // evaluated stale — but `edited` is in the trigger list, so the edit fires
-  // its own corrective run. pr_scope_file_check.yml makes the same tradeoff.
+  // Every input to the decision is read live, never from the event payload.
+  // The payload is a snapshot taken at delivery, and two rapid title edits
+  // produce two runs against the same head SHA and the same check name.
+  // `cancel-in-progress: false` lets both finish and GitHub does not promise
+  // FIFO ordering, so the older event can land last: a payload still reading
+  // `docs:` would clear the sticky comment and publish a green required check
+  // over a PR whose title is now `feat:`. Re-running the check cannot repair
+  // that, because the stale run is the most recent result. One `pulls.get`
+  // removes the race for the title and, at no extra cost, for the
+  // release-please provenance and changed-file total alongside it.
+  let livePullRequest;
+  try {
+    ({ data: livePullRequest } = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: number,
+    }));
+  } catch (error) {
+    // A gate input, so it fails closed like listFiles and listLabelsOnIssue.
+    // Falling back to the payload would reinstate exactly the race above, and
+    // silently — the run would look like any other pass.
+    core.setFailed(`Could not read the pull request: ${describeError(error)}`);
+    return;
+  }
+
+  const title = livePullRequest.title;
+
   if (isDocsTitle(title)) {
     await clearStickyComment({ github, owner, repo, number, core });
     core.info("PR type is docs; no acknowledgment required.");
@@ -275,10 +298,10 @@ async function run({ github, context, core }) {
 
   if (isReleasePleasePr(
     {
-      authorLogin: pullRequest.user?.login,
-      authorType: pullRequest.user?.type,
-      headRef: pullRequest.head?.ref,
-      headRepo: pullRequest.head?.repo?.full_name,
+      authorLogin: livePullRequest.user?.login,
+      authorType: livePullRequest.user?.type,
+      headRef: livePullRequest.head?.ref,
+      headRepo: livePullRequest.head?.repo?.full_name,
     },
     { owner, repo },
   )) {
@@ -309,7 +332,7 @@ async function run({ github, context, core }) {
   // checks with distinct messages — as pr_scope_file_check.yml does — because
   // a missing payload field and a truncated list are different root causes and
   // a maintainer needs to tell them apart.
-  const expected = pullRequest.changed_files;
+  const expected = livePullRequest.changed_files;
   if (typeof expected !== "number") {
     core.setFailed(
       `PR payload missing numeric changed_files (got ${JSON.stringify(expected)}); ` +

--- a/.github/scripts/checks/markdown_file_check.js
+++ b/.github/scripts/checks/markdown_file_check.js
@@ -1,15 +1,75 @@
 "use strict";
 
+// Detector for the "new Markdown files need acknowledgment" gate.
+//
+// The workflow (.github/workflows/markdown_file_check.yml) is a thin shim that
+// requires `run` from this file, matching the repo pattern established by
+// .github/scripts/labeling/close-old-prs.js. Everything the gate decides lives
+// here so it can be executed against a fake octokit in
+// .github/scripts/tests/checks/markdown_file_check.test.js — a decision that
+// only appears inside the workflow's YAML `script:` string can be asserted on
+// as text but never actually run, which lets an inverted condition ship green.
+
+const STICKY_MARKER = "<!-- markdown-file-check -->";
+const ACKNOWLEDGMENT_LABEL = "markdown-added: acknowledged";
+
+// Who authors this workflow's own sticky comments. Matched on when finding the
+// comment to update so a PR author cannot pre-post the marker and capture the
+// slot; see findStickyComment.
+const WORKFLOW_BOT_LOGIN = "github-actions[bot]";
+
+// Distinct identity from WORKFLOW_BOT_LOGIN despite the same value today:
+// this is "who opens release PRs" (release-please runs on GITHUB_TOKEN).
+// Kept in step with RELEASE_PLEASE_AUTHOR in close-old-prs.js.
+const RELEASE_PLEASE_AUTHOR = "github-actions[bot]";
+
+// Mirrors the branch shape `separate-pull-requests: true` produces in
+// release-please-config.json. The same literal is independently hardcoded in
+// close-old-prs.js, release-notes.js, check_sdk_pin.yml, check_partner_bounds.yml,
+// release_please_fanout_watch.yml, and release-please.yml — keep them in
+// lockstep. A test pins this against release-please-config.json.
+const RELEASE_PLEASE_BRANCH_PREFIX =
+  "release-please--branches--main--components--";
+
+// How many file paths the sticky comment lists before collapsing the rest into
+// a count. Bounds an author-controlled list against GitHub's 65536-character
+// comment limit.
+const FILE_LIST_LIMIT = 50;
+
 function isDocsTitle(title) {
+  // Lowercase-only on purpose: this mirrors `_TITLE_RE` in
+  // .github/scripts/labeling/check_pr_scope_files.py, and pr_lint.yml enforces
+  // the Conventional Commit type list case-sensitively. "Docs: ..." is not a
+  // valid title in this repo, so it must not earn the bypass either.
   return /^docs(?:\([^)]*\))?!?:\s/.test(title || "");
 }
 
+function isMarkdown(filename) {
+  return typeof filename === "string" && filename.toLowerCase().endsWith(".md");
+}
+
+// Files this PR causes to exist as Markdown when they did not before.
+//
+// `status === "added"` alone is not enough: GitHub reports a `git mv
+// notes.txt notes.md` as `renamed` and a copy as `copied`, both of which land
+// a brand new Markdown document at a path the repo did not have. Keying on
+// "the destination is Markdown and the source was not" closes that bypass
+// while still ignoring a pure move of an existing `.md` file, which adds no
+// new document to review.
 function addedMarkdownFiles(files) {
   return files
-    .filter(
-      (file) =>
-        file.status === "added" && file.filename.toLowerCase().endsWith(".md"),
-    )
+    .filter((file) => {
+      if (!isMarkdown(file.filename)) {
+        return false;
+      }
+      if (file.status === "added" || file.status === "copied") {
+        return true;
+      }
+      if (file.status === "renamed") {
+        return !isMarkdown(file.previous_filename ?? "");
+      }
+      return false;
+    })
     .map((file) => file.filename);
 }
 
@@ -20,7 +80,7 @@ function escapeHtml(value) {
     .replaceAll(">", "&gt;");
 }
 
-function fileLines(files, limit = 50) {
+function fileLines(files, limit = FILE_LIST_LIMIT) {
   const lines = files
     .slice(0, limit)
     .map((file) => `- <code>${escapeHtml(file)}</code>`);
@@ -30,4 +90,293 @@ function fileLines(files, limit = 50) {
   return lines;
 }
 
-module.exports = { addedMarkdownFiles, fileLines, isDocsTitle };
+// Release PRs add a package's first CHANGELOG.md when a new component is
+// onboarded, under a `release(<pkg>): ...` title that this gate would
+// otherwise block — and a bot PR cannot apply the acknowledgment label to
+// unblock itself, so the release pipeline would stall until a human noticed.
+//
+// Provenance, not the title, drives the exemption: author identity, branch
+// prefix, and same-repo head must all match. An outside contributor can name
+// a branch anything, but cannot push it to this repository nor author a PR as
+// the bot, so no single spoofable signal carries the bypass. This mirrors
+// isReleasePr in close-old-prs.js.
+function isReleasePleasePr(
+  { authorLogin, authorType, headRef, headRepo },
+  { owner, repo },
+) {
+  if (authorLogin !== RELEASE_PLEASE_AUTHOR || authorType !== "Bot") {
+    return false;
+  }
+  if (
+    typeof headRef !== "string" ||
+    !headRef.startsWith(RELEASE_PLEASE_BRANCH_PREFIX) ||
+    headRef.length <= RELEASE_PLEASE_BRANCH_PREFIX.length
+  ) {
+    return false;
+  }
+  return (
+    typeof headRepo === "string" &&
+    headRepo.toLowerCase() === `${owner}/${repo}`.toLowerCase()
+  );
+}
+
+// A thrown non-Error (or an octokit error without `.status`) otherwise logs as
+// "undefined", which is worse than no message at all — it reads as a transient
+// blip when it may be a permanent misconfiguration.
+function describeError(error) {
+  const status = error?.status ?? "n/a";
+  const message = error?.message ?? String(error);
+  return `[status=${status}] ${message}`;
+}
+
+// Matched on the marker AND the bot login: matching the marker alone lets a PR
+// author pre-post a comment starting with the marker and capture the sticky
+// slot. The subsequent update/delete then 403s, so the genuine explanation is
+// never posted while an author-authored — and author-editable — notice sits on
+// the PR looking official. Same reasoning as ripgrep_timeout_comment.yml.
+// If the posting identity ever changes, update WORKFLOW_BOT_LOGIN; a missed
+// match only costs one extra comment, a hijacked slot costs the explanation.
+async function findStickyComment({ github, owner, repo, number }) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: number,
+    per_page: 100,
+  });
+  return comments.find(
+    (comment) =>
+      comment.user?.login === WORKFLOW_BOT_LOGIN &&
+      (comment.body ?? "").startsWith(STICKY_MARKER),
+  );
+}
+
+// Called when the PR no longer needs the gate (retitled to `docs:`, or the
+// Markdown file dropped). Failure here cannot turn a clean result red, but it
+// does leave a stale block notice on a now-passing PR, so the warning goes out
+// as core.notice: a warning inside a *successful* step is log-only, and nobody
+// opens the log of a green check.
+async function clearStickyComment({ github, owner, repo, number, core }) {
+  try {
+    const existing = await findStickyComment({ github, owner, repo, number });
+    if (existing) {
+      await github.rest.issues.deleteComment({
+        owner,
+        repo,
+        comment_id: existing.id,
+      });
+    }
+  } catch (error) {
+    core.notice(
+      "Could not remove the prior Markdown-file comment; a stale block notice " +
+        `may still be shown on this now-passing PR: ${describeError(error)}`,
+    );
+  }
+}
+
+async function upsertStickyComment({ github, owner, repo, number, core, body }) {
+  try {
+    const existing = await findStickyComment({ github, owner, repo, number });
+    if (existing) {
+      // Skip a no-op edit so re-runs (a label toggle, a rebase) do not
+      // re-notify every subscriber with identical content.
+      if (existing.body !== body) {
+        await github.rest.issues.updateComment({
+          owner,
+          repo,
+          comment_id: existing.id,
+          body,
+        });
+      }
+    } else {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: number,
+        body,
+      });
+    }
+    return;
+  } catch (error) {
+    // 403 is not a blip. It means either the sticky slot was captured by
+    // another author, or `pull-requests: write` was dropped from the workflow
+    // — a permanent regression that silently degrades every future run to
+    // log-only. core.error surfaces it as a Checks annotation; anything else
+    // is plausibly transient (rate limit, 5xx) and stays a warning.
+    const report = error?.status === 403 ? core.error : core.warning;
+    report.call(
+      core,
+      `Could not post the Markdown-file comment: ${describeError(error)}`,
+    );
+  }
+
+  // The comment was the user-facing channel and it failed, so fall back —
+  // unconditionally first, because core.info cannot throw and the file list is
+  // the only actionable part of this check. The job summary is nicer to read
+  // but is itself failable (unwritable summary, size limit), so it comes
+  // second and its failure costs nothing.
+  core.info(`Markdown-file check details:\n${body}`);
+  try {
+    await core.summary
+      .addHeading("New Markdown files require acknowledgment")
+      .addRaw(body)
+      .write();
+  } catch (summaryError) {
+    core.warning(
+      `Could not write the job summary fallback: ${describeError(summaryError)}`,
+    );
+  }
+}
+
+function buildBody({ acknowledged, markdownFiles }) {
+  const shownFiles = fileLines(markdownFiles);
+  if (acknowledged) {
+    return [
+      STICKY_MARKER,
+      `ℹ️ **New Markdown files acknowledged** via the \`${ACKNOWLEDGMENT_LABEL}\` label.`,
+      "",
+      ...shownFiles,
+      "",
+      "Remove the label to re-enable the block.",
+    ].join("\n");
+  }
+  return [
+    STICKY_MARKER,
+    "⛔ **This non-docs PR adds new Markdown files.**",
+    "",
+    ...shownFiles,
+    "",
+    "Change the PR type to `docs` if it only contains documentation changes. Otherwise, review the new files and apply the acknowledgment label:",
+    "",
+    `\`${ACKNOWLEDGMENT_LABEL}\``,
+  ].join("\n");
+}
+
+async function run({ github, context, core }) {
+  const { owner, repo } = context.repo;
+  const pullRequest = context.payload.pull_request;
+  if (!pullRequest) {
+    core.setFailed(
+      "No pull_request payload; this workflow only supports pull_request_target events.",
+    );
+    return;
+  }
+
+  const { number, title } = pullRequest;
+
+  // The title comes from the event payload while files and labels are read
+  // live. A title edited between event delivery and this run is therefore
+  // evaluated stale — but `edited` is in the trigger list, so the edit fires
+  // its own corrective run. pr_scope_file_check.yml makes the same tradeoff.
+  if (isDocsTitle(title)) {
+    await clearStickyComment({ github, owner, repo, number, core });
+    core.info("PR type is docs; no acknowledgment required.");
+    return;
+  }
+
+  if (isReleasePleasePr(
+    {
+      authorLogin: pullRequest.user?.login,
+      authorType: pullRequest.user?.type,
+      headRef: pullRequest.head?.ref,
+      headRepo: pullRequest.head?.repo?.full_name,
+    },
+    { owner, repo },
+  )) {
+    await clearStickyComment({ github, owner, repo, number, core });
+    core.info(
+      "Release-please PR (verified by author, branch, and head repo); " +
+        "a new component's first CHANGELOG.md needs no acknowledgment.",
+    );
+    return;
+  }
+
+  let files;
+  try {
+    files = await github.paginate(github.rest.pulls.listFiles, {
+      owner,
+      repo,
+      pull_number: number,
+      per_page: 100,
+    });
+  } catch (error) {
+    core.setFailed(`Could not list PR files: ${describeError(error)}`);
+    return;
+  }
+
+  // listFiles is hard-capped by GitHub at 3000 files regardless of pagination.
+  // A truncated list would hide newly added Markdown, so verify the collected
+  // count against the PR's own total and fail closed otherwise. Split into two
+  // checks with distinct messages — as pr_scope_file_check.yml does — because
+  // a missing payload field and a truncated list are different root causes and
+  // a maintainer needs to tell them apart.
+  const expected = pullRequest.changed_files;
+  if (typeof expected !== "number") {
+    core.setFailed(
+      `PR payload missing numeric changed_files (got ${JSON.stringify(expected)}); ` +
+        "cannot verify the changed-file list is complete. Failing closed.",
+    );
+    return;
+  }
+  if (files.length !== expected) {
+    core.setFailed(
+      `Changed-file list is incomplete (${files.length} of ${expected}); cannot ` +
+        "determine whether this PR adds Markdown files. Failing closed. A PR " +
+        "over GitHub's 3000-file listing cap cannot pass this check — split it.",
+    );
+    return;
+  }
+
+  const markdownFiles = addedMarkdownFiles(files);
+  if (markdownFiles.length === 0) {
+    await clearStickyComment({ github, owner, repo, number, core });
+    core.info("No newly added Markdown files.");
+    return;
+  }
+
+  let labels;
+  try {
+    // per_page: 100 is the whole story, not a page size — GitHub caps an issue
+    // at 100 labels, so one request always sees every label. The REST default
+    // of 30 would drop the acknowledgment label on a heavily labeled PR and
+    // fail it while telling the maintainer to apply a label they can see is
+    // already there.
+    ({ data: labels } = await github.rest.issues.listLabelsOnIssue({
+      owner,
+      repo,
+      issue_number: number,
+      per_page: 100,
+    }));
+  } catch (error) {
+    core.setFailed(`Could not read PR labels: ${describeError(error)}`);
+    return;
+  }
+
+  const acknowledged = labels.some(
+    (label) => label.name === ACKNOWLEDGMENT_LABEL,
+  );
+  const body = buildBody({ acknowledged, markdownFiles });
+
+  // setFailed before the comment write: upsertStickyComment swallows its own
+  // errors so the red check is the load-bearing signal and must be set first.
+  if (!acknowledged) {
+    core.setFailed(
+      `Non-docs PR adds ${markdownFiles.length} Markdown file(s); apply ` +
+        `'${ACKNOWLEDGMENT_LABEL}' to acknowledge.`,
+    );
+  }
+  await upsertStickyComment({ github, owner, repo, number, core, body });
+}
+
+module.exports = {
+  ACKNOWLEDGMENT_LABEL,
+  FILE_LIST_LIMIT,
+  RELEASE_PLEASE_BRANCH_PREFIX,
+  STICKY_MARKER,
+  WORKFLOW_BOT_LOGIN,
+  addedMarkdownFiles,
+  buildBody,
+  fileLines,
+  isDocsTitle,
+  isReleasePleasePr,
+  run,
+};

--- a/.github/scripts/tests/checks/markdown_file_check.test.js
+++ b/.github/scripts/tests/checks/markdown_file_check.test.js
@@ -76,10 +76,26 @@ function httpError(message, status) {
   return error;
 }
 
+const DEFAULT_PR = {
+  number: 7,
+  title: "feat(code): add a thing",
+  changed_files: 1,
+  user: { login: "contributor", type: "User" },
+  head: {
+    ref: "feature-branch",
+    repo: { full_name: "langchain-ai/deepagents" },
+  },
+};
+
 function makeGithub({
+  // What `pulls.get` returns. Every gate input is read from here rather than
+  // the event payload, so tests set the PR's real state here and use
+  // makeContext only to model what the (possibly stale) event carried.
+  pr = {},
   files = [],
   labels = [],
   comments = [],
+  pullsGetError = null,
   listFilesError = null,
   listLabelsError = null,
   listCommentsError = null,
@@ -87,10 +103,12 @@ function makeGithub({
   updateCommentError = null,
   deleteCommentError = null,
 } = {}) {
+  const livePr = { ...DEFAULT_PR, ...pr };
   const calls = {
     createComment: [],
     updateComment: [],
     deleteComment: [],
+    pullsGet: [],
     listFiles: [],
     listLabels: [],
   };
@@ -118,6 +136,11 @@ function makeGithub({
       },
       pulls: {
         listFiles: "listFiles",
+        get: async (params) => {
+          calls.pullsGet.push(params);
+          if (pullsGetError) throw pullsGetError;
+          return { data: livePr };
+        },
       },
     },
     async paginate(route, params) {
@@ -136,23 +159,14 @@ function makeGithub({
   return { github, calls };
 }
 
-function makeContext({
-  title = "feat(code): add a thing",
-  number = 7,
-  changedFiles = 1,
-  user = { login: "contributor", type: "User" },
-  head = { ref: "feature-branch", repo: { full_name: "langchain-ai/deepagents" } },
-} = {}) {
+// The event payload contributes only the PR number; everything the gate
+// decides on is re-read live. `stale` models what an out-of-order event still
+// claims, so a test can prove the payload's version is never consulted.
+function makeContext({ number = 7, stale = {} } = {}) {
   return {
     repo: { owner: "langchain-ai", repo: "deepagents" },
     payload: {
-      pull_request: {
-        number,
-        title,
-        changed_files: changedFiles,
-        user,
-        head,
-      },
+      pull_request: { number, ...stale },
     },
   };
 }
@@ -350,13 +364,14 @@ test("blocks a PR that lands Markdown by renaming a non-Markdown file", async ()
 
 test("passes a docs PR without consulting files or labels", async () => {
   const { github, calls } = makeGithub({
+    pr: { title: "docs: add a guide" },
     files: [{ filename: "NOTES.md", status: "added" }],
     labels: [],
     comments: [botComment()],
   });
   const core = newCore();
 
-  await run({ github, context: makeContext({ title: "docs: add a guide" }), core });
+  await run({ github, context: makeContext(), core });
 
   assert.equal(core.failed, null);
   assert.equal(calls.listFiles.length, 0);
@@ -367,40 +382,40 @@ test("passes a docs PR without consulting files or labels", async () => {
 
 test("passes a release-please PR that adds a new component CHANGELOG", async () => {
   const { github } = makeGithub({
+    pr: {
+      title: "release(newpkg): 0.1.0",
+      user: { login: "github-actions[bot]", type: "Bot" },
+      head: {
+        ref: `${RELEASE_PLEASE_BRANCH_PREFIX}newpkg`,
+        repo: { full_name: "langchain-ai/deepagents" },
+      },
+    },
     files: [{ filename: "libs/newpkg/CHANGELOG.md", status: "added" }],
     labels: [],
   });
   const core = newCore();
-  const context = makeContext({
-    title: "release(newpkg): 0.1.0",
-    user: { login: "github-actions[bot]", type: "Bot" },
-    head: {
-      ref: `${RELEASE_PLEASE_BRANCH_PREFIX}newpkg`,
-      repo: { full_name: "langchain-ai/deepagents" },
-    },
-  });
 
-  await run({ github, context, core });
+  await run({ github, context: makeContext(), core });
 
   assert.equal(core.failed, null);
 });
 
 test("blocks a PR imitating a release-please branch from a fork", async () => {
   const { github } = makeGithub({
+    pr: {
+      title: "release(newpkg): 0.1.0",
+      user: { login: "attacker", type: "User" },
+      head: {
+        ref: `${RELEASE_PLEASE_BRANCH_PREFIX}newpkg`,
+        repo: { full_name: "attacker/deepagents" },
+      },
+    },
     files: [{ filename: "sneaky.md", status: "added" }],
     labels: [],
   });
   const core = newCore();
-  const context = makeContext({
-    title: "release(newpkg): 0.1.0",
-    user: { login: "attacker", type: "User" },
-    head: {
-      ref: `${RELEASE_PLEASE_BRANCH_PREFIX}newpkg`,
-      repo: { full_name: "attacker/deepagents" },
-    },
-  });
 
-  await run({ github, context, core });
+  await run({ github, context: makeContext(), core });
 
   assert.match(core.failed, /adds 1 Markdown file/);
 });
@@ -421,15 +436,108 @@ test("passes and clears the sticky comment when no Markdown is added", async () 
   );
 });
 
+// --- run(): the payload is never trusted ------------------------------------
+
+test("a stale docs: payload title cannot pass a PR now titled feat:", async () => {
+  // Two rapid title edits produce two runs against the same head SHA and check
+  // name. Ordering is not guaranteed, so the older `docs:` event can land last
+  // — and its result is the one branch protection reads.
+  const { github } = makeGithub({
+    pr: { title: "feat(code): add a thing" },
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [],
+  });
+  const core = newCore();
+  const context = makeContext({ stale: { title: "docs: add a guide" } });
+
+  await run({ github, context, core });
+
+  assert.match(core.failed, /adds 1 Markdown file/);
+});
+
+test("a stale feat: payload title cannot block a PR now titled docs:", async () => {
+  const { github } = makeGithub({
+    pr: { title: "docs: add a guide" },
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [],
+  });
+  const core = newCore();
+  const context = makeContext({ stale: { title: "feat(code): add a thing" } });
+
+  await run({ github, context, core });
+
+  assert.equal(core.failed, null);
+});
+
+test("release-please provenance is read live, not from the payload", async () => {
+  // Otherwise a stale payload claiming bot provenance would carry the
+  // exemption for a PR that is no longer a release PR.
+  const { github } = makeGithub({
+    pr: { title: "feat(code): add a thing" },
+    files: [{ filename: "sneaky.md", status: "added" }],
+    labels: [],
+  });
+  const core = newCore();
+  const context = makeContext({
+    stale: {
+      title: "release(newpkg): 0.1.0",
+      user: { login: "github-actions[bot]", type: "Bot" },
+      head: {
+        ref: `${RELEASE_PLEASE_BRANCH_PREFIX}newpkg`,
+        repo: { full_name: "langchain-ai/deepagents" },
+      },
+    },
+  });
+
+  await run({ github, context, core });
+
+  assert.match(core.failed, /adds 1 Markdown file/);
+});
+
+test("the truncation guard compares live files against the live total", async () => {
+  // A live file list measured against a stale payload total would fail honest
+  // PRs whenever a push landed between event delivery and this run.
+  const { github } = makeGithub({
+    pr: { changed_files: 2 },
+    files: [
+      { filename: "main.py", status: "modified" },
+      { filename: "other.py", status: "modified" },
+    ],
+  });
+  const core = newCore();
+  const context = makeContext({ stale: { changed_files: 1 } });
+
+  await run({ github, context, core });
+
+  assert.equal(core.failed, null);
+});
+
+test("fails closed when the live pull request cannot be read", async () => {
+  // Falling back to the payload here would quietly reinstate the whole race.
+  const { github, calls } = makeGithub({
+    pullsGetError: httpError("upstream boom", 502),
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [],
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.match(core.failed, /Could not read the pull request.*status=502/s);
+  assert.equal(calls.listFiles.length, 0);
+  assert.equal(calls.createComment.length, 0);
+});
+
 // --- run(): fail-closed guards ---------------------------------------------
 
 test("fails closed when the changed-file list is truncated", async () => {
   const { github, calls } = makeGithub({
+    pr: { changed_files: 3000 },
     files: [{ filename: "main.py", status: "modified" }],
   });
   const core = newCore();
 
-  await run({ github, context: makeContext({ changedFiles: 3000 }), core });
+  await run({ github, context: makeContext(), core });
 
   assert.match(core.failed, /incomplete \(1 of 3000\)/);
   // The guard must block, not merely warn, and must not proceed to the label read.
@@ -438,12 +546,10 @@ test("fails closed when the changed-file list is truncated", async () => {
 });
 
 test("fails closed when changed_files is missing from the payload", async () => {
-  const { github } = makeGithub({ files: [] });
+  const { github } = makeGithub({ pr: { changed_files: undefined }, files: [] });
   const core = newCore();
-  const context = makeContext();
-  delete context.payload.pull_request.changed_files;
 
-  await run({ github, context, core });
+  await run({ github, context: makeContext(), core });
 
   assert.match(core.failed, /missing numeric changed_files/);
 });

--- a/.github/scripts/tests/checks/markdown_file_check.test.js
+++ b/.github/scripts/tests/checks/markdown_file_check.test.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  addedMarkdownFiles,
+  fileLines,
+  isDocsTitle,
+} = require("../../checks/markdown_file_check.js");
+
+test("recognizes only docs Conventional Commit titles", () => {
+  assert.equal(isDocsTitle("docs(sdk): add a guide"), true);
+  assert.equal(isDocsTitle("docs!: replace the guide"), true);
+  assert.equal(isDocsTitle("fix(docs): repair rendering"), false);
+  assert.equal(isDocsTitle("documentation: add a guide"), false);
+});
+
+test("returns only newly added Markdown files", () => {
+  const files = [
+    { filename: "README.md", status: "added" },
+    { filename: "guides/UPPER.MD", status: "added" },
+    { filename: "old.md", status: "modified" },
+    { filename: "removed.md", status: "removed" },
+    { filename: "notes.mdx", status: "added" },
+  ];
+
+  assert.deepEqual(addedMarkdownFiles(files), ["README.md", "guides/UPPER.MD"]);
+});
+
+test("escapes and bounds file paths rendered in the sticky comment", () => {
+  assert.deepEqual(fileLines(["<script>&.md", "second.md"], 1), [
+    "- <code>&lt;script&gt;&amp;.md</code>",
+    "- _and 1 more_",
+  ]);
+});

--- a/.github/scripts/tests/checks/markdown_file_check.test.js
+++ b/.github/scripts/tests/checks/markdown_file_check.test.js
@@ -3,16 +3,179 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 const {
+  ACKNOWLEDGMENT_LABEL,
+  FILE_LIST_LIMIT,
+  RELEASE_PLEASE_BRANCH_PREFIX,
+  STICKY_MARKER,
+  WORKFLOW_BOT_LOGIN,
   addedMarkdownFiles,
+  buildBody,
   fileLines,
   isDocsTitle,
+  isReleasePleasePr,
+  run,
 } = require("../../checks/markdown_file_check.js");
+
+// --- Fakes ------------------------------------------------------------------
+
+function makeCore() {
+  return {
+    failed: null,
+    infos: [],
+    notices: [],
+    warnings: [],
+    errors: [],
+    summaryWrites: [],
+    summaryError: null,
+    info(message) {
+      this.infos.push(message);
+    },
+    notice(message) {
+      this.notices.push(message);
+    },
+    warning(message) {
+      this.warnings.push(message);
+    },
+    error(message) {
+      this.errors.push(message);
+    },
+    setFailed(message) {
+      this.failed = message;
+    },
+    summary: {
+      pending: [],
+      addHeading(text) {
+        this.pending.push(text);
+        return this;
+      },
+      addRaw(text) {
+        this.pending.push(text);
+        return this;
+      },
+      async write() {
+        const owner = this.owner;
+        if (owner.summaryError) {
+          throw owner.summaryError;
+        }
+        owner.summaryWrites.push(this.pending.join("\n"));
+        this.pending = [];
+      },
+    },
+  };
+}
+
+function newCore() {
+  const core = makeCore();
+  core.summary.owner = core;
+  return core;
+}
+
+function httpError(message, status) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
+function makeGithub({
+  files = [],
+  labels = [],
+  comments = [],
+  listFilesError = null,
+  listLabelsError = null,
+  listCommentsError = null,
+  createCommentError = null,
+  updateCommentError = null,
+  deleteCommentError = null,
+} = {}) {
+  const calls = {
+    createComment: [],
+    updateComment: [],
+    deleteComment: [],
+    listFiles: [],
+    listLabels: [],
+  };
+  const github = {
+    rest: {
+      issues: {
+        listComments: "listComments",
+        listLabelsOnIssue: async (params) => {
+          calls.listLabels.push(params);
+          if (listLabelsError) throw listLabelsError;
+          return { data: labels };
+        },
+        createComment: async (params) => {
+          calls.createComment.push(params);
+          if (createCommentError) throw createCommentError;
+        },
+        updateComment: async (params) => {
+          calls.updateComment.push(params);
+          if (updateCommentError) throw updateCommentError;
+        },
+        deleteComment: async (params) => {
+          calls.deleteComment.push(params);
+          if (deleteCommentError) throw deleteCommentError;
+        },
+      },
+      pulls: {
+        listFiles: "listFiles",
+      },
+    },
+    async paginate(route, params) {
+      if (route === "listFiles") {
+        calls.listFiles.push(params);
+        if (listFilesError) throw listFilesError;
+        return files;
+      }
+      if (route === "listComments") {
+        if (listCommentsError) throw listCommentsError;
+        return comments;
+      }
+      throw new Error(`unexpected paginate route: ${route}`);
+    },
+  };
+  return { github, calls };
+}
+
+function makeContext({
+  title = "feat(code): add a thing",
+  number = 7,
+  changedFiles = 1,
+  user = { login: "contributor", type: "User" },
+  head = { ref: "feature-branch", repo: { full_name: "langchain-ai/deepagents" } },
+} = {}) {
+  return {
+    repo: { owner: "langchain-ai", repo: "deepagents" },
+    payload: {
+      pull_request: {
+        number,
+        title,
+        changed_files: changedFiles,
+        user,
+        head,
+      },
+    },
+  };
+}
+
+function botComment({ id = 1, body = `${STICKY_MARKER}\nold` } = {}) {
+  return { id, body, user: { login: WORKFLOW_BOT_LOGIN } };
+}
+
+// --- Pure helpers -----------------------------------------------------------
 
 test("recognizes only docs Conventional Commit titles", () => {
   assert.equal(isDocsTitle("docs(sdk): add a guide"), true);
   assert.equal(isDocsTitle("docs!: replace the guide"), true);
+  assert.equal(isDocsTitle("docs: add a guide"), true);
   assert.equal(isDocsTitle("fix(docs): repair rendering"), false);
   assert.equal(isDocsTitle("documentation: add a guide"), false);
+  // Lowercase-only, matching _TITLE_RE in check_pr_scope_files.py.
+  assert.equal(isDocsTitle("Docs: add a guide"), false);
+  assert.equal(isDocsTitle("DOCS: add a guide"), false);
+  // The space after the colon is required by the Conventional Commit grammar.
+  assert.equal(isDocsTitle("docs:add a guide"), false);
+  assert.equal(isDocsTitle(undefined), false);
+  assert.equal(isDocsTitle(""), false);
 });
 
 test("returns only newly added Markdown files", () => {
@@ -22,9 +185,34 @@ test("returns only newly added Markdown files", () => {
     { filename: "old.md", status: "modified" },
     { filename: "removed.md", status: "removed" },
     { filename: "notes.mdx", status: "added" },
+    { filename: "unchanged.md", status: "unchanged" },
   ];
 
   assert.deepEqual(addedMarkdownFiles(files), ["README.md", "guides/UPPER.MD"]);
+});
+
+test("treats a rename or copy into Markdown as a new Markdown file", () => {
+  const files = [
+    // A new Markdown document that did not exist before: must be caught.
+    { filename: "notes.md", status: "renamed", previous_filename: "notes.txt" },
+    { filename: "copied.md", status: "copied", previous_filename: "source.txt" },
+    // Moving an existing .md adds no new document to review: must be ignored.
+    { filename: "docs/moved.md", status: "renamed", previous_filename: "moved.md" },
+    // Case-only rename: the source was already Markdown, so nothing is new.
+    { filename: "docs/CASE.md", status: "renamed", previous_filename: "CASE.MD" },
+    // A rename whose destination is not Markdown is irrelevant either way.
+    { filename: "notes.txt", status: "renamed", previous_filename: "notes.md" },
+  ];
+
+  assert.deepEqual(addedMarkdownFiles(files), ["notes.md", "copied.md"]);
+});
+
+test("a rename with no previous_filename counts as new Markdown", () => {
+  // Fail closed: without provenance we cannot prove the source was Markdown.
+  assert.deepEqual(
+    addedMarkdownFiles([{ filename: "new.md", status: "renamed" }]),
+    ["new.md"],
+  );
 });
 
 test("escapes and bounds file paths rendered in the sticky comment", () => {
@@ -32,4 +220,440 @@ test("escapes and bounds file paths rendered in the sticky comment", () => {
     "- <code>&lt;script&gt;&amp;.md</code>",
     "- _and 1 more_",
   ]);
+});
+
+test("the default file-list limit truncates at exactly one over", () => {
+  const exact = Array.from({ length: FILE_LIST_LIMIT }, (_, i) => `f${i}.md`);
+  const overflow = [...exact, "extra.md"];
+
+  const atLimit = fileLines(exact);
+  assert.equal(atLimit.length, FILE_LIST_LIMIT);
+  assert.ok(!atLimit.some((line) => line.includes("more")));
+
+  const past = fileLines(overflow);
+  assert.equal(past.length, FILE_LIST_LIMIT + 1);
+  assert.equal(past.at(-1), "- _and 1 more_");
+});
+
+test("recognizes release-please PRs only on full provenance", () => {
+  const repo = { owner: "langchain-ai", repo: "deepagents" };
+  const genuine = {
+    authorLogin: "github-actions[bot]",
+    authorType: "Bot",
+    headRef: `${RELEASE_PLEASE_BRANCH_PREFIX}deepagents`,
+    headRepo: "langchain-ai/deepagents",
+  };
+  assert.equal(isReleasePleasePr(genuine, repo), true);
+  // Case-insensitive repo comparison, since GitHub is inconsistent about case.
+  assert.equal(
+    isReleasePleasePr({ ...genuine, headRepo: "LangChain-AI/DeepAgents" }, repo),
+    true,
+  );
+
+  // Each signal alone must be insufficient.
+  assert.equal(
+    isReleasePleasePr({ ...genuine, authorLogin: "attacker" }, repo),
+    false,
+  );
+  assert.equal(isReleasePleasePr({ ...genuine, authorType: "User" }, repo), false);
+  assert.equal(
+    isReleasePleasePr({ ...genuine, headRef: "release-please-ish" }, repo),
+    false,
+  );
+  // The prefix with no component suffix is not a fanout release branch.
+  assert.equal(
+    isReleasePleasePr({ ...genuine, headRef: RELEASE_PLEASE_BRANCH_PREFIX }, repo),
+    false,
+  );
+  // A fork cannot borrow the exemption.
+  assert.equal(
+    isReleasePleasePr({ ...genuine, headRepo: "attacker/deepagents" }, repo),
+    false,
+  );
+  assert.equal(isReleasePleasePr({ ...genuine, headRepo: undefined }, repo), false);
+});
+
+test("acknowledged and blocking bodies are distinguishable and carry the marker", () => {
+  const files = ["a.md"];
+  const blocking = buildBody({ acknowledged: false, markdownFiles: files });
+  const acked = buildBody({ acknowledged: true, markdownFiles: files });
+
+  assert.ok(blocking.startsWith(STICKY_MARKER));
+  assert.ok(acked.startsWith(STICKY_MARKER));
+  assert.ok(blocking.includes("⛔"));
+  assert.ok(acked.includes("acknowledged"));
+  assert.ok(blocking.includes(ACKNOWLEDGMENT_LABEL));
+  assert.ok(blocking.includes("<code>a.md</code>"));
+});
+
+// --- run(): the gate decision ----------------------------------------------
+
+test("blocks a non-docs PR that adds Markdown and has no label", async () => {
+  const { github, calls } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [{ name: "size:S" }],
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.match(core.failed, /adds 1 Markdown file/);
+  assert.equal(calls.createComment.length, 1);
+  assert.ok(calls.createComment[0].body.includes("⛔"));
+});
+
+test("passes a non-docs PR that adds Markdown once the label is applied", async () => {
+  const { github, calls } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [{ name: ACKNOWLEDGMENT_LABEL }],
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.equal(core.failed, null);
+  assert.equal(calls.createComment.length, 1);
+  assert.ok(calls.createComment[0].body.includes("acknowledged"));
+});
+
+test("reads every label so acknowledgment is never missed", async () => {
+  // The REST default is 30 per page; an issue caps at 100 labels. Asking for
+  // fewer than the cap would drop the acknowledgment label on a busy PR and
+  // fail it while telling the maintainer to apply a label already present.
+  const labels = Array.from({ length: 99 }, (_, i) => ({ name: `label-${i}` }));
+  labels.push({ name: ACKNOWLEDGMENT_LABEL });
+  const { github, calls } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels,
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.equal(calls.listLabels[0].per_page, 100);
+  assert.equal(core.failed, null);
+});
+
+test("blocks a PR that lands Markdown by renaming a non-Markdown file", async () => {
+  const { github } = makeGithub({
+    files: [
+      { filename: "DESIGN.md", status: "renamed", previous_filename: "DESIGN.txt" },
+    ],
+    labels: [],
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.match(core.failed, /adds 1 Markdown file/);
+});
+
+test("passes a docs PR without consulting files or labels", async () => {
+  const { github, calls } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [],
+    comments: [botComment()],
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext({ title: "docs: add a guide" }), core });
+
+  assert.equal(core.failed, null);
+  assert.equal(calls.listFiles.length, 0);
+  assert.equal(calls.listLabels.length, 0);
+  // A stale block notice from before the retitle is cleared.
+  assert.equal(calls.deleteComment.length, 1);
+});
+
+test("passes a release-please PR that adds a new component CHANGELOG", async () => {
+  const { github } = makeGithub({
+    files: [{ filename: "libs/newpkg/CHANGELOG.md", status: "added" }],
+    labels: [],
+  });
+  const core = newCore();
+  const context = makeContext({
+    title: "release(newpkg): 0.1.0",
+    user: { login: "github-actions[bot]", type: "Bot" },
+    head: {
+      ref: `${RELEASE_PLEASE_BRANCH_PREFIX}newpkg`,
+      repo: { full_name: "langchain-ai/deepagents" },
+    },
+  });
+
+  await run({ github, context, core });
+
+  assert.equal(core.failed, null);
+});
+
+test("blocks a PR imitating a release-please branch from a fork", async () => {
+  const { github } = makeGithub({
+    files: [{ filename: "sneaky.md", status: "added" }],
+    labels: [],
+  });
+  const core = newCore();
+  const context = makeContext({
+    title: "release(newpkg): 0.1.0",
+    user: { login: "attacker", type: "User" },
+    head: {
+      ref: `${RELEASE_PLEASE_BRANCH_PREFIX}newpkg`,
+      repo: { full_name: "attacker/deepagents" },
+    },
+  });
+
+  await run({ github, context, core });
+
+  assert.match(core.failed, /adds 1 Markdown file/);
+});
+
+test("passes and clears the sticky comment when no Markdown is added", async () => {
+  const { github, calls } = makeGithub({
+    files: [{ filename: "main.py", status: "added" }],
+    comments: [botComment({ id: 42 })],
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.equal(core.failed, null);
+  assert.deepEqual(
+    calls.deleteComment.map((c) => c.comment_id),
+    [42],
+  );
+});
+
+// --- run(): fail-closed guards ---------------------------------------------
+
+test("fails closed when the changed-file list is truncated", async () => {
+  const { github, calls } = makeGithub({
+    files: [{ filename: "main.py", status: "modified" }],
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext({ changedFiles: 3000 }), core });
+
+  assert.match(core.failed, /incomplete \(1 of 3000\)/);
+  // The guard must block, not merely warn, and must not proceed to the label read.
+  assert.equal(core.warnings.length, 0);
+  assert.equal(calls.listLabels.length, 0);
+});
+
+test("fails closed when changed_files is missing from the payload", async () => {
+  const { github } = makeGithub({ files: [] });
+  const core = newCore();
+  const context = makeContext();
+  delete context.payload.pull_request.changed_files;
+
+  await run({ github, context, core });
+
+  assert.match(core.failed, /missing numeric changed_files/);
+});
+
+test("fails closed when the file listing errors", async () => {
+  const { github } = makeGithub({ listFilesError: httpError("boom", 502) });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.match(core.failed, /Could not list PR files.*status=502/s);
+});
+
+test("fails closed when the label read errors", async () => {
+  const { github } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    listLabelsError: httpError("nope", 403),
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.match(core.failed, /Could not read PR labels.*status=403/s);
+});
+
+test("fails closed when there is no pull_request payload", async () => {
+  const { github } = makeGithub();
+  const core = newCore();
+
+  await run({ github, context: { repo: { owner: "o", repo: "r" }, payload: {} }, core });
+
+  assert.match(core.failed, /No pull_request payload/);
+});
+
+// --- run(): sticky comment handling ----------------------------------------
+
+test("ignores a sticky marker posted by someone other than the bot", async () => {
+  // A PR author who pre-posts the marker must not capture the slot, or the
+  // real explanation is never posted and their forged notice stands.
+  const impostor = {
+    id: 99,
+    body: `${STICKY_MARKER}\nℹ️ **New Markdown files acknowledged**`,
+    user: { login: "contributor" },
+  };
+  const { github, calls } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [],
+    comments: [impostor],
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.match(core.failed, /adds 1 Markdown file/);
+  assert.equal(calls.updateComment.length, 0);
+  assert.equal(calls.createComment.length, 1);
+});
+
+test("updates an existing bot comment instead of posting a second one", async () => {
+  const { github, calls } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [],
+    comments: [botComment({ id: 5 })],
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.equal(calls.createComment.length, 0);
+  assert.deepEqual(
+    calls.updateComment.map((c) => c.comment_id),
+    [5],
+  );
+});
+
+test("skips a no-op edit so re-runs do not re-notify subscribers", async () => {
+  const body = buildBody({ acknowledged: false, markdownFiles: ["NOTES.md"] });
+  const { github, calls } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [],
+    comments: [botComment({ id: 5, body })],
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.equal(calls.updateComment.length, 0);
+  assert.equal(calls.createComment.length, 0);
+  assert.match(core.failed, /adds 1 Markdown file/);
+});
+
+test("a failed comment write cannot turn a block into a pass", async () => {
+  const { github } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [],
+    createCommentError: httpError("rate limited", 429),
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.match(core.failed, /adds 1 Markdown file/);
+  assert.equal(core.warnings.length, 1);
+  // The file list still reaches the log and the summary.
+  assert.ok(core.infos.some((m) => m.includes("NOTES.md")));
+  assert.equal(core.summaryWrites.length, 1);
+});
+
+test("a 403 on the comment write is escalated above a warning", async () => {
+  // Either the slot was captured or pull-requests: write was dropped. Both are
+  // permanent, so they must not read as a transient blip.
+  const { github } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [],
+    createCommentError: httpError("Resource not accessible by integration", 403),
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.equal(core.errors.length, 1);
+  assert.match(core.errors[0], /status=403/);
+  assert.equal(core.warnings.length, 0);
+});
+
+test("the log fallback survives a job-summary failure", async () => {
+  const { github } = makeGithub({
+    files: [{ filename: "NOTES.md", status: "added" }],
+    labels: [],
+    createCommentError: httpError("boom", 500),
+  });
+  const core = newCore();
+  core.summaryError = new Error("summary unwritable");
+
+  await run({ github, context: makeContext(), core });
+
+  assert.match(core.failed, /adds 1 Markdown file/);
+  // core.info runs before the failable summary, so the file list survives.
+  assert.ok(core.infos.some((m) => m.includes("NOTES.md")));
+  assert.equal(core.summaryWrites.length, 0);
+});
+
+test("a failed cleanup notices rather than reddening a passing PR", async () => {
+  const { github } = makeGithub({
+    files: [{ filename: "main.py", status: "modified" }],
+    comments: [botComment({ id: 3 })],
+    deleteCommentError: httpError("gone", 404),
+  });
+  const core = newCore();
+
+  await run({ github, context: makeContext(), core });
+
+  assert.equal(core.failed, null);
+  assert.equal(core.notices.length, 1);
+  assert.match(core.notices[0], /stale block notice/);
+});
+
+// --- Cross-file constant pinning -------------------------------------------
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+
+// RELEASE_PLEASE_BRANCH_PREFIX is a hardcoded literal duplicated across six
+// workflows, and nothing notices when the config that determines the real
+// branch name changes. Here the consequence is a stalled release pipeline: the
+// exemption stops matching, a new component's first CHANGELOG.md is blocked,
+// and the bot cannot label its way out. Mirrors the pin in close-old-prs.test.js.
+test("the release branch prefix matches release-please-config.json", () => {
+  const config = JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, "release-please-config.json"), "utf8"),
+  );
+
+  assert.equal(
+    config["separate-pull-requests"],
+    true,
+    "separate-pull-requests drives the --components-- branch segment",
+  );
+  assert.equal(
+    config["target-branch"],
+    undefined,
+    "a target-branch override changes the <base> segment of the branch name",
+  );
+  assert.equal(
+    RELEASE_PLEASE_BRANCH_PREFIX,
+    "release-please--branches--main--components--",
+  );
+});
+
+// The label name is a literal in three places: this module, the workflow's
+// bypass documentation, and LAYOUT.md. If it drifts from the label that
+// actually exists on the repo the gate becomes permanently unbypassable, so
+// pin the documentation to the constant rather than trusting three copies.
+test("the acknowledgment label is documented consistently", () => {
+  const workflow = fs.readFileSync(
+    path.join(REPO_ROOT, ".github/workflows/markdown_file_check.yml"),
+    "utf8",
+  );
+  const layout = fs.readFileSync(
+    path.join(REPO_ROOT, ".github/LAYOUT.md"),
+    "utf8",
+  );
+
+  assert.ok(
+    workflow.includes(ACKNOWLEDGMENT_LABEL),
+    `markdown_file_check.yml should document the '${ACKNOWLEDGMENT_LABEL}' label`,
+  );
+  assert.ok(
+    layout.includes(ACKNOWLEDGMENT_LABEL),
+    `LAYOUT.md should document the '${ACKNOWLEDGMENT_LABEL}' label`,
+  );
 });

--- a/.github/scripts/tests/checks/test_markdown_file_check.py
+++ b/.github/scripts/tests/checks/test_markdown_file_check.py
@@ -1,0 +1,15 @@
+"""Pytest shim for the Markdown-file gate Node.js tests."""
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_markdown_file_check_node_tests() -> None:
+    subprocess.run(
+        ["node", "--test", ".github/scripts/tests/checks/markdown_file_check.test.js"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+    )

--- a/.github/scripts/tests/checks/test_markdown_file_check.py
+++ b/.github/scripts/tests/checks/test_markdown_file_check.py
@@ -7,9 +7,18 @@ ROOT = Path(__file__).resolve().parents[4]
 
 
 def test_markdown_file_check_node_tests() -> None:
-    subprocess.run(
+    """Run native Node.js tests for the Markdown-file gate detector."""
+    result = subprocess.run(
         ["node", "--test", ".github/scripts/tests/checks/markdown_file_check.test.js"],
         cwd=ROOT,
-        check=True,
+        check=False,
         text=True,
+        capture_output=True,
     )
+    # Surface the node output instead of a bare CalledProcessError with no
+    # context, matching test_release_notes.py.
+    if result.returncode != 0:
+        raise AssertionError(
+            f"node --test failed ({result.returncode})\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )

--- a/.github/scripts/tests/workflows/test_markdown_workflow.py
+++ b/.github/scripts/tests/workflows/test_markdown_workflow.py
@@ -1,0 +1,70 @@
+"""Contracts for the new-Markdown-file pull request gate."""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[4]
+WORKFLOW = ROOT / ".github" / "workflows" / "markdown_file_check.yml"
+GITHUB_SCRIPT_PIN = "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3"
+CHECKOUT_PIN = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+
+
+def _load_workflow() -> dict:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    workflow["on"] = workflow.pop(True, workflow.get("on"))
+    return workflow
+
+
+def _steps() -> list[dict]:
+    return _load_workflow()["jobs"]["markdown-file-check"]["steps"]
+
+
+def _script() -> str:
+    return _steps()[1]["with"]["script"]
+
+
+def test_markdown_gate_reruns_for_title_file_and_label_changes() -> None:
+    workflow = _load_workflow()
+
+    assert set(workflow["on"]["pull_request_target"]["types"]) == {
+        "opened",
+        "edited",
+        "synchronize",
+        "reopened",
+        "labeled",
+        "unlabeled",
+    }
+    assert workflow["permissions"] == {"contents": "read", "pull-requests": "write"}
+
+
+def test_markdown_gate_runs_only_base_revision_code() -> None:
+    checkout, check = _steps()
+
+    assert checkout["uses"] == CHECKOUT_PIN
+    assert checkout["with"] == {
+        "ref": "${{ github.event.pull_request.base.sha }}",
+        "persist-credentials": False,
+        "sparse-checkout": ".github/scripts/checks/markdown_file_check.js",
+    }
+    assert check["uses"] == GITHUB_SCRIPT_PIN
+    assert "require('./.github/scripts/checks/markdown_file_check.js')" in _script()
+
+
+def test_markdown_gate_uses_live_files_labels_and_fail_closed_checks() -> None:
+    script = _script()
+
+    assert "github.paginate(github.rest.pulls.listFiles" in script
+    assert "typeof pullRequest.changed_files !== 'number'" in script
+    assert "files.length !== pullRequest.changed_files" in script
+    assert "markdown-added: acknowledged" in script
+    assert "listLabelsOnIssue" in script
+    assert "<!-- markdown-file-check -->" in script
+
+
+def test_markdown_gate_sets_failure_before_comment_write() -> None:
+    script = _script()
+
+    failure = script.index("core.setFailed(`Non-docs PR adds")
+    comment = script.index("await upsertStickyComment(body)", failure)
+    assert failure < comment

--- a/.github/scripts/tests/workflows/test_markdown_workflow.py
+++ b/.github/scripts/tests/workflows/test_markdown_workflow.py
@@ -1,4 +1,11 @@
-"""Contracts for the new-Markdown-file pull request gate."""
+"""Structural contracts for the new-Markdown-file pull request gate.
+
+The gate's *behavior* is tested in
+`.github/scripts/tests/checks/markdown_file_check.test.js`, which runs the real
+`run()` against a fake octokit. This module covers only what lives in YAML and
+therefore cannot be executed: the trigger list, the permissions, the trusted
+checkout, and the thinness of the inline script itself.
+"""
 
 from pathlib import Path
 
@@ -6,12 +13,14 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[4]
 WORKFLOW = ROOT / ".github" / "workflows" / "markdown_file_check.yml"
+DETECTOR = ".github/scripts/checks/markdown_file_check.js"
 GITHUB_SCRIPT_PIN = "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3"
 CHECKOUT_PIN = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
 
 
 def _load_workflow() -> dict:
     workflow = yaml.safe_load(WORKFLOW.read_text())
+    # PyYAML resolves the bare `on:` key to the boolean True.
     workflow["on"] = workflow.pop(True, workflow.get("on"))
     return workflow
 
@@ -25,6 +34,7 @@ def _script() -> str:
 
 
 def test_markdown_gate_reruns_for_title_file_and_label_changes() -> None:
+    """Without `labeled`/`unlabeled` the bypass label needs a push to take effect."""
     workflow = _load_workflow()
 
     assert set(workflow["on"]["pull_request_target"]["types"]) == {
@@ -39,32 +49,51 @@ def test_markdown_gate_reruns_for_title_file_and_label_changes() -> None:
 
 
 def test_markdown_gate_runs_only_base_revision_code() -> None:
+    """The detector must come from base, never from the PR's own head.
+
+    This job holds `pull-requests: write` under `pull_request_target`. A head
+    checkout would both run PR-authored code against that token and let a PR
+    edit the detector to pass itself.
+    """
     checkout, check = _steps()
 
     assert checkout["uses"] == CHECKOUT_PIN
-    assert checkout["with"] == {
-        "ref": "${{ github.event.pull_request.base.sha }}",
-        "persist-credentials": False,
-        "sparse-checkout": ".github/scripts/checks/markdown_file_check.js",
-    }
+    assert checkout["with"]["ref"] == "${{ github.event.pull_request.base.sha }}"
+    assert checkout["with"]["persist-credentials"] is False
+    assert checkout["with"]["sparse-checkout"].strip() == DETECTOR
+    # Cone mode is for directory prefixes; declare the single-file intent.
+    assert checkout["with"]["sparse-checkout-cone-mode"] is False
     assert check["uses"] == GITHUB_SCRIPT_PIN
-    assert "require('./.github/scripts/checks/markdown_file_check.js')" in _script()
 
 
-def test_markdown_gate_uses_live_files_labels_and_fail_closed_checks() -> None:
+def test_markdown_gate_delegates_to_the_tested_module() -> None:
+    """Logic in the YAML string cannot be executed by any test, so keep it out.
+
+    Anything that moves back into the `script:` block silently loses its
+    coverage: an inverted condition there still ships green.
+    """
     script = _script()
 
-    assert "github.paginate(github.rest.pulls.listFiles" in script
-    assert "typeof pullRequest.changed_files !== 'number'" in script
-    assert "files.length !== pullRequest.changed_files" in script
-    assert "markdown-added: acknowledged" in script
-    assert "listLabelsOnIssue" in script
-    assert "<!-- markdown-file-check -->" in script
+    assert "require(detector)" in script
+    assert DETECTOR in script
+    assert "await run({ github, context, core })" in script
+
+    # Allow the existence guard and the require, nothing resembling a decision.
+    for forbidden in ("setFailed", "listFiles", "listLabelsOnIssue", "createComment"):
+        assert forbidden not in script, (
+            f"{forbidden} belongs in {DETECTOR}, where it can be tested"
+        )
 
 
-def test_markdown_gate_sets_failure_before_comment_write() -> None:
+def test_markdown_gate_tolerates_a_base_without_the_detector() -> None:
+    """Every PR open when this merges has a base.sha predating the detector.
+
+    Without the guard those runs die on an unhandled module-resolution error:
+    an opaque red X clearable only by rebasing.
+    """
     script = _script()
 
-    failure = script.index("core.setFailed(`Non-docs PR adds")
-    comment = script.index("await upsertStickyComment(body)", failure)
-    assert failure < comment
+    assert "fs.existsSync(detector)" in script
+    # Warning, not notice: a detector renamed on base without updating this
+    # path silently disarms the gate, which must surface in the Checks UI.
+    assert "core.warning(" in script

--- a/.github/workflows/markdown_file_check.yml
+++ b/.github/workflows/markdown_file_check.yml
@@ -1,0 +1,156 @@
+name: "📝 Markdown file check"
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  markdown-file-check:
+    name: "require acknowledgment for new Markdown files"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    concurrency:
+      group: markdown-file-check-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: "Checkout detector from trusted base"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/checks/markdown_file_check.js
+
+      - name: "Check newly added Markdown files"
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const {
+              addedMarkdownFiles,
+              fileLines,
+              isDocsTitle,
+            } = require('./.github/scripts/checks/markdown_file_check.js');
+            const STICKY_MARKER = '<!-- markdown-file-check -->';
+            const ACKNOWLEDGMENT_LABEL = 'markdown-added: acknowledged';
+            const pullRequest = context.payload.pull_request;
+            if (!pullRequest) {
+              core.setFailed('No pull_request payload; this workflow only supports pull_request_target events.');
+              return;
+            }
+
+            const { number, title } = pullRequest;
+
+            async function findStickyComment() {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                ...context.repo,
+                issue_number: number,
+                per_page: 100,
+              });
+              return comments.find(comment => comment.body?.startsWith(STICKY_MARKER));
+            }
+
+            async function removeStickyComment() {
+              try {
+                const existing = await findStickyComment();
+                if (existing) {
+                  await github.rest.issues.deleteComment({
+                    ...context.repo,
+                    comment_id: existing.id,
+                  });
+                }
+              } catch (error) {
+                core.warning(`Could not remove the prior Markdown-file comment: ${error.message}`);
+              }
+            }
+
+            async function upsertStickyComment(body) {
+              try {
+                const existing = await findStickyComment();
+                if (existing) {
+                  if (existing.body !== body) {
+                    await github.rest.issues.updateComment({
+                      ...context.repo,
+                      comment_id: existing.id,
+                      body,
+                    });
+                  }
+                } else {
+                  await github.rest.issues.createComment({
+                    ...context.repo,
+                    issue_number: number,
+                    body,
+                  });
+                }
+              } catch (error) {
+                core.warning(`Could not post the Markdown-file comment: ${error.message}`);
+                try {
+                  await core.summary.addHeading('New Markdown files require acknowledgment').addRaw(body).write();
+                } catch (summaryError) {
+                  core.warning(`Could not write the job summary fallback: ${summaryError.message}`);
+                }
+              }
+            }
+
+            let files;
+            try {
+              files = await github.paginate(github.rest.pulls.listFiles, {
+                ...context.repo,
+                pull_number: number,
+                per_page: 100,
+              });
+            } catch (error) {
+              core.setFailed(`Could not list PR files: ${error.message}`);
+              return;
+            }
+
+            if (typeof pullRequest.changed_files !== 'number' || files.length !== pullRequest.changed_files) {
+              core.setFailed(`Changed-file list is incomplete (${files.length} collected, ${JSON.stringify(pullRequest.changed_files)} reported); failing closed.`);
+              return;
+            }
+
+            const markdownFiles = addedMarkdownFiles(files);
+            if (markdownFiles.length === 0 || isDocsTitle(title)) {
+              await removeStickyComment();
+              core.info(isDocsTitle(title) ? 'PR type is docs; no acknowledgment required.' : 'No newly added Markdown files.');
+              return;
+            }
+
+            let labels;
+            try {
+              ({ data: labels } = await github.rest.issues.listLabelsOnIssue({
+                ...context.repo,
+                issue_number: number,
+              }));
+            } catch (error) {
+              core.setFailed(`Could not read PR labels: ${error.message}`);
+              return;
+            }
+            const acknowledged = labels.some(label => label.name === ACKNOWLEDGMENT_LABEL);
+            const shownFiles = fileLines(markdownFiles);
+            const body = acknowledged
+              ? [
+                  STICKY_MARKER,
+                  `ℹ️ **New Markdown files acknowledged** via the \`${ACKNOWLEDGMENT_LABEL}\` label.`,
+                  '',
+                  ...shownFiles,
+                  '',
+                  'Remove the label to re-enable the block.',
+                ].join('\n')
+              : [
+                  STICKY_MARKER,
+                  '⛔ **This non-docs PR adds new Markdown files.**',
+                  '',
+                  ...shownFiles,
+                  '',
+                  'Change the PR type to `docs` if it only contains documentation changes. Otherwise, review the new files and apply the acknowledgment label:',
+                  '',
+                  `\`${ACKNOWLEDGMENT_LABEL}\``,
+                ].join('\n');
+
+            if (!acknowledged) {
+              core.setFailed(`Non-docs PR adds ${markdownFiles.length} Markdown file(s); apply '${ACKNOWLEDGMENT_LABEL}' to acknowledge.`);
+            }
+            await upsertStickyComment(body);

--- a/.github/workflows/markdown_file_check.yml
+++ b/.github/workflows/markdown_file_check.yml
@@ -45,10 +45,12 @@
 # Limitations:
 #   - Matches `.md` only. The repo has no `.mdx` or `.markdown` files today; add
 #     them to `isMarkdown` if that changes.
-#   - The PR title is read from the event payload while files and labels are read
-#     live, so a title edited between event delivery and job execution is
-#     evaluated stale. `edited` is in the trigger list, so the edit fires its own
-#     corrective run; the residual exposure is one green check a merge could race.
+#   - Nothing is decided from the event payload except the PR number. Title,
+#     author, head, and changed-file total all come from a live `pulls.get`,
+#     because two rapid title edits queue two runs against the same head SHA and
+#     check name, and nothing guarantees the newer event finishes last. A stale
+#     `docs:` payload landing after a `feat:` retitle would otherwise publish a
+#     green required check that a re-run cannot repair.
 
 name: "📝 Markdown file check"
 
@@ -70,8 +72,9 @@ jobs:
     concurrency:
       group: markdown-file-check-${{ github.event.pull_request.number }}
       # Not cancel-in-progress: a cancelled run leaves whatever sticky comment
-      # the previous one wrote, and the label-toggle path depends on the final
-      # state being written by the last event, not the fastest one.
+      # the previous one wrote. Runs are allowed to overlap because none of them
+      # trusts its own event payload — each re-reads the PR live — so a run that
+      # finishes out of order still decides on current state.
       cancel-in-progress: false
     steps:
       - name: "Checkout detector from trusted base"

--- a/.github/workflows/markdown_file_check.yml
+++ b/.github/workflows/markdown_file_check.yml
@@ -1,7 +1,61 @@
+# Pre-merge blocking check for newly added Markdown files on non-docs PRs.
+#
+# Why this exists:
+#   Markdown accumulates faster than anyone reads it. A `feat:` or `fix:` PR
+#   that quietly lands a new README, design note, or migration guide adds a
+#   document nobody agreed to maintain, and it is invisible in a diff dominated
+#   by code. This check finds Markdown files the PR causes to exist, posts a
+#   sticky comment listing them, and FAILS so a maintainer makes an explicit
+#   call before merge.
+#
+# Bypasses:
+#   - `docs(...)` PR titles pass: a docs-typed PR is already declaring that
+#     documentation is the point of the change.
+#   - release-please PRs pass. Onboarding a new package produces that package's
+#     first CHANGELOG.md under a `release(<pkg>):` title, and a bot PR cannot
+#     apply the acknowledgment label to unblock itself. The exemption is gated
+#     on provenance (author identity, branch prefix, same-repo head), never on
+#     the title — see isReleasePleasePr in the detector.
+#   - Apply the `markdown-added: acknowledged` label when the new files are
+#     intentional. The check re-runs on `labeled`/`unlabeled`, leaves an
+#     informational sticky note, and passes while the label is present.
+#
+# To actually gate merges, add this check to the branch's required status checks.
+#
+# Trust model:
+#   - NEVER CHECK OUT UNTRUSTED CODE FROM A PR's HEAD IN A pull_request_target
+#     JOB. This job holds `pull-requests: write`, so head code would run with a
+#     token that can write to the PR. The checkout below is pinned to
+#     `base.sha` and sparse to the single detector file; no head-supplied code
+#     is fetched, and nothing is executed from the PR.
+#   - The detector runs from the PR *base* revision, so a PR cannot edit
+#     markdown_file_check.js to return "[]" and self-bypass the gate. The PR
+#     title (event payload), changed-file list, and labels (API) are fed in
+#     separately and are authoritative regardless of this checkout.
+#   - `pull_request_target` rather than the `pull_request` its sibling
+#     pr_scope_file_check.yml uses. Deliberate, and it buys two things: fork
+#     PRs get a real sticky comment instead of a job-summary consolation prize,
+#     and the *workflow file itself* comes from base, so a PR that edits this
+#     file cannot neuter its own gate. The cost is the write token, which is
+#     why the checkout discipline above is load-bearing rather than incidental.
+#   - `persist-credentials: false` so the job token is not written into the
+#     checkout's git config; the detector needs no git credentials, and the
+#     github-script step receives its own token directly.
+#
+# Limitations:
+#   - Matches `.md` only. The repo has no `.mdx` or `.markdown` files today; add
+#     them to `isMarkdown` if that changes.
+#   - The PR title is read from the event payload while files and labels are read
+#     live, so a title edited between event delivery and job execution is
+#     evaluated stale. `edited` is in the trigger list, so the edit fires its own
+#     corrective run; the residual exposure is one green check a merge could race.
+
 name: "📝 Markdown file check"
 
 on:
   pull_request_target:
+    # `labeled`/`unlabeled` so applying the acknowledgment label re-runs the
+    # check and clears the red without needing a new commit.
     types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 permissions:
@@ -15,6 +69,9 @@ jobs:
     timeout-minutes: 3
     concurrency:
       group: markdown-file-check-${{ github.event.pull_request.number }}
+      # Not cancel-in-progress: a cancelled run leaves whatever sticky comment
+      # the previous one wrote, and the label-toggle path depends on the final
+      # state being written by the last event, not the fastest one.
       cancel-in-progress: false
     steps:
       - name: "Checkout detector from trusted base"
@@ -22,135 +79,34 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
-          sparse-checkout: .github/scripts/checks/markdown_file_check.js
+          sparse-checkout: |
+            .github/scripts/checks/markdown_file_check.js
+          # Cone mode is for directory prefixes; this is a single file path.
+          # It happens to resolve under cone mode too, but declaring the
+          # non-cone form states the intent rather than relying on that.
+          sparse-checkout-cone-mode: false
 
       - name: "Check newly added Markdown files"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const {
-              addedMarkdownFiles,
-              fileLines,
-              isDocsTitle,
-            } = require('./.github/scripts/checks/markdown_file_check.js');
-            const STICKY_MARKER = '<!-- markdown-file-check -->';
-            const ACKNOWLEDGMENT_LABEL = 'markdown-added: acknowledged';
-            const pullRequest = context.payload.pull_request;
-            if (!pullRequest) {
-              core.setFailed('No pull_request payload; this workflow only supports pull_request_target events.');
+            const fs = require('fs');
+            const detector = './.github/scripts/checks/markdown_file_check.js';
+            // The detector is absent on base revisions predating this check:
+            // the bootstrapping PR that introduces it, and every PR already
+            // open when it merges (their recorded base.sha is older). Without
+            // this guard those runs die on an unhandled module-resolution
+            // error — an opaque red X the author can only clear by rebasing.
+            //
+            // Not a self-bypass vector: presence is read from trusted base, and
+            // head edits never change base. An author can target an old base
+            // that never had the detector, but gains nothing — that base never
+            // gated anything. Warn (not notice) so a detector renamed on base
+            // without updating this path surfaces in the Checks UI instead of
+            // silently disarming the gate.
+            if (!fs.existsSync(detector)) {
+              core.warning(`Detector '${detector}' absent on the base revision; the Markdown-file check is NOT enforcing. Expected on the bootstrapping PR or a branch cut from before it existed — otherwise the detector path here may be out of sync with the repo.`);
               return;
             }
-
-            const { number, title } = pullRequest;
-
-            async function findStickyComment() {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                ...context.repo,
-                issue_number: number,
-                per_page: 100,
-              });
-              return comments.find(comment => comment.body?.startsWith(STICKY_MARKER));
-            }
-
-            async function removeStickyComment() {
-              try {
-                const existing = await findStickyComment();
-                if (existing) {
-                  await github.rest.issues.deleteComment({
-                    ...context.repo,
-                    comment_id: existing.id,
-                  });
-                }
-              } catch (error) {
-                core.warning(`Could not remove the prior Markdown-file comment: ${error.message}`);
-              }
-            }
-
-            async function upsertStickyComment(body) {
-              try {
-                const existing = await findStickyComment();
-                if (existing) {
-                  if (existing.body !== body) {
-                    await github.rest.issues.updateComment({
-                      ...context.repo,
-                      comment_id: existing.id,
-                      body,
-                    });
-                  }
-                } else {
-                  await github.rest.issues.createComment({
-                    ...context.repo,
-                    issue_number: number,
-                    body,
-                  });
-                }
-              } catch (error) {
-                core.warning(`Could not post the Markdown-file comment: ${error.message}`);
-                try {
-                  await core.summary.addHeading('New Markdown files require acknowledgment').addRaw(body).write();
-                } catch (summaryError) {
-                  core.warning(`Could not write the job summary fallback: ${summaryError.message}`);
-                }
-              }
-            }
-
-            let files;
-            try {
-              files = await github.paginate(github.rest.pulls.listFiles, {
-                ...context.repo,
-                pull_number: number,
-                per_page: 100,
-              });
-            } catch (error) {
-              core.setFailed(`Could not list PR files: ${error.message}`);
-              return;
-            }
-
-            if (typeof pullRequest.changed_files !== 'number' || files.length !== pullRequest.changed_files) {
-              core.setFailed(`Changed-file list is incomplete (${files.length} collected, ${JSON.stringify(pullRequest.changed_files)} reported); failing closed.`);
-              return;
-            }
-
-            const markdownFiles = addedMarkdownFiles(files);
-            if (markdownFiles.length === 0 || isDocsTitle(title)) {
-              await removeStickyComment();
-              core.info(isDocsTitle(title) ? 'PR type is docs; no acknowledgment required.' : 'No newly added Markdown files.');
-              return;
-            }
-
-            let labels;
-            try {
-              ({ data: labels } = await github.rest.issues.listLabelsOnIssue({
-                ...context.repo,
-                issue_number: number,
-              }));
-            } catch (error) {
-              core.setFailed(`Could not read PR labels: ${error.message}`);
-              return;
-            }
-            const acknowledged = labels.some(label => label.name === ACKNOWLEDGMENT_LABEL);
-            const shownFiles = fileLines(markdownFiles);
-            const body = acknowledged
-              ? [
-                  STICKY_MARKER,
-                  `ℹ️ **New Markdown files acknowledged** via the \`${ACKNOWLEDGMENT_LABEL}\` label.`,
-                  '',
-                  ...shownFiles,
-                  '',
-                  'Remove the label to re-enable the block.',
-                ].join('\n')
-              : [
-                  STICKY_MARKER,
-                  '⛔ **This non-docs PR adds new Markdown files.**',
-                  '',
-                  ...shownFiles,
-                  '',
-                  'Change the PR type to `docs` if it only contains documentation changes. Otherwise, review the new files and apply the acknowledgment label:',
-                  '',
-                  `\`${ACKNOWLEDGMENT_LABEL}\``,
-                ].join('\n');
-
-            if (!acknowledged) {
-              core.setFailed(`Non-docs PR adds ${markdownFiles.length} Markdown file(s); apply '${ACKNOWLEDGMENT_LABEL}' to acknowledge.`);
-            }
-            await upsertStickyComment(body);
+            const { run } = require(detector);
+            await run({ github, context, core });


### PR DESCRIPTION
Non-`docs` pull requests that add Markdown files now fail a dedicated check until a maintainer applies `markdown-added: acknowledged`.

---

The `markdown-added: acknowledged` repository label was created for the bypass path.

Made by [Open SWE](https://openswe.vercel.app/agents/1516c9b5-b6a8-5915-be33-276e59bf178b)