### PR TITLE
fix(sdk): rework state constructor in forking

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -57,8 +57,8 @@ from deepagents.middleware.subagents import (
     ForkedSubAgent,
     SubAgent,
     SubAgentMiddleware,
+    _is_compiled_subagent,
     _is_forked_subagent,
-    _ParentSystemMessageMiddleware,
 )
 from deepagents.middleware.summarization import create_summarization_middleware
 from deepagents.profiles.harness.harness_profiles import (
@@ -667,12 +667,12 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             # Then spec is an AsyncSubAgent
             async_subagents.append(cast("AsyncSubAgent", spec))
             continue
-        if "runnable" in spec:
+        if _is_compiled_subagent(spec):
             # CompiledSubAgent - use as-is
             inline_subagents.append(spec)
         else:
             # Declarative subagent - fill in defaults and prepend base middleware
-            is_forked = spec.get("mode") == "fork"
+            is_forked = _is_forked_subagent(spec)
             raw_subagent_model = spec.get("model", model)
             subagent_model = resolve_model(raw_subagent_model)
 
@@ -917,9 +917,6 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     # stripped last and cannot be restored by a custom wrap_model_call.
     if _profile.excluded_tools:
         deepagent_middleware.append(_ToolExclusionMiddleware(excluded=_profile.excluded_tools))
-    # Only a declarative fork consumes the captured message; compiled forks keep their own prompt.
-    if sub_agent_middleware is not None and any(_is_forked_subagent(spec) and "runnable" not in spec for spec in inline_subagents):
-        deepagent_middleware.append(_ParentSystemMessageMiddleware())
     state_schemas = [state_schema] if state_schema is not None else []
     state_schemas.extend(mw.state_schema for mw in deepagent_middleware if getattr(mw, "state_schema", None) is not None)
     private_state_keys = private_state_field_names(*state_schemas)

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -682,8 +682,14 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             # Resolve permissions: subagent's own rules take priority, else inherit parent's
             subagent_permissions = spec.get("permissions", permissions)
 
-            # Build middleware: base stack + skills (if specified) + user's middleware
-            subagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [
+            # Build middleware: base stack + skills (if specified) + user's middleware.
+            # A fork also mirrors the parent's prompt-producing middleware, in the
+            # parent's order, so its own stack rebuilds the parent's system message
+            # from the inherited state.
+            subagent_middleware: list[AgentMiddleware[Any, Any, Any]] = []
+            if is_forked and skills is not None:
+                subagent_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
+            subagent_middleware += [
                 FilesystemMiddleware(
                     backend=backend,
                     custom_tool_descriptions=_subagent_profile.tool_description_overrides,
@@ -692,8 +698,6 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 create_summarization_middleware(subagent_model, backend),
                 PatchToolCallsMiddleware(),
             ]
-            # A fork's system message always gets overwritten by the parent's
-            # captured one, so building Memory/Skills prompt content here is wasted.
             subagent_skills = spec.get("skills")
             if subagent_skills and not is_forked:
                 subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills))
@@ -703,6 +707,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             subagent_middleware.extend(_subagent_profile.materialize_extra_middleware())
 
             append_prompt_caching_middleware(subagent_middleware)
+            if is_forked and memory is not None:
+                subagent_middleware.append(MemoryMiddleware(backend=backend, sources=memory, add_cache_control=True))
 
             _subagent_matched_classes: set[type[AgentMiddleware[Any, Any, Any]]] = set()
             _subagent_matched_names: set[str] = set()
@@ -717,9 +723,14 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 matched_classes=_subagent_matched_classes,
                 matched_names=_subagent_matched_names,
             )
