### PR TITLE
fix(code): show bound workspace in shell approvals

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -139,6 +139,7 @@ from deepagents_code.unicode_security import (
     detect_dangerous_unicode,
     format_warning_detail,
     render_with_unicode_markers,
+    sanitize_control_chars,
     strip_dangerous_unicode,
     summarize_issues,
 )
@@ -1821,7 +1822,8 @@ def _format_execute_description(
             if project_context is not None
             else str(Path.cwd())
         )
-    lines = [f"Execute Command: {command}", f"Working Directory: {effective_cwd}"]
+    display_cwd = sanitize_control_chars(str(effective_cwd), collapse_whitespace=False)
+    lines = [f"Execute Command: {command}", f"Working Directory: {display_cwd}"]
 
     issues = detect_dangerous_unicode(command_raw)
     if issues:

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1796,7 +1796,7 @@ def _format_task_description(
 
 
 def _format_execute_description(
-    tool_call: ToolCall, _state: AgentState[Any], _runtime: Runtime[Any]
+    tool_call: ToolCall, _state: AgentState[Any], runtime: Runtime[Any]
 ) -> str:
     """Format execute tool call for approval prompt.
 
@@ -1806,12 +1806,21 @@ def _format_execute_description(
     args = tool_call["args"]
     command_raw = str(args.get("command", "N/A"))
     command = strip_dangerous_unicode(command_raw)
-    project_context = get_server_project_context()
-    effective_cwd = (
-        str(project_context.user_cwd)
-        if project_context is not None
-        else str(Path.cwd())
-    )
+    context = runtime.context
+    if isinstance(context, CLIContextSchema):
+        workspace: object = context.workspace
+    elif isinstance(context, dict):
+        workspace = context.get("workspace")
+    else:
+        workspace = None
+    effective_cwd = workspace.get("cwd") if isinstance(workspace, dict) else None
+    if not isinstance(effective_cwd, str) or not effective_cwd:
+        project_context = get_server_project_context()
+        effective_cwd = (
+            str(project_context.user_cwd)
+            if project_context is not None
+            else str(Path.cwd())
+        )
     lines = [f"Execute Command: {command}", f"Working Directory: {effective_cwd}"]
 
     issues = detect_dangerous_unicode(command_raw)

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1801,21 +1801,36 @@ def _format_execute_description(
 ) -> str:
     """Format execute tool call for approval prompt.
 
+    The working directory shown is the one the command runs in. The run's
+    bound workspace supplies it: `require_thread_workspace` matches every
+    field of the claimed context against the durable binding before the run
+    starts, so the value is server-validated and not a client claim. A run
+    with no workspace -- the in-process `Pregel` path -- falls back to the
+    server project context, then to the process CWD. Both fallbacks are
+    process-global, so on a server hosting several bound workspaces they can
+    name a directory the command will not run in; the warning below marks
+    that.
+
     Returns:
         Formatted description string for the execute tool call.
     """
     args = tool_call["args"]
     command_raw = str(args.get("command", "N/A"))
     command = strip_dangerous_unicode(command_raw)
-    context = runtime.context
-    if isinstance(context, CLIContextSchema):
-        workspace: object = context.workspace
-    elif isinstance(context, dict):
-        workspace = context.get("workspace")
-    else:
-        workspace = None
+    # `from_payload` is the single conversion point for the two context
+    # shapes (in-process dataclass, remote JSON dict); it also normalizes a
+    # malformed `workspace` to `{}`.
+    context = CLIContextSchema.from_payload(runtime.context)
+    workspace = context.workspace if context is not None else {}
     effective_cwd = workspace.get("cwd") if isinstance(workspace, dict) else None
+    # An empty or non-str `cwd` would render a blank directory line, which
+    # reads as "no directory" rather than as missing data. Fall through.
     if not isinstance(effective_cwd, str) or not effective_cwd:
+        logger.warning(
+            "Shell approval prompt has no bound workspace cwd; the directory "
+            "shown may not be where this command runs (workspace=%r)",
+            workspace,
+        )
         project_context = get_server_project_context()
         effective_cwd = (
             str(project_context.user_cwd)

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1801,15 +1801,11 @@ def _format_execute_description(
 ) -> str:
     """Format execute tool call for approval prompt.
 
-    The working directory shown is the one the command runs in. The run's
-    bound workspace supplies it: `require_thread_workspace` matches every
-    field of the claimed context against the durable binding before the run
-    starts, so the value is server-validated and not a client claim. A run
-    with no workspace -- the in-process `Pregel` path -- falls back to the
-    server project context, then to the process CWD. Both fallbacks are
-    process-global, so on a server hosting several bound workspaces they can
-    name a directory the command will not run in; the warning below marks
-    that.
+    The working directory comes from the run's bound workspace, which
+    `require_thread_workspace` validates against the durable binding before
+    the run starts. A run with no workspace falls back to the process-global
+    server project context and then the process CWD; both can name a
+    directory the command will not run in, so the fallback warns.
 
     Returns:
         Formatted description string for the execute tool call.
@@ -1817,9 +1813,6 @@ def _format_execute_description(
     args = tool_call["args"]
     command_raw = str(args.get("command", "N/A"))
     command = strip_dangerous_unicode(command_raw)
-    # `from_payload` is the single conversion point for the two context
-    # shapes (in-process dataclass, remote JSON dict); it also normalizes a
-    # malformed `workspace` to `{}`.
     context = CLIContextSchema.from_payload(runtime.context)
     workspace = context.workspace if context is not None else {}
     effective_cwd = workspace.get("cwd") if isinstance(workspace, dict) else None
@@ -1837,7 +1830,7 @@ def _format_execute_description(
             if project_context is not None
             else str(Path.cwd())
         )
-    display_cwd = sanitize_control_chars(str(effective_cwd), collapse_whitespace=False)
+    display_cwd = sanitize_control_chars(effective_cwd, collapse_whitespace=False)
     lines = [f"Execute Command: {command}", f"Working Directory: {display_cwd}"]
 
     issues = detect_dangerous_unicode(command_raw)

--- a/libs/code/deepagents_code/tui/widgets/approval.py
+++ b/libs/code/deepagents_code/tui/widgets/approval.py
@@ -272,6 +272,24 @@ class ApprovalMenu(Container):
             ),
         )
 
