### PR TITLE
fix(code): bind request-time working directories

### DIFF
--- a/libs/code/Makefile
+++ b/libs/code/Makefile
@@ -73,6 +73,7 @@ lint lint_diff lint_package lint_tests:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES) --diff
 	$(MAKE) type PYTHON_FILES="$(PYTHON_FILES)"
 	uv run --all-groups python scripts/generate_commands_catalog.py --check
+	uv run --all-groups python scripts/check_process_cwd.py deepagents_code
 
 type: ## Run type checker
 type typecheck:

--- a/libs/code/deepagents_code/offload_middleware.py
+++ b/libs/code/deepagents_code/offload_middleware.py
@@ -814,6 +814,16 @@ class _HasRunContext(Protocol):
         ...
 
 
+def _runtime_cwd(runtime: _HasRunContext) -> Path:
+    """Return the bound workspace directory, or preserve the process fallback."""
+    context = CLIContextSchema.from_payload(runtime.context)
+    if context is not None:
+        cwd = context.workspace.get("cwd")
+        if isinstance(cwd, str) and cwd:
+            return Path(cwd)
+    return Path.cwd()
+
+
 def _runtime_model_config(runtime: _HasRunContext) -> RuntimeModelConfig:
     """Read the active model configuration from a run context carrier.
 
@@ -1058,7 +1068,7 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
         except RuntimeError:
             config = None
         decision = _invoke_hook(
-            _hook_context(runtime.context, config, Path.cwd()),
+            _hook_context(runtime.context, config, _runtime_cwd(runtime)),
             PreCompactEvent(event=HookEvent.PRE_COMPACT, trigger=CompactTrigger.AUTO),
             gate=gate,
             config=config,

--- a/libs/code/scripts/check_process_cwd.py
+++ b/libs/code/scripts/check_process_cwd.py
@@ -1,0 +1,284 @@
+"""Reject unreviewed process working-directory reads."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, order=True)
+class CallSite:
+    """Stable identity for one process working-directory read."""
+
+    path: str
+    scope: str
+    kind: str
+    occurrence: int = 1
+
+
+_ALLOWLIST = {
+    CallSite(
+        "agent.py", "get_system_prompt", "Path.cwd"
+    ): "Direct agent builders may omit `cwd`; workspace server builders do not.",
+    CallSite(
+        "agent.py", "_format_execute_description", "Path.cwd"
+    ): "The shell approval display is owned by a separate change.",
+    CallSite(
+        "agent.py", "create_cli_agent._subagent_cli_middleware", "Path.cwd"
+    ): "The workspace server always supplies `effective_cwd` at graph build time.",
+    CallSite(
+        "agent.py", "create_cli_agent", "Path.cwd", 1
+    ): "The local backend fallback serves direct builders without project context.",
+    CallSite(
+        "agent.py", "create_cli_agent", "Path.cwd", 2
+    ): "Auto mode uses this only without project context or `effective_cwd`.",
+    CallSite(
+        "agent.py", "create_cli_agent", "Path.cwd", 3
+    ): "Main hooks use this only outside the workspace server build path.",
+    CallSite(
+        "app.py", "DeepAgentsApp.__init__", "Path.cwd"
+    ): "The TUI runs in the client process.",
+    CallSite(
+        "client/commands/config.py", "_config_paths", "Path.cwd", 1
+    ): "The config command runs in the client process.",
+    CallSite(
+        "client/commands/config.py", "_config_paths", "Path.cwd", 2
+    ): "The config command builds project context in the client process.",
+    CallSite(
+        "client/launch/server_manager.py", "_capture_project_context", "Path.cwd"
+    ): "The client captures the directory used to launch or bind the server.",
+    CallSite(
+        "client/non_interactive.py", "_run_agent_loop", "Path.cwd", 1
+    ): "The headless client records its local working directory.",
+    CallSite(
+        "client/non_interactive.py", "_run_agent_loop", "Path.cwd", 2
+    ): "The headless client evaluates local hook trust.",
+    CallSite(
+        "client/non_interactive.py", "run_non_interactive", "Path.cwd", 1
+    ): "The headless entrypoint builds client-side project context.",
+    CallSite(
+        "client/non_interactive.py", "run_non_interactive", "Path.cwd", 2
+    ): "The headless entrypoint evaluates client-side hook trust.",
+    CallSite(
+        "client/non_interactive.py", "run_non_interactive", "Path.cwd", 3
+    ): "The headless client sends its directory in run context.",
+    CallSite(
+        "config.py", "_preview_dotenv_environ", "Path.cwd"
+    ): "The client-side tracing diagnostic previews the local dotenv file.",
+    CallSite(
+        "config.py", "_get_git_branch", "Path.cwd"
+    ): "Client stream metadata describes the local checkout.",
+    CallSite(
+        "config.py", "_get_git_commit_sha", "Path.cwd"
+    ): "Client stream metadata describes the local checkout.",
+    CallSite(
+        "config.py", "_get_repository_metadata", "Path.cwd"
+    ): "Client stream metadata describes the local checkout.",
+    CallSite(
+        "config.py", "build_stream_config", "Path.cwd"
+    ): "The client builds tracing metadata before sending a run.",
+    CallSite(
+        "extensions/runtime.py", "_prepare", "Path.cwd"
+    ): "Workspace server callers supply `cwd`; the fallback preserves direct loading.",
+    CallSite(
+        "file_ops.py", "resolve_physical_path", "Path.cwd"
+    ): "Approval previews and file tracking run in the client process.",
+    CallSite(
+        "input.py", "parse_file_mentions", "Path.cwd"
+    ): "Prompt parsing runs in the client process.",
+    CallSite(
+        "input.py", "_resolve_with_unicode_space_variants", "Path.cwd"
+    ): "Prompt path correction runs in the client process.",
+    CallSite(
+        "main.py", "_normalize_cwd_filter", "Path.cwd"
+    ): "The CLI normalizes a client-side session filter.",
+    CallSite(
+        "main.py", "_preload_session_mcp_server_info", "Path.cwd"
+    ): "The CLI preloads MCP data before server requests.",
+    CallSite(
+        "main.py", "run_textual_cli_async", "Path.cwd"
+    ): "The interactive CLI captures its launch directory.",
+    CallSite(
+        "main.py", "_run_acp_cli_async", "Path.cwd"
+    ): "The ACP client builds local project context.",
+    CallSite(
+        "main.py", "_check_mcp_project_trust", "Path.cwd"
+    ): "The CLI checks MCP trust for its local project.",
+    CallSite(
+        "main.py", "_check_project_hooks_trust", "Path.cwd"
+    ): "The CLI checks hook trust for its local project.",
+    CallSite(
+        "main.py", "_check_project_extensions_trust", "Path.cwd"
+    ): "The CLI checks extension trust for its local project.",
+    CallSite(
+        "mcp_tools.py", "_resolve_project_config_base", "find_project_root"
+    ): "Client callers may omit project context; workspace server callers supply it.",
+    CallSite(
+        "mcp_tools.py", "_resolve_project_config_base", "Path.cwd"
+    ): "Client callers without a git root fall back to their process directory.",
+    CallSite(
+        "offload_middleware.py", "_runtime_cwd", "Path.cwd"
+    ): "Runs without workspace context retain the process-directory behavior.",
+    CallSite(
+        "project_utils.py", "find_project_root", "Path.cwd"
+    ): "The helper default supports client callers; server callers pass a start path.",
+    CallSite(
+        "skills/invocation.py", "discover_skills_and_roots", "Path.cwd"
+    ): "Skill invocation discovery runs in the TUI or headless client.",
+    CallSite(
+        "tool_catalog.py", "_load_mcp_server_info", "Path.cwd"
+    ): "The standalone tool catalog command runs in the client process.",
+    CallSite(
+        "tool_display.py", "format_tool_display.abbreviate_path", "Path.cwd"
+    ): "Tool result rendering runs in the client process.",
+    CallSite(
+        "tui/widgets/autocomplete.py", "FuzzyFileController.__init__", "Path.cwd"
+    ): "File autocomplete runs in the client TUI.",
+    CallSite(
+        "tui/widgets/chat_input.py", "ChatInput.__init__", "Path.cwd"
+    ): "The chat input runs in the client TUI.",
+    CallSite(
+        "tui/widgets/messages.py", "ToolCallMessage._format_search_output", "Path.cwd"
+    ): "Tool output formatting runs in the client TUI.",
+    CallSite(
+        "tui/widgets/status.py", "StatusBar.__init__", "Path.cwd"
+    ): "The status bar runs in the client TUI.",
+    CallSite(
+        "tui/widgets/thread_selector.py", "_safe_cwd_string", "Path.cwd"
+    ): "The thread selector filters against the client directory.",
+    CallSite(
+        "tui/widgets/welcome.py", "WelcomeBanner.__init__", "Path.cwd"
+    ): "The welcome banner runs in the client TUI.",
+}
+
+
+class _Visitor(ast.NodeVisitor):
+    def __init__(self, path: str, tree: ast.AST) -> None:
+        self.path = path
+        self.scopes: list[str] = []
+        self.counts: Counter[tuple[str, str]] = Counter()
+        self.sites: list[tuple[CallSite, int]] = []
+        self.path_names: set[str] = set()
+        self.pathlib_names: set[str] = set()
+        self.os_names: set[str] = set()
+        self.getcwd_names: set[str] = set()
+        self.project_root_names: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "pathlib":
+                        self.pathlib_names.add(alias.asname or alias.name)
+                    elif alias.name == "os":
+                        self.os_names.add(alias.asname or alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    name = alias.asname or alias.name
+                    if node.module == "pathlib" and alias.name == "Path":
+                        self.path_names.add(name)
+                    elif node.module == "os" and alias.name == "getcwd":
+                        self.getcwd_names.add(name)
+                    elif alias.name == "find_project_root":
+                        self.project_root_names.add(name)
+
+    def _call_kind(self, node: ast.Call) -> str | None:
+        if node.args or node.keywords:
+            return None
+        function = node.func
+        if isinstance(function, ast.Name):
+            if function.id in self.getcwd_names:
+                return "os.getcwd"
+            if function.id in self.project_root_names:
+                return "find_project_root"
+            return None
+        if not isinstance(function, ast.Attribute):
+            return None
+        if (
+            function.attr == "cwd"
+            and isinstance(function.value, ast.Name)
+            and function.value.id in self.path_names
+        ):
+            return "Path.cwd"
+        if (
+            function.attr == "cwd"
+            and isinstance(function.value, ast.Attribute)
+            and function.value.attr == "Path"
+            and isinstance(function.value.value, ast.Name)
+            and function.value.value.id in self.pathlib_names
+        ):
+            return "Path.cwd"
+        if (
+            function.attr == "getcwd"
+            and isinstance(function.value, ast.Name)
+            and function.value.id in self.os_names
+        ):
+            return "os.getcwd"
+        return None
+
+    def _visit_scope(self, node: ast.AST, name: str) -> None:
+        self.scopes.append(name)
+        self.generic_visit(node)
+        self.scopes.pop()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_scope(node, node.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_scope(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_scope(node, node.name)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        kind = self._call_kind(node)
+        if kind is not None:
+            scope = ".".join(self.scopes) or "<module>"
+            key = (scope, kind)
+            self.counts[key] += 1
+            site = CallSite(self.path, scope, kind, self.counts[key])
+            self.sites.append((site, node.lineno))
+        self.generic_visit(node)
+
+
+def find_violations(package_dir: Path) -> list[str]:
+    """Return unreviewed and stale process-cwd allowlist entries."""
+    found: dict[CallSite, int] = {}
+    for path in sorted(package_dir.rglob("*.py")):
+        relative = path.relative_to(package_dir).as_posix()
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        visitor = _Visitor(relative, tree)
+        visitor.visit(tree)
+        found.update(visitor.sites)
+
+    violations = [
+        f"{site.path}:{line}: unreviewed {site.kind} call in {site.scope}"
+        for site, line in found.items()
+        if site not in _ALLOWLIST
+    ]
+    violations.extend(
+        f"stale allowlist entry: {site.path}: {site.kind} in {site.scope}"
+        for site in _ALLOWLIST
+        if site not in found
+    )
+    return sorted(violations)
+
+
+def main() -> int:
+    """Check the package selected on the command line.
+
+    Returns:
+        Zero when every process-cwd read is reviewed, otherwise one.
+    """
+    package_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("deepagents_code")
+    violations = find_violations(package_dir)
+    if violations:
+        print("Process working-directory reads must be reviewed and allowlisted:")
+        print("\n".join(f"- {violation}" for violation in violations))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/libs/code/scripts/check_process_cwd.py
+++ b/libs/code/scripts/check_process_cwd.py
@@ -1,179 +1,253 @@
-"""Reject unreviewed process working-directory reads."""
+"""Reject unreviewed reads of the process working directory.
+
+One server process serves many bound workspaces, so a request must use the
+directory recorded for its workspace. A read of the process directory returns
+the directory the server was launched in, which is the wrong answer for every
+workspace but one.
+
+This check reports two things. A call that no allowlist entry covers is
+unreviewed. An allowlist entry that no call matches is stale. To clear an
+unreviewed call, either pass the workspace directory to it, or add a `CallSite`
+entry whose reason names the process the code runs in and why the process
+directory is correct there.
+
+The check reads `Path.cwd()`, `os.getcwd()`, and every call to
+`find_project_root`, which falls back to the process directory when its
+argument is empty. It does not see equivalent spellings such as
+`Path(".").resolve()`, `os.path.abspath(".")`, or a call through an attribute
+or a saved reference. A clean run means every read it can see is reviewed, not
+that no other read exists.
+"""
 
 from __future__ import annotations
 
 import ast
+import hashlib
 import sys
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
+
+_Kind = Literal["Path.cwd", "os.getcwd", "find_project_root"]
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True)
 class CallSite:
-    """Stable identity for one process working-directory read."""
+    """Identity for one process working-directory read.
+
+    `path` is package-relative and POSIX-separated. `scope` is the dot-joined
+    chain of enclosing class and function names, or `<module>`. `token` digests
+    the call and its enclosing statement, so an entry stays bound to one call
+    when its neighbors change. Editing the statement changes the token, which
+    reports the old entry as stale and the edited call as unreviewed: that pair
+    is the signal to review the change. `occurrence` disambiguates calls that
+    remain identical under that digest, and is the one component that shifts
+    when such a call is added or removed.
+    """
 
     path: str
     scope: str
-    kind: str
+    kind: _Kind
+    token: str
     occurrence: int = 1
 
 
-_ALLOWLIST = {
+_ALLOWLIST: dict[CallSite, str] = {
     CallSite(
-        "agent.py", "get_system_prompt", "Path.cwd"
+        "agent.py", "get_system_prompt", "Path.cwd", "aafaff15"
     ): "Direct agent builders may omit `cwd`; workspace server builders do not.",
     CallSite(
-        "agent.py", "_format_execute_description", "Path.cwd"
+        "agent.py", "_format_execute_description", "Path.cwd", "664fe885"
     ): "The shell approval display is owned by a separate change.",
     CallSite(
-        "agent.py", "create_cli_agent._subagent_cli_middleware", "Path.cwd"
+        "agent.py", "create_cli_agent._subagent_cli_middleware", "Path.cwd", "9f5c0d79"
     ): "The workspace server always supplies `effective_cwd` at graph build time.",
     CallSite(
-        "agent.py", "create_cli_agent", "Path.cwd", 1
+        "agent.py", "create_cli_agent", "Path.cwd", "c572ebd9"
     ): "The local backend fallback serves direct builders without project context.",
     CallSite(
-        "agent.py", "create_cli_agent", "Path.cwd", 2
+        "agent.py", "create_cli_agent", "Path.cwd", "cbdd2016"
     ): "Auto mode uses this only without project context or `effective_cwd`.",
     CallSite(
-        "agent.py", "create_cli_agent", "Path.cwd", 3
+        "agent.py", "create_cli_agent", "Path.cwd", "9f5c0d79"
     ): "Main hooks use this only outside the workspace server build path.",
     CallSite(
-        "app.py", "DeepAgentsApp.__init__", "Path.cwd"
+        "app.py", "DeepAgentsApp.__init__", "Path.cwd", "d2c4b637"
     ): "The TUI runs in the client process.",
     CallSite(
-        "client/commands/config.py", "_config_paths", "Path.cwd", 1
+        "client/commands/config.py", "_config_paths", "Path.cwd", "e6106216"
     ): "The config command runs in the client process.",
     CallSite(
-        "client/commands/config.py", "_config_paths", "Path.cwd", 2
+        "client/commands/config.py", "_config_paths", "Path.cwd", "53b35c21"
     ): "The config command builds project context in the client process.",
     CallSite(
-        "client/launch/server_manager.py", "_capture_project_context", "Path.cwd"
+        "client/launch/server_manager.py",
+        "_capture_project_context",
+        "Path.cwd",
+        "2956b508",
     ): "The client captures the directory used to launch or bind the server.",
     CallSite(
-        "client/non_interactive.py", "_run_agent_loop", "Path.cwd", 1
+        "client/non_interactive.py", "_run_agent_loop", "Path.cwd", "8826e907"
     ): "The headless client records its local working directory.",
     CallSite(
-        "client/non_interactive.py", "_run_agent_loop", "Path.cwd", 2
+        "client/non_interactive.py", "_run_agent_loop", "Path.cwd", "8826e907", 2
     ): "The headless client evaluates local hook trust.",
     CallSite(
-        "client/non_interactive.py", "run_non_interactive", "Path.cwd", 1
+        "client/non_interactive.py", "run_non_interactive", "Path.cwd", "164dbd9d"
     ): "The headless entrypoint builds client-side project context.",
     CallSite(
-        "client/non_interactive.py", "run_non_interactive", "Path.cwd", 2
+        "client/non_interactive.py", "run_non_interactive", "Path.cwd", "164dbd9d", 2
     ): "The headless entrypoint evaluates client-side hook trust.",
     CallSite(
-        "client/non_interactive.py", "run_non_interactive", "Path.cwd", 3
+        "client/non_interactive.py", "run_non_interactive", "Path.cwd", "0f2377b6"
     ): "The headless client sends its directory in run context.",
     CallSite(
-        "config.py", "_preview_dotenv_environ", "Path.cwd"
+        "config.py", "_preview_dotenv_environ", "Path.cwd", "e3f140b7"
     ): "The client-side tracing diagnostic previews the local dotenv file.",
     CallSite(
-        "config.py", "_get_git_branch", "Path.cwd"
+        "config.py", "_get_git_branch", "Path.cwd", "7a7a7e4f"
     ): "Client stream metadata describes the local checkout.",
     CallSite(
-        "config.py", "_get_git_commit_sha", "Path.cwd"
+        "config.py", "_get_git_commit_sha", "Path.cwd", "7a7a7e4f"
     ): "Client stream metadata describes the local checkout.",
     CallSite(
-        "config.py", "_get_repository_metadata", "Path.cwd"
+        "config.py", "_get_repository_metadata", "Path.cwd", "7a7a7e4f"
     ): "Client stream metadata describes the local checkout.",
     CallSite(
-        "config.py", "build_stream_config", "Path.cwd"
+        "config.py", "build_stream_config", "Path.cwd", "7a7a7e4f"
     ): "The client builds tracing metadata before sending a run.",
     CallSite(
-        "config.py", "Credentials.from_environment", "find_project_root"
-    ): "Client callers may omit `start_path`; server callers supply workspace context.",
+        "config.py", "Credentials.from_environment", "find_project_root", "a0389172"
+    ): "The skills CLI omits `start_path`. Bootstrap supplies the launch directory.",
     CallSite(
-        "config.py", "Credentials._reload_values", "find_project_root"
+        "config.py", "Credentials._reload_values", "find_project_root", "a0389172"
     ): "Client reloads may omit `start_path`; server callers supply workspace context.",
     CallSite(
-        "extensions/runtime.py", "_prepare", "Path.cwd"
+        "extensions/runtime.py", "_prepare", "Path.cwd", "454696d6"
     ): "Workspace server callers supply `cwd`; the fallback preserves direct loading.",
     CallSite(
-        "file_ops.py", "resolve_physical_path", "Path.cwd"
+        "file_ops.py", "resolve_physical_path", "Path.cwd", "41c20ddf"
     ): "Approval previews and file tracking run in the client process.",
     CallSite(
-        "input.py", "parse_file_mentions", "Path.cwd"
+        "input.py", "parse_file_mentions", "Path.cwd", "848de78e"
     ): "Prompt parsing runs in the client process.",
     CallSite(
-        "input.py", "_resolve_with_unicode_space_variants", "Path.cwd"
+        "input.py", "_resolve_with_unicode_space_variants", "Path.cwd", "f71ec895"
     ): "Prompt path correction runs in the client process.",
     CallSite(
-        "main.py", "_normalize_cwd_filter", "Path.cwd"
+        "main.py", "_normalize_cwd_filter", "Path.cwd", "af8d4df1"
     ): "The CLI normalizes a client-side session filter.",
     CallSite(
-        "main.py", "_preload_session_mcp_server_info", "Path.cwd"
+        "main.py", "_preload_session_mcp_server_info", "Path.cwd", "53b35c21"
     ): "The CLI preloads MCP data before server requests.",
     CallSite(
-        "main.py", "run_textual_cli_async", "Path.cwd"
+        "main.py", "run_textual_cli_async", "Path.cwd", "47da3baa"
     ): "The interactive CLI captures its launch directory.",
     CallSite(
-        "main.py", "_run_acp_cli_async", "Path.cwd"
+        "main.py", "_run_acp_cli_async", "Path.cwd", "53b35c21"
     ): "The ACP client builds local project context.",
     CallSite(
-        "main.py", "_check_mcp_project_trust", "Path.cwd"
+        "main.py", "_check_mcp_project_trust", "Path.cwd", "53b35c21"
     ): "The CLI checks MCP trust for its local project.",
     CallSite(
-        "main.py", "_check_project_hooks_trust", "Path.cwd"
+        "main.py", "_check_project_hooks_trust", "Path.cwd", "3124f423"
     ): "The CLI checks hook trust for its local project.",
     CallSite(
-        "main.py", "_check_project_extensions_trust", "Path.cwd"
+        "main.py", "_check_project_extensions_trust", "Path.cwd", "3124f423"
     ): "The CLI checks extension trust for its local project.",
     CallSite(
-        "mcp_tools.py", "_resolve_project_config_base", "find_project_root"
+        "mcp_tools.py", "_resolve_project_config_base", "find_project_root", "55e278e6"
     ): "Client callers may omit project context; workspace server callers supply it.",
     CallSite(
-        "mcp_tools.py", "_resolve_project_config_base", "Path.cwd"
+        "mcp_tools.py", "_resolve_project_config_base", "Path.cwd", "9050f1d8"
     ): "Client callers without a git root fall back to their process directory.",
     CallSite(
-        "offload_middleware.py", "_runtime_cwd", "Path.cwd"
+        "offload_middleware.py", "_runtime_cwd", "Path.cwd", "c5238c5c"
     ): "Runs without workspace context retain the process-directory behavior.",
     CallSite(
-        "project_utils.py", "find_project_root", "Path.cwd"
+        "project_utils.py", "find_project_root", "Path.cwd", "60fa8f5e"
     ): "The helper default supports client callers; server callers pass a start path.",
     CallSite(
-        "skills/invocation.py", "discover_skills_and_roots", "Path.cwd"
+        "skills/invocation.py", "discover_skills_and_roots", "Path.cwd", "7649626b"
     ): "Skill invocation discovery runs in the TUI or headless client.",
     CallSite(
-        "tool_catalog.py", "_load_mcp_server_info", "Path.cwd"
+        "tool_catalog.py", "_load_mcp_server_info", "Path.cwd", "53b35c21"
     ): "The standalone tool catalog command runs in the client process.",
     CallSite(
-        "tool_display.py", "format_tool_display.abbreviate_path", "Path.cwd"
+        "tool_display.py", "format_tool_display.abbreviate_path", "Path.cwd", "3aa6f3a0"
     ): "Tool result rendering runs in the client process.",
     CallSite(
-        "tui/widgets/autocomplete.py", "FuzzyFileController.__init__", "Path.cwd"
+        "tui/widgets/autocomplete.py",
+        "FuzzyFileController.__init__",
+        "Path.cwd",
+        "1c6451f3",
     ): "File autocomplete runs in the client TUI.",
     CallSite(
         "tui/widgets/autocomplete.py",
         "FuzzyFileController.__init__",
         "find_project_root",
+        "fb0caed2",
     ): "File autocomplete resolves its process or caller-provided directory first.",
     CallSite(
-        "tui/widgets/chat_input.py", "ChatInput.__init__", "Path.cwd"
+        "tui/widgets/chat_input.py", "ChatInput.__init__", "Path.cwd", "ded5e2c9"
     ): "The chat input runs in the client TUI.",
     CallSite(
-        "tui/widgets/messages.py", "ToolCallMessage._format_search_output", "Path.cwd"
+        "tui/widgets/messages.py",
+        "ToolCallMessage._format_search_output",
+        "Path.cwd",
+        "bb3631d2",
     ): "Tool output formatting runs in the client TUI.",
     CallSite(
-        "tui/widgets/status.py", "StatusBar.__init__", "Path.cwd"
+        "tui/widgets/status.py", "StatusBar.__init__", "Path.cwd", "5d61c81b"
     ): "The status bar runs in the client TUI.",
     CallSite(
-        "tui/widgets/thread_selector.py", "_safe_cwd_string", "Path.cwd"
+        "tui/widgets/thread_selector.py", "_safe_cwd_string", "Path.cwd", "af8d4df1"
     ): "The thread selector filters against the client directory.",
     CallSite(
-        "tui/widgets/welcome.py", "WelcomeBanner.__init__", "Path.cwd"
+        "tui/widgets/welcome.py", "WelcomeBanner.__init__", "Path.cwd", "ecc0d716"
     ): "The welcome banner runs in the client TUI.",
     CallSite(
-        "workspace.py", "resolve_workspace", "find_project_root"
+        "workspace.py", "resolve_workspace", "find_project_root", "6091a322"
     ): "Workspace resolution validates and canonicalizes the request directory first.",
+    CallSite(
+        "project_utils.py",
+        "ProjectContext.from_user_cwd",
+        "find_project_root",
+        "67630849",
+    ): "The argument is the resolved directory the caller supplied.",
+    CallSite(
+        "project_utils.py",
+        "get_server_project_context",
+        "find_project_root",
+        "32fc96f5",
+    ): "Server bootstrap supplies this directory from the environment.",
 }
+
+
+def _statement_text(node: ast.stmt) -> str:
+    """Return a summary of a statement that its body cannot change."""
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+        return f"{type(node).__name__}:{node.name}"
+    if isinstance(node, ast.If):
+        return f"if {ast.unparse(node.test)}"
+    if isinstance(node, ast.While):
+        return f"while {ast.unparse(node.test)}"
+    if isinstance(node, ast.For | ast.AsyncFor):
+        return f"for {ast.unparse(node.target)} in {ast.unparse(node.iter)}"
+    if isinstance(node, ast.With | ast.AsyncWith):
+        return "with " + ", ".join(ast.unparse(item) for item in node.items)
+    if isinstance(node, ast.Try):
+        return "try"
+    return ast.unparse(node)
 
 
 class _Visitor(ast.NodeVisitor):
     def __init__(self, path: str, tree: ast.AST) -> None:
         self.path = path
         self.scopes: list[str] = []
-        self.counts: Counter[tuple[str, str]] = Counter()
+        self.statement = "<module>"
+        self.counts: Counter[tuple[str, str, str]] = Counter()
         self.sites: list[tuple[CallSite, int]] = []
         self.path_names: set[str] = set()
         self.pathlib_names: set[str] = set()
@@ -196,8 +270,14 @@ class _Visitor(ast.NodeVisitor):
                         self.getcwd_names.add(name)
                     elif alias.name == "find_project_root":
                         self.project_root_names.add(name)
+            elif (
+                isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+                and node.name == "find_project_root"
+            ):
+                # The defining module calls the helper without importing it.
+                self.project_root_names.add(node.name)
 
-    def _call_kind(self, node: ast.Call) -> str | None:
+    def _call_kind(self, node: ast.Call) -> _Kind | None:
         function = node.func
         if isinstance(function, ast.Name) and function.id in self.project_root_names:
             return "find_project_root"
@@ -231,6 +311,15 @@ class _Visitor(ast.NodeVisitor):
             return "os.getcwd"
         return None
 
+    def visit(self, node: ast.AST) -> None:
+        if isinstance(node, ast.stmt):
+            previous = self.statement
+            self.statement = _statement_text(node)
+            super().visit(node)
+            self.statement = previous
+            return
+        super().visit(node)
+
     def _visit_scope(self, node: ast.AST, name: str) -> None:
         self.scopes.append(name)
         self.generic_visit(node)
@@ -249,19 +338,44 @@ class _Visitor(ast.NodeVisitor):
         kind = self._call_kind(node)
         if kind is not None:
             scope = ".".join(self.scopes) or "<module>"
-            key = (scope, kind)
+            digest = hashlib.sha256(
+                f"{self.statement}|{ast.unparse(node)}".encode()
+            ).hexdigest()[:8]
+            key = (scope, kind, digest)
             self.counts[key] += 1
-            site = CallSite(self.path, scope, kind, self.counts[key])
+            site = CallSite(self.path, scope, kind, digest, self.counts[key])
             self.sites.append((site, node.lineno))
         self.generic_visit(node)
 
 
 def find_violations(package_dir: Path) -> list[str]:
-    """Return unreviewed and stale process-cwd allowlist entries."""
+    """Return one message per unreviewed call and per stale allowlist entry.
+
+    Args:
+        package_dir: Root of the package to scan. Every `*.py` file below it is
+            parsed, and allowlist paths are relative to it.
+
+    Returns:
+        The messages, sorted. An empty list means every call the check can see
+        is allowlisted and every entry matches a call.
+
+    Raises:
+        SystemExit: If a file cannot be read or parsed, because its reads would
+            otherwise go unchecked.
+    """
     found: dict[CallSite, int] = {}
     for path in sorted(package_dir.rglob("*.py")):
         relative = path.relative_to(package_dir).as_posix()
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            msg = f"{relative}: cannot be read, so its reads are unchecked: {exc}"
+            raise SystemExit(msg) from exc
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            msg = f"{relative}: cannot be parsed, so its reads are unchecked: {exc}"
+            raise SystemExit(msg) from exc
         visitor = _Visitor(relative, tree)
         visitor.visit(tree)
         found.update(visitor.sites)
@@ -272,23 +386,25 @@ def find_violations(package_dir: Path) -> list[str]:
         if site not in _ALLOWLIST
     ]
     violations.extend(
-        f"stale allowlist entry: {site.path}: {site.kind} in {site.scope}"
-        for site in _ALLOWLIST
+        f"stale allowlist entry: {site.path}: {site.kind} "
+        f"[{site.token}] in {site.scope}: {reason}"
+        for site, reason in _ALLOWLIST.items()
         if site not in found
     )
     return sorted(violations)
 
 
 def main() -> int:
-    """Check the package selected on the command line.
+    """Check the package named on the command line, or `deepagents_code`.
 
     Returns:
-        Zero when every process-cwd read is reviewed, otherwise one.
+        Zero when every call the check can see is allowlisted and every entry
+        matches a call, otherwise one.
     """
     package_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("deepagents_code")
     violations = find_violations(package_dir)
     if violations:
-        print("Process working-directory reads must be reviewed and allowlisted:")
+        print("Reads of the process working directory must be allowlisted:")
         print("\n".join(f"- {violation}" for violation in violations))
         return 1
     return 0

--- a/libs/code/scripts/check_process_cwd.py
+++ b/libs/code/scripts/check_process_cwd.py
@@ -246,7 +246,7 @@ class _Visitor(ast.NodeVisitor):
     def __init__(self, path: str, tree: ast.AST) -> None:
         self.path = path
         self.scopes: list[str] = []
-        self.statement = "<module>"
+        self.statement: ast.stmt | None = None
         self.counts: Counter[tuple[str, str, str]] = Counter()
         self.sites: list[tuple[CallSite, int]] = []
         self.path_names: set[str] = set()
@@ -314,7 +314,7 @@ class _Visitor(ast.NodeVisitor):
     def visit(self, node: ast.AST) -> None:
         if isinstance(node, ast.stmt):
             previous = self.statement
-            self.statement = _statement_text(node)
+            self.statement = node
             super().visit(node)
             self.statement = previous
             return
@@ -338,14 +338,31 @@ class _Visitor(ast.NodeVisitor):
         kind = self._call_kind(node)
         if kind is not None:
             scope = ".".join(self.scopes) or "<module>"
+            statement = (
+                "<module>"
+                if self.statement is None
+                else _statement_text(self.statement)
+            )
             digest = hashlib.sha256(
-                f"{self.statement}|{ast.unparse(node)}".encode()
+                f"{statement}|{ast.unparse(node)}".encode()
             ).hexdigest()[:8]
             key = (scope, kind, digest)
             self.counts[key] += 1
             site = CallSite(self.path, scope, kind, digest, self.counts[key])
             self.sites.append((site, node.lineno))
         self.generic_visit(node)
+
+
+def _token_text(site: CallSite) -> str:
+    """Render the identity an allowlist entry must repeat for this call.
+
+    Returns:
+        The token, suffixed with the occurrence when more than one call shares
+        it, which is the pair a new `CallSite` entry has to name.
+    """
+    if site.occurrence > 1:
+        return f"{site.token}#{site.occurrence}"
+    return site.token
 
 
 def find_violations(package_dir: Path) -> list[str]:
@@ -381,7 +398,8 @@ def find_violations(package_dir: Path) -> list[str]:
         found.update(visitor.sites)
 
     violations = [
-        f"{site.path}:{line}: unreviewed {site.kind} call in {site.scope}"
+        f"{site.path}:{line}: unreviewed {site.kind} call "
+        f"[{_token_text(site)}] in {site.scope}"
         for site, line in found.items()
         if site not in _ALLOWLIST
     ]

--- a/libs/code/scripts/check_process_cwd.py
+++ b/libs/code/scripts/check_process_cwd.py
@@ -81,6 +81,12 @@ _ALLOWLIST = {
         "config.py", "build_stream_config", "Path.cwd"
     ): "The client builds tracing metadata before sending a run.",
     CallSite(
+        "config.py", "Credentials.from_environment", "find_project_root"
+    ): "Client callers may omit `start_path`; server callers supply workspace context.",
+    CallSite(
+        "config.py", "Credentials._reload_values", "find_project_root"
+    ): "Client reloads may omit `start_path`; server callers supply workspace context.",
+    CallSite(
         "extensions/runtime.py", "_prepare", "Path.cwd"
     ): "Workspace server callers supply `cwd`; the fallback preserves direct loading.",
     CallSite(
@@ -138,6 +144,11 @@ _ALLOWLIST = {
         "tui/widgets/autocomplete.py", "FuzzyFileController.__init__", "Path.cwd"
     ): "File autocomplete runs in the client TUI.",
     CallSite(
+        "tui/widgets/autocomplete.py",
+        "FuzzyFileController.__init__",
+        "find_project_root",
+    ): "File autocomplete resolves its process or caller-provided directory first.",
+    CallSite(
         "tui/widgets/chat_input.py", "ChatInput.__init__", "Path.cwd"
     ): "The chat input runs in the client TUI.",
     CallSite(
@@ -152,6 +163,9 @@ _ALLOWLIST = {
     CallSite(
         "tui/widgets/welcome.py", "WelcomeBanner.__init__", "Path.cwd"
     ): "The welcome banner runs in the client TUI.",
+    CallSite(
+        "workspace.py", "resolve_workspace", "find_project_root"
+    ): "Workspace resolution validates and canonicalizes the request directory first.",
 }
 
 
@@ -184,14 +198,14 @@ class _Visitor(ast.NodeVisitor):
                         self.project_root_names.add(name)
 
     def _call_kind(self, node: ast.Call) -> str | None:
+        function = node.func
+        if isinstance(function, ast.Name) and function.id in self.project_root_names:
+            return "find_project_root"
         if node.args or node.keywords:
             return None
-        function = node.func
         if isinstance(function, ast.Name):
             if function.id in self.getcwd_names:
                 return "os.getcwd"
-            if function.id in self.project_root_names:
-                return "find_project_root"
             return None
         if not isinstance(function, ast.Attribute):
             return None

--- a/libs/code/tests/unit_tests/test_compact_tool.py
+++ b/libs/code/tests/unit_tests/test_compact_tool.py
@@ -152,8 +152,6 @@ class TestCLICompactionMiddleware:
         """One process must expose each run's bound directory to hooks."""
         launch_dir = tmp_path / "launch"
         workspaces = [tmp_path / "one", tmp_path / "two"]
-        for directory in [launch_dir, *workspaces]:
-            directory.mkdir()
         middleware = CLICompactionMiddleware(self._summarization())
         request = MagicMock()
         request.messages = [HumanMessage("compact")]
@@ -186,7 +184,6 @@ class TestCLICompactionMiddleware:
     ) -> None:
         """Runs without a workspace must retain the process-cwd behavior."""
         launch_dir = tmp_path / "launch"