+            subagent_custom_middleware = list(spec.get("middleware", []))
+            if is_forked and middleware:
+                # `create_agent` rejects two middleware sharing a name, so a spec
+                # entry replaces the inherited one in place rather than adding to it.
+                subagent_custom_middleware = list({m.name: m for m in [*middleware, *subagent_custom_middleware]}.values())
             subagent_middleware = _apply_custom_middleware(
                 subagent_middleware,
-                spec.get("middleware", []),
+                subagent_custom_middleware,
                 core_names=_subagent_core_names,
             )
             subagent_middleware = _apply_excluded_middleware(

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -33,13 +33,22 @@ from typing_extensions import TypeIs
 from deepagents.backends.protocol import BackendProtocol
 from deepagents.middleware._utils import append_to_system_message
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
-from deepagents.middleware.summarization import SummarizationEvent, _DeepAgentsSummarizationMiddleware
+from deepagents.middleware.summarization import (
+    SUMMARIZATION_EVENT_KEY,
+    SUMMARIZATION_SESSION_ID_KEY,
+    SummarizationEvent,
+    _DeepAgentsSummarizationMiddleware,
+)
 
 SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY = "__deepagents_subagent_response_format"
 """Configurable key used by task-tool callers to request dynamic response format."""
 
-_SUMMARIZATION_EVENT_KEY = "_summarization_event"
-"""Summarization state key, owned by `summarization.py`."""
+_FORK_EXCLUDED_STATE_KEYS = frozenset({SUMMARIZATION_EVENT_KEY, SUMMARIZATION_SESSION_ID_KEY})
+"""Summarization state a fork must not resume.
+
+The event is folded into the fork's messages instead. Dropping the session ID lets the
+subagent generate its own.
+"""
 
 _FORKED_CONTEXT_KEY = "_deepagents_forked_context"
 """Set on a forked subagent's own initial state; never on the parent's.
@@ -206,6 +215,10 @@ class ForkedSubAgent(_SubAgentBase):
 
     `tools` isn't restricted the same way -- a forked subagent's own tools
     work normally. The tradeoff is cache misses.
+
+    Full state inheritance is specific to this declarative form. A
+    [`CompiledSubAgent`][deepagents.middleware.subagents.CompiledSubAgent] with
+    `mode="fork"` inherits the conversation only.
     """
 
     mode: Literal["fork"]
@@ -292,7 +305,11 @@ class CompiledSubAgent(TypedDict):
     """
 
     mode: NotRequired[Literal["handoff", "fork"]]
-    """Use `fork` to inherit parent history without changing the runnable prompt."""
+    """Use `fork` to inherit the parent's conversation without changing the runnable prompt.
+
+    [`ForkedSubAgent`][deepagents.middleware.subagents.ForkedSubAgent] inherits the
+    full state, including private keys.
+    """
 
 
 _SubAgentSpec = SubAgent | ForkedSubAgent | CompiledSubAgent
@@ -744,13 +761,22 @@ def _build_task_tool(  # noqa: C901, PLR0915
         subagent_runnable = _select_subagent(subagent_type, runtime)
 
         if _is_forked_subagent(subagent) or _is_forked_compiled_subagent(subagent):
-            # The event is folded into the message list above to suport compiled subagents
+            # The event is folded into the message list above to support compiled subagents
+            if _is_forked_subagent(subagent):
+                # A declarative fork runs the same graph shape as its parent, so
+                # private channels carry over and its own middleware can rebuild
+                # what the parent built from them.
+                inherited = {key: value for key, value in runtime.state.items() if key not in _FORK_EXCLUDED_STATE_KEYS}
+            else:
+                # A compiled runnable is opaque -- it may not declare these
+                # channels, and internal state isn't ours to hand it.
+                inherited = {key: value for key, value in runtime.state.items() if key not in _EXCLUDED_STATE_KEYS | private_state_keys}
             subagent_state = {
-                **{key: value for key, value in runtime.state.items() if key != _SUMMARIZATION_EVENT_KEY},
+                **inherited,
                 _FORKED_CONTEXT_KEY: True,
                 "messages": _fork_messages(
                     runtime.state.get("messages", []),
-                    runtime.state.get(_SUMMARIZATION_EVENT_KEY),
+                    runtime.state.get(SUMMARIZATION_EVENT_KEY),
                     description,
                 ),
             }

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -43,11 +43,12 @@ from deepagents.middleware.summarization import (
 SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY = "__deepagents_subagent_response_format"
 """Configurable key used by task-tool callers to request dynamic response format."""
 
-_FORK_EXCLUDED_STATE_KEYS = frozenset({SUMMARIZATION_EVENT_KEY, SUMMARIZATION_SESSION_ID_KEY})
-"""Summarization state a fork must not resume.
+_FORK_EXCLUDED_STATE_KEYS = frozenset({"structured_response", SUMMARIZATION_EVENT_KEY, SUMMARIZATION_SESSION_ID_KEY})
+"""State a fork must not resume.
 
-The event is folded into the fork's messages instead. Dropping the session ID lets the
-subagent generate its own.
+The summarization event is folded into the fork's messages instead. Dropping the
+session ID lets the subagent generate its own, and dropping a prior structured response
+ensures it cannot be mistaken for the fork's result.
 """
 
 _FORKED_CONTEXT_KEY = "_deepagents_forked_context"

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -33,9 +33,13 @@ from typing_extensions import TypeIs
 from deepagents.backends.protocol import BackendProtocol
 from deepagents.middleware._utils import append_to_system_message
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
+from deepagents.middleware.summarization import SummarizationEvent, _DeepAgentsSummarizationMiddleware
 
 SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY = "__deepagents_subagent_response_format"
 """Configurable key used by task-tool callers to request dynamic response format."""
+
+_SUMMARIZATION_EVENT_KEY = "_summarization_event"
+"""Summarization state key, owned by `summarization.py`."""
 
 _FORKED_CONTEXT_KEY = "_deepagents_forked_context"
 """Set on a forked subagent's own initial state; never on the parent's.
@@ -366,17 +370,21 @@ _FORK_TASK_PREAMBLE = (
 )
 
 
-def _fork_messages(messages: Sequence[AnyMessage], description: str) -> list[AnyMessage]:
-    """Build a fork's history, dropping the parent's in-flight tool-call message.
+def _fork_messages(
+    messages: Sequence[AnyMessage],
+    event: SummarizationEvent | None,
+    description: str,
+) -> list[AnyMessage]:
+    """Build a fork's history: the parent's effective conversation, then the task.
 
-    The parent calls `task` from its latest message, so replaying it would hand
-    the fork a tool call with no result -- rejected outright by some providers,
-    and patched into a misleading "was cancelled" result by others.
+    Applies summarization event so that a compiled subagent sees the
+    compacted conversation instead of replaying what the parent already evicted.
     """
     history = list(messages)
     if history and isinstance(history[-1], AIMessage) and history[-1].tool_calls:
         history.pop()
-    return [*history, HumanMessage(content=_FORK_TASK_PREAMBLE + description)]
+    effective = _DeepAgentsSummarizationMiddleware._apply_event_to_messages(history, event)
+    return [*effective, HumanMessage(content=_FORK_TASK_PREAMBLE + description)]
 
 
 DEFAULT_SUBAGENT_PROMPT = """In order to complete the objective that the user asks of you, you have access to a number of standard tools.
@@ -736,10 +744,15 @@ def _build_task_tool(  # noqa: C901, PLR0915
         subagent_runnable = _select_subagent(subagent_type, runtime)
 
         if _is_forked_subagent(subagent) or _is_forked_compiled_subagent(subagent):
+            # The event is folded into the message list above to suport compiled subagents
             subagent_state = {
-                **runtime.state,
+                **{key: value for key, value in runtime.state.items() if key != _SUMMARIZATION_EVENT_KEY},
                 _FORKED_CONTEXT_KEY: True,
-                "messages": _fork_messages(runtime.state.get("messages", []), description),
+                "messages": _fork_messages(
+                    runtime.state.get("messages", []),
+                    runtime.state.get(_SUMMARIZATION_EVENT_KEY),
+                    description,
+                ),
             }
         else:
             subagent_state = {key: value for key, value in runtime.state.items() if key not in _EXCLUDED_STATE_KEYS | private_state_keys}

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -3,7 +3,7 @@
 import contextlib
 import dataclasses
 import json
-from collections.abc import Awaitable, Callable, Generator, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Generator, Sequence
 from typing import Annotated, Any, Literal, NotRequired, TypedDict, cast
 
 from langchain.agents import create_agent
@@ -11,7 +11,6 @@ from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnCon
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     ContextT,
-    ExtendedModelResponse,
     ModelRequest,
     ModelResponse,
     OmitFromSchema,
@@ -22,7 +21,7 @@ from langchain.agents.middleware.types import (
 from langchain.agents.structured_output import ResponseFormat
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
@@ -33,12 +32,9 @@ from typing_extensions import TypeIs
 from deepagents.backends.protocol import BackendProtocol
 from deepagents.middleware._utils import append_to_system_message
 from deepagents.middleware.filesystem import FilesystemPermission
-from deepagents.middleware.summarization import SummarizationEvent, _apply_summarization_event
 
 SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY = "__deepagents_subagent_response_format"
 """Configurable key used by task-tool callers to request dynamic response format."""
-
-_PARENT_SYSTEM_MESSAGE_KEY = "_deepagents_parent_system_message"
 
 _FORKED_CONTEXT_KEY = "_deepagents_forked_context"
 """Set on a forked subagent's own initial state; never on the parent's.
@@ -50,12 +46,6 @@ omitting the tool -- see `_ForkTaskToolMiddleware` for why.
 _FORK_RECURSION_REFUSAL = (
     "You are a subagent and cannot delegate to another subagent. Complete this task yourself instead of calling this tool again."
 )
-
-
-class _ParentSystemMessageState(TypedDict):
-    """Private state used to carry the parent's effective system message."""
-
-    _deepagents_parent_system_message: NotRequired[Annotated[SystemMessage | None, OmitFromSchema(input=False, output=True)]]
 
 
 class _SubAgentBase(TypedDict):
@@ -205,9 +195,9 @@ class ForkedSubAgent(_SubAgentBase):
 
         Forked subagents are experimental and may change in a future release.
 
-    A forked subagent receives the parent's effective conversation history and
-    exact system prompt. It cannot define a separate `system_prompt` or
-    `skills`, since either would diverge from the parent's exact message.
+    A forked subagent receives a copy of the parent's state and configured
+    system prompt. It cannot define a separate `system_prompt` or `skills`,
+    since either would diverge from the parent's configured prompt.
 
     `tools` isn't restricted the same way -- a forked subagent's own tools
     work normally. The tradeoff is cache misses.
@@ -310,7 +300,7 @@ def _validate_subagent_mode(spec: _SubAgentSpec) -> None:
         msg = f"SubAgent '{spec['name']}' has invalid mode '{mode}'; expected 'handoff' or 'fork'"
         raise ValueError(msg)
     if mode == "fork" and spec.get("system_prompt") is not None:
-        msg = f"ForkedSubAgent '{spec['name']}' cannot set system_prompt; it always inherits the parent's."
+        msg = f"ForkedSubAgent '{spec['name']}' cannot set system_prompt; it inherits the parent's configured prompt."
         raise ValueError(msg)
     if mode == "fork" and spec.get("skills"):
         msg = f"ForkedSubAgent '{spec['name']}' cannot set skills; the parent's system message would discard it."
@@ -333,9 +323,28 @@ def _validate_unique_subagent_names(subagents: Sequence[_SubAgentSpec]) -> None:
         seen.add(name)
 
 
+def _is_subagent(spec: _SubAgentSpec) -> TypeIs[SubAgent]:
+    """Return whether a spec is an isolated declarative subagent.
+
+    Compiled specs provide a `runnable`; forked declarative specs use
+    `mode="fork"`. All remaining specs are regular `SubAgent` definitions.
+    """
+    return "runnable" not in spec and spec.get("mode") != "fork"
+
+
 def _is_forked_subagent(spec: _SubAgentSpec) -> TypeIs[ForkedSubAgent]:
-    """Return whether a subagent inherits parent conversation history."""
-    return spec.get("mode") == "fork"
+    """Return whether a declarative subagent inherits its parent's state."""
+    return "runnable" not in spec and spec.get("mode") == "fork"
+
+
+def _is_compiled_subagent(spec: _SubAgentSpec) -> TypeIs[CompiledSubAgent]:
+    """Return whether a spec provides an already-compiled runnable."""
+    return "runnable" in spec
+
+
+def _is_forked_compiled_subagent(spec: _SubAgentSpec) -> TypeIs[CompiledSubAgent]:
+    """Return whether a compiled subagent inherits its parent's state."""
+    return "runnable" in spec and spec.get("mode") == "fork"
 
 
 # A forked subagent replays the parent's exact history, including the human
@@ -356,16 +365,6 @@ _FORK_TASK_PREAMBLE = (
 )
 
 
-def _fork_messages(state: Mapping[str, object], description: str) -> list[AnyMessage]:
-    """Build fork input without replaying the in-flight tool-call message."""
-    messages = list(cast("Sequence[AnyMessage]", state.get("messages", [])))
-    if messages and isinstance(messages[-1], AIMessage) and messages[-1].tool_calls:
-        messages.pop()
-    event = cast("SummarizationEvent | None", state.get("_summarization_event"))
-    effective_messages = _apply_summarization_event(messages, event)
-    return [*effective_messages, HumanMessage(content=_FORK_TASK_PREAMBLE + description)]
-
-
 DEFAULT_SUBAGENT_PROMPT = """In order to complete the objective that the user asks of you, you have access to a number of standard tools.
 
 The calling agent only sees your final assistant message, not your intermediate work, tool results, or status tracking. Ensure your final
@@ -375,7 +374,6 @@ _EXCLUDED_STATE_KEYS = {
     "messages",
     "todos",
     "structured_response",
-    _PARENT_SYSTEM_MESSAGE_KEY,
     _FORKED_CONTEXT_KEY,
 }
 """State keys that are excluded when passing state to subagents and when
@@ -399,7 +397,9 @@ class TaskToolSchema(BaseModel):
     description: str = Field(
         description=(
             "A detailed description of the task for the subagent to perform autonomously. "
-            "Include all necessary context and specify the expected output format."
+            "State the expected output and any constraints not already present in the "
+            "selected agent's context. An agent marked as inheriting the conversation "
+            "already receives that context; do not redundantly restate it."
         )
     )
 
@@ -413,19 +413,16 @@ Available agent types and the tools they have access to:
 
 Specify subagent_type to select the agent. Usage notes:
 - Launch multiple agents concurrently when their tasks are independent, using a single message with multiple tool calls.
-- Each invocation is stateless by default: the agent sees only the prompt you give it and returns a single final report. Put full detail in the prompt and state exactly what it should return — unless an agent type below says it inherits your conversation instead.
+- Agents are isolated by default: they see only the task prompt and return a single final report. Put the necessary context and expected output in their task. An agent explicitly marked as inheriting your conversation is a fork: it receives a snapshot of the prior conversation and configured system prompt, so give it the outcome and only the constraints not already in that context.
 - The agent's report is not shown to the user; relay a summary yourself.
-- Tell the agent whether to create content, analyze, or only research, since it can't necessarily see the user's intent unless it inherits your conversation, as noted per agent type below.
+- Tell an isolated agent whether to create content, analyze, or only research. A forked agent can use the inherited user intent, but the delegated outcome should still be clear.
 - If an agent's description says to use it proactively, do so without waiting to be asked.
 - When only general-purpose is available, use it for any complex, context-heavy task; it has the same capabilities as the main agent."""  # noqa: E501
 
-_FORKED_SUBAGENT_TOOL_NOTE = " (inherits your full conversation and system prompt — no need to restate context here)"
-"""Appended to a forked subagent's line in the task tool's listing.
-
-Load-bearing: without it, the "Each invocation is stateless" line above is
-the model's only signal, and it can refuse to delegate to a forked subagent
-even when told the subagent inherits the conversation.
-"""
+_FORKED_SUBAGENT_TOOL_NOTE = (
+    " (forked: inherits a snapshot of your conversation and configured system prompt — give the outcome without restating inherited context)"
+)
+"""Appended to a forked subagent's line in the task tool's listing."""
 
 
 def _describe_subagent_for_tool(name: str, description: str, *, forked: bool) -> str:
@@ -444,62 +441,12 @@ GENERAL_PURPOSE_SUBAGENT: SubAgent = {
 """Base spec for general-purpose subagent (caller adds model, tools, middleware)."""
 
 
-class _ParentSystemMessageMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
-    state_schema = _ParentSystemMessageState
-
-    def wrap_model_call(
-        self,
-        request: ModelRequest[ContextT],
-        handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
-    ) -> ExtendedModelResponse[ResponseT]:
-        response = handler(request)
-        return ExtendedModelResponse(
-            model_response=response,
-            command=Command(update={_PARENT_SYSTEM_MESSAGE_KEY: request.system_message}),
-        )
-
-    async def awrap_model_call(
-        self,
-        request: ModelRequest[ContextT],
-        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
-    ) -> ExtendedModelResponse[ResponseT]:
-        response = await handler(request)
-        return ExtendedModelResponse(
-            model_response=response,
-            command=Command(update={_PARENT_SYSTEM_MESSAGE_KEY: request.system_message}),
-        )
-
-
-class _ForkSystemMessageMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
-    state_schema = _ParentSystemMessageState
-
-    def wrap_model_call(
-        self,
-        request: ModelRequest[ContextT],
-        handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
-    ) -> ModelResponse[ResponseT]:
-        parent_message = request.state.get(_PARENT_SYSTEM_MESSAGE_KEY)
-        if parent_message is not None:
-            request = request.override(system_message=parent_message)
-        return handler(request)
-
-    async def awrap_model_call(
-        self,
-        request: ModelRequest[ContextT],
-        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
-    ) -> ModelResponse[ResponseT]:
-        parent_message = request.state.get(_PARENT_SYSTEM_MESSAGE_KEY)
-        if parent_message is not None:
-            request = request.override(system_message=parent_message)
-        return await handler(request)
-
-
 class _ForkedContextState(TypedDict):
     """Private state marking a graph as running as a forked subagent.
 
-    Needs a declared schema, like `_ParentSystemMessageState` above -- an
-    undeclared key on a subagent's initial state isn't tracked as a real
-    channel, so `task()` would never see it via `runtime.state.get(...)`.
+    The key needs a declared schema: an undeclared key on a subagent's initial
+    state is not tracked as a real channel, so `task()` would never see it via
+    `runtime.state.get(...)`.
     """
 
     _deepagents_forked_context: NotRequired[Annotated[bool, OmitFromSchema(input=False, output=True)]]
@@ -635,7 +582,14 @@ def _build_task_tool(  # noqa: C901, PLR0915
 
     # Computed early (from raw specs) so the mirrored `task` tool below has
     # this exact string for cache hits.
-    subagent_description_str = "\n".join(_describe_subagent_for_tool(s["name"], s["description"], forked=_is_forked_subagent(s)) for s in subagents)
+    subagent_description_str = "\n".join(
+        _describe_subagent_for_tool(
+            s["name"],
+            s["description"],
+            forked=_is_forked_subagent(s) or _is_forked_compiled_subagent(s),
+        )
+        for s in subagents
+    )
     if task_description is None:
         description = TASK_TOOL_DESCRIPTION.format(available_agents=subagent_description_str)
     elif "{available_agents}" in task_description:
@@ -659,7 +613,6 @@ def _build_task_tool(  # noqa: C901, PLR0915
         )
         resolved["middleware"] = [
             *spec.get("middleware", []),
-            _ForkSystemMessageMiddleware(),
             _ForkTaskToolMiddleware(fork_task_tool),
         ]
         return cast("SubAgent", resolved)
@@ -760,21 +713,24 @@ def _build_task_tool(  # noqa: C901, PLR0915
         subagent_type: str,
         description: str,
         runtime: ToolRuntime,
-        effective_system_message: SystemMessage | None,
     ) -> tuple[Runnable, dict]:
         """Prepare state for invocation."""
-        subagent = _select_subagent(subagent_type, runtime)
-        forked = subagent_type in fork_mode_names
-        subagent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
-        subagent_state = {k: v for k, v in subagent_state.items() if k not in private_state_keys}
-        if forked and "runnable" not in subagents_by_name[subagent_type] and effective_system_message is not None:
-            subagent_state[_PARENT_SYSTEM_MESSAGE_KEY] = effective_system_message
-        if forked:
-            subagent_state[_FORKED_CONTEXT_KEY] = True
-            subagent_state["messages"] = _fork_messages(runtime.state, description)
+        subagent = subagents_by_name[subagent_type]
+        subagent_runnable = _select_subagent(subagent_type, runtime)
+
+        if _is_forked_subagent(subagent) or _is_forked_compiled_subagent(subagent):
+            subagent_state = {
+                **runtime.state,
+                _FORKED_CONTEXT_KEY: True,
+                "messages": [
+                    *runtime.state.get("messages", []),
+                    HumanMessage(content=_FORK_TASK_PREAMBLE + description),
+                ],
+            }
         else:
+            subagent_state = {key: value for key, value in runtime.state.items() if key not in _EXCLUDED_STATE_KEYS | private_state_keys}
             subagent_state["messages"] = [HumanMessage(content=description)]
-        return subagent, subagent_state
+        return subagent_runnable, subagent_state
 
     def task(
         description: str,
@@ -789,12 +745,10 @@ def _build_task_tool(  # noqa: C901, PLR0915
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
-        effective_system_message = runtime.state.get(_PARENT_SYSTEM_MESSAGE_KEY)
         subagent, subagent_state = _validate_and_prepare_state(
             subagent_type,
             description,
             runtime,
-            effective_system_message,
         )
         # The parent's callbacks, tags and configurable reach the subagent
         # automatically: langgraph's `ensure_config` seeds each run from the
@@ -821,12 +775,10 @@ def _build_task_tool(  # noqa: C901, PLR0915
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
-        effective_system_message = runtime.state.get(_PARENT_SYSTEM_MESSAGE_KEY)
         subagent, subagent_state = _validate_and_prepare_state(
             subagent_type,
             description,
             runtime,
-            effective_system_message,
         )
         # The parent's callbacks, tags and configurable reach the subagent
         # automatically: langgraph's `ensure_config` seeds each run from the
@@ -842,7 +794,6 @@ def _build_task_tool(  # noqa: C901, PLR0915
 
     compiled_subagents = [_compile_spec(spec) for spec in subagents]
     subagents_by_name = {spec["name"]: spec for spec in subagents}
-    fork_mode_names = {name for name, spec in subagents_by_name.items() if _is_forked_subagent(spec)}
 
     # Build the graphs dict from the unified spec list
     subagent_graphs: dict[str, Runnable] = {spec["name"]: spec["runnable"] for spec in compiled_subagents}
@@ -919,8 +870,6 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     trace_policy = TracePolicy(process_inputs=omit_payload)
     """Omit hook inputs from traces by default; set a `TracePolicy` to override."""
 
-    state_schema = _ParentSystemMessageState
-
     def __init__(
         self,
         *,
@@ -958,7 +907,14 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
 
         # Build system prompt with available agents
         if system_prompt and subagents:
-            agents_desc = "\n".join(_describe_subagent_for_tool(s["name"], s["description"], forked=_is_forked_subagent(s)) for s in subagents)
+            agents_desc = "\n".join(
+                _describe_subagent_for_tool(
+                    s["name"],
+                    s["description"],
+                    forked=_is_forked_subagent(s) or _is_forked_compiled_subagent(s),
+                )
+                for s in subagents
+            )
             self.system_prompt = system_prompt + "\n\nAvailable subagent types:\n\n" + agents_desc
         else:
             self.system_prompt = system_prompt

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -209,9 +209,10 @@ class ForkedSubAgent(_SubAgentBase):
 
         Forked subagents are experimental and may change in a future release.
 
-    A forked subagent receives a copy of the parent's state and configured
+    A forked subagent receives the parent's effective conversation history and
+    mirrors the parent's prompt-producing middleware, so it rebuilds the same
     system prompt. It cannot define a separate `system_prompt` or `skills`,
-    since either would diverge from the parent's configured prompt.
+    since either would diverge from the parent's.
 
     `tools` isn't restricted the same way -- a forked subagent's own tools
     work normally. The tradeoff is cache misses.
@@ -322,7 +323,7 @@ def _validate_subagent_mode(spec: _SubAgentSpec) -> None:
         msg = f"SubAgent '{spec['name']}' has invalid mode '{mode}'; expected 'handoff' or 'fork'"
         raise ValueError(msg)
     if mode == "fork" and spec.get("system_prompt") is not None:
-        msg = f"ForkedSubAgent '{spec['name']}' cannot set system_prompt; it inherits the parent's configured prompt."
+        msg = f"ForkedSubAgent '{spec['name']}' cannot set system_prompt; it always inherits the parent's."
         raise ValueError(msg)
     if mode == "fork" and spec.get("skills"):
         msg = f"ForkedSubAgent '{spec['name']}' cannot set skills; the parent's system message would discard it."
@@ -436,9 +437,7 @@ class TaskToolSchema(BaseModel):
     description: str = Field(
         description=(
             "A detailed description of the task for the subagent to perform autonomously. "
-            "State the expected output and any constraints not already present in the "
-            "selected agent's context. An agent marked as inheriting the conversation "
-            "already receives that context; do not redundantly restate it."
+            "Include all necessary context and specify the expected output format."
         )
     )
 
@@ -452,16 +451,19 @@ Available agent types and the tools they have access to:
 
 Specify subagent_type to select the agent. Usage notes:
 - Launch multiple agents concurrently when their tasks are independent, using a single message with multiple tool calls.
-- Agents are isolated by default: they see only the task prompt and return a single final report. Put the necessary context and expected output in their task. An agent explicitly marked as inheriting your conversation is a fork: it receives a snapshot of the prior conversation and configured system prompt, so give it the outcome and only the constraints not already in that context.
+- Each invocation is stateless by default: the agent sees only the prompt you give it and returns a single final report. Put full detail in the prompt and state exactly what it should return — unless an agent type below says it inherits your conversation instead.
 - The agent's report is not shown to the user; relay a summary yourself.
-- Tell an isolated agent whether to create content, analyze, or only research. A forked agent can use the inherited user intent, but the delegated outcome should still be clear.
+- Tell the agent whether to create content, analyze, or only research, since it can't necessarily see the user's intent unless it inherits your conversation, as noted per agent type below.
 - If an agent's description says to use it proactively, do so without waiting to be asked.
 - When only general-purpose is available, use it for any complex, context-heavy task; it has the same capabilities as the main agent."""  # noqa: E501
 
-_FORKED_SUBAGENT_TOOL_NOTE = (
-    " (forked: inherits a snapshot of your conversation and configured system prompt — give the outcome without restating inherited context)"
-)
-"""Appended to a forked subagent's line in the task tool's listing."""
+_FORKED_SUBAGENT_TOOL_NOTE = " (inherits your full conversation and system prompt — no need to restate context here)"
+"""Appended to a forked subagent's line in the task tool's listing.
+
+Load-bearing: without it, the "Each invocation is stateless" line above is
+the model's only signal, and it can refuse to delegate to a forked subagent
+even when told the subagent inherits the conversation.
+"""
 
 
 def _describe_subagent_for_tool(name: str, description: str, *, forked: bool) -> str:

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -22,7 +22,7 @@ from langchain.agents.structured_output import ResponseFormat
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core._api.beta_decorator import warn_beta
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
@@ -364,6 +364,19 @@ _FORK_TASK_PREAMBLE = (
     "generically when exact details are already available above. Your "
     "actual task is below.]\n\n"
 )
+
+
+def _fork_messages(messages: Sequence[AnyMessage], description: str) -> list[AnyMessage]:
+    """Build a fork's history, dropping the parent's in-flight tool-call message.
+
+    The parent calls `task` from its latest message, so replaying it would hand
+    the fork a tool call with no result -- rejected outright by some providers,
+    and patched into a misleading "was cancelled" result by others.
+    """
+    history = list(messages)
+    if history and isinstance(history[-1], AIMessage) and history[-1].tool_calls:
+        history.pop()
+    return [*history, HumanMessage(content=_FORK_TASK_PREAMBLE + description)]
 
 
 DEFAULT_SUBAGENT_PROMPT = """In order to complete the objective that the user asks of you, you have access to a number of standard tools.
@@ -726,10 +739,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
             subagent_state = {
                 **runtime.state,
                 _FORKED_CONTEXT_KEY: True,
-                "messages": [
-                    *runtime.state.get("messages", []),
-                    HumanMessage(content=_FORK_TASK_PREAMBLE + description),
-                ],
+                "messages": _fork_messages(runtime.state.get("messages", []), description),
             }
         else:
             subagent_state = {key: value for key, value in runtime.state.items() if key not in _EXCLUDED_STATE_KEYS | private_state_keys}

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -132,6 +132,13 @@ class CompactConversationSchema(BaseModel):
     """Input schema for the `compact_conversation` tool."""
 
 
+SUMMARIZATION_EVENT_KEY = "_summarization_event"
+"""State key holding the most recent `SummarizationEvent`."""
+
+SUMMARIZATION_SESSION_ID_KEY = "_summarization_session_id"
+"""State key holding the id that names the offload history file."""
+
+
 class SummarizationEvent(TypedDict):
     """Represents a summarization event."""
 
@@ -672,7 +679,7 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
         Returns:
             A session id (e.g. `'session_<uuid4 hex>'`).
         """
-        existing = state.get("_summarization_session_id")
+        existing = state.get(SUMMARIZATION_SESSION_ID_KEY)
         if isinstance(existing, str) and existing:
             return existing
         # Full uuid4 entropy: history filenames must not collide across
@@ -770,7 +777,7 @@ A condensed summary follows:
         Returns:
             The effective message list to use for the model call.
         """
-        event = request.state.get("_summarization_event")
+        event = request.state.get(SUMMARIZATION_EVENT_KEY)
         return self._apply_event_to_messages(request.messages, event)
 
     @staticmethod
@@ -1449,7 +1456,7 @@ A condensed summary follows:
         # Build summary message with file path reference
         new_messages = self._build_new_messages_with_path(summary, file_path)
 
-        previous_event = request.state.get("_summarization_event")
+        previous_event = request.state.get(SUMMARIZATION_EVENT_KEY)
         state_cutoff_index = self._compute_state_cutoff(previous_event, cutoff_index)
 
         # Create new summarization event
@@ -1464,8 +1471,8 @@ A condensed summary follows:
         response = handler(request.override(messages=modified_messages))
 
         update: dict[str, Any] = {
-            "_summarization_event": new_event,
-            "_summarization_session_id": session_id,
+            SUMMARIZATION_EVENT_KEY: new_event,
+            SUMMARIZATION_SESSION_ID_KEY: session_id,
         }
         if new_state_tail:
             update["messages"] = list(new_state_tail)
@@ -1591,7 +1598,7 @@ A condensed summary follows:
         # Build summary message with file path reference
         new_messages = self._build_new_messages_with_path(summary, file_path)
 
-        previous_event = request.state.get("_summarization_event")
+        previous_event = request.state.get(SUMMARIZATION_EVENT_KEY)
         state_cutoff_index = self._compute_state_cutoff(previous_event, cutoff_index)
 
         # Create new summarization event
@@ -1606,8 +1613,8 @@ A condensed summary follows:
         response = await handler(request.override(messages=modified_messages))
 
         update: dict[str, Any] = {
-            "_summarization_event": new_event,
-            "_summarization_session_id": session_id,
+            SUMMARIZATION_EVENT_KEY: new_event,
+            SUMMARIZATION_SESSION_ID_KEY: session_id,
         }
         if new_state_tail:
             update["messages"] = list(new_state_tail)
@@ -1934,8 +1941,8 @@ class SummarizationToolMiddleware(AgentMiddleware):
 
         return Command(
             update={
-                "_summarization_event": new_event,
-                "_summarization_session_id": session_id,
+                SUMMARIZATION_EVENT_KEY: new_event,
+                SUMMARIZATION_SESSION_ID_KEY: session_id,
                 "messages": [
                     ToolMessage(
                         content=f"Conversation compacted. Summarized {len(to_summarize)} messages into a concise summary.",
@@ -2058,7 +2065,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
         s = self._summarization
         tool_call_id = runtime.tool_call_id or ""
         messages = runtime.state.get("messages", [])
-        event = runtime.state.get("_summarization_event")
+        event = runtime.state.get(SUMMARIZATION_EVENT_KEY)
         effective = s._apply_event_to_messages(messages, event)
 
         if not self._is_eligible_for_compaction(effective):
@@ -2092,7 +2099,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
         s = self._summarization
         tool_call_id = runtime.tool_call_id or ""
         messages = runtime.state.get("messages", [])
-        event = runtime.state.get("_summarization_event")
+        event = runtime.state.get(SUMMARIZATION_EVENT_KEY)
         effective = s._apply_event_to_messages(messages, event)
 
         if not self._is_eligible_for_compaction(effective):

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -145,32 +145,6 @@ class SummarizationEvent(TypedDict):
     """Path where the conversation history was offloaded, or `None` if offload failed."""
 
 
-def _apply_summarization_event(
-    messages: list[AnyMessage],
-    event: SummarizationEvent | None,
-) -> list[AnyMessage]:
-    """Reconstruct the effective conversation represented by a summary event."""
-    if event is None:
-        return list(messages)
-
-    try:
-        summary_message = event["summary_message"]
-        cutoff_index = event["cutoff_index"]
-    except (KeyError, TypeError) as exc:
-        logger.warning("Malformed _summarization_event (missing keys): %s", exc)
-        return list(messages)
-
-    if cutoff_index > len(messages):
-        logger.warning(
-            "Summarization cutoff_index %d exceeds message count %d; remaining slice will be empty",
-            cutoff_index,
-            len(messages),
-        )
-        return [summary_message]
-
-    return [summary_message, *messages[cutoff_index:]]
-
-
 class TriggerClause(TypedDict, total=False):
     """Dictionary-based summarization trigger with AND semantics."""
 
@@ -804,8 +778,39 @@ A condensed summary follows:
         messages: list[AnyMessage],
         event: SummarizationEvent | None,
     ) -> list[AnyMessage]:
-        """Reconstruct effective messages from raw state and a summary event."""
-        return _apply_summarization_event(messages, event)
+        """Reconstruct effective messages from raw state messages and a summarization event.
+
+        When a prior summarization event exists, the effective conversation is
+        the summary message followed by all messages from `cutoff_index` onward.
+
+        Args:
+            messages: Full message list from state.
+            event: The `_summarization_event` dict, or `None`.
+
+        Returns:
+            The effective message list the model would see.
+        """
+        if event is None:
+            return list(messages)
+
+        try:
+            summary_msg = event["summary_message"]
+            cutoff_idx = event["cutoff_index"]
+        except (KeyError, TypeError) as exc:
+            logger.warning("Malformed _summarization_event (missing keys): %s", exc)
+            return list(messages)
+
+        if cutoff_idx > len(messages):
+            logger.warning(
+                "Summarization cutoff_index %d exceeds message count %d; remaining slice will be empty",
+                cutoff_idx,
+                len(messages),
+            )
+            return [summary_msg]
+
+        result: list[AnyMessage] = [summary_msg]
+        result.extend(messages[cutoff_idx:])
+        return result
 
     @staticmethod
     def _compute_state_cutoff(

--- a/libs/deepagents/tests/integration_tests/test_subagent_middleware.py
+++ b/libs/deepagents/tests/integration_tests/test_subagent_middleware.py
@@ -1,5 +1,5 @@
 import json
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import pytest
 from langchain.agents.middleware import AgentMiddleware
@@ -9,7 +9,7 @@ from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
 from deepagents.backends.state import StateBackend
-from deepagents.graph import create_agent
+from deepagents.graph import create_agent, create_deep_agent
 from deepagents.middleware.subagents import (
     GENERAL_PURPOSE_SUBAGENT,
     SubAgentMiddleware,
@@ -263,3 +263,47 @@ class TestSubagentMiddleware:
         assert isinstance(parsed["findings"], str)
         assert isinstance(parsed["confidence"], (int, float))
         assert isinstance(parsed["summary"], str)
+
+    def test_forked_subagent_reuses_parent_prompt_cache(self):
+        """A fork reads the parent prompt prefix from Anthropic's prompt cache."""
+        cacheable_context = " ".join("The project identifier is context-cache-test." for _ in range(200))
+        agent = create_deep_agent(
+            model="anthropic:claude-sonnet-4-6",
+            system_prompt=(
+                "Delegate the user's request to the forked worker with the task tool. "
+                "Do not answer directly.\n\n"
+                f"<reference_context>{cacheable_context}</reference_context>"
+            ),
+            subagents=[
+                {
+                    "name": "forked-worker",
+                    "description": "Completes the delegated task using the inherited context.",
+                    "mode": "fork",
+                    "tools": [],
+                }
+            ],
+        )
+
+        model_messages: list[tuple[Any, AIMessage]] = []
+        for namespace, update in agent.stream(
+            {"messages": [HumanMessage(content="Delegate this task: reply with the project identifier.")]},
+            subgraphs=True,
+            stream_mode="updates",
+        ):
+            if not isinstance(update, dict):
+                continue
+            model_update = update.get("model")
+            if not isinstance(model_update, dict):
+                continue
+            messages = model_update.get("messages", [])
+            if messages and isinstance(messages[-1], AIMessage):
+                model_messages.append((namespace, messages[-1]))
+
+        parent_task_calls = [call for namespace, message in model_messages if not namespace for call in message.tool_calls if call["name"] == "task"]
+        assert any(call["args"].get("subagent_type") == "forked-worker" for call in parent_task_calls)
+
+        forked_response = next(message for namespace, message in model_messages if namespace)
+        input_details = (forked_response.usage_metadata or {}).get("input_token_details", {})
+        cache_read_tokens = input_details.get("cache_read", 0)
+        assert isinstance(cache_read_tokens, int)
+        assert cache_read_tokens > 0

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -881,7 +881,7 @@ class TestSubagentMiddlewareInit:
             def invoke(self, state: dict[str, object], config: object = None) -> dict[str, object]:
                 del config
                 captured.update(state)
-                return {"messages": [AIMessage(content="done")]}
+                return {**state, "messages": [AIMessage(content="done")]}
 
         def fake_create_sub_agent(spec: dict[str, Any], **kwargs: Any) -> object:
             del spec, kwargs
@@ -904,6 +904,7 @@ class TestSubagentMiddlewareInit:
             state={
                 "messages": [HumanMessage(content="parent history")],
                 "memory_contents": {"/m.md": "PARENT MEMORY"},
+                "structured_response": {"answer": "stale"},
                 "_summarization_session_id": "session_parent",
             },
             context={},
@@ -913,12 +914,15 @@ class TestSubagentMiddlewareInit:
             tool_call_id="call_worker",
             store=None,
         )
