### PR TITLE
fix(sdk): surface a failure a pipeline hides from `execute`

### DIFF
--- a/libs/deepagents/THREAT_MODEL.md
+++ b/libs/deepagents/THREAT_MODEL.md
@@ -128,7 +128,7 @@
 | C1 | Agent Factory (`graph.py`) | Assembles and returns a `CompiledStateGraph`; the primary user-facing API | framework-controlled | Yes | `graph.py:create_deep_agent`, `graph.py:resolve_model`, `graph.py:get_default_model` |
 | C2 | StateBackend | Stores files in LangGraph agent state (ephemeral, per-thread) | framework-controlled | **Yes** (default backend) | `backends/state.py:StateBackend.__init__`, `StateBackend.read`, `StateBackend.write`, `StateBackend.edit` |
 | C3 | FilesystemBackend | Reads/writes files directly from the host filesystem | user-controlled | No (opt-in) | `backends/filesystem.py:FilesystemBackend.__init__`, `FilesystemBackend._resolve_path` |
-| C4 | LocalShellBackend | FilesystemBackend + unrestricted local shell execution via `subprocess.run(shell=True)` | user-controlled | **No** (must be explicitly provided) | `backends/local_shell.py:LocalShellBackend.execute` |
+| C4 | LocalShellBackend | FilesystemBackend + unrestricted local shell execution via `subprocess.Popen(shell=True)` | user-controlled | **No** (must be explicitly provided) | `backends/local_shell.py:LocalShellBackend.execute` |
 | C5 | StoreBackend | Persistent cross-thread storage via LangGraph `BaseStore` | user-controlled | No (opt-in, requires `store=`) | `backends/store.py:StoreBackend.__init__`, `StoreBackend._validate_namespace` |
 | C6 | CompositeBackend | Routes file operations by path prefix to multiple backends | user-controlled | No (opt-in) | `backends/composite.py:CompositeBackend.__init__` |
 | C7 | MemoryMiddleware | Loads AGENTS.md files from backend and injects into system prompt | framework-controlled | No (opt-in, `memory=` param) | `middleware/memory.py:MemoryMiddleware.modify_request` |
@@ -177,7 +177,7 @@
 
 - **Inside** (virtual_mode=True only): `FilesystemBackend._resolve_path` checks `..` and `~` and verifies `full.relative_to(self.cwd)` (`backends/filesystem.py:FilesystemBackend._resolve_path`). `LocalShellBackend` runs commands with configurable timeout (`backends/local_shell.py:LocalShellBackend.execute`). Output capped at 100KB.
 - **Outside**: Host filesystem layout, environment variables, OS user permissions, installed software. Shell commands with `shell=True` have full access regardless of `virtual_mode`.
-- **Crossing mechanism**: `os.open` / `subprocess.run` with `shell=True` (LocalShellBackend).
+- **Crossing mechanism**: `os.open` / `subprocess.Popen` with `shell=True` (LocalShellBackend).
 
 #### TB6: Framework / Remote LangGraph API
 
@@ -197,7 +197,7 @@
 | DF4 | C1 (User) | C8 (SkillsMiddleware) | Skill source paths | — | TB1 | function argument |
 | DF5 | C1 (User) | C7 (MemoryMiddleware) | Memory file paths | — | TB1 | function argument |
 | DF6 | C1 (User) | C5 (StoreBackend) | Namespace factory callable | — | TB1 | function argument → callable invoked at runtime |
-| DF7 | C10 (LLM) | C4 (LocalShellBackend) | LLM-generated shell command string | DC4 | TB3, TB5 | function call → `subprocess.run(shell=True)` |
+| DF7 | C10 (LLM) | C4 (LocalShellBackend) | LLM-generated shell command string | DC4 | TB3, TB5 | function call → `subprocess.Popen(shell=True)` |
 | DF8 | C2/C3/C5 (Backend) | C9 (SubAgentMiddleware) | LangGraph state (files, todos, context) | DC1 | TB3 | state dict pass-through to subagent |
 | DF9 | C11 (Checkpointer) | C10 (LLM) | Deserialized checkpoint state (messages, files) | DC1 | TB4, TB2 | LangGraph checkpoint load → agent state → prompt |
 | DF10 | C12 (AsyncSubAgentMiddleware) | Remote LangGraph server | Task launch: `graph_id`, `description` (LLM-generated), `thread_id` | DC7 | TB6 | HTTPS via LangGraph SDK |
@@ -220,7 +220,7 @@
 
 #### DF7: LLM → LocalShellBackend (`execute`)
 
-- **Data**: LLM-generated shell command string, passed through `FilesystemMiddleware._create_execute_tool` to `subprocess.run(shell=True)`. Produces DC4 (shell output) that re-enters agent context via DF12.
+- **Data**: LLM-generated shell command string, passed through `FilesystemMiddleware._create_execute_tool` to `subprocess.Popen(shell=True)`. Produces DC4 (shell output) that re-enters agent context via DF12.
 - **Validation**: Command validated as non-empty string only (`backends/local_shell.py:LocalShellBackend.execute`). No command allow-listing, blocklisting, or pattern filtering. Timeout enforced (default 120s). Output truncated at 100KB.
 - **Trust assumption**: Requires user to explicitly provide `LocalShellBackend` (not the default) and trust the LLM + HITL middleware.
 
@@ -263,7 +263,7 @@
 #### T3: Arbitrary Shell Command Execution (LocalShellBackend)
 
 - **Flow**: DF7 (LLM → LocalShellBackend), DF12 (output → context)
-- **Description**: `LocalShellBackend.execute` passes the LLM-generated command string directly to `subprocess.run(shell=True)` at `backends/local_shell.py:LocalShellBackend.execute`. Zero validation on command content beyond a non-empty string check. Commands execute with the process owner's full permissions. With `inherit_env=True`, all process environment variables (including API keys) are available to every command.
+- **Description**: `LocalShellBackend.execute` passes the LLM-generated command string directly to `subprocess.Popen(shell=True)` at `backends/local_shell.py:LocalShellBackend.execute`. Zero validation on command content beyond a non-empty string check. Commands execute with the process owner's full permissions. With `inherit_env=True`, all process environment variables (including API keys) are available to every command.
 - **Preconditions**: User must explicitly configure `LocalShellBackend` as the backend (not the default — `StateBackend` is default, and it does not implement `SandboxBackendProtocol`, so the `execute` tool is filtered out at `middleware/filesystem.py:FilesystemMiddleware`). HITL middleware (`interrupt_on={"execute": True}`) is available but opt-in, not default.
 
 #### T4: Unsafe msgpack Deserialization in LangGraph Checkpointer

--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -11,18 +11,15 @@ import contextlib
 import os
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
 import uuid
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
 
 DEFAULT_EXECUTE_TIMEOUT = 120
 """Default timeout in seconds for shell command execution."""
