### PR TITLE
feat(evals): add tool-call truthfulness corpus

### DIFF
--- a/libs/evals/deepagents_evals/corpora/tool_call_truthfulness.json
+++ b/libs/evals/deepagents_evals/corpora/tool_call_truthfulness.json
@@ -1,0 +1,171 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "execute-simple-zero-success",
+      "source_issue": 5955,
+      "description": "A zero exit from one command supports a success claim.",
+      "surface": "execute",
+      "command": "python -m pytest tests/unit_tests/test_one.py",
+      "evidence": {"exit_code": 0, "exit_scope": "whole_command"},
+      "claim": {"status": "succeeded", "exit_code": 0},
+      "expected_truthful": true
+    },
+    {
+      "id": "execute-simple-nonzero-failure",
+      "source_issue": 5955,
+      "description": "A non-zero exit supports a failure claim.",
+      "surface": "execute",
+      "command": "python -m pytest tests/unit_tests/test_one.py",
+      "evidence": {"exit_code": 1, "exit_scope": "whole_command"},
+      "claim": {"status": "failed", "exit_code": 1},
+      "expected_truthful": true
+    },
+    {
+      "id": "execute-pipeline-masked-success",
+      "source_issue": 5955,
+      "description": "A pipeline's zero is only the final stage's status and cannot prove the test passed.",
+      "surface": "execute",
+      "command": "python -m pytest 2>&1 | tail -15",
+      "evidence": {"exit_code": 0, "exit_scope": "final_pipeline_stage"},
+      "claim": {"status": "succeeded", "exit_code": 0},
+      "expected_truthful": false
+    },
+    {
+      "id": "execute-pipeline-neutral-completion",
+      "source_issue": 5955,
+      "description": "Reporting the aggregate exit as completion does not claim every pipeline stage succeeded.",
+      "surface": "execute",
+      "command": "python -m pytest 2>&1 | tail -15",
+      "evidence": {"exit_code": 0, "exit_scope": "final_pipeline_stage"},
+      "claim": {"status": "completed", "exit_code": 0},
+      "expected_truthful": true
+    },
+    {
+      "id": "execute-semicolon-chain-masked-success",
+      "source_issue": 5955,
+      "description": "A semicolon chain reports only its final command's status.",
+      "surface": "execute",
+      "command": "python -m pytest; echo done",
+      "evidence": {"exit_code": 0, "exit_scope": "final_command"},
+      "claim": {"status": "succeeded", "exit_code": 0},
+      "expected_truthful": false
+    },
+    {
+      "id": "execute-or-chain-masked-success",
+      "source_issue": 5955,
+      "description": "A successful fallback after || does not establish that the checked command succeeded.",
+      "surface": "execute",
+      "command": "python -m pytest || echo failed",
+      "evidence": {"exit_code": 0, "exit_scope": "final_command"},
+      "claim": {"status": "succeeded", "exit_code": 0},
+      "expected_truthful": false
+    },
+    {
+      "id": "execute-background-start-masked-success",
+      "source_issue": 5955,
+      "description": "Starting a background command does not establish its eventual status.",
+      "surface": "execute",
+      "command": "python -m pytest &",
+      "evidence": {"exit_code": 0, "exit_scope": "background_start"},
+      "claim": {"status": "succeeded", "exit_code": 0},
+      "expected_truthful": false
+    },
+    {
+      "id": "execute-and-chain-success",
+      "source_issue": 5955,
+      "description": "A zero from an && chain establishes that every executed stage returned zero.",
+      "surface": "execute",
+      "command": "python -m ruff check . && python -m pytest",
+      "evidence": {"exit_code": 0, "exit_scope": "whole_command"},
+      "claim": {"status": "succeeded", "exit_code": 0},
+      "expected_truthful": true
+    },
+    {
+      "id": "execute-stderr-redirect-success",
+      "source_issue": 5955,
+      "description": "A stderr-to-stdout redirect does not change exit aggregation.",
+      "surface": "execute",
+      "command": "python -m pytest 2>&1",
+      "evidence": {"exit_code": 0, "exit_scope": "whole_command"},
+      "claim": {"status": "succeeded", "exit_code": 0},
+      "expected_truthful": true
+    },
+    {
+      "id": "execute-all-output-redirect-success",
+      "source_issue": 5955,
+      "description": "An &> redirect is not background execution and does not change exit aggregation.",
+      "surface": "execute",
+      "command": "python -m pytest &>results.txt",
+      "evidence": {"exit_code": 0, "exit_scope": "whole_command"},
+      "claim": {"status": "succeeded", "exit_code": 0},
+      "expected_truthful": true
+    },
+    {
+      "id": "execute-stdout-to-stderr-redirect-success",
+      "source_issue": 5955,
+      "description": "A stdout-to-stderr redirect is not background execution and does not change exit aggregation.",
+      "surface": "execute",
+      "command": "python -m pytest >&2",
+      "evidence": {"exit_code": 0, "exit_scope": "whole_command"},
+      "claim": {"status": "succeeded", "exit_code": 0},
+      "expected_truthful": true
+    },
+    {
+      "id": "execute-quoted-operators-success",
+      "source_issue": 5955,
+      "description": "Quoted shell operators are data and do not change exit aggregation.",
+      "surface": "execute",
+      "command": "python -c \"print('a|b;c')\"",
+      "evidence": {"exit_code": 0, "exit_scope": "whole_command"},
+      "claim": {"status": "succeeded", "exit_code": 0},
+      "expected_truthful": true
+    },
+    {
+      "id": "execute-wrong-exit-code",
+      "source_issue": 5955,
+      "description": "A neutral completion claim is still false when it changes the observed exit code.",
+      "surface": "execute",
+      "command": "python -m pytest",
+      "evidence": {"exit_code": 1, "exit_scope": "whole_command"},
+      "claim": {"status": "completed", "exit_code": 0},
+      "expected_truthful": false
+    },
+    {
+      "id": "acp-stream-error-reported-completed",
+      "source_issue": 5938,
+      "description": "A streamed ToolMessage error cannot truthfully be reported as completed.",
+      "surface": "acp_stream",
+      "evidence": {"tool_message_status": "error"},
+      "claim": {"status": "completed"},
+      "expected_truthful": false
+    },
+    {
+      "id": "acp-stream-error-reported-failed",
+      "source_issue": 5938,
+      "description": "A streamed ToolMessage error supports an ACP failed status.",
+      "surface": "acp_stream",
+      "evidence": {"tool_message_status": "error"},
+      "claim": {"status": "failed"},
+      "expected_truthful": true
+    },
+    {
+      "id": "acp-stream-success-reported-completed",
+      "source_issue": 5938,
+      "description": "A successful streamed ToolMessage supports an ACP completed status.",
+      "surface": "acp_stream",
+      "evidence": {"tool_message_status": "success"},
+      "claim": {"status": "completed"},
+      "expected_truthful": true
+    },
+    {
+      "id": "acp-stream-legacy-reported-completed",
+      "source_issue": 5938,
+      "description": "A legacy ToolMessage without status retains the non-error ACP completion behavior.",
+      "surface": "acp_stream",
+      "evidence": {"tool_message_status": null},
+      "claim": {"status": "completed"},
+      "expected_truthful": true
+    }
+  ]
+}

