### PR TITLE
feat(code): trace effective approval mode

### DIFF
--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -851,7 +851,9 @@ class ApprovalModeResolution(TypedDict):
     """Server-resolved approval mode and trace-safe diagnostics."""
 
     mode: ApprovalMode
+    """Effective mode resolved by the server for this turn."""
     fallback_reason: Literal["approval_mode_unavailable"] | None
+    """Fixed reason when Store state is unavailable or cannot be trusted."""
 
 
 async def _live_mode(runtime: object) -> ApprovalModeResolution:

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -2816,17 +2816,22 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             Primary response with a private decision-plan state update.
         """
         await self._reconcile_routed_plan(request)
-        resolution = await _live_mode(request.runtime)
-        mode_tags, mode_metadata = _approval_mode_telemetry(request.runtime, resolution)
-        _attach_approval_mode_telemetry(mode_tags, mode_metadata)
+        trace_resolution = await _live_mode(request.runtime)
+        trace_tags, trace_metadata = _approval_mode_telemetry(
+            request.runtime, trace_resolution
+        )
+        _attach_approval_mode_telemetry(trace_tags, trace_metadata)
         from langsmith import tracing_context
         from langsmith.run_helpers import get_tracing_context
 
         current_trace = get_tracing_context()
-        trace_tags = sorted({*(current_trace.get("tags") or []), *mode_tags})
-        trace_metadata = {**(current_trace.get("metadata") or {}), **mode_metadata}
-        with tracing_context(tags=trace_tags, metadata=trace_metadata):
+        model_tags = sorted({*(current_trace.get("tags") or []), *trace_tags})
+        model_metadata = {**(current_trace.get("metadata") or {}), **trace_metadata}
+        with tracing_context(tags=model_tags, metadata=model_metadata):
             response = await handler(request)
+        resolution = await _live_mode(request.runtime)
+        mode_tags, mode_metadata = _approval_mode_telemetry(request.runtime, resolution)
+        _attach_approval_mode_telemetry(mode_tags, mode_metadata)
         ai_message = next(
             (
                 message

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -341,6 +341,9 @@ class AutoDecisionPlan(TypedDict):
     batch_id: str
     thread_key: str
     mode_at_proposal: str
+    effective_approval_mode: NotRequired[str]
+    approval_mode_tags: NotRequired[list[str]]
+    approval_mode_metadata: NotRequired[dict[str, str]]
     phase: Literal["planned", "routed"]
     manual_gated_ids: list[str]
     decisions: list[PlannedDecision]
@@ -844,20 +847,81 @@ def _thread_key(runtime: object) -> str | None:
     return raw_key if raw_key == approval_mode_key(thread_id) else None
 
 
-async def _live_mode(runtime: object) -> tuple[ApprovalMode, bool]:
-    """Read the live mode and report whether control state was unavailable.
+class ApprovalModeResolution(TypedDict):
+    """Server-resolved approval mode and trace-safe diagnostics."""
+
+    mode: ApprovalMode
+    fallback_reason: Literal["approval_mode_unavailable"] | None
+
+
+async def _live_mode(runtime: object) -> ApprovalModeResolution:
+    """Read the live mode, failing closed with an explicit reason.
 
     Returns:
-        The effective mode and whether the Store control record was unavailable.
+        The effective mode and a fixed fallback reason when Store state is unavailable.
     """
     key = _thread_key(runtime)
     if key is None:
         logger.warning("Approval-mode Store key is missing or invalid; using Manual")
-        return ApprovalMode.MANUAL, True
+        return {
+            "mode": ApprovalMode.MANUAL,
+            "fallback_reason": "approval_mode_unavailable",
+        }
     mode = await aread_approval_mode_from_store(getattr(runtime, "store", None), key)