-        task_tool.func(description="new task", subagent_type="worker", runtime=runtime)
+        result = task_tool.func(description="new task", subagent_type="worker", runtime=runtime)
 
         # Reusing the parent's session id would append the fork's evicted
-        # history into the parent's offload file.
+        # history into the parent's offload file. A stale parent structured
+        # response must likewise not be available to override this fork's result.
         assert "_summarization_session_id" not in captured
+        assert "structured_response" not in captured
         assert ("memory_contents" in captured) is declarative
+        assert result.update["messages"][0].content == "done"
 
     def test_rejects_duplicate_subagent_names(self) -> None:
         class _Runnable:

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -856,17 +856,14 @@ class TestSubagentMiddlewareInit:
 
         task_tool.func(description="new task", subagent_type="worker", runtime=runtime)
 
-        # `in_flight` holds the unresolved `task` call that spawned this fork.
+        # `in_flight` holds the unresolved `task` call that spawned this fork, and
+        # the summary replaces everything before the parent's cutoff.
         assert captured["messages"] == [
-            HumanMessage(content="old"),
+            summary,
             after_cutoff,
             HumanMessage(content=_FORK_TASK_PREAMBLE + "new task"),
         ]
-        assert captured["_summarization_event"] == {
-            "cutoff_index": 1,
-            "summary_message": summary,
-            "file_path": None,
-        }
+        assert "_summarization_event" not in captured
         assert captured[_FORKED_CONTEXT_KEY] is True
 
     def test_rejects_duplicate_subagent_names(self) -> None:

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -24,12 +24,11 @@ from deepagents.middleware.skills import SkillsMiddleware
 from deepagents.middleware.subagents import (
     _FORK_RECURSION_REFUSAL,
     _FORK_TASK_PREAMBLE,
-    _PARENT_SYSTEM_MESSAGE_KEY,
+    _FORKED_CONTEXT_KEY,
     GENERAL_PURPOSE_SUBAGENT,
     SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY,
     SubAgentMiddleware,
     _build_task_tool,
-    _ParentSystemMessageMiddleware,
     create_sub_agent,
 )
 from tests.unit_tests.chat_model import GenericFakeChatModel