@@ -39,6 +36,48 @@ rather than the wrapper, and the `EXIT` trap still fires, so the statuses are re
 way. Writing them to a file rather than a stream keeps the command's own stdout and stderr
 untouched.
 """
+
+
+def _run_shell(command: str, *, executable: str | None, timeout: int, env: dict[str, str], cwd: str) -> subprocess.CompletedProcess[str]:
+    """Run `command` under the shell, killing the whole process group on timeout.
+
+    `subprocess.run` kills only the process it started. That was enough when bash could
+    `exec` the command in place, but wrapping it to capture `PIPESTATUS` means the direct
+    child is the shell and the real work is a grandchild, which survives. The timeout is
+    listed in `THREAT_MODEL.md` as the mitigation at trust boundary TB5, so it has to reach
+    everything the command started.
+    """
+    new_session = sys.platform != "win32"
+    with subprocess.Popen(  # noqa: S602
+        command,
+        shell=True,  # Intentional: designed for LLM-controlled shell execution
+        executable=executable,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,  # Prevent hanging on commands that read stdin
+        text=True,
+        env=env,
+        cwd=cwd,
+        start_new_session=new_session,
+    ) as process:
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _terminate_process_group(process, new_session=new_session)
+            process.communicate()
+            raise
+    return subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
+
+
+def _terminate_process_group(process: subprocess.Popen, *, new_session: bool) -> None:
+    """Kill the timed-out command and anything it spawned."""
+    if not new_session:
+        process.kill()
+        return
+    try:
+        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        process.kill()
 
 
 def _prepare_pipeline_status_capture(command: str) -> tuple[str, str | None, str | None]:
@@ -67,8 +106,7 @@ def _read_pipeline_statuses(statusfile: str | None) -> list[int]:
     if statusfile is None:
         return []
     try:
-        with open(statusfile) as handle:  # noqa: PTH123
-            return [int(token) for token in handle.read().split()]
+        return [int(token) for token in Path(statusfile).read_text().split()]
     except (OSError, ValueError):
         return []
 
@@ -78,7 +116,7 @@ def _discard_status_file(statusfile: str | None) -> None:
     if statusfile is None:
         return
     with contextlib.suppress(OSError):
-        os.unlink(statusfile)  # noqa: PTH108
+        Path(statusfile).unlink()
 
 
 def _describe_pipeline_stages(statuses: list[int], returncode: int) -> str:
@@ -340,8 +378,10 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
 
             **Always use Human-in-the-Loop (HITL) middleware when using this method.**
 
-        The command is executed using the system shell (`/bin/sh` or equivalent)
-        with the working directory set to the backend's `root_dir`.
+        The command is executed using bash where it is available, falling back to the
+        system shell (`/bin/sh` or equivalent) otherwise, with the working directory set to
+        the backend's `root_dir`. Bash is preferred because it exposes `PIPESTATUS`, which
+        is what lets a failure hidden inside a pipeline be reported rather than dropped.
         Stdout and stderr are combined into a single output stream.
 
         Args:
@@ -406,22 +446,14 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
         run_command, bash, statusfile = _prepare_pipeline_status_capture(command)
 
         try:
-            result = subprocess.run(  # noqa: S602
+            result = _run_shell(
                 run_command,
-                check=False,
-                shell=True,  # Intentional: designed for LLM-controlled shell execution
                 executable=bash,
-                capture_output=True,
-                stdin=subprocess.DEVNULL,  # Prevent hanging on commands that read stdin (e.g. python, cat)
-                text=True,
                 timeout=effective_timeout,
                 env=self._env,
                 cwd=str(self.cwd),  # Use the root_dir from FilesystemBackend
-                start_new_session=(sys.platform != "win32"),
             )
-            stages = _describe_pipeline_stages(
-                _read_pipeline_statuses(statusfile), result.returncode
-            )
+            stages = _describe_pipeline_stages(_read_pipeline_statuses(statusfile), result.returncode)
 
             output, truncated = self._combine_output(result.stdout, result.stderr)
             if stages:

--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -24,17 +24,30 @@ from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 DEFAULT_EXECUTE_TIMEOUT = 120
 """Default timeout in seconds for shell command execution."""
 
+_POSIX = sys.platform != "win32"
+"""Whether this host has POSIX process groups and a POSIX shell. Windows has neither."""
+
 _MIN_PIPELINE_STAGES = 2
 """Below this, the recorded statuses say nothing `returncode` does not already say."""
+
+_SIGPIPE_STATUS = 141
+"""128 + `SIGPIPE`: how a shell reports a stage stopped because a later stage stopped reading.
+
+`seq 1 100000 | head -3` and `yes | head` end this way by construction, so this status on a
+non-final stage is the pipeline working rather than a fault. It is excluded from the check
+for a hidden failure, and spelled out wherever it is shown, because a bare `141` reads as an
+error to a model.
+"""
 
 _PIPESTATUS_WRAPPER = """trap 'printf "%s " "${{PIPESTATUS[@]}}" > {statusfile}' EXIT
 {command}"""
 """Run the command under bash and side-channel the per-stage statuses of its last pipeline.
 
-The subshell is what makes this safe: a command containing `exit` terminates the subshell
-rather than the wrapper, and the `EXIT` trap still fires, so the statuses are recorded either
-way. Writing them to a file rather than a stream keeps the command's own stdout and stderr
-untouched.
+The `EXIT` trap fires however the command ends, including on `exit`, so the statuses are
+always recorded. `exit` is a builtin that returns before `PIPESTATUS` is reset, though, so
+what the trap records then belongs to an earlier pipeline; `_describe_pipeline_stages` detects
+that and reports nothing. Writing to a file rather than a stream keeps the command's own
+stdout and stderr untouched.
 """
 
 
@@ -47,7 +60,6 @@ def _run_shell(command: str, *, executable: str | None, timeout: int, env: dict[
     listed in `THREAT_MODEL.md` as the mitigation at trust boundary TB5, so it has to reach
     everything the command started.
     """
