### PR TITLE
fix(talon): restrict WhatsApp replies to self-chat

### DIFF
--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -534,7 +534,7 @@ class WhatsAppChannel:
                     )
                 accepted = 0
                 for message in messages:
-                    if self.config.exposure.allows(message):
+                    if _allows_whatsapp_message(self.config.exposure, message):
                         accepted += 1
                         checked = _enforce_inbound_media_cap(
                             message,
@@ -734,6 +734,12 @@ def _parse_messages(payload: object) -> list[ChannelMessage]:
     return [_parse_message(item) for item in payload]
 
 
+def _allows_whatsapp_message(exposure: ChannelExposure, message: ChannelMessage) -> bool:
+    if message.metadata.get("from_self") is True:
+        return message.metadata.get("self_chat") is True and exposure.allows(message)
+    return exposure.allows(message)
+
+
 def _parse_message(payload: object) -> ChannelMessage:
     if not isinstance(payload, dict):
         msg = "WhatsApp bridge message must be an object"
@@ -771,6 +777,7 @@ def _parse_message(payload: object) -> ChannelMessage:
             "user_name": values.get("user_name") or values.get("senderName"),
             "raw_message": values.get("raw_message") or {},
             "from_self": values.get("from_self") is True or values.get("fromSelf") is True,
+            "self_chat": values.get("self_chat") is True or values.get("selfChat") is True,
         },
     )
     return message_with_media_paths(

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
@@ -8,7 +8,9 @@ const qrcode = require("qrcode-terminal");
 const {
   AckTracker,
   SentBodyReservations,
+  contactIdentityIds,
   createCompatibleClientClass,
+  isSelfChat,
   normalizeMessage,
   serializedId,
   widString,
@@ -29,6 +31,8 @@ const MAX_CACHED_SENT_MESSAGES = 200;
 
 let status = "disconnected";
 let botId = null;
+let botIds = [];
+let bridgeMediaSends = 0;
 const queue = [];
 const sentMessageIds = new Set();
 const sentMessages = new Map();
@@ -119,6 +123,12 @@ client.on("message", (message) => {
   void enqueueMessage(message, false);
 });
 
+client.on("media_uploaded", (message) => {
+  if (bridgeMediaSends === 0) {
+    void enqueueMessage(message, true);
+  }
+});
+
 client.on("message_ack", (message, ack) => {
   recordMessageAck(message, ack);
 });
@@ -130,14 +140,29 @@ async function onClientReady() {
       throw new Error("WhatsApp message key compatibility is not active");
     }
     const webVersion = safeVersion(await client.getWWebVersion());
-    botId = widString(client.info && client.info.wid);
+    botIds = await resolveBotIds();
+    botId = botIds[0] || null;
     status = "connected";
     console.log(
-      `[bridge] WhatsApp connected; webVersion=${webVersion} idCompatibilityInstalled=${compatibility.installed === true} botIdAvailable=${Boolean(botId)}`,
+      `[bridge] WhatsApp connected; webVersion=${webVersion} idCompatibilityInstalled=${compatibility.installed === true} botIdAvailable=${Boolean(botId)} botIdAliasAvailable=${botIds.length > 1}`,
     );
   } catch (error) {
     status = "compatibility_error";
     console.error(`[bridge] WhatsApp compatibility setup failed: ${error.message || error}`);
+  }
+}
+
+async function resolveBotIds() {
+  const initialIds = contactIdentityIds(client.info && client.info.wid);
+  if (initialIds.length === 0 || typeof client.getContactLidAndPhone !== "function") {
+    return initialIds;
+  }
+  try {
+    const mappings = await client.getContactLidAndPhone(initialIds);
+    return contactIdentityIds(initialIds[0], mappings);
+  } catch (_error) {
+    console.log("[bridge] Paired-account ID aliases unavailable; using primary ID only");
+    return initialIds;
   }
 }
 