+    def _get_minimal_description(self) -> Content | None:
+        """Get supplemental details for a minimal execute approval.
+
+        Returns:
+            Styled supplemental details, or `None` when none are available.
+        """
+        request = self._action_requests[0]
+        description = request.get("description")
+        if not isinstance(description, str) or not description:
+            return None
+
+        command_raw = str(request.get("args", {}).get("command", ""))
+        command = strip_dangerous_unicode(command_raw)
+        details = description.replace(f"Execute Command: {command}\n", "", 1)
+        if not details:
+            return None
+        return Content.from_markup("[dim]$details[/dim]", details=details)
+
     def compose(self) -> ComposeResult:
         """Compose the widget with Static children.
 
@@ -316,6 +334,9 @@ class ApprovalMenu(Container):
                 classes="approval-command",
             )
             yield self._command_widget
+            description = self._get_minimal_description()
+            if description is not None:
+                yield Static(description, classes="approval-description")
 
         # Tool info - only for non-minimal tools (diffs, writes show actual content)
         if not self._is_minimal:

--- a/libs/code/deepagents_code/tui/widgets/approval.py
+++ b/libs/code/deepagents_code/tui/widgets/approval.py
@@ -290,8 +290,10 @@ class ApprovalMenu(Container):
     def _get_minimal_description(self) -> Static | None:
         """Get supplemental details for a minimal execute approval.
 
-        The command has its own widget, so drop the first line the formatter
-        reserves for it and keep the rest.
+        The command has its own widget, so drop the formatter's
+        `Execute Command:` line and keep the rest. Auto-mode fallbacks prefix
+        the description with a review notice ahead of that line, so match the
+        line itself rather than assuming it is first.
 
         Returns:
             Widget holding the supplemental details, or `None` when there are
