### PR TITLE
feat(talon): add channel debug logging

### DIFF
--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -42,6 +42,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_DCODE_DEBUG_ENV = "DEEPAGENTS_CODE_DEBUG"
+_DCODE_LOG_LEVEL_ENV = "DEEPAGENTS_CODE_LOG_LEVEL"
+_DCODE_DEBUG_VALUES = frozenset({"1", "true", "yes", "on"})
+_DCODE_LOG_LEVELS = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
+}
+_CHANNEL_LOGGER_NAME = "deepagents_talon.channels"
+
 
 def main() -> None:
     """Run the Talon host with the placeholder runtime."""
@@ -66,7 +78,7 @@ def main() -> None:
     _add_mcp_parsers(subparsers)
     args = parser.parse_args()
 
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+    _configure_logging(os.environ)
 
     config = TalonConfig.from_env()
     if args.command == "import-fleet":
@@ -254,6 +266,26 @@ def _channels(
     if telegram or _env_enabled(config.env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED"):
         channels.append(TelegramChannel(TelegramChannelConfig.from_talon_config(config)))
     return tuple(channels)
+
+
+def _configure_logging(env: Mapping[str, str]) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+    logging.getLogger(_CHANNEL_LOGGER_NAME).setLevel(_channel_log_level(env))
+
+
+def _channel_log_level(env: Mapping[str, str]) -> int:
+    debug_enabled = env.get(_DCODE_DEBUG_ENV, "").strip().lower() in _DCODE_DEBUG_VALUES
+    fallback = logging.DEBUG if debug_enabled else logging.INFO
+    raw_level = env.get(_DCODE_LOG_LEVEL_ENV, "").strip().upper()
+    if not raw_level:
+        return fallback
+    if level := _DCODE_LOG_LEVELS.get(raw_level):
+        return level
+    logger.warning(
+        "Ignoring invalid %s; expected DEBUG, INFO, WARNING, ERROR, or CRITICAL",
+        _DCODE_LOG_LEVEL_ENV,
+    )
+    return fallback
 
 
 def _env_enabled(env: Mapping[str, str], key: str) -> bool:

--- a/libs/talon/deepagents_talon/channels/telegram.py
+++ b/libs/talon/deepagents_talon/channels/telegram.py
@@ -44,6 +44,7 @@ from deepagents_talon.interfaces import (
     ReactionHandler,
     SendResult,
 )
+from deepagents_talon.observability import log_debug_event
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -74,6 +75,11 @@ class _TelegramError(RuntimeError):
         """Initialize the Telegram error."""
         super().__init__(message)
         self.retry_after = retry_after
+
+
+def _telegram_error_type(error: _TelegramError) -> str:
+    cause = error.__cause__
+    return type(cause).__name__ if cause is not None else type(error).__name__
 
 
 @dataclass(frozen=True, slots=True)
@@ -217,7 +223,16 @@ class _TelegramTransport:
         Raises:
             _TelegramError: If the request fails or the API returns an error.
         """
-        return await asyncio.to_thread(self._request, method, params)
+        try:
+            return await asyncio.to_thread(self._request, method, params)
+        except _TelegramError as error:
+            log_debug_event(
+                logger,
+                "telegram.api.request.failed",
+                error_type=_telegram_error_type(error),
+                method=method,
+            )
+            raise
 
     async def upload(
         self,
@@ -241,7 +256,16 @@ class _TelegramTransport:
         Raises:
             _TelegramError: If the request fails or the API returns an error.
         """
-        return await asyncio.to_thread(self._upload, method, file_field, file_path, params)
+        try:
+            return await asyncio.to_thread(self._upload, method, file_field, file_path, params)
+        except _TelegramError as error:
+            log_debug_event(
+                logger,
+                "telegram.api.upload.failed",
+                error_type=_telegram_error_type(error),
+                method=method,
+            )
+            raise
 
     def _request(self, method: str, params: dict[str, object]) -> object:
         url = f"{self.api_base}/bot{self.token}/{method}"
@@ -346,6 +370,14 @@ class TelegramChannel:
 
     async def start(self) -> None:
         """Load persisted offset, call getMe, and start the long-polling loop."""
+        log_debug_event(
+            logger,
+            "telegram.channel.starting",
+            exposure=self._exposure.mode.value,
+            inbound_media_enabled=self.config.inbound_media_dir is not None,
+            poll_interval_seconds=self.config.poll_interval_seconds,
+            poll_timeout_seconds=self.config.poll_timeout_seconds,
+        )
         self.config.session_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         self.config.session_dir.chmod(0o700)
         if self.config.inbound_media_dir is not None:
@@ -355,15 +387,23 @@ class TelegramChannel:
         self._offset = _load_offset(self.config.offset_file)
         await self._identify_bot()
         self._poll = asyncio.create_task(self._poll_updates(), name="talon:telegram:poll")
+        log_debug_event(
+            logger,
+            "telegram.channel.started",
+            connected=self._status.connected,
+            offset_loaded=self._offset > 0,
+        )
 
     async def stop(self) -> None:
         """Stop the polling task and mark the channel as disconnected."""
+        log_debug_event(logger, "telegram.channel.stopping", poll_active=self._poll is not None)
         self._stopped.set()
         if self._poll is not None:
             self._poll.cancel()
             await asyncio.gather(self._poll, return_exceptions=True)
             self._poll = None
         self._status = ChannelStatus(provider="telegram", connected=False, detail="disconnected")
+        log_debug_event(logger, "telegram.channel.stopped")
 
     async def send_message(self, conversation_id: str, text: str) -> SendResult:
         """Send chunked plain text.
@@ -375,13 +415,27 @@ class TelegramChannel:
         Returns:
             Result indicating whether the send succeeded.
         """
-        for chunk in chunk_text(text, limit=MAX_TEXT_CHARS):
+        chunks = chunk_text(text, limit=MAX_TEXT_CHARS)
+        log_debug_event(
+            logger,
+            "telegram.outbound.text.started",
+            chunk_count=len(chunks),
+            text_chars=len(text),
+        )
+        for chunk in chunks:
             payload = await self._transport.call(
                 "sendMessage",
                 chat_id=conversation_id,
                 text=chunk,
             )
-        return SendResult(success=True, message_id=_extract_telegram_message_id(payload))
+        message_id = _extract_telegram_message_id(payload)
+        log_debug_event(
+            logger,
+            "telegram.outbound.text.completed",
+            chunk_count=len(chunks),
+            message_id_present=message_id is not None,
+        )
+        return SendResult(success=True, message_id=message_id)
 
     async def send_media(self, conversation_id: str, media: ChannelMedia) -> SendResult:
         """Send validated image, video, or document media to a Telegram chat.
@@ -403,6 +457,13 @@ class TelegramChannel:
         )
         caption = await self._media_caption(conversation_id, checked.caption)
         method, file_field = _telegram_send_method(checked.media_type)
+        log_debug_event(
+            logger,
+            "telegram.outbound.media.started",
+            caption_present=caption is not None,
+            media_type=checked.media_type,
+            method=method,
+        )
         params: dict[str, object] = {"chat_id": conversation_id}
         if caption:
             params["caption"] = caption
@@ -412,7 +473,15 @@ class TelegramChannel:
             file_path=checked.path,
             **params,
         )
-        return SendResult(success=True, message_id=_extract_telegram_message_id(payload))
+        message_id = _extract_telegram_message_id(payload)
+        log_debug_event(
+            logger,
+            "telegram.outbound.media.completed",
+            media_type=checked.media_type,
+            message_id_present=message_id is not None,
+            method=method,
+        )
+        return SendResult(success=True, message_id=message_id)
 
     async def send_typing(self, conversation_id: str) -> None:
         """Send a Telegram typing indicator.
@@ -426,8 +495,12 @@ class TelegramChannel:
                 chat_id=conversation_id,
                 action="typing",
             )
-        except _TelegramError:
-            logger.debug("Could not send Telegram typing indicator", exc_info=True)
+        except _TelegramError as error:
+            log_debug_event(
+                logger,
+                "telegram.outbound.typing.failed",
+                error_type=_telegram_error_type(error),
+            )
 
     async def edit_message(self, conversation_id: str, message_id: str, text: str) -> SendResult:
         """Edit a previously sent Telegram message.
@@ -453,10 +526,16 @@ class TelegramChannel:
         return self._status
 
     async def _identify_bot(self) -> None:
+        log_debug_event(logger, "telegram.bot.identification.started")
         try:
             payload = await self._transport.call("getMe")
-        except _TelegramError:
-            logger.exception("Telegram getMe failed during startup")
+        except _TelegramError as error:
+            logger.log(logging.ERROR, "Telegram getMe failed during startup")
+            log_debug_event(
+                logger,
+                "telegram.bot.identification.failed",
+                error_type=_telegram_error_type(error),
+            )
             self._status = ChannelStatus(
                 provider="telegram",
                 connected=False,
@@ -470,7 +549,13 @@ class TelegramChannel:
         username = result.get("username") if isinstance(result, dict) else None
         if isinstance(username, str):
             self._bot_username = username
-            logger.info("Telegram bot connected as @%s", username)
+            logger.info("Telegram bot connected")
+        log_debug_event(
+            logger,
+            "telegram.bot.identification.completed",
+            bot_id_present=self._bot_id is not None,
+            username_present=self._bot_username is not None,
+        )
         self._status = ChannelStatus(
             provider="telegram",
             connected=True,
@@ -495,6 +580,12 @@ class TelegramChannel:
                     allowed_updates=_ALLOWED_UPDATES,
                 )
                 updates = _extract_updates(payload)
+                if updates:
+                    log_debug_event(
+                        logger,
+                        "telegram.poll.batch.received",
+                        update_count=len(updates),
+                    )
                 self._status = ChannelStatus(
                     provider="telegram",
                     connected=True,
@@ -504,6 +595,11 @@ class TelegramChannel:
                     await self._process_update(update)
                 if updates:
                     self._advance_offset(updates)
+                    log_debug_event(
+                        logger,
+                        "telegram.poll.batch.completed",
+                        update_count=len(updates),
+                    )
             except _TelegramError as error:
                 delay = (
                     error.retry_after
@@ -515,6 +611,13 @@ class TelegramChannel:
                     delay,
                     error,
                 )
+                log_debug_event(
+                    logger,
+                    "telegram.poll.retrying",
+                    error_type=_telegram_error_type(error),
+                    retry_after_seconds=delay,
+                    server_retry_after=error.retry_after is not None,
+                )
                 self._status = ChannelStatus(
                     provider="telegram",
                     connected=False,
@@ -522,8 +625,15 @@ class TelegramChannel:
                 )
                 await asyncio.sleep(delay)
                 continue
-            except (urllib.error.URLError, TimeoutError):
-                logger.exception("Telegram long-polling error; retrying after interval")
+            except (urllib.error.URLError, TimeoutError) as error:
+                logger.warning("Telegram long-polling error; retrying after interval")
+                log_debug_event(
+                    logger,
+                    "telegram.poll.retrying",
+                    error_type=type(error).__name__,
+                    retry_after_seconds=self.config.poll_interval_seconds,
+                    server_retry_after=False,
+                )
                 self._status = ChannelStatus(
                     provider="telegram",
                     connected=False,
@@ -567,14 +677,24 @@ class TelegramChannel:
             self.config.allowed_user_ids,
             message,
         ):
-            logger.debug(
-                "Dropping Telegram message %s from %s due to exposure policy",
-                message.message_id,
-                message.conversation_id,
+            log_debug_event(
+                logger,
+                "telegram.inbound.message.rejected",
+                exposure=self._exposure.mode.value,
+                has_media=bool(message.metadata.get("has_media")),
+                text_chars=len(message.text),
             )
             return
         message = await self._prepare_inbound_media(message)
+        log_debug_event(
+            logger,
+            "telegram.inbound.message.dispatching",
+            has_media=bool(message.metadata.get("has_media")),
+            media_type=message.metadata.get("media_type"),
+            text_chars=len(message.text),
+        )
         await dispatch_message(self._handler, message, provider="Telegram")
+        log_debug_event(logger, "telegram.inbound.message.dispatched")
 
     async def _process_reaction(self, reaction: ChannelReaction) -> None:
         if not _allows_telegram_reaction(
@@ -582,13 +702,15 @@ class TelegramChannel:
             self.config.allowed_user_ids,
             reaction,
         ):
-            logger.debug(
-                "Dropping Telegram reaction %s on %s due to exposure policy",
-                reaction.message_id,
-                reaction.conversation_id,
+            log_debug_event(
+                logger,
+                "telegram.inbound.reaction.rejected",
+                exposure=self._exposure.mode.value,
             )
             return
+        log_debug_event(logger, "telegram.inbound.reaction.dispatching")
         await self._dispatch_reaction(reaction)
+        log_debug_event(logger, "telegram.inbound.reaction.dispatched")
 
     async def _dispatch_reaction(self, reaction: ChannelReaction) -> None:
         if self._reaction_handler is None:
@@ -611,10 +733,12 @@ class TelegramChannel:
                 message_id=message.message_id,
             )
         except (ChannelMediaError, _TelegramError, urllib.error.URLError, TimeoutError) as error:
-            logger.warning(
-                "Skipping Telegram inbound media for message %s: %s",
-                message.message_id,
-                error,
+            logger.warning("Skipping Telegram inbound media after download failure")
+            log_debug_event(
+                logger,
+                "telegram.inbound.media.failed",
+                error_type=type(error).__name__,
+                media_type=media_type,
             )
             metadata = dict(message.metadata)
             metadata["has_media"] = False
@@ -622,6 +746,12 @@ class TelegramChannel:
             return replace(message, metadata=metadata)
         path = str(destination)
         mime_type = _downloaded_mime_type(destination, dict(message.metadata))
+        log_debug_event(
+            logger,
+            "telegram.inbound.media.completed",
+            media_type=media_type,
+            mime_type_present=mime_type is not None,
+        )
         return message_with_media_paths(
             message,
             media_paths=[path],

--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -45,6 +45,7 @@ from deepagents_talon.interfaces import (
     MessageHandler,
     SendResult,
 )
+from deepagents_talon.observability import log_debug_event
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -285,6 +286,14 @@ class WhatsAppChannel:
 
     async def start(self) -> None:
         """Start the bridge subprocess and background polling tasks."""
+        log_debug_event(
+            logger,
+            "whatsapp.channel.starting",
+            exposure=self.config.exposure.mode.value,
+            health_interval_seconds=self.config.health_interval_seconds,
+            managed_bridge=self.config.bridge_command is not None,
+            poll_interval_seconds=self.config.poll_interval_seconds,
+        )
         self.config.session_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         self.config.session_dir.chmod(0o700)
         media_dir = _bridge_media_dir(self.config)
@@ -294,9 +303,21 @@ class WhatsAppChannel:
         await self._start_bridge()
         self._poll = asyncio.create_task(self._poll_messages(), name="talon:whatsapp:poll")
         self._health = asyncio.create_task(self._watch_health(), name="talon:whatsapp:health")
+        log_debug_event(
+            logger,
+            "whatsapp.channel.started",
+            connected=self._status.connected,
+            managed_bridge=self.config.bridge_command is not None,
+        )
 
     async def stop(self) -> None:
         """Stop polling tasks and terminate the bridge subprocess."""
+        log_debug_event(
+            logger,
+            "whatsapp.channel.stopping",
+            health_active=self._health is not None,
+            poll_active=self._poll is not None,
+        )
         self._stopped.set()
         tasks = [task for task in (self._poll, self._health) if task is not None]
         for task in tasks:
@@ -307,6 +328,7 @@ class WhatsAppChannel:
         self._health = None
         await self._stop_bridge()
         self._status = ChannelStatus(provider="whatsapp", connected=False, detail="disconnected")
+        log_debug_event(logger, "whatsapp.channel.stopped")
 
     async def send_message(self, conversation_id: str, text: str) -> SendResult:
         """Send chunked, formatted text to a WhatsApp chat.
@@ -318,9 +340,23 @@ class WhatsAppChannel:
         Returns:
             Result indicating whether the send succeeded.
         """
-        for chunk in _chunk_with_bot_header(text, bot_header=self.config.bot_header):
+        chunks = _chunk_with_bot_header(text, bot_header=self.config.bot_header)
+        log_debug_event(
+            logger,
+            "whatsapp.outbound.text.started",
+            chunk_count=len(chunks),
+            text_chars=len(text),
+        )
+        for chunk in chunks:
             response = await self._post_result("/send", {"chatId": conversation_id, "text": chunk})
-        return SendResult(success=True, message_id=_extract_message_id(response))
+        message_id = _extract_message_id(response)
+        log_debug_event(
+            logger,
+            "whatsapp.outbound.text.completed",
+            chunk_count=len(chunks),
+            message_id_present=message_id is not None,
+        )
+        return SendResult(success=True, message_id=message_id)
 
     async def send_media(self, conversation_id: str, media: ChannelMedia) -> SendResult:
         """Send validated image or video media to a WhatsApp chat.
@@ -338,6 +374,13 @@ class WhatsAppChannel:
             max_bytes=self.config.max_media_bytes,
         )
         staged = await asyncio.to_thread(_stage_bridge_media, checked.path, self.config)