@@ -215,44 +214,10 @@ class TestSubagentMiddlewareInit:
         forked = next(spec for spec in captured if spec["name"] == "forked-worker")
         isolated = next(spec for spec in captured if spec["name"] == "isolated-worker")
         assert forked["system_prompt"] == "PARENT_PROMPT"
-        # No mirrored MemoryMiddleware for the fork: the captured parent
-        # message already carries the parent's own memory content, so a
-        # second instance would only reload files to build a prompt
-        # fragment that _ForkSystemMessageMiddleware immediately discards.
+        # Child stacks do not mirror the parent's MemoryMiddleware. Forked
+        # subagents instead receive a copy of the parent state at invocation.
         assert not any(isinstance(middleware, MemoryMiddleware) for middleware in forked["middleware"])
         assert not any(isinstance(middleware, MemoryMiddleware) for middleware in isolated["middleware"])
-
-    @pytest.mark.parametrize(
-        ("subagents", "expected"),
-        [
-            (None, False),
-            ([{"name": "w", "description": "Starts fresh.", "system_prompt": "S"}], False),
-            ([{"name": "w", "description": "Continues with context.", "mode": "fork"}], True),
-        ],
-        ids=["no-subagents", "isolated", "declarative-fork"],
-    )
-    def test_parent_system_message_middleware_only_installed_for_declarative_forks(
-        self,
-        subagents: list[dict[str, Any]] | None,
-        expected: bool,  # noqa: FBT001
-    ) -> None:
-        """Capturing the parent's system message costs a state write per model call."""
-        captured: dict[str, Any] = {}
-
-        def fake_create_agent(model: object, **kwargs: Any) -> object:
-            del model
-            captured.update(kwargs)
-            return MagicMock()
-
-        with patch("deepagents.graph.create_agent", fake_create_agent):
-            create_deep_agent(
-                model=GenericFakeChatModel(messages=iter([AIMessage(content="done")])),
-                system_prompt="PARENT_PROMPT",
-                subagents=subagents,
-            )
-
-        installed = any(isinstance(middleware, _ParentSystemMessageMiddleware) for middleware in captured["middleware"])
-        assert installed is expected
 
     def test_isolated_subagent_keeps_its_own_skills_middleware(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, Any]] = []