@@ -300,7 +302,10 @@ class ApprovalMenu(Container):
         description = self._action_requests[0].get("description")
         if not isinstance(description, str):
             return None
-        details = description.partition("\n")[2]
+        lines = description.splitlines()
+        details = "\n".join(
+            line for line in lines if not line.startswith("Execute Command:")
+        ).strip()
         if not details:
             return None
         return _description_widget(details)

--- a/libs/code/deepagents_code/tui/widgets/approval.py
+++ b/libs/code/deepagents_code/tui/widgets/approval.py
@@ -84,6 +84,21 @@ def _truncate_command(command: str) -> str:
     return command + ellipsis if truncated else command
 
 
+def _description_widget(description: str) -> Static:
+    """Build the dim widget that renders an approval description.
+
+    Args:
+        description: The description text to render.
+
+    Returns:
+        The styled description widget.
+    """
+    return Static(
+        Content.from_markup("[dim]$desc[/dim]", desc=description),
+        classes="approval-description",
+    )
+
+
 class ApprovalMenu(Container):
     """Approval menu using standard Textual patterns.
 
@@ -272,23 +287,23 @@ class ApprovalMenu(Container):
             ),
         )
 
-    def _get_minimal_description(self) -> Content | None:
+    def _get_minimal_description(self) -> Static | None:
         """Get supplemental details for a minimal execute approval.
 
-        Returns:
-            Styled supplemental details, or `None` when none are available.
-        """
-        request = self._action_requests[0]
-        description = request.get("description")
-        if not isinstance(description, str) or not description:
-            return None
+        The command has its own widget, so drop the first line the formatter
+        reserves for it and keep the rest.
 
-        command_raw = str(request.get("args", {}).get("command", ""))
-        command = strip_dangerous_unicode(command_raw)
-        details = description.replace(f"Execute Command: {command}\n", "", 1)
+        Returns:
+            Widget holding the supplemental details, or `None` when there are
+            none.
+        """
+        description = self._action_requests[0].get("description")
+        if not isinstance(description, str):
+            return None
+        details = description.partition("\n")[2]
         if not details:
             return None