-    new_session = sys.platform != "win32"
     with subprocess.Popen(  # noqa: S602
         command,
         shell=True,  # Intentional: designed for LLM-controlled shell execution
@@ -58,40 +70,66 @@ def _run_shell(command: str, *, executable: str | None, timeout: int, env: dict[
         text=True,
         env=env,
         cwd=cwd,
-        start_new_session=new_session,
+        start_new_session=_POSIX,
     ) as process:
         try:
             stdout, stderr = process.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
-            _terminate_process_group(process, new_session=new_session)
-            process.communicate()
+            _terminate_process_group(process)
+            _collect_killed_process(process)
             raise
     return subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
 
 
-def _terminate_process_group(process: subprocess.Popen, *, new_session: bool) -> None:
-    """Kill the timed-out command and anything it spawned."""
-    if not new_session:
+def _terminate_process_group(process: subprocess.Popen[str]) -> None:
+    """Kill the timed-out command and anything it spawned.
+
+    `start_new_session=True` makes the shell the leader of a new process group, so its pgid
+    is its pid and `os.killpg` reaches every descendant. Looking the pgid up with
+    `os.getpgid` instead fails in exactly the case that matters: a shell that has already
+    returned while leaving a background descendant behind is an unreaped zombie, and on macOS
+    `os.getpgid` raises `ProcessLookupError` for it, so nothing is signalled at all.
+    """
+    if not _POSIX:
         process.kill()
         return
     try:
-        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
-    except (OSError, ProcessLookupError):
+        os.killpg(process.pid, signal.SIGKILL)
+    except OSError:
         process.kill()
+
+
+def _collect_killed_process(process: subprocess.Popen[str]) -> None:
+    """Collect the killed shell, doing what `subprocess.run` does on each platform.
+
+    Windows accumulates the output on reader threads that only `communicate` joins. On POSIX
+    `communicate` would read the pipes to EOF with no timeout, so a descendant that inherited
+    them could hold `execute` open for its whole lifetime, long past the timeout. `wait`
+    waits only for the shell, which has just been killed.
+    """
+    if _POSIX:
+        process.wait()
+    else:
+        process.communicate()
 
 
 def _prepare_pipeline_status_capture(command: str) -> tuple[str, str | None, str | None]:
     """Wrap `command` so its pipeline statuses are recoverable, when the shell allows it.
 
     Returns the command to run, the shell to run it with, and the status file to read
-    afterwards. Where bash is unavailable -- POSIX `sh` has no `PIPESTATUS`, and Windows has
-    no `sh` at all -- returns the command untouched and `None` for the rest, leaving the
-    existing behaviour exactly as it was.
+    afterwards. Where the wrapper cannot be set up -- POSIX `sh` has no `PIPESTATUS`, Windows
+    has no `sh` at all, and a read-only or exhausted temp directory has nowhere to record the
+    statuses -- returns the command untouched and `None` for the rest, leaving the existing
+    behaviour exactly as it was. The detail is a diagnostic, so failing to arrange it must
+    never stop the agent's command from running.
     """
-    bash = shutil.which("bash") if sys.platform != "win32" else None
+    bash = shutil.which("bash") if _POSIX else None
     if bash is None:
         return command, None, None
-    descriptor, statusfile = tempfile.mkstemp(prefix="deepagents-pipestatus-")
+    try:
+        descriptor, statusfile = tempfile.mkstemp(prefix="deepagents-pipestatus-")
+    except OSError:
+        return command, None, None
     os.close(descriptor)
     wrapped = _PIPESTATUS_WRAPPER.format(statusfile=shlex.quote(statusfile), command=command)
     return wrapped, bash, statusfile
@@ -133,14 +171,18 @@ def _describe_pipeline_stages(statuses: list[int], returncode: int) -> str:
     - A last stage disagreeing with `returncode` means the array is stale. `exit` is a
       builtin that terminates before `PIPESTATUS` is reset, so for `false | cat; exit 9`
       the trap still sees the earlier pipeline's `[1, 0]` while the command exited 9.
+    - No non-final stage failing. `returncode` is the last stage's status, so for
+      `cat hosts | grep -c zzz` the detail would only repeat it, and a pipeline whose
+      earlier stages were all fine has nothing hidden in it. `SIGPIPE` does not count as a
+      failure here, since it is how `seq 1 100000 | head -3` is meant to end.
     """
     if len(statuses) < _MIN_PIPELINE_STAGES:
         return ""
     if statuses[-1] != returncode:
         return ""
-    if all(status == 0 for status in statuses):
+    if all(status in (0, _SIGPIPE_STATUS) for status in statuses[:-1]):
         return ""
-    return ", ".join(str(status) for status in statuses)
+    return ", ".join(f"{status} (SIGPIPE)" if status == _SIGPIPE_STATUS else str(status) for status in statuses)
 
 
 class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
@@ -365,7 +407,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
         !!! danger "Unrestricted Execution"
 
             Commands are executed directly on your host system
-            using `subprocess.run()` with `shell=True`. There is **no sandboxing,
+            using `subprocess.Popen` with `shell=True`. There is **no sandboxing,
             isolation, or security restrictions**. The command runs with
             your user's full permissions and can:
 

--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -27,15 +27,11 @@ if TYPE_CHECKING:
 DEFAULT_EXECUTE_TIMEOUT = 120
 """Default timeout in seconds for shell command execution."""
 
-_SIGPIPE_STATUS = 128 + 13
-"""Exit status of a process killed by `SIGPIPE`, i.e. one whose reader closed the pipe."""
-
 _MIN_PIPELINE_STAGES = 2
 """Below this, the recorded statuses say nothing `returncode` does not already say."""
 
-_PIPESTATUS_WRAPPER = """( trap 'printf "%s " "${{PIPESTATUS[@]}}" > {statusfile}' EXIT
-{command}
-)"""
+_PIPESTATUS_WRAPPER = """trap 'printf "%s " "${{PIPESTATUS[@]}}" > {statusfile}' EXIT
+{command}"""
 """Run the command under bash and side-channel the per-stage statuses of its last pipeline.
 
 The subshell is what makes this safe: a command containing `exit` terminates the subshell
@@ -66,7 +62,7 @@ def _read_pipeline_statuses(statusfile: str | None) -> list[int]:
     """Read the statuses the wrapper recorded, tolerating anything unexpected.
 
     An unreadable or malformed file must never fail the command the agent ran, so this
-    degrades to an empty list, which `_resolve_pipeline_status` treats as "use returncode".
+    degrades to an empty list, which `_describe_pipeline_stages` reports nothing for.
     """
     if statusfile is None:
         return []
@@ -85,31 +81,28 @@ def _discard_status_file(statusfile: str | None) -> None:
         os.unlink(statusfile)  # noqa: PTH108
 
 
-def _resolve_pipeline_status(statuses: list[int], returncode: int) -> int:
-    """Reduce a pipeline's per-stage statuses to the one worth reporting.
+def _describe_pipeline_stages(statuses: list[int], returncode: int) -> str:
+    """Describe a pipeline's per-stage statuses, or "" when there is nothing to add.
 
-    A shell reports only the last stage of a pipeline, so `pytest ... | tail` looks
-    successful whenever `tail` succeeds. Walking the stages instead surfaces the failure
-    the agent actually needs to see.
+    Deliberately does not decide whether the command failed. Nothing at this layer can:
+    `pytest` exiting 1 means the tests failed, `grep` exiting 1 means it matched nothing,
+    and the shell cannot tell them apart. The agent can, because it chose the command, so
+    the stage statuses are reported and the judgement is left to the reader.
 
-    Two rules matter:
+    Returns "" when the statuses add nothing or cannot be trusted:
 
-    - A stage killed by `SIGPIPE` *before the last one* is not a failure. It means a later
-      stage closed the pipe early, which is exactly what `head` and `grep -q` do on
-      purpose. Treating it as failure would break far more commands than it fixes.
-    - Fewer than two stages carries no more information than `returncode` and can carry
-      less: for `echo hi; exit 5` the last pipeline succeeded, so the statuses read `[0]`
-      while the command as a whole exited 5. Defer to `returncode` there.
+    - Fewer than two stages says no more than `returncode` already does.
+    - A last stage disagreeing with `returncode` means the array is stale. `exit` is a
+      builtin that terminates before `PIPESTATUS` is reset, so for `false | cat; exit 9`
+      the trap still sees the earlier pipeline's `[1, 0]` while the command exited 9.
     """
     if len(statuses) < _MIN_PIPELINE_STAGES:
-        return returncode
-    last = len(statuses) - 1
-    for index, status in enumerate(statuses):
-        if status == _SIGPIPE_STATUS and index < last:
-            continue
-        if status != 0:
-            return status
-    return 0
+        return ""
+    if statuses[-1] != returncode:
+        return ""
+    if all(status == 0 for status in statuses):
+        return ""
+    return ", ".join(str(status) for status in statuses)
 
 
 class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
@@ -426,17 +419,19 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 cwd=str(self.cwd),  # Use the root_dir from FilesystemBackend
                 start_new_session=(sys.platform != "win32"),
             )
-            returncode = result.returncode
-            if statusfile is not None:
-                returncode = _resolve_pipeline_status(_read_pipeline_statuses(statusfile), result.returncode)
+            stages = _describe_pipeline_stages(
+                _read_pipeline_statuses(statusfile), result.returncode
+            )
 
             output, truncated = self._combine_output(result.stdout, result.stderr)
-            if returncode != 0:
-                output = f"{output.rstrip()}\n\nExit code: {returncode}"
+            if stages:
+                output = f"{output.rstrip()}\n\nPipeline stages exited: {stages}"
+            if result.returncode != 0:
+                output = f"{output.rstrip()}\n\nExit code: {result.returncode}"
 
             return ExecuteResponse(
                 output=output,
-                exit_code=returncode,
+                exit_code=result.returncode,
                 truncated=truncated,
             )
 

--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -7,9 +7,13 @@ run directly on the host machine with full system access.
 
 from __future__ import annotations
 
+import contextlib
 import os
+import shlex
+import shutil
 import subprocess
 import sys
+import tempfile
 import uuid
 from typing import TYPE_CHECKING
 
@@ -22,6 +26,90 @@ if TYPE_CHECKING:
 
 DEFAULT_EXECUTE_TIMEOUT = 120
 """Default timeout in seconds for shell command execution."""
+
+_SIGPIPE_STATUS = 128 + 13
+"""Exit status of a process killed by `SIGPIPE`, i.e. one whose reader closed the pipe."""
+
+_MIN_PIPELINE_STAGES = 2
+"""Below this, the recorded statuses say nothing `returncode` does not already say."""
+
+_PIPESTATUS_WRAPPER = """( trap 'printf "%s " "${{PIPESTATUS[@]}}" > {statusfile}' EXIT
+{command}
+)"""
+"""Run the command under bash and side-channel the per-stage statuses of its last pipeline.
+
+The subshell is what makes this safe: a command containing `exit` terminates the subshell
+rather than the wrapper, and the `EXIT` trap still fires, so the statuses are recorded either
+way. Writing them to a file rather than a stream keeps the command's own stdout and stderr
+untouched.
+"""
+
+
+def _prepare_pipeline_status_capture(command: str) -> tuple[str, str | None, str | None]:
+    """Wrap `command` so its pipeline statuses are recoverable, when the shell allows it.
+
+    Returns the command to run, the shell to run it with, and the status file to read
+    afterwards. Where bash is unavailable -- POSIX `sh` has no `PIPESTATUS`, and Windows has
+    no `sh` at all -- returns the command untouched and `None` for the rest, leaving the
+    existing behaviour exactly as it was.
+    """
+    bash = shutil.which("bash") if sys.platform != "win32" else None
+    if bash is None:
+        return command, None, None
+    descriptor, statusfile = tempfile.mkstemp(prefix="deepagents-pipestatus-")
+    os.close(descriptor)
+    wrapped = _PIPESTATUS_WRAPPER.format(statusfile=shlex.quote(statusfile), command=command)
+    return wrapped, bash, statusfile
+
+
+def _read_pipeline_statuses(statusfile: str | None) -> list[int]:
+    """Read the statuses the wrapper recorded, tolerating anything unexpected.
+
+    An unreadable or malformed file must never fail the command the agent ran, so this
+    degrades to an empty list, which `_resolve_pipeline_status` treats as "use returncode".
+    """
+    if statusfile is None:
+        return []
+    try:
+        with open(statusfile) as handle:  # noqa: PTH123
+            return [int(token) for token in handle.read().split()]
+    except (OSError, ValueError):
+        return []
+
+
+def _discard_status_file(statusfile: str | None) -> None:
+    """Remove the status side-channel, tolerating it never having been created."""
+    if statusfile is None:
+        return
+    with contextlib.suppress(OSError):
+        os.unlink(statusfile)  # noqa: PTH108
+
+
+def _resolve_pipeline_status(statuses: list[int], returncode: int) -> int:
+    """Reduce a pipeline's per-stage statuses to the one worth reporting.
+
+    A shell reports only the last stage of a pipeline, so `pytest ... | tail` looks
+    successful whenever `tail` succeeds. Walking the stages instead surfaces the failure
+    the agent actually needs to see.
+
+    Two rules matter:
+
+    - A stage killed by `SIGPIPE` *before the last one* is not a failure. It means a later
+      stage closed the pipe early, which is exactly what `head` and `grep -q` do on
+      purpose. Treating it as failure would break far more commands than it fixes.
+    - Fewer than two stages carries no more information than `returncode` and can carry
+      less: for `echo hi; exit 5` the last pipeline succeeded, so the statuses read `[0]`
+      while the command as a whole exited 5. Defer to `returncode` there.
+    """
+    if len(statuses) < _MIN_PIPELINE_STAGES:
+        return returncode
+    last = len(statuses) - 1
+    for index, status in enumerate(statuses):
+        if status == _SIGPIPE_STATUS and index < last:
+            continue
+        if status != 0:
+            return status
+    return 0
 
 
 class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
@@ -213,6 +301,28 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
         """
         return self._sandbox_id
 
+    def _combine_output(self, stdout: str, stderr: str) -> tuple[str, bool]:
+        r"""Merge stdout and stderr into one stream, truncating past the size limit.
+
+        Each stderr line is prefixed with `[stderr]` for clear attribution, e.g.
+        `hello\n[stderr] error: file not found`.
+        """
+        output_parts = []
+        if stdout:
+            output_parts.append(stdout)
+        if stderr:
+            output_parts.extend(f"[stderr] {line}" for line in stderr.strip().split("\n"))
+
+        output = "\n".join(output_parts) if output_parts else "<no output>"
+
+        if len(output) > self._max_output_bytes:
+            truncated_output = output[: self._max_output_bytes]
+            return (
+                f"{truncated_output}\n\n... Output truncated at {self._max_output_bytes} bytes.",
+                True,
+            )
+        return output, False
+
     def execute(
         self,
         command: str,
@@ -300,11 +410,14 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
             msg = f"timeout must be positive, got {effective_timeout}"
             raise ValueError(msg)
 
+        run_command, bash, statusfile = _prepare_pipeline_status_capture(command)
+
         try:
             result = subprocess.run(  # noqa: S602
-                command,
+                run_command,
                 check=False,
                 shell=True,  # Intentional: designed for LLM-controlled shell execution
+                executable=bash,
                 capture_output=True,
                 stdin=subprocess.DEVNULL,  # Prevent hanging on commands that read stdin (e.g. python, cat)
                 text=True,
@@ -313,33 +426,17 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 cwd=str(self.cwd),  # Use the root_dir from FilesystemBackend
                 start_new_session=(sys.platform != "win32"),
             )
+            returncode = result.returncode
+            if statusfile is not None:
+                returncode = _resolve_pipeline_status(_read_pipeline_statuses(statusfile), result.returncode)
 
-            # Combine stdout and stderr
-            # Prefix each stderr line with [stderr] for clear attribution.
-            # Example: "hello\n[stderr] error: file not found"  # noqa: ERA001
-            output_parts = []
-            if result.stdout:
-                output_parts.append(result.stdout)
-            if result.stderr:
-                stderr_lines = result.stderr.strip().split("\n")
-                output_parts.extend(f"[stderr] {line}" for line in stderr_lines)
-
-            output = "\n".join(output_parts) if output_parts else "<no output>"
-
-            # Check for truncation
-            truncated = False
-            if len(output) > self._max_output_bytes:
-                output = output[: self._max_output_bytes]
-                output += f"\n\n... Output truncated at {self._max_output_bytes} bytes."
-                truncated = True
-
-            # Add exit code info if non-zero
-            if result.returncode != 0:
-                output = f"{output.rstrip()}\n\nExit code: {result.returncode}"
+            output, truncated = self._combine_output(result.stdout, result.stderr)
+            if returncode != 0:
+                output = f"{output.rstrip()}\n\nExit code: {returncode}"
 
             return ExecuteResponse(
                 output=output,
-                exit_code=result.returncode,
+                exit_code=returncode,
                 truncated=truncated,
             )
 
@@ -361,6 +458,8 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 exit_code=1,
                 truncated=False,
             )
+        finally:
+            _discard_status_file(statusfile)
 
 
 __all__ = ["DEFAULT_EXECUTE_TIMEOUT", "LocalShellBackend"]

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from deepagents.backends.local_shell import LocalShellBackend, _resolve_pipeline_status
+from deepagents.backends.local_shell import LocalShellBackend, _describe_pipeline_stages
 from deepagents.backends.protocol import ExecuteResponse
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="LocalShellBackend requires sh, not available on Windows")
@@ -384,72 +384,82 @@ class TestLocalShellVirtualModeDefault:
         assert deprecations == []
 
 
-@pytest.mark.skipif(shutil.which("bash") is None, reason="pipeline status recovery requires bash")
+@pytest.mark.skipif(shutil.which("bash") is None, reason="pipeline status detail requires bash")
 @pytest.mark.parametrize(
-    ("command", "expected"),
+    ("command", "expected_stages"),
     [
-        pytest.param("sh -c 'echo out; exit 1' | tail -1", 1, id="failure-piped-into-filter"),
-        pytest.param("sh -c 'exit 3' | sh -c 'exit 0' | tail -1", 3, id="first-of-three-stages-fails"),
-        pytest.param("echo hi | cat", 0, id="clean-pipeline"),
+        pytest.param("sh -c 'echo out; exit 1' | tail -1", "1, 0", id="failure-hidden-by-a-filter"),
+        pytest.param("sh -c 'exit 3' | sh -c 'exit 0' | tail -1", "3, 0, 0", id="first-of-three-stages"),
+        pytest.param("grep zzz /etc/hosts | wc -l", "1, 0", id="non-zero-as-information-is-still-shown"),
     ],
 )
-def test_local_shell_backend_reports_failure_masked_by_a_pipeline(command: str, expected: int) -> None:
-    """A shell reports only a pipeline's last stage, hiding `pytest ... | tail`-style failures."""
+def test_local_shell_backend_reports_pipeline_stage_statuses(command: str, expected_stages: str) -> None:
+    """The stages a shell hides are surfaced for the agent to interpret."""
     with tempfile.TemporaryDirectory() as temp_dir:
         result = LocalShellBackend(root_dir=temp_dir).execute(command)
-        assert result.exit_code == expected
+        assert f"Pipeline stages exited: {expected_stages}" in result.output
 
 
-@pytest.mark.skipif(shutil.which("bash") is None, reason="pipeline status recovery requires bash")
 @pytest.mark.parametrize(
     "command",
     [
-        pytest.param("seq 1 100000 | head -3", id="head-closes-the-pipe"),
-        pytest.param("yes | head -1", id="infinite-writer-closed-early"),
-        pytest.param("seq 1 100000 | grep -q 5", id="grep-q-exits-on-first-match"),
+        pytest.param("grep zzz /etc/hosts | wc -l", id="grep-no-match"),
+        pytest.param("diff /etc/hosts /etc/passwd | head -2", id="diff-differs"),
+        pytest.param("sh -c 'echo out; exit 1' | tail -1", id="failure-hidden-by-a-filter"),
+        pytest.param("seq 1 100000 | head -3", id="reader-exits-early"),
+        pytest.param("false | cat; exit 9", id="command-exiting-after-a-pipeline"),
+        pytest.param("{ sh -c 'exit 3' | cat; } || exit 0", id="explicit-suppression"),
+        pytest.param("echo a; exit 5", id="command-exiting-directly"),
+        pytest.param("sh -c 'exit 7'", id="plain-failure"),
+        pytest.param("echo ok", id="plain-success"),
     ],
 )
-def test_local_shell_backend_ignores_sigpipe_from_a_reader_exiting_early(command: str) -> None:
-    """`head` and `grep -q` close the pipe on purpose; the writer's SIGPIPE is not a failure."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        result = LocalShellBackend(root_dir=temp_dir).execute(command)
-        assert result.exit_code == 0
+def test_local_shell_backend_never_changes_the_exit_code(command: str) -> None:
+    """Reporting stage detail must not rewrite the status.
 
-
-@pytest.mark.parametrize(
-    ("command", "expected"),
-    [
-        pytest.param("sh -c 'exit 1'; echo done", 0, id="semicolon-chain-reports-last-command"),
-        pytest.param("sh -c 'exit 1' || true", 0, id="explicit-suppression-is-honoured"),
-        pytest.param("echo a; exit 5", 5, id="command-exiting-directly"),
-        pytest.param("sh -c 'exit 7'", 7, id="plain-failure"),
-        pytest.param("echo ok", 0, id="plain-success"),
-    ],
-)
-def test_local_shell_backend_leaves_non_pipeline_status_alone(command: str, expected: int) -> None:
-    """`a; b` and `a || true` mean what they say -- recovering a status there would break them."""
+    Nothing at this layer can tell `pytest` exiting 1 from `grep` exiting 1, so it does not
+    try. Every command must return exactly what a plain shell would.
+    """
+    expected = subprocess.run(command, shell=True, capture_output=True, check=False).returncode  # noqa: S602
     with tempfile.TemporaryDirectory() as temp_dir:
         result = LocalShellBackend(root_dir=temp_dir).execute(command)
         assert result.exit_code == expected
 
 
-def test_local_shell_backend_pipeline_recovery_preserves_output() -> None:
-    """The status side-channel must not leak into the output the agent reads."""
+@pytest.mark.skipif(shutil.which("bash") is None, reason="pipeline status detail requires bash")
+def test_local_shell_backend_omits_stale_pipeline_detail() -> None:
+    """`exit` terminates before PIPESTATUS is reset, so the trap can see an older pipeline."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = LocalShellBackend(root_dir=temp_dir).execute("false | cat; exit 9")
+        assert "Pipeline stages exited" not in result.output
+        assert result.exit_code == 9
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="pipeline status detail requires bash")
+def test_local_shell_backend_wrapper_preserves_an_unterminated_heredoc() -> None:
+    """The wrapper must not turn a command a plain shell accepts into a syntax error."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = LocalShellBackend(root_dir=temp_dir).execute("cat <<EOF\nhello")
+        assert result.exit_code == 0
+        assert "hello" in result.output
+
+
+def test_local_shell_backend_pipeline_detail_preserves_output() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         result = LocalShellBackend(root_dir=temp_dir).execute("echo HELLO | cat")
-        assert result.output.strip() == "HELLO"
+        assert result.output.splitlines()[0] == "HELLO"
 
 
 @pytest.mark.parametrize(
     ("statuses", "returncode", "expected"),
     [
-        pytest.param([1, 0], 0, 1, id="earlier-stage-failed"),
-        pytest.param([141, 0], 0, 0, id="sigpipe-before-last-stage-is-benign"),
-        pytest.param([0, 141], 141, 141, id="sigpipe-on-last-stage-is-real"),
-        pytest.param([0], 5, 5, id="single-stage-defers-to-returncode"),
-        pytest.param([], 5, 5, id="unavailable-defers-to-returncode"),
-        pytest.param([0, 0], 0, 0, id="all-clean"),
+        pytest.param([1, 0], 0, "1, 0", id="earlier-stage-failed"),
+        pytest.param([141, 0], 0, "141, 0", id="sigpipe-reported-not-judged"),
+        pytest.param([0, 0], 0, "", id="all-clean-adds-nothing"),
+        pytest.param([0], 5, "", id="single-stage-adds-nothing"),
+        pytest.param([], 5, "", id="unavailable"),
+        pytest.param([1, 0], 9, "", id="stale-array-suppressed"),
     ],
 )
-def test_resolve_pipeline_status(statuses: list[int], returncode: int, expected: int) -> None:
-    assert _resolve_pipeline_status(statuses, returncode) == expected
+def test_describe_pipeline_stages(statuses: list[int], returncode: int, expected: str) -> None:
+    assert _describe_pipeline_stages(statuses, returncode) == expected

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -1,6 +1,8 @@
 """Unit tests for LocalShellBackend."""
 
+import errno
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -12,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from deepagents.backends.local_shell import LocalShellBackend, _describe_pipeline_stages
+from deepagents.backends.local_shell import LocalShellBackend, _describe_pipeline_stages, _prepare_pipeline_status_capture
 from deepagents.backends.protocol import ExecuteResponse
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="LocalShellBackend requires sh, not available on Windows")
@@ -458,7 +460,12 @@ def test_local_shell_backend_pipeline_detail_preserves_output() -> None:
     ("statuses", "returncode", "expected"),
     [
         pytest.param([1, 0], 0, "1, 0", id="earlier-stage-failed"),
-        pytest.param([141, 0], 0, "141, 0", id="sigpipe-reported-not-judged"),
+        pytest.param([3, 0, 0], 0, "3, 0, 0", id="first-of-three-stages-failed"),
+        pytest.param([2, 141, 0], 0, "2, 141 (SIGPIPE), 0", id="sigpipe-spelled-out-alongside-a-real-failure"),
+        pytest.param([0, 1], 1, "", id="only-the-last-stage-failed-so-the-exit-code-says-it"),
+        pytest.param([0, 0, 5], 5, "", id="only-the-last-of-three-failed"),
+        pytest.param([141, 0], 0, "", id="sigpipe-alone-is-how-a-reader-stops-a-producer"),
+        pytest.param([141, 141, 0], 0, "", id="sigpipe-throughout-adds-nothing"),
         pytest.param([0, 0], 0, "", id="all-clean-adds-nothing"),
         pytest.param([0], 5, "", id="single-stage-adds-nothing"),
         pytest.param([], 5, "", id="unavailable"),
@@ -469,27 +476,112 @@ def test_describe_pipeline_stages(statuses: list[int], returncode: int, expected
     assert _describe_pipeline_stages(statuses, returncode) == expected
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="process groups are POSIX-only")
-def test_local_shell_backend_timeout_kills_what_the_command_started() -> None:
-    """A timed-out command must die, not just stop being waited on.
+@pytest.mark.skipif(shutil.which("bash") is None, reason="pipeline status detail requires bash")
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param("cat /etc/hosts | grep -c zzz", id="only-the-last-stage-failed"),
+        pytest.param("seq 1 100000 | head -3", id="reader-stops-the-producer"),
+        pytest.param("yes | head -2", id="endless-producer-stopped-by-its-reader"),
+        pytest.param("echo hi | cat", id="nothing-went-wrong"),
+    ],
+)
+def test_local_shell_backend_omits_detail_a_reader_cannot_use(command: str) -> None:
+    """Detail that only repeats the exit code, or that reports a pipeline working, is noise.
 
-    Wrapping the command to capture `PIPESTATUS` stops bash `exec`-ing it in place, so the
-    direct child is the shell and the real work is a grandchild. Killing only the child
-    would leave it running. `THREAT_MODEL.md` lists this timeout as the mitigation at trust
-    boundary TB5.
+    `grep -c` exiting 1 as the last stage is already in `Exit code: 1`, and the 141 that
+    `head` provokes in `seq` is how the command is supposed to end. A bare number next to
+    either reads as a second, unexplained failure.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = LocalShellBackend(root_dir=temp_dir).execute(command)
+        assert "Pipeline stages exited" not in result.output
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="pipeline status detail requires bash")
+def test_local_shell_backend_names_sigpipe_when_it_reports_a_hidden_failure() -> None:
+    """When there is a real failure to report, any `SIGPIPE` beside it is named, not numbered."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = LocalShellBackend(root_dir=temp_dir).execute("sh -c 'exit 2' | seq 1 100000 | head -3")
+        assert "Pipeline stages exited: 2, 141 (SIGPIPE), 0" in result.output
+
+
+def test_local_shell_backend_runs_when_the_status_file_cannot_be_created() -> None:
+    """A temp directory that is read-only, full, or out of descriptors must not fail the command."""
+    unwritable = OSError(errno.EROFS, "Read-only file system")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        backend = LocalShellBackend(root_dir=temp_dir)
+        with patch("tempfile.mkstemp", side_effect=unwritable):
+            result = backend.execute("echo still here | cat")
+    assert result.exit_code == 0
+    assert "still here" in result.output
+
+
+def test_prepare_pipeline_status_capture_degrades_to_the_plain_command() -> None:
+    """Without a status file the command must run exactly as it did before this diagnostic."""
+    with patch("tempfile.mkstemp", side_effect=OSError(errno.ENOSPC, "No space left on device")):
+        assert _prepare_pipeline_status_capture("echo hi | cat") == ("echo hi | cat", None, None)
+
+
+TIMEOUT_SECONDS = 2
+"""Short enough to keep the timeout tests quick, long enough not to race a loaded machine."""
+
+RETURN_DEADLINE_SECONDS = 15
+"""`execute` must be back long before its descendant finishes, and with room over the timeout.
+
+The markers below double as the descendants' lifetimes, so each is at least 27 seconds -- far
+enough past this deadline that a run hitting it has genuinely waited for the descendant.
+"""
+
+
+def _reap_survivors(pattern: str) -> int:
+    """Count -- and then kill -- any process whose command line still matches `pattern`."""
+    # S603/S607: fixed argv, no shell; the only interpolation is a constant marker from a test.
+    found = subprocess.run(["pgrep", "-f", pattern], capture_output=True, text=True, check=False)  # noqa: S603, S607
+    survivors = found.stdout.split()
+    if survivors:
+        subprocess.run(["pkill", "-f", pattern], check=False)  # noqa: S603, S607
+    return len(survivors)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="process groups are POSIX-only")
+def test_local_shell_backend_timeout_kills_a_background_descendant_and_returns() -> None:
+    """A timed-out command must die at the timeout, and `execute` must come back then too.
+
+    `echo hi; sleep N &` is the awkward shape: the shell returns immediately, so by the time
+    the timeout fires it is an exited-but-unreaped zombie whose pgid can no longer be looked
+    up, while the descendant it left behind is still holding the pipes `execute` reads.
+    `THREAT_MODEL.md` lists this timeout as the mitigation at trust boundary TB5, so neither
+    the kill nor the return may depend on the shell still being alive.
     """
     marker = "31.41592"
     with tempfile.TemporaryDirectory() as temp_dir:
