### PR TITLE
feat(code): link current pull request in footer

### DIFF
--- a/libs/code/deepagents_code/_git.py
+++ b/libs/code/deepagents_code/_git.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import os
 import re
+from contextlib import suppress
 from pathlib import Path
 from typing import NamedTuple
 from urllib.parse import urlparse
@@ -22,6 +25,8 @@ _GIT_REF_PREFIXES = ("refs/heads/", "refs/remotes/", "refs/tags/", "refs/")
 
 _git_dir_cache: dict[str, Path] = {}
 """Positive-only cache of resolved git metadata directories keyed by lookup path."""
+
+_MAX_PR_OUTPUT_BYTES = 4096
 
 
 def _abbreviate_git_ref(ref: str) -> str:
@@ -480,6 +485,104 @@ def resolve_git_branch(path: str | Path) -> str:
     if branch is not None:
         return branch
     return read_git_branch_via_subprocess(path)
+
+
+class PullRequestMetadata(NamedTuple):
+    """GitHub pull request identity for the current branch."""
+
+    number: int
+    url: str
+
+
+def _parse_github_pull_request(raw: bytes) -> PullRequestMetadata | None:
+    """Validate bounded JSON returned by `gh pr view`.
+
+    Returns:
+        Validated pull request metadata, or `None` for malformed output.
+    """
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    number = payload.get("number")
+    url = payload.get("url")
+    if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+        return None
+    if not isinstance(url, str):
+        return None
+    parsed = urlparse(url)
+    expected_path = re.compile(rf"\A/[^/]+/[^/]+/pull/{number}\Z")
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "github.com"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port is not None
+        or parsed.query
+        or parsed.fragment
+        or expected_path.fullmatch(parsed.path) is None
+    ):
+        return None
+    return PullRequestMetadata(number, url)
+
+
+async def read_github_pull_request(path: str | Path) -> PullRequestMetadata | None:
+    """Read the open GitHub pull request for the current branch via `gh`.
+
+    Args:
+        path: Directory inside the repository to inspect.
+
+    Returns:
+        Validated pull request metadata, or `None` when no open pull request can
+        be resolved.
+
+    Raises:
+        asyncio.CancelledError: If the lookup task is cancelled.
+    """
+    process: asyncio.subprocess.Process | None = None
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "gh",
+            "pr",
+            "view",
+            "--json",
+            "number,url",
+            cwd=path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout_reader = process.stdout
+        if stdout_reader is None:
+            with suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
+            return None
+        stdout = await asyncio.wait_for(
+            stdout_reader.read(_MAX_PR_OUTPUT_BYTES + 1), timeout=3
+        )
+        if len(stdout) > _MAX_PR_OUTPUT_BYTES:
+            with suppress(ProcessLookupError):
+                process.kill()
+        await asyncio.wait_for(process.wait(), timeout=3)
+    except TimeoutError:
+        if process is not None:
+            with suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
+        return None
+    except asyncio.CancelledError:
+        if process is not None:
+            with suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
+        raise
+    except (FileNotFoundError, OSError):
+        return None
+    if process.returncode != 0 or len(stdout) > _MAX_PR_OUTPUT_BYTES:
+        return None
+    return _parse_github_pull_request(stdout)
 
 
 _GIT_SHA_RE = re.compile(r"\A[0-9a-f]{40}(?:[0-9a-f]{24})?\Z")

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -72,6 +72,7 @@ from deepagents_code._content_blocks import reasoning_text
 from deepagents_code._git import (
     read_git_branch_from_filesystem,
     read_git_branch_via_subprocess,
+    read_github_pull_request,
 )
 from deepagents_code._invocation import invoked_name
 from deepagents_code._markdown import escape_markdown as _escape_markdown
@@ -4460,6 +4461,9 @@ class DeepAgentsApp(App):
         self._git_branch_refresh_task: asyncio.Task[None] | None = None
         """Latest background git-branch refresh task, if one is running."""
 
