### PR TITLE
docs(repo): relax test coverage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ When adding or updating model names in docs, examples, or defaults, verify the l
 
 ### Testing
 
-Every feature or bugfix needs unit coverage.
+Add unit coverage when it meaningfully protects changed observable behavior; do not add tests solely to accompany every change.
 
 - Put network-free tests in `tests/unit_tests/` and networked tests in `tests/integration_tests/`.
 - Do not add `@pytest.mark.asyncio`; packages use `asyncio_mode = "auto"`.


### PR DESCRIPTION
The repository guidance currently requires unit coverage for every feature or bugfix, even when a test would not provide meaningful protection.

This updates the rule to ask for tests when they protect observable behavior and explicitly discourages tests added solely to accompany a change.

Made by [Open SWE](https://openswe.vercel.app/agents/0d4492a0-f72d-5b8e-82c3-cd5f3606f5c5)