### PR TITLE
fix(talon): restore WhatsApp bridge compatibility

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -84,6 +84,12 @@ jobs:
           cache-suffix: test-${{ inputs.working-directory }}
           working-directory: ${{ inputs.working-directory }}
 
+      - name: "🟩 Set up Node for Talon"
+        if: inputs.working-directory == 'libs/talon'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+
       - name: "📦 Install Test Dependencies"
         shell: bash
         run: uv sync --group test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -651,6 +651,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: "false"
 
+      - name: Set up Node for Talon
+        if: needs.build.outputs.pkg-name == 'deepagents-talon'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist

--- a/libs/talon/Makefile
+++ b/libs/talon/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format type typecheck test tests test_watch help
+.PHONY: lint format type typecheck test tests test_bridge test_watch help
 
 .DEFAULT_GOAL := help
 
@@ -10,9 +10,12 @@ COV_ARGS ?= --cov=deepagents_talon --cov-report=term-missing
 PYTEST_EXTRA ?=
 
 test: ## Run unit tests
-test tests:
+test tests: test_bridge
 	uv run --group test pytest --disable-socket --allow-unix-socket $(PYTEST_EXTRA) $(TEST_FILE) \
 		--timeout 10 $(COV_ARGS)
+
+test_bridge: ## Run WhatsApp bridge unit tests
+	node --test tests/channels/whatsapp_bridge/*.test.js
 
 test_watch: ## Run tests in watch mode
 	uv run --group test ptw . -- $(TEST_FILE)

--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -16,6 +16,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field, replace
+from http import HTTPStatus
 from importlib.resources import files
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -69,6 +70,10 @@ OPEN_EXPOSURE_ACK_ENV = "DEEPAGENTS_TALON_WHATSAPP_OPEN_ACK"
 
 class _WhatsAppBridgeError(RuntimeError):
     """Raised when the WhatsApp bridge reports or causes a transport error."""
+
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
 
 
 @dataclass(frozen=True, slots=True)
@@ -242,7 +247,11 @@ class _BridgeTransport:
                 return json.loads(response.read().decode())
         except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
             msg = f"WhatsApp bridge request failed: {method} {path}"
-            raise _WhatsAppBridgeError(msg) from error
+            retryable = (
+                isinstance(error, urllib.error.HTTPError)
+                and error.code == HTTPStatus.SERVICE_UNAVAILABLE
+            )
+            raise _WhatsAppBridgeError(msg, retryable=retryable) from error
 
 
 class WhatsAppChannel:
@@ -347,8 +356,14 @@ class WhatsAppChannel:
             chunk_count=len(chunks),
             text_chars=len(text),
         )
-        for chunk in chunks:
-            response = await self._post_result("/send", {"chatId": conversation_id, "text": chunk})
+        try:
+            for chunk in chunks:
+                response = await self._post_result(
+                    "/send",
+                    {"chatId": conversation_id, "text": chunk},
+                )
+        except _WhatsAppBridgeError as error:
+            return SendResult(success=False, error=str(error), retryable=error.retryable)
         message_id = _extract_message_id(response)
         log_debug_event(
             logger,
@@ -374,12 +389,13 @@ class WhatsAppChannel:
             max_bytes=self.config.max_media_bytes,
         )
         staged = await asyncio.to_thread(_stage_bridge_media, checked.path, self.config)
+        staged_copy = staged != checked.path.expanduser().resolve()
         log_debug_event(
             logger,
             "whatsapp.outbound.media.started",
             caption_present=checked.caption is not None,
             media_type=checked.media_type,
-            staged_copy=staged != checked.path,
+            staged_copy=staged_copy,
         )
         payload: dict[str, object] = {
             "chatId": conversation_id,
@@ -392,7 +408,13 @@ class WhatsAppChannel:
             )
         else:
             payload["caption"] = _bot_header(self.config.bot_header)
-        response = await self._post_result("/send-media", payload)
+        try:
+            response = await self._post_result("/send-media", payload)
+        except _WhatsAppBridgeError as error:
+            return SendResult(success=False, error=str(error), retryable=error.retryable)
+        finally:
+            if staged_copy:
+                await asyncio.to_thread(_remove_staged_media, staged)
         message_id = _extract_message_id(response)
         log_debug_event(
             logger,
@@ -421,7 +443,7 @@ class WhatsAppChannel:
         Returns:
             Result indicating whether the edit succeeded.
         """
-        await self._post_result(
+        response = await self._post_result(
             "/edit",
             {
                 "chatId": conversation_id,
@@ -429,7 +451,7 @@ class WhatsAppChannel:
                 "content": _with_bot_header(text, bot_header=self.config.bot_header),
             },
         )
-        return SendResult(success=True, message_id=message_id)
+        return SendResult(success=True, message_id=_extract_message_id(response) or message_id)
 
     async def status(self) -> ChannelStatus:
         """Report the most recent bridge connection status."""
@@ -688,6 +710,13 @@ def _stage_bridge_media(path: Path, config: WhatsAppChannelConfig) -> Path:
     return destination
 
 
+def _remove_staged_media(path: Path) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        logger.warning("Failed to remove staged WhatsApp outbound media")
+
+
 def _validate_loopback_url(value: str) -> str:
     parsed = urllib.parse.urlparse(value)
     if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
@@ -739,7 +768,7 @@ def _parse_message(payload: object) -> ChannelMessage:
             "chat_id_from": values.get("chat_id_from") or values.get("chatIdFrom"),
             "user_name": values.get("user_name") or values.get("senderName"),
             "raw_message": values.get("raw_message") or {},
-            "from_self": bool(values.get("from_self") or values.get("fromSelf")),
+            "from_self": values.get("from_self") is True or values.get("fromSelf") is True,
         },
     )
     return message_with_media_paths(

--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -251,6 +251,8 @@ class _BridgeTransport:
                 isinstance(error, urllib.error.HTTPError)
                 and error.code == HTTPStatus.SERVICE_UNAVAILABLE
             )
+            if isinstance(error, urllib.error.HTTPError):
+                error.close()
             raise _WhatsAppBridgeError(msg, retryable=retryable) from error
 
 

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
@@ -5,27 +5,43 @@ const http = require("http");
 const path = require("path");
 const { Client, LocalAuth, MessageMedia } = require("whatsapp-web.js");
 const qrcode = require("qrcode-terminal");
+const {
+  AckTracker,
+  SentBodyReservations,
+  createCompatibleClientClass,
+  normalizeMessage,
+  serializedId,
+  widString,
+} = require("./id_compat");
 
 const host = process.env.WHATSAPP_BRIDGE_HOST || "127.0.0.1";
 const port = Number(process.env.WHATSAPP_BRIDGE_PORT || "3000");
 const sessionDir = path.resolve(process.env.WHATSAPP_SESSION_DIR || path.join(process.cwd(), ".whatsapp"));
 const mediaDir = path.resolve(process.env.WHATSAPP_MEDIA_DIR || path.join(sessionDir, "..", "media"));
-const botHeader = process.env.WHATSAPP_BOT_HEADER || "deepagents bot";
 const bridgeToken = process.env.WHATSAPP_BRIDGE_TOKEN || "";
-const maxMediaBytes = Number(process.env.WHATSAPP_MAX_MEDIA_BYTES) || (64 * 1024 * 1024);
+const maxMediaBytes = Number(process.env.WHATSAPP_MAX_MEDIA_BYTES) || 64 * 1024 * 1024;
 const webVersionCacheUrl =
   process.env.WHATSAPP_WEB_VERSION_CACHE_URL ||
   "https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.3000.1026029003.html";
 
+const ACK_TIMEOUT_MS = 60 * 1000;
 const MAX_CACHED_SENT_MESSAGES = 200;
-const SENT_BODY_TTL_MS = 5 * 60 * 1000;
 
 let status = "disconnected";
 let botId = null;
 const queue = [];
 const sentMessageIds = new Set();
 const sentMessages = new Map();
-const recentSentBodies = new Map();
+const sentBodies = new SentBodyReservations();
+const ackTracker = new AckTracker({
+  timeoutMs: ACK_TIMEOUT_MS,
+  onAck: (ack, tracked) => {
+    console.log(`[bridge] Outbound message acknowledgement; ack=${ack} tracked=${tracked}`);
+  },
+  onTimeout: () => {
+    console.error("[bridge] Outbound message acknowledgement timed out");
+  },
+});
 
 process.on("unhandledRejection", (reason) => {
   const message = reason && reason.message ? reason.message : reason;
@@ -43,7 +59,7 @@ cleanStaleLocks(sessionDir);
 
 const chromePath = process.env.CHROME_PATH || process.env.WHATSAPP_CHROME_PATH || findChrome();
 if (chromePath) {
-  console.log(`Using Chrome at: ${chromePath}`);
+  console.log("Using configured Chrome executable");
 } else {
   console.log("No system Chrome found; using Puppeteer's bundled browser if available");
 }
@@ -56,7 +72,8 @@ if (chromePath) {
   puppeteer.executablePath = chromePath;
 }
 
-const client = new Client({
+const CompatibleClient = createCompatibleClientClass(Client);
+const client = new CompatibleClient({
   authStrategy: new LocalAuth({
     dataPath: sessionDir,
   }),
@@ -74,9 +91,7 @@ client.on("qr", (qr) => {
 });
 
 client.on("ready", () => {
-  status = "connected";
-  botId = client.info && client.info.wid ? client.info.wid._serialized : null;
-  console.log(`WhatsApp connected as ${botId || "unknown"}`);
+  void onClientReady();
 });
 
 client.on("disconnected", (reason) => {
@@ -89,40 +104,81 @@ client.on("auth_failure", (message) => {
   console.error(`WhatsApp auth failure: ${message || "unknown error"}`);
 });
 
-client.on("message_create", (message) => {
-  void enqueueMessage(message);
+client.on("compatibility_error", (error) => {
+  status = "compatibility_error";
+  console.error(`[bridge] WhatsApp compatibility setup failed: ${error.message || error}`);
 });
 
-async function enqueueMessage(message) {
-  if (message.from === "status@broadcast") {
+client.on("message_create", (message) => {
+  if (message.fromMe === true) {
+    void enqueueMessage(message, true);
+  }
+});
+
+client.on("message", (message) => {
+  void enqueueMessage(message, false);
+});
+
+client.on("message_ack", (message, ack) => {
+  recordMessageAck(message, ack);
+});
+
+async function onClientReady() {
+  try {
+    const compatibility = client.idCompatibility;
+    if (!compatibility || compatibility.compatible !== true) {
+      throw new Error("WhatsApp message key compatibility is not active");
+    }
+    const webVersion = safeVersion(await client.getWWebVersion());
+    botId = widString(client.info && client.info.wid);
+    status = "connected";
+    console.log(
+      `[bridge] WhatsApp connected; webVersion=${webVersion} idCompatibilityInstalled=${compatibility.installed === true} botIdAvailable=${Boolean(botId)}`,
+    );
+  } catch (error) {
+    status = "compatibility_error";
+    console.error(`[bridge] WhatsApp compatibility setup failed: ${error.message || error}`);
+  }
+}
+
+async function enqueueMessage(message, fromSelf) {
+  normalizeMessage(message);
+  const data = message && message._data ? message._data : {};
+  const messageFrom = widString(message.from) || widString(data.from);
+  if (messageFrom === "status@broadcast") {
     return;
   }
-  const fromSelf = isSelfMessage(message);
   if (fromSelf && isBridgeSentMessage(message)) {
     return;
   }
 
-  const chat = await safeGetChat(message);
-  const contact = await safeGetContact(message);
-  const messageId = serializedId(message.id);
-  const chatId = serializedId(chat && chat.id) || (fromSelf ? message.to : message.from);
+  const messageId = serializedId(message.id) || serializedId(data.id);
+  const messageTo = widString(message.to) || widString(data.to);
+  const remoteId = widString(message.id && message.id.remote) || widString(data.id && data.id.remote);
+  const chatId = (fromSelf ? messageTo : messageFrom) || remoteId;
   if (!messageId || !chatId) {
     console.error("Skipping WhatsApp message without a message id or chat id");
     return;
   }
 
+  const [chat, contact] = await Promise.all([safeGetChat(message), safeGetContact(message)]);
   const media = await downloadMessageMedia(message);
   const mediaType = classifyMedia(message, media);
   if (message.hasMedia && media.length === 0) {
     console.log(
-      `[bridge] Message ${messageId} reported media but no attachment was downloaded; type=${message.type || "unknown"} mediaType=${mediaType}`,
+      `[bridge] Message media unavailable; type=${message.type || "unknown"} mediaType=${mediaType}`,
     );
   }
-  const senderId = message.author || (fromSelf && botId ? botId : message.from);
+  const senderId = widString(message.author) || (fromSelf && botId ? botId : messageFrom);
+  const senderName =
+    (contact && (contact.pushname || contact.name || contact.shortName)) ||
+    data.notifyName ||
+    data.senderName ||
+    senderId ||
+    null;
+  const chatName = (chat && chat.name) || data.chatName || chatId;
   const isGroup =
-    chat && typeof chat.isGroup === "boolean"
-      ? chat.isGroup
-      : typeof chatId === "string" && chatId.endsWith("@g.us");
+    chat && typeof chat.isGroup === "boolean" ? chat.isGroup : chatId.endsWith("@g.us");
 
   const entry = {
     text: message.body || "",
@@ -133,19 +189,17 @@ async function enqueueMessage(message) {
     mediaType,
     chat_id: chatId,
     chatId,
-    chat_id_from: message.from,
-    chatIdFrom: message.from,
-    chat_name: (chat && chat.name) || chatId,
-    chatName: (chat && chat.name) || chatId,
+    chat_id_from: messageFrom,
+    chatIdFrom: messageFrom,
+    chat_name: chatName,
+    chatName,
     chat_type: isGroup ? "group" : "direct",
     chatType: isGroup ? "group" : "direct",
     isGroup,
     user_id: senderId || null,
     senderId: senderId || null,
-    user_name:
-      (contact && (contact.pushname || contact.name || contact.shortName)) || senderId || null,
-    senderName:
-      (contact && (contact.pushname || contact.name || contact.shortName)) || senderId || null,
+    user_name: senderName,
+    senderName,
     message_id: messageId,
     messageId,
     has_media: Boolean(message.hasMedia || media.length > 0),
@@ -165,16 +219,18 @@ async function enqueueMessage(message) {
     botIds: botId ? [botId] : [],
     quotedParticipant: await quotedParticipant(message),
     raw_message: {
-      from: message.from,
-      to: message.to,
-      author: message.author || null,
-      fromMe: Boolean(message.fromMe),
-      idFromMe: Boolean(message.id && message.id.fromMe),
+      from: messageFrom,
+      to: messageTo,
+      author: widString(message.author),
+      fromMe: message.fromMe === true,
+      idFromMe: message.id && message.id.fromMe === true,
       timestamp: message.timestamp || null,
     },
   };
 
-  console.log(`[bridge] Queued message ${messageId} for ${chatId}`);
+  console.log(
+    `[bridge] Queued message; fromSelf=${fromSelf} hasMedia=${entry.hasMedia} chatType=${entry.chatType}`,
+  );
   queue.push(entry);
 }
 
@@ -243,8 +299,8 @@ function findChrome() {
 async function safeGetChat(message) {
   try {
     return await message.getChat();
-  } catch (error) {
-    console.log(`[bridge] getChat failed (non-fatal): ${error.message || error}`);
+  } catch (_error) {
+    console.log("[bridge] getChat failed (non-fatal)");
     return null;
   }
 }
@@ -252,8 +308,8 @@ async function safeGetChat(message) {
 async function safeGetContact(message) {
   try {
     return await message.getContact();
-  } catch (error) {
-    console.log(`[bridge] getContact failed (non-fatal): ${error.message || error}`);
+  } catch (_error) {
+    console.log("[bridge] getContact failed (non-fatal)");
     return null;
   }
 }
@@ -279,7 +335,7 @@ async function downloadMessageMedia(message) {
     const expectedSize = messageMediaSize(message);
     if (expectedSize !== null && expectedSize > maxMediaBytes) {
       console.log(
-        `[bridge] Skipping oversized media ${messageId}: ${expectedSize} bytes exceeds ${maxMediaBytes}`,
+        `[bridge] Skipping oversized media; bytes=${expectedSize} maxBytes=${maxMediaBytes}`,
       );
       return [];
     }
@@ -293,7 +349,7 @@ async function downloadMessageMedia(message) {
     const size = decodedBase64Size(media.data);
     if (size > maxMediaBytes) {
       console.log(
-        `[bridge] Skipping oversized media ${messageId}: ${size} bytes exceeds ${maxMediaBytes}`,
+        `[bridge] Skipping oversized media; bytes=${size} maxBytes=${maxMediaBytes}`,
       );
       return [];
     }
@@ -368,50 +424,44 @@ function decodedBase64Size(value) {
   return Math.floor((data.length * 3) / 4) - padding;
 }
 
-function serializedId(value) {
-  return value && value._serialized ? value._serialized : null;
-}
-
 function normalizeIds(values) {
-  return values.map((value) => (typeof value === "object" ? value._serialized : value)).filter(Boolean);
+  return values.map(widString).filter(Boolean);
 }
 
-function isSelfMessage(message) {
-  if (message.fromMe === true || (message.id && message.id.fromMe === true)) {
-    return true;
-  }
-  const id = serializedId(message.id);
-  return typeof id === "string" && id.startsWith("true_");
+function safeVersion(value) {
+  const version = String(value || "unknown").replace(/[^0-9A-Za-z._-]/g, "");
+  return version.slice(0, 64) || "unknown";
 }
 
-function rememberSentMessage(message, body) {
+function cacheSentMessage(message) {
+  normalizeMessage(message);
   const id = serializedId(message && message.id);
   if (!id) {
-    return;
+    return null;
   }
   sentMessageIds.add(id);
   sentMessages.set(id, message);
-  rememberSentBody(body);
   if (sentMessages.size > MAX_CACHED_SENT_MESSAGES) {
     const oldest = sentMessages.keys().next().value;
     sentMessages.delete(oldest);
+    sentMessageIds.delete(oldest);
+    ackTracker.forget(oldest);
   }
+  return id;
 }
 
-function rememberSentBody(body) {
-  if (!body) {
-    return;
+function rememberSentMessage(message) {
+  const id = cacheSentMessage(message);
+  if (!id) {
+    return null;
   }
-  const key = String(body);
-  recentSentBodies.set(key, (recentSentBodies.get(key) || 0) + 1);
-  setTimeout(() => {
-    const count = recentSentBodies.get(key) || 0;
-    if (count <= 1) {
-      recentSentBodies.delete(key);
-    } else {
-      recentSentBodies.set(key, count - 1);
-    }
-  }, SENT_BODY_TTL_MS).unref();
+  ackTracker.register(id, message.ack);
+  return id;
+}
+
+function recordMessageAck(message, ack) {
+  normalizeMessage(message);
+  ackTracker.record(serializedId(message && message.id), ack);
 }
 
 function isBridgeSentMessage(message) {
@@ -419,11 +469,16 @@ function isBridgeSentMessage(message) {
   if (id && sentMessageIds.has(id)) {
     return true;
   }
-  const body = message.body || "";
-  if (body && recentSentBodies.has(body)) {
-    return true;
+  return sentBodies.has(message.body || "");
+}
+
+async function withSentBodyReservation(body, operation) {
+  const release = sentBodies.reserve(body);
+  try {
+    return await operation();
+  } finally {
+    release();
   }
-  return Boolean(body && body.startsWith(`*${botHeader}*`));
 }
 
 function readJson(req) {
@@ -487,6 +542,11 @@ async function handle(req, res) {
       return;
     }
 
+    if (req.method === "POST" && status !== "connected") {
+      sendJson(res, 503, { success: false, error: "WhatsApp bridge is not connected" });
+      return;
+    }
+
     if (req.method === "POST" && req.url === "/send") {
       const body = await readJson(req);
       const chatId = body.chat_id || body.chatId;
@@ -495,12 +555,16 @@ async function handle(req, res) {
         sendJson(res, 400, { success: false, error: "chat_id and text required" });
         return;
       }
-      rememberSentBody(text);
-      const sent = await client.sendMessage(chatId, text, {
-        quotedMessageId: body.replyTo || body.reply_to || undefined,
+      const messageId = await withSentBodyReservation(text, async () => {
+        const sent = await client.sendMessage(chatId, text, {
+          quotedMessageId: body.replyTo || body.reply_to || undefined,
+        });
+        return rememberSentMessage(sent);
       });
-      rememberSentMessage(sent, text);
-      const messageId = serializedId(sent.id);
+      if (!messageId) {
+        sendJson(res, 502, { success: false, error: "WhatsApp send returned no message id" });
+        return;
+      }
       sendJson(res, 200, {
         success: true,
         message_id: messageId,
@@ -527,15 +591,17 @@ async function handle(req, res) {
         media.filename = body.fileName || body.file_name;
       }
       const caption = body.caption || undefined;
-      if (caption) {
-        rememberSentBody(caption);
-      }
-      const sent = await client.sendMessage(chatId, media, {
-        caption,
-        sendMediaAsDocument: body.mediaType === "document",
+      const messageId = await withSentBodyReservation(caption, async () => {
+        const sent = await client.sendMessage(chatId, media, {
+          caption,
+          sendMediaAsDocument: body.mediaType === "document",
+        });
+        return rememberSentMessage(sent);
       });
-      rememberSentMessage(sent, caption || "");
-      const messageId = serializedId(sent.id);
+      if (!messageId) {
+        sendJson(res, 502, { success: false, error: "WhatsApp send returned no message id" });
+        return;
+      }
       sendJson(res, 200, {
         success: true,
         message_id: messageId,
@@ -570,10 +636,13 @@ async function handle(req, res) {
         sendJson(res, 200, { success: false, error: "message not found" });
         return;
       }
-      rememberSentBody(content);
-      const edited = await message.edit(content);
-      rememberSentMessage(edited, content);
-      const editedId = serializedId(edited.id) || messageId;
+      normalizeMessage(message);
+      const edited = await withSentBodyReservation(content, () => message.edit(content));
+      if (!edited) {
+        sendJson(res, 200, { success: false, error: "message could not be edited" });
+        return;
+      }
+      const editedId = cacheSentMessage(edited) || messageId;
       sendJson(res, 200, {
         success: true,
         message_id: editedId,

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/id_compat.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/id_compat.js
@@ -1,0 +1,247 @@
+"use strict";
+
+function widString(value) {
+  if (!value) {
+    return null;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value !== "object") {
+    return null;
+  }
+  if (typeof value._serialized === "string" && value._serialized) {
+    return value._serialized;
+  }
+  if (typeof value.$1 === "string" && value.$1) {
+    return value.$1;
+  }
+  if (typeof value.user === "string" && typeof value.server === "string") {
+    return `${value.user}@${value.server}`;
+  }
+  return null;
+}
+
+function serializedId(value) {
+  const serialized = widString(value);
+  if (serialized || !value || typeof value !== "object") {
+    return serialized;
+  }
+  const remote = widString(value.remote);
+  if (remote && typeof value.id === "string" && value.id) {
+    return `${value.fromMe === true ? "true" : "false"}_${remote}_${value.id}`;
+  }
+  return typeof value.id === "string" && value.id ? value.id : null;
+}
+
+function normalizeId(value) {
+  if (!value || typeof value !== "object" || value._serialized) {
+    return value;
+  }
+  const serialized = serializedId(value);
+  if (!serialized) {
+    return value;
+  }
+  try {
+    value._serialized = serialized;
+    if (value._serialized === serialized) {
+      return value;
+    }
+  } catch (_error) {
+    return { ...value, _serialized: serialized };
+  }
+  return { ...value, _serialized: serialized };
+}
+
+function normalizeMessage(message) {
+  if (!message || typeof message !== "object") {
+    return message;
+  }
+  const data = message._data && typeof message._data === "object" ? message._data : {};
+  message.id = normalizeId(message.id || data.id);
+  message._data = { ...data, id: normalizeId(data.id || message.id) };
+  message.from = widString(message.from) || widString(data.from);
+  message.to = widString(message.to) || widString(data.to);
+  message.author = widString(message.author) || widString(data.author);
+  return message;
+}
+
+function installMessageKeyCompatibility() {
+  const MessageKey = window.require("WAWebMsgKey");
+  if (!MessageKey || !MessageKey.prototype) {
+    return { installed: false, compatible: false };
+  }
+  const prototype = MessageKey.prototype;
+  let descriptorOwner = prototype;
+  let descriptor;
+  while (descriptorOwner && !descriptor) {
+    descriptor = Object.getOwnPropertyDescriptor(descriptorOwner, "_serialized");
+    descriptorOwner = Object.getPrototypeOf(descriptorOwner);
+  }
+  let installed = false;
+  if (!descriptor) {
+    Object.defineProperty(prototype, "_serialized", {
+      configurable: true,
+      get() {
+        if (typeof this.$1 === "string" && this.$1) {
+          return this.$1;
+        }
+        const remote =
+          typeof this.remote === "string"
+            ? this.remote
+            : this.remote &&
+                (this.remote._serialized ||
+                  this.remote.$1 ||
+                  (this.remote.user && this.remote.server
+                    ? `${this.remote.user}@${this.remote.server}`
+                    : null));
+        if (!remote || typeof this.id !== "string" || !this.id) {
+          return undefined;
+        }
+        return `${this.fromMe === true ? "true" : "false"}_${remote}_${this.id}`;
+      },
+    });
+    installed = true;
+  }
+  const chats = window.require("WAWebCollections").Chat.getModelsArray();
+  const sample = chats.map((chat) => chat.lastReceivedKey).find(Boolean);
+  const compatible = !sample || typeof sample._serialized === "string";
+  return { installed, compatible };
+}
+
+async function installPageCompatibility(page) {
+  const result = await page.evaluate(installMessageKeyCompatibility);
+  if (!result || result.compatible !== true) {
+    throw new Error("WhatsApp message key compatibility check failed");
+  }
+  return result;
+}
+
+function createCompatibleClientClass(ClientClass) {
+  return class CompatibleClient extends ClientClass {
+    async attachEventListeners() {
+      try {
+        this.idCompatibility = await installPageCompatibility(this.pupPage);
+      } catch (error) {
+        this.emit("compatibility_error", error);
+        throw error;
+      }
+      return super.attachEventListeners();
+    }
+  };
+}
+
+function isTerminalAck(ack) {
+  return Number.isFinite(ack) && (ack < 0 || ack >= 1);
+}
+
+class AckTracker {
+  constructor({ timeoutMs, onAck, onTimeout, maxEarlyAcks = 200 }) {
+    this.timeoutMs = timeoutMs;
+    this.onAck = onAck;
+    this.onTimeout = onTimeout;
+    this.maxEarlyAcks = maxEarlyAcks;
+    this.known = new Set();
+    this.pending = new Map();
+    this.early = new Map();
+  }
+
+  register(id, currentAck) {
+    this.known.add(id);
+    const pendingTimer = this.pending.get(id);
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      this.pending.delete(id);
+    }
+    const earlyAck = this.early.get(id);
+    this.early.delete(id);
+    const ack = isTerminalAck(Number(currentAck)) ? Number(currentAck) : earlyAck;
+    if (isTerminalAck(ack)) {
+      this.onAck(ack, true);
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.pending.delete(id);
+      this.onTimeout();
+    }, this.timeoutMs);
+    timer.unref();
+    this.pending.set(id, timer);
+  }
+
+  record(id, value) {
+    const ack = Number(value);
+    if (!id || !Number.isFinite(ack)) {
+      return false;
+    }
+    if (!this.known.has(id)) {
+      if (isTerminalAck(ack)) {
+        this.rememberEarly(id, ack);
+      }
+      return false;
+    }
+    const timer = this.pending.get(id);
+    if (timer && isTerminalAck(ack)) {
+      clearTimeout(timer);
+      this.pending.delete(id);
+    }
+    this.onAck(ack, Boolean(timer));
+    return true;
+  }
+
+  forget(id) {
+    this.known.delete(id);
+    const timer = this.pending.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.pending.delete(id);
+    }
+    this.early.delete(id);
+  }
+
+  rememberEarly(id, ack) {
+    this.early.set(id, ack);
+    while (this.early.size > this.maxEarlyAcks) {
+      this.early.delete(this.early.keys().next().value);
+    }
+  }
+}
+
+class SentBodyReservations {
+  constructor() {
+    this.counts = new Map();
+  }
+
+  reserve(body) {
+    if (!body) {
+      return () => {};
+    }
+    const key = String(body);
+    this.counts.set(key, (this.counts.get(key) || 0) + 1);
+    return () => this.release(key);
+  }
+
+  has(body) {
+    return Boolean(body && this.counts.has(String(body)));
+  }
+
+  release(key) {
+    const count = this.counts.get(key) || 0;
+    if (count <= 1) {
+      this.counts.delete(key);
+    } else {
+      this.counts.set(key, count - 1);
+    }
+  }
+}
+
+module.exports = {
+  AckTracker,
+  SentBodyReservations,
+  createCompatibleClientClass,
+  installMessageKeyCompatibility,
+  installPageCompatibility,
+  normalizeId,
+  normalizeMessage,
+  serializedId,
+  widString,
+};

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/package-lock.json
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/package-lock.json
@@ -8,6 +8,9 @@
       "dependencies": {
         "qrcode-terminal": "^0.12.0",
         "whatsapp-web.js": "^1.26.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/package.json
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/package.json
@@ -2,6 +2,12 @@
   "name": "deepagents-talon-whatsapp-bridge",
   "private": true,
   "type": "commonjs",
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "scripts": {
+    "test": "node --test ../../../tests/channels/whatsapp_bridge/*.test.js"
+  },
   "dependencies": {
     "qrcode-terminal": "^0.12.0",
     "whatsapp-web.js": "^1.26.0"

--- a/libs/talon/pyproject.toml
+++ b/libs/talon/pyproject.toml
@@ -66,6 +66,8 @@ package = true
 packages = ["deepagents_talon"]
 artifacts = [
     "deepagents_talon/channels/whatsapp_bridge/bridge.js",
+    "deepagents_talon/channels/whatsapp_bridge/id_compat.js",
+    "deepagents_talon/channels/whatsapp_bridge/package-lock.json",
     "deepagents_talon/channels/whatsapp_bridge/package.json",
 ]
 

--- a/libs/talon/tests/channels/test_whatsapp.py
+++ b/libs/talon/tests/channels/test_whatsapp.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import urllib.error
+import urllib.request
 from pathlib import Path
-from typing import TYPE_CHECKING, Self, cast
+from typing import Self, cast
 
 import pytest
 
@@ -12,6 +14,7 @@ from deepagents_talon.channels.base import (
     ChannelExposure,
     ChannelMediaError,
     ExposureMode,
+    send_with_retry,
 )
 from deepagents_talon.channels.whatsapp import (
     DEFAULT_WHATSAPP_MAX_MEDIA_BYTES,
@@ -24,14 +27,12 @@ from deepagents_talon.channels.whatsapp import (
 from deepagents_talon.config import TalonConfig
 from deepagents_talon.interfaces import ChannelMedia, ChannelMessage
 
-if TYPE_CHECKING:
-    import urllib.request
-
 
 class RecordingTransport:
     def __init__(self, messages: list[dict[str, object]] | None = None) -> None:
         self.messages = messages or []
         self.posts: list[tuple[str, dict[str, object]]] = []
+        self.media_bytes: list[bytes] = []
 
     async def get(self, path: str) -> object:
         if path == "/messages":
@@ -45,6 +46,9 @@ class RecordingTransport:
 
     async def post(self, path: str, payload: dict[str, object]) -> object:
         self.posts.append((path, payload))
+        file_path = payload.get("filePath")
+        if isinstance(file_path, str):
+            self.media_bytes.append(await asyncio.to_thread(Path(file_path).read_bytes))
         return {"success": True, "message_id": "sent"}
 
 
@@ -59,6 +63,20 @@ class DelayedHealthTransport:
             msg = "bridge not listening yet"
             raise _WhatsAppBridgeError(msg)
         return {"status": "qr_pending", "botId": None}
+
+
+class FailingSendTransport:
+    def __init__(self, *, retryable: bool = False, failures: int | None = None) -> None:
+        self.posts: list[tuple[str, dict[str, object]]] = []
+        self.retryable = retryable
+        self.failures = failures
+
+    async def post(self, path: str, payload: dict[str, object]) -> object:
+        self.posts.append((path, payload))
+        if self.failures is not None and len(self.posts) > self.failures:
+            return {"success": True, "message_id": "sent"}
+        msg = f"WhatsApp bridge request failed: POST {path}"
+        raise _WhatsAppBridgeError(msg, retryable=self.retryable)
 
 
 class JsonResponse:
@@ -194,6 +212,30 @@ def test_bridge_transport_sends_bearer_token(monkeypatch: pytest.MonkeyPatch) ->
     assert request.get_header("Authorization") == "Bearer test-token"
 
 
+def test_bridge_transport_marks_service_unavailable_as_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_urlopen(request: object, *, timeout: float) -> JsonResponse:
+        del request, timeout
+        url = "http://127.0.0.1:3000/send"
+        reason = "Service Unavailable"
+        raise urllib.error.HTTPError(
+            url,
+            503,
+            reason,
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    transport = _BridgeTransport(base_url="http://127.0.0.1:3000", timeout=2)
+
+    with pytest.raises(_WhatsAppBridgeError) as exc_info:
+        transport._request("POST", "/send", {"chatId": "chat", "text": "hello"})
+
+    assert exc_info.value.retryable is True
+
+
 def test_config_rejects_open_exposure_without_acknowledgement(tmp_path: Path) -> None:
     config = TalonConfig.from_env(
         {
@@ -263,6 +305,41 @@ async def test_channel_polls_and_dispatches_allowed_messages(tmp_path: Path) -> 
 
     assert [message.text for message in received] == ["allowed"]
     assert received[0].metadata["provider"] == "whatsapp"
+
+
+async def test_channel_rejects_truthy_non_boolean_self_markers(tmp_path: Path) -> None:
+    transport = RecordingTransport(
+        messages=[
+            {
+                "body": "not self",
+                "chatId": "chat",
+                "senderId": "other",
+                "messageId": "message-1",
+                "messageType": "chat",
+                "fromSelf": "false",
+            },
+        ],
+    )
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path,
+            poll_interval_seconds=60,
+            health_interval_seconds=60,
+        ),
+        transport=cast("_BridgeTransport", transport),
+    )
+    received: list[ChannelMessage] = []
+
+    async def record(message: ChannelMessage) -> None:
+        received.append(message)
+
+    channel.set_message_handler(record)
+
+    await channel.start()
+    await asyncio.sleep(0)
+    await channel.stop()
+
+    assert received == []
 
 
 async def test_channel_polls_self_messages_without_operator_id(tmp_path: Path) -> None:
@@ -515,6 +592,81 @@ async def test_send_message_debug_logs_are_payload_safe(
     assert text not in caplog.text
 
 
+async def test_channel_does_not_retry_ambiguous_text_send_failures(tmp_path: Path) -> None:
+    transport = FailingSendTransport()
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(session_dir=tmp_path),
+        transport=cast("_BridgeTransport", transport),
+    )
+
+    result = await send_with_retry(
+        lambda: channel.send_message("chat", "hello"),
+        base_delay=0,
+    )
+
+    assert result.success is False
+    assert result.retryable is False
+    assert transport.posts == [("/send", {"chatId": "chat", "text": "*deepagents bot*\nhello"})]
+
+
+async def test_channel_does_not_retry_ambiguous_media_send_failures(tmp_path: Path) -> None:
+    transport = FailingSendTransport()
+    image = tmp_path / "image.png"
+    image.write_bytes(b"image")
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(session_dir=tmp_path, inbound_media_dir=tmp_path / "bridge-media"),
+        transport=cast("_BridgeTransport", transport),
+    )
+
+    result = await send_with_retry(
+        lambda: channel.send_media("chat", ChannelMedia(path=image, media_type="image")),
+        base_delay=0,
+    )
+
+    assert result.success is False
+    assert result.retryable is False
+    assert [path for path, _payload in transport.posts] == ["/send-media"]
+    staged = Path(cast("str", transport.posts[0][1]["filePath"]))
+    assert not await asyncio.to_thread(staged.exists)
+
+
+async def test_channel_retries_text_rejected_before_send(tmp_path: Path) -> None:
+    transport = FailingSendTransport(retryable=True, failures=1)
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(session_dir=tmp_path),
+        transport=cast("_BridgeTransport", transport),
+    )
+
+    result = await send_with_retry(
+        lambda: channel.send_message("chat", "hello"),
+        base_delay=0,
+    )
+
+    assert result.success is True
+    assert [path for path, _payload in transport.posts] == ["/send", "/send"]
+
+
+async def test_channel_retries_media_rejected_before_send(tmp_path: Path) -> None:
+    transport = FailingSendTransport(retryable=True, failures=1)
+    image = tmp_path / "image.png"
+    image.write_bytes(b"image")
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(session_dir=tmp_path, inbound_media_dir=tmp_path / "bridge-media"),
+        transport=cast("_BridgeTransport", transport),
+    )
+
+    result = await send_with_retry(
+        lambda: channel.send_media("chat", ChannelMedia(path=image, media_type="image")),
+        base_delay=0,
+    )
+
+    assert result.success is True
+    assert [path for path, _payload in transport.posts] == ["/send-media", "/send-media"]
+    for _path, payload in transport.posts:
+        staged = Path(cast("str", payload["filePath"]))
+        assert not await asyncio.to_thread(staged.exists)
+
+
 async def test_channel_sends_media_and_edits_messages(tmp_path: Path) -> None:
     transport = RecordingTransport()
     image = tmp_path / "image.png"
@@ -532,7 +684,8 @@ async def test_channel_sends_media_and_edits_messages(tmp_path: Path) -> None:
 
     staged = Path(cast("str", transport.posts[0][1]["filePath"]))
     assert staged.parent == media_dir
-    assert await asyncio.to_thread(staged.read_bytes) == b"image"
+    assert transport.media_bytes == [b"image"]
+    assert not await asyncio.to_thread(staged.exists)
     assert transport.posts == [
         (
             "/send-media",
@@ -552,6 +705,22 @@ async def test_channel_sends_media_and_edits_messages(tmp_path: Path) -> None:
             },
         ),
     ]
+
+
+async def test_channel_preserves_media_already_in_bridge_directory(tmp_path: Path) -> None:
+    transport = RecordingTransport()
+    media_dir = tmp_path / "bridge-media"
+    media_dir.mkdir()
+    image = media_dir / "image.png"
+    image.write_bytes(b"image")
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(session_dir=tmp_path, inbound_media_dir=media_dir),
+        transport=cast("_BridgeTransport", transport),
+    )
+
+    await channel.send_media("chat", ChannelMedia(path=image, media_type="image"))
+
+    assert await asyncio.to_thread(image.read_bytes) == b"image"
 
 
 async def test_channel_rejects_media_outside_configured_outbound_root(tmp_path: Path) -> None:
@@ -644,3 +813,5 @@ async def test_channel_forwards_bridge_output_to_logs(
 def test_bridge_script_is_packaged() -> None:
     assert _bridge_script_path().name == "bridge.js"
     assert _bridge_script_path().is_file()
+    assert _bridge_script_path().with_name("id_compat.js").is_file()
+    assert _bridge_script_path().with_name("package-lock.json").is_file()

--- a/libs/talon/tests/channels/whatsapp_bridge/id_compat.test.js
+++ b/libs/talon/tests/channels/whatsapp_bridge/id_compat.test.js
@@ -1,0 +1,156 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const EventEmitter = require("node:events");
+const test = require("node:test");
+
+const {
+  AckTracker,
+  SentBodyReservations,
+  createCompatibleClientClass,
+  installMessageKeyCompatibility,
+  normalizeId,
+  normalizeMessage,
+  serializedId,
+  widString,
+} = require("../../../deepagents_talon/channels/whatsapp_bridge/id_compat");
+
+test("reads legacy, renamed, and component WhatsApp IDs", () => {
+  assert.equal(widString({ _serialized: "123@lid" }), "123@lid");
+  assert.equal(widString({ $1: "123@lid" }), "123@lid");
+  assert.equal(widString({ user: "123", server: "lid" }), "123@lid");
+  assert.equal(
+    serializedId({ fromMe: true, remote: { user: "123", server: "lid" }, id: "ABC" }),
+    "true_123@lid_ABC",
+  );
+});
+
+test("reconstructs self state only from boolean true", () => {
+  assert.equal(
+    serializedId({ fromMe: "false", remote: "123@lid", id: "ABC" }),
+    "false_123@lid_ABC",
+  );
+});
+
+test("normalizes frozen IDs and message fields", () => {
+  const id = Object.freeze({ fromMe: false, remote: "123@lid", id: "ABC" });
+  const message = normalizeMessage({
+    id,
+    _data: {
+      id,
+      from: { $1: "123@lid" },
+      to: { user: "456", server: "lid" },
+      author: { _serialized: "789@lid" },
+    },
+  });
+  assert.equal(normalizeId(id)._serialized, "false_123@lid_ABC");
+  assert.equal(message.id._serialized, "false_123@lid_ABC");
+  assert.equal(message.from, "123@lid");
+  assert.equal(message.to, "456@lid");
+  assert.equal(message.author, "789@lid");
+});
+
+test("installs a message-key prototype fallback", () => {
+  class MessageKey {}
+  const sample = new MessageKey();
+  sample.$1 = "false_123@lid_ABC";
+  const originalWindow = global.window;
+  global.window = {
+    require(name) {
+      if (name === "WAWebMsgKey") {
+        return MessageKey;
+      }
+      return { Chat: { getModelsArray: () => [{ lastReceivedKey: sample }] } };
+    },
+  };
+  try {
+    assert.deepEqual(installMessageKeyCompatibility(), { installed: true, compatible: true });
+    assert.equal(sample._serialized, "false_123@lid_ABC");
+  } finally {
+    global.window = originalWindow;
+  }
+});
+
+test("installs compatibility before upstream event listeners", async () => {
+  const order = [];
+  class BaseClient extends EventEmitter {
+    constructor() {
+      super();
+      this.pupPage = {
+        evaluate: async () => {
+          order.push("compatibility");
+          return { installed: true, compatible: true };
+        },
+      };
+    }
+
+    async attachEventListeners() {
+      order.push("listeners");
+    }
+  }
+  const CompatibleClient = createCompatibleClientClass(BaseClient);
+  const client = new CompatibleClient();
+  await client.attachEventListeners();
+  assert.deepEqual(order, ["compatibility", "listeners"]);
+  assert.deepEqual(client.idCompatibility, { installed: true, compatible: true });
+});
+
+test("reconciles an acknowledgement received before send registration", () => {
+  const acknowledgements = [];
+  const tracker = new AckTracker({
+    timeoutMs: 100,
+    onAck: (ack, tracked) => acknowledgements.push([ack, tracked]),
+    onTimeout: () => assert.fail("unexpected acknowledgement timeout"),
+  });
+  assert.equal(tracker.record("message", 1), false);
+  tracker.register("message", 0);
+  assert.deepEqual(acknowledgements, [[1, true]]);
+  assert.equal(tracker.pending.size, 0);
+  tracker.forget("message");
+});
+
+test("tracks terminal acknowledgements after send registration", () => {
+  const acknowledgements = [];
+  const tracker = new AckTracker({
+    timeoutMs: 100,
+    onAck: (ack, tracked) => acknowledgements.push([ack, tracked]),
+    onTimeout: () => assert.fail("unexpected acknowledgement timeout"),
+  });
+  tracker.register("message", 0);
+  assert.equal(tracker.record("message", 1), true);
+  assert.deepEqual(acknowledgements, [[1, true]]);
+  assert.equal(tracker.pending.size, 0);
+  tracker.forget("message");
+});
+
+test("times out sends without an acknowledgement", async () => {
+  let resolveTimeout;
+  const timedOut = new Promise((resolve) => {
+    resolveTimeout = resolve;
+  });
+  const tracker = new AckTracker({
+    timeoutMs: 1,
+    onAck: () => assert.fail("unexpected acknowledgement"),
+    onTimeout: resolveTimeout,
+  });
+  const keepAlive = setTimeout(() => {}, 100);
+  try {
+    tracker.register("message", 0);
+    await timedOut;
+    assert.equal(tracker.pending.size, 0);
+    tracker.forget("message");
+  } finally {
+    clearTimeout(keepAlive);
+  }
+});
+
+test("reserves identical sent bodies only while sends are in flight", () => {
+  const reservations = new SentBodyReservations();
+  const releaseFirst = reservations.reserve("same body");
+  const releaseSecond = reservations.reserve("same body");
+  assert.equal(reservations.has("same body"), true);
+  releaseFirst();
+  assert.equal(reservations.has("same body"), true);
+  releaseSecond();
+  assert.equal(reservations.has("same body"), false);
+});


### PR DESCRIPTION
Talon WhatsApp connections now remain compatible with WhatsApp Web local-ID messages and report outbound delivery more reliably.

---

WhatsApp Web can expose message and chat IDs in several shapes, including local-ID values that the bridge did not consistently understand. This adds a focused compatibility layer that normalizes those IDs before Talon consumes them and tracks acknowledgements so ambiguous sends are not retried and duplicated.

This is useful because it keeps inbound messages, self-message filtering, edits, and outbound delivery working across WhatsApp Web representation changes. It also cleans up staged outbound media and runs the bridge test suite in CI and release verification.