### PR TITLE
perf(code,quickjs): omit middleware trace inputs

### DIFF
--- a/libs/code/deepagents_code/model_retry.py
+++ b/libs/code/deepagents_code/model_retry.py
@@ -32,7 +32,7 @@ from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import TYPE_CHECKING, Any
 
-from langchain.agents.middleware.types import AgentMiddleware
+from langchain.agents.middleware.types import AgentMiddleware, TracePolicy, omit_payload
 from langchain_core.callbacks import BaseCallbackManager
 from langchain_core.exceptions import ModelError
 from langchain_core.runnables.config import var_child_runnable_config
@@ -1036,6 +1036,8 @@ class CodeModelRetryMiddleware(AgentMiddleware):
     reconcile output from a superseded attempt when a transient failure is
     retried after streaming began.
     """
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     def __init__(
         self,

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -16,6 +16,8 @@ from langchain.agents.middleware.types import (
     ModelResponse,
     PrivateStateAttr,
     ResponseT,
+    TracePolicy,
+    omit_payload,
 )
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core._api import beta
@@ -235,6 +237,8 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         )
         ```
     """
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     state_schema = REPLState
 


### PR DESCRIPTION
`CodeInterpreterMiddleware` and `CodeModelRetryMiddleware` no longer serialize full model requests into every wrapper span, reducing tracing overhead for long conversations.

---

Both middleware now use `TracePolicy(process_inputs=omit_payload)`, matching the existing Deep Agents middleware tracing policy. Their behavior is otherwise unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/bf7bb34a-16fc-509a-80a9-7f4f1af71620)