### PR TITLE
hotfix(code): resolve graph factory annotations at runtime

### DIFF
--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -20,6 +20,12 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+# Imported at runtime rather than under TYPE_CHECKING: the LangGraph server
+# classifies `make_graph` by resolving its annotations with
+# `typing.get_type_hints` at graph-load time. A name that only type checkers
+# can see fails to resolve, and the server then refuses to load the graph.
+from langgraph_sdk.runtime import ServerRuntime as LangGraphServerRuntime  # noqa: TC002
+
 from deepagents_code._cli_context import CLIContextSchema
 from deepagents_code._server_config import ServerConfig
 from deepagents_code._startup_error import (
@@ -34,7 +40,6 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from deepagents.backends.composite import CompositeBackend
-    from langgraph_sdk.runtime import ServerRuntime as LangGraphServerRuntime
 
     from deepagents_code.extensions.registry import ExtensionRegistry
     from deepagents_code.offload_middleware import OffloadOperation

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -6,6 +6,7 @@ import importlib
 import os
 import sys
 from types import ModuleType, SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -355,3 +356,43 @@ class TestStartupErrorMarker:
     The marker is the contract `wait_for_server_healthy` parses to surface
     a one-line summary instead of "Server process exited with code N".
     """
+
+
+class TestGraphFactorySignature:
+    """`make_graph` must stay loadable as a LangGraph server graph factory.
+
+    The server does not call the factory to learn what it wants. It resolves
+    the factory's annotations with `typing.get_type_hints` at graph-load time
+    and builds a keyword dispatch from them. An annotation that names a symbol
+    which exists only for type checkers fails to resolve, and the server then
+    rejects the graph before it serves a request. Calling `make_graph`
+    directly cannot detect this, because Python never evaluates annotations.
+    """
+
+    def test_factory_annotations_resolve_at_runtime(self) -> None:
+        """Every `make_graph` annotation must resolve outside TYPE_CHECKING."""
+        import typing
+
+        module = _import_fresh_server_graph()
+
+        hints = typing.get_type_hints(module.make_graph)
+
+        assert "runtime" in hints
+        assert "config" in hints
+
+    def test_server_classifies_factory_as_config_and_runtime(self) -> None:
+        """The server must map both parameters, not reject the factory."""
+        from langgraph_api._factory_utils import _classify_factory
+
+        module = _import_fresh_server_graph()
+
+        # `_classify_factory` returns the keyword dispatch the server uses for
+        # every graph load. The public `classify_factory` caches into a process
+        # global, so it is deliberately not used here.
+        dispatch = _classify_factory(module.make_graph)
+
+        assert dispatch is not None
+        # Sentinels: the dispatch only routes these values by keyword.
+        config: Any = object()
+        runtime: Any = object()
+        assert dispatch(config, runtime) == {"config": config, "runtime": runtime}


### PR DESCRIPTION
Every `dcode` launch exits with code 3 before the server accepts a request:

```
ValueError: Graph factory <function make_graph> can only accept arguments of type
ServerRuntime and/or RunnableConfig, got
['dict[str, Any] | None', 'LangGraphServerRuntime[CLIContextSchema] | None']
```

The LangGraph server picks a graph factory's arguments by reading its type annotations at load time. This module uses `from __future__ import annotations`, so those annotations are strings the server resolves with `typing.get_type_hints`. The runtime type was imported under `TYPE_CHECKING`, so the name did not exist at runtime and resolution raised `NameError`. The server swallows that and falls back to the unresolved strings, which match no type — hence the message quoting them back.