-        launch_dir.mkdir()
         middleware = CLICompactionMiddleware(self._summarization())
         request = MagicMock()
         request.messages = [HumanMessage("compact")]

--- a/libs/code/tests/unit_tests/test_compact_tool.py
+++ b/libs/code/tests/unit_tests/test_compact_tool.py
@@ -19,6 +19,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 
 from deepagents_code._cli_context import CLIContextSchema
 from deepagents_code.config import MODEL_RETRIES_ATTR
+from deepagents_code.hooks.models.domain import HookEvent, PreCompactDecision
 from deepagents_code.offload_middleware import (
     _SUMMARY_TRIM_FALLBACK,
     CLICompactionMiddleware,
@@ -33,6 +34,8 @@ from deepagents_code.offload_middleware import (
 _NO_BACKOFF = "deepagents_code.model_retry._retry_delay_seconds"
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from deepagents.backends.protocol import BackendProtocol
     from langchain_core.messages import AnyMessage
 
@@ -144,6 +147,67 @@ class TestCLICompactionMiddleware:
         ]
         summarization._compute_state_cutoff.return_value = 2
         return summarization
+
+    def test_auto_compaction_uses_each_runtime_workspace(self, tmp_path: Path) -> None:
+        """One process must expose each run's bound directory to hooks."""
+        launch_dir = tmp_path / "launch"
+        workspaces = [tmp_path / "one", tmp_path / "two"]
+        for directory in [launch_dir, *workspaces]:
+            directory.mkdir()
+        middleware = CLICompactionMiddleware(self._summarization())
+        request = MagicMock()
+        request.messages = [HumanMessage("compact")]
+        context: dict[str, Any] = {
+            "hooks_snapshot_id": "snapshot",
+            "hooks_server_events": [HookEvent.PRE_COMPACT.value],
+        }
+        request.runtime.context = context
+        decisions = PreCompactDecision(event=HookEvent.PRE_COMPACT)
+
+        with (
+            patch(
+                "deepagents_code.offload_middleware.Path.cwd", return_value=launch_dir
+            ),
+            patch(
+                "deepagents_code.offload_middleware._invoke_hook",
+                return_value=decisions,
+            ) as invoke_hook,
+        ):
+            resolved = []
+            for workspace in workspaces:
+                context["workspace"] = {"cwd": str(workspace)}
+                assert middleware._pre_auto_compact(request)
+                resolved.append(invoke_hook.call_args.args[0].cwd)
+
+        assert resolved == workspaces
+
+    def test_auto_compaction_without_workspace_uses_process_cwd(
+        self, tmp_path: Path
+    ) -> None:
+        """Runs without a workspace must retain the process-cwd behavior."""
+        launch_dir = tmp_path / "launch"
+        launch_dir.mkdir()
+        middleware = CLICompactionMiddleware(self._summarization())
+        request = MagicMock()
+        request.messages = [HumanMessage("compact")]
+        request.runtime.context = {
+            "hooks_snapshot_id": "snapshot",
+            "hooks_server_events": [HookEvent.PRE_COMPACT.value],
+        }
+        decision = PreCompactDecision(event=HookEvent.PRE_COMPACT)
+
+        with (
+            patch(
+                "deepagents_code.offload_middleware.Path.cwd", return_value=launch_dir
+            ),
+            patch(
+                "deepagents_code.offload_middleware._invoke_hook",
+                return_value=decision,
+            ) as invoke_hook,
+        ):
+            assert middleware._pre_auto_compact(request)
+
+        assert invoke_hook.call_args.args[0].cwd == launch_dir
 
     async def test_operation_plan_defers_archive_until_checkpoint_reservation(
         self,

--- a/libs/code/tests/unit_tests/test_process_cwd_check.py
+++ b/libs/code/tests/unit_tests/test_process_cwd_check.py
@@ -40,6 +40,26 @@ def test_new_process_cwd_read_fails_guard(tmp_path: Path) -> None:
     ]
 
 
+def test_nullable_project_root_read_fails_guard(tmp_path: Path) -> None:
+    """A nullable project-root argument must remain subject to review."""
+    package = tmp_path / "deepagents_code"
+    package.mkdir()
+    (package / "request_path.py").write_text(
+        "from deepagents_code.project_utils import find_project_root as root\n"
+        "\n"
+        "def handle_request(start_path=None):\n"
+        "    return root(start_path)\n",
+        encoding="utf-8",
+    )
+
+    check = cast("Any", _load_check())
+    check._ALLOWLIST = {}
+
+    assert check.find_violations(package) == [
+        "request_path.py:4: unreviewed find_project_root call in handle_request"
+    ]
+
+
 def test_current_package_matches_allowlist() -> None:
     """The reviewed package must have no new or stale entries."""
     check = cast("Any", _load_check())

--- a/libs/code/tests/unit_tests/test_process_cwd_check.py
+++ b/libs/code/tests/unit_tests/test_process_cwd_check.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+
+import pytest
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -21,6 +24,18 @@ def _load_check() -> ModuleType:
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _detected_sites(check: Any, package: Path) -> list[Any]:  # noqa: ANN401
+    """Return the call sites the guard finds, so a test can allowlist them."""
+    sites = []
+    for path in sorted(package.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        visitor = check._Visitor(path.relative_to(package).as_posix(), tree)
+        visitor.visit(tree)
+        sites.extend(site for site, _line in visitor.sites)
+    return sites
 
 
 def test_new_process_cwd_read_fails_guard(tmp_path: Path) -> None:
@@ -41,7 +56,7 @@ def test_new_process_cwd_read_fails_guard(tmp_path: Path) -> None:
 
 
 def test_nullable_project_root_read_fails_guard(tmp_path: Path) -> None:
-    """A nullable project-root argument must remain subject to review."""
+    """A `find_project_root` call with an argument must also fail the guard."""
     package = tmp_path / "deepagents_code"
     package.mkdir()
     (package / "request_path.py").write_text(
@@ -58,6 +73,93 @@ def test_nullable_project_root_read_fails_guard(tmp_path: Path) -> None:
     assert check.find_violations(package) == [
         "request_path.py:4: unreviewed find_project_root call in handle_request"
     ]
+
+
+def test_defining_module_read_fails_guard(tmp_path: Path) -> None:
+    """The module that defines `find_project_root` must not be exempt."""
+    package = tmp_path / "deepagents_code"
+    package.mkdir()
+    (package / "project_utils.py").write_text(
+        "def find_project_root(start_path=None):\n"
+        "    return start_path\n"
+        "\n"
+        "def get_context(user_cwd):\n"
+        "    return find_project_root(user_cwd)\n",
+        encoding="utf-8",
+    )
+
+    check = cast("Any", _load_check())
+    check._ALLOWLIST = {}
+
+    assert check.find_violations(package) == [
+        "project_utils.py:5: unreviewed find_project_root call in get_context"
+    ]
+
+
+def test_added_read_does_not_shift_reviewed_entries(tmp_path: Path) -> None:
+    """A new read must be reported, and must not take a reviewed reason."""
+    package = tmp_path / "deepagents_code"
+    package.mkdir()
+    module = package / "request_path.py"
+    reviewed = (
+        "from pathlib import Path\n"
+        "\n"
+        "def build():\n"
+        "    first = Path.cwd()\n"
+        "    second = Path.cwd()\n"
+    )
+    module.write_text(reviewed, encoding="utf-8")
+
+    check = cast("Any", _load_check())
+    check._ALLOWLIST = dict.fromkeys(
+        _detected_sites(check, package), "reviewed: client process"
+    )
+    assert check.find_violations(package) == []
+
+    module.write_text(
+        reviewed.replace("    first =", "    fresh = Path.cwd()\n    first ="),
+        encoding="utf-8",
+    )
+
+    # The added read is reported at its own line, and neither reviewed entry
+    # goes stale, so no reason moves to a call nobody reviewed.
+    assert check.find_violations(package) == [
+        "request_path.py:4: unreviewed Path.cwd call in build"
+    ]
+
+
+def test_stale_allowlist_entry_reports_its_reason(tmp_path: Path) -> None:
+    """A removed read must report the reason that no longer applies."""
+    package = tmp_path / "deepagents_code"
+    package.mkdir()
+    (package / "request_path.py").write_text(
+        "from pathlib import Path\n\ndef build():\n    return Path.cwd()\n",
+        encoding="utf-8",
+    )
+
+    check = cast("Any", _load_check())
+    (site,) = _detected_sites(check, package)
+    check._ALLOWLIST = {site: "The builder runs in the client process."}
+    (package / "request_path.py").write_text("", encoding="utf-8")
+
+    assert check.find_violations(package) == [
+        (
+            f"stale allowlist entry: request_path.py: Path.cwd [{site.token}] "
+            "in build: The builder runs in the client process."
+        )
+    ]
+
+
+def test_unreadable_file_stops_the_check(tmp_path: Path) -> None:
+    """A file the check cannot parse must fail instead of going unchecked."""
+    package = tmp_path / "deepagents_code"
+    package.mkdir()
+    (package / "broken.py").write_text("def build(:\n", encoding="utf-8")
+
+    check = cast("Any", _load_check())
+
+    with pytest.raises(SystemExit, match=r"broken\.py: cannot be parsed"):
+        check.find_violations(package)
 
 
 def test_current_package_matches_allowlist() -> None:

--- a/libs/code/tests/unit_tests/test_process_cwd_check.py
+++ b/libs/code/tests/unit_tests/test_process_cwd_check.py
@@ -49,9 +49,10 @@ def test_new_process_cwd_read_fails_guard(tmp_path: Path) -> None:
 
     check = cast("Any", _load_check())
     check._ALLOWLIST = {}
+    (site,) = _detected_sites(check, package)
 
     assert check.find_violations(package) == [
-        "request_path.py:4: unreviewed Path.cwd call in handle_request"
+        f"request_path.py:4: unreviewed Path.cwd call [{site.token}] in handle_request"
     ]
 
 
@@ -69,9 +70,13 @@ def test_nullable_project_root_read_fails_guard(tmp_path: Path) -> None:
 
     check = cast("Any", _load_check())
     check._ALLOWLIST = {}
+    (site,) = _detected_sites(check, package)
 
     assert check.find_violations(package) == [
-        "request_path.py:4: unreviewed find_project_root call in handle_request"
+        (
+            f"request_path.py:4: unreviewed find_project_root call "
+            f"[{site.token}] in handle_request"
+        )
     ]
 
 
@@ -90,9 +95,13 @@ def test_defining_module_read_fails_guard(tmp_path: Path) -> None:
 
     check = cast("Any", _load_check())
     check._ALLOWLIST = {}
+    (site,) = _detected_sites(check, package)
 
     assert check.find_violations(package) == [
-        "project_utils.py:5: unreviewed find_project_root call in get_context"
+        (
+            f"project_utils.py:5: unreviewed find_project_root call "
+            f"[{site.token}] in get_context"
+        )
     ]
 
 
@@ -123,8 +132,11 @@ def test_added_read_does_not_shift_reviewed_entries(tmp_path: Path) -> None:
 
     # The added read is reported at its own line, and neither reviewed entry
     # goes stale, so no reason moves to a call nobody reviewed.
+    added = next(
+        site for site in _detected_sites(check, package) if site not in check._ALLOWLIST
+    )
     assert check.find_violations(package) == [
-        "request_path.py:4: unreviewed Path.cwd call in build"
+        f"request_path.py:4: unreviewed Path.cwd call [{added.token}] in build"
     ]
 
 

--- a/libs/code/tests/unit_tests/test_process_cwd_check.py
+++ b/libs/code/tests/unit_tests/test_process_cwd_check.py
@@ -1,0 +1,48 @@
+"""Tests for the process working-directory guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+_SCRIPT = Path(__file__).parents[2] / "scripts" / "check_process_cwd.py"
+
+
+def _load_check() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_process_cwd", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_new_process_cwd_read_fails_guard(tmp_path: Path) -> None:
+    """An unreviewed process-cwd read must fail with its source location."""
+    package = tmp_path / "deepagents_code"
+    package.mkdir()
+    (package / "request_path.py").write_text(
+        "from pathlib import Path as P\n\ndef handle_request():\n    return P.cwd()\n",
+        encoding="utf-8",
+    )
+
+    check = cast("Any", _load_check())
+    check._ALLOWLIST = {}
+
+    assert check.find_violations(package) == [
+        "request_path.py:4: unreviewed Path.cwd call in handle_request"
+    ]
+
+
+def test_current_package_matches_allowlist() -> None:
+    """The reviewed package must have no new or stale entries."""
+    check = cast("Any", _load_check())
+    package = Path(__file__).parents[2] / "deepagents_code"
+
+    assert check.find_violations(package) == []


### PR DESCRIPTION
Automatic compaction hooks now use each conversation's recorded working directory, even when one server hosts several workspaces.

---

A server process has one operating-system working directory. That directory can differ from the workspace bound to a request. Request-time code must use the validated workspace binding. It must not read the server process directory silently.

This change reads `workspace.cwd` from the existing run context when automatic compaction builds its `PreCompact` hook context. Two runs in one process can now expose different directories. A run with no workspace keeps the existing process-directory fallback.

A new AST check scans `deepagents_code` for `Path.cwd()`, `os.getcwd()`, and `find_project_root()` without a start path. The check has an explicit allowlist. Each entry states why the read is valid. New or stale entries fail `make lint`.

### Audit

- `offload_middleware.py`: Converted. Automatic compaction runs during a server request. Its runtime carries the validated workspace.
- `agent.py` shell approval description: Not changed. A separate change owns that display path.
- `agent.py` build-time fallbacks: Allowed. The workspace runtime always builds the agent with `cwd` and `project_context`. The fallbacks are not reached on that server path. They preserve direct agent construction.
- `extensions/runtime.py`: Allowed. The workspace runtime passes `cwd`. The fallback preserves direct extension loading.
- `mcp_tools.py`: Allowed. Server MCP discovery passes `project_context`. Calls without context run in client commands.
- `file_ops.py`: Allowed. Relative physical-path resolution is used by client approval previews and client file tracking.
- `tool_catalog.py`: Allowed. This discovery path is used by the client `tools` command. Server graph construction uses a supplied project context.
- `skills/invocation.py`: Allowed. Skill invocation discovery runs in the TUI or headless client.
- `project_utils.py`: Allowed. Server callers pass a start path to `find_project_root`. The default serves client callers.
- `config.py`: Allowed. These reads build client tracing data or client diagnostics.
- `main.py`, `client/`, `input.py`, `tool_display.py`, `app.py`, and `tui/`: Allowed. These paths run in the client process or render the TUI.
- `server_graph.py`: No executable process-directory read exists. Its matches are comments about blocking calls.

Made by [Open SWE](https://openswe.vercel.app/agents/86a8f498-a153-5f91-a229-da22cd9cf8e5)