@@ -290,7 +255,7 @@ class TestSubagentMiddlewareInit:
         isolated = next(spec for spec in captured if spec["name"] == "isolated-worker")
         assert any(isinstance(middleware, SkillsMiddleware) for middleware in isolated["middleware"])
 
-    def test_forked_subagent_inherits_dynamic_parent_prompt(self) -> None:
+    def test_forked_subagent_inherits_configured_parent_prompt(self) -> None:
         class _AppendPromptMiddleware(AgentMiddleware):
             def wrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]) -> ModelResponse:
                 message = request.system_message
@@ -330,11 +295,10 @@ class TestSubagentMiddlewareInit:
             ],
         )
 
-        result = agent.invoke({"messages": [HumanMessage(content="start")]})
+        agent.invoke({"messages": [HumanMessage(content="start")]})
 
         worker_system_message = worker_model.call_history[0]["messages"][0]
-        assert worker_system_message.text == "PARENT_PROMPT\n\nDYNAMIC_PROMPT"
-        assert _PARENT_SYSTEM_MESSAGE_KEY not in result
+        assert worker_system_message.text == "PARENT_PROMPT"
 
     def test_forked_subagent_replaces_repeated_prompt_updates(self) -> None:
         class _AppendPromptMiddleware(AgentMiddleware):