-    if mode is None:
-        return ApprovalMode.MANUAL, True
-    return mode, False
+    return {
+        "mode": mode or ApprovalMode.MANUAL,
+        "fallback_reason": None if mode is not None else "approval_mode_unavailable",
+    }
+
+
+def _approval_mode_telemetry(
+    runtime: object, resolution: ApprovalModeResolution
+) -> tuple[list[str], dict[str, str]]:
+    """Build validated approval-mode tags and metadata for one resolution.
+
+    Returns:
+        LangSmith tags and trace-safe metadata.
+    """
+    mode = resolution["mode"]
+    raw_client_mode = _context_value(_runtime_context(runtime), "approval_mode")
+    client_mode = raw_client_mode if isinstance(raw_client_mode, str) else None
+    metadata = {"effective_approval_mode": mode.value}
+    tags: list[str] = []
+    if client_mode in {item.value for item in ApprovalMode}:
+        metadata["client_approval_mode"] = client_mode
+        metadata["server_approval_mode"] = mode.value
+        if client_mode != mode.value:
+            tags.append("approval_mode:mismatch")
+            metadata["approval_mode_warning"] = "client_server_mismatch"
+            logger.warning(
+                "Approval mode mismatch client_approval_mode=%s "
+                "server_approval_mode=%s",
+                client_mode,
+                mode.value,
+            )
+    if fallback_reason := resolution["fallback_reason"]:
+        tags.extend(["approval_mode:fallback", "approval_mode:store_unavailable"])
+        metadata["approval_mode_fallback_reason"] = fallback_reason
+    return tags, metadata
+
+
+def _attach_approval_mode_telemetry(
+    tags: Sequence[str], metadata: Mapping[str, str]
+) -> None:
+    """Attach approval-mode diagnostics to the active LangSmith trace."""
+    from langsmith import get_current_run_tree
+
+    run = get_current_run_tree()
+    if run is None:
+        return
+    run.add_tags([tag for tag in tags if tag not in (run.tags or [])])
+    run.add_metadata(dict(metadata))
+    root = run
+    while root.parent_run is not None:
+        root = root.parent_run
+    if root is not run:
+        root.add_tags([tag for tag in tags if tag not in (root.tags or [])])
+        root.add_metadata(dict(metadata))
 
 
 def _trusted_prompt_rows(
@@ -2414,8 +2478,10 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         thread_key = _thread_key(request.runtime)
         if thread_key is None:
             return
-        mode, _mode_unavailable = await _live_mode(request.runtime)
-        counters = await _read_counters(request.runtime.store, thread_key, mode)
+        resolution = await _live_mode(request.runtime)
+        counters = await _read_counters(
+            request.runtime.store, thread_key, resolution["mode"]
+        )
         if counters is None:
             return
         if any(message.status != "error" for message in terminal.values()):
@@ -2748,7 +2814,17 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             Primary response with a private decision-plan state update.
         """
         await self._reconcile_routed_plan(request)
-        response = await handler(request)
+        resolution = await _live_mode(request.runtime)
+        mode_tags, mode_metadata = _approval_mode_telemetry(request.runtime, resolution)
+        _attach_approval_mode_telemetry(mode_tags, mode_metadata)
+        from langsmith import tracing_context
+        from langsmith.run_helpers import get_tracing_context
+
+        current_trace = get_tracing_context()
+        trace_tags = sorted({*(current_trace.get("tags") or []), *mode_tags})
+        trace_metadata = {**(current_trace.get("metadata") or {}), **mode_metadata}
+        with tracing_context(tags=trace_tags, metadata=trace_metadata):
+            response = await handler(request)
         ai_message = next(
             (
                 message
@@ -2765,7 +2841,7 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
 
         calls = list(ai_message.tool_calls)
         gated_calls = [call for call in calls if call["name"] in self.interrupt_on]
-        mode, mode_unavailable = await _live_mode(request.runtime)
+        mode = resolution["mode"]
         if mode is ApprovalMode.AUTO:
             _validate_unique_tool_call_ids(calls)
         thread_key = _thread_key(request.runtime) or ""
@@ -2775,6 +2851,9 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             "batch_id": batch_id,
             "thread_key": thread_key,
             "mode_at_proposal": mode.value,
+            "effective_approval_mode": mode.value,
+            "approval_mode_tags": mode_tags,
+            "approval_mode_metadata": mode_metadata,
             "phase": "planned",
             "manual_gated_ids": manual_ids,
             "decisions": [],
@@ -2782,10 +2861,8 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             "processed_result_ids": [],
             "counters_applied": False,
             "fallback_reason": (
-                "approval_mode_unavailable"
-                if mode_unavailable
-                and _context_value(_runtime_context(request.runtime), "approval_mode")
-                == ApprovalMode.AUTO.value
+                resolution["fallback_reason"]
+                if mode_metadata.get("client_approval_mode") == ApprovalMode.AUTO.value
                 else None
             ),
             "review_tool_call_ids": [],
@@ -2871,6 +2948,18 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
 
         if counter_context is None:
             plan["fallback_reason"] = "control_state_unavailable"
+            fallback_tags = [
+                "approval_mode:fallback",
+                "approval_mode:store_unavailable",
+            ]
+            fallback_metadata = {
+                "approval_mode_fallback_reason": "control_state_unavailable"
+            }
+            plan["approval_mode_tags"] = sorted(
+                {*plan["approval_mode_tags"], *fallback_tags}
+            )
+            plan["approval_mode_metadata"].update(fallback_metadata)
+            _attach_approval_mode_telemetry(fallback_tags, fallback_metadata)
             for call in review_calls:
                 plan["decisions"].append(
                     {
@@ -3482,9 +3571,26 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         if thread_key is None or raw.get("thread_key") != thread_key:
             return None
         raw_mode = raw.get("mode_at_proposal")
-        if not isinstance(raw_mode, str) or raw_mode not in {
-            mode.value for mode in ApprovalMode
-        }:
+        valid_modes = {mode.value for mode in ApprovalMode}
+        if not isinstance(raw_mode, str) or raw_mode not in valid_modes:
+            return None
+        effective_mode = raw.get("effective_approval_mode")
+        if effective_mode is not None and effective_mode not in valid_modes:
+            return None
+        mode_tags = raw.get("approval_mode_tags")
+        if mode_tags is not None and (
+            not isinstance(mode_tags, list)
+            or not all(isinstance(tag, str) for tag in mode_tags)
+        ):
+            return None
+        mode_metadata = raw.get("approval_mode_metadata")
+        if mode_metadata is not None and (
+            not isinstance(mode_metadata, Mapping)
+            or not all(
+                isinstance(key, str) and isinstance(value, str)
+                for key, value in mode_metadata.items()
+            )
+        ):
             return None
         decisions = raw.get("decisions")
         manual_ids = raw.get("manual_gated_ids")
@@ -3611,7 +3717,9 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         # a caller ever passed a message whose tool calls had been filtered.
         event_scope = _event_scope(runtime, ai_message.tool_calls)
         plan = self._validated_plan(state, ai_message, thread_key)
-        current_mode, current_mode_unavailable = await _live_mode(runtime)
+        current_resolution = await _live_mode(runtime)
+        current_mode = current_resolution["mode"]
+        current_mode_unavailable = current_resolution["fallback_reason"] is not None
         manual_ids = {
             _tool_call_id(call)
             for call in ai_message.tool_calls

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -876,6 +876,18 @@ async def _live_mode(runtime: object) -> ApprovalModeResolution:
     }
 
 
+def _fallback_telemetry(reason: str) -> tuple[list[str], dict[str, str]]:
+    """Build the tags and metadata that mark an approval-mode fallback.
+
+    Returns:
+        LangSmith tags and trace-safe metadata for one fallback reason.
+    """
+    return (
+        ["approval_mode:fallback", "approval_mode:store_unavailable"],
+        {"approval_mode_fallback_reason": reason},
+    )
+
+
 def _approval_mode_telemetry(
     runtime: object, resolution: ApprovalModeResolution
 ) -> tuple[list[str], dict[str, str]]:
@@ -885,11 +897,10 @@ def _approval_mode_telemetry(
         LangSmith tags and trace-safe metadata.
     """
     mode = resolution["mode"]
-    raw_client_mode = _context_value(_runtime_context(runtime), "approval_mode")
-    client_mode = raw_client_mode if isinstance(raw_client_mode, str) else None
+    client_mode = _context_value(_runtime_context(runtime), "approval_mode")
     metadata = {"effective_approval_mode": mode.value}
     tags: list[str] = []
-    if client_mode in {item.value for item in ApprovalMode}:
+    if isinstance(client_mode, str) and client_mode in ApprovalMode:
         metadata["client_approval_mode"] = client_mode
         metadata["server_approval_mode"] = mode.value
         if client_mode != mode.value:
@@ -902,8 +913,9 @@ def _approval_mode_telemetry(
                 mode.value,
             )
     if fallback_reason := resolution["fallback_reason"]:
-        tags.extend(["approval_mode:fallback", "approval_mode:store_unavailable"])
-        metadata["approval_mode_fallback_reason"] = fallback_reason
+        fallback_tags, fallback_metadata = _fallback_telemetry(fallback_reason)
+        tags.extend(fallback_tags)
+        metadata.update(fallback_metadata)
     return tags, metadata
 
 
@@ -916,14 +928,14 @@ def _attach_approval_mode_telemetry(
     run = get_current_run_tree()
     if run is None:
         return
-    run.add_tags([tag for tag in tags if tag not in (run.tags or [])])
-    run.add_metadata(dict(metadata))
     root = run
     while root.parent_run is not None:
         root = root.parent_run
-    if root is not run:
-        root.add_tags([tag for tag in tags if tag not in (root.tags or [])])
-        root.add_metadata(dict(metadata))
+    targets = [run] if root is run else [run, root]
+    payload = dict(metadata)
+    for target in targets:
+        target.add_tags([tag for tag in tags if tag not in (target.tags or [])])
+        target.add_metadata(payload)
 
 
 def _trusted_prompt_rows(
@@ -2831,7 +2843,10 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             response = await handler(request)
         resolution = await _live_mode(request.runtime)
         mode_tags, mode_metadata = _approval_mode_telemetry(request.runtime, resolution)
-        _attach_approval_mode_telemetry(mode_tags, mode_metadata)
+        # The mode rarely changes across the model call, so re-attaching identical
+        # diagnostics would only re-walk the run tree.
+        if (mode_tags, mode_metadata) != (trace_tags, trace_metadata):
+            _attach_approval_mode_telemetry(mode_tags, mode_metadata)
         ai_message = next(
             (
                 message
@@ -2869,7 +2884,8 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             "counters_applied": False,
             "fallback_reason": (
                 resolution["fallback_reason"]
-                if mode_metadata.get("client_approval_mode") == ApprovalMode.AUTO.value
+                if _context_value(_runtime_context(request.runtime), "approval_mode")
+                == ApprovalMode.AUTO.value
                 else None
             ),
             "review_tool_call_ids": [],
@@ -2955,13 +2971,9 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
 
         if counter_context is None:
             plan["fallback_reason"] = "control_state_unavailable"
-            fallback_tags = [
-                "approval_mode:fallback",
-                "approval_mode:store_unavailable",
-            ]
-            fallback_metadata = {
-                "approval_mode_fallback_reason": "control_state_unavailable"
-            }
+            fallback_tags, fallback_metadata = _fallback_telemetry(
+                "control_state_unavailable"
+            )
             plan["approval_mode_tags"] = sorted(
                 {*plan["approval_mode_tags"], *fallback_tags}
             )
@@ -3578,11 +3590,12 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         if thread_key is None or raw.get("thread_key") != thread_key:
             return None
         raw_mode = raw.get("mode_at_proposal")
-        valid_modes = {mode.value for mode in ApprovalMode}
-        if not isinstance(raw_mode, str) or raw_mode not in valid_modes:
+        if not isinstance(raw_mode, str) or raw_mode not in ApprovalMode:
             return None
         effective_mode = raw.get("effective_approval_mode")
-        if effective_mode is not None and effective_mode not in valid_modes:
+        if effective_mode is not None and (
+            not isinstance(effective_mode, str) or effective_mode not in ApprovalMode
+        ):
             return None
         mode_tags = raw.get("approval_mode_tags")
         if mode_tags is not None and (

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -408,6 +408,41 @@ async def _plan(
     )
 
 
+async def _plan_with_trace_context(
+    middleware: AutoModeHITLMiddleware,
+    request: ModelRequest[Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    from langsmith.run_helpers import get_tracing_context
+
+    context: dict[str, Any] = {}
+
+    async def handler(_request: ModelRequest) -> ModelResponse:
+        await asyncio.sleep(0)
+        context.update(get_tracing_context())
+        return ModelResponse(
+            result=[
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "delete",
+                            "args": {"file_path": "old.py"},
+                            "id": "call-1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        )
+
+    response = await middleware.awrap_model_call(request, handler)
+    assert isinstance(response, ExtendedModelResponse)
+    assert response.command is not None
+    assert response.command.update is not None
+    plan = cast("dict[str, Any]", response.command.update)["_auto_decision_plan"]
+    return plan, context
+
+
 async def _route_plan(
     middleware: AutoModeHITLMiddleware,
     request: ModelRequest[Any],
@@ -2111,6 +2146,76 @@ async def test_counter_write_failure_is_not_reported_as_classifier_approval(
     assert plan["decisions"][0]["disposition"] == "require_human"
     completed = next(event for event in events if event["event"] == "review_completed")
     assert completed["approved_tool_call_ids"] == []
+
+
+async def test_effective_approval_mode_reaches_model_metadata_and_plan(
+    tmp_path: Path,
+) -> None:
+    middleware = _middleware(tmp_path)
+    request, _store, _key = _request(
+        tmp_path,
+        model=_StructuredModel(_allow_result()),
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+
+    plan, context = await _plan_with_trace_context(middleware, request)
+
+    assert context["metadata"]["effective_approval_mode"] == "auto"
+    assert plan["effective_approval_mode"] == "auto"
+    assert plan["approval_mode_metadata"] == {
+        "effective_approval_mode": "auto",
+        "client_approval_mode": "auto",
+        "server_approval_mode": "auto",
+    }
+    assert plan["approval_mode_tags"] == []
+
+
+async def test_approval_mode_mismatch_is_tagged_and_logged(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    middleware = _middleware(tmp_path)
+    request, _store, _key = _request(
+        tmp_path,
+        model=_FailIfClassifiedModel(),
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+    request.runtime.context["approval_mode"] = "yolo"
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_code.auto_mode"):
+        plan, context = await _plan_with_trace_context(middleware, request)
+
+    assert "approval_mode:mismatch" in context["tags"]
+    assert plan["approval_mode_metadata"] == {
+        "effective_approval_mode": "auto",
+        "client_approval_mode": "yolo",
+        "server_approval_mode": "auto",
+        "approval_mode_warning": "client_server_mismatch",
+    }
+    assert "client_approval_mode=yolo server_approval_mode=auto" in caplog.text
+
+
+async def test_missing_approval_mode_key_tags_store_fallback(tmp_path: Path) -> None:
+    middleware = _middleware(tmp_path)
+    request, _store, _key = _request(
+        tmp_path,
+        model=_FailIfClassifiedModel(),
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+    request.runtime.context.pop("approval_mode_key")
+
+    plan, context = await _plan_with_trace_context(middleware, request)
+
+    assert plan["effective_approval_mode"] == "manual"
+    assert plan["fallback_reason"] == "approval_mode_unavailable"
+    assert {"approval_mode:fallback", "approval_mode:store_unavailable"}.issubset(
+        context["tags"]
+    )
+    assert context["metadata"]["approval_mode_fallback_reason"] == (
+        "approval_mode_unavailable"
+    )
 
 
 async def test_unavailable_auto_control_state_surfaces_manual_fallback(

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -2171,6 +2171,47 @@ async def test_effective_approval_mode_reaches_model_metadata_and_plan(
     assert plan["approval_mode_tags"] == []
 
 
+async def test_mode_switch_during_model_call_uses_latest_mode_for_plan(
+    tmp_path: Path,
+) -> None:
+    middleware = _middleware(tmp_path)
+    request, store, key = _request(
+        tmp_path,
+        model=_FailIfClassifiedModel(),
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+
+    async def handler(_request: ModelRequest) -> ModelResponse:
+        await asyncio.sleep(0)
+        store.put(APPROVAL_MODE_NAMESPACE, key, {"mode": "manual"})
+        return ModelResponse(
+            result=[
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "delete",
+                            "args": {"file_path": "old.py"},
+                            "id": "call-1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        )
+
+    response = await middleware.awrap_model_call(request, handler)
+
+    assert isinstance(response, ExtendedModelResponse)
+    assert response.command is not None
+    update = cast("dict[str, Any]", response.command.update)
+    plan = update["_auto_decision_plan"]
+    assert plan["mode_at_proposal"] == "manual"
+    assert plan["effective_approval_mode"] == "manual"
+    assert plan["decisions"] == []
+
+
 async def test_approval_mode_mismatch_is_tagged_and_logged(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
Approval-mode traces now expose the server-resolved mode, client/server mismatches, and Store fallbacks.

---

`AutoModeHITLMiddleware` now adds validated approval-mode metadata and tags to model calls and active/root LangSmith traces, while carrying the same diagnostics in its private decision plan for downstream middleware. Mismatches emit structured warnings, and unavailable approval/control Store state is explicitly tagged with a fixed reason code.

Made by [Open SWE](https://openswe.vercel.app/agents/7a65ba17-e74d-5c65-b825-05696c75265a)