### PR TITLE
docs(repo): remove PR test plan guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,6 @@ Follow [the PR template](.github/PULL_REQUEST_TEMPLATE.md).
 - For features and behavior-changing fixes, place one plain-English user-visible summary above `---`. It is the release note; do not add a release-note heading or repeat it below the divider. Omit it for chores, refactors, and test-only changes.
 - Below `---`, explain why the change is needed and why the approach is appropriate. Keep prose concise and public-reader friendly.
 - Do not cite line numbers. Prefer symbols or subsystems over full paths, and format code entities with backticks.
-- Add a collapsed test plan only for large or consequential changes. Call out areas needing careful review.
 
 ## Core development principles
 


### PR DESCRIPTION
PR testing sections are often vacuous and the current pull request template does not ask for one. Remove the remaining guidance to add collapsed test plans so contributors can keep descriptions focused on rationale and review context.

Made by [Open SWE](https://openswe.vercel.app/agents/e7f8334e-9a64-524d-b553-91c0e8e3cc51)