### PR TITLE
ci(ci): remove unit test coverage collection

### DIFF
--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -189,13 +189,27 @@ SELECTION_CASES = [
 ]
 
 
-def test_deepagents_code_collects_coverage_on_python_3_14() -> None:
-    """Keep all supported runtimes while collecting coverage on Python 3.14."""
+def test_ci_unit_tests_do_not_collect_coverage() -> None:
+    """Run every supported runtime without coverage bookkeeping."""
     workflow = _load_workflow(CI_WORKFLOW)
+    test_workflow = _load_workflow(TEST_WORKFLOW)
     config = workflow["jobs"]["test-code"]["with"]
 
     assert json.loads(config["python-versions"]) == ["3.12", "3.13", "3.14"]
-    assert config["coverage-python-version"] == "3.14"
+    assert all(
+        "coverage-python-version" not in job.get("with", {})
+        for job in workflow["jobs"].values()
+    )
+    inputs = test_workflow["on"]["workflow_call"]["inputs"]
+    assert "coverage-python-version" not in inputs
+    assert "coverage-os" not in inputs
+    for name in ("🧪 Run Unit Tests", "🧪 Run Unit Tests (Windows)"):
+        run = _find_step(test_workflow, job="build", name=name)["run"]
+        assert "--cov" not in run
+    assert (
+        "COV_ARGS="
+        in _find_step(test_workflow, job="build", name="🧪 Run Unit Tests")["run"]
+    )
 
 
 def test_ci_success_builds_named_results_from_needs_object() -> None:

--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -11,7 +11,6 @@ the strict step's bypass runs against a stubbed `gh` in
 
 from __future__ import annotations
 
-import json
 import re
 import subprocess
 import sys
@@ -187,29 +186,6 @@ SELECTION_CASES = [
         None,
     ),
 ]
-
-
-def test_ci_unit_tests_do_not_collect_coverage() -> None:
-    """Run every supported runtime without coverage bookkeeping."""
-    workflow = _load_workflow(CI_WORKFLOW)
-    test_workflow = _load_workflow(TEST_WORKFLOW)
-    config = workflow["jobs"]["test-code"]["with"]
-
-    assert json.loads(config["python-versions"]) == ["3.12", "3.13", "3.14"]
-    assert all(
-        "coverage-python-version" not in job.get("with", {})
-        for job in workflow["jobs"].values()
-    )
-    inputs = test_workflow["on"]["workflow_call"]["inputs"]
-    assert "coverage-python-version" not in inputs
-    assert "coverage-os" not in inputs
-    for name in ("🧪 Run Unit Tests", "🧪 Run Unit Tests (Windows)"):
-        run = _find_step(test_workflow, job="build", name=name)["run"]
-        assert "--cov" not in run
-    assert (
-        "COV_ARGS="
-        in _find_step(test_workflow, job="build", name="🧪 Run Unit Tests")["run"]
-    )
 
 
 def test_ci_success_builds_named_results_from_needs_object() -> None:

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -23,16 +23,6 @@ on:
         type: string
         default: "[]"
         description: "JSON array of additional {python-version, os} legs (e.g. '[{\"python-version\":\"3.13\",\"os\":\"windows-latest\"}]')"
-      coverage-python-version:
-        required: false
-        type: string
-        default: ""
-        description: "Python version of the leg on which to collect coverage; empty disables coverage for all legs"
-      coverage-os:
-        required: false
-        type: string
-        default: ""
-        description: "Runner OS of the coverage leg; empty defaults to the primary 'os' input"
 
 # `pull-requests: read` lets the reusable workflow read live PR labels for the
 # warnings bypass below; a called workflow can only narrow the caller's token,
@@ -52,14 +42,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - name: "🔍 Validate matrix inputs and coverage leg"
+      - name: "🔍 Validate matrix inputs"
         shell: bash
         env:
           VERSIONS: ${{ inputs.python-versions }}
           EXTRAS: ${{ inputs.extra-configurations }}
-          PRIMARY_OS: ${{ inputs.os }}
-          COV_PY: ${{ inputs.coverage-python-version }}
-          COV_OS: ${{ inputs.coverage-os || inputs.os }}
         run: |
           if ! echo "$VERSIONS" | jq -e 'type == "array" and all(.[]; type == "string")' > /dev/null; then
             echo "::error::python-versions must be a JSON array of quoted strings (got: $VERSIONS)"
@@ -69,21 +56,6 @@ jobs:
             echo "::error::extra-configurations must be a JSON array of objects each with string 'python-version' and 'os' keys (got: $EXTRAS)"
             exit 1
           fi
-          if [ -z "$COV_PY" ]; then
-            echo "coverage-python-version is empty; coverage disabled for all legs"
-            exit 0
-          fi
-          LEGS=$(jq -nc \
-            --argjson versions "$VERSIONS" \
-            --arg primary_os "$PRIMARY_OS" \
-            --argjson extras "$EXTRAS" \
-            '($versions | map({"python-version": ., "os": $primary_os})) + $extras')
-          if ! echo "$LEGS" | jq -e --arg py "$COV_PY" --arg os "$COV_OS" \
-            'any(.[]; .["python-version"] == $py and .os == $os)' > /dev/null; then
-            echo "::error::coverage leg (python=$COV_PY, os=$COV_OS) is not among configured legs: $LEGS"
-            exit 1
-          fi
-          echo "Coverage will be collected on Python $COV_PY / $COV_OS"
 
   build:
     needs: validate-inputs
@@ -365,20 +337,10 @@ jobs:
         shell: bash
         env:
           RUN_SANDBOX_TESTS: "true"