+        log_debug_event(
+            logger,
+            "whatsapp.outbound.media.started",
+            caption_present=checked.caption is not None,
+            media_type=checked.media_type,
+            staged_copy=staged != checked.path,
+        )
         payload: dict[str, object] = {
             "chatId": conversation_id,
             "filePath": str(staged),
@@ -350,7 +393,14 @@ class WhatsAppChannel:
         else:
             payload["caption"] = _bot_header(self.config.bot_header)
         response = await self._post_result("/send-media", payload)
-        return SendResult(success=True, message_id=_extract_message_id(response))
+        message_id = _extract_message_id(response)
+        log_debug_event(
+            logger,
+            "whatsapp.outbound.media.completed",
+            media_type=checked.media_type,
+            message_id_present=message_id is not None,
+        )
+        return SendResult(success=True, message_id=message_id)
 
     async def send_typing(self, conversation_id: str) -> None:
         """Send a WhatsApp typing indicator when the bridge supports it.
@@ -386,7 +436,11 @@ class WhatsAppChannel:
         return self._status
 
     async def _start_bridge(self) -> None:
-        if self.config.bridge_command is None or self._process is not None:
+        if self.config.bridge_command is None:
+            log_debug_event(logger, "whatsapp.bridge.start.skipped", reason="external")
+            return
+        if self._process is not None:
+            log_debug_event(logger, "whatsapp.bridge.start.skipped", reason="already_running")
             return
         env = {
             **os.environ,
@@ -402,12 +456,14 @@ class WhatsAppChannel:
             env["WHATSAPP_CHROME_PATH"] = self.config.chrome_path
         if self.config.web_version_cache_url:
             env["WHATSAPP_WEB_VERSION_CACHE_URL"] = self.config.web_version_cache_url
+        log_debug_event(logger, "whatsapp.bridge.starting")
         self._process = await asyncio.create_subprocess_exec(
             *self.config.bridge_command,
             env=env,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+        log_debug_event(logger, "whatsapp.bridge.spawned")
         if self._process.stdout is not None:
             self._bridge_stdout = asyncio.create_task(
                 self._forward_bridge_output(self._process.stdout, logging.INFO),
@@ -422,7 +478,9 @@ class WhatsAppChannel:
 
     async def _stop_bridge(self) -> None:
         if self._process is None:
+            log_debug_event(logger, "whatsapp.bridge.stop.skipped", reason="not_running")
             return
+        log_debug_event(logger, "whatsapp.bridge.stopping")
         self._process.terminate()
         try:
             await asyncio.wait_for(self._process.wait(), timeout=5)
@@ -431,6 +489,7 @@ class WhatsAppChannel:
             await self._process.wait()
         await self._stop_bridge_output_tasks()
         self._process = None
+        log_debug_event(logger, "whatsapp.bridge.stopped")
 
     async def _restart_bridge(self) -> None:
         logger.warning("Restarting WhatsApp bridge after failed health checks")
@@ -442,31 +501,72 @@ class WhatsAppChannel:
         while not self._stopped.is_set():
             try:
                 payload = await self._transport.get("/messages")
-                for message in _parse_messages(payload):
+                messages = _parse_messages(payload)
+                if messages:
+                    log_debug_event(
+                        logger,
+                        "whatsapp.poll.batch.received",
+                        message_count=len(messages),
+                    )
+                accepted = 0
+                for message in messages:
                     if self.config.exposure.allows(message):
+                        accepted += 1
                         checked = _enforce_inbound_media_cap(
                             message,
                             max_bytes=self.config.max_media_bytes,
                         )
-                        await dispatch_message(self._handler, checked, provider="WhatsApp")
-                    else:
-                        logger.debug(
-                            "Dropping WhatsApp message %s from %s due to exposure policy",
-                            message.message_id,
-                            message.conversation_id,
+                        log_debug_event(
+                            logger,
+                            "whatsapp.inbound.message.dispatching",
+                            has_media=bool(checked.metadata.get("has_media")),
+                            media_type=checked.metadata.get("media_type"),
+                            text_chars=len(checked.text),
                         )
+                        await dispatch_message(self._handler, checked, provider="WhatsApp")
+                        log_debug_event(logger, "whatsapp.inbound.message.dispatched")
+                    else:
+                        log_debug_event(
+                            logger,
+                            "whatsapp.inbound.message.rejected",
+                            exposure=self.config.exposure.mode.value,
+                            has_media=bool(message.metadata.get("has_media")),
+                            text_chars=len(message.text),
+                        )
+                if messages:
+                    log_debug_event(
+                        logger,
+                        "whatsapp.poll.batch.completed",
+                        accepted_count=accepted,
+                        rejected_count=len(messages) - accepted,
+                    )
             except _WhatsAppBridgeError:
                 logger.exception("Failed to poll WhatsApp bridge messages")
+                log_debug_event(logger, "whatsapp.poll.failed")
             await asyncio.sleep(self.config.poll_interval_seconds)
 
     async def _watch_health(self) -> None:
         while not self._stopped.is_set():
             try:
                 payload = await self._transport.get("/health")
+                previous_status = self._status
                 self._status = _parse_status(payload)
                 self._failed_health_checks = 0
+                if self._status != previous_status:
+                    log_debug_event(
+                        logger,
+                        "whatsapp.health.changed",
+                        connected=self._status.connected,
+                        status=self._status.detail,
+                    )
             except _WhatsAppBridgeError:
                 self._failed_health_checks += 1
+                log_debug_event(
+                    logger,
+                    "whatsapp.health.failed",
+                    consecutive_failures=self._failed_health_checks,
+                    restart_threshold=_FAILED_HEALTH_RESTART_THRESHOLD,
+                )
                 self._status = ChannelStatus(
                     provider="whatsapp",
                     connected=False,
@@ -494,6 +594,12 @@ class WhatsAppChannel:
                 await asyncio.sleep(0.2)
             else:
                 self._status = status
+                log_debug_event(
+                    logger,
+                    "whatsapp.bridge.ready",
+                    connected=status.connected,
+                    status=status.detail,
+                )
                 return
 
     async def _forward_bridge_output(
@@ -520,13 +626,17 @@ class WhatsAppChannel:
         self._bridge_stderr = None
 
     async def _post_result(self, path: str, payload: Mapping[str, object]) -> object:
+        log_debug_event(logger, "whatsapp.bridge.operation.started", path=path)
         response = await self._transport.post(path, payload)
         if isinstance(response, dict):
             result = cast("Mapping[str, object]", response)
             if result.get("success") is not False:
+                log_debug_event(logger, "whatsapp.bridge.operation.completed", path=path)
                 return response
+            log_debug_event(logger, "whatsapp.bridge.operation.failed", path=path)
             msg = str(result.get("error") or "WhatsApp bridge returned an error")
             raise _WhatsAppBridgeError(msg)
+        log_debug_event(logger, "whatsapp.bridge.operation.completed", path=path)
         return response
 
 
@@ -665,10 +775,12 @@ def _enforce_inbound_media_cap(message: ChannelMessage, *, max_bytes: int) -> Ch
         except FileNotFoundError:
             pass  # download may still be in progress
         except ChannelMediaError as error:
-            logger.warning(
-                "Skipping WhatsApp inbound media for message %s: %s",
-                message.message_id,
-                error,
+            logger.warning("Skipping WhatsApp inbound media that exceeds the configured limit")
+            log_debug_event(
+                logger,
+                "whatsapp.inbound.media.rejected",
+                error_type=type(error).__name__,
+                max_bytes=max_bytes,
             )
             changed = True
             continue

--- a/libs/talon/deepagents_talon/observability.py
+++ b/libs/talon/deepagents_talon/observability.py
@@ -109,8 +109,29 @@ def log_event(logger: logging.Logger, event: str, **fields: Any) -> None:
         event: Stable event name.
         fields: JSON-serializable event fields.
     """
+    _emit_event(logger, logging.INFO, event, fields)
+
+
+def log_debug_event(logger: logging.Logger, event: str, **fields: Any) -> None:
+    """Emit one structured JSON event when debug logging is enabled.
+
+    Args:
+        logger: Logger used by the emitting subsystem.
+        event: Stable event name.
+        fields: JSON-serializable event fields.
+    """
+    if logger.isEnabledFor(logging.DEBUG):
+        _emit_event(logger, logging.DEBUG, event, fields)
+
+
+def _emit_event(
+    logger: logging.Logger,
+    level: int,
+    event: str,
+    fields: Mapping[str, object],
+) -> None:
     payload = {"event": event, **_redact_mapping(fields)}
-    logger.info("talon_event %s", json.dumps(payload, sort_keys=True, default=str))
+    logger.log(level, "talon_event %s", json.dumps(payload, sort_keys=True, default=str))
 
 
 def redact_for_logging(value: object) -> object:

--- a/libs/talon/tests/channels/test_telegram.py
+++ b/libs/talon/tests/channels/test_telegram.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 from dataclasses import replace
 from pathlib import Path
@@ -822,6 +823,29 @@ async def test_send_message_uses_plain_text(tmp_path: Path) -> None:
     assert "parse_mode" not in params
     assert params["text"] == "hello *world*"
     assert params["chat_id"] == "123"
+
+
+async def test_send_message_debug_logs_are_payload_safe(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    transport = RecordingTransport()
+    channel = TelegramChannel(
+        _make_config(tmp_path),
+        transport=cast("_TelegramTransport", transport),
+    )
+    conversation_id = "private-chat-123"
+    text = "private message contents"
+
+    with caplog.at_level(logging.DEBUG, logger="deepagents_talon.channels.telegram"):
+        await channel.send_message(conversation_id, text)
+
+    assert "telegram.outbound.text.started" in caplog.text
+    assert "telegram.outbound.text.completed" in caplog.text
+    assert '"chunk_count": 1' in caplog.text
+    assert f'"text_chars": {len(text)}' in caplog.text
+    assert conversation_id not in caplog.text
+    assert text not in caplog.text
 
 
 async def test_send_message_chunks_long_text(tmp_path: Path) -> None:

--- a/libs/talon/tests/channels/test_whatsapp.py
+++ b/libs/talon/tests/channels/test_whatsapp.py
@@ -492,6 +492,29 @@ async def test_channel_sends_chunked_formatted_text(tmp_path: Path) -> None:
     assert cast("str", transport.posts[1][1]["text"]).startswith("*deepagents bot*\n")
 
 
+async def test_send_message_debug_logs_are_payload_safe(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    transport = RecordingTransport()
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(session_dir=tmp_path),
+        transport=cast("_BridgeTransport", transport),
+    )
+    conversation_id = "private-chat-123"
+    text = "private message contents"
+
+    with caplog.at_level(logging.DEBUG, logger="deepagents_talon.channels.whatsapp"):
+        await channel.send_message(conversation_id, text)
+
+    assert "whatsapp.outbound.text.started" in caplog.text
+    assert "whatsapp.outbound.text.completed" in caplog.text
+    assert '"chunk_count": 1' in caplog.text
+    assert f'"text_chars": {len(text)}' in caplog.text
+    assert conversation_id not in caplog.text
+    assert text not in caplog.text
+
+
 async def test_channel_sends_media_and_edits_messages(tmp_path: Path) -> None:
     transport = RecordingTransport()
     image = tmp_path / "image.png"

--- a/libs/talon/tests/test_main.py
+++ b/libs/talon/tests/test_main.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from deepagents_talon.__main__ import _channel_log_level, _configure_logging
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ({}, logging.INFO),
+        ({"DEEPAGENTS_CODE_DEBUG": "1"}, logging.DEBUG),
+        ({"DEEPAGENTS_CODE_DEBUG": " TrUe "}, logging.DEBUG),
+        ({"DEEPAGENTS_CODE_DEBUG": "on"}, logging.DEBUG),
+        ({"DEEPAGENTS_CODE_DEBUG": "false"}, logging.INFO),
+        ({"DEEPAGENTS_CODE_LOG_LEVEL": "debug"}, logging.DEBUG),
+        ({"DEEPAGENTS_CODE_LOG_LEVEL": " WARNING "}, logging.WARNING),
+        (
+            {
+                "DEEPAGENTS_CODE_DEBUG": "1",
+                "DEEPAGENTS_CODE_LOG_LEVEL": "INFO",
+            },
+            logging.INFO,
+        ),
+        (
+            {
+                "DEEPAGENTS_CODE_DEBUG": "1",
+                "DEEPAGENTS_CODE_LOG_LEVEL": "invalid",
+            },
+            logging.DEBUG,
+        ),
+        ({"DEEPAGENTS_CODE_LOG_LEVEL": "invalid"}, logging.INFO),
+    ],
+)
+def test_channel_log_level_matches_dcode_environment(
+    env: dict[str, str],
+    expected: int,
+) -> None:
+    assert _channel_log_level(env) == expected
+
+
+def test_configure_logging_enables_only_channel_debug_logs(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: calls.append(kwargs))
+    channel_logger = logging.getLogger("deepagents_talon.channels")
+    runtime_logger = logging.getLogger("deepagents_talon.runtime")
+    previous_channel_level = channel_logger.level
+    previous_runtime_level = runtime_logger.level
+
+    try:
+        _configure_logging({"DEEPAGENTS_CODE_DEBUG": "1"})
+
+        assert channel_logger.level == logging.DEBUG
+        assert runtime_logger.level == previous_runtime_level
+        assert calls == [
+            {
+                "level": logging.INFO,
+                "format": "%(levelname)s:%(name)s:%(message)s",
+            }
+        ]
+    finally:
+        channel_logger.setLevel(previous_channel_level)
+
+
+def test_channel_log_level_reports_invalid_value_without_echoing_it(caplog) -> None:
+    invalid_value = "private-invalid-value"
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_talon.__main__"):
+        level = _channel_log_level({"DEEPAGENTS_CODE_LOG_LEVEL": invalid_value})
+
+    assert level == logging.INFO
+    assert "DEEPAGENTS_CODE_LOG_LEVEL" in caplog.text
+    assert invalid_value not in caplog.text