@@ -589,6 +553,44 @@ class TestSubagentMiddlewareInit:
         task_tool = next(t for t in middleware.tools if t.name == "task")
         assert "weather" in (task_tool.description or "")
 
+    def test_task_tool_explains_forked_context_to_the_parent_agent(self) -> None:
+        """The task tool must distinguish a fork from an isolated worker."""
+        middleware = SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[
+                {
+                    "name": "worker",
+                    "description": "Continues the current task.",
+                    "model": GenericFakeChatModel(messages=iter([AIMessage(content="done")])),
+                    "tools": [],
+                    "mode": "fork",
+                }
+            ],
+        )
+
+        task_description = middleware.tools[0].description or ""
+
+        assert "Agents are isolated by default" in task_description
+        assert "forked: inherits a snapshot of your conversation and configured system prompt" in task_description
+        assert "outcome without restating inherited context" in task_description
+
+    def test_task_tool_marks_compiled_forks_as_context_aware(self) -> None:
+        middleware = SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[
+                {
+                    "name": "worker",
+                    "description": "Continues the current task.",
+                    "runnable": RunnableLambda(lambda _state: {"messages": [AIMessage(content="done")]}),
+                    "mode": "fork",
+                }
+            ],
+        )
+
+        task_description = middleware.tools[0].description or ""
+
+        assert "forked: inherits a snapshot of your conversation and configured system prompt" in task_description
+
     def test_subagent_middleware_custom_system_prompt(self) -> None:
         """Test SubAgentMiddleware with a custom system prompt."""
         middleware = SubAgentMiddleware(
@@ -670,7 +672,7 @@ class TestSubagentMiddlewareInit:
             store=None,
         )
 