-          PY: ${{ matrix.python-version }}
-          PY_OS: ${{ matrix.os }}
-          COV_PY: ${{ inputs.coverage-python-version }}
-          COV_OS: ${{ inputs.coverage-os || inputs.os }}
           # A command-line `-W` filter outranks every ini `filterwarnings`
           # entry, so the bypass also demotes intentional `error:` filters.
           WARNINGS_FLAG: ${{ steps.warnings.outputs.flag }}
-        run: |
-          if [ -n "$COV_PY" ] && [ "$PY" = "$COV_PY" ] && [ "$PY_OS" = "$COV_OS" ]; then
-            make test PYTEST_EXTRA="-q $WARNINGS_FLAG"
-          else
-            echo "Coverage disabled for Python $PY / $PY_OS (target=$COV_PY / $COV_OS)"
-            make test COV_ARGS= PYTEST_EXTRA="-q $WARNINGS_FLAG"
-          fi
+        run: make test COV_ARGS= PYTEST_EXTRA="-q $WARNINGS_FLAG"
 
       # Windows cannot run `make test` because `LocalShellBackend` requires POSIX
       # `sh`, so the sandbox matrix is skipped here (`RUN_SANDBOX_TESTS` is
@@ -390,19 +352,9 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         env:
-          PY: ${{ matrix.python-version }}
-          PY_OS: ${{ matrix.os }}
-          COV_PY: ${{ inputs.coverage-python-version }}
-          COV_OS: ${{ inputs.coverage-os || inputs.os }}
           # See the POSIX step: the command-line bypass outranks ini filters.
           WARNINGS_FLAG: ${{ steps.warnings.outputs.flag }}
-        run: |
-          if [ -n "$COV_PY" ] && [ "$PY" = "$COV_PY" ] && [ "$PY_OS" = "$COV_OS" ]; then
-            uv run --group test pytest -n auto -vvv $WARNINGS_FLAG tests/unit_tests/ --cov=deepagents --cov-report=term-missing
-          else
-            echo "Coverage disabled for Python $PY / $PY_OS (target=$COV_PY / $COV_OS)"
-            uv run --group test pytest -n auto -vvv $WARNINGS_FLAG tests/unit_tests/
-          fi
+        run: uv run --group test pytest -n auto -vvv $WARNINGS_FLAG tests/unit_tests/
 
       - name: "🧹 Verify Clean Working Directory"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,6 @@ jobs:
       working-directory: "libs/deepagents"
       python-versions: '["3.11", "3.12", "3.13", "3.14"]'
       extra-configurations: '[{"python-version": "3.13", "os": "windows-latest"}]'
-      coverage-python-version: "3.12"
 
   test-code:
     name: "🧪 Test deepagents-code"
@@ -276,7 +275,6 @@ jobs:
     with:
       working-directory: "libs/code"
       python-versions: '["3.12", "3.13", "3.14"]'
-      coverage-python-version: "3.14"
 
   test-talon:
     name: "🧪 Test deepagents-talon"
@@ -286,7 +284,6 @@ jobs:
     with:
       working-directory: "libs/talon"
       python-versions: '["3.12", "3.13", "3.14"]'
-      coverage-python-version: "3.12"
 
   test-evals:
     name: "🧪 Test evals"
@@ -296,7 +293,6 @@ jobs:
     with:
       working-directory: "libs/evals"
       python-versions: '["3.12", "3.13"]'
-      coverage-python-version: "3.12"
 
   test-acp:
     name: "🧪 Test acp"
@@ -306,7 +302,6 @@ jobs:
     with:
       working-directory: "libs/acp"
       python-versions: '["3.11", "3.12", "3.13", "3.14"]'
-      coverage-python-version: "3.12"
 
   test-daytona:
     name: "🧪 Test daytona"
@@ -316,7 +311,6 @@ jobs:
     with:
       working-directory: "libs/partners/daytona"
       python-versions: '["3.11", "3.12", "3.13", "3.14"]'
-      coverage-python-version: "3.12"
 
   test-modal:
     name: "🧪 Test modal"
@@ -326,7 +320,6 @@ jobs:
     with:
       working-directory: "libs/partners/modal"
       python-versions: '["3.11", "3.12", "3.13", "3.14"]'
-      coverage-python-version: "3.12"
 
   test-runloop:
     name: "🧪 Test runloop"
@@ -336,7 +329,6 @@ jobs:
     with:
       working-directory: "libs/partners/runloop"
       python-versions: '["3.11", "3.12", "3.13", "3.14"]'
-      coverage-python-version: "3.12"
 
   test-vercel:
     name: "🧪 Test vercel"
@@ -346,7 +338,6 @@ jobs:
     with:
       working-directory: "libs/partners/vercel"
       python-versions: '["3.11", "3.12", "3.13", "3.14"]'
-      coverage-python-version: "3.12"
 
   test-quickjs:
     name: "🧪 Test quickjs"
@@ -356,7 +347,6 @@ jobs:
     with:
       working-directory: "libs/partners/quickjs"
       python-versions: '["3.11", "3.12", "3.13", "3.14"]'
-      coverage-python-version: "3.11"
 
   # Catch SDK -> quickjs prompt-snapshot drift: when the deepagents SDK
   # changes but the quickjs partner is untouched, the full test-quickjs suite


### PR DESCRIPTION
Unit-test CI currently prints coverage information but does not enforce a threshold or publish a report that protects merges. Remove that bookkeeping from every package test leg while preserving the existing Python-version matrix and test execution. Local `make coverage` targets and release workflows remain unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/3d4976fc-fe67-5022-9a59-582f2d6b16b9)