### PR TITLE
fix(code): use sharp splash border

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/welcome.py
+++ b/libs/code/deepagents_code/tui/widgets/welcome.py
@@ -189,7 +189,7 @@ class WelcomeBanner(Static):
     DEFAULT_CSS = """
     WelcomeBanner {
         height: auto;
-        border: round $primary;
+        border: solid $primary;
         padding: 0 2;
         margin-bottom: 1;
     }

--- a/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
@@ -290,13 +290,6 @@ class _BannerApp(App[None]):
 class TestBorder:
     """Tests for the charset-aware banner border."""
 
-    async def test_default_border_has_sharp_corners(self) -> None:
-        """Unicode mode uses a solid border with sharp corners."""
-        banner = _make_banner(show_model=False)
-        app = _BannerApp(banner)
-        async with app.run_test(size=(80, 24)):
-            assert banner.styles.border_top[0] == "solid"
-
     async def test_ascii_mode_uses_ascii_border(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
@@ -290,10 +290,17 @@ class _BannerApp(App[None]):
 class TestBorder:
     """Tests for the charset-aware banner border."""
 
+    async def test_default_border_has_sharp_corners(self) -> None:
+        """Unicode mode uses a solid border with sharp corners."""
+        banner = _make_banner(show_model=False)
+        app = _BannerApp(banner)
+        async with app.run_test(size=(80, 24)):
+            assert banner.styles.border_top[0] == "solid"
+
     async def test_ascii_mode_uses_ascii_border(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """ASCII mode replaces the default rounded border."""
+        """ASCII mode replaces the default solid border."""
         monkeypatch.setattr(welcome_module, "is_ascii_mode", lambda: True)
         banner = _make_banner(show_model=False)
         app = _BannerApp(banner)


### PR DESCRIPTION
The splash banner now uses sharp corners, consistent with every other bordered `libs/code` Textual surface.

---

An audit of TUI border declarations found the splash `WelcomeBanner` was the only remaining rounded border. This changes its Unicode border from `round` to `solid` while preserving the charset-aware ASCII fallback.

Made by [Open SWE](https://openswe.vercel.app/agents/6c06a444-08c0-5b29-8c8f-f5add7b23a76)
