### PR TITLE
feat(talon): keep typing indicator alive during long agent turns

### DIFF
--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -59,6 +59,7 @@ _APPROVE_REPLIES = frozenset({"approve", "approved", "yes", "y"})
 _DENY_REPLIES = frozenset({"deny", "denied", "reject", "rejected", "no", "n"})
 _RESET_THREAD_SEPARATOR = ":talon-reset:"
 _APPROVAL_LOG_RAW_IDS_ENV = "DEEPAGENTS_TALON_APPROVAL_LOG_RAW_IDS"
+_TYPING_REFRESH_SECONDS = 4.0
 _EMOJI_VARIATION_SELECTOR = "\ufe0f"
 _EMOJI_SKIN_TONES = frozenset(
     {
@@ -282,19 +283,26 @@ class TalonHost:
         if content != message.text:
             metadata["model_content"] = content
 
-        await _send_typing(channel, message.conversation_id)
-        result = await self._invoke_agent(
-            conversation_id=agent_conversation_id,
-            text=message.text,
-            metadata=metadata,
-            approval_handler=lambda approval: self._request_tool_approval(
-                channel,
-                approval,
-                provider=_channel_key(channel, provider),
-                reply_conversation_id=message.conversation_id,
-                sender_id=message.sender_id,
-            ),
+        typing_task = asyncio.create_task(
+            _typing_refresh_loop(channel, message.conversation_id),
         )
+        try:
+            result = await self._invoke_agent(
+                conversation_id=agent_conversation_id,
+                text=message.text,
+                metadata=metadata,
+                approval_handler=lambda approval: self._request_tool_approval(
+                    channel,
+                    approval,
+                    provider=_channel_key(channel, provider),
+                    reply_conversation_id=message.conversation_id,
+                    sender_id=message.sender_id,
+                ),
+            )
+        finally:
+            typing_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await typing_task
         await self._deliver_agent_result(channel, message.conversation_id, result)
 
     async def run_scheduled_job(self, job: CronJob) -> str:
@@ -749,6 +757,13 @@ async def _send_typing(channel: ChannelAdapter, conversation_id: str) -> None:
         await channel.send_typing(conversation_id)
     except Exception:  # noqa: BLE001  # typing indicators are best-effort adapter calls.
         logger.debug("Could not send typing indicator", exc_info=True)
+
+
+async def _typing_refresh_loop(channel: ChannelAdapter, conversation_id: str) -> None:
+    """Repeat the typing indicator for as long as an agent turn is in flight."""
+    while True:
+        await _send_typing(channel, conversation_id)
+        await asyncio.sleep(_TYPING_REFRESH_SECONDS)
 
 
 async def _channel_provider(channel: ChannelAdapter) -> str | None:

--- a/libs/talon/tests/conftest.py
+++ b/libs/talon/tests/conftest.py
@@ -30,6 +30,7 @@ class RecordingChannel:
         self.stopped = False
         self.sent: list[tuple[str, str]] = []
         self.media: list[tuple[str, ChannelMedia]] = []
+        self.typing_calls: list[str] = []
         self.status_report = ChannelStatus(provider=provider, connected=True, detail="connected")
 
     async def start(self) -> None:
@@ -61,7 +62,7 @@ class RecordingChannel:
         return SendResult(success=True)
 
     async def send_typing(self, conversation_id: str) -> None:
-        pass
+        self.typing_calls.append(conversation_id)
 
     async def status(self) -> ChannelStatus:
         return self.status_report

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -20,6 +20,8 @@ from tests.conftest import RecordingChannel
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
 
 class RecordingScheduler:
     def __init__(self) -> None:
@@ -155,6 +157,28 @@ async def test_host_serializes_messages_per_conversation(tmp_path: Path) -> None
 
     assert [request.text for request in agent.requests] == ["block", "second"]
     assert channel.sent == [("chat", "reply:block"), ("chat", "reply:second")]
+
+
+async def test_typing_indicator_refreshes_during_long_agent_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("deepagents_talon.host._TYPING_REFRESH_SECONDS", 0.01)
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+    await _wait_for_request(agent, "block")
+    await _wait_for_typing_count(channel, 3)
+
+    agent.released.set()
+    await _wait_for_sent_count(channel, 1)
+    await host.stop()
+
+    assert len(channel.typing_calls) >= 3
+    assert set(channel.typing_calls) == {"chat"}
 
 
 async def test_stop_cancels_in_flight_conversation(tmp_path: Path) -> None:
@@ -838,6 +862,15 @@ async def _wait_for_sent_count(channel: RecordingChannel, count: int) -> None:
             return
         await asyncio.sleep(0)
     msg = f"channel sent {len(channel.sent)} message(s), expected {count}"
+    raise AssertionError(msg)
+
+
+async def _wait_for_typing_count(channel: RecordingChannel, count: int) -> None:
+    for _ in range(200):
+        if len(channel.typing_calls) >= count:
+            return
+        await asyncio.sleep(0.01)
+    msg = f"channel received {len(channel.typing_calls)} typing call(s), expected {count}"
     raise AssertionError(msg)
 
 


### PR DESCRIPTION
## Summary
- Stacked on #5992 (Discord channel adapter).
- Channel typing indicators expire well before a slow agent turn finishes (Discord ~10s, Telegram ~5s), so a long response makes the "typing..." indicator disappear early.
- `TalonHost._run_agent_turn` now runs a background loop that refreshes the typing indicator every 4s for the duration of the agent invocation, cancelled once the result is ready (success or error path). This is a host-level fix — no channel adapter changes needed, since it just calls the existing `ChannelAdapter.send_typing` Protocol method repeatedly.

## Test plan
- [x] `uv run --group test pytest tests/test_host.py` — new test proves the typing indicator refreshes multiple times during a simulated long-running turn
- [x] `uv run --group test pytest` (full `libs/talon` suite)
- [x] `uv run --group test ruff check .`
- [x] `uv run --group test ty check` (clean aside from 2 pre-existing unrelated errors in `tests/test_observability.py`)
- [ ] Manual smoke test: send a prompt that takes the agent >15s to answer over Discord and confirm the typing indicator stays visible until the reply arrives