--- a/libs/talon/tests/test_observability.py
+++ b/libs/talon/tests/test_observability.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from deepagents_talon.config import TalonConfig
 from deepagents_talon.host import TalonHost
 from deepagents_talon.interfaces import AgentRequest, AgentResult, ChannelMessage, ChannelStatus
-from deepagents_talon.observability import langsmith_tracing_enabled, log_event
+from deepagents_talon.observability import langsmith_tracing_enabled, log_debug_event, log_event
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterator
@@ -115,6 +115,26 @@ def test_log_event_emits_json_payload(caplog) -> None:
 
     payload = caplog.messages[0].removeprefix("talon_event ")
     assert json.loads(payload) == {"event": "cron.tick", "due_count": 2}
+
+
+def test_log_debug_event_requires_debug_level_and_redacts_fields(caplog) -> None:
+    logger = logging.getLogger("deepagents_talon.tests.debug")
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        log_debug_event(logger, "channel.hidden", conversation_id="private-chat")
+
+    assert caplog.messages == []
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        log_debug_event(logger, "channel.visible", conversation_id="private-chat", count=2)
+
+    payload = json.loads(caplog.messages[0].removeprefix("talon_event "))
+    assert payload == {
+        "conversation_id": "[redacted]",
+        "count": 2,
+        "event": "channel.visible",
+    }
+    assert "private-chat" not in caplog.text
 
 
 def test_log_event_redacts_secrets_and_url_credentials(caplog) -> None:


### PR DESCRIPTION
Operators can enable structured debug logs for Talon’s Telegram and WhatsApp channels without exposing message contents or credentials.

---

This adds configurable channel log levels plus redacted lifecycle, polling, request, media, delivery, retry, and health events. It is useful for diagnosing channel failures and timing issues while keeping the default output concise and sensitive values out of logs.

To enable full channel debug logging, set either environment variable before starting Talon:

```bash
export DEEPAGENTS_CODE_DEBUG=1
# Or set the channel log level explicitly:
export DEEPAGENTS_CODE_LOG_LEVEL=DEBUG
```

`DEEPAGENTS_CODE_DEBUG` also accepts `true`, `yes`, or `on` (case-insensitive). `DEEPAGENTS_CODE_LOG_LEVEL` accepts `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` and takes precedence when both variables are set. These settings enable debug output only for the `deepagents_talon.channels` logger; other Talon loggers remain at their normal levels.