### PR TITLE
fix(sdk): normalize line endings in state and store edits

### DIFF
--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -26,6 +26,7 @@ from deepagents.backends.utils import (
     _copy_file_data_with_content,
     _get_backend_read_file_type,
     _glob_search_files,
+    _normalize_newlines,
     create_file_data,
     file_data_to_string,
     grep_matches_from_files,
@@ -237,6 +238,10 @@ class StateBackend(BackendProtocol):
             return EditResult(error=f"Error: File '{file_path}' not found")
 
         content = file_data_to_string(file_data)
+        if _get_backend_read_file_type(file_path) == "text":
+            content = _normalize_newlines(content)
+            old_string = _normalize_newlines(old_string)
+            new_string = _normalize_newlines(new_string)
         result = perform_string_replacement(content, old_string, new_string, replace_all)
 
         if isinstance(result, str):

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -27,6 +27,7 @@ from deepagents.backends.utils import (
     InvalidGlobPatternError,
     _get_backend_read_file_type,
     _glob_search_files,
+    _normalize_newlines,
     create_file_data,
     file_data_to_string,
     grep_matches_from_files,
@@ -494,6 +495,10 @@ class StoreBackend(BackendProtocol):
             return EditResult(error=f"Error: {e}")
 
         content = file_data_to_string(file_data)
+        if _get_backend_read_file_type(file_path) == "text":
+            content = _normalize_newlines(content)
+            old_string = _normalize_newlines(old_string)
+            new_string = _normalize_newlines(new_string)
         result = perform_string_replacement(content, old_string, new_string, replace_all)
 
         if isinstance(result, str):
@@ -532,6 +537,10 @@ class StoreBackend(BackendProtocol):
             return EditResult(error=f"Error: {e}")
 
         content = file_data_to_string(file_data)
+        if _get_backend_read_file_type(file_path) == "text":
+            content = _normalize_newlines(content)
+            old_string = _normalize_newlines(old_string)
+            new_string = _normalize_newlines(new_string)
         result = perform_string_replacement(content, old_string, new_string, replace_all)
 
         if isinstance(result, str):

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -197,6 +197,21 @@ def _normalize_content(file_data: FileData) -> str:
     return content
 
 
+def _normalize_newlines(content: str) -> str:
+    r"""Normalize CRLF and bare-CR newlines to LF.
+
+    `read()` and `edit()` share this normalization so exact-match edits can use
+    text copied from `read_file` output even when storage retains CRLF.
+
+    Args:
+        content: Text content that may contain `\r\n` and/or bare `\r`.
+
+    Returns:
+        Content with all line endings normalized to `\n`.
+    """
+    return content.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def sanitize_tool_call_id(tool_call_id: str) -> str:
     r"""Sanitize tool_call_id to prevent path traversal and separator issues.
 
@@ -506,7 +521,7 @@ def slice_read_response(
     # Normalize line endings to LF, but only across the requested window.
     # State/Store backends may carry CRLF or CR content as written;
     # downstream tooling (edit match, grep, format) assumes LF.
-    sliced = "".join(lines[start_idx:end_idx]).replace("\r\n", "\n").replace("\r", "\n")
+    sliced = _normalize_newlines("".join(lines[start_idx:end_idx]))
     next_offset = end_idx if end_idx < total_lines else None
     return ReadResult(
         file_data=_copy_file_data_with_content(file_data, sliced),

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
@@ -109,3 +109,31 @@ def test_state_backend_edit_migrates_legacy_list_content(monkeypatch: pytest.Mon
     assert result.error is None
     assert updates[0]["/legacy.txt"]["content"] == "hello\nthere"
     assert updates[0]["/legacy.txt"]["encoding"] == "utf-8"
+
+
+def test_state_backend_edit_normalizes_crlf_from_read_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CRLF-backed state files can be edited with LF text copied from `read`."""
+    backend = StateBackend()
+    files = {
+        "/main.py": {
+            "content": "def main():\r\n    print('hi')\r\n    return 0\r\n",
+            "encoding": "utf-8",
+        }
+    }
+    updates: list[dict[str, Any]] = []
+    monkeypatch.setattr(backend, "_read_files", lambda: files)
+    monkeypatch.setattr(backend, "_send_files_update", updates.append)
+
+    shown = backend.read("/main.py")
+    assert shown.file_data is not None
+    assert shown.file_data["content"] == "def main():\n    print('hi')\n    return 0\n"
+
+    result = backend.edit(
+        "/main.py",
+        "    print('hi')\n    return 0\n",
+        "    print('bye')\n    return 0\n",
+    )
+
+    assert result.error is None
+    assert result.occurrences == 1
+    assert updates[0]["/main.py"]["content"] == "def main():\n    print('bye')\n    return 0\n"

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -193,6 +193,29 @@ def test_store_backend_edit_migrates_legacy_list_content() -> None:
     assert stored.value["encoding"] == "utf-8"
 
 
+def test_store_backend_edit_normalizes_crlf_from_read_content() -> None:
+    """CRLF-backed store files can be edited with LF text copied from `read`."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/main.py", "def main():\r\n    print('hi')\r\n    return 0\r\n")
+
+    shown = be.read("/main.py")
+    assert shown.file_data is not None
+    assert shown.file_data["content"] == "def main():\n    print('hi')\n    return 0\n"
+
+    result = be.edit(
+        "/main.py",
+        "    print('hi')\n    return 0\n",
+        "    print('bye')\n    return 0\n",
+    )
+
+    assert result.error is None
+    assert result.occurrences == 1
+    stored = mem_store.get(("filesystem",), "/main.py")
+    assert stored is not None
+    assert stored.value["content"] == "def main():\n    print('bye')\n    return 0\n"
+
+
 def test_store_backend_write_overwrites_existing_file():
     mem_store = InMemoryStore()
     be = StoreBackend(store=mem_store, namespace=lambda _ctx: ("filesystem",))

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
@@ -117,6 +117,29 @@ async def test_store_backend_aedit_migrates_legacy_list_content() -> None:
     assert stored.value["encoding"] == "utf-8"
 
 
+async def test_store_backend_aedit_normalizes_crlf_from_aread_content() -> None:
+    """CRLF-backed store files can be edited with LF text copied from `aread`."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/main.py", "def main():\r\n    print('hi')\r\n    return 0\r\n")
+
+    shown = await be.aread("/main.py")
+    assert shown.file_data is not None
+    assert shown.file_data["content"] == "def main():\n    print('hi')\n    return 0\n"
+
+    result = await be.aedit(
+        "/main.py",
+        "    print('hi')\n    return 0\n",
+        "    print('bye')\n    return 0\n",
+    )
+
+    assert result.error is None
+    assert result.occurrences == 1
+    stored = await mem_store.aget(("filesystem",), "/main.py")
+    assert stored is not None
+    assert stored.value["content"] == "def main():\n    print('bye')\n    return 0\n"
+
+
 async def test_store_backend_aread_surfaces_pagination_metadata():
     """`StoreBackend.aread` propagates the pagination metadata from `slice_read_response`."""
     mem_store = InMemoryStore()


### PR DESCRIPTION
Fixes #5840

State and store files with CRLF line endings can now be edited using the LF-normalized text returned by `read_file`.

---

`StateBackend` and `StoreBackend` returned LF-normalized text from reads but matched edits against raw stored content. This normalizes textual content and replacement strings before exact matching, including the asynchronous store path. ContextHub is intentionally left for a follow-up.