### PR TITLE
ci(evals): add fork-vs-handoff cache demo workflow (workflow_dispatch)

### DIFF
--- a/.github/scripts/evals/assert_cache_hit_gate.py
+++ b/.github/scripts/evals/assert_cache_hit_gate.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Fail if the fork leg didn't show a real prompt-cache advantage over handoff.
+
+Sums each leg's per-lens first-call `cache_read` (excluding the parent's own
+"main" bucket) and asserts fork's total is both non-zero and strictly greater
+than handoff's -- the concrete claim this whole demo exists to support.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def total_first_hit(payload: dict[str, Any]) -> int:
+    return sum(
+        (bucket.get("first_call_cache_read") or 0)
+        for name, bucket in payload.get("per_agent", {}).items()
+        if name != "main"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fork-json", required=True)
+    parser.add_argument("--handoff-json", required=True)
+    args = parser.parse_args()
+
+    fork = json.loads(Path(args.fork_json).read_text())
+    handoff = json.loads(Path(args.handoff_json).read_text())
+
+    fork_total = total_first_hit(fork)
+    handoff_total = total_first_hit(handoff)
+
+    print(f"fork first-call cache_read total: {fork_total}")
+    print(f"handoff first-call cache_read total: {handoff_total}")
+
+    if fork_total <= 0:
+        print(
+            "::error::fork leg showed zero cache_read on any lens's first call -- "
+            "the fork mechanism isn't reusing the parent's cached prefix."
+        )
+        sys.exit(1)
+    if fork_total <= handoff_total:
+        print(
+            f"::error::fork leg's cache_read ({fork_total}) did not exceed "
+            f"handoff's ({handoff_total}) -- no demonstrated cache advantage."
+        )
+        sys.exit(1)
+
+    print("Cache-hit gate passed: fork showed a real, non-zero cache advantage over handoff.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/evals/compare_fork_cache_demo.py
+++ b/.github/scripts/evals/compare_fork_cache_demo.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Render a fork-vs-handoff comparison from two fork_cache_demo.py --out-json files.
+
+Purely a formatting step over numbers fork_cache_demo.py already computed
+locally (via its callback handler) -- no LangSmith dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def load(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text())
+
+
+def fmt_row(name: str, fork: dict[str, Any] | None, handoff: dict[str, Any] | None) -> str:
+    def cell(bucket: dict[str, Any] | None, key: str) -> str:
+        if bucket is None:
+            return "-"
+        value = bucket.get(key)
+        return "-" if value is None else str(value)
+
+    return (
+        f"| {name} "
+        f"| {cell(fork, 'llm_calls')} | {cell(fork, 'input_tokens')} | {cell(fork, 'output_tokens')} "
+        f"| {cell(fork, 'cache_read')} | {cell(fork, 'first_call_cache_read')} | {cell(fork, 'tool_calls')} "
+        f"| {cell(handoff, 'llm_calls')} | {cell(handoff, 'input_tokens')} | {cell(handoff, 'output_tokens')} "
+        f"| {cell(handoff, 'cache_read')} | {cell(handoff, 'first_call_cache_read')} | {cell(handoff, 'tool_calls')} |"
+    )
+
+
+def total_tokens(per_agent: dict[str, dict[str, Any]]) -> int:
+    return sum(b.get("input_tokens", 0) + b.get("output_tokens", 0) for b in per_agent.values())
+
+
+def total_tool_calls(per_agent: dict[str, dict[str, Any]]) -> int:
+    return sum(b.get("tool_calls", 0) for b in per_agent.values())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fork-json", required=True)
+    parser.add_argument("--handoff-json", required=True)
+    parser.add_argument(
+        "--out-md", default=None, help="Optional path to also write the Markdown table"
+    )
+    args = parser.parse_args()
+
+    fork = load(args.fork_json)
+    handoff = load(args.handoff_json)
+
+    names = sorted(set(fork["per_agent"]) | set(handoff["per_agent"]))
+
+    lines = [
+        f"## Fork vs handoff — PR #{fork.get('pr')} ({fork.get('repo')})",
+        "",
+        (
+            "| agent | fork llm_calls | fork in_tok | fork out_tok | fork cache_read | fork 1st_hit | fork tools "
+            "| handoff llm_calls | handoff in_tok | handoff out_tok | handoff cache_read | handoff 1st_hit | handoff tools |"
+        ),
+        "|---" * 13 + "|",
+    ]
+    for name in names:
+        lines.append(fmt_row(name, fork["per_agent"].get(name), handoff["per_agent"].get(name)))
+
+    fork_tokens = total_tokens(fork["per_agent"])
+    handoff_tokens = total_tokens(handoff["per_agent"])
+    fork_tools = total_tool_calls(fork["per_agent"])
+    handoff_tools = total_tool_calls(handoff["per_agent"])
+    token_delta_pct = (
+        ((handoff_tokens - fork_tokens) / fork_tokens * 100) if fork_tokens else float("nan")
+    )
+    wall_delta_pct = (
+        (handoff["total_wall_clock"] - fork["total_wall_clock"]) / fork["total_wall_clock"] * 100
+        if fork.get("total_wall_clock")
+        else float("nan")
+    )
+
+    lines += [
+        "",
+        "### Totals",
+        "",
+        "| metric | fork | handoff | handoff vs fork |",
+        "|---|---|---|---|",
+        f"| total tokens (in+out, all agents) | {fork_tokens} | {handoff_tokens} | {token_delta_pct:+.0f}% |",
+        f"| total tool calls (all agents) | {fork_tools} | {handoff_tools} | {handoff_tools - fork_tools:+d} |",
+        (
+            f"| total wall clock (s) | {fork.get('total_wall_clock', 0):.1f} "
+            f"| {handoff.get('total_wall_clock', 0):.1f} | {wall_delta_pct:+.0f}% |"
+        ),
+        "",
+        (
+            "`1st_hit` is the `cache_read` on each subagent's very first model call — "
+            "a full hit for fork means it matched the parent's cached prefix exactly; "
+            "0 for handoff is expected, since an isolated subagent starts cold."
+        ),
+        "",
+        ("### Delegation directives"),
+        "",
+        "| lens | fork chars | handoff chars |",
+        "|---|---|---|",
+    ]
+    for name in names:
+        fork_desc = fork.get("directives", {}).get(name)
+        handoff_desc = handoff.get("directives", {}).get(name)
+        fork_len = len(fork_desc) if fork_desc is not None else "-"
+        handoff_len = len(handoff_desc) if handoff_desc is not None else "-"
+        lines.append(f"| {name} | {fork_len} | {handoff_len} |")
+
+    text = "\n".join(lines) + "\n"
+    print(text)
+
+    if args.out_md:
+        Path(args.out_md).write_text(text)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/evals/fork_cache_demo.py
+++ b/.github/scripts/evals/fork_cache_demo.py
@@ -111,9 +111,13 @@ class MetricsHandler(BaseCallbackHandler):
         self._lenses = lenses
         self._task_seq = 0
 
-        self._parent_of: dict[str, str | None] = {}
+        # Timing-based, not run-id-based: subagent.invoke() starts a genuinely
+        # separate run tree, so a child's parent_run_id does not chain back to
+        # the task call that spawned it. Execution is synchronous and one lens
+        # at a time, so "current lens" is just what's on top of this stack.
+        self._active_stack: list[str] = []
+        self._task_run_lens: dict[str, str] = {}
         self._run_label: dict[str, str] = {}
-        self._task_run_label: dict[str, str] = {}
         self._run_start: dict[str, float] = {}
 
         self.per_agent: dict[str, dict[str, Any]] = defaultdict(
@@ -129,16 +133,8 @@ class MetricsHandler(BaseCallbackHandler):
         )
         self.directives: dict[str, str] = {}
 
-    def _label_for(self, run_id: Any, parent_run_id: Any) -> str:
-        rid = str(run_id)
-        pid = str(parent_run_id) if parent_run_id is not None else None
-        self._parent_of[rid] = pid
-        cursor = pid
-        while cursor is not None:
-            if cursor in self._task_run_label:
-                return self._task_run_label[cursor]
-            cursor = self._parent_of.get(cursor)
-        return "main"
+    def _current_label(self) -> str:
+        return self._active_stack[-1] if self._active_stack else "main"
 
     def on_chat_model_start(
         self,
@@ -151,7 +147,7 @@ class MetricsHandler(BaseCallbackHandler):
         metadata: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        label = self._label_for(run_id, parent_run_id)
+        label = self._current_label()
         self._run_label[str(run_id)] = label
         self._run_start[str(run_id)] = time.monotonic()
 
@@ -200,8 +196,9 @@ class MetricsHandler(BaseCallbackHandler):
         metadata: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        label = self._label_for(run_id, parent_run_id)
-        self.per_agent[label]["tool_calls"] += 1
+        # Attribute the delegation call itself to whoever is making it (the
+        # parent, or a fork mid-delegation-refusal attempt), before pushing.
+        self.per_agent[self._current_label()]["tool_calls"] += 1
 
         if serialized.get("name") != "task":
             return
@@ -221,8 +218,22 @@ class MetricsHandler(BaseCallbackHandler):
             else f"unexpected-lens-{self._task_seq}"
         )
         self._task_seq += 1
-        self._task_run_label[str(run_id)] = lens
+        self._task_run_lens[str(run_id)] = lens
+        self._active_stack.append(lens)
         self.directives[lens] = parsed.get("description", "")
+
+    def on_tool_end(
+        self,
+        output: Any,
+        *,
+        run_id: Any,
+        parent_run_id: Any = None,
+        tags: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        lens = self._task_run_lens.pop(str(run_id), None)
+        if lens is not None and self._active_stack and self._active_stack[-1] == lens:
+            self._active_stack.pop()
 
     def as_json(self) -> dict[str, Any]:
         return {"per_agent": self.per_agent, "directives": self.directives}

--- a/.github/scripts/evals/fork_cache_demo.py
+++ b/.github/scripts/evals/fork_cache_demo.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import ast
 import json
+import re
 import subprocess
 import time
 from collections import defaultdict
@@ -37,6 +38,13 @@ from langchain_core.tools import tool
 from deepagents import create_deep_agent
 
 DEFAULT_LENSES = ["correctness", "backcompat", "tests", "performance", "api_design"]
+
+
+def pr_number_type(value: str) -> str:
+    if not re.fullmatch(r"[0-9]+", value):
+        msg = f"pr_number must be numeric, got {value!r}"
+        raise argparse.ArgumentTypeError(msg)
+    return value
 
 
 def repo_root() -> Path:
@@ -269,7 +277,9 @@ def build_agent(model: str, tools: list):
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", required=True, help="owner/repo, e.g. langchain-ai/deepagents")
-    parser.add_argument("--pr", required=True, help="PR number to use as the diff substrate")
+    parser.add_argument(
+        "--pr", required=True, type=pr_number_type, help="PR number to use as the diff substrate"
+    )
     parser.add_argument(
         "--branch-tag",
         default="unknown",

--- a/.github/scripts/evals/fork_cache_demo.py
+++ b/.github/scripts/evals/fork_cache_demo.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Fork-vs-handoff cost/cache demo: PR review with specialized reviewers.
+
+A parent agent fetches a real PR's diff (and any repo files it needs) once,
+then delegates review to N specialist subagents (one per lens, e.g.
+correctness/backcompat/tests/performance/api_design) using an IDENTICAL short
+instruction regardless of mode:
+
+    "Review this change specifically for {lens} issues."
+
+Only the subagents' `mode` changes between runs -- "fork" (inherits the
+parent's full context for free, via cache reuse) vs "handoff" (isolated;
+must re-fetch context itself via tool calls, or have the parent paste it
+into the directive, to do useful work at all).
+
+Metrics are captured via a plain callback handler attached to the top-level
+`invoke()` call -- subagent `.invoke()` calls run in the same call stack and
+inherit callbacks/config automatically, so no LangSmith round-trip is needed
+for the numbers themselves. LangSmith tracing (when LANGSMITH_API_KEY is set)
+is enabled purely so a human can inspect the run visually afterward; it is
+not load-bearing for anything this script prints or writes.
+
+Local usage (from libs/deepagents, with a real ANTHROPIC_API_KEY exported):
+
+    uv run python ../../.github/scripts/evals/fork_cache_demo.py \
+        --repo langchain-ai/deepagents --pr 5873 --mode fork
+
+CI usage: see .github/workflows/fork_cache_demo.yml, which runs this once per
+mode and compares the resulting --out-json files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import subprocess
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+
+from deepagents import create_deep_agent
+
+DEFAULT_LENSES = ["correctness", "backcompat", "tests", "performance", "api_design"]
+
+
+def repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def fetch_pr_diff(repo: str, pr_number: str) -> str:
+    result = subprocess.run(
+        ["gh", "pr", "diff", pr_number, "--repo", repo],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def fetch_pr_meta(repo: str, pr_number: str) -> dict[str, str]:
+    result = subprocess.run(
+        ["gh", "pr", "view", pr_number, "--repo", repo, "--json", "title,body"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def build_parent_instruction(
+    repo: str, pr_number: str, title: str, body: str, lenses: list[str]
+) -> str:
+    trimmed_body = (body or "(no description)").strip()[:2000]
+    lens_line = '  "Review this change specifically for {lens} issues."'
+    return f"""You are reviewing pull request #{pr_number} in the {repo} repo: "{title}"
+
+{trimmed_body}
+
+First, use get_pr_diff to fetch the diff, and read_repo_file for any files you
+need to understand the change in its surrounding context.
+
+Then delegate the review to specialist subagents, one call each, using
+EXACTLY this instruction for each (only the lens name changes):
+
+{lens_line}
+
+The subagent_type values to delegate to, in this order: {", ".join(lenses)}.
+
+Once all have reported back, summarize their findings in one paragraph.
+"""
+
+
+class MetricsHandler(BaseCallbackHandler):
+    """Captures per-subagent token/tool/wall-clock metrics locally, keyed by
+    `lc_agent_name` -- no LangSmith dependency for the numbers themselves.
+    """
+
+    def __init__(self) -> None:
+        self._run_metadata: dict[str, dict[str, Any]] = {}
+        self._run_start: dict[str, float] = {}
+        self.per_agent: dict[str, dict[str, Any]] = defaultdict(
+            lambda: {
+                "llm_calls": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read": 0,
+                "first_call_cache_read": None,
+                "tool_calls": 0,
+                "wall_clock": 0.0,
+            }
+        )
+        self.directives: dict[str, str] = {}
+
+    @staticmethod
+    def _agent_name(metadata: dict[str, Any] | None) -> str:
+        return (metadata or {}).get("lc_agent_name") or "main"
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[Any]],
+        *,
+        run_id: Any,
+        parent_run_id: Any = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        key = str(run_id)
+        self._run_metadata[key] = metadata or {}
+        self._run_start[key] = time.monotonic()
+
+    def on_llm_end(
+        self,
+        response: Any,
+        *,
+        run_id: Any,
+        parent_run_id: Any = None,
+        tags: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        key = str(run_id)
+        agent_name = self._agent_name(self._run_metadata.pop(key, None))
+        start = self._run_start.pop(key, None)
+        elapsed = time.monotonic() - start if start is not None else 0.0
+
+        bucket = self.per_agent[agent_name]
+        bucket["llm_calls"] += 1
+        bucket["wall_clock"] += elapsed
+
+        try:
+            message = response.generations[0][0].message
+        except (AttributeError, IndexError):
+            return
+        usage = getattr(message, "usage_metadata", None) or {}
+        input_tokens = usage.get("input_tokens", 0) or 0
+        output_tokens = usage.get("output_tokens", 0) or 0
+        details = usage.get("input_token_details", {}) or {}
+        cache_read = details.get("cache_read", 0) or 0
+
+        bucket["input_tokens"] += input_tokens
+        bucket["output_tokens"] += output_tokens
+        bucket["cache_read"] += cache_read
+        if bucket["first_call_cache_read"] is None:
+            bucket["first_call_cache_read"] = cache_read
+
+    def on_tool_start(
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        run_id: Any,
+        parent_run_id: Any = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        agent_name = self._agent_name(metadata)
+        self.per_agent[agent_name]["tool_calls"] += 1
+
+        if serialized.get("name") != "task":
+            return
+        # on_tool_start's input_str is Python's dict repr (single quotes),
+        # not JSON -- confirmed empirically, json.loads fails on it silently.
+        try:
+            parsed = ast.literal_eval(input_str)
+        except (ValueError, SyntaxError):
+            return
+        if not isinstance(parsed, dict):
+            return
+        subagent_type = parsed.get("subagent_type")
+        description = parsed.get("description", "")
+        if subagent_type:
+            self.directives[subagent_type] = description
+
+    def as_json(self) -> dict[str, Any]:
+        return {"per_agent": self.per_agent, "directives": self.directives}
+
+    def print_report(self) -> None:
+        print("\n=== Per-agent metrics ===")
+        header = (
+            f"{'agent':<14} {'llm_calls':>9} {'in_tok':>8} {'out_tok':>8} "
+            f"{'cache_read':>10} {'1st_hit':>8} {'tool_calls':>10} {'wall_s':>7}"
+        )
+        print(header)
+        for name, b in sorted(self.per_agent.items()):
+            print(
+                f"{name:<14} {b['llm_calls']:>9} {b['input_tokens']:>8} "
+                f"{b['output_tokens']:>8} {b['cache_read']:>10} "
+                f"{str(b['first_call_cache_read']):>8} {b['tool_calls']:>10} "
+                f"{b['wall_clock']:>7.1f}"
+            )
+
+        print("\n=== Delegation directives ===")
+        for lens, desc in sorted(self.directives.items()):
+            print(f"  {lens}: {len(desc)} chars -- {desc!r}")
+
+
+def make_tools(allowed_prefix: Path, diff_text: str):
+    @tool
+    def get_pr_diff() -> str:
+        """Return the full diff for the pull request under review."""
+        return diff_text
+
+    @tool
+    def read_repo_file(path: str) -> str:
+        """Read a file from the repo. `path` must be relative to the repo
+        root and stay under the allowed prefix.
+        """
+        resolved = (allowed_prefix.parent / path).resolve()
+        if not str(resolved).startswith(str(allowed_prefix)):
+            return f"Error: access denied for path outside {allowed_prefix.name}/: {path}"
+        if not resolved.is_file():
+            return f"Error: file not found: {path}"
+        try:
+            return resolved.read_text()
+        except Exception as exc:  # noqa: BLE001
+            return f"Error reading file: {exc}"
+
+    return get_pr_diff, read_repo_file
+
+
+def build_agent(mode: str, model: str, lenses: list[str], tools: list):
+    subagents = [
+        {
+            "name": lens,
+            "description": f"Specialist reviewer focused on {lens} issues for a code change.",
+            "tools": list(tools),
+            "mode": mode,
+        }
+        for lens in lenses
+    ]
+    return create_deep_agent(model=model, tools=list(tools), subagents=subagents)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True, help="owner/repo, e.g. langchain-ai/deepagents")
+    parser.add_argument("--pr", required=True, help="PR number to use as the diff substrate")
+    parser.add_argument("--mode", choices=["fork", "handoff"], required=True)
+    parser.add_argument("--model", default="anthropic:claude-sonnet-4-6")
+    parser.add_argument(
+        "--lenses",
+        default=",".join(DEFAULT_LENSES),
+        help="Comma-separated review lenses / subagent names",
+    )
+    parser.add_argument(
+        "--allowed-prefix",
+        default="libs",
+        help="Repo-relative dir read_repo_file is scoped to",
+    )
+    parser.add_argument("--out-json", default=None, help="Optional path to write metrics as JSON")
+    args = parser.parse_args()
+
+    lenses = [lens.strip() for lens in args.lenses.split(",") if lens.strip()]
+    allowed_prefix = (repo_root() / args.allowed_prefix).resolve()
+
+    print(f"Fetching PR #{args.pr} from {args.repo}...", flush=True)
+    diff_text = fetch_pr_diff(args.repo, args.pr)
+    meta = fetch_pr_meta(args.repo, args.pr)
+    instruction = build_parent_instruction(
+        args.repo, args.pr, meta.get("title", ""), meta.get("body", ""), lenses
+    )
+
+    tools = make_tools(allowed_prefix, diff_text)
+    handler = MetricsHandler()
+    agent = build_agent(args.mode, args.model, lenses, tools)
+
+    print(f"=== Running mode={args.mode} model={args.model} ===", flush=True)
+    start = time.monotonic()
+    result = agent.invoke(
+        {"messages": [HumanMessage(content=instruction)]},
+        config={"callbacks": [handler], "recursion_limit": 50},
+    )
+    elapsed = time.monotonic() - start
+    print(f"Total wall clock: {elapsed:.1f}s", flush=True)
+
+    handler.print_report()
+
+    final = result["messages"][-1]
+    print("\n=== Parent's final summary ===")
+    print(getattr(final, "text", None) or final.content)
+
+    if args.out_json:
+        out_path = Path(args.out_json)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "mode": args.mode,
+            "model": args.model,
+            "repo": args.repo,
+            "pr": args.pr,
+            "lenses": lenses,
+            "total_wall_clock": elapsed,
+            **handler.as_json(),
+        }
+        out_path.write_text(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/evals/fork_cache_demo.py
+++ b/.github/scripts/evals/fork_cache_demo.py
@@ -2,16 +2,20 @@
 """Fork-vs-handoff cost/cache demo: PR review with specialized reviewers.
 
 A parent agent fetches a real PR's diff (and any repo files it needs) once,
-then delegates review to N specialist subagents (one per lens, e.g.
-correctness/backcompat/tests/performance/api_design) using an IDENTICAL short
-instruction regardless of mode:
+then delegates review to the general-purpose subagent N times -- one call per
+lens (e.g. correctness/backcompat/tests/performance/api_design) -- using an
+IDENTICAL short instruction regardless of branch:
 
     "Review this change specifically for {lens} issues."
 
-Only the subagents' `mode` changes between runs -- "fork" (inherits the
-parent's full context for free, via cache reuse) vs "handoff" (isolated;
-must re-fetch context itself via tool calls, or have the parent paste it
-into the directive, to do useful work at all).
+This deliberately does NOT declare a custom subagent or pass a `mode=` flag.
+The general-purpose subagent's own default (fork vs. handoff) comes entirely
+from whichever `deepagents` checkout this script runs against -- compare a
+branch that forces it into `mode: "fork"` by default (e.g.
+`bengret/sug-agent-forking-evals`) against one that leaves it as the normal
+isolated default (e.g. `bengret/feat-subagent-forking`). See
+.github/workflows/fork_cache_demo.yml, which checks out a different
+`deepagents` ref per leg rather than passing this script a mode flag.
 
 Metrics are captured via a plain callback handler attached to the top-level
 `invoke()` call -- subagent `.invoke()` calls run in the same call stack and
@@ -20,13 +24,20 @@ for the numbers themselves. LangSmith tracing (when LANGSMITH_API_KEY is set)
 is enabled purely so a human can inspect the run visually afterward; it is
 not load-bearing for anything this script prints or writes.
 
+Each of the general-purpose subagent's five invocations shares the same
+`lc_agent_name` ("general-purpose"), so per-lens attribution instead walks
+each event's `parent_run_id` chain back to the specific `task` tool call that
+spawned it, and labels that invocation by its position in the (deterministic,
+instructed) delegation order.
+
 Local usage (from libs/deepagents, with a real ANTHROPIC_API_KEY exported):
 
     uv run python ../../.github/scripts/evals/fork_cache_demo.py \
-        --repo langchain-ai/deepagents --pr 5873 --mode fork
+        --repo langchain-ai/deepagents --pr 5873 --branch-tag fork
 
 CI usage: see .github/workflows/fork_cache_demo.yml, which runs this once per
-mode and compares the resulting --out-json files.
+branch (checking out a different `deepagents` ref each time) and compares the
+resulting --out-json files.
 """
 
 from __future__ import annotations
@@ -91,25 +102,38 @@ def build_parent_instruction(
 First, use get_pr_diff to fetch the diff, and read_repo_file for any files you
 need to understand the change in its surrounding context.
 
-Then delegate the review to specialist subagents, one call each, using
-EXACTLY this instruction for each (only the lens name changes):
+Then delegate the review to the general-purpose subagent, ONE CALL AT A TIME
+(wait for each result before starting the next -- do not delegate in
+parallel), using EXACTLY this instruction each time (only the lens name
+changes):
 
 {lens_line}
 
-The subagent_type values to delegate to, in this order: {", ".join(lenses)}.
+Use these lenses in this exact order: {", ".join(lenses)}.
 
 Once all have reported back, summarize their findings in one paragraph.
 """
 
 
 class MetricsHandler(BaseCallbackHandler):
-    """Captures per-subagent token/tool/wall-clock metrics locally, keyed by
-    `lc_agent_name` -- no LangSmith dependency for the numbers themselves.
+    """Captures per-lens token/tool/wall-clock metrics locally.
+
+    Every call to the general-purpose subagent shares the same
+    `lc_agent_name`, so attribution instead walks each event's
+    `parent_run_id` chain back to the enclosing `task` tool call and labels
+    it by that call's position in the (instructed, deterministic) lens
+    order -- not by `lc_agent_name`.
     """
 
-    def __init__(self) -> None:
-        self._run_metadata: dict[str, dict[str, Any]] = {}
+    def __init__(self, lenses: list[str]) -> None:
+        self._lenses = lenses
+        self._task_seq = 0
+
+        self._parent_of: dict[str, str | None] = {}
+        self._run_label: dict[str, str] = {}
+        self._task_run_label: dict[str, str] = {}
         self._run_start: dict[str, float] = {}
+
         self.per_agent: dict[str, dict[str, Any]] = defaultdict(
             lambda: {
                 "llm_calls": 0,
@@ -123,9 +147,16 @@ class MetricsHandler(BaseCallbackHandler):
         )
         self.directives: dict[str, str] = {}
 
-    @staticmethod
-    def _agent_name(metadata: dict[str, Any] | None) -> str:
-        return (metadata or {}).get("lc_agent_name") or "main"
+    def _label_for(self, run_id: Any, parent_run_id: Any) -> str:
+        rid = str(run_id)
+        pid = str(parent_run_id) if parent_run_id is not None else None
+        self._parent_of[rid] = pid
+        cursor = pid
+        while cursor is not None:
+            if cursor in self._task_run_label:
+                return self._task_run_label[cursor]
+            cursor = self._parent_of.get(cursor)
+        return "main"
 
     def on_chat_model_start(
         self,
@@ -138,9 +169,9 @@ class MetricsHandler(BaseCallbackHandler):
         metadata: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        key = str(run_id)
-        self._run_metadata[key] = metadata or {}
-        self._run_start[key] = time.monotonic()
+        label = self._label_for(run_id, parent_run_id)
+        self._run_label[str(run_id)] = label
+        self._run_start[str(run_id)] = time.monotonic()
 
     def on_llm_end(
         self,
@@ -152,7 +183,7 @@ class MetricsHandler(BaseCallbackHandler):
         **kwargs: Any,
     ) -> None:
         key = str(run_id)
-        agent_name = self._agent_name(self._run_metadata.pop(key, None))
+        agent_name = self._run_label.pop(key, "main")
         start = self._run_start.pop(key, None)
         elapsed = time.monotonic() - start if start is not None else 0.0
 
@@ -187,8 +218,8 @@ class MetricsHandler(BaseCallbackHandler):
         metadata: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        agent_name = self._agent_name(metadata)
-        self.per_agent[agent_name]["tool_calls"] += 1
+        label = self._label_for(run_id, parent_run_id)
+        self.per_agent[label]["tool_calls"] += 1
 
         if serialized.get("name") != "task":
             return
@@ -200,18 +231,25 @@ class MetricsHandler(BaseCallbackHandler):
             return
         if not isinstance(parsed, dict):
             return
-        subagent_type = parsed.get("subagent_type")
-        description = parsed.get("description", "")
-        if subagent_type:
-            self.directives[subagent_type] = description
+        if parsed.get("subagent_type") != "general-purpose":
+            return
+
+        lens = (
+            self._lenses[self._task_seq]
+            if self._task_seq < len(self._lenses)
+            else f"unexpected-lens-{self._task_seq}"
+        )
+        self._task_seq += 1
+        self._task_run_label[str(run_id)] = lens
+        self.directives[lens] = parsed.get("description", "")
 
     def as_json(self) -> dict[str, Any]:
         return {"per_agent": self.per_agent, "directives": self.directives}
 
     def print_report(self) -> None:
-        print("\n=== Per-agent metrics ===")
+        print("\n=== Per-lens metrics ===")
         header = (
-            f"{'agent':<14} {'llm_calls':>9} {'in_tok':>8} {'out_tok':>8} "
+            f"{'lens':<14} {'llm_calls':>9} {'in_tok':>8} {'out_tok':>8} "
             f"{'cache_read':>10} {'1st_hit':>8} {'tool_calls':>10} {'wall_s':>7}"
         )
         print(header)
@@ -252,29 +290,30 @@ def make_tools(allowed_prefix: Path, diff_text: str):
     return get_pr_diff, read_repo_file
 
 
-def build_agent(mode: str, model: str, lenses: list[str], tools: list):
-    subagents = [
-        {
-            "name": lens,
-            "description": f"Specialist reviewer focused on {lens} issues for a code change.",
-            "tools": list(tools),
-            "mode": mode,
-        }
-        for lens in lenses
-    ]
-    return create_deep_agent(model=model, tools=list(tools), subagents=subagents)
+def build_agent(model: str, tools: list):
+    # No `subagents=` override: the general-purpose subagent this delegates
+    # to is whichever default `create_deep_agent` auto-adds -- fork or
+    # handoff is entirely a property of the `deepagents` checkout this runs
+    # against, not anything this script configures.
+    return create_deep_agent(model=model, tools=list(tools))
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", required=True, help="owner/repo, e.g. langchain-ai/deepagents")
     parser.add_argument("--pr", required=True, help="PR number to use as the diff substrate")
-    parser.add_argument("--mode", choices=["fork", "handoff"], required=True)
+    parser.add_argument(
+        "--branch-tag",
+        default="unknown",
+        help="Label for this run's output only (e.g. 'fork'/'handoff') -- "
+        "does not affect agent construction. The actual fork/handoff "
+        "behavior comes from whichever deepagents checkout is on PYTHONPATH.",
+    )
     parser.add_argument("--model", default="anthropic:claude-sonnet-4-6")
     parser.add_argument(
         "--lenses",
         default=",".join(DEFAULT_LENSES),
-        help="Comma-separated review lenses / subagent names",
+        help="Comma-separated review lenses, delegated to in this exact order",
     )
     parser.add_argument(
         "--allowed-prefix",
@@ -295,10 +334,10 @@ def main() -> None:
     )
 
     tools = make_tools(allowed_prefix, diff_text)
-    handler = MetricsHandler()
-    agent = build_agent(args.mode, args.model, lenses, tools)
+    handler = MetricsHandler(lenses)
+    agent = build_agent(args.model, tools)
 
-    print(f"=== Running mode={args.mode} model={args.model} ===", flush=True)
+    print(f"=== Running branch_tag={args.branch_tag} model={args.model} ===", flush=True)
     start = time.monotonic()
     result = agent.invoke(
         {"messages": [HumanMessage(content=instruction)]},
@@ -317,7 +356,7 @@ def main() -> None:
         out_path = Path(args.out_json)
         out_path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
-            "mode": args.mode,
+            "branch_tag": args.branch_tag,
             "model": args.model,
             "repo": args.repo,
             "pr": args.pr,

--- a/.github/scripts/evals/fork_cache_demo.py
+++ b/.github/scripts/evals/fork_cache_demo.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import ast
 import json
+import os
 import re
 import subprocess
 import time
@@ -31,6 +32,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+from langchain_anthropic import ChatAnthropic
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
@@ -271,6 +273,17 @@ def make_tools(repo_root_dir: Path, allowed_prefix: Path, diff_text: str):
 
 def build_agent(model: str, tools: list):
     # No subagents= override: fork/handoff comes from the deepagents checkout, not this script.
+    custom_header = os.environ.get("ANTHROPIC_CUSTOM_HEADERS")
+    if custom_header and model.startswith("anthropic:"):
+        # Gateway auth: ChatAnthropic.default_headers has no env-var binding of its
+        # own (unlike base_url, which already reads ANTHROPIC_BASE_URL directly), so
+        # a header-based key has to go through the constructor.
+        header_name, _, header_value = custom_header.partition(":")
+        chat_model = ChatAnthropic(
+            model=model.split(":", 1)[1],
+            default_headers={header_name.strip(): header_value.strip()},
+        )
+        return create_deep_agent(model=chat_model, tools=list(tools))
     return create_deep_agent(model=model, tools=list(tools))
 
 

--- a/.github/scripts/evals/fork_cache_demo.py
+++ b/.github/scripts/evals/fork_cache_demo.py
@@ -237,7 +237,7 @@ class MetricsHandler(BaseCallbackHandler):
             print(f"  {lens}: {len(desc)} chars -- {desc!r}")
 
 
-def make_tools(allowed_prefix: Path, diff_text: str):
+def make_tools(repo_root_dir: Path, allowed_prefix: Path, diff_text: str):
     @tool
     def get_pr_diff() -> str:
         """Return the full diff for the pull request under review."""
@@ -248,8 +248,8 @@ def make_tools(allowed_prefix: Path, diff_text: str):
         """Read a file from the repo. `path` must be relative to the repo
         root and stay under the allowed prefix.
         """
-        resolved = (allowed_prefix.parent / path).resolve()
-        if not str(resolved).startswith(str(allowed_prefix)):
+        resolved = (repo_root_dir / path).resolve()
+        if resolved != allowed_prefix and not resolved.is_relative_to(allowed_prefix):
             return f"Error: access denied for path outside {allowed_prefix.name}/: {path}"
         if not resolved.is_file():
             return f"Error: file not found: {path}"
@@ -292,7 +292,8 @@ def main() -> None:
     args = parser.parse_args()
 
     lenses = [lens.strip() for lens in args.lenses.split(",") if lens.strip()]
-    allowed_prefix = (repo_root() / args.allowed_prefix).resolve()
+    root = repo_root()
+    allowed_prefix = (root / args.allowed_prefix).resolve()
 
     print(f"Fetching PR #{args.pr} from {args.repo}...", flush=True)
     diff_text = fetch_pr_diff(args.repo, args.pr)
@@ -301,7 +302,7 @@ def main() -> None:
         args.repo, args.pr, meta.get("title", ""), meta.get("body", ""), lenses
     )
 
-    tools = make_tools(allowed_prefix, diff_text)
+    tools = make_tools(root, allowed_prefix, diff_text)
     handler = MetricsHandler(lenses)
     agent = build_agent(args.model, tools)
 

--- a/.github/scripts/evals/fork_cache_demo.py
+++ b/.github/scripts/evals/fork_cache_demo.py
@@ -282,8 +282,11 @@ def make_tools(repo_root_dir: Path, allowed_prefix: Path, diff_text: str):
     return get_pr_diff, read_repo_file
 
 
-def build_agent(model: str, tools: list):
+def build_agent(model: str, tools: list, branch_tag: str):
     # No subagents= override: fork/handoff comes from the deepagents checkout, not this script.
+    # name= gives the parent's own LangSmith run this label instead of the generic
+    # "LangGraph" default -- otherwise every leg's top-level trace looks identical.
+    agent_name = f"fork-cache-demo-{branch_tag}"
     custom_header = os.environ.get("ANTHROPIC_CUSTOM_HEADERS")
     if custom_header and model.startswith("anthropic:"):
         # Gateway auth: ChatAnthropic.default_headers has no env-var binding of its
@@ -294,8 +297,8 @@ def build_agent(model: str, tools: list):
             model=model.split(":", 1)[1],
             default_headers={header_name.strip(): header_value.strip()},
         )
-        return create_deep_agent(model=chat_model, tools=list(tools))
-    return create_deep_agent(model=model, tools=list(tools))
+        return create_deep_agent(model=chat_model, tools=list(tools), name=agent_name)
+    return create_deep_agent(model=model, tools=list(tools), name=agent_name)
 
 
 def main() -> None:
@@ -338,7 +341,7 @@ def main() -> None:
 
     tools = make_tools(root, allowed_prefix, diff_text)
     handler = MetricsHandler(lenses)
-    agent = build_agent(args.model, tools)
+    agent = build_agent(args.model, tools, args.branch_tag)
 
     print(f"=== Running branch_tag={args.branch_tag} model={args.model} ===", flush=True)
     start = time.monotonic()

--- a/.github/scripts/evals/fork_cache_demo.py
+++ b/.github/scripts/evals/fork_cache_demo.py
@@ -1,43 +1,22 @@
 #!/usr/bin/env python3
 """Fork-vs-handoff cost/cache demo: PR review with specialized reviewers.
 
-A parent agent fetches a real PR's diff (and any repo files it needs) once,
-then delegates review to the general-purpose subagent N times -- one call per
-lens (e.g. correctness/backcompat/tests/performance/api_design) -- using an
-IDENTICAL short instruction regardless of branch:
+Parent fetches a real PR's diff once, then delegates to the general-purpose
+subagent N times (one per lens), with an identical instruction each time. No
+custom subagent or `mode=` flag: fork vs. handoff comes entirely from which
+`deepagents` checkout this runs against (see fork_cache_demo.yml, which
+checks out a different ref per leg).
 
-    "Review this change specifically for {lens} issues."
-
-This deliberately does NOT declare a custom subagent or pass a `mode=` flag.
-The general-purpose subagent's own default (fork vs. handoff) comes entirely
-from whichever `deepagents` checkout this script runs against -- compare a
-branch that forces it into `mode: "fork"` by default (e.g.
-`bengret/sug-agent-forking-evals`) against one that leaves it as the normal
-isolated default (e.g. `bengret/feat-subagent-forking`). See
-.github/workflows/fork_cache_demo.yml, which checks out a different
-`deepagents` ref per leg rather than passing this script a mode flag.
-
-Metrics are captured via a plain callback handler attached to the top-level
-`invoke()` call -- subagent `.invoke()` calls run in the same call stack and
-inherit callbacks/config automatically, so no LangSmith round-trip is needed
-for the numbers themselves. LangSmith tracing (when LANGSMITH_API_KEY is set)
-is enabled purely so a human can inspect the run visually afterward; it is
-not load-bearing for anything this script prints or writes.
-
-Each of the general-purpose subagent's five invocations shares the same
-`lc_agent_name` ("general-purpose"), so per-lens attribution instead walks
-each event's `parent_run_id` chain back to the specific `task` tool call that
-spawned it, and labels that invocation by its position in the (deterministic,
-instructed) delegation order.
+Metrics come from a callback handler on the top-level `invoke()` (subagents
+inherit it automatically). Since every call shares `lc_agent_name`
+("general-purpose"), attribution walks each event's `parent_run_id` chain
+back to its `task` call and labels it by delegation order. LangSmith tracing
+(LANGSMITH_API_KEY) is just for visual inspection, not load-bearing.
 
 Local usage (from libs/deepagents, with a real ANTHROPIC_API_KEY exported):
 
     uv run python ../../.github/scripts/evals/fork_cache_demo.py \
         --repo langchain-ai/deepagents --pr 5873 --branch-tag fork
-
-CI usage: see .github/workflows/fork_cache_demo.yml, which runs this once per
-branch (checking out a different `deepagents` ref each time) and compares the
-resulting --out-json files.
 """
 
 from __future__ import annotations
@@ -116,14 +95,7 @@ Once all have reported back, summarize their findings in one paragraph.
 
 
 class MetricsHandler(BaseCallbackHandler):
-    """Captures per-lens token/tool/wall-clock metrics locally.
-
-    Every call to the general-purpose subagent shares the same
-    `lc_agent_name`, so attribution instead walks each event's
-    `parent_run_id` chain back to the enclosing `task` tool call and labels
-    it by that call's position in the (instructed, deterministic) lens
-    order -- not by `lc_agent_name`.
-    """
+    """Captures per-lens token/tool/wall-clock metrics locally."""
 
     def __init__(self, lenses: list[str]) -> None:
         self._lenses = lenses
@@ -223,8 +195,7 @@ class MetricsHandler(BaseCallbackHandler):
 
         if serialized.get("name") != "task":
             return
-        # on_tool_start's input_str is Python's dict repr (single quotes),
-        # not JSON -- confirmed empirically, json.loads fails on it silently.
+        # input_str is Python's dict repr, not JSON -- json.loads fails on it silently.
         try:
             parsed = ast.literal_eval(input_str)
         except (ValueError, SyntaxError):
@@ -291,10 +262,7 @@ def make_tools(allowed_prefix: Path, diff_text: str):
 
 
 def build_agent(model: str, tools: list):
-    # No `subagents=` override: the general-purpose subagent this delegates
-    # to is whichever default `create_deep_agent` auto-adds -- fork or
-    # handoff is entirely a property of the `deepagents` checkout this runs
-    # against, not anything this script configures.
+    # No subagents= override: fork/handoff comes from the deepagents checkout, not this script.
     return create_deep_agent(model=model, tools=list(tools))
 
 

--- a/.github/workflows/fork_cache_demo.yml
+++ b/.github/workflows/fork_cache_demo.yml
@@ -1,0 +1,197 @@
+# Fork-vs-handoff cost/cache demo workflow for Deep Agents subagents.
+#
+# Manual only (workflow_dispatch) -- this spends real model tokens on a live
+# PR review and is not wired to pull_request/push, so it never runs on a PR
+# or merge. Runs fork_cache_demo.py once per selected mode against a real
+# PR's diff, then (when both "fork" and "handoff" ran) compares the two
+# runs' locally-captured metrics: cache-read tokens, token/tool-call cost,
+# wall-clock, and delegation-directive size.
+#
+# LangSmith tracing is enabled automatically when LANGSMITH_API_KEY is
+# present in the `evals` environment, purely so a human can inspect the run
+# visually afterward -- the printed/uploaded metrics come from
+# fork_cache_demo.py's own callback handler, not from LangSmith, so tracing
+# being off does not affect the comparison.
+#
+# Required secrets (in the `evals` environment):
+#   ANTHROPIC_API_KEY  — needed for anthropic: models (the default)
+#   OPENAI_API_KEY     — needed for openai: models
+#   LANGSMITH_API_KEY  — optional; enables tracing when present
+
+name: "🍴 Fork cache demo"
+run-name: >-
+  🍴 Fork cache demo — PR #${{ inputs.pr_number }} (${{ inputs.repo }}) / ${{ inputs.modes }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "owner/repo to pull the PR diff from"
+        type: string
+        required: true
+        default: "langchain-ai/deepagents"
+      pr_number:
+        description: "PR number to use as the review substrate"
+        type: string
+        required: true
+      model:
+        description: "provider:model spec passed to init_chat_model"
+        type: string
+        default: "anthropic:claude-sonnet-4-6"
+      modes:
+        description: "Comma-separated modes to run. Include both to get the comparison job; a single mode just runs and uploads its own metrics."
+        type: string
+        default: "fork,handoff"
+      lenses:
+        description: "Comma-separated review lenses (= subagent names delegated to)"
+        type: string
+        default: "correctness,backcompat,tests,performance,api_design"
+      allowed_path_prefix:
+        description: "Repo-relative directory the reviewer subagents' read_repo_file tool may read from"
+        type: string
+        default: "libs"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fork-cache-demo-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prep:
+    name: "🔧 Parse modes"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: "📝 Log dispatch inputs"
+        env:
+          REPO: ${{ inputs.repo }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          MODEL: ${{ inputs.model }}
+          MODES: ${{ inputs.modes }}
+          LENSES: ${{ inputs.lenses }}
+          ALLOWED_PATH_PREFIX: ${{ inputs.allowed_path_prefix }}
+        run: |
+          {
+            echo "### 🍴 Fork cache demo dispatch inputs"
+            echo ""
+            echo "| Input | Value |"
+            echo "|---|---|"
+            echo "| \`repo\` | \`${REPO}\` |"
+            echo "| \`pr_number\` | \`${PR_NUMBER}\` |"
+            echo "| \`model\` | \`${MODEL}\` |"
+            echo "| \`modes\` | \`${MODES}\` |"
+            echo "| \`lenses\` | \`${LENSES}\` |"
+            echo "| \`allowed_path_prefix\` | \`${ALLOWED_PATH_PREFIX}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "🧮 Build mode matrix"
+        id: set-matrix
+        env:
+          MODES: ${{ inputs.modes }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          modes = [m.strip() for m in os.environ["MODES"].split(",") if m.strip()]
+          valid = {"fork", "handoff"}
+          unknown = [m for m in modes if m not in valid]
+          if unknown:
+              raise SystemExit(f"::error::Unknown mode(s): {unknown}; must be 'fork' or 'handoff'")
+          if not modes:
+              raise SystemExit("::error::No modes given")
+
+          matrix = json.dumps({"mode": modes})
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"matrix={matrix}\n")
+          PY
+
+  demo:
+    name: "🍴 Run (${{ matrix.mode }})"
+    needs: prep
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prep.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    environment: evals
+    timeout-minutes: 20
+    env:
+      MODEL: ${{ inputs.model }}
+      # Trace-level LangSmith tracing only, purely for visual inspection --
+      # this script's own metrics come from its callback handler, not
+      # LangSmith. Tracing turns on only when the secret is present (no
+      # warnings when absent), same idiom as clbench.yml.
+      LANGSMITH_TRACING: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
+      LANGSMITH_PROJECT: fork-cache-demo-${{ matrix.mode }}-${{ github.run_id }}
+    steps:
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: "🐍 Set up Python + UV"
+        uses: "./.github/actions/uv_setup"
+        with:
+          python-version: "3.12"
+          cache-suffix: fork-cache-demo
+          working-directory: libs/evals
+
+      - name: "📦 Install Dependencies"
+        working-directory: libs/evals
+        run: uv sync --group test --locked
+
+      - name: "🍴 Run fork_cache_demo.py"
+        working-directory: libs/evals
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ANTHROPIC_API_KEY: ${{ startsWith(inputs.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
+          OPENAI_API_KEY: ${{ startsWith(inputs.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+        run: |
+          uv run python ../../.github/scripts/evals/fork_cache_demo.py \
+            --repo "${{ inputs.repo }}" \
+            --pr "${{ inputs.pr_number }}" \
+            --mode "${{ matrix.mode }}" \
+            --model "$MODEL" \
+            --lenses "${{ inputs.lenses }}" \
+            --allowed-prefix "${{ inputs.allowed_path_prefix }}" \
+            --out-json "../../_fork_cache_demo/${{ matrix.mode }}.json"
+
+      - name: "📤 Upload metrics"
+        if: ${{ always() && hashFiles(format('_fork_cache_demo/{0}.json', matrix.mode)) != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: fork-cache-demo-${{ matrix.mode }}
+          path: _fork_cache_demo/${{ matrix.mode }}.json
+          if-no-files-found: error
+
+  compare:
+    name: "📊 Compare fork vs handoff"
+    needs: demo
+    if: ${{ always() && needs.demo.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: "⬇️ Download metrics"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: fork-cache-demo-*
+          path: _fork_cache_demo
+          merge-multiple: true
+
+      - name: "📊 Compare"
+        # Only meaningful once both modes ran; a single-mode dispatch has
+        # nothing to diff against, so just say so rather than failing.
+        run: |
+          if [ -f _fork_cache_demo/fork.json ] && [ -f _fork_cache_demo/handoff.json ]; then
+            python3 .github/scripts/evals/compare_fork_cache_demo.py \
+              --fork-json _fork_cache_demo/fork.json \
+              --handoff-json _fork_cache_demo/handoff.json
+          else
+            echo "## Fork cache demo" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Only one mode was dispatched (\`${{ inputs.modes }}\`); nothing to compare. See that mode's own job log/artifact for its metrics." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/fork_cache_demo.yml
+++ b/.github/workflows/fork_cache_demo.yml
@@ -1,31 +1,11 @@
-# Fork-vs-handoff cost/cache demo workflow for Deep Agents subagents.
-#
-# Manual only (workflow_dispatch) -- this spends real model tokens on a live
-# PR review and is not wired to pull_request/push, so it never runs on a PR
-# or merge. Runs fork_cache_demo.py once per branch leg against a real PR's
-# diff, checking out a *different* `deepagents` ref for each leg so the
-# general-purpose subagent's own real default (fork vs. handoff) drives the
-# comparison -- not a `--mode` flag on a single checkout. Then (when both
-# legs ran) compares the two runs' locally-captured metrics: cache-read
-# tokens, token/tool-call cost, wall-clock, and delegation-directive size.
-#
-# The workflow file and eval scripts always come from wherever this workflow
-# itself is running from (main, once this is merged); only the `libs/`
-# directory tree gets overlaid per leg from `fork_ref`/`handoff_ref`, so
-# those branches don't need to carry the eval scripts themselves.
-#
-# LangSmith tracing is enabled automatically when LANGSMITH_API_KEY is
-# present in the `evals` environment, purely so a human can inspect the run
-# visually afterward -- the printed/uploaded metrics come from
-# fork_cache_demo.py's own callback handler, not from LangSmith, so tracing
-# being off does not affect the comparison.
-#
-# Required secrets (in the `evals` environment): whichever provider key
-# matches `inputs.model`'s prefix -- ANTHROPIC_API_KEY (the default model),
-# BASETEN_API_KEY, FIREWORKS_API_KEY, GOOGLE_API_KEY, GROQ_API_KEY,
-# NVIDIA_API_KEY, OLLAMA_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, or
-# XAI_API_KEY, same provider-key gating as _harbor_run.yml. LANGSMITH_API_KEY
-# is optional; enables tracing when present.
+# Fork-vs-handoff cost/cache demo. Manual only (workflow_dispatch); never runs on push/PR.
+# Runs fork_cache_demo.py once per branch leg (fork_ref/handoff_ref) so the general-purpose
+# subagent's own real default drives the comparison, not a --mode flag. Only libs/ gets
+# overlaid per leg, so those branches don't need to carry the eval scripts themselves.
+# LangSmith tracing turns on automatically when LANGSMITH_API_KEY is set, purely for visual
+# inspection -- not load-bearing for the comparison, which comes from the script's own metrics.
+# Secrets (evals environment): the provider key matching inputs.model's prefix, same gating
+# as _harbor_run.yml; LANGSMITH_API_KEY optional.
 
 name: "🍴 Fork cache demo"
 run-name: >-
@@ -138,18 +118,12 @@ jobs:
     timeout-minutes: 20
     env:
       MODEL: ${{ inputs.model }}
-      # Trace-level LangSmith tracing only, purely for visual inspection --
-      # this script's own metrics come from its callback handler, not
-      # LangSmith. Tracing turns on only when the secret is present (no
-      # warnings when absent), same idiom as clbench.yml.
+      # Visual inspection only; metrics come from the script's own callback handler.
       LANGSMITH_TRACING: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
       LANGSMITH_PROJECT: fork-cache-demo-${{ matrix.tag }}-${{ github.run_id }}
     steps:
       - name: "📋 Checkout Code"
-        # No `ref:` override here -- this gives us the workflow's own
-        # eval scripts/config from wherever this workflow runs from
-        # (main, once merged). Only `libs/` gets overlaid per leg below,
-        # so fork_ref/handoff_ref don't need to carry the eval scripts.
+        # No ref override: eval scripts come from the workflow's own ref; libs/ is overlaid below.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "📋 Overlay libs/ from ${{ matrix.ref }}"
@@ -174,9 +148,7 @@ jobs:
         working-directory: libs/evals
         env:
           GH_TOKEN: ${{ github.token }}
-          # Same provider-key gating as _harbor_run.yml: only the secret matching
-          # inputs.model's own prefix gets threaded through, so `model` alone is
-          # enough to pick up the right key -- no separate provider input needed.
+          # Same provider-key gating as _harbor_run.yml, keyed off inputs.model's prefix.
           ANTHROPIC_API_KEY: ${{ startsWith(inputs.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
           BASETEN_API_KEY: ${{ startsWith(inputs.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
           FIREWORKS_API_KEY: ${{ startsWith(inputs.model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}
@@ -223,8 +195,7 @@ jobs:
           merge-multiple: true
 
       - name: "📊 Compare"
-        # Only meaningful once both legs ran; a fork_ref-only dispatch has
-        # nothing to diff against, so just say so rather than failing.
+        # Only meaningful once both legs ran.
         run: |
           if [ -f _fork_cache_demo/fork.json ] && [ -f _fork_cache_demo/handoff.json ]; then
             python3 .github/scripts/evals/compare_fork_cache_demo.py \

--- a/.github/workflows/fork_cache_demo.yml
+++ b/.github/workflows/fork_cache_demo.yml
@@ -2,6 +2,11 @@
 # Runs fork_cache_demo.py once per branch leg (fork_ref/handoff_ref) so the general-purpose
 # subagent's own real default drives the comparison, not a --mode flag. Only libs/ gets
 # overlaid per leg, so those branches don't need to carry the eval scripts themselves.
+# The compare job hard-fails (assert_cache_hit_gate.py) if fork's first-call cache_read
+# isn't a real, non-zero improvement over handoff -- not just a printed comparison.
+# The fork leg also runs a second, independent check: the multiturn-incident-correction
+# Harbor task (its own real Verifier, unrelated to our cache metrics) -- it only exists
+# on fork_ref, so it can't run against handoff_ref; see that step's own comment.
 # LangSmith tracing turns on automatically when LANGSMITH_API_KEY is set, purely for visual
 # inspection -- not load-bearing for the comparison, which comes from the script's own metrics.
 # Secrets (evals environment): the provider key matching inputs.model's prefix, same gating
@@ -126,6 +131,19 @@ jobs:
       # Visual inspection only; metrics come from the script's own callback handler.
       LANGSMITH_TRACING: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
       LANGSMITH_PROJECT: fork-cache-demo-${{ matrix.tag }}-${{ github.run_id }}
+      # Job-level so both the fork_cache_demo.py step and the incident-correction
+      # step below can reach them. Same provider-key gating as _harbor_run.yml.
+      ANTHROPIC_API_KEY: ${{ startsWith(inputs.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
+      BASETEN_API_KEY: ${{ startsWith(inputs.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
+      FIREWORKS_API_KEY: ${{ startsWith(inputs.model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}
+      GOOGLE_API_KEY: ${{ startsWith(inputs.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
+      GROQ_API_KEY: ${{ startsWith(inputs.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
+      LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+      NVIDIA_API_KEY: ${{ startsWith(inputs.model, 'nvidia:') && secrets.NVIDIA_API_KEY || '' }}
+      OLLAMA_API_KEY: ${{ startsWith(inputs.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
+      OPENAI_API_KEY: ${{ startsWith(inputs.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
+      OPENROUTER_API_KEY: ${{ startsWith(inputs.model, 'openrouter:') && secrets.OPENROUTER_API_KEY || '' }}
+      XAI_API_KEY: ${{ startsWith(inputs.model, 'xai:') && secrets.XAI_API_KEY || '' }}
     steps:
       - name: "📋 Checkout Code"
         # No ref override: eval scripts come from the workflow's own ref; libs/ is overlaid below.
@@ -165,18 +183,6 @@ jobs:
           BRANCH_TAG: ${{ matrix.tag }}
           LENSES: ${{ inputs.lenses }}
           ALLOWED_PATH_PREFIX: ${{ inputs.allowed_path_prefix }}
-          # Same provider-key gating as _harbor_run.yml, keyed off inputs.model's prefix.
-          ANTHROPIC_API_KEY: ${{ startsWith(inputs.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
-          BASETEN_API_KEY: ${{ startsWith(inputs.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
-          FIREWORKS_API_KEY: ${{ startsWith(inputs.model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}
-          GOOGLE_API_KEY: ${{ startsWith(inputs.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
-          GROQ_API_KEY: ${{ startsWith(inputs.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
-          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          NVIDIA_API_KEY: ${{ startsWith(inputs.model, 'nvidia:') && secrets.NVIDIA_API_KEY || '' }}
-          OLLAMA_API_KEY: ${{ startsWith(inputs.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
-          OPENAI_API_KEY: ${{ startsWith(inputs.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
-          OPENROUTER_API_KEY: ${{ startsWith(inputs.model, 'openrouter:') && secrets.OPENROUTER_API_KEY || '' }}
-          XAI_API_KEY: ${{ startsWith(inputs.model, 'xai:') && secrets.XAI_API_KEY || '' }}
         run: |
           uv run python ../../.github/scripts/evals/fork_cache_demo.py \
             --repo "$REPO" \
@@ -194,6 +200,85 @@ jobs:
           name: fork-cache-demo-${{ matrix.tag }}
           path: _fork_cache_demo/${{ matrix.tag }}.json
           if-no-files-found: error
+
+      # Second, independent check on the fork leg only: multiturn-incident-correction
+      # requires require_replay_before_delegation/replay_correction, which only exists
+      # on fork_ref -- it cannot run against handoff_ref. Not a fork-vs-handoff
+      # comparison; this is a real Harbor Verifier (postmortem-fact + evidence-hash
+      # checks), independent of our own cache-read metrics above.
+      - name: "🚑 Stage local deps + run incident-correction check"
+        if: ${{ matrix.tag == 'fork' }}
+        working-directory: libs/evals
+        env:
+          # Own project, separate from this leg's fork-cache-demo-fork-* trace above.
+          LANGSMITH_PROJECT: fork-cache-demo-incident-check-${{ github.run_id }}
+        run: |
+          make stage-harbor-local-deps
+          mkdir -p _incident_check_jobs
+          uv run harbor run \
+            --path datasets/subagent-forking-evals/tasks \
+            --include-task-name multiturn-incident-correction \
+            --agent langgraph \
+            --agent-kwarg project_path=deepagents_harbor/langgraph_project \
+            --agent-kwarg graph=dcode \
+            --agent-kwarg 'configurable={"enable_replay_tool":true,"deepagents_require_replay_before_delegation":true,"replay_correction_text":"The deployment/feature-flag change is the candidate trigger; pool saturation and 5xx/timeouts are downstream symptoms."}' \
+            --agent-env 'LANGSMITH_API_KEY=${LANGSMITH_API_KEY}' \
+            --agent-env 'LANGSMITH_TRACING=${LANGSMITH_TRACING}' \
+            --agent-env 'LANGSMITH_PROJECT=${LANGSMITH_PROJECT}' \
+            --agent-env 'ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}' \
+            --agent-env 'BASETEN_API_KEY=${BASETEN_API_KEY}' \
+            --agent-env 'FIREWORKS_API_KEY=${FIREWORKS_API_KEY}' \
+            --agent-env 'GOOGLE_API_KEY=${GOOGLE_API_KEY}' \
+            --agent-env 'GROQ_API_KEY=${GROQ_API_KEY}' \
+            --agent-env 'NVIDIA_API_KEY=${NVIDIA_API_KEY}' \
+            --agent-env 'OLLAMA_API_KEY=${OLLAMA_API_KEY}' \
+            --agent-env 'OPENAI_API_KEY=${OPENAI_API_KEY}' \
+            --agent-env 'OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' \
+            --agent-env 'XAI_API_KEY=${XAI_API_KEY}' \
+            --model "$MODEL" \
+            --env docker \
+            --yes \
+            -n 1 \
+            --jobs-dir _incident_check_jobs
+
+      - name: "🚑 Report incident-correction result"
+        if: ${{ matrix.tag == 'fork' && always() }}
+        working-directory: libs/evals
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          jobs_dir = Path("_incident_check_jobs")
+          job_dirs = sorted(p for p in jobs_dir.iterdir() if p.is_dir()) if jobs_dir.is_dir() else []
+          if not job_dirs:
+              print("::error::No Harbor job directory found for multiturn-incident-correction")
+              sys.exit(1)
+          trial_dirs = sorted(
+              p for p in job_dirs[-1].rglob("result.json")
+          )
+          if not trial_dirs:
+              print(f"::error::No trial result found under {job_dirs[-1]}")
+              sys.exit(1)
+          result = json.loads(trial_dirs[-1].read_text())
+          reward = (result.get("verifier_result") or {}).get("rewards", {}).get("reward")
+          exception = (result.get("exception_info") or {}).get("exception_type")
+
+          summary = (
+              "## Incident-correction check (fork leg)\n\n"
+              f"- Reward: `{reward}`\n"
+              f"- Exception: `{exception or 'none'}`\n"
+          )
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write(summary + "\n")
+          print(summary)
+
+          if exception or reward != 1.0:
+              print("::error::multiturn-incident-correction did not pass")
+              sys.exit(1)
+          PY
 
   compare:
     name: "📊 Compare fork vs handoff"
@@ -223,3 +308,12 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "\`handoff_ref\` was not given; nothing to compare. See the fork leg's own job log/artifact for its metrics." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: "🚦 Assert cache-hit gate"
+        # Hard gate: fails the workflow if fork didn't show a real, non-zero
+        # cache advantage over handoff. Only meaningful once both legs ran.
+        if: ${{ hashFiles('_fork_cache_demo/fork.json') != '' && hashFiles('_fork_cache_demo/handoff.json') != '' }}
+        run: |
+          python3 .github/scripts/evals/assert_cache_hit_gate.py \
+            --fork-json _fork_cache_demo/fork.json \
+            --handoff-json _fork_cache_demo/handoff.json

--- a/.github/workflows/fork_cache_demo.yml
+++ b/.github/workflows/fork_cache_demo.yml
@@ -20,10 +20,12 @@
 # fork_cache_demo.py's own callback handler, not from LangSmith, so tracing
 # being off does not affect the comparison.
 #
-# Required secrets (in the `evals` environment):
-#   ANTHROPIC_API_KEY  — needed for anthropic: models (the default)
-#   OPENAI_API_KEY     — needed for openai: models
-#   LANGSMITH_API_KEY  — optional; enables tracing when present
+# Required secrets (in the `evals` environment): whichever provider key
+# matches `inputs.model`'s prefix -- ANTHROPIC_API_KEY (the default model),
+# BASETEN_API_KEY, FIREWORKS_API_KEY, GOOGLE_API_KEY, GROQ_API_KEY,
+# NVIDIA_API_KEY, OLLAMA_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, or
+# XAI_API_KEY, same provider-key gating as _harbor_run.yml. LANGSMITH_API_KEY
+# is optional; enables tracing when present.
 
 name: "🍴 Fork cache demo"
 run-name: >-
@@ -172,9 +174,20 @@ jobs:
         working-directory: libs/evals
         env:
           GH_TOKEN: ${{ github.token }}
+          # Same provider-key gating as _harbor_run.yml: only the secret matching
+          # inputs.model's own prefix gets threaded through, so `model` alone is
+          # enough to pick up the right key -- no separate provider input needed.
           ANTHROPIC_API_KEY: ${{ startsWith(inputs.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
-          OPENAI_API_KEY: ${{ startsWith(inputs.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
+          BASETEN_API_KEY: ${{ startsWith(inputs.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
+          FIREWORKS_API_KEY: ${{ startsWith(inputs.model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}
+          GOOGLE_API_KEY: ${{ startsWith(inputs.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
+          GROQ_API_KEY: ${{ startsWith(inputs.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          NVIDIA_API_KEY: ${{ startsWith(inputs.model, 'nvidia:') && secrets.NVIDIA_API_KEY || '' }}
+          OLLAMA_API_KEY: ${{ startsWith(inputs.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
+          OPENAI_API_KEY: ${{ startsWith(inputs.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
+          OPENROUTER_API_KEY: ${{ startsWith(inputs.model, 'openrouter:') && secrets.OPENROUTER_API_KEY || '' }}
+          XAI_API_KEY: ${{ startsWith(inputs.model, 'xai:') && secrets.XAI_API_KEY || '' }}
         run: |
           uv run python ../../.github/scripts/evals/fork_cache_demo.py \
             --repo "${{ inputs.repo }}" \

--- a/.github/workflows/fork_cache_demo.yml
+++ b/.github/workflows/fork_cache_demo.yml
@@ -127,11 +127,16 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "📋 Overlay libs/ from ${{ matrix.ref }}"
+        # Dispatch inputs must reach the shell via env:, never interpolated directly into
+        # run: -- GitHub substitutes ${{ }} before Bash parses the script, so an input
+        # containing shell metacharacters would execute rather than being treated as data.
+        env:
+          REF: ${{ matrix.ref }}
         run: |
-          git fetch --depth=1 origin "${{ matrix.ref }}"
+          git fetch --depth=1 origin "$REF"
           rm -rf libs
           git checkout FETCH_HEAD -- libs
-          echo "Overlaid libs/ from ${{ matrix.ref }} ($(git rev-parse FETCH_HEAD))"
+          echo "Overlaid libs/ from $REF ($(git rev-parse FETCH_HEAD))"
 
       - name: "🐍 Set up Python + UV"
         uses: "./.github/actions/uv_setup"
@@ -148,6 +153,13 @@ jobs:
         working-directory: libs/evals
         env:
           GH_TOKEN: ${{ github.token }}
+          # Dispatch inputs go through env: too -- same script-injection reasoning as the
+          # overlay step above, and this step's env already carries live secrets.
+          REPO: ${{ inputs.repo }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          BRANCH_TAG: ${{ matrix.tag }}
+          LENSES: ${{ inputs.lenses }}
+          ALLOWED_PATH_PREFIX: ${{ inputs.allowed_path_prefix }}
           # Same provider-key gating as _harbor_run.yml, keyed off inputs.model's prefix.
           ANTHROPIC_API_KEY: ${{ startsWith(inputs.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
           BASETEN_API_KEY: ${{ startsWith(inputs.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
@@ -162,13 +174,13 @@ jobs:
           XAI_API_KEY: ${{ startsWith(inputs.model, 'xai:') && secrets.XAI_API_KEY || '' }}
         run: |
           uv run python ../../.github/scripts/evals/fork_cache_demo.py \
-            --repo "${{ inputs.repo }}" \
-            --pr "${{ inputs.pr_number }}" \
-            --branch-tag "${{ matrix.tag }}" \
+            --repo "$REPO" \
+            --pr "$PR_NUMBER" \
+            --branch-tag "$BRANCH_TAG" \
             --model "$MODEL" \
-            --lenses "${{ inputs.lenses }}" \
-            --allowed-prefix "${{ inputs.allowed_path_prefix }}" \
-            --out-json "../../_fork_cache_demo/${{ matrix.tag }}.json"
+            --lenses "$LENSES" \
+            --allowed-prefix "$ALLOWED_PATH_PREFIX" \
+            --out-json "../../_fork_cache_demo/$BRANCH_TAG.json"
 
       - name: "📤 Upload metrics"
         if: ${{ always() && hashFiles(format('_fork_cache_demo/{0}.json', matrix.tag)) != '' }}

--- a/.github/workflows/fork_cache_demo.yml
+++ b/.github/workflows/fork_cache_demo.yml
@@ -88,15 +88,20 @@ jobs:
         env:
           FORK_REF: ${{ inputs.fork_ref }}
           HANDOFF_REF: ${{ inputs.handoff_ref }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           python3 - <<'PY'
           import json
           import os
+          import re
 
           fork_ref = os.environ["FORK_REF"].strip()
           handoff_ref = os.environ["HANDOFF_REF"].strip()
+          pr_number = os.environ["PR_NUMBER"].strip()
           if not fork_ref:
               raise SystemExit("::error::fork_ref is required")
+          if not re.fullmatch(r"[0-9]+", pr_number):
+              raise SystemExit(f"::error::pr_number must be numeric, got {pr_number!r}")
 
           legs = [{"tag": "fork", "ref": fork_ref}]
           if handoff_ref:

--- a/.github/workflows/fork_cache_demo.yml
+++ b/.github/workflows/fork_cache_demo.yml
@@ -2,10 +2,17 @@
 #
 # Manual only (workflow_dispatch) -- this spends real model tokens on a live
 # PR review and is not wired to pull_request/push, so it never runs on a PR
-# or merge. Runs fork_cache_demo.py once per selected mode against a real
-# PR's diff, then (when both "fork" and "handoff" ran) compares the two
-# runs' locally-captured metrics: cache-read tokens, token/tool-call cost,
-# wall-clock, and delegation-directive size.
+# or merge. Runs fork_cache_demo.py once per branch leg against a real PR's
+# diff, checking out a *different* `deepagents` ref for each leg so the
+# general-purpose subagent's own real default (fork vs. handoff) drives the
+# comparison -- not a `--mode` flag on a single checkout. Then (when both
+# legs ran) compares the two runs' locally-captured metrics: cache-read
+# tokens, token/tool-call cost, wall-clock, and delegation-directive size.
+#
+# The workflow file and eval scripts always come from wherever this workflow
+# itself is running from (main, once this is merged); only the `libs/`
+# directory tree gets overlaid per leg from `fork_ref`/`handoff_ref`, so
+# those branches don't need to carry the eval scripts themselves.
 #
 # LangSmith tracing is enabled automatically when LANGSMITH_API_KEY is
 # present in the `evals` environment, purely so a human can inspect the run
@@ -20,7 +27,8 @@
 
 name: "🍴 Fork cache demo"
 run-name: >-
-  🍴 Fork cache demo — PR #${{ inputs.pr_number }} (${{ inputs.repo }}) / ${{ inputs.modes }}
+  🍴 Fork cache demo — PR #${{ inputs.pr_number }} (${{ inputs.repo }}) —
+  ${{ inputs.fork_ref }} vs ${{ inputs.handoff_ref }}
 
 on:
   workflow_dispatch:
@@ -38,12 +46,16 @@ on:
         description: "provider:model spec passed to init_chat_model"
         type: string
         default: "anthropic:claude-sonnet-4-6"
-      modes:
-        description: "Comma-separated modes to run. Include both to get the comparison job; a single mode just runs and uploads its own metrics."
+      fork_ref:
+        description: "Git ref whose deepagents package forces the general-purpose subagent into mode: \"fork\" by default"
         type: string
-        default: "fork,handoff"
+        default: "bengret/sug-agent-forking-evals"
+      handoff_ref:
+        description: "Git ref whose deepagents package leaves the general-purpose subagent as the normal (handoff) default. Leave blank to skip this leg and only run fork_ref."
+        type: string
+        default: "bengret/feat-subagent-forking"
       lenses:
-        description: "Comma-separated review lenses (= subagent names delegated to)"
+        description: "Comma-separated review lenses, delegated to (in order) via the general-purpose subagent"
         type: string
         default: "correctness,backcompat,tests,performance,api_design"
       allowed_path_prefix:
@@ -60,7 +72,7 @@ concurrency:
 
 jobs:
   prep:
-    name: "🔧 Parse modes"
+    name: "🔧 Parse refs"
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -70,7 +82,8 @@ jobs:
           REPO: ${{ inputs.repo }}
           PR_NUMBER: ${{ inputs.pr_number }}
           MODEL: ${{ inputs.model }}
-          MODES: ${{ inputs.modes }}
+          FORK_REF: ${{ inputs.fork_ref }}
+          HANDOFF_REF: ${{ inputs.handoff_ref }}
           LENSES: ${{ inputs.lenses }}
           ALLOWED_PATH_PREFIX: ${{ inputs.allowed_path_prefix }}
         run: |
@@ -82,35 +95,38 @@ jobs:
             echo "| \`repo\` | \`${REPO}\` |"
             echo "| \`pr_number\` | \`${PR_NUMBER}\` |"
             echo "| \`model\` | \`${MODEL}\` |"
-            echo "| \`modes\` | \`${MODES}\` |"
+            echo "| \`fork_ref\` | \`${FORK_REF}\` |"
+            echo "| \`handoff_ref\` | \`${HANDOFF_REF:-(skipped)}\` |"
             echo "| \`lenses\` | \`${LENSES}\` |"
             echo "| \`allowed_path_prefix\` | \`${ALLOWED_PATH_PREFIX}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: "🧮 Build mode matrix"
+      - name: "🧮 Build ref matrix"
         id: set-matrix
         env:
-          MODES: ${{ inputs.modes }}
+          FORK_REF: ${{ inputs.fork_ref }}
+          HANDOFF_REF: ${{ inputs.handoff_ref }}
         run: |
           python3 - <<'PY'
           import json
           import os
 
-          modes = [m.strip() for m in os.environ["MODES"].split(",") if m.strip()]
-          valid = {"fork", "handoff"}
-          unknown = [m for m in modes if m not in valid]
-          if unknown:
-              raise SystemExit(f"::error::Unknown mode(s): {unknown}; must be 'fork' or 'handoff'")
-          if not modes:
-              raise SystemExit("::error::No modes given")
+          fork_ref = os.environ["FORK_REF"].strip()
+          handoff_ref = os.environ["HANDOFF_REF"].strip()
+          if not fork_ref:
+              raise SystemExit("::error::fork_ref is required")
 
-          matrix = json.dumps({"mode": modes})
+          legs = [{"tag": "fork", "ref": fork_ref}]
+          if handoff_ref:
+              legs.append({"tag": "handoff", "ref": handoff_ref})
+
+          matrix = json.dumps({"include": legs})
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"matrix={matrix}\n")
           PY
 
   demo:
-    name: "🍴 Run (${{ matrix.mode }})"
+    name: "🍴 Run (${{ matrix.tag }}: ${{ matrix.ref }})"
     needs: prep
     strategy:
       fail-fast: false
@@ -125,10 +141,21 @@ jobs:
       # LangSmith. Tracing turns on only when the secret is present (no
       # warnings when absent), same idiom as clbench.yml.
       LANGSMITH_TRACING: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
-      LANGSMITH_PROJECT: fork-cache-demo-${{ matrix.mode }}-${{ github.run_id }}
+      LANGSMITH_PROJECT: fork-cache-demo-${{ matrix.tag }}-${{ github.run_id }}
     steps:
       - name: "📋 Checkout Code"
+        # No `ref:` override here -- this gives us the workflow's own
+        # eval scripts/config from wherever this workflow runs from
+        # (main, once merged). Only `libs/` gets overlaid per leg below,
+        # so fork_ref/handoff_ref don't need to carry the eval scripts.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: "📋 Overlay libs/ from ${{ matrix.ref }}"
+        run: |
+          git fetch --depth=1 origin "${{ matrix.ref }}"
+          rm -rf libs
+          git checkout FETCH_HEAD -- libs
+          echo "Overlaid libs/ from ${{ matrix.ref }} ($(git rev-parse FETCH_HEAD))"
 
       - name: "🐍 Set up Python + UV"
         uses: "./.github/actions/uv_setup"
@@ -152,18 +179,18 @@ jobs:
           uv run python ../../.github/scripts/evals/fork_cache_demo.py \
             --repo "${{ inputs.repo }}" \
             --pr "${{ inputs.pr_number }}" \
-            --mode "${{ matrix.mode }}" \
+            --branch-tag "${{ matrix.tag }}" \
             --model "$MODEL" \
             --lenses "${{ inputs.lenses }}" \
             --allowed-prefix "${{ inputs.allowed_path_prefix }}" \
-            --out-json "../../_fork_cache_demo/${{ matrix.mode }}.json"
+            --out-json "../../_fork_cache_demo/${{ matrix.tag }}.json"
 
       - name: "📤 Upload metrics"
-        if: ${{ always() && hashFiles(format('_fork_cache_demo/{0}.json', matrix.mode)) != '' }}
+        if: ${{ always() && hashFiles(format('_fork_cache_demo/{0}.json', matrix.tag)) != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: fork-cache-demo-${{ matrix.mode }}
-          path: _fork_cache_demo/${{ matrix.mode }}.json
+          name: fork-cache-demo-${{ matrix.tag }}
+          path: _fork_cache_demo/${{ matrix.tag }}.json
           if-no-files-found: error
 
   compare:
@@ -183,7 +210,7 @@ jobs:
           merge-multiple: true
 
       - name: "📊 Compare"
-        # Only meaningful once both modes ran; a single-mode dispatch has
+        # Only meaningful once both legs ran; a fork_ref-only dispatch has
         # nothing to diff against, so just say so rather than failing.
         run: |
           if [ -f _fork_cache_demo/fork.json ] && [ -f _fork_cache_demo/handoff.json ]; then
@@ -193,5 +220,5 @@ jobs:
           else
             echo "## Fork cache demo" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Only one mode was dispatched (\`${{ inputs.modes }}\`); nothing to compare. See that mode's own job log/artifact for its metrics." >> "$GITHUB_STEP_SUMMARY"
+            echo "\`handoff_ref\` was not given; nothing to compare. See the fork leg's own job log/artifact for its metrics." >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
Adds a manual-only GitHub Actions workflow (`fork_cache_demo.yml`) that quantifies the prompt-cache benefit of forking the general-purpose subagent: it runs a real PR review through 5 delegated lenses (correctness, backcompat, tests, performance, api_design) once per branch leg. Fork vs. handoff is driven entirely by which branch's deepagents is checked out.
Metrics (cache-read tokens, token/tool-call cost, wall-clock, delegation-directive size) come from a local callback handler, not LangSmith; Provider API keys are gated by inputs.model's prefix, matching `_harbor_run.yml`'s convention.