-        result = LocalShellBackend(root_dir=temp_dir).execute(f"sleep {marker}", timeout=1)
+        backend = LocalShellBackend(root_dir=temp_dir)
+        start = time.monotonic()
+        result = backend.execute(f"echo hi; sleep {marker} &", timeout=TIMEOUT_SECONDS)
+        elapsed = time.monotonic() - start
+    survivors = _reap_survivors(f"^sleep {marker}$")
     assert result.exit_code == 124
-    time.sleep(0.5)
-    # S603/S607: fixed argv, no shell; the only interpolation is the constant marker above
-    survivors = subprocess.run(  # noqa: S603
-        ["pgrep", "-f", f"^sleep {marker}$"],  # noqa: S607
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if survivors.stdout.split():
-        subprocess.run(["pkill", "-f", f"^sleep {marker}$"], check=False)  # noqa: S603, S607
-        pytest.fail(f"timeout left {len(survivors.stdout.split())} process(es) running")
+    assert elapsed < RETURN_DEADLINE_SECONDS, f"execute blocked for {elapsed:.1f}s on a {TIMEOUT_SECONDS}s timeout"
+    assert survivors == 0, f"timeout left {survivors} process(es) running"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="process groups are POSIX-only")
+def test_local_shell_backend_timeout_returns_even_when_a_descendant_escapes_the_kill() -> None:
+    """A descendant the kill cannot reach must not be able to hold `execute` open either.
+
+    Nothing can signal a process that has put itself in another session, so this one outlives
+    the timeout by design -- and it still holds the inherited pipes. Draining those pipes
+    after the kill would wait for it. Waiting for the shell alone does not.
+    """
+    marker = "27.182818"
+    escapee = f"import os, time; os.setsid(); time.sleep({marker})"
+    command = f"echo hi; {shlex.quote(sys.executable)} -c {shlex.quote(escapee)} &"
+    with tempfile.TemporaryDirectory() as temp_dir:
+        backend = LocalShellBackend(root_dir=temp_dir)
+        start = time.monotonic()
+        result = backend.execute(command, timeout=TIMEOUT_SECONDS)
+        elapsed = time.monotonic() - start
+    _reap_survivors(f"time.sleep\\({marker}\\)")
+    assert result.exit_code == 124
+    assert elapsed < RETURN_DEADLINE_SECONDS, f"execute blocked for {elapsed:.1f}s on a {TIMEOUT_SECONDS}s timeout"

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -1,6 +1,7 @@
 """Unit tests for LocalShellBackend."""
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -10,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from deepagents.backends.local_shell import LocalShellBackend
+from deepagents.backends.local_shell import LocalShellBackend, _resolve_pipeline_status
 from deepagents.backends.protocol import ExecuteResponse
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="LocalShellBackend requires sh, not available on Windows")
@@ -381,3 +382,74 @@ class TestLocalShellVirtualModeDefault:
 
         deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning) and "virtual_mode" in str(w.message)]
         assert deprecations == []
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="pipeline status recovery requires bash")
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        pytest.param("sh -c 'echo out; exit 1' | tail -1", 1, id="failure-piped-into-filter"),
+        pytest.param("sh -c 'exit 3' | sh -c 'exit 0' | tail -1", 3, id="first-of-three-stages-fails"),
+        pytest.param("echo hi | cat", 0, id="clean-pipeline"),
+    ],
+)
+def test_local_shell_backend_reports_failure_masked_by_a_pipeline(command: str, expected: int) -> None:
+    """A shell reports only a pipeline's last stage, hiding `pytest ... | tail`-style failures."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = LocalShellBackend(root_dir=temp_dir).execute(command)
+        assert result.exit_code == expected
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="pipeline status recovery requires bash")
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param("seq 1 100000 | head -3", id="head-closes-the-pipe"),
+        pytest.param("yes | head -1", id="infinite-writer-closed-early"),
+        pytest.param("seq 1 100000 | grep -q 5", id="grep-q-exits-on-first-match"),
+    ],
+)
+def test_local_shell_backend_ignores_sigpipe_from_a_reader_exiting_early(command: str) -> None:
+    """`head` and `grep -q` close the pipe on purpose; the writer's SIGPIPE is not a failure."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = LocalShellBackend(root_dir=temp_dir).execute(command)
+        assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        pytest.param("sh -c 'exit 1'; echo done", 0, id="semicolon-chain-reports-last-command"),
+        pytest.param("sh -c 'exit 1' || true", 0, id="explicit-suppression-is-honoured"),
+        pytest.param("echo a; exit 5", 5, id="command-exiting-directly"),
+        pytest.param("sh -c 'exit 7'", 7, id="plain-failure"),
+        pytest.param("echo ok", 0, id="plain-success"),
+    ],
+)
+def test_local_shell_backend_leaves_non_pipeline_status_alone(command: str, expected: int) -> None:
+    """`a; b` and `a || true` mean what they say -- recovering a status there would break them."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = LocalShellBackend(root_dir=temp_dir).execute(command)
+        assert result.exit_code == expected
+
+
+def test_local_shell_backend_pipeline_recovery_preserves_output() -> None:
+    """The status side-channel must not leak into the output the agent reads."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = LocalShellBackend(root_dir=temp_dir).execute("echo HELLO | cat")
+        assert result.output.strip() == "HELLO"
+
+
+@pytest.mark.parametrize(
+    ("statuses", "returncode", "expected"),
+    [
+        pytest.param([1, 0], 0, 1, id="earlier-stage-failed"),
+        pytest.param([141, 0], 0, 0, id="sigpipe-before-last-stage-is-benign"),
+        pytest.param([0, 141], 141, 141, id="sigpipe-on-last-stage-is-real"),
+        pytest.param([0], 5, 5, id="single-stage-defers-to-returncode"),
+        pytest.param([], 5, 5, id="unavailable-defers-to-returncode"),
+        pytest.param([0, 0], 0, 0, id="all-clean"),
+    ],
+)
+def test_resolve_pipeline_status(statuses: list[int], returncode: int, expected: int) -> None:
+    assert _resolve_pipeline_status(statuses, returncode) == expected

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -5,9 +5,10 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import warnings
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -72,13 +73,16 @@ def test_local_shell_backend_execute_simple_command() -> None:
 
 def test_local_shell_backend_execute_starts_new_session() -> None:
     """Test that commands cannot access the parent's controlling terminal."""