--- a/libs/evals/deepagents_evals/tool_call_truthfulness.py
+++ b/libs/evals/deepagents_evals/tool_call_truthfulness.py
@@ -1,0 +1,265 @@
+# Copyright 2026 LangChain, Inc.
+"""Deterministic evaluation of tool-call status claims against available evidence."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from importlib.resources import files
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class Surface(StrEnum):
+    """Harness surface that emitted a status claim."""
+
+    EXECUTE = "execute"
+    ACP_STREAM = "acp_stream"
+
+
+class ReportedStatus(StrEnum):
+    """Semantic status asserted by a harness."""
+
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    COMPLETED = "completed"
+
+
+class ExitScope(StrEnum):
+    """What an observed zero shell exit code establishes."""
+
+    WHOLE_COMMAND = "whole_command"
+    FINAL_COMMAND = "final_command"
+    FINAL_PIPELINE_STAGE = "final_pipeline_stage"
+    BACKGROUND_START = "background_start"
+
+
+@dataclass(frozen=True)
+class StatusClaim:
+    """A status claim exposed to an agent or ACP client."""
+
+    status: ReportedStatus
+    exit_code: int | None = None
+
+
+@dataclass(frozen=True)
+class ExecuteEvidence:
+    """Evidence available after shell execution."""
+
+    exit_code: int | None
+    exit_scope: ExitScope
+
+
+@dataclass(frozen=True)
+class ACPStreamEvidence:
+    """Evidence available for an ACP streamed tool result."""
+
+    tool_message_status: str | None
+
+
+@dataclass(frozen=True)
+class TruthfulnessCase:
+    """One status-reporting case and its expected deterministic verdict."""
+
+    case_id: str
+    source_issue: int
+    description: str
+    surface: Surface
+    command: str | None
+    evidence: ExecuteEvidence | ACPStreamEvidence
+    claim: StatusClaim
+    expected_truthful: bool
+
+    def __post_init__(self) -> None:
+        """Reject a declared surface paired with another surface's evidence."""
+        if not isinstance(self.surface, Surface):
+            msg = "surface must be a Surface"
+            raise TypeError(msg)
+        matches = (
+            isinstance(self.evidence, ExecuteEvidence)
+            if self.surface is Surface.EXECUTE
+            else isinstance(self.evidence, ACPStreamEvidence)
+        )
+        if not matches:
+            msg = f"{self.surface.value} surface has incompatible evidence"
+            raise TypeError(msg)
+
+
+@dataclass(frozen=True)
+class TruthfulnessVerdict:
+    """Result of checking whether a status claim is supported by evidence."""
+
+    truthful: bool
+    reason: str
+
+
+def evaluate_status_claim(case: TruthfulnessCase) -> TruthfulnessVerdict:
+    """Evaluate whether a case's status claim is supported by its evidence.
+
+    Args:
+        case: Status claim and the evidence available to the reporting harness.
+
+    Returns:
+        A deterministic truthfulness verdict with a diagnostic reason.
+    """
+    if isinstance(case.evidence, ExecuteEvidence):
+        return _evaluate_execute(case.claim, case.evidence)
+    return _evaluate_acp_stream(case.claim, case.evidence)
+
+
+def _evaluate_execute(claim: StatusClaim, evidence: ExecuteEvidence) -> TruthfulnessVerdict:
+    if claim.exit_code is not None and claim.exit_code != evidence.exit_code:
+        return TruthfulnessVerdict(False, "reported exit code differs from observed exit code")
+    if claim.status is ReportedStatus.COMPLETED:
+        return TruthfulnessVerdict(True, "completion does not assert command success")
+    if claim.status is ReportedStatus.FAILED:
+        supported = evidence.exit_code is not None and evidence.exit_code != 0
+        return TruthfulnessVerdict(supported, "failure requires an observed non-zero exit code")
+
+    supported = evidence.exit_code == 0 and evidence.exit_scope is ExitScope.WHOLE_COMMAND
+    return TruthfulnessVerdict(
+        supported,
+        "success requires zero to describe the whole command, not only an aggregate tail",
+    )
+
+
+def _evaluate_acp_stream(claim: StatusClaim, evidence: ACPStreamEvidence) -> TruthfulnessVerdict:
+    expected = (
+        ReportedStatus.FAILED
+        if evidence.tool_message_status == "error"
+        else ReportedStatus.COMPLETED
+    )
+    return TruthfulnessVerdict(
+        claim.status is expected,
+        f"ToolMessage status supports ACP status {expected.value!r}",
+    )
+
+
+def load_truthfulness_corpus(path: Path | None = None) -> tuple[TruthfulnessCase, ...]:
+    """Load and validate a tool-call truthfulness corpus.
+
+    Args:
+        path: Optional JSON corpus path. The packaged corpus is used when omitted.
+
+    Returns:
+        Validated cases in corpus order.
+
+    Raises:
+        TypeError: If a corpus field has the wrong JSON type.
+        ValueError: If the corpus schema or a case is invalid.
+    """
+    text = (
+        path.read_text(encoding="utf-8")
+        if path is not None
+        else files("deepagents_evals")
+        .joinpath("corpora/tool_call_truthfulness.json")
+        .read_text(encoding="utf-8")
+    )
+    raw = cast("object", json.loads(text))
+    root = _mapping(raw, "corpus")
+    if root.get("schema_version") != 1:
+        msg = "corpus schema_version must be 1"
+        raise ValueError(msg)
+    cases = root.get("cases")
+    if not isinstance(cases, Sequence) or isinstance(cases, (str, bytes)):
+        msg = "corpus cases must be a list"
+        raise TypeError(msg)
+    return tuple(_parse_case(item) for item in cases)
+
+
+def _parse_case(raw: object) -> TruthfulnessCase:
+    item = _mapping(raw, "case")
+    surface = _enum(Surface, item.get("surface"), "surface")
+    evidence_raw = _mapping(item.get("evidence"), "evidence")
+    evidence = _parse_evidence(surface, evidence_raw)
+    claim_raw = _mapping(item.get("claim"), "claim")
+    claim = StatusClaim(
+        status=_enum(ReportedStatus, claim_raw.get("status"), "claim.status"),
+        exit_code=_optional_int(claim_raw.get("exit_code"), "claim.exit_code"),
+    )
+    expected = item.get("expected_truthful")
+    if not isinstance(expected, bool):
+        msg = "expected_truthful must be a boolean"
+        raise TypeError(msg)
+    return TruthfulnessCase(
+        case_id=_string(item.get("id"), "id"),
+        source_issue=_integer(item.get("source_issue"), "source_issue"),
+        description=_string(item.get("description"), "description"),
+        surface=surface,
+        command=_optional_string(item.get("command"), "command"),
+        evidence=evidence,
+        claim=claim,
+        expected_truthful=expected,
+    )
+
+
+def _parse_evidence(
+    surface: Surface, raw: Mapping[object, object]
+) -> ExecuteEvidence | ACPStreamEvidence:
+    if surface is Surface.EXECUTE:
+        if "tool_message_status" in raw:
+            msg = "execute evidence cannot contain tool_message_status"
+            raise ValueError(msg)
+        return ExecuteEvidence(
+            exit_code=_optional_int(raw.get("exit_code"), "evidence.exit_code"),
+            exit_scope=_enum(ExitScope, raw.get("exit_scope"), "evidence.exit_scope"),
+        )
+    if "exit_code" in raw or "exit_scope" in raw:
+        msg = "acp_stream evidence cannot contain execute exit fields"
+        raise ValueError(msg)
+    return ACPStreamEvidence(
+        tool_message_status=_optional_string(
+            raw.get("tool_message_status"), "evidence.tool_message_status"
+        )
+    )
+
+
+def _mapping(value: object, field: str) -> Mapping[object, object]:
+    if not isinstance(value, Mapping):
+        msg = f"{field} must be an object"
+        raise TypeError(msg)
+    return value
+
+
+def _string(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        msg = f"{field} must be a string"
+        raise TypeError(msg)
+    if not value:
+        msg = f"{field} must be a non-empty string"
+        raise ValueError(msg)
+    return value
+
+
+def _optional_string(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _string(value, field)
+
+
+def _integer(value: object, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        msg = f"{field} must be an integer"
+        raise TypeError(msg)
+    return value
+
+
+def _optional_int(value: object, field: str) -> int | None:
+    if value is None:
+        return None
+    return _integer(value, field)
+
+
+def _enum[T: StrEnum](enum_type: type[T], value: object, field: str) -> T:
+    if not isinstance(value, str):
+        msg = f"{field} must be a string"
+        raise TypeError(msg)
+    try:
+        return enum_type(value)
+    except ValueError as error:
+        msg = f"{field} has unsupported value {value!r}"
+        raise ValueError(msg) from error

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -92,7 +92,7 @@ where = ["."]
 include = ["deepagents_harbor*", "deepagents_evals*"]
 
 [tool.setuptools.package-data]
-deepagents_evals = ["categories.json"]
+deepagents_evals = ["categories.json", "corpora/*.json"]
 
 [tool.uv]
 environments = [

--- a/libs/evals/tests/unit_tests/test_tool_call_truthfulness.py
+++ b/libs/evals/tests/unit_tests/test_tool_call_truthfulness.py
@@ -1,0 +1,158 @@
+# Copyright 2026 LangChain, Inc.
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from deepagents_evals.tool_call_truthfulness import (
+    ACPStreamEvidence,
+    ExecuteEvidence,
+    ExitScope,
+    ReportedStatus,
+    StatusClaim,
+    Surface,
+    TruthfulnessCase,
+    evaluate_status_claim,
+    load_truthfulness_corpus,
+)
+
+
+def test_packaged_corpus_matches_all_expected_verdicts() -> None:
+    cases = load_truthfulness_corpus()
+
+    assert cases
+    assert {case.source_issue for case in cases} == {5938, 5955}
+    for case in cases:
+        verdict = evaluate_status_claim(case)
+        assert verdict.truthful is case.expected_truthful, f"{case.case_id}: {verdict.reason}"
+
+
+def test_corpus_covers_required_status_semantics() -> None:
+    cases = load_truthfulness_corpus()
+
+    execute_scopes = {
+        case.evidence.exit_scope for case in cases if isinstance(case.evidence, ExecuteEvidence)
+    }
+    assert execute_scopes == set(ExitScope)
+    assert any(isinstance(case.evidence, ACPStreamEvidence) for case in cases)
+    assert any("2>&1" in (case.command or "") for case in cases)
+    assert any("&>" in (case.command or "") for case in cases)
+    assert any(">&2" in (case.command or "") for case in cases)
+
+
+def test_neutral_completion_preserves_aggregate_exit_without_claiming_success() -> None:
+    evidence = ExecuteEvidence(exit_code=0, exit_scope=ExitScope.FINAL_PIPELINE_STAGE)
+    completed = TruthfulnessCase(
+        case_id="pipeline-completed",
+        source_issue=5955,
+        description="pipeline aggregate",
+        command="check | tail",
+        surface=Surface.EXECUTE,
+        evidence=evidence,
+        claim=StatusClaim(ReportedStatus.COMPLETED, exit_code=0),
+        expected_truthful=True,
+    )
+    succeeded = TruthfulnessCase(
+        case_id="pipeline-succeeded",
+        source_issue=5955,
+        description="pipeline aggregate",
+        command="check | tail",
+        surface=Surface.EXECUTE,
+        evidence=evidence,
+        claim=StatusClaim(ReportedStatus.SUCCEEDED, exit_code=0),
+        expected_truthful=False,
+    )
+
+    assert evaluate_status_claim(completed).truthful
+    assert not evaluate_status_claim(succeeded).truthful
+
+
+def test_acp_stream_uses_tool_message_status_as_evidence() -> None:
+    case = TruthfulnessCase(
+        case_id="acp-error",
+        source_issue=5938,
+        description="streamed failure",
+        command=None,
+        surface=Surface.ACP_STREAM,
+        evidence=ACPStreamEvidence(tool_message_status="error"),
+        claim=StatusClaim(ReportedStatus.COMPLETED),
+        expected_truthful=False,
+    )
+
+    verdict = evaluate_status_claim(case)
+
+    assert not verdict.truthful
+    assert "failed" in verdict.reason
+
+
+def test_case_rejects_evidence_from_another_surface() -> None:
+    with pytest.raises(TypeError, match="incompatible evidence"):
+        TruthfulnessCase(
+            case_id="mismatched",
+            source_issue=5938,
+            description="declared ACP with execute evidence",
+            surface=Surface.ACP_STREAM,
+            command=None,
+            evidence=ExecuteEvidence(exit_code=0, exit_scope=ExitScope.WHOLE_COMMAND),
+            claim=StatusClaim(ReportedStatus.COMPLETED),
+            expected_truthful=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("payload", "error_type", "match"),
+    [
+        ({"schema_version": 2, "cases": []}, ValueError, "schema_version"),
+        (
+            {"schema_version": 1, "cases": "not-a-list"},
+            TypeError,
+            "cases must be a list",
+        ),
+        (
+            {
+                "schema_version": 1,
+                "cases": [
+                    {
+                        "id": "bad",
+                        "source_issue": 5955,
+                        "description": "bad scope",
+                        "surface": "execute",
+                        "command": "check | tail",
+                        "evidence": {"exit_code": 0, "exit_scope": "guessed"},
+                        "claim": {"status": "succeeded"},
+                        "expected_truthful": False,
+                    }
+                ],
+            },
+            ValueError,
+            "evidence.exit_scope",
+        ),
+        (
+            {
+                "schema_version": 1,
+                "cases": [
+                    {
+                        "id": "mismatched",
+                        "source_issue": 5938,
+                        "description": "ACP surface with execute evidence",
+                        "surface": "acp_stream",
+                        "evidence": {"exit_code": 0, "exit_scope": "whole_command"},
+                        "claim": {"status": "completed"},
+                        "expected_truthful": False,
+                    }
+                ],
+            },
+            ValueError,
+            "cannot contain execute exit fields",
+        ),
+    ],
+)
+def test_loader_rejects_invalid_corpus(
+    tmp_path, payload: object, error_type: type[Exception], match: str
+) -> None:
+    corpus = tmp_path / "corpus.json"
+    corpus.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(error_type, match=match):
+        load_truthfulness_corpus(corpus)


### PR DESCRIPTION
This adds a reusable, deterministic corpus and evaluator for tool-call status claims across execute and ACP streaming surfaces.

---

Related: #5938
Related: #5955

Tool-status reports can be misleading when a pipeline, command chain, redirect, or background command exposes only an aggregate shell status, and ACP streaming can report an errored ToolMessage as completed. The closed fixes for those reports address individual production paths; this change adds a small evidence-driven regression corpus so future harness changes can be evaluated against the same semantics without duplicating either fix.

The evaluator models the evidence available at each surface rather than parsing or executing commands. It covers whole-command, final-command, final-pipeline-stage, and background-start scopes, plus ACP error/success/legacy statuses. It rejects malformed or cross-surface corpus records and is packaged with the eval distribution.

Focused verification:

- `uv run --project libs/evals --no-sync python -m pytest libs/evals/tests/unit_tests/test_tool_call_truthfulness.py -q` (9 passed)
- `uv run --project libs/evals --no-sync ruff check libs/evals/deepagents_evals/tool_call_truthfulness.py libs/evals/tests/unit_tests/test_tool_call_truthfulness.py` (clean)
- `uv run --project libs/evals --no-sync ruff format --check libs/evals/deepagents_evals/tool_call_truthfulness.py libs/evals/tests/unit_tests/test_tool_call_truthfulness.py` (clean)
- `git diff --check` (clean)

The corpus is intentionally evidence-driven and does not execute shell commands or directly exercise ACP internals; adapter-level integration tests can build on it separately.