-        return Content.from_markup("[dim]$details[/dim]", details=details)
+        return _description_widget(details)
 
     def compose(self) -> ComposeResult:
         """Compose the widget with Static children.
@@ -334,9 +349,9 @@ class ApprovalMenu(Container):
                 classes="approval-command",
             )
             yield self._command_widget
-            description = self._get_minimal_description()
-            if description is not None:
-                yield Static(description, classes="approval-description")
+            description_widget = self._get_minimal_description()
+            if description_widget is not None:
+                yield description_widget
 
         # Tool info - only for non-minimal tools (diffs, writes show actual content)
         if not self._is_minimal:
@@ -441,11 +456,7 @@ class ApprovalMenu(Container):
             # Show description if present
             description = action_request.get("description")
             if description:
-                desc_widget = Static(
-                    Content.from_markup("[dim]$desc[/dim]", desc=description),
-                    classes="approval-description",
-                )
-                await self._tool_info_container.mount(desc_widget)
+                await self._tool_info_container.mount(_description_widget(description))
 
             # Get the appropriate renderer for this tool
             renderer = get_renderer(tool_name)

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -1,6 +1,7 @@
 """Unit tests for agent formatting functions."""
 
 import asyncio
+import logging
 import sys
 import warnings
 from collections.abc import Iterator, Mapping
@@ -999,7 +1000,7 @@ def test_format_delete_description() -> None:
 
 
 def test_format_execute_description_prefers_workspace_binding() -> None:
-    """The approval prompt shows the run's workspace instead of the server CWD."""
+    """The prompt shows the run's workspace, not the server CWD (dict context)."""
     tool_call = cast(
         "ToolCall",
         {"name": "execute", "args": {"command": "pwd"}, "id": "call-6"},
@@ -1023,7 +1024,11 @@ def test_format_execute_description_prefers_workspace_binding() -> None:
 
 
 def test_format_execute_description_varies_by_workspace_binding() -> None:
-    """One server formats each run with its own bound working directory."""
+    """Each run formats with its own bound working directory (typed context).
+
+    One server process hosts several bound workspaces, so a per-run value is
+    the property under test.
+    """
     tool_call = cast(
         "ToolCall",
         {"name": "execute", "args": {"command": "pwd"}, "id": "call-7"},
@@ -1049,6 +1054,8 @@ def test_format_execute_description_varies_by_workspace_binding() -> None:
 
     assert "Working Directory: /workspace/thread-a" in descriptions[0]
     assert "Working Directory: /workspace/thread-b" in descriptions[1]
+    assert "/workspace/server" not in descriptions[0]
+    assert "/workspace/server" not in descriptions[1]
 
 
 def test_format_execute_description_sanitizes_workspace_binding() -> None:
@@ -1104,7 +1111,58 @@ def test_format_execute_description_without_workspace_uses_existing_fallback(
         )
 
     assert "Working Directory: /workspace/server" in server_description
-    assert f"Working Directory: {tmp_path}" in process_description
+    assert f"Working Directory: {tmp_path.resolve()}" in process_description
+
+
+@pytest.mark.parametrize(
+    "context",
+    [
+        pytest.param({"workspace": "not-a-dict"}, id="workspace-not-a-mapping"),
+        pytest.param({"workspace": ["cwd"]}, id="workspace-is-a-list"),
+        pytest.param({"workspace": {"cwd": ""}}, id="cwd-empty"),
+        pytest.param({"workspace": {"cwd": None}}, id="cwd-none"),
+        pytest.param({"workspace": {"cwd": 7}}, id="cwd-not-a-string"),
+        pytest.param({"workspace": {"working_dir": "/x"}}, id="cwd-key-renamed"),
+        pytest.param(None, id="context-absent"),
+        pytest.param("not-a-context", id="context-wrong-type"),
+    ],
+)
+def test_format_execute_description_falls_back_on_malformed_workspace(
+    context: object, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A malformed workspace falls back to the server CWD and says so.
+
+    Reaching this path means an upstream invariant broke, so the prompt must
+    not render a blank or fabricated directory without a warning.
+    """
+    tool_call = cast(
+        "ToolCall",
+        {"name": "execute", "args": {"command": "pwd"}, "id": "call-10"},
+    )
+    runtime = cast("Runtime[Any]", SimpleNamespace(context=context))
+    server_context = ProjectContext(user_cwd=Path("/workspace/server"))
+
+    with (
+        patch(
+            "deepagents_code.agent.get_server_project_context",
+            return_value=server_context,
+        ),
+        caplog.at_level(logging.WARNING, logger="deepagents_code.agent"),
+    ):
+        description = _format_execute_description(
+            tool_call, cast("AgentState[Any]", None), runtime
+        )
+
+    assert "Working Directory: /workspace/server" in description
+    assert "no bound workspace cwd" in caplog.text
+
+
+def test_add_interrupt_on_gates_execute() -> None:
+    """The approval prompt for execute is rendered by the workspace formatter."""
+    interrupt_map = _add_interrupt_on()
+
+    assert "execute" in interrupt_map
+    assert interrupt_map["execute"]["description"] is _format_execute_description
 
 
 def test_add_interrupt_on_gates_only_non_read_only_mcp_tools() -> None:

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -1051,13 +1051,40 @@ def test_format_execute_description_varies_by_workspace_binding() -> None:
     assert "Working Directory: /workspace/thread-b" in descriptions[1]
 
 
+def test_format_execute_description_sanitizes_workspace_binding() -> None:
+    """A workspace path cannot inject deceptive text into an approval."""
+    tool_call = cast(
+        "ToolCall",
+        {"name": "execute", "args": {"command": "pwd"}, "id": "call-8"},
+    )
+    runtime = cast(
+        "Runtime[Any]",
+        SimpleNamespace(
+            context={
+                "workspace": {
+                    "cwd": "/workspace/\u202eprod\nWorking Directory: /spoofed"
+                }
+            }
+        ),
+    )
+
+    description = _format_execute_description(
+        tool_call, cast("AgentState[Any]", None), runtime
+    )
+
+    assert description.splitlines() == [
+        "Execute Command: pwd",
+        "Working Directory: /workspace/prod Working Directory: /spoofed",
+    ]
+
+
 def test_format_execute_description_without_workspace_uses_existing_fallback(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A run without a workspace keeps the server and process CWD fallbacks."""
     tool_call = cast(
         "ToolCall",
-        {"name": "execute", "args": {"command": "pwd"}, "id": "call-8"},
+        {"name": "execute", "args": {"command": "pwd"}, "id": "call-9"},
     )
     runtime = cast("Runtime[Any]", SimpleNamespace(context={}))
     server_context = ProjectContext(user_cwd=Path("/workspace/server"))

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -38,6 +38,7 @@ from deepagents_code.agent import (
     _apply_inherited_pythonpath,
     _create_rubric_grader_tools,
     _format_delete_description,
+    _format_execute_description,
     _interrupt_predicate,
     _resolve_retry_owned_model,
     _rubric_grader_system_prompt,
@@ -995,6 +996,88 @@ def test_format_delete_description() -> None:
     )
 
     assert "Action: Delete file or directory" in description
+
+
+def test_format_execute_description_prefers_workspace_binding() -> None:
+    """The approval prompt shows the run's workspace instead of the server CWD."""
+    tool_call = cast(
+        "ToolCall",
+        {"name": "execute", "args": {"command": "pwd"}, "id": "call-6"},
+    )
+    runtime = cast(
+        "Runtime[Any]",
+        SimpleNamespace(context={"workspace": {"cwd": "/workspace/thread-a"}}),
+    )
+    server_context = ProjectContext(user_cwd=Path("/workspace/server"))
+
+    with patch(
+        "deepagents_code.agent.get_server_project_context",
+        return_value=server_context,
+    ):
+        description = _format_execute_description(
+            tool_call, cast("AgentState[Any]", None), runtime
+        )
+
+    assert "Working Directory: /workspace/thread-a" in description
+    assert "/workspace/server" not in description
+
+
+def test_format_execute_description_varies_by_workspace_binding() -> None:
+    """One server formats each run with its own bound working directory."""
+    tool_call = cast(
+        "ToolCall",
+        {"name": "execute", "args": {"command": "pwd"}, "id": "call-7"},
+    )
+    contexts = [
+        CLIContextSchema(workspace={"cwd": "/workspace/thread-a"}),
+        CLIContextSchema(workspace={"cwd": "/workspace/thread-b"}),
+    ]
+    server_context = ProjectContext(user_cwd=Path("/workspace/server"))
+
+    with patch(
+        "deepagents_code.agent.get_server_project_context",
+        return_value=server_context,
+    ):
+        descriptions = [
+            _format_execute_description(
+                tool_call,
+                cast("AgentState[Any]", None),
+                cast("Runtime[Any]", SimpleNamespace(context=context)),
+            )
+            for context in contexts
+        ]
+
+    assert "Working Directory: /workspace/thread-a" in descriptions[0]
+    assert "Working Directory: /workspace/thread-b" in descriptions[1]
+
+
+def test_format_execute_description_without_workspace_uses_existing_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run without a workspace keeps the server and process CWD fallbacks."""
+    tool_call = cast(
+        "ToolCall",
+        {"name": "execute", "args": {"command": "pwd"}, "id": "call-8"},
+    )
+    runtime = cast("Runtime[Any]", SimpleNamespace(context={}))
+    server_context = ProjectContext(user_cwd=Path("/workspace/server"))
+
+    with patch(
+        "deepagents_code.agent.get_server_project_context",
+        return_value=server_context,
+    ):
+        server_description = _format_execute_description(
+            tool_call, cast("AgentState[Any]", None), runtime
+        )
+
+    monkeypatch.chdir(tmp_path)
+    with patch("deepagents_code.agent.get_server_project_context", return_value=None):
+        process_description = _format_execute_description(
+            tool_call, cast("AgentState[Any]", None), runtime
+        )
+
+    assert "Working Directory: /workspace/server" in server_description
+    assert f"Working Directory: {tmp_path}" in process_description
 
 
 def test_add_interrupt_on_gates_only_non_read_only_mcp_tools() -> None:

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -999,16 +999,43 @@ def test_format_delete_description() -> None:
     assert "Action: Delete file or directory" in description
 
 
-def test_format_execute_description_prefers_workspace_binding() -> None:
-    """The prompt shows the run's workspace, not the server CWD (dict context)."""
-    tool_call = cast(
-        "ToolCall",
-        {"name": "execute", "args": {"command": "pwd"}, "id": "call-6"},
-    )
-    runtime = cast(
-        "Runtime[Any]",
-        SimpleNamespace(context={"workspace": {"cwd": "/workspace/thread-a"}}),
-    )
+_EXECUTE_TOOL_CALL = cast(
+    "ToolCall", {"name": "execute", "args": {"command": "pwd"}, "id": "call-6"}
+)
+
+
+def _execute_runtime(context: object) -> "Runtime[Any]":
+    return cast("Runtime[Any]", SimpleNamespace(context=context))
+
+
+@pytest.mark.parametrize(
+    ("context", "expected_cwd"),
+    [
+        pytest.param(
+            {"workspace": {"cwd": "/workspace/thread-a"}},
+            "/workspace/thread-a",
+            id="dict-context",
+        ),
+        pytest.param(
+            CLIContextSchema(workspace={"cwd": "/workspace/thread-a"}),
+            "/workspace/thread-a",
+            id="typed-context",
+        ),
+        pytest.param(
+            CLIContextSchema(workspace={"cwd": "/workspace/thread-b"}),
+            "/workspace/thread-b",
+            id="typed-context-other-workspace",
+        ),
+    ],
+)
+def test_format_execute_description_prefers_workspace_binding(
+    context: object, expected_cwd: str
+) -> None:
+    """The prompt shows the run's workspace, not the process-global server CWD.
+
+    One server process hosts several bound workspaces, so a per-run value is
+    the property under test.
+    """
     server_context = ProjectContext(user_cwd=Path("/workspace/server"))
 
     with patch(
@@ -1016,67 +1043,21 @@ def test_format_execute_description_prefers_workspace_binding() -> None:
         return_value=server_context,
     ):
         description = _format_execute_description(
-            tool_call, cast("AgentState[Any]", None), runtime
+            _EXECUTE_TOOL_CALL, cast("AgentState[Any]", None), _execute_runtime(context)
         )
 
-    assert "Working Directory: /workspace/thread-a" in description
+    assert f"Working Directory: {expected_cwd}" in description
     assert "/workspace/server" not in description
-
-
-def test_format_execute_description_varies_by_workspace_binding() -> None:
-    """Each run formats with its own bound working directory (typed context).
-
-    One server process hosts several bound workspaces, so a per-run value is
-    the property under test.
-    """
-    tool_call = cast(
-        "ToolCall",
-        {"name": "execute", "args": {"command": "pwd"}, "id": "call-7"},
-    )
-    contexts = [
-        CLIContextSchema(workspace={"cwd": "/workspace/thread-a"}),
-        CLIContextSchema(workspace={"cwd": "/workspace/thread-b"}),
-    ]
-    server_context = ProjectContext(user_cwd=Path("/workspace/server"))
-
-    with patch(
-        "deepagents_code.agent.get_server_project_context",
-        return_value=server_context,
-    ):
-        descriptions = [
-            _format_execute_description(
-                tool_call,
-                cast("AgentState[Any]", None),
-                cast("Runtime[Any]", SimpleNamespace(context=context)),
-            )
-            for context in contexts
-        ]
-
-    assert "Working Directory: /workspace/thread-a" in descriptions[0]
-    assert "Working Directory: /workspace/thread-b" in descriptions[1]
-    assert "/workspace/server" not in descriptions[0]
-    assert "/workspace/server" not in descriptions[1]
 
 
 def test_format_execute_description_sanitizes_workspace_binding() -> None:
     """A workspace path cannot inject deceptive text into an approval."""
-    tool_call = cast(
-        "ToolCall",
-        {"name": "execute", "args": {"command": "pwd"}, "id": "call-8"},
-    )
-    runtime = cast(
-        "Runtime[Any]",
-        SimpleNamespace(
-            context={
-                "workspace": {
-                    "cwd": "/workspace/\u202eprod\nWorking Directory: /spoofed"
-                }
-            }
-        ),
+    runtime = _execute_runtime(
+        {"workspace": {"cwd": "/workspace/\u202eprod\nWorking Directory: /spoofed"}}
     )
 
     description = _format_execute_description(
-        tool_call, cast("AgentState[Any]", None), runtime
+        _EXECUTE_TOOL_CALL, cast("AgentState[Any]", None), runtime
     )
 
     assert description.splitlines() == [
@@ -1085,40 +1066,33 @@ def test_format_execute_description_sanitizes_workspace_binding() -> None:
     ]
 
 
-def test_format_execute_description_without_workspace_uses_existing_fallback(
+def test_format_execute_description_without_workspace_uses_process_cwd(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A run without a workspace keeps the server and process CWD fallbacks."""
-    tool_call = cast(
-        "ToolCall",
-        {"name": "execute", "args": {"command": "pwd"}, "id": "call-9"},
-    )
-    runtime = cast("Runtime[Any]", SimpleNamespace(context={}))
-    server_context = ProjectContext(user_cwd=Path("/workspace/server"))
-
-    with patch(
-        "deepagents_code.agent.get_server_project_context",
-        return_value=server_context,
-    ):
-        server_description = _format_execute_description(
-            tool_call, cast("AgentState[Any]", None), runtime
-        )
-
+    """With neither a workspace nor a server context, the process CWD is shown."""
     monkeypatch.chdir(tmp_path)
+
     with patch("deepagents_code.agent.get_server_project_context", return_value=None):
-        process_description = _format_execute_description(
-            tool_call, cast("AgentState[Any]", None), runtime
+        description = _format_execute_description(
+            _EXECUTE_TOOL_CALL, cast("AgentState[Any]", None), _execute_runtime({})
         )
 
-    assert "Working Directory: /workspace/server" in server_description
-    assert f"Working Directory: {tmp_path.resolve()}" in process_description
+    assert f"Working Directory: {tmp_path.resolve()}" in description
 
 
 @pytest.mark.parametrize(
     "context",
     [
+        pytest.param({}, id="workspace-absent"),
+        pytest.param({"workspace": {}}, id="workspace-empty"),
         pytest.param({"workspace": "not-a-dict"}, id="workspace-not-a-mapping"),
         pytest.param({"workspace": ["cwd"]}, id="workspace-is-a-list"),
+        pytest.param(
+            # A dataclass does not enforce field types, so a directly built
+            # context can carry a non-mapping workspace past `from_payload`.
+            CLIContextSchema(workspace=cast("dict[str, Any]", "not-a-dict")),
+            id="typed-not-a-mapping",
+        ),
         pytest.param({"workspace": {"cwd": ""}}, id="cwd-empty"),
         pytest.param({"workspace": {"cwd": None}}, id="cwd-none"),
         pytest.param({"workspace": {"cwd": 7}}, id="cwd-not-a-string"),
@@ -1135,11 +1109,6 @@ def test_format_execute_description_falls_back_on_malformed_workspace(
     Reaching this path means an upstream invariant broke, so the prompt must
     not render a blank or fabricated directory without a warning.
     """
-    tool_call = cast(
-        "ToolCall",
-        {"name": "execute", "args": {"command": "pwd"}, "id": "call-10"},
-    )
-    runtime = cast("Runtime[Any]", SimpleNamespace(context=context))
     server_context = ProjectContext(user_cwd=Path("/workspace/server"))
 
     with (
@@ -1150,7 +1119,7 @@ def test_format_execute_description_falls_back_on_malformed_workspace(
         caplog.at_level(logging.WARNING, logger="deepagents_code.agent"),
     ):
         description = _format_execute_description(
-            tool_call, cast("AgentState[Any]", None), runtime
+            _EXECUTE_TOOL_CALL, cast("AgentState[Any]", None), _execute_runtime(context)
         )
 
     assert "Working Directory: /workspace/server" in description

--- a/libs/code/tests/unit_tests/tui/widgets/test_approval.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_approval.py
@@ -66,6 +66,40 @@ class TestToggleExpand:
 class TestExecuteToolMinimalDisplay:
     """Tests confirming `execute` is treated as the shell-execution tool."""
 
+    async def test_mounted_widget_shows_working_directory(self) -> None:
+        """The compact shell approval renders its supplemental description."""
+        from textual.app import App, ComposeResult
+        from textual.content import Content
+        from textual.widgets import Static
+
+        class ApprovalTestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield ApprovalMenu(
+                    {
+                        "name": "execute",
+                        "args": {"command": "pwd"},
+                        "description": (
+                            "Execute Command: pwd\n"
+                            "Working Directory: /workspace/thread-a"
+                        ),
+                    }
+                )
+
+        async with ApprovalTestApp().run_test() as pilot:
+            await pilot.pause()
+            menu = pilot.app.query_one(ApprovalMenu)
+            description = menu.query_one(".approval-description", Static)
+            command = menu.query_one(".approval-command", Static)
+
+            rendered_description = description.render()
+            rendered_command = command.render()
+            assert isinstance(rendered_description, Content)
+            assert isinstance(rendered_command, Content)
+            assert rendered_description.plain == (
+                "Working Directory: /workspace/thread-a"
+            )
+            assert rendered_command.plain == "pwd"
+
 
 class TestSecurityWarnings:
     """Tests for approval-level Unicode/URL warning collection."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_approval.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_approval.py
@@ -100,6 +100,32 @@ class TestExecuteToolMinimalDisplay:
             )
             assert rendered_command.plain == "pwd"
 
+    def test_auto_fallback_keeps_review_notice(self) -> None:
+        """An Auto fallback description keeps its notice, not a duplicate command."""
+        from textual.content import Content
+
+        menu = ApprovalMenu(
+            {
+                "name": "execute",
+                "args": {"command": "pwd"},
+                "description": (
+                    "Auto human fallback: this action needs your review.\n\n"
+                    "Execute Command: pwd\n"
+                    "Working Directory: /workspace/thread-a"
+                ),
+            }
+        )
+
+        widget = menu._get_minimal_description()
+
+        assert widget is not None
+        rendered = widget.render()
+        assert isinstance(rendered, Content)
+        assert rendered.plain == (
+            "Auto human fallback: this action needs your review.\n\n"
+            "Working Directory: /workspace/thread-a"
+        )
+
 
 class TestSecurityWarnings:
     """Tests for approval-level Unicode/URL warning collection."""


### PR DESCRIPTION
Shell approval prompts now show the working directory bound to each conversation.

---

A server can host conversations from different workspaces. The shell approval prompt used the server launch directory for every conversation. This could show the wrong directory when a user approved a command.

Before, a conversation bound to `/work/project-a` on a server launched from `/srv/deepagents` showed the server directory:

```text
$ pwd
Working Directory: /srv/deepagents
```

After, it shows the conversation's bound workspace:

```text
$ pwd
Working Directory: /work/project-a
```

`_format_execute_description` now reads `workspace.cwd` from the run context. It accepts the typed local context and the plain dictionary used by remote runs. If no binding is present, it uses the server project context and then the process working directory. This keeps the current fallback behavior.

Sandbox behavior does not change. The prompt still shows a local path when a sandbox is configured.

Other process working directory readers remain out of scope. They include hook context, file operation path fallback, the tool catalog, MCP project root, extension discovery, and the skill path base.

Made by [Open SWE](https://openswe.vercel.app/agents/efc82064-f5ba-5b6e-a05e-83701d31cd9d)