-    def test_forked_compiled_subagent_receives_effective_parent_history(self) -> None:
+    def test_forked_compiled_subagent_receives_parent_state(self) -> None:
         captured: dict[str, object] = {}
 
         class _Runnable:
@@ -735,53 +737,17 @@ class TestSubagentMiddlewareInit:
         task_tool.func(description="new task", subagent_type="worker", runtime=runtime)
 
         assert captured["messages"] == [
-            summary,
+            HumanMessage(content="old"),
             after_cutoff,
+            in_flight,
             HumanMessage(content=_FORK_TASK_PREAMBLE + "new task"),
         ]
-        assert "_summarization_event" not in captured
-
-    def test_compiled_fork_does_not_receive_parent_prompt_state(self) -> None:
-        captured: dict[str, object] = {}
-
-        class _Runnable:
-            def with_config(self, config: dict[str, object]) -> "_Runnable":
-                del config
-                return self
-
-            def invoke(self, state: dict[str, object], config: object = None) -> dict[str, object]:
-                del config
-                captured.update(state)
-                return {"messages": [AIMessage(content="done")]}
-
-        middleware = SubAgentMiddleware(
-            backend=StateBackend(),
-            subagents=[
-                {
-                    "name": "worker",
-                    "description": "Continues with context.",
-                    "runnable": _Runnable(),
-                    "mode": "fork",
-                }
-            ],
-        )
-        task_tool = middleware.tools[0]
-        runtime = ToolRuntime(
-            state={
-                "messages": [HumanMessage(content="parent history")],
-                _PARENT_SYSTEM_MESSAGE_KEY: SystemMessage(content="SESSION_PROMPT"),
-            },
-            context={},
-            config={"configurable": {}},
-            stream_writer=lambda _chunk: None,
-            tools=[task_tool],
-            tool_call_id="call_worker",
-            store=None,
-        )
-
-        task_tool.func(description="new task", subagent_type="worker", runtime=runtime)
-
-        assert _PARENT_SYSTEM_MESSAGE_KEY not in captured
+        assert captured["_summarization_event"] == {
+            "cutoff_index": 1,
+            "summary_message": summary,
+            "file_path": None,
+        }
+        assert captured[_FORKED_CONTEXT_KEY] is True
 
     def test_rejects_duplicate_subagent_names(self) -> None:
         class _Runnable:

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -237,6 +237,41 @@ class TestSubagentMiddlewareInit:
         if expected:
             assert "`ForkedSubAgent` is in beta" in str(beta_warnings[0].message)
 
+    def test_forked_subagent_history_has_no_dangling_task_call(self) -> None:
+        """The spawning `task` call is dropped, so nothing patches a bogus result over it."""
+        parent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {"description": "continue", "subagent_type": "worker"},
+                                "id": "call_worker",
+                                "type": "tool_call",
+                            },
+                            {"name": "ls", "args": {"path": "/"}, "id": "call_ls", "type": "tool_call"},
+                        ],
+                    ),
+                    AIMessage(content="parent done"),
+                ]
+            )
+        )
+        worker_model = GenericFakeChatModel(messages=iter([AIMessage(content="worker done")]))
+        agent = create_deep_agent(
+            model=parent_model,
+            system_prompt="PARENT_PROMPT",
+            subagents=[{"name": "worker", "description": "Continues with context.", "model": worker_model, "mode": "fork"}],
+        )
+
+        agent.invoke({"messages": [HumanMessage(content="start")]}, {"recursion_limit": 25})
+
+        inherited = worker_model.call_history[0]["messages"]
+        assert not any(isinstance(m, AIMessage) and any(c["name"] == "task" for c in m.tool_calls) for m in inherited)
+        assert not any(isinstance(m, ToolMessage) and "was cancelled" in str(m.content) for m in inherited)
+        assert inherited[-1].text.startswith(_FORK_TASK_PREAMBLE)
+
     def test_forked_subagent_tool_order_matches_parent(self) -> None:
         """A fork's tools block must serialize identically to the parent's to reuse its cache."""
 
@@ -821,10 +856,10 @@ class TestSubagentMiddlewareInit:
 
         task_tool.func(description="new task", subagent_type="worker", runtime=runtime)
 
+        # `in_flight` holds the unresolved `task` call that spawned this fork.
         assert captured["messages"] == [
             HumanMessage(content="old"),
             after_cutoff,
-            in_flight,
             HumanMessage(content=_FORK_TASK_PREAMBLE + "new task"),
         ]
         assert captured["_summarization_event"] == {

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -173,7 +173,7 @@ class TestSubagentMiddlewareInit:
         with pytest.raises(ValueError, match="cannot set skills"):
             SubAgentMiddleware(backend=StateBackend(), subagents=[invalid_spec])
 
-    def test_forked_subagent_inherits_prompt_and_skips_memory_middleware(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_forked_subagent_mirrors_parent_memory_middleware(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, Any]] = []
         runnable = self._make_echo_graph()
 
@@ -216,9 +216,9 @@ class TestSubagentMiddlewareInit:
         forked = next(spec for spec in captured if spec["name"] == "forked-worker")
         isolated = next(spec for spec in captured if spec["name"] == "isolated-worker")
         assert forked["system_prompt"] == "PARENT_PROMPT"
-        # Child stacks do not mirror the parent's MemoryMiddleware. Forked
-        # subagents instead receive a copy of the parent state at invocation.
-        assert not any(isinstance(middleware, MemoryMiddleware) for middleware in forked["middleware"])
+        # A fork mirrors the parent's MemoryMiddleware so its own stack rebuilds
+        # the parent's memory block; an isolated subagent starts without one.
+        assert any(isinstance(middleware, MemoryMiddleware) for middleware in forked["middleware"])
         assert not any(isinstance(middleware, MemoryMiddleware) for middleware in isolated["middleware"])
 
     @pytest.mark.parametrize(("mode", "expected"), [(None, 0), ("fork", 1)], ids=["isolated", "fork"])
@@ -375,7 +375,7 @@ class TestSubagentMiddlewareInit:
         isolated = next(spec for spec in captured if spec["name"] == "isolated-worker")
         assert any(isinstance(middleware, SkillsMiddleware) for middleware in isolated["middleware"])
 
-    def test_forked_subagent_inherits_configured_parent_prompt(self) -> None:
+    def test_forked_subagent_inherits_dynamic_parent_prompt(self) -> None:
         class _AppendPromptMiddleware(AgentMiddleware):
             def wrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]) -> ModelResponse:
                 message = request.system_message