-    completed = subprocess.CompletedProcess(args="echo hello", returncode=0, stdout="hello\n", stderr="")
+    process = MagicMock()
+    process.communicate.return_value = ("hello\n", "")
+    process.returncode = 0
+    process.__enter__.return_value = process
     with tempfile.TemporaryDirectory() as tmpdir:
         backend = LocalShellBackend(root_dir=tmpdir)
-        with patch("subprocess.run", return_value=completed) as run:
+        with patch("subprocess.Popen", return_value=process) as popen:
             backend.execute("echo hello")
 
-    assert run.call_args.kwargs["start_new_session"] is True
+    assert popen.call_args.kwargs["start_new_session"] is True
 
 
 def test_local_shell_backend_cannot_open_parent_controlling_terminal(tmp_path: Path) -> None:
@@ -463,3 +467,29 @@ def test_local_shell_backend_pipeline_detail_preserves_output() -> None:
 )
 def test_describe_pipeline_stages(statuses: list[int], returncode: int, expected: str) -> None:
     assert _describe_pipeline_stages(statuses, returncode) == expected
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="process groups are POSIX-only")
+def test_local_shell_backend_timeout_kills_what_the_command_started() -> None:
+    """A timed-out command must die, not just stop being waited on.
+
+    Wrapping the command to capture `PIPESTATUS` stops bash `exec`-ing it in place, so the
+    direct child is the shell and the real work is a grandchild. Killing only the child
+    would leave it running. `THREAT_MODEL.md` lists this timeout as the mitigation at trust
+    boundary TB5.
+    """
+    marker = "31.41592"
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = LocalShellBackend(root_dir=temp_dir).execute(f"sleep {marker}", timeout=1)
+    assert result.exit_code == 124
+    time.sleep(0.5)
+    # S603/S607: fixed argv, no shell; the only interpolation is the constant marker above
+    survivors = subprocess.run(  # noqa: S603
+        ["pgrep", "-f", f"^sleep {marker}$"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if survivors.stdout.split():
+        subprocess.run(["pkill", "-f", f"^sleep {marker}$"], check=False)  # noqa: S603, S607
+        pytest.fail(f"timeout left {len(survivors.stdout.split())} process(es) running")


### PR DESCRIPTION
Related: #5955

Draft, and posted as a reference implementation rather than a merge request. @liuxusummer asked for this issue first and I said on the thread I wouldn't cut across that. I'd already built this before the thread moved and offered to push the branch if it was useful, so here it is to look at and take from. Close it whenever it has served that purpose.

---

A shell reports only the last stage of a pipeline, so `pytest ... 2>&1 | tail -15` exits 0 whenever `tail` does. `execute` passed that through as `[Command succeeded with exit code 0]` and published `exit_code: 0` in the tool artifact, on exactly the commands an agent uses to decide whether its work is finished.

The obvious fixes both make it worse, which is most of what this branch is worth.

`pipefail` misreports a reader that exits early, because closing the pipe sends SIGPIPE to the writer:

| command | today | with `pipefail` |
|---|---|---|
| `sh -c 'echo out; exit 1' \| tail -1` | 0 | 1 (fixed) |
| `seq 1 100000 \| head -3` | 0 | 141 |
| `yes \| head -1` | 0 | 141 |

Reading `PIPESTATUS` and excusing SIGPIPE on non-final stages passes all of those, and is also wrong:

| command | today | that rule |
|---|---|---|
| `grep zzz /etc/hosts \| wc -l` | 0 | 1 |
| `diff a b \| head -2` | 0 | 1 |
| `git diff --quiet \| cat` | 0 | 129 |

Nothing at this layer can tell `pytest` exiting 1 from `grep` exiting 1. They are the same integer, and what separates them is what the tool meant, which never gets transmitted. Any rule that rewrites the status has to guess.

So this doesn't rewrite it. The exit code is exactly what a plain shell would return, verified across 26 command shapes with no divergence. The per-stage statuses are added to the output instead, for the agent to interpret, since the agent chose the command and can:

```
2 failed, 10 passed

[Command completed with exit code 0]
Pipeline stages exited: 1, 0
```

Worth being clear that this improves the odds rather than guaranteeing anything, because it depends on the model reading that line. It is not a deterministic fix and there may not be one.

Scope and caveats:

- `LocalShellBackend` only. `BaseSandbox`'s capture wrapper records `$?` of a subshell, so it has the same hole. Left out to keep this to one backend.
- `PIPESTATUS` needs bash. POSIX `sh` is `dash` on Debian, so where bash is absent the behaviour is byte-identical to today.
- Wrapping the command stops bash `exec`-ing it in place, which changes what the timeout has to kill. That is handled here, but it is the part I would review first.
- `_combine_output` is existing code extracted unchanged, because `execute` was already at the `C901` limit and `AGENTS.md` rules out hiding that with a suppression.
- One behaviour change I could not avoid and do not want to bury: when the shell itself dies by signal, `exit_code` changes. `sh -c 'kill -TERM $$'` returns `-15` today and `143` here, because the trap stops bash `exec`-ing in place, so bash reports `128+SIGTERM` rather than Python surfacing a negative. Both are non-zero and `143` is the more conventional spelling, but `exit_code` is public, so it is a real difference.
- `THREAT_MODEL.md` named `subprocess.run(shell=True)` as this backend's mechanism in five places. That became untrue here, so the symbol is corrected. No semantic change to the threat model.