+        self._pull_request_refresh_task: asyncio.Task[None] | None = None
+        """Latest background GitHub pull request refresh task."""
+
         self._graceful_exit_task: asyncio.Task[None] | None = None
         """Fire-and-forget task for the deferred, overlapping teardown.
 
@@ -5051,6 +5055,49 @@ class DeepAgentsApp(App):
         if self._status_bar:
             self._status_bar.branch = branch
 
+    async def _refresh_pull_request(self, cwd: str) -> None:
+        """Resolve and render the open pull request for the current branch.
+
+        Raises:
+            asyncio.CancelledError: If a newer refresh supersedes this one.
+        """
+        try:
+            pull_request = await read_github_pull_request(cwd)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Pull request resolution failed", exc_info=True)
+            return
+        if self._status_bar is None:
+            return
+        if pull_request is None:
+            self._status_bar.set_pull_request(None)
+        else:
+            self._status_bar.set_pull_request(pull_request.number, pull_request.url)
+
+    def _schedule_pull_request_refresh(self) -> None:
+        """Replace any pending pull request lookup with a fresh one."""
+        prior_task = self._pull_request_refresh_task
+        if prior_task is not None and not prior_task.done():
+            prior_task.cancel()
+        refresh_task = asyncio.create_task(self._refresh_pull_request(self._cwd))
+        self._pull_request_refresh_task = refresh_task
+
+        def finalize(task: asyncio.Task[None]) -> None:
+            if self._pull_request_refresh_task is task:
+                self._pull_request_refresh_task = None
+            try:
+                task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.warning(
+                    "Background pull request refresh failed unexpectedly",
+                    exc_info=True,
+                )
+
+        refresh_task.add_done_callback(finalize)
+
     def _cancel_git_branch_refresh_task(self) -> None:
         """Cancel and clear any in-flight background branch refresh task."""
         prior_task = self._git_branch_refresh_task
@@ -5081,6 +5128,7 @@ class DeepAgentsApp(App):
             if self._status_bar:
                 self._status_bar.branch = branch
             self._cancel_git_branch_refresh_task()
+            self._schedule_pull_request_refresh()
             return
 
         # Unusual repo layout — hop to a thread for `git rev-parse`.
@@ -5104,6 +5152,7 @@ class DeepAgentsApp(App):
                 )
 
         refresh_task.add_done_callback(_finalize_git_branch_refresh)
+        self._schedule_pull_request_refresh()
 
     async def _resolve_git_branch_and_continue(self) -> None:
         """Resolve git branch, then schedule remaining init workers.
@@ -5119,6 +5168,7 @@ class DeepAgentsApp(App):
             # Always schedule post-paint init — even if branch resolution
             # fails, the app must still start the server, session, etc.
             self.call_after_refresh(self._post_paint_init)
+            self.call_after_refresh(self._schedule_pull_request_refresh)
 
     async def _post_paint_init(self) -> None:
         """Fire background workers for remaining startup work.
@@ -21189,6 +21239,8 @@ class DeepAgentsApp(App):
             self._agent_worker.cancel()
         if self._git_branch_refresh_task is not None:
             self._git_branch_refresh_task.cancel()
+        if self._pull_request_refresh_task is not None:
+            self._pull_request_refresh_task.cancel()
         if self._external_event_source_task is not None:
             self._external_event_source_task.cancel()
         # Cancellation alone is not enough: the task's `finally` block runs

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -21,6 +21,7 @@ from deepagents_code._constants import FIREWORKS_MODEL_ID_PREFIXES
 from deepagents_code._env_vars import HIDE_CWD, HIDE_GIT_BRANCH, is_env_truthy
 from deepagents_code._session_stats import format_cost, format_token_count
 from deepagents_code.config import get_glyphs
+from deepagents_code.tui.widgets._links import event_targets_link, open_style_link
 from deepagents_code.tui.widgets.loading import Spinner
 
 logger = logging.getLogger(__name__)
@@ -335,6 +336,38 @@ class ModelLabel(Widget):
         return self._clickable_content(ellipsis[:width])
 
 
+class PullRequestLabel(Static):
+    """A clickable link to the open pull request for the current branch."""
+
+    number: reactive[int | None] = reactive(None)
+    url: reactive[str] = reactive("")
+
+    def render(self) -> RenderResult:
+        """Render the pull request number as a terminal hyperlink.
+
+        Returns:
+            Linked pull request text, or an empty string when unset.
+        """
+        if self.number is None or not self.url:
+            return ""
+        return Content.styled(
+            f"PR #{self.number}",
+            Style(link=self.url, underline=True),
+        )
+
+    def on_click(self, event: events.Click) -> None:  # noqa: PLR6301
+        """Open the linked pull request in the default browser."""
+        open_style_link(event)
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        """Show a pointer while hovering the link."""
+        self.styles.pointer = "pointer" if event_targets_link(event) else "default"
+
+    def on_leave(self) -> None:
+        """Restore the default pointer after leaving the label."""
+        self.styles.pointer = "default"
+
+
 class BranchLabel(Widget):
     """A label that displays the git branch with glyph-aware truncation.
 