@@ -158,6 +183,11 @@ async function enqueueMessage(message, fromSelf) {
   const chatId = (fromSelf ? messageTo : messageFrom) || remoteId;
   if (!messageId || !chatId) {
     console.error("Skipping WhatsApp message without a message id or chat id");
+    return;
+  }
+  const selfChat = isSelfChat(fromSelf, chatId, botIds);
+  if (fromSelf && !selfChat) {
+    console.log("[bridge] Ignoring paired-account message outside the self-chat");
     return;
   }
 
@@ -215,8 +245,10 @@ async function enqueueMessage(message, fromSelf) {
     media_file_names: media.map((item) => item.fileName),
     from_self: fromSelf,
     fromSelf,
+    self_chat: selfChat,
+    selfChat,
     mentionedIds: normalizeIds(message.mentionedIds || []),
-    botIds: botId ? [botId] : [],
+    botIds,
     quotedParticipant: await quotedParticipant(message),
     raw_message: {
       from: messageFrom,
@@ -481,6 +513,15 @@ async function withSentBodyReservation(body, operation) {
   }
 }
 
+async function withBridgeMediaSend(operation) {
+  bridgeMediaSends += 1;
+  try {
+    return await operation();
+  } finally {
+    bridgeMediaSends -= 1;
+  }
+}
+
 function readJson(req) {
   return new Promise((resolve, reject) => {
     const chunks = [];
@@ -591,13 +632,15 @@ async function handle(req, res) {
         media.filename = body.fileName || body.file_name;
       }
       const caption = body.caption || undefined;
-      const messageId = await withSentBodyReservation(caption, async () => {
-        const sent = await client.sendMessage(chatId, media, {
-          caption,
-          sendMediaAsDocument: body.mediaType === "document",
-        });
-        return rememberSentMessage(sent);
-      });
+      const messageId = await withBridgeMediaSend(() =>
+        withSentBodyReservation(caption, async () => {
+          const sent = await client.sendMessage(chatId, media, {
+            caption,
+            sendMediaAsDocument: body.mediaType === "document",
+          });
+          return rememberSentMessage(sent);
+        }),
+      );
       if (!messageId) {
         sendJson(res, 502, { success: false, error: "WhatsApp send returned no message id" });
         return;

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/id_compat.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/id_compat.js
@@ -22,6 +22,19 @@ function widString(value) {
   return null;
 }
 
+function contactIdentityIds(primary, mappings = []) {
+  const aliases = mappings.flatMap((mapping) => [mapping && mapping.lid, mapping && mapping.pn]);
+  return [...new Set([primary, ...aliases].map(widString).filter(Boolean))];
+}
+
+function isSelfChat(fromSelf, chatId, ownIds) {
+  if (fromSelf !== true) {
+    return false;
+  }
+  const serializedChatId = widString(chatId);
+  return Boolean(serializedChatId && ownIds.some((value) => widString(value) === serializedChatId));
+}
+
 function serializedId(value) {
   const serialized = widString(value);
   if (serialized || !value || typeof value !== "object") {
@@ -237,9 +250,11 @@ class SentBodyReservations {
 module.exports = {
   AckTracker,
   SentBodyReservations,
+  contactIdentityIds,
   createCompatibleClientClass,
   installMessageKeyCompatibility,
   installPageCompatibility,
+  isSelfChat,
   normalizeId,
   normalizeMessage,
   serializedId,

--- a/libs/talon/tests/channels/test_whatsapp.py
+++ b/libs/talon/tests/channels/test_whatsapp.py
@@ -352,6 +352,7 @@ async def test_channel_polls_self_messages_without_operator_id(tmp_path: Path) -
                 "messageId": "message-1",
                 "messageType": "chat",
                 "fromSelf": True,
+                "selfChat": True,
             },
             {
                 "body": "other",
@@ -385,6 +386,50 @@ async def test_channel_polls_self_messages_without_operator_id(tmp_path: Path) -
     assert received[0].metadata["from_self"] is True
 
 
+async def test_channel_never_dispatches_outbound_messages_to_other_chats(tmp_path: Path) -> None:
+    transport = RecordingTransport(
+        messages=[
+            {
+                "body": "outbound direct message",
+                "chatId": "other-user",
+                "senderId": "operator",
+                "messageId": "message-1",
+                "messageType": "chat",
+                "fromSelf": True,
+                "selfChat": False,
+            },
+            {
+                "body": "inbound direct message",
+                "chatId": "other-user",
+                "senderId": "other-user",
+                "messageId": "message-2",
+                "messageType": "chat",
+            },
+        ],
+    )
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path,
+            exposure=ChannelExposure(mode=ExposureMode.OPEN),
+            poll_interval_seconds=60,
+            health_interval_seconds=60,
+        ),
+        transport=cast("_BridgeTransport", transport),
+    )
+    received: list[ChannelMessage] = []
+
+    async def record(message: ChannelMessage) -> None:
+        received.append(message)
+
+    channel.set_message_handler(record)
+
+    await channel.start()
+    await asyncio.sleep(0)
+    await channel.stop()
+
+    assert [message.text for message in received] == ["inbound direct message"]
+
+
 async def test_channel_parses_inbound_media_payload(tmp_path: Path) -> None:
     media = tmp_path / "voice.ogg"
     media.write_bytes(b"voice")
@@ -401,6 +446,7 @@ async def test_channel_parses_inbound_media_payload(tmp_path: Path) -> None:
                 "mediaPaths": [str(media)],
                 "mediaMimeTypes": ["audio/ogg"],
                 "fromSelf": True,
+                "selfChat": True,
             },
         ],
     )
@@ -445,6 +491,7 @@ async def test_channel_filters_oversized_inbound_media_payload(tmp_path: Path) -
                 "mediaPaths": [str(media)],
                 "mediaMimeTypes": ["audio/ogg"],
                 "fromSelf": True,
+                "selfChat": True,
             },
         ],
     )
@@ -486,6 +533,7 @@ async def test_channel_normalizes_ptt_payload_as_voice(tmp_path: Path) -> None:
                 "mediaPaths": [str(media)],
                 "mediaMimeTypes": ["application/octet-stream"],
                 "fromSelf": True,
+                "selfChat": True,
             },
         ],
     )
