### PR TITLE
fix(code): scope project dotenv to workspaces

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -24,6 +24,10 @@ ever renamed, only the value here changes.
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 # ---------------------------------------------------------------------------
 # Constants — import these instead of bare string literals.
@@ -694,7 +698,12 @@ def classify_env_bool(raw: str) -> bool | None:
     return None
 
 
-def is_env_truthy(name: str, *, default: bool = False) -> bool:
+def is_env_truthy(
+    name: str,
+    *,
+    default: bool = False,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
     """Return whether env var *name* is set to a recognizably truthy value.
 
     Unlike `bool(os.environ.get(name))`, this does not treat `"0"` or
@@ -706,12 +715,14 @@ def is_env_truthy(name: str, *, default: bool = False) -> bool:
             constant from this module).
         default: Value returned when the variable is unset OR set to a
             value that is neither recognizably truthy nor falsy.
+        environ: Environment to read, defaulting to the process environment.
+            Pass a workspace snapshot to keep the read scoped.
 
     Returns:
         `True` for `1`/`true`/`yes`/`on` (case-insensitive), `False` for
         `0`/`false`/`no`/`off`/empty string, or `default` otherwise.
     """
-    raw = os.environ.get(name)
+    raw = (os.environ if environ is None else environ).get(name)
     if raw is None:
         return default
     classified = classify_env_bool(raw)

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -107,6 +107,7 @@ from deepagents_code.config import (
     _INHERITED_PYTHONPATH_ENV,
     DEFAULT_MODEL_RETRIES,
     _ShellAllowAll,
+    apply_inherited_user_tracing,
     console,
     credentials,
     get_default_coding_instructions,
@@ -3000,7 +3001,13 @@ def create_cli_agent(
                 )
             else:
                 shell_env.pop("LANGSMITH_PROJECT", None)
-            if environ is None:
+            # Restore the caller's tracing flags and key so `execute` commands
+            # never run under the agent's session credentials. On the server
+            # path the client relays its pre-bootstrap values through
+            # `_INHERITED_USER_TRACING_ENV`, because this process's own
+            # `_bootstrap_state` already holds the agent's values; when nothing
+            # was relayed, the local capture is authoritative.
+            if not apply_inherited_user_tracing(shell_env):
                 restore_user_tracing_env(shell_env)
                 restore_user_tracing_api_keys(shell_env)
             # Re-apply a launch-time PYTHONPATH that was stripped from the server
@@ -3011,11 +3018,11 @@ def create_cli_agent(
             # The SDK's FilesystemMiddleware exposes per-command timeout
             # on the execute tool natively.
             # `inherit_env=False`: `shell_env` is already a complete, curated
-            # copy of `os.environ`. Inheriting again would re-copy `os.environ`
-            # and resurrect the popped carrier var, leaking it into `execute`.
-            # `restore_user_tracing_api_keys` above depends on this too: flipping
-            # to `inherit_env=True` would re-copy the agent's overridden
-            # `LANGSMITH_API_KEY` and undo the restore, leaking it into `execute`.
+            # copy of the active environment. Inheriting again would re-copy
+            # `os.environ` and resurrect the popped carrier vars, leaking them
+            # into `execute`. The tracing restore above depends on this too:
+            # flipping to `inherit_env=True` would re-copy the agent's
+            # overridden `LANGSMITH_API_KEY` and undo the restore.
             backend = LocalShellBackend(
                 root_dir=root_dir,
                 virtual_mode=False,

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -2399,7 +2399,12 @@ def get_skill_sources(
     user_claude_skills_dir = get_user_claude_skills_dir()
     if user_claude_skills_dir is not None and user_claude_skills_dir.exists():
         sources.append((str(user_claude_skills_dir), "User Claude"))
-    project_claude_skills_dir = get_project_claude_skills_dir(credentials.project_root)
+    project_claude_root = (
+        project_context.project_root
+        if project_context is not None
+        else credentials.project_root
+    )
+    project_claude_skills_dir = get_project_claude_skills_dir(project_claude_root)
     if project_claude_skills_dir:
         sources.append((str(project_claude_skills_dir), "Project Claude"))
 

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from langgraph.store.base import BaseStore
     from langgraph.types import Command
 
+    from deepagents_code.config import CredentialsSnapshot, ModelResult
     from deepagents_code.extensions.registry import ExtensionRegistry
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.output import OutputFormat
@@ -1529,6 +1530,8 @@ def get_system_prompt(
     interactive: bool = True,
     cwd: str | Path | None = None,
     fs_tools: list[FsToolName] | None = None,
+    has_tavily: bool | None = None,
+    model_result: ModelResult | None = None,
 ) -> str:
     """Get the base system prompt for the agent.
 
@@ -1547,6 +1550,8 @@ def get_system_prompt(
         cwd: Override the working directory shown in the prompt.
         fs_tools: Filesystem tool allowlist. Restricted prompts omit guidance
             for unavailable tools; `None` retains all guidance.
+        has_tavily: Workspace credential availability override.
+        model_result: Workspace model metadata override.
 
     Returns:
         The system prompt string
@@ -1601,15 +1606,28 @@ def get_system_prompt(
         )
 
     model_identity_section = build_model_identity_section(
-        runtime_state.model_name,
-        provider=runtime_state.model_provider,
-        context_limit=runtime_state.model_context_limit,
-        unsupported_modalities=runtime_state.model_unsupported_modalities,
+        model_result.model_name
+        if model_result is not None
+        else runtime_state.model_name,
+        provider=(
+            model_result.provider
+            if model_result is not None
+            else runtime_state.model_provider
+        ),
+        context_limit=(
+            model_result.context_limit
+            if model_result is not None
+            else runtime_state.model_context_limit
+        ),
+        unsupported_modalities=(
+            model_result.unsupported_modalities
+            if model_result is not None
+            else runtime_state.model_unsupported_modalities
+        ),
     )
     filesystem_tool_guidance = _build_fs_tool_prompt_guidance(fs_tools)
-    web_search_tool_guidance = (
-        _WEB_SEARCH_TOOL_GUIDANCE if credentials.has_tavily else ""
-    )
+    tavily_available = credentials.has_tavily if has_tavily is None else has_tavily
+    web_search_tool_guidance = _WEB_SEARCH_TOOL_GUIDANCE if tavily_available else ""
 
     # Build working directory section (local vs sandbox)
     if sandbox_type:
@@ -2427,6 +2445,9 @@ def create_cli_agent(
     summarization_model: str | None = None,
     enforce_model_policy: bool = True,
     extension_registry: ExtensionRegistry | None = None,
+    environ: Mapping[str, str] | None = None,
+    credentials_snapshot: CredentialsSnapshot | None = None,
+    model_result: ModelResult | None = None,
 ) -> tuple[Pregel[Any, Any, Any, Any], CompositeBackend]:
     """Create a CLI-configured agent with flexible options.
 
@@ -2597,6 +2618,9 @@ def create_cli_agent(
             listing rather than raising. Any caller that can run the graph must
             leave this `True`.
         extension_registry: Server-owned Python extension registrations.
+        environ: Environment snapshot frozen into local shell execution.
+        credentials_snapshot: Credentials resolved from `environ` for this runtime.
+        model_result: Workspace model metadata used in the generated prompt.
 
     Returns:
         2-tuple of `(agent_graph, backend)`
@@ -2617,10 +2641,15 @@ def create_cli_agent(
             a prebuilt `BaseChatModel` came from a path that already checked.
     """  # noqa: DOC502 - propagates from `ModelConfig.require_model_allowed`
     tools = list(tools or [])
+    environment = os.environ if environ is None else environ
+    runtime_credentials = (
+        credentials if credentials_snapshot is None else credentials_snapshot
+    )
     if extension_registry is not None:
-        from deepagents_code._env_vars import EXPERIMENTAL
+        from deepagents_code._env_vars import EXPERIMENTAL, classify_env_bool
 
-        if not is_env_truthy(EXPERIMENTAL):
+        experimental = classify_env_bool(environment.get(EXPERIMENTAL, "")) is True
+        if not experimental:
             extension_registry = None
     mcp_tools = tuple(mcp_tools or ())
     if auto_mode_enabled and sandbox is not None:
@@ -2678,7 +2707,7 @@ def create_cli_agent(
     project_agents_dir = (
         project_context.project_agents_dir()
         if project_context is not None
-        else get_project_agents_dir(credentials.project_root)
+        else get_project_agents_dir(runtime_credentials.project_root)
     )
 
     def _subagent_cli_middleware(
@@ -2695,6 +2724,7 @@ def create_cli_agent(
                 ConfigurableModelMiddleware(
                     persist_model_state=False,
                     cli_max_retries=cli_max_retries,
+                    environ=environment,
                 )
             )
         # Checkpoint nested spend before HITL can pause the subgraph, then hand
@@ -2846,7 +2876,11 @@ def create_cli_agent(
 
     # Build middleware stack based on enabled features
     agent_middleware: list[AgentMiddleware[Any, Any]] = [
-        ConfigurableModelMiddleware(cli_max_retries=cli_max_retries),
+        ConfigurableModelMiddleware(
+            cli_max_retries=cli_max_retries,
+            environ=environment,
+            model_result=model_result,
+        ),
     ]
     if not interactive:
         agent_middleware.append(_GlmTerminalStallRecovery())
@@ -2898,7 +2932,7 @@ def create_cli_agent(
         project_agent_md_paths = (
             project_context.project_agent_md_paths()
             if project_context is not None
-            else get_project_agent_md_path(credentials.project_root)
+            else get_project_agent_md_path(runtime_credentials.project_root)
         )
         memory_sources.extend(str(p) for p in project_agent_md_paths)
 
@@ -2953,14 +2987,17 @@ def create_cli_agent(
             # separately. When they had none, drop the agent's override (the
             # `deepagents-code` default applied at bootstrap) entirely so shell
             # commands don't inherit it.
-            shell_env = os.environ.copy()
+            shell_env = dict(environment)
             shell_env["GIT_TERMINAL_PROMPT"] = "0"
-            if credentials.user_langchain_project is not None:
-                shell_env["LANGSMITH_PROJECT"] = credentials.user_langchain_project
+            if runtime_credentials.user_langchain_project is not None:
+                shell_env["LANGSMITH_PROJECT"] = (
+                    runtime_credentials.user_langchain_project
+                )
             else:
                 shell_env.pop("LANGSMITH_PROJECT", None)
-            restore_user_tracing_env(shell_env)
-            restore_user_tracing_api_keys(shell_env)
+            if environ is None:
+                restore_user_tracing_env(shell_env)
+                restore_user_tracing_api_keys(shell_env)
             # Re-apply a launch-time PYTHONPATH that was stripped from the server
             # interpreter but relayed for approval-gated `execute` commands.
             _apply_inherited_pythonpath(shell_env)
@@ -3035,7 +3072,7 @@ def create_cli_agent(
                 backend=backend,
                 mcp_server_info=mcp_server_info,
                 tracing_project=get_langsmith_project_name(),
-                user_tracing_project=credentials.user_langchain_project,
+                user_tracing_project=runtime_credentials.user_langchain_project,
             )
         )
 
@@ -3051,6 +3088,8 @@ def create_cli_agent(
             interactive=interactive,
             cwd=effective_cwd,
             fs_tools=fs_tools,
+            has_tavily=runtime_credentials.has_tavily,
+            model_result=model_result,
         )
 
     interrupt_on: dict[str, bool | InterruptOnConfig] = {}
@@ -3142,6 +3181,7 @@ def create_cli_agent(
         composite_backend,
         cli_max_retries=cli_max_retries,
         summarization_model_spec=summarization_model,
+        environ=environment,
     )
     if auto_mode_config is not None and resolved_interrupt_on is not None:
         from deepagents_code.auto_mode import AutoModeHITLMiddleware
@@ -3164,6 +3204,7 @@ def create_cli_agent(
                 shell_allow_list=narrow_allow_list,
                 classifier_model=classifier_model,
                 cli_max_retries=cli_max_retries,
+                environ=environment,
                 classifier_timeout_seconds=resolve_auto_classifier_timeout(),
                 trusted_ask_user_tool=trusted_ask_user_tool,
                 trusted_compaction_tool=compaction_middleware.tools[0],
@@ -3259,11 +3300,13 @@ def create_cli_agent(
             fs_tools=fs_tools,
             model_retries=model_retries,
             cli_max_retries=cli_max_retries,
+            environ=environment,
         )
         criteria_fallback_agent = create_goal_criteria_fallback_agent(
             model=model,
             model_retries=model_retries,
             cli_max_retries=cli_max_retries,
+            environ=environment,
         )
         agent_middleware.append(
             GoalCriteriaMiddleware(criteria_agent, criteria_fallback_agent)
@@ -3332,6 +3375,7 @@ def create_cli_agent(
             persist_model_state=False,
             cli_max_retries=cli_max_retries,
             strict_model_resolution=True,
+            environ=environment,
         ),
         # Both clients filter this nested message stream. A transient fault can
         # safely retry the failed model node without replaying grader tools.

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -67,6 +67,7 @@ from deepagents_code import theme
 from deepagents_code._cli_context import CLIContextSchema
 from deepagents_code._constants import DEFAULT_AGENT_NAME
 from deepagents_code._env_vars import (
+    EXPERIMENTAL,
     FORKED_SUBAGENTS,
     is_env_truthy,
 )
@@ -1606,25 +1607,26 @@ def get_system_prompt(
             "available. Never run commands that block waiting for stdin."
         )
 
+    if model_result is not None:
+        model_identity = (
+            model_result.model_name,
+            model_result.provider,
+            model_result.context_limit,
+            model_result.unsupported_modalities,
+        )
+    else:
+        model_identity = (
+            runtime_state.model_name,
+            runtime_state.model_provider,
+            runtime_state.model_context_limit,
+            runtime_state.model_unsupported_modalities,
+        )
+    model_name, model_provider, model_context_limit, model_modalities = model_identity
     model_identity_section = build_model_identity_section(
-        model_result.model_name
-        if model_result is not None
-        else runtime_state.model_name,
-        provider=(
-            model_result.provider
-            if model_result is not None
-            else runtime_state.model_provider
-        ),
-        context_limit=(
-            model_result.context_limit
-            if model_result is not None
-            else runtime_state.model_context_limit
-        ),
-        unsupported_modalities=(
-            model_result.unsupported_modalities
-            if model_result is not None
-            else runtime_state.model_unsupported_modalities
-        ),
+        model_name,
+        provider=model_provider,
+        context_limit=model_context_limit,
+        unsupported_modalities=model_modalities,
     )
     filesystem_tool_guidance = _build_fs_tool_prompt_guidance(fs_tools)
     tavily_available = credentials.has_tavily if has_tavily is None else has_tavily
@@ -2651,12 +2653,10 @@ def create_cli_agent(
     runtime_credentials = (
         credentials if credentials_snapshot is None else credentials_snapshot
     )
-    if extension_registry is not None:
-        from deepagents_code._env_vars import EXPERIMENTAL, classify_env_bool
-
-        experimental = classify_env_bool(environment.get(EXPERIMENTAL, "")) is True
-        if not experimental:
-            extension_registry = None
+    if extension_registry is not None and not is_env_truthy(
+        EXPERIMENTAL, environ=environment
+    ):
+        extension_registry = None
     mcp_tools = tuple(mcp_tools or ())
     if auto_mode_enabled and sandbox is not None:
         logger.warning(

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -613,9 +613,11 @@ def _redact_remote(value: str) -> str:
     return _CONTROL_RE.sub("", value)[:2000]
 
 
-def _known_credential_values() -> tuple[str, ...]:
+def _known_credential_values(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[str, ...]:
     values: set[str] = set()
-    for name, value in os.environ.items():
+    for name, value in (os.environ if environ is None else environ).items():
         if _SECRET_KEY_RE.search(name) and len(value) >= _MIN_SECRET_LENGTH:
             values.add(value)
     try:
@@ -2136,6 +2138,7 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         ),
         classifier_model: str | BaseChatModel | None = None,
         cli_max_retries: int | None = None,
+        environ: Mapping[str, str] | None = None,
         trusted_ask_user_tool: BaseTool | None = None,
         trusted_compaction_tool: BaseTool | None = None,
     ) -> None:
@@ -2157,6 +2160,7 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
                 `classifier_model` on the runtime context wins over this value.
             cli_max_retries: Explicit `--max-retries` value to retain when a
                 distinct classifier model is constructed.
+            environ: Workspace environment retained for lazy model construction.
             trusted_ask_user_tool: Built-in tool allowed to create consent receipts.
             trusted_compaction_tool: Built-in tool that performs conversation
                 compaction.
@@ -2217,12 +2221,13 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         )
         self._configured_classifier_model = classifier_model
         self._cli_max_retries = cli_max_retries
+        self._environ = environ
         self._classifier_model_cache: OrderedDict[str, BaseChatModel] = OrderedDict()
         self._classifier_model_lock = asyncio.Lock()
         self._classifier_model_constructions: dict[
             str, asyncio.Task[BaseChatModel]
         ] = {}
-        self._known_secrets = _known_credential_values()
+        self._known_secrets = _known_credential_values(environ)
         self._trusted_ask_user_tool = trusted_ask_user_tool
         self._trusted_compaction_tool = trusted_compaction_tool
         self._emitted_events: OrderedDict[str, set[tuple[str, ...]]] = OrderedDict()
@@ -2593,11 +2598,14 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
                     if self._cli_max_retries is not None
                     else {}
                 )
-                result = await asyncio.to_thread(
-                    create_model,
-                    selected,
-                    **retry_kwargs,
-                )
+                from deepagents_code.config import use_environment
+
+                with use_environment(self._environ):
+                    result = await asyncio.to_thread(
+                        create_model,
+                        selected,
+                        **retry_kwargs,
+                    )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:

--- a/libs/code/deepagents_code/client/launch/server.py
+++ b/libs/code/deepagents_code/client/launch/server.py
@@ -27,7 +27,7 @@ from deepagents_code._paths import (
     PATHS,
     export_profile_env,
 )
-from deepagents_code.config import _INHERITED_PYTHONPATH_ENV
+from deepagents_code.config import _INHERITED_PYTHONPATH_ENV, _dotenv_loaded_values
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Mapping
@@ -401,6 +401,9 @@ def _build_server_env() -> dict[str, str]:
         Environment dict for `subprocess.Popen`.
     """
     env = os.environ.copy()
+    for key, value in _dotenv_loaded_values.items():
+        if env.get(key) == value:
+            env.pop(key)
     export_profile_env(env)
     env["PYTHONDONTWRITEBYTECODE"] = "1"
     env["LANGGRAPH_AUTH_TYPE"] = "noop"

--- a/libs/code/deepagents_code/client/launch/server.py
+++ b/libs/code/deepagents_code/client/launch/server.py
@@ -27,7 +27,11 @@ from deepagents_code._paths import (
     PATHS,
     export_profile_env,
 )
-from deepagents_code.config import _INHERITED_PYTHONPATH_ENV, _dotenv_loaded_values
+from deepagents_code.config import (
+    _INHERITED_PYTHONPATH_ENV,
+    _dotenv_loaded_values,
+    export_user_tracing_env,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Mapping
@@ -424,6 +428,12 @@ def _build_server_env() -> dict[str, str]:
 
     if inherited_pythonpath is not None:
         env[_INHERITED_PYTHONPATH_ENV] = inherited_pythonpath
+
+    # Relay the caller's pre-bootstrap tracing values. The server inherits an
+    # environment where bootstrap already replaced them, so it cannot recapture
+    # them itself; without this, `execute` commands would run under the agent's
+    # LangSmith key and project.
+    export_user_tracing_env(env)
     return env
 
 

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -5187,6 +5187,26 @@ _OPENROUTER_APP_CATEGORIES: list[str] = ["cli-agent"]
 _cli_openrouter_profile_registered = False
 """Process-wide guard so the app's OpenRouter profile is registered exactly once."""
 
+_AWS_MODEL_SDK_ENV_KWARGS = {
+    "region_name": ("AWS_REGION", "AWS_DEFAULT_REGION"),
+    "credentials_profile_name": ("AWS_PROFILE", "AWS_DEFAULT_PROFILE"),
+    "aws_access_key_id": ("AWS_ACCESS_KEY_ID",),
+    "aws_secret_access_key": ("AWS_SECRET_ACCESS_KEY",),
+    "aws_session_token": ("AWS_SESSION_TOKEN",),
+}
+"""AWS model environment values accepted directly by LangChain constructors."""
+
+_PROVIDER_SDK_ENV_KWARGS: dict[str, dict[str, tuple[str, ...]]] = {
+    "anthropic_bedrock": _AWS_MODEL_SDK_ENV_KWARGS,
+    "azure_openai": {
+        "api_version": ("OPENAI_API_VERSION",),
+        "azure_ad_token": ("AZURE_OPENAI_AD_TOKEN",),
+    },
+    "bedrock": _AWS_MODEL_SDK_ENV_KWARGS,
+    "bedrock_converse": _AWS_MODEL_SDK_ENV_KWARGS,
+}
+"""SDK-read environment values that must be explicit in workspace runtimes."""
+
 
 def _cli_openrouter_attribution_kwargs() -> dict[str, Any]:
     """App-specific OpenRouter attribution kwargs.
@@ -5230,6 +5250,42 @@ def _ensure_cli_openrouter_profile_registered() -> None:
         ),
     )
     _cli_openrouter_profile_registered = True
+
+
+def _apply_azure_sdk_endpoint(kwargs: dict[str, Any]) -> None:
+    """Forward the Azure endpoint under the constructor's current field name."""
+    from deepagents_code.model_config import resolve_env_var
+
+    endpoint = resolve_env_var("AZURE_OPENAI_ENDPOINT")
+    if endpoint and kwargs.get("base_url") == endpoint:
+        kwargs.pop("base_url")
+    if endpoint and "base_url" not in kwargs:
+        kwargs.setdefault("azure_endpoint", endpoint)
+
+
+def _apply_provider_sdk_environment(
+    provider: str,
+    kwargs: dict[str, Any],
+) -> None:
+    """Apply SDK-only environment defaults without replacing explicit kwargs."""
+    from deepagents_code.model_config import resolve_env_var
+
+    if provider == "azure_openai":
+        _apply_azure_sdk_endpoint(kwargs)
+
+    for argument, env_names in _PROVIDER_SDK_ENV_KWARGS.get(provider, {}).items():
+        if argument in kwargs:
+            continue
+        value = next(
+            (
+                value
+                for name in env_names
+                if (value := resolve_env_var(name)) is not None
+            ),
+            None,
+        )
+        if value is not None:
+            kwargs[argument] = value
 
 
 def _get_provider_kwargs(
@@ -5307,6 +5363,7 @@ def _get_provider_kwargs(
                         client_kwargs["headers"] = headers
                         result["client_kwargs"] = client_kwargs
 
+    _apply_provider_sdk_environment(provider, result)
     return result
 
 

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -23,6 +23,7 @@ from dataclasses import (
 from enum import StrEnum
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Protocol, cast
 from urllib.parse import urlparse
 from urllib.request import url2pathname
@@ -408,34 +409,84 @@ def _dotenv_files_are_same(first: Path | None, second: Path) -> bool:
         return True
 
 
-def _preview_dotenv_environ(*, start_path: Path | None = None) -> dict[str, str]:
-    """Return the environment after dotenv loading without mutating `os.environ`.
+_active_environment: ContextVar[Mapping[str, str] | None] = ContextVar(
+    "deepagents_code_active_environment", default=None
+)
 
-    Args:
-        start_path: Directory to use for project `.env` discovery.
+
+def active_environment() -> Mapping[str, str]:
+    """Return the construction-scoped environment or the live process environment.
 
     Returns:
-        Environment mapping with project and global dotenv values applied using
-        the same first-write-wins precedence as `_load_dotenv`. The project
-        `.env` is skipped when `startup.read_project_dotenv` resolves false, so
-        a preview never reports a value a real reload would not load.
+        Active immutable snapshot or `os.environ` outside construction.
     """
-    import dotenv
+    environment = _active_environment.get()
+    return os.environ if environment is None else environment
 
-    env = dict(os.environ)
-    for key, value in _dotenv_loaded_values.items():
-        if env.get(key) == value:
-            env.pop(key)
+
+@contextmanager
+def use_environment(environ: Mapping[str, str] | None) -> Iterator[None]:
+    """Bind an immutable environment snapshot for runtime construction."""
+    if environ is None:
+        yield
+        return
+    token = _active_environment.set(MappingProxyType(dict(environ)))
+    try:
+        yield
+    finally:
+        _active_environment.reset(token)
+
+
+def _dotenv_values_from(
+    dotenv_path: Path,
+    environ: Mapping[str, str],
+) -> dict[str, str | None]:
+    """Parse one dotenv file with interpolation against an explicit mapping.
+
+    Returns:
+        Parsed values with references resolved against `environ`.
+    """
+    from dotenv.main import DotEnv
+    from dotenv.variables import parse_variables
+
+    parsed = DotEnv(
+        dotenv_path=str(dotenv_path),
+        override=False,
+        interpolate=False,
+    ).dict()
+    resolved: dict[str, str | None] = {}
+    for key, value in parsed.items():
+        if value is None:
+            resolved[key] = None
+            continue
+        interpolation_env: dict[str, str | None] = dict(environ)
+        interpolation_env.update(resolved)
+        resolved[key] = "".join(
+            atom.resolve(interpolation_env) for atom in parse_variables(value)
+        )
+    return resolved
+
+
+def _dotenv_environment(
+    *,
+    start_path: Path | None,
+    environ: Mapping[str, str],
+) -> dict[str, str]:
+    """Apply the project/global dotenv stack to an explicit environment mapping.
+
+    Returns:
+        A new effective environment mapping.
+    """
+    env = dict(environ)
 
     def apply_dotenv(dotenv_path: Path | None, *, is_project: bool) -> None:
         if dotenv_path is None:
             return
         try:
-            values = dotenv.dotenv_values(dotenv_path=dotenv_path)
+            values = _dotenv_values_from(dotenv_path, env)
         except (OSError, ValueError):
             logger.warning(
-                "Could not read dotenv at %s; previewed project env vars may be "
-                "incomplete",
+                "Could not read dotenv at %s; environment may be incomplete",
                 dotenv_path,
                 exc_info=True,
             )
@@ -446,58 +497,76 @@ def _preview_dotenv_environ(*, start_path: Path | None = None) -> dict[str, str]
             if _is_dotenv_denied_env_key(key):
                 _report_denied_env_key(key, dotenv_path, is_project=is_project)
                 continue
-            if key in env:
-                continue
             if is_project and key.upper() in _PROJECT_DOTENV_DENIED_ENV_KEYS:
-                # Mirror `_load_dotenv`: a project `.env` cannot preview-set a
-                # user-level trust decision — MCP trust lists or the Auto
-                # classifier model/deadline (the global `.env`/shell can). The
-                # key is uppercased so a case variant cannot slip past on
-                # Windows, where `os.environ` assignment normalizes it back to
-                # the active uppercase form.
                 logger.debug(
                     "Ignoring project-denied env key %r from %s", key, dotenv_path
                 )
                 continue
+            if key in env:
+                continue
             env[key] = value
 
-    project_dotenv: Path | None = None
     try:
         project_dotenv = _find_dotenv_from_start_path(start_path or Path.cwd())
     except OSError:
         logger.warning(
-            "Could not inspect project dotenv at %s; previewed project env vars "
-            "may be incomplete",
+            "Could not inspect project dotenv at %s; environment may be incomplete",
             start_path or "cwd",
             exc_info=True,
         )
+        project_dotenv = None
     global_is_project = _dotenv_files_are_same(project_dotenv, _GLOBAL_DOTENV_PATH)
 
-    from deepagents_code.config_manifest import resolve_read_project_dotenv
-
-    if resolve_read_project_dotenv():
-        apply_dotenv(project_dotenv, is_project=True)
-    else:
-        logger.debug(
-            "Skipping project dotenv preview at %s: startup.read_project_dotenv "
-            "is false",
-            start_path or "cwd",
-        )
-
+    global_toggle: dict[str, str] = {}
     try:
-        global_dotenv = _GLOBAL_DOTENV_PATH if _GLOBAL_DOTENV_PATH.is_file() else None
-    except OSError:
+        if not global_is_project and _GLOBAL_DOTENV_PATH.is_file():
+            raw = _dotenv_values_from(_GLOBAL_DOTENV_PATH, env).get(READ_PROJECT_DOTENV)
+            if raw is not None:
+                global_toggle[READ_PROJECT_DOTENV] = raw
+    except (OSError, ValueError):
         logger.warning(
-            "Could not inspect global dotenv at %s; previewed global defaults may "
-            "be incomplete",
+            "Could not read global dotenv at %s; global defaults may be incomplete",
             _GLOBAL_DOTENV_PATH,
             exc_info=True,
         )
-        global_dotenv = None
-    if not global_is_project:
-        apply_dotenv(global_dotenv, is_project=False)
 
+    from deepagents_code.config_manifest import resolve_read_project_dotenv
+
+    if resolve_read_project_dotenv(global_dotenv=global_toggle):
+        apply_dotenv(project_dotenv, is_project=True)
+    else:
+        logger.debug(
+            "Skipping project dotenv at %s: startup.read_project_dotenv is false",
+            start_path or "cwd",
+        )
+    if not global_is_project:
+        try:
+            global_dotenv = (
+                _GLOBAL_DOTENV_PATH if _GLOBAL_DOTENV_PATH.is_file() else None
+            )
+        except OSError:
+            logger.warning(
+                "Could not inspect global dotenv at %s; global defaults may be "
+                "incomplete",
+                _GLOBAL_DOTENV_PATH,
+                exc_info=True,
+            )
+            global_dotenv = None
+        apply_dotenv(global_dotenv, is_project=False)
     return env
+
+
+def _preview_dotenv_environ(*, start_path: Path | None = None) -> dict[str, str]:
+    """Return the effective dotenv environment without mutating `os.environ`.
+
+    Returns:
+        Effective environment for the requested project path.
+    """
+    env = dict(os.environ)
+    for key, value in _dotenv_loaded_values.items():
+        if env.get(key) == value:
+            env.pop(key)
+    return _dotenv_environment(start_path=start_path, environ=env)
 
 
 def _resolve_env_var_from(env: dict[str, str], name: str) -> str | None:
@@ -518,155 +587,28 @@ def _resolve_env_var_from(env: dict[str, str], name: str) -> str | None:
 def _load_dotenv(
     *, start_path: Path | None = None, refresh_loaded: bool = False
 ) -> bool:
-    """Load environment variables from project and global `.env` files.
+    """Load the effective project/global dotenv stack into `os.environ`.
 
-    Loads in order (first write wins, `override=False`):
-
-    1. Project/CWD `.env` — project-specific values (skipped when
-       `startup.read_project_dotenv` resolves false)
-    2. `~/.deepagents/.env` — global user defaults
-
-    Both layers use `override=False` (the python-dotenv default) so that
-    shell-exported variables always take precedence over dotenv files.
-    Because project loads first, the effective precedence is:
-
-    ```text
-    shell env (incl. inline `VAR=x`)  >  project `.env`  >  global `.env`
-    ```
-
-    !!! note
-
-        To scope credentials to the app without colliding with
-        identically-named shell exports, use the `DEEPAGENTS_CODE_` env-var
-        prefix (see `resolve_env_var` in `deepagents_code.model_config`).
-
-    Args:
-        start_path: Directory to use for project `.env` discovery.
-        refresh_loaded: Remove values previously injected by this loader before
-            applying the current project/global dotenv stack. Values modified
-            after loading are preserved.
+    Shell values win over the nearest project `.env`, which wins over the global
+    profile `.env`. Previously injected values are removable for serialized
+    single-workspace reloads; workspace server runtimes use immutable previews.
 
     Returns:
-        `True` when at least one dotenv file was loaded, `False` otherwise.
+        Whether dotenv loading injected at least one value.
     """
-    import dotenv
-
-    loaded = False
-
     if refresh_loaded:
         for key, value in list(_dotenv_loaded_values.items()):
             if os.environ.get(key) == value:
                 os.environ.pop(key)
         _dotenv_loaded_values.clear()
 
-    def apply_dotenv(dotenv_path: Path, *, is_project: bool) -> bool:
-        values = dotenv.dotenv_values(dotenv_path=dotenv_path)
-        applied = False
-        for key, value in values.items():
-            if value is None:
-                continue
-            if _is_dotenv_denied_env_key(key):
-                _report_denied_env_key(key, dotenv_path, is_project=is_project)
-                continue
-            if key in os.environ:
-                continue
-            if is_project and key.upper() in _PROJECT_DOTENV_DENIED_ENV_KEYS:
-                # A committed project `.env` must not set a user-level trust
-                # decision — MCP trust lists or the Auto classifier model and
-                # deadline that authorize this repo's own tool calls; the
-                # global `.env` and shell may (is_project=False). The key is
-                # uppercased so a case variant cannot slip past on Windows,
-                # where `os.environ` assignment normalizes it back to the
-                # active uppercase form.
-                logger.debug(
-                    "Ignoring project-denied env key %r from %s", key, dotenv_path
-                )
-                continue
+    baseline = dict(os.environ)
+    effective = _dotenv_environment(start_path=start_path, environ=baseline)
+    for key, value in effective.items():
+        if key not in baseline:
             os.environ[key] = value
             _dotenv_loaded_values[key] = value
-            applied = True
-        return applied
-
-    # 1. Project/CWD .env — loads first so project values are set before the
-    # global file, which can only fill in vars not already present. Skipped
-    # entirely when `startup.read_project_dotenv` resolves false. The option's
-    # own env var is denied from *every* `.env` (see `_DOTENV_DENIED_ENV_KEYS`),
-    # so neither file can inject it; but the trusted global `.env` is a
-    # legitimate place to opt out, so read just that key from it *before* the
-    # project file is touched — otherwise a hostile project file would load (and
-    # could pin the var true) before the trusted opt-out was ever seen.
-    from deepagents_code.config_manifest import resolve_read_project_dotenv
-
-    project_dotenv: Path | None = None
-    try:
-        if start_path is None:
-            found = dotenv.find_dotenv(usecwd=True)
-            if found:
-                project_dotenv = Path(found)
-        else:
-            project_dotenv = _find_dotenv_from_start_path(start_path)
-    except (OSError, ValueError):
-        logger.warning(
-            "Could not inspect project dotenv at %s; project env vars will not "
-            "be loaded",
-            start_path or "cwd",
-            exc_info=True,
-        )
-    global_is_project = _dotenv_files_are_same(project_dotenv, _GLOBAL_DOTENV_PATH)
-
-    global_toggle: dict[str, str] = {}
-    try:
-        if not global_is_project and _GLOBAL_DOTENV_PATH.is_file():
-            raw = dotenv.dotenv_values(dotenv_path=_GLOBAL_DOTENV_PATH).get(
-                READ_PROJECT_DOTENV
-            )
-            if raw is not None:
-                global_toggle[READ_PROJECT_DOTENV] = raw
-    except (OSError, ValueError):
-        logger.warning(
-            "Could not read global dotenv at %s; global defaults will not be applied",
-            _GLOBAL_DOTENV_PATH,
-            exc_info=True,
-        )
-
-    read_project = resolve_read_project_dotenv(global_dotenv=global_toggle)
-    if read_project:
-        try:
-            if project_dotenv is not None:
-                loaded = apply_dotenv(project_dotenv, is_project=True) or loaded
-        except (OSError, ValueError):
-            logger.warning(
-                "Could not read project dotenv at %s; project env vars will not "
-                "be loaded",
-                project_dotenv or start_path or "cwd",
-                exc_info=True,
-            )
-    else:
-        logger.debug(
-            "Skipping project dotenv at %s: startup.read_project_dotenv is false",
-            start_path or "cwd",
-        )
-
-    # 2. Global (~/.deepagents/.env) — fills in any vars not already set by
-    # the shell or the project dotenv.
-    # try/except wraps both is_file() and load_dotenv() to cover the TOCTOU
-    # window where the file can vanish between stat and open.
-    try:
-        if (
-            not global_is_project
-            and _GLOBAL_DOTENV_PATH.is_file()
-            and apply_dotenv(_GLOBAL_DOTENV_PATH, is_project=False)
-        ):
-            loaded = True
-            logger.debug("Loaded global dotenv: %s", _GLOBAL_DOTENV_PATH)
-    except (OSError, ValueError):
-        logger.warning(
-            "Could not read global dotenv at %s; global defaults will not be applied",
-            _GLOBAL_DOTENV_PATH,
-            exc_info=True,
-        )
-
-    return loaded
+    return bool(effective.keys() - baseline.keys())
 
 
 _TRACING_ENABLE_ENV_VARS = (
@@ -1050,10 +992,11 @@ def _tracing_enabled() -> bool:
     """
     from deepagents_code._env_vars import classify_env_bool
 
+    environ = active_environment()
     return any(
-        classify_env_bool(os.environ[var])
+        classify_env_bool(environ[var])
         for var in _TRACING_ENABLE_ENV_VARS
-        if var in os.environ
+        if var in environ
     )
 
 
@@ -3221,67 +3164,66 @@ class Credentials:
         object.__setattr__(self, name, value)
 
     @classmethod
-    def from_environment(cls, *, start_path: Path | None = None) -> Credentials:
-        """Create credentials by detecting the current environment.
-
-        Args:
-            start_path: Directory to start project detection from (defaults to cwd)
+    def snapshot_from_environment(
+        cls,
+        *,
+        start_path: Path | None = None,
+        environ: Mapping[str, str] | None = None,
+    ) -> CredentialsSnapshot:
+        """Resolve an immutable credential snapshot without publishing state.
 
         Returns:
-            Credentials instance with detected configuration.
-
+            Workspace-local credential and project context values.
         """
-        # Detect API keys (normalize empty strings to None).
-        from deepagents_code.model_config import resolve_env_var
-
-        openai_key = resolve_env_var("OPENAI_API_KEY")
-        anthropic_key = resolve_env_var("ANTHROPIC_API_KEY")
-        google_key = resolve_env_var("GOOGLE_API_KEY")
-        nvidia_key = resolve_env_var("NVIDIA_API_KEY")
-        tavily_key = resolve_env_var("TAVILY_API_KEY")
-        google_cloud_project = resolve_env_var("GOOGLE_CLOUD_PROJECT")
-        google_cloud_location = resolve_env_var("GOOGLE_CLOUD_LOCATION")
-
-        # Detect LangSmith configuration
-        # DEEPAGENTS_CODE_LANGSMITH_PROJECT: Project for deepagents agent tracing
-        # user_langchain_project: User's ORIGINAL LANGSMITH_PROJECT (before override)
-        # When accessed via the module-level `credentials` proxy,
-        # `_ensure_bootstrap()` has already run and may have overridden
-        # LANGSMITH_PROJECT. We use the saved original value, not the
-        # current os.environ value. Direct callers should ensure
-        # bootstrap has run if they depend on the override.
-        from deepagents_code._env_vars import (
-            LANGSMITH_PROJECT,
+        env = active_environment() if environ is None else environ
+        openai_key = _resolve_env_var_from(dict(env), "OPENAI_API_KEY")
+        anthropic_key = _resolve_env_var_from(dict(env), "ANTHROPIC_API_KEY")
+        google_key = _resolve_env_var_from(dict(env), "GOOGLE_API_KEY")
+        nvidia_key = _resolve_env_var_from(dict(env), "NVIDIA_API_KEY")
+        tavily_key = _resolve_env_var_from(dict(env), "TAVILY_API_KEY")
+        google_cloud_project = _resolve_env_var_from(dict(env), "GOOGLE_CLOUD_PROJECT")
+        google_cloud_location = _resolve_env_var_from(
+            dict(env), "GOOGLE_CLOUD_LOCATION"
         )
-
-        deepagents_langchain_project = resolve_env_var(LANGSMITH_PROJECT)
-        # Use the saved original, not the current `LANGSMITH_PROJECT` that
-        # bootstrap may have overridden for agent traces.
-        user_langchain_project = _bootstrap_state.original_langsmith_project
-
-        # Detect project
+        from deepagents_code._env_vars import LANGSMITH_PROJECT
         from deepagents_code.project_utils import find_project_root
 
-        project_root = find_project_root(start_path)
+        return CredentialsSnapshot(
+            openai_api_key=openai_key,
+            anthropic_api_key=anthropic_key,
+            google_api_key=google_key,
+            nvidia_api_key=nvidia_key,
+            tavily_api_key=tavily_key,
+            google_cloud_project=google_cloud_project,
+            google_cloud_location=google_cloud_location,
+            deepagents_langchain_project=_resolve_env_var_from(
+                dict(env), LANGSMITH_PROJECT
+            ),
+            user_langchain_project=env.get("LANGSMITH_PROJECT"),
+            project_root=find_project_root(start_path),
+        )
+
+    @classmethod
+    def from_environment(
+        cls,
+        *,
+        start_path: Path | None = None,
+        environ: Mapping[str, str] | None = None,
+    ) -> Credentials:
+        """Create credentials and publish legacy resolver reload state.
+
+        Returns:
+            Stable owner of the resolved credential snapshot.
+        """
+        snapshot = cls.snapshot_from_environment(
+            start_path=start_path,
+            environ=environ,
+        )
         _reload_override_provider.replace({})
         _remember_resolver_reload_values(
             _current_resolver_reload_values(path_base=start_path)
         )
-
-        return cls(
-            CredentialsSnapshot(
-                openai_api_key=openai_key,
-                anthropic_api_key=anthropic_key,
-                google_api_key=google_key,
-                nvidia_api_key=nvidia_key,
-                tavily_api_key=tavily_key,
-                google_cloud_project=google_cloud_project,
-                google_cloud_location=google_cloud_location,
-                deepagents_langchain_project=deepagents_langchain_project,
-                user_langchain_project=user_langchain_project,
-                project_root=project_root,
-            )
-        )
+        return cls(snapshot)
 
     @staticmethod
     def _reload_values(
@@ -3842,9 +3784,10 @@ def get_langsmith_project_name() -> str | None:
     if not (langsmith_key and _tracing_enabled()):
         return None
 
+    environ = active_environment()
     return (
         _get_credentials().deepagents_langchain_project
-        or os.environ.get("LANGSMITH_PROJECT")
+        or environ.get("LANGSMITH_PROJECT")
         or LANGSMITH_PROJECT_DEFAULT
     )
 
@@ -4217,7 +4160,7 @@ def configure_langsmith_secret_redaction() -> bool:
     """
     from deepagents_code._env_vars import LANGSMITH_REDACT
 
-    env = dict(os.environ)
+    env = dict(active_environment())
     # Cheap env-var checks first so the common (tracing-off) startup path skips
     # the TOML read in `is_langsmith_redaction_enabled`. These are plain env
     # reads with no failure mode of their own, so they stay outside the
@@ -4310,7 +4253,7 @@ def get_langsmith_replica_projects() -> list[str]:
     Returns:
         Project names, or `[]` when the env var is unset or empty.
     """
-    return _get_langsmith_replica_projects_from(dict(os.environ))
+    return _get_langsmith_replica_projects_from(dict(active_environment()))
 
 
 def _get_langsmith_replica_projects_from(env: dict[str, str]) -> list[str]:
@@ -4454,7 +4397,7 @@ def _tracing_explicitly_disabled_from(env: dict[str, str]) -> bool:
 
 def _tracing_enabled() -> bool:
     """Return whether tracing is (or will be) enabled, prefix-aware."""
-    return _tracing_enabled_from(dict(os.environ))
+    return _tracing_enabled_from(dict(active_environment()))
 
 
 def _tracing_has_credentials_from(env: dict[str, str]) -> bool:
@@ -5024,13 +4967,21 @@ def detect_provider(model_name: str) -> str | None:
         return "perplexity"
 
     if model_lower.startswith("claude"):
-        credentials = _get_credentials()
+        credentials = (
+            Credentials.snapshot_from_environment()
+            if _active_environment.get() is not None
+            else _get_credentials()
+        )
         if not credentials.has_anthropic and credentials.has_vertex_ai:
             return "google_anthropic_vertex"
         return "anthropic"
 
     if model_lower.startswith("gemini"):
-        credentials = _get_credentials()
+        credentials = (
+            Credentials.snapshot_from_environment()
+            if _active_environment.get() is not None
+            else _get_credentials()
+        )
         if credentials.has_vertex_ai and not credentials.has_google:
             return "google_vertexai"
         return "google_genai"
@@ -5330,6 +5281,37 @@ def _get_provider_kwargs(
     return result
 
 
+def _apply_scoped_stored_endpoint(provider: str, kwargs: dict[str, Any]) -> None:
+    """Pair stored credentials with their endpoint without mutating the process."""
+    from deepagents_code.model_config import (
+        PROVIDER_CUSTOM_HEADERS_ENV,
+        ModelConfig,
+        _configured_base_url_survives_env_clear,
+        auth_store,
+    )
+
+    try:
+        stored_key = auth_store.get_stored_key(provider)
+        stored_base_url = auth_store.get_stored_base_url(provider)
+    except RuntimeError:
+        return
+    if not stored_key:
+        return
+    provider_config = ModelConfig.load().providers.get(provider)
+    configured_url = provider_config.get("base_url") if provider_config else None
+    if configured_url or _configured_base_url_survives_env_clear(provider):
+        return
+    if stored_base_url:
+        kwargs["base_url"] = stored_base_url
+        return
+    kwargs.pop("base_url", None)
+    if provider == "anthropic":
+        kwargs["base_url"] = "https://api.anthropic.com"
+    custom_headers = PROVIDER_CUSTOM_HEADERS_ENV.get(provider)
+    if custom_headers:
+        kwargs["default_headers"] = {}
+
+
 def _apply_google_anthropic_vertex_kwargs(
     provider: str, kwargs: dict[str, Any]
 ) -> None:
@@ -5340,11 +5322,22 @@ def _apply_google_anthropic_vertex_kwargs(
     """
     if provider != "google_anthropic_vertex":
         return
-    credentials = _get_credentials()
-    if credentials.google_cloud_project:
-        kwargs.setdefault("project", credentials.google_cloud_project)
-    if credentials.google_cloud_location:
-        kwargs.setdefault("location", credentials.google_cloud_location)
+    from deepagents_code.model_config import resolve_env_var
+
+    project = resolve_env_var("GOOGLE_CLOUD_PROJECT")
+    location = resolve_env_var("GOOGLE_CLOUD_LOCATION")
+    if _active_environment.get() is not None:
+        from deepagents_code.model_config import auth_store
+
+        try:
+            if not project:
+                project = auth_store.get_stored_key(provider)
+        except RuntimeError:
+            pass
+    if project:
+        kwargs.setdefault("project", project)
+    if location:
+        kwargs.setdefault("location", location)
     if not kwargs.get("location"):
         from deepagents_code.model_config import ModelConfigError
 
@@ -5754,6 +5747,7 @@ def create_model(
         apply_stored_credentials,
         get_credential_env_var,
         has_provider_credentials,
+        resolve_provider_credential,
         warn_on_split_credential_source,
     )
 
@@ -5819,7 +5813,10 @@ def create_model(
         # so the check sees the user's raw env intent rather than post-bridge
         # state. Diagnostic only -- never alters resolution.
         warn_on_split_credential_source(provider)
-        apply_stored_credentials(provider)
+        scoped_environment = _active_environment.get() is not None
+        if not scoped_environment:
+            apply_stored_credentials(provider)
+        stored_credential = resolve_provider_credential(provider)
 
     from deepagents_code.model_config import CODEX_PROVIDER
 
@@ -5849,6 +5846,8 @@ def create_model(
 
     # Provider-specific kwargs (with per-model overrides)
     kwargs = _get_provider_kwargs(provider, model_name=model_name)
+    if provider and stored_credential and provider != "google_anthropic_vertex":
+        kwargs["api_key"] = stored_credential
 
     # Compose under existing kwargs: profile < config.toml < --model-params
     # (applied below). The app's OpenRouter profile is stacked on top of the
@@ -5889,6 +5888,21 @@ def create_model(
         reasoning_effort_override = extra_kwargs.get("reasoning_effort")
         reasoning_override = extra_kwargs.get("reasoning")
         kwargs.update(extra_kwargs)
+    if provider and scoped_environment:
+        if extra_kwargs and "api_key" in extra_kwargs:
+            if "base_url" not in extra_kwargs:
+                from deepagents_code.model_config import auth_store
+
+                try:
+                    stored_base_url = auth_store.get_stored_base_url(provider)
+                except RuntimeError:
+                    stored_base_url = None
+                if stored_base_url and kwargs.get("base_url") == stored_base_url:
+                    kwargs.pop("base_url", None)
+        else:
+            _apply_scoped_stored_endpoint(provider, kwargs)
+            if extra_kwargs and "base_url" in extra_kwargs:
+                kwargs["base_url"] = extra_kwargs["base_url"]
     kwargs = _compose_openai_reasoning_effort(
         provider,
         kwargs,

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -437,6 +437,15 @@ def use_environment(environ: Mapping[str, str] | None) -> Iterator[None]:
         _active_environment.reset(token)
 
 
+def _environment_key(key: str) -> str:
+    """Normalize an environment key using the host platform's semantics.
+
+    Returns:
+        Uppercase key on Windows, otherwise the original key.
+    """
+    return key.upper() if sys.platform == "win32" else key
+
+
 def _dotenv_values_from(
     dotenv_path: Path,
     environ: Mapping[str, str],
@@ -455,7 +464,8 @@ def _dotenv_values_from(
         interpolate=False,
     ).dict()
     resolved: dict[str, str | None] = {}
-    for key, value in parsed.items():
+    for parsed_key, value in parsed.items():
+        key = _environment_key(parsed_key)
         if value is None:
             resolved[key] = None
             continue
@@ -477,7 +487,7 @@ def _dotenv_environment(
     Returns:
         A new effective environment mapping.
     """
-    env = dict(environ)
+    env = {_environment_key(key): value for key, value in environ.items()}
 
     def apply_dotenv(dotenv_path: Path | None, *, is_project: bool) -> None:
         if dotenv_path is None:

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3785,6 +3785,14 @@ def get_langsmith_project_name() -> str | None:
         return None
 
     environ = active_environment()
+    if _active_environment.get() is not None:
+        from deepagents_code._env_vars import LANGSMITH_PROJECT
+
+        return (
+            _resolve_env_var_from(dict(environ), LANGSMITH_PROJECT)
+            or environ.get("LANGSMITH_PROJECT")
+            or LANGSMITH_PROJECT_DEFAULT
+        )
     return (
         _get_credentials().deepagents_langchain_project
         or environ.get("LANGSMITH_PROJECT")

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -127,6 +127,26 @@ re-applied only to the approval-gated shell backend's `execute` subprocesses by
 `agent._apply_inherited_pythonpath`.
 """
 
+_INHERITED_USER_TRACING_ENV = "DEEPAGENTS_INHERITED_USER_TRACING"
+"""Carrier var that relays the caller's pre-bootstrap tracing env to the server.
+
+`restore_user_tracing_env` / `restore_user_tracing_api_keys` revert bootstrap's
+overwrites of the canonical LangSmith flags and key so `execute` subprocesses
+run under the caller's own tracing identity. Both read `_bootstrap_state`, which
+is process-local — and the server subprocess inherits an environment where
+bootstrap has *already* overwritten those values (they are not in
+`_dotenv_loaded_values`, so the dotenv strip in `server._build_server_env`
+cannot undo them). Its own captured "originals" would therefore be the agent's
+values, and restoring from them would be a no-op that leaks the agent session
+key into user commands.
+
+The client instead serializes its true originals into this var, and
+`agent._apply_inherited_user_tracing` consumes it when building the shell
+environment. Denied from every `.env` for the same reason as
+`_INHERITED_PYTHONPATH_ENV`: a project file must not be able to choose which
+tracing credentials user commands run under.
+"""
+
 _DOTENV_DENIED_ENV_KEYS = frozenset(
     {
         "BASH_ENV",
@@ -163,6 +183,7 @@ _DOTENV_DENIED_ENV_KEYS = frozenset(
         "WINDIR",
         READ_PROJECT_DOTENV,
         _INHERITED_PYTHONPATH_ENV,
+        _INHERITED_USER_TRACING_ENV,
     }
 )
 """Environment keys that no `.env` file may inject.
@@ -207,6 +228,9 @@ without checking which category it belongs to:
 `_INHERITED_PYTHONPATH_ENV` is denied so a project `.env` cannot smuggle a
 `PYTHONPATH` into agent `execute` commands through the carrier var; the carrier
 is only meant to relay a value the user set in their launch environment.
+`_INHERITED_USER_TRACING_ENV` is denied for the same reason: it decides which
+LangSmith flags and key user commands run under, so only the client's captured
+pre-bootstrap state may populate it.
 
 `READ_PROJECT_DOTENV` is denied from *every* `.env` (not just the project one)
 because it is a trust decision about the loader itself: if a project `.env`
@@ -1063,6 +1087,67 @@ def restore_user_tracing_api_keys(env: dict[str, str]) -> None:
             env.pop(var, None)
         else:
             env[var] = value
+
+
+def export_user_tracing_env(env: dict[str, str]) -> None:
+    """Relay the caller's pre-bootstrap tracing env into a server subprocess.
+
+    The server cannot recover these values itself: it inherits an environment
+    bootstrap has already overwritten, so its own capture would restore the
+    agent's key. See `_INHERITED_USER_TRACING_ENV`. Mutates `env` in place; the
+    carrier is always popped first so an inherited value is never trusted.
+
+    Args:
+        env: Environment mapping for the server subprocess, modified in place.
+    """
+    env.pop(_INHERITED_USER_TRACING_ENV, None)
+    if not _bootstrap_state.done:
+        return
+    originals = {
+        **_bootstrap_state.original_tracing_env,
+        **_bootstrap_state.original_tracing_api_keys,
+    }
+    env[_INHERITED_USER_TRACING_ENV] = json.dumps(originals)
+
+
+def apply_inherited_user_tracing(env: dict[str, str]) -> bool:
+    """Apply relayed caller tracing values to a shell-command environment.
+
+    Mirrors `restore_user_tracing_env` / `restore_user_tracing_api_keys` for the
+    server path, where `_bootstrap_state` holds the agent's values rather than
+    the caller's. A `None` entry means the caller had no value, so the variable
+    is removed rather than set. Mutates `env` in place.
+
+    Args:
+        env: Environment mapping for the shell backend, modified in place.
+
+    Returns:
+        Whether a relayed value was found and applied.
+    """
+    relayed = env.pop(_INHERITED_USER_TRACING_ENV, None)
+    if relayed is None:
+        return False
+    try:
+        originals = json.loads(relayed)
+    except ValueError:
+        logger.warning(
+            "Could not parse relayed caller tracing environment; dropping the "
+            "agent's tracing variables from shell commands instead of "
+            "restoring the caller's."
+        )
+        originals = None
+    if not isinstance(originals, dict):
+        # Fail closed: without the caller's values, removing the agent's is
+        # still better than passing the agent session key to user commands.
+        for var in (*_TRACING_ENABLE_ENV_VARS, *_TRACING_API_KEY_ENV_VARS):
+            env.pop(var, None)
+        return True
+    for var, value in originals.items():
+        if value is None:
+            env.pop(var, None)
+        else:
+            env[var] = str(value)
+    return True
 
 
 def _disable_orphaned_tracing() -> None:
@@ -5380,8 +5465,23 @@ def _apply_scoped_stored_endpoint(provider: str, kwargs: dict[str, Any]) -> None
         stored_key = auth_store.get_stored_key(provider)
         stored_base_url = auth_store.get_stored_base_url(provider)
     except RuntimeError:
-        return
-    if not stored_key:
+        # On the scoped path this function is the only thing enforcing the
+        # key/endpoint pairing, because `apply_stored_credentials` is skipped.
+        # `resolve_provider_credential` still falls back to the environment key,
+        # so fail closed: drop an inherited gateway endpoint and its auth
+        # headers rather than shipping that key to it.
+        logger.warning(
+            "Could not read the stored credential for %r; the credential file "
+            "may be corrupt. Clearing any inherited endpoint so the resolved "
+            "key is not sent to it. Re-add the key via /auth.",
+            provider,
+        )
+        stored_key = None
+        stored_base_url = None
+        store_unreadable = True
+    else:
+        store_unreadable = False
+    if not store_unreadable and not stored_key:
         return
     provider_config = ModelConfig.load().providers.get(provider)
     configured_url = provider_config.get("base_url") if provider_config else None
@@ -5419,7 +5519,16 @@ def _apply_google_anthropic_vertex_kwargs(
             if not project:
                 project = auth_store.get_stored_key(provider)
         except RuntimeError:
-            pass
+            # `google_anthropic_vertex` stores the GCP project id in the key
+            # slot. It is also an implicit-auth provider, so the early
+            # credential check never fires — without this log a corrupt store
+            # surfaces only as an opaque ADC project-inference error.
+            logger.warning(
+                "Could not read the stored Google Cloud project for %r; the "
+                "credential file may be corrupt. Falling back to ADC project "
+                "inference. Re-add the project via /auth.",
+                provider,
+            )
     if project:
         kwargs.setdefault("project", project)
     if location:
@@ -5982,9 +6091,24 @@ def create_model(
                 try:
                     stored_base_url = auth_store.get_stored_base_url(provider)
                 except RuntimeError:
-                    stored_base_url = None
-                if stored_base_url and kwargs.get("base_url") == stored_base_url:
+                    # The caller passed an explicit `api_key` with no
+                    # `base_url`. Without the store we cannot tell whether the
+                    # inherited endpoint was paired with the *stored* key, so
+                    # fail closed and drop it: sending an explicitly supplied
+                    # key to a gateway it was not issued for is the worse
+                    # outcome.
+                    logger.warning(
+                        "Could not read the stored endpoint for %r; the "
+                        "credential file may be corrupt. Dropping the "
+                        "inherited base URL so the explicitly supplied key is "
+                        "not sent to it. Pass `base_url` via `--model-params` "
+                        "to target an endpoint explicitly.",
+                        provider,
+                    )
                     kwargs.pop("base_url", None)
+                else:
+                    if stored_base_url and kwargs.get("base_url") == stored_base_url:
+                        kwargs.pop("base_url", None)
         else:
             _apply_scoped_stored_endpoint(provider, kwargs)
             if extra_kwargs and "base_url" in extra_kwargs:

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -454,7 +454,12 @@ def use_environment(environ: Mapping[str, str] | None) -> Iterator[None]:
     if environ is None:
         yield
         return
-    token = _active_environment.set(MappingProxyType(dict(environ)))
+    frozen = (
+        environ
+        if isinstance(environ, MappingProxyType)
+        else MappingProxyType(dict(environ))
+    )
+    token = _active_environment.set(frozen)
     try:
         yield
     finally:
@@ -488,16 +493,19 @@ def _dotenv_values_from(
         interpolate=False,
     ).dict()
     resolved: dict[str, str | None] = {}
+    # Built once: `resolved` only grows, and each new key is folded in below, so
+    # later values see every earlier one without re-copying the environment.
+    interpolation_env: dict[str, str | None] = dict(environ)
     for parsed_key, value in parsed.items():
         key = _environment_key(parsed_key)
         if value is None:
             resolved[key] = None
+            interpolation_env[key] = None
             continue
-        interpolation_env: dict[str, str | None] = dict(environ)
-        interpolation_env.update(resolved)
         resolved[key] = "".join(
             atom.resolve(interpolation_env) for atom in parse_variables(value)
         )
+        interpolation_env[key] = resolved[key]
     return resolved
 
 
@@ -603,7 +611,7 @@ def _preview_dotenv_environ(*, start_path: Path | None = None) -> dict[str, str]
     return _dotenv_environment(start_path=start_path, environ=env)
 
 
-def _resolve_env_var_from(env: dict[str, str], name: str) -> str | None:
+def _resolve_env_var_from(env: Mapping[str, str], name: str) -> str | None:
     """Resolve an env var from a mapping using app prefix precedence.
 
     Returns:
@@ -953,7 +961,7 @@ def _quiet_sdk_logging() -> None:
 
 
 def _load_langsmith_profile_config(
-    env: dict[str, str] | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> _LangSmithProfileConfig | None:
     """Return the active LangSmith profile client config, if available."""
     try:
@@ -974,7 +982,7 @@ def _load_langsmith_profile_config(
         return profiles.load_profile_client_config()
 
 
-def _has_langsmith_profile_credentials(env: dict[str, str] | None = None) -> bool:
+def _has_langsmith_profile_credentials(env: Mapping[str, str] | None = None) -> bool:
     """Return whether the LangSmith profile config has usable auth material."""
     config = _load_langsmith_profile_config(env)
     if config is None:
@@ -985,7 +993,9 @@ def _has_langsmith_profile_credentials(env: dict[str, str] | None = None) -> boo
     )
 
 
-def _has_langsmith_profile_custom_endpoint(env: dict[str, str] | None = None) -> bool:
+def _has_langsmith_profile_custom_endpoint(
+    env: Mapping[str, str] | None = None,
+) -> bool:
     """Return whether the LangSmith profile points at a custom endpoint.
 
     The SDK default US SaaS URL does not count: profiles often store it
@@ -3282,15 +3292,13 @@ class Credentials:
             Workspace-local credential and project context values.
         """
         env = active_environment() if environ is None else environ
-        openai_key = _resolve_env_var_from(dict(env), "OPENAI_API_KEY")
-        anthropic_key = _resolve_env_var_from(dict(env), "ANTHROPIC_API_KEY")
-        google_key = _resolve_env_var_from(dict(env), "GOOGLE_API_KEY")
-        nvidia_key = _resolve_env_var_from(dict(env), "NVIDIA_API_KEY")
-        tavily_key = _resolve_env_var_from(dict(env), "TAVILY_API_KEY")
-        google_cloud_project = _resolve_env_var_from(dict(env), "GOOGLE_CLOUD_PROJECT")
-        google_cloud_location = _resolve_env_var_from(
-            dict(env), "GOOGLE_CLOUD_LOCATION"
-        )
+        openai_key = _resolve_env_var_from(env, "OPENAI_API_KEY")
+        anthropic_key = _resolve_env_var_from(env, "ANTHROPIC_API_KEY")
+        google_key = _resolve_env_var_from(env, "GOOGLE_API_KEY")
+        nvidia_key = _resolve_env_var_from(env, "NVIDIA_API_KEY")
+        tavily_key = _resolve_env_var_from(env, "TAVILY_API_KEY")
+        google_cloud_project = _resolve_env_var_from(env, "GOOGLE_CLOUD_PROJECT")
+        google_cloud_location = _resolve_env_var_from(env, "GOOGLE_CLOUD_LOCATION")
         from deepagents_code._env_vars import LANGSMITH_PROJECT
         from deepagents_code.project_utils import find_project_root
 
@@ -3302,9 +3310,7 @@ class Credentials:
             tavily_api_key=tavily_key,
             google_cloud_project=google_cloud_project,
             google_cloud_location=google_cloud_location,
-            deepagents_langchain_project=_resolve_env_var_from(
-                dict(env), LANGSMITH_PROJECT
-            ),
+            deepagents_langchain_project=_resolve_env_var_from(env, LANGSMITH_PROJECT),
             user_langchain_project=_user_langsmith_project_from(env),
             project_root=find_project_root(start_path),
         )
@@ -3895,7 +3901,7 @@ def get_langsmith_project_name() -> str | None:
         from deepagents_code._env_vars import LANGSMITH_PROJECT
 
         return (
-            _resolve_env_var_from(dict(environ), LANGSMITH_PROJECT)
+            _resolve_env_var_from(environ, LANGSMITH_PROJECT)
             or environ.get("LANGSMITH_PROJECT")
             or LANGSMITH_PROJECT_DEFAULT
         )
@@ -4274,7 +4280,7 @@ def configure_langsmith_secret_redaction() -> bool:
     """
     from deepagents_code._env_vars import LANGSMITH_REDACT
 
-    env = dict(active_environment())
+    env = active_environment()
     # Cheap env-var checks first so the common (tracing-off) startup path skips
     # the TOML read in `is_langsmith_redaction_enabled`. These are plain env
     # reads with no failure mode of their own, so they stay outside the
@@ -4367,10 +4373,10 @@ def get_langsmith_replica_projects() -> list[str]:
     Returns:
         Project names, or `[]` when the env var is unset or empty.
     """
-    return _get_langsmith_replica_projects_from(dict(active_environment()))
+    return _get_langsmith_replica_projects_from(active_environment())
 
 
-def _get_langsmith_replica_projects_from(env: dict[str, str]) -> list[str]:
+def _get_langsmith_replica_projects_from(env: Mapping[str, str]) -> list[str]:
     """Parse replica project names from an environment snapshot.
 
     Args:
@@ -4445,7 +4451,7 @@ are not bridged, so only their canonical form takes effect.
 """
 
 
-def _tracing_enabled_from(env: dict[str, str]) -> bool:
+def _tracing_enabled_from(env: Mapping[str, str]) -> bool:
     """Return whether tracing is (or will be) enabled, prefix-aware.
 
     Mirrors the runtime: `DEEPAGENTS_CODE_`-prefixed forms of the bridged flags
@@ -4468,7 +4474,7 @@ def _tracing_enabled_from(env: dict[str, str]) -> bool:
     )
 
 
-def _tracing_explicitly_disabled_from(env: dict[str, str]) -> bool:
+def _tracing_explicitly_disabled_from(env: Mapping[str, str]) -> bool:
     """Return whether a tracing flag is explicitly set to a recognized off value.
 
     True only when tracing is not enabled and at least one tracing-enable flag
@@ -4511,10 +4517,10 @@ def _tracing_explicitly_disabled_from(env: dict[str, str]) -> bool:
 
 def _tracing_enabled() -> bool:
     """Return whether tracing is (or will be) enabled, prefix-aware."""
-    return _tracing_enabled_from(dict(active_environment()))
+    return _tracing_enabled_from(active_environment())
 
 
-def _tracing_has_credentials_from(env: dict[str, str]) -> bool:
+def _tracing_has_credentials_from(env: Mapping[str, str]) -> bool:
     """Return whether a LangSmith API key (env or active profile) is available.
 
     Both API-key vars are bridged from a `DEEPAGENTS_CODE_` prefix at bootstrap,
@@ -4527,7 +4533,7 @@ def _tracing_has_credentials_from(env: dict[str, str]) -> bool:
     return has_key or _has_langsmith_profile_credentials(env)
 
 
-def _langsmith_runs_endpoint_urls_from(env: dict[str, str]) -> tuple[str, ...]:
+def _langsmith_runs_endpoint_urls_from(env: Mapping[str, str]) -> tuple[str, ...]:
     """Return the replica trace ingestion URLs configured via runs-endpoints.
 
     Mirrors the LangSmith SDK's accepted `LANGSMITH_RUNS_ENDPOINTS` shapes: a
@@ -4574,7 +4580,7 @@ def _langsmith_runs_endpoint_urls_from(env: dict[str, str]) -> tuple[str, ...]:
     return ()
 
 
-def _has_langsmith_runs_endpoints_from(env: dict[str, str]) -> bool:
+def _has_langsmith_runs_endpoints_from(env: Mapping[str, str]) -> bool:
     """Return whether replica trace ingestion targets are configured.
 
     Args:
@@ -4586,7 +4592,7 @@ def _has_langsmith_runs_endpoints_from(env: dict[str, str]) -> bool:
     return bool(_langsmith_runs_endpoint_urls_from(env))
 
 
-def _tracing_can_upload_from(env: dict[str, str]) -> bool:
+def _tracing_can_upload_from(env: Mapping[str, str]) -> bool:
     """Return whether tracing has credentials or an ingestion endpoint.
 
     Custom and replica endpoints are supported as keyless ingestion targets, so
@@ -4606,7 +4612,7 @@ def _tracing_can_upload_from(env: dict[str, str]) -> bool:
     )
 
 
-def _tracing_endpoint_from(env: dict[str, str]) -> str | None:
+def _tracing_endpoint_from(env: Mapping[str, str]) -> str | None:
     """Return a custom tracing endpoint (env or active profile), if configured.
 
     The endpoint vars are not bridged from a `DEEPAGENTS_CODE_` prefix and the
@@ -4638,7 +4644,7 @@ def _tracing_endpoint_from(env: dict[str, str]) -> str | None:
     return None
 
 
-def _resolve_tracing_project_from(env: dict[str, str]) -> tuple[str, bool]:
+def _resolve_tracing_project_from(env: Mapping[str, str]) -> tuple[str, bool]:
     """Resolve the project agent traces would route to, without bootstrap.
 
     The reported project matches the `tracing.langsmith_project` manifest
@@ -5034,6 +5040,18 @@ def _is_bedrock_model_id(model_lower: str) -> bool:
     return bool(dot) and vendor.isalnum()
 
 
+def _detection_credentials() -> Credentials | CredentialsSnapshot:
+    """Return the credential source that matches the active environment scope.
+
+    Returns:
+        A workspace-scoped snapshot when an environment is bound, otherwise the
+        cached process-global credentials.
+    """
+    if _active_environment.get() is not None:
+        return Credentials.snapshot_from_environment()
+    return _get_credentials()
+
+
 def detect_provider(model_name: str) -> str | None:
     """Auto-detect provider from model name.
 
@@ -5081,21 +5099,13 @@ def detect_provider(model_name: str) -> str | None:
         return "perplexity"
 
     if model_lower.startswith("claude"):
-        credentials = (
-            Credentials.snapshot_from_environment()
-            if _active_environment.get() is not None
-            else _get_credentials()
-        )
+        credentials = _detection_credentials()
         if not credentials.has_anthropic and credentials.has_vertex_ai:
             return "google_anthropic_vertex"
         return "anthropic"
 
     if model_lower.startswith("gemini"):
-        credentials = (
-            Credentials.snapshot_from_environment()
-            if _active_environment.get() is not None
-            else _get_credentials()
-        )
+        credentials = _detection_credentials()
         if credentials.has_vertex_ai and not credentials.has_google:
             return "google_vertexai"
         return "google_genai"
@@ -5272,14 +5282,53 @@ _OPENROUTER_APP_CATEGORIES: list[str] = ["cli-agent"]
 _cli_openrouter_profile_registered = False
 """Process-wide guard so the app's OpenRouter profile is registered exactly once."""
 
-_AWS_MODEL_SDK_ENV_KWARGS = {
-    "region_name": ("AWS_REGION", "AWS_DEFAULT_REGION"),
-    "credentials_profile_name": ("AWS_PROFILE", "AWS_DEFAULT_PROFILE"),
+AWS_CREDENTIAL_ENV_SOURCES: dict[str, tuple[str, ...]] = {
+    "profile_name": ("AWS_PROFILE", "AWS_DEFAULT_PROFILE"),
     "aws_access_key_id": ("AWS_ACCESS_KEY_ID",),
     "aws_secret_access_key": ("AWS_SECRET_ACCESS_KEY",),
     "aws_session_token": ("AWS_SESSION_TOKEN",),
 }
+"""Canonical AWS credential sources, keyed by the `boto3.Session` argument.
+
+Shared with `integrations.sandbox_factory` so a new AWS credential source is
+added in one place rather than drifting between the model and sandbox paths.
+"""
+
+_AWS_MODEL_SDK_ENV_KWARGS = {
+    "region_name": ("AWS_REGION", "AWS_DEFAULT_REGION"),
+    # LangChain constructors spell the profile argument differently to boto3.
+    "credentials_profile_name": AWS_CREDENTIAL_ENV_SOURCES["profile_name"],
+    **{
+        argument: names
+        for argument, names in AWS_CREDENTIAL_ENV_SOURCES.items()
+        if argument != "profile_name"
+    },
+}
 """AWS model environment values accepted directly by LangChain constructors."""
+
+
+def resolve_env_kwargs(
+    table: Mapping[str, tuple[str, ...]],
+    lookup: Callable[[str], str | None],
+) -> dict[str, str]:
+    """Translate an argument/env-name table into explicit constructor kwargs.
+
+    The first name that `lookup` resolves to a non-empty value wins.
+
+    Args:
+        table: Constructor argument name mapped to candidate env var names.
+        lookup: Resolver for a single env var name.
+
+    Returns:
+        Populated keyword arguments, omitting arguments with no value.
+    """
+    resolved: dict[str, str] = {}
+    for argument, env_names in table.items():
+        value = next((value for name in env_names if (value := lookup(name))), None)
+        if value:
+            resolved[argument] = value
+    return resolved
+
 
 _PROVIDER_SDK_ENV_KWARGS: dict[str, dict[str, tuple[str, ...]]] = {
     "anthropic_bedrock": _AWS_MODEL_SDK_ENV_KWARGS,
@@ -5358,19 +5407,12 @@ def _apply_provider_sdk_environment(
     if provider == "azure_openai":
         _apply_azure_sdk_endpoint(kwargs)
 
-    for argument, env_names in _PROVIDER_SDK_ENV_KWARGS.get(provider, {}).items():
-        if argument in kwargs:
-            continue
-        value = next(
-            (
-                value
-                for name in env_names
-                if (value := resolve_env_var(name)) is not None
-            ),
-            None,
-        )
-        if value is not None:
-            kwargs[argument] = value
+    table = {
+        argument: env_names
+        for argument, env_names in _PROVIDER_SDK_ENV_KWARGS.get(provider, {}).items()
+        if argument not in kwargs
+    }
+    kwargs.update(resolve_env_kwargs(table, resolve_env_var))
 
 
 def _get_provider_kwargs(
@@ -5478,11 +5520,9 @@ def _apply_scoped_stored_endpoint(provider: str, kwargs: dict[str, Any]) -> None
         )
         stored_key = None
         stored_base_url = None
-        store_unreadable = True
     else:
-        store_unreadable = False
-    if not store_unreadable and not stored_key:
-        return
+        if not stored_key:
+            return
     provider_config = ModelConfig.load().providers.get(provider)
     configured_url = provider_config.get("base_url") if provider_config else None
     if configured_url or _configured_base_url_survives_env_clear(provider):

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -584,6 +584,17 @@ def _resolve_env_var_from(env: dict[str, str], name: str) -> str | None:
     return env.get(name) or None
 
 
+def _user_langsmith_project_from(env: Mapping[str, str]) -> str | None:
+    """Return the caller's project when bootstrap replaced the canonical value."""
+    from deepagents_code._env_vars import LANGSMITH_PROJECT
+
+    project = env.get("LANGSMITH_PROJECT")
+    agent_project = env.get(LANGSMITH_PROJECT)
+    if _bootstrap_state.done and agent_project and project == agent_project:
+        return _bootstrap_state.original_langsmith_project
+    return project
+
+
 def _load_dotenv(
     *, start_path: Path | None = None, refresh_loaded: bool = False
 ) -> bool:
@@ -3199,7 +3210,7 @@ class Credentials:
             deepagents_langchain_project=_resolve_env_var_from(
                 dict(env), LANGSMITH_PROJECT
             ),
-            user_langchain_project=env.get("LANGSMITH_PROJECT"),
+            user_langchain_project=_user_langsmith_project_from(env),
             project_root=find_project_root(start_path),
         )
 

--- a/libs/code/deepagents_code/configurable_model.py
+++ b/libs/code/deepagents_code/configurable_model.py
@@ -342,8 +342,12 @@ def _get_context(request: ModelRequest) -> CLIContextSchema | None:
     return CLIContextSchema.from_payload(runtime.context)
 
 
-def _model_spec_from_model(model: BaseChatModel) -> str | None:
+def _model_spec_from_model(
+    model: BaseChatModel, model_result: ModelResult | None = None
+) -> str | None:
     """Return a resumable `provider:model` spec for a model object."""
+    if model_result is not None:
+        return f"{model_result.provider}:{model_result.model_name}"
     model_name = get_model_identifier(model)
     from deepagents_code.config import runtime_state
 
@@ -517,6 +521,7 @@ def _apply_overrides(
     openai_prompt_cache_key: bool,
     cli_max_retries: int | None,
     strict_model_resolution: bool = False,
+    construction_model_result: ModelResult | None = None,
 ) -> _ResolvedModelRequest:
     """Apply model/param overrides and return checkpoint persistence metadata.
 
@@ -532,6 +537,7 @@ def _apply_overrides(
             opt-out, threaded through to `_build_overrides`.
         cli_max_retries: Explicit CLI retry count retained across model switches.
         strict_model_resolution: Whether model construction failures should propagate.
+        construction_model_result: Construction-time workspace model metadata.
 
     Returns:
         The request to send downstream plus the actual model spec and user-supplied
@@ -543,7 +549,9 @@ def _apply_overrides(
     """
     ctx = _get_context(request)
     if ctx is None:
-        return _ResolvedModelRequest(request, _model_spec_from_model(request.model))
+        return _ResolvedModelRequest(
+            request, _model_spec_from_model(request.model, construction_model_result)
+        )
 
     model_result = None
     model = ctx.model
@@ -578,7 +586,7 @@ def _apply_overrides(
             # permanent, false "the model changed".
             return _ResolvedModelRequest(
                 request,
-                _model_spec_from_model(request.model),
+                _model_spec_from_model(request.model, construction_model_result),
                 model_params_known=False,
             )
 
@@ -600,6 +608,7 @@ async def _apply_overrides_async(
     openai_prompt_cache_key: bool,
     cli_max_retries: int | None,
     strict_model_resolution: bool = False,
+    construction_model_result: ModelResult | None = None,
 ) -> _ResolvedModelRequest:
     """Async variant of `_apply_overrides` that offloads model construction.
 
@@ -609,6 +618,7 @@ async def _apply_overrides_async(
             opt-out, threaded through to `_build_overrides`.
         cli_max_retries: Explicit CLI retry count retained across model switches.
         strict_model_resolution: Whether model construction failures should propagate.
+        construction_model_result: Construction-time workspace model metadata.
 
     Returns:
         The request to send downstream plus the actual model spec and user-supplied
@@ -620,7 +630,9 @@ async def _apply_overrides_async(
     """
     ctx = _get_context(request)
     if ctx is None:
-        return _ResolvedModelRequest(request, _model_spec_from_model(request.model))
+        return _ResolvedModelRequest(
+            request, _model_spec_from_model(request.model, construction_model_result)
+        )
 
     model_result = None
     model = ctx.model
@@ -659,7 +671,7 @@ async def _apply_overrides_async(
             # permanent, false "the model changed".
             return _ResolvedModelRequest(
                 request,
-                _model_spec_from_model(request.model),
+                _model_spec_from_model(request.model, construction_model_result),
                 model_params_known=False,
             )
 
@@ -839,6 +851,8 @@ class ConfigurableModelMiddleware(AgentMiddleware):
         openai_prompt_cache_key: bool | None = None,
         cli_max_retries: int | None = None,
         strict_model_resolution: bool = False,
+        environ: Mapping[str, str] | None = None,
+        model_result: ModelResult | None = None,
     ) -> None:
         """Initialize the middleware.
 
@@ -861,8 +875,12 @@ class ConfigurableModelMiddleware(AgentMiddleware):
                 runtime model switches.
             strict_model_resolution: Whether invalid runtime model overrides should
                 fail the call instead of falling back to the construction-time model.
+            environ: Workspace environment retained for lazy model switches.
+            model_result: Construction-time workspace model metadata.
         """
         self._persist_model_state = persist_model_state
+        self._environ = environ
+        self._model_result = model_result
         self._cli_max_retries = cli_max_retries
         self._strict_model_resolution = strict_model_resolution
         self._openai_prompt_cache_key = (
@@ -882,24 +900,28 @@ class ConfigurableModelMiddleware(AgentMiddleware):
             The downstream response plus a private resume-state update when the
             completed call has model metadata to checkpoint.
         """
-        resolved = _apply_overrides(
-            request,
-            openai_prompt_cache_key=self._openai_prompt_cache_key,
-            cli_max_retries=self._cli_max_retries,
-            strict_model_resolution=self._strict_model_resolution,
-        )
-        request_started_at = _utc_now_iso()
-        response = handler(resolved.request)
-        if not self._persist_model_state:
-            return response
-        cache_endpoint = (
-            _cache_endpoint_identity(resolved.model_spec, resolved.model_params)
-            if resolved.model_params is not None
-            else _cache_endpoint_identity(resolved.model_spec)
-        )
-        cache_params = _effective_cache_params(
-            resolved.model_spec, resolved.model_params
-        )
+        from deepagents_code.config import use_environment
+
+        with use_environment(self._environ):
+            resolved = _apply_overrides(
+                request,
+                openai_prompt_cache_key=self._openai_prompt_cache_key,
+                cli_max_retries=self._cli_max_retries,
+                strict_model_resolution=self._strict_model_resolution,
+                construction_model_result=self._model_result,
+            )
+            request_started_at = _utc_now_iso()
+            response = handler(resolved.request)
+            if not self._persist_model_state:
+                return response
+            cache_endpoint = (
+                _cache_endpoint_identity(resolved.model_spec, resolved.model_params)
+                if resolved.model_params is not None
+                else _cache_endpoint_identity(resolved.model_spec)
+            )
+            cache_params = _effective_cache_params(
+                resolved.model_spec, resolved.model_params
+            )
         command = _checkpoint_command(
             resolved,
             request_started_at,
@@ -919,33 +941,39 @@ class ConfigurableModelMiddleware(AgentMiddleware):
             The downstream response plus a private resume-state update when the
             completed call has model metadata to checkpoint.
         """
-        resolved = await _apply_overrides_async(
-            request,
-            openai_prompt_cache_key=self._openai_prompt_cache_key,
-            cli_max_retries=self._cli_max_retries,
-            strict_model_resolution=self._strict_model_resolution,
-        )
-        request_started_at = _utc_now_iso()
-        response = await handler(resolved.request)
-        if not self._persist_model_state:
-            return response
-        # Offloaded: `_cache_endpoint_identity` and `_effective_cache_params`
-        # read the config and credential store, which `blockbuster` rejects on
-        # the server event loop.
-        cache_endpoint = (
-            await asyncio.to_thread(
-                _cache_endpoint_identity,
+        from deepagents_code.config import use_environment
+
+        with use_environment(self._environ):
+            resolved = await _apply_overrides_async(
+                request,
+                openai_prompt_cache_key=self._openai_prompt_cache_key,
+                cli_max_retries=self._cli_max_retries,
+                strict_model_resolution=self._strict_model_resolution,
+                construction_model_result=self._model_result,
+            )
+            request_started_at = _utc_now_iso()
+            response = await handler(resolved.request)
+            if not self._persist_model_state:
+                return response
+            # Offloaded: `_cache_endpoint_identity` and `_effective_cache_params`
+            # read the config and credential store, which `blockbuster` rejects on
+            # the server event loop.
+            cache_endpoint = (
+                await asyncio.to_thread(
+                    _cache_endpoint_identity,
+                    resolved.model_spec,
+                    resolved.model_params,
+                )
+                if resolved.model_params is not None
+                else await asyncio.to_thread(
+                    _cache_endpoint_identity, resolved.model_spec
+                )
+            )
+            cache_params = await asyncio.to_thread(
+                _effective_cache_params,
                 resolved.model_spec,
                 resolved.model_params,
             )
-            if resolved.model_params is not None
-            else await asyncio.to_thread(_cache_endpoint_identity, resolved.model_spec)
-        )
-        cache_params = await asyncio.to_thread(
-            _effective_cache_params,
-            resolved.model_spec,
-            resolved.model_params,
-        )
         command = _checkpoint_command(
             resolved, request_started_at, cache_endpoint, cache_params
         )

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -523,8 +523,6 @@ def ranked_theme_toml_value(
 
     resolved = resolve_terminal_mapping(ui)
     if resolved is not None:
-        import os
-
         term_program = os.environ.get("TERM_PROGRAM", "").strip()
         selected = replace(
             status,
@@ -1581,8 +1579,8 @@ class EnvProvider:
 
     name: str = "environment"
     rank: int = ENVIRONMENT_RANK
-    environ: Mapping[str, str] = field(
-        default_factory=lambda: os.environ,
+    environ: Mapping[str, str] | None = field(
+        default=None,
         repr=False,
         compare=False,
     )
@@ -1607,14 +1605,16 @@ class EnvProvider:
         Returns:
             Ranked and coerced provider result.
         """
+        from deepagents_code.config import active_environment
         from deepagents_code.config_manifest import OptionKind
 
+        environ = active_environment() if self.environ is None else self.environ
         if option.kind is OptionKind.THEME_DELEGATE:
             return _ranked_for(
                 option,
-                ranked_theme_environment_value(self.environ, rank=self.rank),
+                ranked_theme_environment_value(environ, rank=self.rank),
             )
-        return ranked_environment_value(option, self.environ, rank=self.rank)
+        return ranked_environment_value(option, environ, rank=self.rank)
 
     def status(self) -> ProviderStatus:
         """Return the always-healthy environment provider status."""

--- a/libs/code/deepagents_code/goal_rubric.py
+++ b/libs/code/deepagents_code/goal_rubric.py
@@ -62,7 +62,7 @@ from deepagents_code.goal_state_notice import is_conversation_control_message
 from deepagents_code.resume_state import ResumeState
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Sequence
+    from collections.abc import Awaitable, Callable, Mapping, Sequence
 
     from deepagents import FsToolName
     from deepagents.backends.protocol import BackendProtocol
@@ -1591,6 +1591,7 @@ def create_goal_criteria_agent(
     context_tools: Sequence[BaseTool | Callable[..., Any]],
     model_retries: int = DEFAULT_MODEL_RETRIES,
     cli_max_retries: int | None = None,
+    environ: Mapping[str, str] | None = None,
 ) -> Any:  # noqa: ANN401
     """Create the ephemeral server-side criteria agent graph.
 
@@ -1602,6 +1603,7 @@ def create_goal_criteria_agent(
         context_tools: Loaded `fetch_url`, optional `web_search`, and MCP tools.
         model_retries: Model-node retry attempts after the first call.
         cli_max_retries: Explicit `--max-retries` value for runtime model switches.
+        environ: Workspace environment retained for runtime model switches.
 
     Returns:
         Compiled criteria agent graph.
@@ -1617,6 +1619,7 @@ def create_goal_criteria_agent(
         auto_mode_enabled=True,
         model_retries=model_retries,
         cli_max_retries=cli_max_retries,
+        environ=environ,
     )
 
 
@@ -1630,6 +1633,7 @@ def _create_goal_criteria_agent(
     fs_tools: list[FsToolName] | None = None,
     model_retries: int = DEFAULT_MODEL_RETRIES,
     cli_max_retries: int | None = None,
+    environ: Mapping[str, str] | None = None,
 ) -> Any:  # noqa: ANN401
     """Build a criteria agent with the parent runtime's Auto eligibility.
 
@@ -1645,6 +1649,7 @@ def _create_goal_criteria_agent(
             repository tools.
         model_retries: Model-node retry attempts after the first call.
         cli_max_retries: Explicit `--max-retries` value for runtime model switches.
+        environ: Workspace environment retained for runtime model switches.
 
     Returns:
         Compiled criteria agent graph.
@@ -1687,6 +1692,7 @@ def _create_goal_criteria_agent(
         ConfigurableModelMiddleware(
             persist_model_state=False,
             cli_max_retries=cli_max_retries,
+            environ=environ,
         ),
         _GoalContextFallbackMiddleware(),
         _WebSearchBudgetMiddleware(),
@@ -1750,6 +1756,7 @@ def create_goal_criteria_fallback_agent(
     model: str | BaseChatModel,
     model_retries: int = DEFAULT_MODEL_RETRIES,
     cli_max_retries: int | None = None,
+    environ: Mapping[str, str] | None = None,
 ) -> Any:  # noqa: ANN401
     """Create the goal-only fallback agent for criteria generation.
 
@@ -1764,6 +1771,7 @@ def create_goal_criteria_fallback_agent(
         model: Chat model or model identifier used by the server graph.
         model_retries: Model-node retry attempts after the first call.
         cli_max_retries: Explicit `--max-retries` value for runtime model switches.
+        environ: Workspace environment retained for runtime model switches.
 
     Returns:
         Compiled goal-only criteria agent graph.
@@ -1779,6 +1787,7 @@ def create_goal_criteria_fallback_agent(
         ConfigurableModelMiddleware(
             persist_model_state=False,
             cli_max_retries=cli_max_retries,
+            environ=environ,
         ),
         CodeModelRetryMiddleware(max_retries=model_retries),
     ]

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from rich.markup import escape as escape_markup
 
-from deepagents_code.config import console, get_glyphs
+from deepagents_code.config import active_environment, console, get_glyphs
 from deepagents_code.integrations.sandbox_provider import (
     SandboxNotFoundError,
     SandboxProvider,
@@ -26,7 +26,7 @@ from deepagents_code.integrations.sandbox_provider import (
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Mapping
     from types import ModuleType
 
     from deepagents.backends.protocol import SandboxBackendProtocol
@@ -711,6 +711,32 @@ class _RunloopProvider(SandboxProvider):
         self._provider.delete(sandbox_id=sandbox_id)
 
 
+_AWS_SESSION_ENV_KWARGS = {
+    "profile_name": ("AWS_PROFILE", "AWS_DEFAULT_PROFILE"),
+    "aws_access_key_id": ("AWS_ACCESS_KEY_ID",),
+    "aws_secret_access_key": ("AWS_SECRET_ACCESS_KEY",),
+    "aws_session_token": ("AWS_SESSION_TOKEN",),
+}
+"""AWS environment values accepted directly by `boto3.Session`."""
+
+
+def _aws_session_kwargs(environment: Mapping[str, str]) -> dict[str, str]:
+    """Translate a workspace environment into explicit boto3 session arguments.
+
+    Returns:
+        Populated boto3 session keyword arguments.
+    """
+    result: dict[str, str] = {}
+    for argument, env_names in _AWS_SESSION_ENV_KWARGS.items():
+        value = next(
+            (value for name in env_names if (value := environment.get(name))),
+            None,
+        )
+        if value:
+            result[argument] = value
+    return result
+
+
 class _AgentCoreProvider(SandboxProvider):
     """AgentCore Code Interpreter sandbox provider.
 
@@ -729,16 +755,20 @@ class _AgentCoreProvider(SandboxProvider):
             ValueError: If boto3 is installed and AWS credentials cannot
                 be resolved.
         """
-        self._region = region or os.environ.get(
-            "AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
+        environment = active_environment()
+        self._region = region or environment.get(
+            "AWS_REGION", environment.get("AWS_DEFAULT_REGION", "us-west-2")
         )
+        self._session: Any = None
 
         # Validate AWS credentials early for a clear error message.
         try:
             import boto3  # ty: ignore[unresolved-import]
 
-            session = boto3.Session()
-            credentials = session.get_credentials()
+            session_kwargs = _aws_session_kwargs(environment)
+            session_kwargs["region_name"] = self._region
+            self._session = boto3.Session(**session_kwargs)
+            credentials = self._session.get_credentials()
             if credentials is None:
                 msg = (
                     "AWS credentials not found. Configure via "
@@ -798,6 +828,7 @@ class _AgentCoreProvider(SandboxProvider):
 
         interpreter = agentcore_module.CodeInterpreter(
             region=self._region,
+            session=self._session,
             integration_source="deepagents-code",
         )
         try:

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -16,7 +16,13 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from rich.markup import escape as escape_markup
 
-from deepagents_code.config import active_environment, console, get_glyphs
+from deepagents_code.config import (
+    AWS_CREDENTIAL_ENV_SOURCES,
+    active_environment,
+    console,
+    get_glyphs,
+    resolve_env_kwargs,
+)
 from deepagents_code.integrations.sandbox_provider import (
     SandboxNotFoundError,
     SandboxProvider,
@@ -713,30 +719,13 @@ class _RunloopProvider(SandboxProvider):
         self._provider.delete(sandbox_id=sandbox_id)
 
 
-_AWS_SESSION_ENV_KWARGS = {
-    "profile_name": ("AWS_PROFILE", "AWS_DEFAULT_PROFILE"),
-    "aws_access_key_id": ("AWS_ACCESS_KEY_ID",),
-    "aws_secret_access_key": ("AWS_SECRET_ACCESS_KEY",),
-    "aws_session_token": ("AWS_SESSION_TOKEN",),
-}
-"""AWS environment values accepted directly by `boto3.Session`."""
-
-
 def _aws_session_kwargs(environment: Mapping[str, str]) -> dict[str, str]:
     """Translate a workspace environment into explicit boto3 session arguments.
 
     Returns:
         Populated boto3 session keyword arguments.
     """
-    result: dict[str, str] = {}
-    for argument, env_names in _AWS_SESSION_ENV_KWARGS.items():
-        value = next(
-            (value for name in env_names if (value := environment.get(name))),
-            None,
-        )
-        if value:
-            result[argument] = value
-    return result
+    return resolve_env_kwargs(AWS_CREDENTIAL_ENV_SOURCES, environment.get)
 
 
 class _AgentCoreProvider(SandboxProvider):

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -6,7 +6,6 @@ import contextlib
 import importlib
 import importlib.util
 import logging
-import os
 import shlex
 import string
 import time
@@ -57,9 +56,12 @@ def _run_sandbox_setup(backend: SandboxBackendProtocol, setup_script_path: str) 
     # Read script content
     script_content = script_path.read_text(encoding="utf-8")
 
-    # Expand ${VAR} syntax using local environment
+    # Expand ${VAR} syntax using the workspace environment. `create_sandbox`
+    # runs inside `use_environment`, so this must read the bound snapshot:
+    # `os.environ` here would expand the server process's values into the
+    # sandbox and hide the workspace's own `.env`.
     template = string.Template(script_content)
-    expanded_script = template.safe_substitute(os.environ)
+    expanded_script = template.safe_substitute(active_environment())
 
     # Execute expanded script in sandbox
     result = backend.execute(f"bash -c {shlex.quote(expanded_script)}")
@@ -781,11 +783,18 @@ class _AgentCoreProvider(SandboxProvider):
         except ValueError:
             raise
         except Exception:
+            # Say what the failure costs, not just that it happened: without a
+            # session the interpreter resolves credentials itself, from the
+            # process environment rather than this workspace's.
             logger.warning(
-                "AWS credential pre-validation failed — the session may "
-                "fail to start. Check your AWS configuration.",
+                "Could not build an AWS session from the workspace environment "
+                "(region=%s). The sandbox will NOT use workspace AWS "
+                "credentials and may fail to start. Check your AWS "
+                "configuration.",
+                self._region,
                 exc_info=True,
             )
+            self._session = None
 
         self._active_interpreters: dict[str, Any] = {}
 
@@ -826,11 +835,16 @@ class _AgentCoreProvider(SandboxProvider):
             package="langchain-agentcore-codeinterpreter",
         )
 
-        interpreter = agentcore_module.CodeInterpreter(
-            region=self._region,
-            session=self._session,
-            integration_source="deepagents-code",
-        )
+        # Pass `session` only when one was built. Handing over `None` would let
+        # "no workspace session" masquerade as "workspace session applied",
+        # since the SDK then falls back to its own credential resolution.
+        interpreter_kwargs: dict[str, Any] = {
+            "region": self._region,
+            "integration_source": "deepagents-code",
+        }
+        if self._session is not None:
+            interpreter_kwargs["session"] = self._session
+        interpreter = agentcore_module.CodeInterpreter(**interpreter_kwargs)
         try:
             interpreter.start()
         except Exception:
@@ -936,8 +950,12 @@ class _VercelProvider(SandboxProvider):
             credential resolution to the Vercel SDK.
         """
         prefix = "DEEPAGENTS_CODE_"
+        # Gate against the same mapping `resolve_env_var` resolves from. Reading
+        # `os.environ` here would miss a prefixed override that came from the
+        # workspace `.env`, silently falling back to default Vercel auth.
+        environment = active_environment()
         has_override = any(
-            f"{prefix}{name}" in os.environ for name in cls._CREDENTIAL_ENV_NAMES
+            f"{prefix}{name}" in environment for name in cls._CREDENTIAL_ENV_NAMES
         )
         if not has_override:
             return {}

--- a/libs/code/deepagents_code/mcp_config.py
+++ b/libs/code/deepagents_code/mcp_config.py
@@ -9,7 +9,6 @@ validates their types. A `${VAR:-default}` reference falls back to
 from __future__ import annotations
 
 import copy
-import os
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -52,7 +51,9 @@ def _interpolate_env(value: str, *, field: str) -> str:
     def replace(match: re.Match[str]) -> str:
         name = match.group(1)
         default = match.group(2)
-        resolved = os.environ.get(name)
+        from deepagents_code.config import active_environment
+
+        resolved = active_environment().get(name)
         # A non-empty value always wins, for both `${VAR}` and `${VAR:-default}`.
         if resolved:
             return resolved

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -66,9 +66,12 @@ def resolved_env_var_name(canonical: str) -> str:
     Returns:
         The resolving env var name (prefixed or canonical).
     """
+    from deepagents_code.config import active_environment
+
+    environ = active_environment()
     if not canonical.startswith(_ENV_PREFIX):
         prefixed = f"{_ENV_PREFIX}{canonical}"
-        if prefixed in os.environ:
+        if prefixed in environ:
             return prefixed
     return canonical
 
@@ -95,11 +98,14 @@ def resolve_env_var(name: str) -> str | None:
     Returns:
         The resolved value, or `None` when absent or empty.
     """
+    from deepagents_code.config import active_environment
+
+    environ = active_environment()
     if not name.startswith(_ENV_PREFIX):
         prefixed = f"{_ENV_PREFIX}{name}"
-        if prefixed in os.environ:
-            val = os.environ[prefixed]
-            if not val and os.environ.get(name):
+        if prefixed in environ:
+            val = environ[prefixed]
+            if not val and environ.get(name):
                 logger.debug(
                     "%s is set but empty, blocking non-empty %s. "
                     "Unset %s to use the canonical variable.",
@@ -116,7 +122,7 @@ def resolve_env_var(name: str) -> str | None:
                 if should_log:
                     logger.debug("Resolved %s from %s", name, prefixed)
             return val or None
-    return os.environ.get(name) or None
+    return environ.get(name) or None
 
 
 PROVIDERS_DOCS_URL = (
@@ -2413,8 +2419,11 @@ def _resolve_gateway_configured(provider: str) -> ProviderAuthStatus | None:
         A `CONFIGURED` status pointing at `LANGSMITH_GATEWAY_API_KEY`, or
         `None` when the gateway cannot authenticate this provider.
     """
-    gateway = os.getenv(LANGSMITH_GATEWAY_ENV)
-    gateway_key = os.getenv(LANGSMITH_GATEWAY_API_KEY_ENV)
+    from deepagents_code.config import active_environment
+
+    environ = active_environment()
+    gateway = environ.get(LANGSMITH_GATEWAY_ENV)
+    gateway_key = environ.get(LANGSMITH_GATEWAY_API_KEY_ENV)
     if (
         provider not in LANGSMITH_GATEWAY_PROVIDERS
         or not gateway
@@ -2960,8 +2969,11 @@ def _configured_base_url_survives_env_clear(provider: str) -> bool:
     provider_cfg = config.providers.get(provider)
     if provider_cfg and provider_cfg.get("base_url"):
         return True
+    from deepagents_code.config import active_environment
+
+    environment = active_environment()
     for env_var in get_base_url_env_vars(provider):
-        if os.environ.get(f"{_ENV_PREFIX}{env_var}"):
+        if environment.get(f"{_ENV_PREFIX}{env_var}"):
             return True
     return False
 
@@ -5137,7 +5149,9 @@ def _parse_csv_env(name: str) -> list[str] | None:
             trimming), or `None` when the variable is unset so callers can
             distinguish "unset, fall back to TOML" from "set but empty".
     """
-    raw = os.environ.get(name)
+    from deepagents_code.config import active_environment
+
+    raw = active_environment().get(name)
     if raw is None:
         return None
     return [item.strip() for item in raw.split(",") if item.strip()]
@@ -5702,7 +5716,11 @@ def load_mcp_server_trust_lists(
     # The old name was renamed to the `DANGEROUSLY_`-prefixed var and is no
     # longer read; flag it set-but-ignored so callers can explain the rename
     # instead of the names silently ceasing to pre-approve.
-    legacy_env_ignored = _env_vars.LEGACY_ENABLED_PROJECT_MCP_SERVERS in os.environ
+    from deepagents_code.config import active_environment
+
+    legacy_env_ignored = (
+        _env_vars.LEGACY_ENABLED_PROJECT_MCP_SERVERS in active_environment()
+    )
     if legacy_env_ignored:
         logger.warning(
             "%s is no longer used; it was renamed to %s",

--- a/libs/code/deepagents_code/offload_middleware.py
+++ b/libs/code/deepagents_code/offload_middleware.py
@@ -59,7 +59,7 @@ from deepagents_code.hooks.server_middleware import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 
     from deepagents.backends.composite import CompositeBackend
     from deepagents.backends.protocol import (
@@ -285,10 +285,12 @@ class _LazySummaryModel:
         summarization: SummarizationMiddleware,
         model_spec: str,
         cli_max_retries: int | None,
+        environ: Mapping[str, str] | None = None,
     ) -> None:
         self._summarization = summarization
         self._model_spec = model_spec
         self._cli_max_retries = cli_max_retries
+        self._environ = environ
         self._lock = Lock()
         self._invocation_lock = Lock()
         self._configured = False
@@ -319,10 +321,13 @@ class _LazySummaryModel:
             from deepagents_code.config import create_model
 
             try:
-                model = create_model(
-                    self._model_spec,
-                    cli_max_retries=self._cli_max_retries,
-                ).model
+                from deepagents_code.config import use_environment
+
+                with use_environment(self._environ):
+                    model = create_model(
+                        self._model_spec,
+                        cli_max_retries=self._cli_max_retries,
+                    ).model
             except Exception as exc:
                 # BlockingError means this ran on the server event loop; that is
                 # a defect in the caller, not a bad model spec, so let it out.
@@ -440,6 +445,7 @@ def _install_lazy_summary_model(
     summarization: SummarizationMiddleware,
     model_spec: str,
     cli_max_retries: int | None,
+    environ: Mapping[str, str] | None = None,
 ) -> None:
     """Defer dedicated model construction until a summary is requested.
 
@@ -449,12 +455,13 @@ def _install_lazy_summary_model(
         summarization: Middleware whose summary hooks are wrapped.
         model_spec: Spec to resolve when a summary is first requested.
         cli_max_retries: Explicit `--max-retries` value, or `None`.
+        environ: Workspace environment retained for lazy model construction.
     """
     for slot in ("_create_summary", "_acreate_summary"):
         _require_helper_slot(
             summarization._lc_helper, slot, "defer summary-model construction"
         )
-    lazy = _LazySummaryModel(summarization, model_spec, cli_max_retries)
+    lazy = _LazySummaryModel(summarization, model_spec, cli_max_retries, environ)
     # LangChain annotates these private attributes as unbound method shapes;
     # instance-local bound wrappers are intentional so only this summarizer is lazy.
     summarization._lc_helper._create_summary = (  # ty: ignore[invalid-assignment]
@@ -1014,6 +1021,7 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
         system_prompt: str | None = None,
         cli_max_retries: int | None = None,
         summarization_model_spec: str | None = None,
+        environ: Mapping[str, str] | None = None,
     ) -> None:
         """Initialize the CLI compaction middleware.
 
@@ -1023,10 +1031,12 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
             cli_max_retries: Explicit `--max-retries` value to retain when
                 rebuilding a runtime-selected model for `/offload`.
             summarization_model_spec: Startup model spec to use only for summaries.
+            environ: Workspace environment retained for lazy model construction.
         """
         super().__init__(summarization, system_prompt=system_prompt)
         self._cli_max_retries = cli_max_retries
         self._summarization_model_spec = summarization_model_spec
+        self._environ = environ
         # One-entry memo for `_summarization_for_runtime`. Every model call
         # consults it, but the runtime model configuration only changes on
         # `/model` or `/summarization-model`, so a single slot hits almost
@@ -1352,12 +1362,15 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
         from deepagents_code.config import create_model
 
         if config.model_spec:
-            model = create_model(
-                config.model_spec,
-                extra_kwargs=config.model_params or None,
-                profile_overrides=config.profile_overrides or None,
-                cli_max_retries=self._cli_max_retries,
-            ).model
+            from deepagents_code.config import use_environment
+
+            with use_environment(self._environ):
+                model = create_model(
+                    config.model_spec,
+                    extra_kwargs=config.model_params or None,
+                    profile_overrides=config.profile_overrides or None,
+                    cli_max_retries=self._cli_max_retries,
+                ).model
         else:
             model = self._summarization.model
         # Only a freshly built model may have its profile mutated. On the
@@ -1409,6 +1422,7 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
                 summarization,
                 summary_model_spec,
                 self._cli_max_retries,
+                self._environ,
             )
         else:
             _install_summary_model_retries(summarization)
@@ -1586,6 +1600,7 @@ def _create_cli_compaction_middleware(
     *,
     cli_max_retries: int | None = None,
     summarization_model_spec: str | None = None,
+    environ: Mapping[str, str] | None = None,
 ) -> CLICompactionMiddleware:
     """Create the dcode compaction middleware from the SDK configuration.
 
@@ -1594,6 +1609,7 @@ def _create_cli_compaction_middleware(
         backend: Agent backend used for archive persistence.
         cli_max_retries: Explicit `--max-retries` value for runtime rebuilds.
         summarization_model_spec: Startup model spec to use only for summaries.
+        environ: Workspace environment retained for lazy model construction.
 
     Returns:
         CLI compaction middleware with the SDK's model-aware defaults.
@@ -1605,6 +1621,7 @@ def _create_cli_compaction_middleware(
         system_prompt=sdk_middleware.system_prompt,
         cli_max_retries=cli_max_retries,
         summarization_model_spec=summarization_model_spec,
+        environ=environ,
     )
 
 

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -18,6 +18,7 @@ import logging
 import sys
 from collections import OrderedDict
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 # Imported at runtime rather than under TYPE_CHECKING: the LangGraph server
@@ -38,10 +39,11 @@ from deepagents_code.project_utils import ProjectContext, get_server_project_con
 from deepagents_code.workspace import WorkspaceConflictError, resolve_workspace
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Mapping
 
     from deepagents.backends.composite import CompositeBackend
 
+    from deepagents_code.config import CredentialsSnapshot
     from deepagents_code.extensions.registry import ExtensionRegistry
     from deepagents_code.offload_middleware import OffloadOperation
     from deepagents_code.workspace import WorkspaceBinding
@@ -88,6 +90,8 @@ def _get_mcp_session_manager() -> Any:  # noqa: ANN401
 async def _build_tools(
     config: ServerConfig,
     project_context: ProjectContext | None,
+    *,
+    has_tavily: bool | None = None,
 ) -> tuple[list[Any], list[Any] | None, list[Any]]:
     """Assemble the tool list based on server config.
 
@@ -106,6 +110,7 @@ async def _build_tools(
     Args:
         config: Deserialized server configuration.
         project_context: Resolved project context for MCP discovery.
+        has_tavily: Workspace credential availability override.
 
     Returns:
         Tuple of `(tools, mcp_server_info, mcp_tools)`.
@@ -114,12 +119,23 @@ async def _build_tools(
         FileNotFoundError: If the MCP config file is not found.
         RuntimeError: If MCP tool loading fails.
     """
-    from deepagents_code.config import credentials
-    from deepagents_code.tools import fetch_url, get_current_thread_id, web_search
+    from deepagents_code.config import active_environment, credentials
+    from deepagents_code.tools import (
+        create_web_search_tool,
+        fetch_url,
+        get_current_thread_id,
+        web_search,
+    )
 
     tools: list[Any] = [fetch_url, get_current_thread_id]
-    if credentials.has_tavily:
-        tools.append(web_search)
+    tavily_available = credentials.has_tavily if has_tavily is None else has_tavily
+    if tavily_available:
+        api_key = active_environment().get(
+            "DEEPAGENTS_CODE_TAVILY_API_KEY"
+        ) or active_environment().get("TAVILY_API_KEY")
+        tools.append(
+            web_search if has_tavily is None else create_web_search_tool(api_key or "")
+        )
 
     mcp_server_info: list[Any] | None = None
     mcp_tools: list[Any] = []
@@ -179,9 +195,10 @@ def _criteria_context_tools(
         MCP tools are included only when their protocol annotations explicitly
         declare them read-only.
     """
-    from deepagents_code.tools import fetch_url, web_search
+    from deepagents_code.tools import fetch_url, is_web_search_tool
 
-    allowed_ids = {id(fetch_url), id(web_search)}
+    allowed_ids = {id(fetch_url)}
+    allowed_ids.update(id(tool) for tool in tools if is_web_search_tool(tool))
     allowed_ids.update(
         id(tool) for tool in mcp_tools if _mcp_tool_is_explicitly_read_only(tool)
     )
@@ -239,6 +256,46 @@ async def _make_graphs(
             offload operation bound to that backend.
     """
     config = config_override or ServerConfig.from_env()
+    from deepagents_code.config import (
+        Credentials,
+        _preview_dotenv_environ,
+        use_environment,
+    )
+
+    workspace_path = (
+        project_context_override.user_cwd
+        if project_context_override is not None
+        else Path(config.cwd)
+        if config.cwd is not None
+        else None
+    )
+    workspace_env = MappingProxyType(_preview_dotenv_environ(start_path=workspace_path))
+    workspace_credentials = Credentials.snapshot_from_environment(
+        start_path=workspace_path,
+        environ=workspace_env,
+    )
+
+    with use_environment(workspace_env):
+        return await _make_graphs_in_environment(
+            config=config,
+            project_context_override=project_context_override,
+            workspace_env=workspace_env,
+            workspace_credentials=workspace_credentials,
+        )
+
+
+async def _make_graphs_in_environment(
+    *,
+    config: ServerConfig,
+    project_context_override: ProjectContext | None,
+    workspace_env: Mapping[str, str],
+    workspace_credentials: CredentialsSnapshot,
+) -> ServerRuntime:
+    """Build one runtime while its immutable workspace environment is active.
+
+    Returns:
+        Agent graph and its workspace-bound resources.
+    """
 
     # Offload cwd/path resolution and the lazy settings bootstrap off the event
     # loop. On Windows, `Path.resolve()` / `Path.cwd()` call `os.getcwd()`, which
@@ -267,13 +324,10 @@ async def _make_graphs(
         from deepagents_code.config import (
             configure_langsmith_secret_redaction,
             create_model,
-            credentials,
             is_memory_auto_save_enabled,
             resolve_auto_classifier_model_for_provider,
         )
 
-        if project_context is not None:
-            credentials.reload_from_environment(start_path=project_context.user_cwd)
         return (
             project_context,
             create_cli_agent,
@@ -308,7 +362,11 @@ async def _make_graphs(
     )
     result.apply_to_runtime_state()
 
-    tools, mcp_server_info, mcp_tools = await _build_tools(config, project_context)
+    tools, mcp_server_info, mcp_tools = await _build_tools(
+        config,
+        project_context,
+        has_tavily=workspace_credentials.has_tavily,
+    )
     read_only_context_tools = _criteria_context_tools(tools, mcp_tools)
 
     # Create sandbox backend if a sandbox provider is configured.
@@ -418,6 +476,9 @@ async def _make_graphs(
             cli_max_retries=result.cli_max_retries,
             summarization_model=config.summarization_model,
             extension_registry=extension_registry,
+            environ=workspace_env,
+            credentials_snapshot=workspace_credentials,
+            model_result=result,
         )
         from deepagents_code.offload_middleware import offload_operation_from
 
@@ -434,9 +495,9 @@ async def _make_graphs(
             offload=offload,
         )
 
-    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+    from deepagents_code._env_vars import EXPERIMENTAL, classify_env_bool
 
-    if is_env_truthy(EXPERIMENTAL):
+    if classify_env_bool(workspace_env.get(EXPERIMENTAL, "")) is True:
         from deepagents_code.extensions import ExtensionMode, load_extensions
         from deepagents_code.extensions.runtime import bind_server_extensions
 

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -269,10 +269,24 @@ async def _make_graphs(
         if config.cwd is not None
         else None
     )
-    workspace_env = MappingProxyType(_preview_dotenv_environ(start_path=workspace_path))
-    workspace_credentials = Credentials.snapshot_from_environment(
-        start_path=workspace_path,
-        environ=workspace_env,
+
+    # Offload the workspace environment snapshot off the event loop. Dotenv
+    # discovery walks parent directories (`Path.resolve()`, `is_file()`) and
+    # reads up to three files, and `snapshot_from_environment` adds
+    # `find_project_root()` -> `Path.cwd()` — all of which `blockbuster`
+    # rejects when invoked directly from the server loop (see issue #5043),
+    # for the same reason as the offload in `_make_graphs_in_environment`.
+    def _resolve_workspace_environment() -> tuple[
+        Mapping[str, str], CredentialsSnapshot
+    ]:
+        environ = MappingProxyType(_preview_dotenv_environ(start_path=workspace_path))
+        return environ, Credentials.snapshot_from_environment(
+            start_path=workspace_path,
+            environ=environ,
+        )
+
+    workspace_env, workspace_credentials = await asyncio.to_thread(
+        _resolve_workspace_environment
     )
 
     with use_environment(workspace_env):

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -92,6 +92,7 @@ async def _build_tools(
     project_context: ProjectContext | None,
     *,
     has_tavily: bool | None = None,
+    tavily_api_key: str | None = None,
 ) -> tuple[list[Any], list[Any] | None, list[Any]]:
     """Assemble the tool list based on server config.
 
@@ -111,6 +112,7 @@ async def _build_tools(
         config: Deserialized server configuration.
         project_context: Resolved project context for MCP discovery.
         has_tavily: Workspace credential availability override.
+        tavily_api_key: Workspace Tavily key that pairs with `has_tavily`.
 
     Returns:
         Tuple of `(tools, mcp_server_info, mcp_tools)`.
@@ -119,7 +121,7 @@ async def _build_tools(
         FileNotFoundError: If the MCP config file is not found.
         RuntimeError: If MCP tool loading fails.
     """
-    from deepagents_code.config import active_environment, credentials
+    from deepagents_code.config import credentials
     from deepagents_code.tools import (
         create_web_search_tool,
         fetch_url,
@@ -130,11 +132,10 @@ async def _build_tools(
     tools: list[Any] = [fetch_url, get_current_thread_id]
     tavily_available = credentials.has_tavily if has_tavily is None else has_tavily
     if tavily_available:
-        api_key = active_environment().get(
-            "DEEPAGENTS_CODE_TAVILY_API_KEY"
-        ) or active_environment().get("TAVILY_API_KEY")
         tools.append(
-            web_search if has_tavily is None else create_web_search_tool(api_key or "")
+            web_search
+            if has_tavily is None
+            else create_web_search_tool(tavily_api_key or "")
         )
 
     mcp_server_info: list[Any] | None = None
@@ -380,6 +381,7 @@ async def _make_graphs_in_environment(
         config,
         project_context,
         has_tavily=workspace_credentials.has_tavily,
+        tavily_api_key=workspace_credentials.tavily_api_key,
     )
     read_only_context_tools = _criteria_context_tools(tools, mcp_tools)
 
@@ -509,9 +511,9 @@ async def _make_graphs_in_environment(
             offload=offload,
         )
 
-    from deepagents_code._env_vars import EXPERIMENTAL, classify_env_bool
+    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
 
-    if classify_env_bool(workspace_env.get(EXPERIMENTAL, "")) is True:
+    if is_env_truthy(EXPERIMENTAL, environ=workspace_env):
         from deepagents_code.extensions import ExtensionMode, load_extensions
         from deepagents_code.extensions.runtime import bind_server_extensions
 

--- a/libs/code/deepagents_code/tools.py
+++ b/libs/code/deepagents_code/tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import ipaddress
 import logging
 import socket
@@ -311,53 +312,25 @@ def _get_tavily_client() -> TavilyClient | None:
 def create_web_search_tool(api_key: str) -> BaseTool:
     """Bind web search to one workspace credential.
 
+    The schema is taken from `web_search` via `functools.wraps` so the built-in
+    and workspace-bound variants can never present different arguments.
+
     Returns:
         Workspace-bound web search tool.
     """
+    # Built on first use and reused: a per-call client would open a fresh
+    # connection pool and repeat the TLS handshake for every search.
+    client: TavilyClient | None = None
 
     @tool("web_search")
-    def workspace_web_search(
-        query: Annotated[
-            str,
-            Field(description="The search query (be specific and detailed)."),
-        ],
-        max_results: Annotated[
-            int,
-            Field(description="Number of results to return."),
-        ] = 5,
-        topic: Annotated[
-            Literal["general", "news", "finance"],
-            Field(
-                description=(
-                    'Search topic type: "general" for most queries, "news" for '
-                    'current events, or "finance".'
-                )
-            ),
-        ] = "general",
-        include_raw_content: Annotated[
-            bool,
-            Field(
-                description=(
-                    "Include full page content (uses more tokens). Prefer `fetch_url` "
-                    "for a single URL."
-                )
-            ),
-        ] = False,
-    ) -> object:
-        """Search the web for current information.
+    @functools.wraps(web_search)
+    def workspace_web_search(**kwargs: Any) -> object:
+        nonlocal client
+        if client is None:
+            from tavily import TavilyClient as _TavilyClient
 
-        Returns:
-            Search hits or a translated error payload.
-        """
-        from tavily import TavilyClient as _TavilyClient
-
-        return _search_with_tavily(
-            _TavilyClient(api_key=api_key),
-            query=query,
-            max_results=max_results,
-            topic=topic,
-            include_raw_content=include_raw_content,
-        )
+            client = _TavilyClient(api_key=api_key)
+        return _search_with_tavily(client, **kwargs)
 
     _workspace_web_search_tools[id(workspace_web_search)] = workspace_web_search
     return workspace_web_search

--- a/libs/code/deepagents_code/tools.py
+++ b/libs/code/deepagents_code/tools.py
@@ -7,6 +7,7 @@ import ipaddress
 import logging
 import socket
 import threading
+import weakref
 from html.parser import HTMLParser
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 from urllib.parse import urljoin, urlparse
@@ -18,12 +19,16 @@ from pydantic import Field
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
+    from langchain_core.tools import BaseTool
     from tavily import TavilyClient
 
 logger = logging.getLogger(__name__)
 
 _UNSET = object()
 _tavily_client: TavilyClient | object | None = _UNSET
+_workspace_web_search_tools: weakref.WeakValueDictionary[int, object] = (
+    weakref.WeakValueDictionary()
+)
 
 _ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
 _MAX_FETCH_REDIRECTS = 5
@@ -303,6 +308,69 @@ def _get_tavily_client() -> TavilyClient | None:
     return _tavily_client
 
 
+def create_web_search_tool(api_key: str) -> BaseTool:
+    """Bind web search to one workspace credential.
+
+    Returns:
+        Workspace-bound web search tool.
+    """
+
+    @tool("web_search")
+    def workspace_web_search(
+        query: Annotated[
+            str,
+            Field(description="The search query (be specific and detailed)."),
+        ],
+        max_results: Annotated[
+            int,
+            Field(description="Number of results to return."),
+        ] = 5,
+        topic: Annotated[
+            Literal["general", "news", "finance"],
+            Field(
+                description=(
+                    'Search topic type: "general" for most queries, "news" for '
+                    'current events, or "finance".'
+                )
+            ),
+        ] = "general",
+        include_raw_content: Annotated[
+            bool,
+            Field(
+                description=(
+                    "Include full page content (uses more tokens). Prefer `fetch_url` "
+                    "for a single URL."
+                )
+            ),
+        ] = False,
+    ) -> object:
+        """Search the web for current information.
+
+        Returns:
+            Search hits or a translated error payload.
+        """
+        from tavily import TavilyClient as _TavilyClient
+
+        return _search_with_tavily(
+            _TavilyClient(api_key=api_key),
+            query=query,
+            max_results=max_results,
+            topic=topic,
+            include_raw_content=include_raw_content,
+        )
+
+    _workspace_web_search_tools[id(workspace_web_search)] = workspace_web_search
+    return workspace_web_search
+
+
+def is_web_search_tool(candidate: object) -> bool:
+    """Return whether `candidate` is a built-in or workspace-bound search tool."""
+    return (
+        candidate is web_search
+        or _workspace_web_search_tools.get(id(candidate)) is candidate
+    )
+
+
 @tool
 def get_current_thread_id() -> str:
     """Get the current Deep Agents thread ID for LangSmith or MCP tooling.
@@ -349,6 +417,35 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
     Returns:
         Search hits with title, URL, snippet, and score.
     """
+    client = _get_tavily_client()
+    if client is None:
+        return {
+            "error": "Tavily API key not configured. "
+            "Please set TAVILY_API_KEY environment variable.",
+            "query": query,
+        }
+    return _search_with_tavily(
+        client,
+        query=query,
+        max_results=max_results,
+        topic=topic,
+        include_raw_content=include_raw_content,
+    )
+
+
+def _search_with_tavily(
+    client: TavilyClient,
+    *,
+    query: str,
+    max_results: int,
+    topic: Literal["general", "news", "finance"],
+    include_raw_content: bool,
+) -> object:
+    """Execute a Tavily search with the standard error translation.
+
+    Returns:
+        Search hits or a translated error payload.
+    """
     try:
         import requests
         from tavily import (
@@ -360,14 +457,6 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
         from tavily.errors import ForbiddenError, TimeoutError as TavilyTimeoutError
     except ImportError as exc:
         return {"error": f"Required package not installed: {exc.name}."}
-
-    client = _get_tavily_client()
-    if client is None:
-        return {
-            "error": "Tavily API key not configured. "
-            "Please set TAVILY_API_KEY environment variable.",
-            "query": query,
-        }
 
     try:
         return client.search(

--- a/libs/code/scripts/check_process_cwd.py
+++ b/libs/code/scripts/check_process_cwd.py
@@ -122,7 +122,7 @@ _ALLOWLIST: dict[CallSite, str] = {
         "config.py",
         "Credentials.snapshot_from_environment",
         "find_project_root",
-        "88bd9ffe",
+        "8f8190fd",
     ): "The skills CLI omits `start_path`. Bootstrap supplies the launch "
     "directory. Server callers pass the workspace path.",
     CallSite(

--- a/libs/code/scripts/check_process_cwd.py
+++ b/libs/code/scripts/check_process_cwd.py
@@ -122,7 +122,7 @@ _ALLOWLIST: dict[CallSite, str] = {
         "config.py",
         "Credentials.snapshot_from_environment",
         "find_project_root",
-        "8f8190fd",
+        "8eea0706",
     ): "The skills CLI omits `start_path`. Bootstrap supplies the launch "
     "directory. Server callers pass the workspace path.",
     CallSite(

--- a/libs/code/scripts/check_process_cwd.py
+++ b/libs/code/scripts/check_process_cwd.py
@@ -103,8 +103,9 @@ _ALLOWLIST: dict[CallSite, str] = {
         "client/non_interactive.py", "run_non_interactive", "Path.cwd", "0f2377b6"
     ): "The headless client sends its directory in run context.",
     CallSite(
-        "config.py", "_preview_dotenv_environ", "Path.cwd", "e3f140b7"
-    ): "The client-side tracing diagnostic previews the local dotenv file.",
+        "config.py", "_dotenv_environment", "Path.cwd", "e3f140b7"
+    ): "Workspace server callers pass `start_path`; client processes fall back "
+    "to their own launch directory, which is the correct project directory there.",
     CallSite(
         "config.py", "_get_git_branch", "Path.cwd", "7a7a7e4f"
     ): "Client stream metadata describes the local checkout.",
@@ -118,8 +119,12 @@ _ALLOWLIST: dict[CallSite, str] = {
         "config.py", "build_stream_config", "Path.cwd", "7a7a7e4f"
     ): "The client builds tracing metadata before sending a run.",
     CallSite(
-        "config.py", "Credentials.from_environment", "find_project_root", "a0389172"
-    ): "The skills CLI omits `start_path`. Bootstrap supplies the launch directory.",
+        "config.py",
+        "Credentials.snapshot_from_environment",
+        "find_project_root",
+        "88bd9ffe",
+    ): "The skills CLI omits `start_path`. Bootstrap supplies the launch "
+    "directory. Server callers pass the workspace path.",
     CallSite(
         "config.py", "Credentials._reload_values", "find_project_root", "a0389172"
     ): "Client reloads may omit `start_path`; server callers supply workspace context.",

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -1160,6 +1160,34 @@ def test_add_interrupt_on_gates_delete() -> None:
     assert interrupt_map["delete"]["when"] is _should_interrupt_tool_call
 
 
+class TestWorkspacePromptCredentials:
+    """Workspace tool guidance uses the bound credential snapshot."""
+
+    def test_model_result_override_controls_identity(self) -> None:
+        """Workspace model metadata does not depend on global runtime state."""
+        from deepagents_code.config import ModelResult
+
+        workspace_model = ModelResult(
+            model=Mock(),
+            model_name="workspace-model",
+            provider="workspace-provider",
+            context_limit=12345,
+        )
+        prompt = get_system_prompt("test-agent", model_result=workspace_model)
+
+        assert "workspace-model" in prompt
+        assert "workspace-provider" in prompt
+        assert "12,345 tokens" in prompt
+
+    def test_has_tavily_override_controls_guidance(self) -> None:
+        """Prompt guidance does not consult process-global credentials."""
+        without = get_system_prompt("test-agent", has_tavily=False)
+        with_tavily = get_system_prompt("test-agent", has_tavily=True)
+
+        assert "When you use the web_search tool" not in without
+        assert "When you use the web_search tool" in with_tavily
+
+
 class TestBuildModelIdentitySection:
     """Direct tests for build_model_identity_section."""
 
@@ -2621,6 +2649,43 @@ class TestCreateCliAgentProjectContext:
             )
 
         return mock_shell, user_cwd
+
+    def test_workspace_environment_is_frozen_for_local_shell(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The shell backend receives the workspace snapshot, not process state."""
+        mock_shell, _ = self._build_shell_agent(
+            monkeypatch, tmp_path, user_langchain_project=None
+        )
+        first = dict(mock_shell.call_args.kwargs["env"])
+        workspace_env = {**first, "WORKSPACE_VALUE": "second"}
+
+        project_root = tmp_path / "other"
+        project_root.mkdir()
+        project_context = ProjectContext.from_user_cwd(project_root)
+        mock_settings = Mock(project_root=project_root, user_langchain_project=None)
+        fake_model = _make_fake_chat_model()
+        with (
+            patch("deepagents_code.agent.MemoryMiddleware"),
+            patch("deepagents_code.agent.PluginSkillsMiddleware"),
+            patch("deepagents_code.agent.LocalShellBackend") as backend,
+            patch("deepagents_code.agent.create_deep_agent") as create,
+            patch("deepagents._models.init_chat_model", return_value=fake_model),
+        ):
+            create.return_value.with_config.return_value = create.return_value
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=False,
+                enable_skills=False,
+                project_context=project_context,
+                environ=workspace_env,
+                credentials_snapshot=mock_settings,
+            )
+
+        assert "WORKSPACE_VALUE" not in first
+        assert backend.call_args.kwargs["env"]["WORKSPACE_VALUE"] == "second"
+        assert backend.call_args.kwargs["inherit_env"] is False
 
     def test_project_context_sets_local_shell_root_dir(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -166,6 +166,7 @@ def _patch_agent_paths(
     project_agent_skills_dir: Path | None = None,
     user_claude_skills_dir: Path | None = None,
     project_claude_skills_dir: Path | None = None,
+    expected_project_claude_root: Path | None = None,
     project_agent_md_paths: tuple[Path, ...] = (),
     user_agents_dir: Path | None = None,
     project_agents_dir: Path | None = None,
@@ -195,7 +196,12 @@ def _patch_agent_paths(
         ),
         patch(
             "deepagents_code.agent.get_project_claude_skills_dir",
-            return_value=project_claude_skills_dir,
+            side_effect=lambda root: (
+                project_claude_skills_dir
+                if expected_project_claude_root is None
+                or root == expected_project_claude_root
+                else None
+            ),
         ),
         patch(
             "deepagents_code.agent.get_user_agent_md_path",
@@ -2427,6 +2433,8 @@ class TestCreateCliAgentProjectContext:
         project_skills_dir.mkdir(parents=True)
         project_agent_skills_dir = project_root / ".agents" / "skills"
         project_agent_skills_dir.mkdir(parents=True)
+        project_claude_skills_dir = project_root / ".claude" / "skills"
+        project_claude_skills_dir.mkdir(parents=True)
         project_agents_dir = project_root / ".deepagents" / "agents"
         project_agents_dir.mkdir(parents=True)
         project_context = ProjectContext.from_user_cwd(user_cwd)
@@ -2474,6 +2482,8 @@ class TestCreateCliAgentProjectContext:
                 agent_dir=agent_dir,
                 skills_dir=user_skills_dir,
                 user_agent_skills_dir=user_agent_skills_dir,
+                project_claude_skills_dir=project_claude_skills_dir,
+                expected_project_claude_root=project_root,
                 user_agents_dir=tmp_path / "agents",
             ),
             patch("deepagents_code.agent.PluginSkillsMiddleware", FakeSkillsMiddleware),
@@ -2497,6 +2507,7 @@ class TestCreateCliAgentProjectContext:
         source_paths = [s[0] if isinstance(s, tuple) else s for s in sources]
         assert str(project_skills_dir) in source_paths
         assert str(project_agent_skills_dir) in source_paths
+        assert str(project_claude_skills_dir) in source_paths
         mock_list.assert_called_once_with(
             user_agents_dir=tmp_path / "agents",
             project_agents_dir=project_agents_dir,

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -1096,6 +1096,18 @@ def _create_test_temp_artifact(
     return state, artifact
 
 
+def test_workspace_credentials_are_known_secrets(tmp_path: Path) -> None:
+    """Auto redaction includes secrets from the workspace snapshot."""
+    config: InterruptOnConfig = {"allowed_decisions": ["approve", "reject"]}
+    middleware = AutoModeHITLMiddleware(
+        {"execute": config},
+        worktree_root=tmp_path,
+        environ={"WORKSPACE_API_KEY": "workspace-secret-value"},
+    )
+
+    assert "workspace-secret-value" in middleware._known_secrets
+
+
 def test_sanitize_auto_reason_redacts_secrets_urls_and_control_text() -> None:
     reason = (
         "TOKEN=supersecret https://user:pass@example.com/path?q=value\x1b[31m\n"

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -1002,6 +1002,76 @@ class TestWorkspaceStoredCredentials:
     """Stored auth remains workspace-local during server model construction."""
 
     @patch("langchain.chat_models.init_chat_model")
+    def test_azure_sdk_environment_is_forwarded_explicitly(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Azure SDK-only workspace settings reach the model constructor."""
+        import os
+
+        from deepagents_code.config import create_model, use_environment
+
+        mock_model = Mock(profile=None)
+        mock_init_chat_model.return_value = mock_model
+        monkeypatch.delenv("OPENAI_API_VERSION", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_AD_TOKEN", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+
+        with use_environment(
+            {
+                "AZURE_OPENAI_API_KEY": "test-key",
+                "AZURE_OPENAI_ENDPOINT": "https://workspace.openai.azure.com/",
+                "OPENAI_API_VERSION": "2026-01-01",
+                "AZURE_OPENAI_AD_TOKEN": "test-token",
+            }
+        ):
+            create_model("azure_openai:deployment")
+
+        kwargs = mock_init_chat_model.call_args.kwargs
+        assert kwargs["azure_endpoint"] == "https://workspace.openai.azure.com/"
+        assert "base_url" not in kwargs
+        assert kwargs["api_version"] == "2026-01-01"
+        assert kwargs["azure_ad_token"] == "test-token"
+        assert "OPENAI_API_VERSION" not in os.environ
+        assert "AZURE_OPENAI_AD_TOKEN" not in os.environ
+        assert "AZURE_OPENAI_ENDPOINT" not in os.environ
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_bedrock_sdk_environment_is_forwarded_explicitly(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """AWS workspace settings reach Bedrock without process mutation."""
+        import os
+
+        from deepagents_code.config import create_model, use_environment
+
+        mock_model = Mock(profile=None)
+        mock_init_chat_model.return_value = mock_model
+        aws_environment = {
+            "AWS_DEFAULT_REGION": "us-test-1",
+            "AWS_DEFAULT_PROFILE": "workspace-profile",
+            "AWS_ACCESS_KEY_ID": "test-access-key",
+            "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+            "AWS_SESSION_TOKEN": "test-session-token",
+        }
+        for name in aws_environment:
+            monkeypatch.delenv(name, raising=False)
+
+        with use_environment(aws_environment):
+            create_model("bedrock:amazon.test-model")
+
+        kwargs = mock_init_chat_model.call_args.kwargs
+        assert kwargs["region_name"] == "us-test-1"
+        assert kwargs["credentials_profile_name"] == "workspace-profile"
+        assert kwargs["aws_access_key_id"] == "test-access-key"
+        assert kwargs["aws_secret_access_key"] == "test-secret-key"
+        assert kwargs["aws_session_token"] == "test-session-token"
+        assert all(name not in os.environ for name in aws_environment)
+
+    @patch("langchain.chat_models.init_chat_model")
     def test_stored_key_and_endpoint_do_not_mutate_process_environment(
         self,
         mock_init_chat_model: Mock,

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -307,6 +307,35 @@ class TestWorkspaceDotenvEnvironment:
             fail()
         assert active_environment() is os.environ
 
+    def test_windows_dotenv_keys_follow_case_insensitive_precedence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lowercase dotenv names normalize and cannot replace shell values."""
+        import deepagents_code.config as config_mod
+        import deepagents_code.config_manifest as manifest
+
+        (tmp_path / ".env").write_text("openai_api_key=dotenv-key\n")
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(
+            config_mod,
+            "_GLOBAL_DOTENV_PATH",
+            tmp_path / "missing-global.env",
+        )
+        monkeypatch.setattr(manifest, "resolve_read_project_dotenv", lambda **_: True)
+
+        from_dotenv = config_mod._dotenv_environment(
+            start_path=tmp_path,
+            environ={},
+        )
+        from_shell = config_mod._dotenv_environment(
+            start_path=tmp_path,
+            environ={"OPENAI_API_KEY": "shell-key"},
+        )
+
+        assert from_dotenv["OPENAI_API_KEY"] == "dotenv-key"
+        assert "openai_api_key" not in from_dotenv
+        assert from_shell["OPENAI_API_KEY"] == "shell-key"
+
     def test_preview_interpolates_prior_dotenv_values(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -196,6 +196,145 @@ class TestRuntimeDotenvReload:
             config_mod._dotenv_loaded_values.clear()
 
 
+class TestWorkspaceDotenvEnvironment:
+    """Workspace previews stay isolated without replacing the process environment."""
+
+    def test_conflicting_workspaces_resolve_independently(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Construction-time consumers read each workspace's immutable snapshot."""
+        import os
+
+        import deepagents_code.config as config_mod
+        from deepagents_code.config_manifest import get_option
+        from deepagents_code.configuration.providers import EnvProvider
+        from deepagents_code.configuration.types import Found
+        from deepagents_code.mcp_config import resolve_mcp_server_env
+        from deepagents_code.model_config import resolve_env_var
+
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        (first / ".env").write_text(
+            "OPENAI_API_KEY=first-key\nDEEPAGENTS_CODE_TEST_VALUE=first\nGOOGLE_CLOUD_LOCATION=first-region\n",
+            encoding="utf-8",
+        )
+        (second / ".env").write_text(
+            "OPENAI_API_KEY=second-key\nDEEPAGENTS_CODE_TEST_VALUE=second\nGOOGLE_CLOUD_LOCATION=second-region\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("DEEPAGENTS_CODE_TEST_VALUE", raising=False)
+        monkeypatch.setattr(
+            config_mod, "_GLOBAL_DOTENV_PATH", tmp_path / "missing-global.env"
+        )
+        option = get_option("credentials.google_cloud_location")
+        assert option is not None
+
+        for workspace, expected in ((first, "first"), (second, "second")):
+            env = config_mod._preview_dotenv_environ(start_path=workspace)
+            with config_mod.use_environment(env):
+                assert resolve_env_var("TEST_VALUE") == expected
+                assert (
+                    resolve_mcp_server_env(
+                        "srv", {"command": "${DEEPAGENTS_CODE_TEST_VALUE}"}
+                    )["command"]
+                    == expected
+                )
+                snapshot = config_mod.Credentials.snapshot_from_environment(
+                    start_path=workspace
+                )
+                assert snapshot.openai_api_key == f"{expected}-key"
+                assert EnvProvider().get(option).result == Found(f"{expected}-region")
+
+        assert "OPENAI_API_KEY" not in os.environ
+        assert "DEEPAGENTS_CODE_TEST_VALUE" not in os.environ
+
+    def test_workspace_only_tracing_is_active(self) -> None:
+        """Tracing flags and project resolve from the workspace snapshot."""
+        import deepagents_code.config as config_mod
+
+        with config_mod.use_environment(
+            {
+                "LANGSMITH_API_KEY": "lsv2-workspace",
+                "LANGSMITH_TRACING": "true",
+                "LANGSMITH_PROJECT": "workspace-traces",
+            }
+        ):
+            assert config_mod.get_langsmith_project_name() == "workspace-traces"
+
+    def test_environment_binding_is_immutable_and_restored(self) -> None:
+        """Bindings copy inputs and reset after exceptions."""
+        import os
+
+        from deepagents_code.config import active_environment, use_environment
+
+        source = {"VALUE": "workspace"}
+        error = RuntimeError("boom")
+
+        def fail() -> None:
+            with use_environment(source):
+                source["VALUE"] = "changed"
+                assert active_environment()["VALUE"] == "workspace"
+                with pytest.raises(TypeError):
+                    active_environment()["VALUE"] = "forbidden"  # ty: ignore[invalid-assignment]
+                raise error
+
+        with pytest.raises(RuntimeError):
+            fail()
+        assert active_environment() is os.environ
+
+    def test_preview_interpolates_prior_dotenv_values(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Later values interpolate earlier values from the same file."""
+        import deepagents_code.config as config_mod
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / ".env").write_text(
+            "BASE=project\nCOMPOSED=${BASE}-value\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("BASE", "shell")
+        monkeypatch.setattr(
+            config_mod, "_GLOBAL_DOTENV_PATH", tmp_path / "missing-global.env"
+        )
+
+        env = config_mod._preview_dotenv_environ(start_path=workspace)
+
+        assert env["BASE"] == "shell"
+        assert env["COMPOSED"] == "project-value"
+
+    def test_preview_preserves_shell_project_global_precedence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Immutable snapshots retain existing first-write-wins behavior."""
+        import deepagents_code.config as config_mod
+
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".env").write_text(
+            "SHELL_VALUE=project\nPROJECT_VALUE=project\n",
+            encoding="utf-8",
+        )
+        global_dotenv = tmp_path / "global.env"
+        global_dotenv.write_text(
+            "SHELL_VALUE=global\nPROJECT_VALUE=global\nGLOBAL_VALUE=global\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("SHELL_VALUE", "shell")
+        monkeypatch.delenv("PROJECT_VALUE", raising=False)
+        monkeypatch.delenv("GLOBAL_VALUE", raising=False)
+        monkeypatch.setattr(config_mod, "_GLOBAL_DOTENV_PATH", global_dotenv)
+
+        env = config_mod._preview_dotenv_environ(start_path=project)
+
+        assert env["SHELL_VALUE"] == "shell"
+        assert env["PROJECT_VALUE"] == "project"
+        assert env["GLOBAL_VALUE"] == "global"
+
+
 class TestProjectDotenvDeniedKeys:
     """A cloned repo must not set user-level environment values."""
 
@@ -806,6 +945,179 @@ class TestDefaultModelSpecAllowlist:
             model_config.NoAllowedModelCredentialsError, match="No discoverable"
         ):
             _get_default_model_spec()
+
+
+class TestWorkspaceStoredCredentials:
+    """Stored auth remains workspace-local during server model construction."""
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_stored_key_and_endpoint_do_not_mutate_process_environment(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Scoped model creation passes stored auth explicitly."""
+        import os
+
+        from deepagents_code.config import create_model, use_environment
+
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_key",
+            lambda provider: "stored-key" if provider == "openai" else None,
+        )
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_base_url",
+            lambda provider: (
+                "https://stored.example/v1" if provider == "openai" else None
+            ),
+        )
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+        with use_environment({}):
+            create_model("openai:gpt-5.5")
+
+        kwargs = mock_init_chat_model.call_args.kwargs
+        assert kwargs["api_key"] == "stored-key"
+        assert kwargs["base_url"] == "https://stored.example/v1"
+        assert "OPENAI_API_KEY" not in os.environ
+        assert "OPENAI_BASE_URL" not in os.environ
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_stored_native_key_clears_workspace_endpoint(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A stored native key is not sent to a workspace gateway URL."""
+        from deepagents_code.config import create_model, use_environment
+
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_key",
+            lambda provider: "stored-key" if provider == "openai" else None,
+        )
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_base_url",
+            lambda _provider: None,
+        )
+
+        with use_environment({"OPENAI_BASE_URL": "https://workspace.example/v1"}):
+            create_model("openai:gpt-5.5")
+
+        kwargs = mock_init_chat_model.call_args.kwargs
+        assert kwargs["api_key"] == "stored-key"
+        assert "base_url" not in kwargs
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_explicit_key_does_not_use_stored_endpoint(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A caller-supplied key is not paired with another key's endpoint."""
+        from deepagents_code.config import create_model, use_environment
+
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_key",
+            lambda provider: "stored-key" if provider == "openai" else None,
+        )
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_base_url",
+            lambda _provider: "https://stored.example/v1",
+        )
+        with use_environment({}):
+            create_model(
+                "openai:gpt-5.5",
+                extra_kwargs={"api_key": "caller-key"},
+            )
+
+        kwargs = mock_init_chat_model.call_args.kwargs
+        assert kwargs["api_key"] == "caller-key"
+        assert "base_url" not in kwargs
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_stored_anthropic_key_clears_endpoint_and_headers(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A native Anthropic key gets explicit native transport settings."""
+        from deepagents_code.config import create_model, use_environment
+
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_key",
+            lambda provider: "stored-key" if provider == "anthropic" else None,
+        )
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_base_url",
+            lambda _provider: None,
+        )
+        with use_environment(
+            {
+                "ANTHROPIC_BASE_URL": "https://workspace.example/v1",
+                "ANTHROPIC_CUSTOM_HEADERS": "X-Api-Key: gateway-key",
+            }
+        ):
+            create_model("anthropic:claude-sonnet-4-6")
+
+        kwargs = mock_init_chat_model.call_args.kwargs
+        assert kwargs["api_key"] == "stored-key"
+        assert kwargs["base_url"] == "https://api.anthropic.com"
+        assert kwargs["default_headers"] == {}
+
+    def test_bare_claude_provider_uses_workspace_credentials(self) -> None:
+        """Bare model inference reads the active workspace snapshot."""
+        from deepagents_code.config import detect_provider, use_environment
+
+        with use_environment(
+            {
+                "GOOGLE_CLOUD_PROJECT": "workspace-project",
+                "GOOGLE_CLOUD_LOCATION": "us-central1",
+            }
+        ):
+            assert detect_provider("claude-sonnet-4-6") == "google_anthropic_vertex"
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_vertex_uses_active_workspace_project_and_not_api_key(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Vertex project settings come from the workspace snapshot."""
+        from deepagents_code.config import create_model, use_environment
+
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_key",
+            lambda _provider: None,
+        )
+
+        with use_environment(
+            {
+                "GOOGLE_CLOUD_PROJECT": "workspace-project",
+                "GOOGLE_CLOUD_LOCATION": "us-central1",
+            }
+        ):
+            create_model("google_anthropic_vertex:claude-sonnet-4-6")
+
+        kwargs = mock_init_chat_model.call_args.kwargs
+        assert kwargs["project"] == "workspace-project"
+        assert kwargs["location"] == "us-central1"
+        assert "api_key" not in kwargs
 
 
 class TestCreateModelProfileExtraction:
@@ -1520,6 +1832,27 @@ class TestLangsmithSecretRedaction:
         redacted = str(kwargs["anonymizer"]([{"text": f"key={secret}"}]))
         assert secret not in redacted
         assert "[SECRET_DETECTED]" in redacted
+
+    def test_workspace_environment_configures_redaction(self) -> None:
+        """Workspace-only tracing settings configure the SDK client."""
+        from deepagents_code.config import use_environment
+
+        client = object()
+        with (
+            use_environment(
+                {
+                    "DEEPAGENTS_CODE_LANGSMITH_API_KEY": "lsv2_workspace",
+                    "DEEPAGENTS_CODE_LANGSMITH_TRACING": "true",
+                }
+            ),
+            patch("deepagents_code.config_manifest.load_config_toml", return_value={}),
+            patch("langsmith.Client", return_value=client) as client_cls,
+            patch("langsmith.configure") as configure,
+        ):
+            assert configure_langsmith_secret_redaction() is True
+
+        configure.assert_called_once_with(client=client)
+        assert client_cls.call_args.kwargs["api_key"] == "lsv2_workspace"
 
     def test_skips_client_configuration_when_redaction_disabled(
         self,

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -264,6 +264,28 @@ class TestWorkspaceDotenvEnvironment:
         ):
             assert config_mod.get_langsmith_project_name() == "workspace-traces"
 
+    def test_snapshot_preserves_project_replaced_during_bootstrap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Shells retain the caller's project after the agent override is applied."""
+        import deepagents_code.config as config_mod
+
+        monkeypatch.setattr(config_mod._bootstrap_state, "done", True)
+        monkeypatch.setattr(
+            config_mod._bootstrap_state,
+            "original_langsmith_project",
+            "caller-traces",
+        )
+        snapshot = config_mod.Credentials.snapshot_from_environment(
+            environ={
+                "DEEPAGENTS_CODE_LANGSMITH_PROJECT": "agent-traces",
+                "LANGSMITH_PROJECT": "agent-traces",
+            }
+        )
+
+        assert snapshot.deepagents_langchain_project == "agent-traces"
+        assert snapshot.user_langchain_project == "caller-traces"
+
     def test_environment_binding_is_immutable_and_restored(self) -> None:
         """Bindings copy inputs and reset after exceptions."""
         import os

--- a/libs/code/tests/unit_tests/test_configurable_model.py
+++ b/libs/code/tests/unit_tests/test_configurable_model.py
@@ -999,6 +999,32 @@ class TestIsAnthropicModel:
     """Direct tests for the `_is_anthropic_model` helper."""
 
 
+class TestWorkspaceEnvironment:
+    """Lazy runtime model switches retain the workspace environment."""
+
+    def test_model_switch_uses_bound_environment(self) -> None:
+        """Construction context is restored around deferred model creation."""
+        from deepagents_code.config import active_environment
+
+        request = _make_request(
+            _make_model("gpt-5.5"),
+            context=CLIContext(model="anthropic:claude-sonnet-4-6"),
+        )
+        replacement = _make_model("claude-sonnet-4-6")
+        replacement._get_ls_params.return_value = {"ls_provider": "anthropic"}
+        middleware = ConfigurableModelMiddleware(
+            openai_prompt_cache_key=True,
+            environ={"ANTHROPIC_API_KEY": "workspace-key"},
+        )
+
+        def create(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+            assert active_environment()["ANTHROPIC_API_KEY"] == "workspace-key"
+            return _make_model_result(replacement)
+
+        with patch(_PATCH_CREATE, side_effect=create):
+            middleware.wrap_model_call(request, lambda _r: _make_response())
+
+
 class TestModelParams:
     """Cases where model_params are merged into model_settings."""
 

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -17,7 +17,7 @@ from deepagents_code.config import Credentials, runtime_state
 from deepagents_code.skills.load import ExtendedSkillMetadata
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
+    from collections.abc import Callable, Coroutine, Mapping
     from pathlib import Path
 
     from deepagents_code.app import _PluginFingerprint
@@ -556,7 +556,9 @@ class TestReloadFromEnvironment:
         tmp_path: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """OSError from `dotenv.dotenv_values` itself is caught."""
+        """OSError from the dotenv parser itself is caught."""
+        import deepagents_code.config as config_mod
+
         credentials = Credentials.from_environment(start_path=tmp_path)
 
         global_env = tmp_path / "global" / ".env"
@@ -568,18 +570,20 @@ class TestReloadFromEnvironment:
         project_env.write_text("OPENAI_API_KEY=sk-ok\n")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
-        original_dotenv_values = _dotenv_module.dotenv_values
+        original_dotenv_values = config_mod._dotenv_values_from
         global_calls = 0
 
-        def _fail_on_global(*, dotenv_path: Path) -> dict[str, str | None]:
+        def _fail_on_global(
+            dotenv_path: Path, environ: Mapping[str, str]
+        ) -> dict[str, str | None]:
             nonlocal global_calls
             if dotenv_path == global_env:
                 global_calls += 1
                 msg = "read error"
                 raise OSError(msg)
-            return dict(original_dotenv_values(dotenv_path=dotenv_path))
+            return original_dotenv_values(dotenv_path, environ)
 
-        monkeypatch.setattr("dotenv.dotenv_values", _fail_on_global)
+        monkeypatch.setattr(config_mod, "_dotenv_values_from", _fail_on_global)
 
         with caplog.at_level(logging.WARNING, logger="deepagents_code.config"):
             credentials.reload_from_environment(start_path=tmp_path)

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -10,6 +10,7 @@ import pytest
 from deepagents_code.integrations.sandbox_config import SandboxConfig
 from deepagents_code.integrations.sandbox_factory import (
     _VERCEL_SANDBOX_TIMEOUT,
+    _AgentCoreProvider,
     _get_provider,
     _VercelProvider,
     create_sandbox,
@@ -175,6 +176,51 @@ def test_agentcore_raises_on_missing_aws_credentials() -> None:
         pytest.raises(ValueError, match="AWS credentials not found"),
     ):
         _get_provider("agentcore")
+
+
+def test_agentcore_uses_workspace_aws_session() -> None:
+    """AgentCore receives a session built from workspace AWS settings."""
+    environment = {
+        "AWS_REGION": "us-test-1",
+        "AWS_PROFILE": "workspace-profile",
+        "AWS_ACCESS_KEY_ID": "test-access-key",
+        "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+        "AWS_SESSION_TOKEN": "test-session-token",
+    }
+    session = MagicMock()
+    session.get_credentials.return_value = MagicMock()
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value = session
+    interpreter = MagicMock()
+    client_module = MagicMock()
+    client_module.CodeInterpreter.return_value = interpreter
+    backend_module = MagicMock()
+    backend_module.AgentCoreSandbox.return_value.id = "sandbox-id"
+
+    with (
+        patch(f"{_FACTORY}.active_environment", return_value=environment),
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+    ):
+        provider = _AgentCoreProvider()
+
+    with patch(
+        f"{_FACTORY}._import_provider_module",
+        side_effect=[client_module, backend_module],
+    ):
+        provider.get_or_create()
+
+    mock_boto3.Session.assert_called_once_with(
+        profile_name="workspace-profile",
+        aws_access_key_id="test-access-key",
+        aws_secret_access_key="test-secret-key",
+        aws_session_token="test-session-token",
+        region_name="us-test-1",
+    )
+    client_module.CodeInterpreter.assert_called_once_with(
+        region="us-test-1",
+        session=session,
+        integration_source="deepagents-code",
+    )
 
 
 def test_agentcore_rejects_sandbox_id() -> None:

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -584,3 +584,89 @@ class TestLangSmithSnapshotResolution:
             )
 
             return _LangSmithProvider()
+
+
+def test_setup_script_expands_workspace_environment() -> None:
+    """The setup script sees the workspace `.env`, not the server process env."""
+    from deepagents_code.integrations.sandbox_factory import _run_sandbox_setup
+
+    backend = MagicMock()
+    backend.execute.return_value = MagicMock(exit_code=0, output="")
+    script = MagicMock()
+    script.read_text.return_value = "echo ${WORKSPACE_ONLY} ${SERVER_ONLY}"
+
+    with (
+        patch(f"{_FACTORY}.Path", return_value=script),
+        patch(
+            f"{_FACTORY}.active_environment",
+            return_value={"WORKSPACE_ONLY": "from-project-dotenv"},
+        ),
+        patch.dict(
+            "os.environ",
+            {"SERVER_ONLY": "server-secret", "WORKSPACE_ONLY": "server-value"},
+            clear=False,
+        ),
+    ):
+        script.exists.return_value = True
+        _run_sandbox_setup(backend, "setup.sh")
+
+    command = backend.execute.call_args[0][0]
+    assert "from-project-dotenv" in command
+    # The server process's values must not leak into the sandbox.
+    assert "server-secret" not in command
+    assert "server-value" not in command
+
+
+def test_vercel_override_gate_reads_workspace_environment() -> None:
+    """A prefixed override from the workspace `.env` still triggers the gate."""
+    environment = {
+        "DEEPAGENTS_CODE_VERCEL_TOKEN": "workspace-token",
+        "DEEPAGENTS_CODE_VERCEL_PROJECT_ID": "workspace-project",
+        "DEEPAGENTS_CODE_VERCEL_TEAM_ID": "workspace-team",
+    }
+    with (
+        patch(f"{_FACTORY}.active_environment", return_value=environment),
+        patch(
+            "deepagents_code.model_config.resolve_env_var",
+            side_effect=lambda name: environment.get(f"DEEPAGENTS_CODE_{name}"),
+        ),
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        kwargs = _VercelProvider._resolve_sdk_kwargs()
+
+    assert kwargs == {
+        "token": "workspace-token",
+        "project_id": "workspace-project",
+        "team_id": "workspace-team",
+    }
+
+
+def test_agentcore_omits_session_when_it_could_not_be_built() -> None:
+    """A failed session must not masquerade as an applied workspace session."""
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.side_effect = RuntimeError("ProfileNotFound: typo")
+    interpreter = MagicMock()
+    client_module = MagicMock()
+    client_module.CodeInterpreter.return_value = interpreter
+    backend_module = MagicMock()
+    backend_module.AgentCoreSandbox.return_value.id = "sandbox-id"
+
+    with (
+        patch(
+            f"{_FACTORY}.active_environment", return_value={"AWS_REGION": "us-test-1"}
+        ),
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+    ):
+        provider = _AgentCoreProvider()
+
+    with patch(
+        f"{_FACTORY}._import_provider_module",
+        side_effect=[client_module, backend_module],
+    ):
+        provider.get_or_create()
+
+    client_module.CodeInterpreter.assert_called_once_with(
+        region="us-test-1",
+        integration_source="deepagents-code",
+    )
+    assert "session" not in client_module.CodeInterpreter.call_args.kwargs

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -175,18 +175,15 @@ class TestServerGraph:
         module = _import_fresh_server_graph()
         bound_tool = object()
 
-        with (
-            patch(
-                "deepagents_code.config.active_environment",
-                return_value={"TAVILY_API_KEY": "workspace-key"},
-            ),
-            patch(
-                "deepagents_code.tools.create_web_search_tool",
-                return_value=bound_tool,
-            ) as create,
-        ):
+        with patch(
+            "deepagents_code.tools.create_web_search_tool",
+            return_value=bound_tool,
+        ) as create:
             tools, _, _ = await module._build_tools(
-                ServerConfig(no_mcp=True), None, has_tavily=True
+                ServerConfig(no_mcp=True),
+                None,
+                has_tavily=True,
+                tavily_api_key="workspace-key",
             )
 
         assert bound_tool in tools
@@ -251,7 +248,7 @@ class TestServerGraph:
             observed["auto_classifier_model"] = kwargs["auto_classifier_model"]
             return graph_obj, _backend_with_offload(object())
 
-        settings_obj = SimpleNamespace(has_tavily=False)
+        settings_obj = SimpleNamespace(has_tavily=False, tavily_api_key=None)
         environment = dict(os.environ)
         config_module = _module_with_attrs(
             "deepagents_code.config",

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -7,7 +7,7 @@ import os
 import sys
 from types import ModuleType, SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -170,6 +170,28 @@ class TestServerGraph:
         captured = capsys.readouterr()
         assert f"{STARTUP_ERROR_MARKER}ValueError: boom: bad model" in captured.err
 
+    async def test_build_tools_binds_workspace_tavily_key(self) -> None:
+        """Web search uses a workspace-specific tool instead of the singleton."""
+        module = _import_fresh_server_graph()
+        bound_tool = object()
+
+        with (
+            patch(
+                "deepagents_code.config.active_environment",
+                return_value={"TAVILY_API_KEY": "workspace-key"},
+            ),
+            patch(
+                "deepagents_code.tools.create_web_search_tool",
+                return_value=bound_tool,
+            ) as create,
+        ):
+            tools, _, _ = await module._build_tools(
+                ServerConfig(no_mcp=True), None, has_tavily=True
+            )
+
+        assert bound_tool in tools
+        create.assert_called_once_with("workspace-key")
+
     async def test_build_tools_skips_mcp_when_disabled(self) -> None:
         """`no_mcp=True` should not call the MCP resolver at all."""
         fetch_tool = object()
@@ -177,12 +199,15 @@ class TestServerGraph:
         resolve_mcp_tools = AsyncMock()
         config_module = _module_with_attrs(
             "deepagents_code.config",
+            active_environment=dict,
             credentials=SimpleNamespace(has_tavily=False),
         )
         tools_module = _module_with_attrs(
             "deepagents_code.tools",
+            create_web_search_tool=Mock(),
             fetch_url=fetch_tool,
             get_current_thread_id=thread_tool,
+            is_web_search_tool=lambda _tool: False,
             web_search=object(),
         )
         mcp_module = _module_with_attrs(
@@ -227,8 +252,15 @@ class TestServerGraph:
             return graph_obj, _backend_with_offload(object())
 
         settings_obj = SimpleNamespace(has_tavily=False)
+        environment = dict(os.environ)
         config_module = _module_with_attrs(
             "deepagents_code.config",
+            Credentials=SimpleNamespace(
+                snapshot_from_environment=MagicMock(return_value=settings_obj)
+            ),
+            _preview_dotenv_environ=MagicMock(return_value=environment),
+            active_environment=MagicMock(return_value=environment),
+            use_environment=__import__("contextlib").nullcontext,
             configure_langsmith_secret_redaction=MagicMock(),
             create_model=MagicMock(
                 return_value=SimpleNamespace(
@@ -252,8 +284,10 @@ class TestServerGraph:
         )
         tools_module = _module_with_attrs(
             "deepagents_code.tools",
+            create_web_search_tool=Mock(),
             fetch_url=object(),
             get_current_thread_id=object(),
+            is_web_search_tool=lambda _tool: False,
             web_search=object(),
         )
         config = ServerConfig(

--- a/libs/code/tests/unit_tests/test_server_helpers.py
+++ b/libs/code/tests/unit_tests/test_server_helpers.py
@@ -63,6 +63,22 @@ class TestBuildServerEnv:
             assert key not in env
         assert "PATH" in env
 
+    def test_strips_values_injected_by_client_dotenv_loader(self) -> None:
+        """A client project value does not become server launch state."""
+        import deepagents_code.config as config_mod
+
+        config_mod._dotenv_loaded_values["WORKSPACE_VALUE"] = "first"
+        try:
+            with patch.dict(os.environ, {"WORKSPACE_VALUE": "first"}, clear=False):
+                env = _build_server_env()
+            assert "WORKSPACE_VALUE" not in env
+
+            with patch.dict(os.environ, {"WORKSPACE_VALUE": "changed"}, clear=False):
+                env = _build_server_env()
+            assert env["WORKSPACE_VALUE"] == "changed"
+        finally:
+            config_mod._dotenv_loaded_values.pop("WORKSPACE_VALUE", None)
+
     def test_relays_pythonpath_off_server_interpreter(self) -> None:
         """A launch `PYTHONPATH` is kept off the server but carried for `execute`."""
         with patch.dict(os.environ, {"PYTHONPATH": "src"}):

--- a/libs/code/tests/unit_tests/test_server_helpers.py
+++ b/libs/code/tests/unit_tests/test_server_helpers.py
@@ -14,7 +14,11 @@ from deepagents_code.client.launch.server import (
     _build_server_env,
     _server_env_with_overrides,
 )
-from deepagents_code.config import _INHERITED_PYTHONPATH_ENV
+from deepagents_code.config import (
+    _INHERITED_PYTHONPATH_ENV,
+    _INHERITED_USER_TRACING_ENV,
+    apply_inherited_user_tracing,
+)
 
 
 class TestBuildServerCmd:
@@ -139,3 +143,80 @@ class TestServerEnvProfilePinning:
     def test_persistent_override_cannot_move_the_profile(self) -> None:
         env = _server_env_with_overrides({"DEEPAGENTS_HOME": "/tmp/evil"}, {})
         assert env["DEEPAGENTS_HOME"] == str(PATHS.profile.root)
+
+
+class TestUserTracingRelay:
+    """The caller's tracing identity must survive the client/server boundary.
+
+    The server inherits an environment where bootstrap has already replaced the
+    canonical LangSmith flags and key, so its own `_bootstrap_state` capture
+    holds the *agent's* values. Restoring from it would be a no-op that leaks
+    the agent session key into user `execute` commands.
+    """
+
+    def test_relays_caller_tracing_values_for_execute(self) -> None:
+        """`execute` receives the caller's key, not the agent's override."""
+        import deepagents_code.config as config_mod
+
+        state = config_mod._bootstrap_state
+        with (
+            patch.object(state, "done", True),
+            patch.object(state, "original_tracing_env", {"LANGSMITH_TRACING": None}),
+            patch.object(
+                state,
+                "original_tracing_api_keys",
+                {"LANGSMITH_API_KEY": "caller-key"},
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "LANGSMITH_API_KEY": "agent-session-key",
+                    "LANGSMITH_TRACING": "true",
+                },
+                clear=False,
+            ),
+        ):
+            server_env = _build_server_env()
+
+        # The agent's own values still reach the server process itself.
+        assert server_env["LANGSMITH_API_KEY"] == "agent-session-key"
+
+        shell_env = dict(server_env)
+        assert apply_inherited_user_tracing(shell_env) is True
+        assert shell_env["LANGSMITH_API_KEY"] == "caller-key"
+        # The caller had no tracing flag, so the agent's must not survive.
+        assert "LANGSMITH_TRACING" not in shell_env
+        assert _INHERITED_USER_TRACING_ENV not in shell_env
+
+    def test_no_relay_reports_absence_so_local_capture_wins(self) -> None:
+        """Without a carrier the local `_bootstrap_state` stays authoritative."""
+        shell_env = {"LANGSMITH_API_KEY": "agent-session-key"}
+        assert apply_inherited_user_tracing(shell_env) is False
+        assert shell_env["LANGSMITH_API_KEY"] == "agent-session-key"
+
+    def test_unparsable_relay_fails_closed(self) -> None:
+        """A corrupt carrier drops the agent's key rather than passing it on."""
+        shell_env = {
+            _INHERITED_USER_TRACING_ENV: "not json",
+            "LANGSMITH_API_KEY": "agent-session-key",
+            "LANGSMITH_TRACING": "true",
+        }
+        assert apply_inherited_user_tracing(shell_env) is True
+        assert "LANGSMITH_API_KEY" not in shell_env
+        assert "LANGSMITH_TRACING" not in shell_env
+
+    def test_inherited_carrier_var_is_never_trusted(self) -> None:
+        """A smuggled carrier cannot choose the tracing identity."""
+        import deepagents_code.config as config_mod
+
+        state = config_mod._bootstrap_state
+        with (
+            patch.object(state, "done", False),
+            patch.dict(
+                os.environ,
+                {_INHERITED_USER_TRACING_ENV: '{"LANGSMITH_API_KEY": "smuggled"}'},
+                clear=False,
+            ),
+        ):
+            server_env = _build_server_env()
+        assert _INHERITED_USER_TRACING_ENV not in server_env


### PR DESCRIPTION
Each validated conversation workspace now keeps its own project `.env` values without changing the server process environment.

A workspace is a conversation's validated working directory: the client's `cwd`, resolved to its project root, fingerprinted, and bound to the conversation thread. Two threads are in different workspaces when those directories differ.

---

The server can host conversations from different workspaces at the same time. Process-wide dotenv reloads could expose one workspace's model settings, credentials, tracing settings, or tool configuration to another workspace.

This change builds one immutable environment snapshot for each validated workspace. It applies launch environment values first, then the nearest project `.env`, then the global profile `.env`. Existing denied-key checks still apply.

Runtime construction and supported lazy model paths use that snapshot. Local shell execution receives a frozen copy with environment inheritance disabled. Web search receives a workspace-bound Tavily client. Stored model credentials remain paired with their stored endpoint without writing to `os.environ`.

The implementation keeps the existing serialized dotenv reload for the single-workspace client. It does not use process-wide reloads in the multi-workspace server because runtime builds and offload work can overlap. It also does not reject later workspaces, because the server is designed to host them concurrently.

Arbitrary third-party code that reads `os.environ` during invocation is not isolated by this change. Supported internal consumers keep the workspace snapshot explicitly.

Made by [Open SWE](https://openswe.vercel.app/agents/4ac38986-5a23-52f1-86a3-dde84db3c4fd)

## References
- Plan: https://openswe.vercel.app/agents/4ac38986-5a23-52f1-86a3-dde84db3c4fd/plan