@@ -521,6 +554,12 @@ class StatusBar(Vertical):
         color: $warning;
     }
 
+    StatusBar .status-pr {
+        width: auto;
+        padding: 0 1 0 0;
+        color: $primary;
+    }
+
     StatusBar .status-cwd {
         width: auto;
         max-width: 45%;
@@ -584,6 +623,8 @@ class StatusBar(Vertical):
     approval_mode: reactive[str] = reactive(default="manual", init=False)
     cwd: reactive[str] = reactive("", init=False)
     branch: reactive[str] = reactive("", init=False)
+    pull_request_number: reactive[int | None] = reactive(None, init=False)
+    pull_request_url: reactive[str] = reactive("", init=False)
     tokens: reactive[int] = reactive(0, init=False)
     cost_usd: reactive[float] = reactive(0.0, init=False)
     rubric_label: reactive[str] = reactive("", init=False)
@@ -625,6 +666,7 @@ class StatusBar(Vertical):
                 classes="status-auto-approve manual",
                 id="auto-approve-indicator",
             )
+            yield PullRequestLabel(classes="status-pr", id="pull-request-display")
             yield Static("", classes="status-cwd", id="cwd-display")
             yield BranchLabel(classes="status-branch", id="branch-display")
             yield Static("", classes="status-rubric", id="rubric-display")
@@ -674,8 +716,8 @@ class StatusBar(Vertical):
         self.set_context_limit(runtime_state.model_context_limit)
         with suppress(NoMatches):
             self.query_one("#rubric-display", Static).display = False
-        # Reactives are `init=False`, so the connection watcher never fires on
-        # mount; render once to hide the empty indicator (and its padding).
+        # Reactives are `init=False`, so these watchers never fire on mount.
+        self.watch_pull_request_number(self.pull_request_number)
         self._render_connection()
         self.watch_status_message(self.status_message)
         self._refresh_metrics()
@@ -727,6 +769,27 @@ class StatusBar(Vertical):
         except NoMatches:
             return
         display.branch = new_value
+
+    def watch_pull_request_number(self, new_value: int | None) -> None:
+        """Update pull request visibility and identity."""
+        try:
+            display = self.query_one("#pull-request-display", PullRequestLabel)
+        except NoMatches:
+            return
+        display.number = new_value
+        display.url = self.pull_request_url
+        display.display = new_value is not None and bool(self.pull_request_url)
+
+    def set_pull_request(self, number: int | None, url: str = "") -> None:
+        """Show or clear the pull request link.
+
+        Args:
+            number: Pull request number, or `None` to clear the link.
+            url: Canonical pull request URL.
+        """
+        self.pull_request_url = url
+        self.pull_request_number = number
+        self.watch_pull_request_number(number)
 
     def watch_status_message(self, new_value: str) -> None:
         """Update status message display."""

--- a/libs/code/tests/unit_tests/test_git.py
+++ b/libs/code/tests/unit_tests/test_git.py
@@ -1,5 +1,6 @@
 """Unit tests for the deepagents_code._git module."""
 
+import asyncio
 import subprocess
 from collections.abc import Iterator
 from pathlib import Path
@@ -8,12 +9,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from deepagents_code._git import (
+    PullRequestMetadata,
     _git_dir_cache,
     _parse_git_dir_pointer,
+    _parse_github_pull_request,
     find_git_common_dir,
     parse_repository_metadata,
     read_git_branch_from_filesystem,
     read_git_remote_url_from_filesystem,
+    read_github_pull_request,
 )
 
 _FULL_SHA = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