@@ -417,8 +417,10 @@ class TestSubagentMiddlewareInit:
 
         agent.invoke({"messages": [HumanMessage(content="start")]})
 
+        # The parent's prompt middleware is inherited, so the fork rebuilds the
+        # same composed message rather than seeing only the configured prompt.
         worker_system_message = worker_model.call_history[0]["messages"][0]
-        assert worker_system_message.text == "PARENT_PROMPT"
+        assert worker_system_message.text == "PARENT_PROMPT\n\nDYNAMIC_PROMPT"
 
     def test_forked_subagent_replaces_repeated_prompt_updates(self) -> None:
         class _AppendPromptMiddleware(AgentMiddleware):

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -692,9 +692,9 @@ class TestSubagentMiddlewareInit:
 
         task_description = middleware.tools[0].description or ""
 
-        assert "Agents are isolated by default" in task_description
-        assert "forked: inherits a snapshot of your conversation and configured system prompt" in task_description
-        assert "outcome without restating inherited context" in task_description
+        assert "Each invocation is stateless by default" in task_description
+        assert "inherits your full conversation and system prompt" in task_description
+        assert "no need to restate context here" in task_description
 
     def test_task_tool_marks_compiled_forks_as_context_aware(self) -> None:
         middleware = SubAgentMiddleware(
@@ -711,7 +711,7 @@ class TestSubagentMiddlewareInit:
 
         task_description = middleware.tools[0].description or ""
 
-        assert "forked: inherits a snapshot of your conversation and configured system prompt" in task_description
+        assert "inherits your full conversation and system prompt" in task_description
 
     def test_subagent_middleware_custom_system_prompt(self) -> None:
         """Test SubAgentMiddleware with a custom system prompt."""

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -866,6 +866,58 @@ class TestSubagentMiddlewareInit:
         assert "_summarization_event" not in captured
         assert captured[_FORKED_CONTEXT_KEY] is True
 
+    @pytest.mark.parametrize("declarative", [True, False], ids=["declarative", "compiled"])
+    def test_fork_state_inheritance_depends_on_spec_kind(self, declarative: bool) -> None:  # noqa: FBT001
+        """Only a declarative fork inherits private channels; both drop summarization state."""
+        captured: dict[str, object] = {}
+
+        class _Runnable:
+            def with_config(self, config: dict[str, object]) -> "_Runnable":
+                del config
+                return self
+
+            def invoke(self, state: dict[str, object], config: object = None) -> dict[str, object]:
+                del config
+                captured.update(state)
+                return {"messages": [AIMessage(content="done")]}
+
+        def fake_create_sub_agent(spec: dict[str, Any], **kwargs: Any) -> object:
+            del spec, kwargs
+            return _Runnable()
+
+        spec: dict[str, Any] = {"name": "worker", "description": "Continues with context.", "mode": "fork"}
+        if declarative:
+            spec |= {"model": GenericFakeChatModel(messages=iter([AIMessage(content="x")])), "tools": []}
+        else:
+            spec["runnable"] = _Runnable()
+
+        with patch("deepagents.middleware.subagents.create_sub_agent", fake_create_sub_agent):
+            middleware = SubAgentMiddleware(
+                backend=StateBackend(),
+                subagents=[spec],
+                private_state_keys=frozenset({"memory_contents", "_summarization_event", "_summarization_session_id"}),
+            )
+        task_tool = middleware.tools[0]
+        runtime = ToolRuntime(
+            state={
+                "messages": [HumanMessage(content="parent history")],
+                "memory_contents": {"/m.md": "PARENT MEMORY"},
+                "_summarization_session_id": "session_parent",
+            },
+            context={},
+            config={"configurable": {}},
+            stream_writer=lambda _chunk: None,
+            tools=[task_tool],
+            tool_call_id="call_worker",
+            store=None,
+        )
+        task_tool.func(description="new task", subagent_type="worker", runtime=runtime)
+
+        # Reusing the parent's session id would append the fork's evicted
+        # history into the parent's offload file.
+        assert "_summarization_session_id" not in captured
+        assert ("memory_contents" in captured) is declarative
+
     def test_rejects_duplicate_subagent_names(self) -> None:
         class _Runnable:
             def with_config(self, config: dict[str, object]) -> "_Runnable":

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -1885,6 +1885,51 @@ class TestSubAgents:
         assert saw_parent_model_update, "Should have seen the parent final model update in the stream"
         assert seen_agent_names == {"supervisor", "worker"}
 
+    def test_subagent_checkpoint_history_is_readable(self) -> None:
+        """A task subagent checkpoint namespace can be resolved back to its transcript."""
+        subagent_content = "SUBAGENT_RESPONSE"
+        parent_model = _ScriptedChatModel(
+            responses=[
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "task",
+                            "args": {"description": "Do task", "subagent_type": "worker"},
+                            "id": "call_worker",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="Done."),
+            ]
+        )
+        subagent_model = _ScriptedChatModel(responses=[AIMessage(content=subagent_content)])
+        checkpointer = InMemorySaver()
+        agent = create_deep_agent(
+            model=parent_model,
+            checkpointer=checkpointer,
+            subagents=[
+                CompiledSubAgent(
+                    name="worker",
+                    description="Does work.",
+                    runnable=create_agent(model=subagent_model, name="worker"),
+                )
+            ],
+        )
+        config = {"configurable": {"thread_id": "subagent-history"}}
+
+        agent.invoke({"messages": [HumanMessage(content="Do something")]}, config)
+
+        subagent_namespace = next(
+            checkpoint.config["configurable"]["checkpoint_ns"]
+            for checkpoint in checkpointer.list(config)
+            if checkpoint.config["configurable"]["checkpoint_ns"].startswith("tools:")
+        )
+        history = list(agent.get_state_history({"configurable": {"thread_id": "subagent-history", "checkpoint_ns": subagent_namespace}}))
+
+        assert any(any(message.content == subagent_content for message in snapshot.values.get("messages", [])) for snapshot in history)
+
     def test_compiled_subagent_lc_agent_name_in_stream_metadata(self) -> None:
         """lc_agent_name in streamed chunks must reflect the CompiledSubAgent's declared name.
 

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -1886,7 +1886,13 @@ class TestSubAgents:
         assert seen_agent_names == {"supervisor", "worker"}
 
     def test_subagent_checkpoint_history_is_readable(self) -> None:
-        """A task subagent checkpoint namespace can be resolved back to its transcript."""
+        """A task subagent's transcript is recoverable from the parent's checkpointer.
+
+        Read through the checkpointer rather than `agent.get_state_history`, which
+        resolves a `checkpoint_ns` by walking registered subgraphs: `task` invokes
+        subagents directly rather than as graph nodes, so the namespace has no
+        subgraph to resolve to.
+        """
         subagent_content = "SUBAGENT_RESPONSE"
         parent_model = _ScriptedChatModel(
             responses=[
@@ -1926,9 +1932,13 @@ class TestSubAgents:
             for checkpoint in checkpointer.list(config)
             if checkpoint.config["configurable"]["checkpoint_ns"].startswith("tools:")
         )
-        history = list(agent.get_state_history({"configurable": {"thread_id": "subagent-history", "checkpoint_ns": subagent_namespace}}))
+        history = [checkpoint for checkpoint in checkpointer.list(config) if checkpoint.config["configurable"]["checkpoint_ns"] == subagent_namespace]
 
-        assert any(any(message.content == subagent_content for message in snapshot.values.get("messages", [])) for snapshot in history)
+        assert history
+        assert any(
+            any(message.content == subagent_content for message in checkpoint.checkpoint["channel_values"].get("messages", []))
+            for checkpoint in history
+        )
 
     def test_compiled_subagent_lc_agent_name_in_stream_metadata(self) -> None:
         """lc_agent_name in streamed chunks must reflect the CompiledSubAgent's declared name.


### PR DESCRIPTION
* instead of forking via attributing messages through middleware state, we instead rework how subagent state gets propagated in `task.invoke` for forked subagents
* also does some type guard cleanups, and moves summarization back to where it was to minimize diff to main in the stacked PR
* also some slight drive by prompt hardening

alt implementation for fix addressed in 7b2302b97596cc4247f1d346dc643a653dd83714