@@ -525,6 +573,7 @@ async def test_channel_normalizes_audio_mime_payload_as_voice(tmp_path: Path) ->
                 "mediaPaths": [str(media)],
                 "mediaMimeTypes": ["audio/ogg; codecs=opus"],
                 "fromSelf": True,
+                "selfChat": True,
             },
         ],
     )

--- a/libs/talon/tests/channels/whatsapp_bridge/id_compat.test.js
+++ b/libs/talon/tests/channels/whatsapp_bridge/id_compat.test.js
@@ -7,8 +7,10 @@ const test = require("node:test");
 const {
   AckTracker,
   SentBodyReservations,
+  contactIdentityIds,
   createCompatibleClientClass,
   installMessageKeyCompatibility,
+  isSelfChat,
   normalizeId,
   normalizeMessage,
   serializedId,
@@ -23,6 +25,25 @@ test("reads legacy, renamed, and component WhatsApp IDs", () => {
     serializedId({ fromMe: true, remote: { user: "123", server: "lid" }, id: "ABC" }),
     "true_123@lid_ABC",
   );
+});
+
+test("collects the paired account phone and LID aliases", () => {
+  assert.deepEqual(
+    contactIdentityIds({ _serialized: "123@c.us" }, [
+      { pn: "123@c.us", lid: "456@lid" },
+    ]),
+    ["123@c.us", "456@lid"],
+  );
+});
+
+test("recognizes only outbound messages addressed to the paired account as self-chat", () => {
+  const ownIds = [{ _serialized: "123@c.us" }, { _serialized: "456@lid" }];
+
+  assert.equal(isSelfChat(true, "123@c.us", ownIds), true);
+  assert.equal(isSelfChat(true, "456@lid", ownIds), true);
+  assert.equal(isSelfChat(true, "789@c.us", ownIds), false);
+  assert.equal(isSelfChat(false, "123@c.us", ownIds), false);
+  assert.equal(isSelfChat(true, "123@c.us", []), false);
 });
 
 test("reconstructs self state only from boolean true", () => {


### PR DESCRIPTION
Talon now replies to WhatsApp messages only in the self-chat for the connected account, preventing responses in other direct-message conversations.

---

WhatsApp Web emits paired-account outbound messages, including messages sent to other contacts. Talon previously treated every paired-account event as operator input, which could trigger an unintended reply.

This change resolves the paired account phone-number and LID aliases, classifies outbound events as self-chat only when their chat ID matches an account alias, and drops other paired-account messages before dispatch. It also avoids re-enqueuing bridge-originated media sends and adds Python and Node regression coverage.