@@ -246,6 +250,63 @@ class TestReadGitBranchFromFilesystem:
 
         mock_read.side_effect = OSError("Permission denied")
         assert read_git_branch_from_filesystem(tmp_path) is None
+
+
+class TestParseGitHubPullRequest:
+    def test_accepts_canonical_pull_request(self) -> None:
+        raw = b'{"number":3328,"url":"https://github.com/acme/repo/pull/3328"}'
+
+        assert _parse_github_pull_request(raw) == PullRequestMetadata(
+            3328,
+            "https://github.com/acme/repo/pull/3328",
+        )
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            b"not json",
+            b'{"number":true,"url":"https://github.com/acme/repo/pull/1"}',
+            b'{"number":1,"url":"https://example.com/acme/repo/pull/1"}',
+            b'{"number":1,"url":"https://github.com/acme/repo/pull/2"}',
+            b'{"number":1,"url":"https://user@github.com/acme/repo/pull/1"}',
+            b'{"number":1,"url":"https://github.com/acme/repo/pull/1?x=1"}',
+        ],
+    )
+    def test_rejects_invalid_output(self, raw: bytes) -> None:
+        assert _parse_github_pull_request(raw) is None
+
+
+class TestReadGitHubPullRequest:
+    async def test_invokes_gh_with_fixed_arguments(self, tmp_path: Path) -> None:
+        class Stdout:
+            async def read(self, limit: int) -> bytes:
+                assert limit == 4097
+                return b'{"number":9,"url":"https://github.com/acme/repo/pull/9"}'
+
+        class Process:
+            stdout = Stdout()
+            returncode = 0
+
+            async def wait(self) -> int:
+                return 0
+
+        with patch(
+            "deepagents_code._git.asyncio.create_subprocess_exec",
+            return_value=Process(),
+        ) as create_process:
+            result = await read_github_pull_request(tmp_path)
+
+        assert result == PullRequestMetadata(9, "https://github.com/acme/repo/pull/9")
+        create_process.assert_awaited_once_with(
+            "gh",
+            "pr",
+            "view",
+            "--json",
+            "number,url",
+            cwd=tmp_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
 
 
 class TestReadGitRemoteUrlFromFilesystem:

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -16,6 +16,7 @@ from deepagents_code.tui.widgets.status import (
     _PICKER_TARGET_META,
     BranchLabel,
     ModelLabel,
+    PullRequestLabel,
     StatusBar,
 )
 
@@ -151,6 +152,30 @@ class TestBranchDisplay:
             from deepagents_code.config import get_glyphs
 
             assert rendered.startswith(get_glyphs().git_branch)
+
+
+class TestPullRequestDisplay:
+    async def test_link_shows_and_clears(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            display = pilot.app.query_one("#pull-request-display", PullRequestLabel)
+            assert display.display is False
+
+            bar.set_pull_request(3328, "https://github.com/acme/repo/pull/3328")
+            await pilot.pause()
+
+            assert display.display is True
+            assert str(display.render()) == "PR #3328"
+            links = {
+                segment.style.link
+                for segment in display.render_line(0)
+                if segment.style is not None and segment.style.link
+            }
+            assert links == {"https://github.com/acme/repo/pull/3328"}
+
+            bar.set_pull_request(None)
+            await pilot.pause()
+            assert display.display is False
 
 
 class TestResizePriority:


### PR DESCRIPTION
dcode now shows a clickable `PR #<number>` link in the footer when the current branch has an open GitHub pull request.

---

- Resolve the current branch's open PR with a bounded, timed `gh pr view` subprocess.
- Strictly validate the returned number and canonical GitHub URL before rendering.
- Refresh the link after startup and repository-changing activity, and hide it when no PR exists.
- Reuse the TUI's safe browser-link handling for click and hover behavior.

Verification:
- `make format`
- `make lint`
- Focused tests: 9 passed
- Broader status/git test files: 46 passed, with one unrelated existing model-ellipsis assertion failure (`…k2p6` expected, `...p6` rendered)

Made by [Open SWE](https://openswe.vercel.app/agents/b5a5383d-bb82-555e-96c5-39ec952b9871)