### PR TITLE
feat(sdk): (forked subagents) drop `ForkedSubAgent` and `parent_system_prompt` param

### DIFF
--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -11,7 +11,6 @@ from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.rubric import RubricMiddleware
 from deepagents.middleware.subagents import (
     CompiledSubAgent,
-    ForkedSubAgent,
     SubAgent,
     SubAgentMiddleware,
 )
@@ -33,7 +32,6 @@ __all__ = [
     "DeepAgentState",
     "FilesystemMiddleware",
     "FilesystemPermission",
-    "ForkedSubAgent",
     "FsToolName",
     "GeneralPurposeSubagentProfile",
     "HarnessProfile",

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -46,6 +46,7 @@ from deepagents.middleware._fs_interrupt import _build_interrupt_on_from_permiss
 from deepagents.middleware._prompt_caching import append_prompt_caching_middleware
 from deepagents.middleware._state import private_state_field_names
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
+from deepagents.middleware._utils import append_to_system_message
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
 from deepagents.middleware.memory import MemoryMiddleware
@@ -769,7 +770,16 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 "tools": subagent_tools or [],
                 "middleware": subagent_middleware,
             }
-            if not is_forked:
+            if is_forked:
+                # The parent's prompt is the fork's base; the fork's own is an addendum.
+                fork_addendum = spec.get("system_prompt")
+                if not fork_addendum:
+                    processed["system_prompt"] = final_system_prompt
+                elif isinstance(final_system_prompt, SystemMessage):
+                    processed["system_prompt"] = append_to_system_message(final_system_prompt, fork_addendum)
+                else:
+                    processed["system_prompt"] = f"{final_system_prompt}\n\n{fork_addendum}" if final_system_prompt else fork_addendum
+            else:
                 processed["system_prompt"] = _apply_profile_prompt(_subagent_profile, spec.get("system_prompt", ""))
             if subagent_interrupt_on is not None:
                 processed["interrupt_on"] = subagent_interrupt_on
@@ -872,7 +882,6 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             # template. Stale keys silently no-op if the tool is renamed.
             task_description=_profile.tool_description_overrides.get("task"),
             state_schema=state_schema,
-            parent_system_prompt=final_system_prompt,
         )
         deepagent_middleware.append(sub_agent_middleware)
     deepagent_middleware.extend(

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -55,7 +55,6 @@ from deepagents.middleware.skills import SkillsMiddleware
 from deepagents.middleware.subagents import (
     GENERAL_PURPOSE_SUBAGENT,
     CompiledSubAgent,
-    ForkedSubAgent,
     SubAgent,
     SubAgentMiddleware,
     _is_compiled_subagent,
@@ -275,7 +274,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     *,
     system_prompt: str | SystemMessage | None = None,
     middleware: Sequence[AgentMiddleware[StateT_co, ContextT]] = (),
-    subagents: Sequence[SubAgent | ForkedSubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
+    subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
     skills: list[str] | None = None,
     memory: list[str] | None = None,
     permissions: list[FilesystemPermission] | None = None,
@@ -412,10 +411,9 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             subagents via `subagents=`. Async subagents are unaffected.
         subagents: Subagent specs available to the main agent.
 
-            This collection supports four forms:
+            This collection supports three forms:
 
-            - [`SubAgent`][deepagents.middleware.subagents.SubAgent]: An isolated declarative synchronous subagent spec.
-            - [`ForkedSubAgent`][deepagents.middleware.subagents.ForkedSubAgent]: A declarative spec that inherits parent context.
+            - [`SubAgent`][deepagents.middleware.subagents.SubAgent]: A declarative synchronous subagent spec.
             - [`CompiledSubAgent`][deepagents.middleware.subagents.CompiledSubAgent]: A pre-compiled runnable subagent.
             - [`AsyncSubAgent`][deepagents.middleware.async_subagents.AsyncSubAgent]: A remote/background subagent spec.
 
@@ -425,9 +423,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             `skills`, `permissions`, and `response_format`. See `interrupt_on`
             below for inheritance and override behavior.
 
-            `ForkedSubAgent` is experimental. It requires `mode="fork"`, inherits
-            the parent's effective message history and exact system prompt, and
-            cannot define its own `system_prompt` or `skills`.
+            Setting `mode="fork"` on a `SubAgent` is experimental. A fork
+            continues the parent's conversation and rebuilds its system prompt
+            instead of starting isolated; any `system_prompt` of its own is appended to
+            the inherited one, and it cannot define `skills`.
 
             `CompiledSubAgent` entries are also exposed through the `task` tool,
             but provide a pre-built `runnable` instead of a declarative prompt
@@ -661,7 +660,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     # auto-add the default general-purpose subagent can factor in an explicit
     # override, and so its middleware stack (including any factory-based
     # `extra_middleware`) isn't built and then discarded.
-    inline_subagents: list[SubAgent | ForkedSubAgent | CompiledSubAgent] = []
+    inline_subagents: list[SubAgent | CompiledSubAgent] = []
     async_subagents: list[AsyncSubAgent] = []
     for spec in subagents or []:
         if "graph_id" in spec:
@@ -784,7 +783,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             if subagent_interrupt_on is not None:
                 processed["interrupt_on"] = subagent_interrupt_on
             if is_forked:
-                inline_subagents.append(cast("ForkedSubAgent", processed))
+                inline_subagents.append(cast("SubAgent", processed))
             else:
                 inline_subagents.append(cast("SubAgent", processed))
 

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -66,7 +66,6 @@ from deepagents.middleware.rubric import (
 from deepagents.middleware.skills import SkillsMiddleware
 from deepagents.middleware.subagents import (
     CompiledSubAgent,
-    ForkedSubAgent,
     SubAgent,
     SubAgentMiddleware,
 )
@@ -89,7 +88,6 @@ __all__ = [
     "CriterionPass",
     "FilesystemMiddleware",
     "FilesystemPermission",
-    "ForkedSubAgent",
     "GraderResponse",
     "GraderVerdict",
     "MemoryMiddleware",

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -134,8 +134,7 @@ class _SubAgentBase(TypedDict):
     """Configure human-in-the-loop for specific tools."""
 
     skills: NotRequired[list[str]]
-    """Skill source paths for `SkillsMiddleware`. Forbidden on
-    [`ForkedSubAgent`][deepagents.middleware.subagents.ForkedSubAgent]."""
+    """Skill source paths for `SkillsMiddleware`. Forbidden under `mode="fork"`."""
 
     permissions: NotRequired[list[FilesystemPermission]]
     """List of `FilesystemPermission` rules for this subagent.
@@ -189,46 +188,33 @@ class _SubAgentBase(TypedDict):
 
 
 class SubAgent(_SubAgentBase):
-    """Specification for an isolated declarative subagent.
+    """Specification for a declarative subagent.
 
-    The subagent receives only the delegated task description. Use
-    [`ForkedSubAgent`][deepagents.middleware.subagents.ForkedSubAgent] to inherit
-    the parent's conversation and system prompt.
-    """
-
-    system_prompt: NotRequired[str]
-    """Instructions for the subagent. Uses an empty prompt when omitted."""
-
-    mode: NotRequired[Literal["handoff"]]
-    """Context mode. Declarative `SubAgent` instances are always isolated."""
-
-
-class ForkedSubAgent(_SubAgentBase):
-    """Specification for a subagent that inherits its parent's context.
+    By default the subagent is isolated: it receives only the delegated task
+    description. Setting `mode="fork"` makes it continue the parent's
+    conversation instead.
 
     !!! warning "Experimental"
 
-        Forked subagents are experimental and may change in a future release.
-
-    A forked subagent receives the parent's effective conversation history and
-    mirrors the parent's prompt-producing middleware, so it rebuilds the same
-    system prompt. Its own `system_prompt` is appended to that rather than
-    replacing it. It cannot define `skills`, which would diverge from the
-    parent's.
-
-    `tools` isn't restricted the same way -- a forked subagent's own tools
-    work normally. The tradeoff is cache misses.
-
-    Full state inheritance is specific to this declarative form. A
-    [`CompiledSubAgent`][deepagents.middleware.subagents.CompiledSubAgent] with
-    `mode="fork"` inherits the conversation only.
+        `mode="fork"` is experimental and may change in a future release.
     """
 
-    mode: Literal["fork"]
-    """Required discriminator that enables conversation forking."""
-
     system_prompt: NotRequired[str]
-    """Extra instructions appended to the inherited prompt."""
+    """Instructions for the subagent. Uses an empty prompt when omitted.
+
+    Under `mode="fork"` this is appended to the inherited prompt rather than
+    replacing it.
+    """
+
+    mode: NotRequired[Literal["handoff", "fork"]]
+    """Context mode. Defaults to `handoff`, an isolated subagent.
+
+    Under `fork`, the subagent receives the parent's effective conversation
+    history and state, and mirrors the parent's prompt-producing middleware so
+    it rebuilds the same system prompt. It cannot define `skills`, which would
+    diverge from the parent's. `tools` isn't restricted the same way -- a fork's
+    own tools work normally; the tradeoff is cache misses.
+    """
 
 
 class CompiledSubAgent(TypedDict):
@@ -313,12 +299,12 @@ class CompiledSubAgent(TypedDict):
     mode: NotRequired[Literal["handoff", "fork"]]
     """Use `fork` to inherit the parent's conversation without changing the runnable prompt.
 
-    [`ForkedSubAgent`][deepagents.middleware.subagents.ForkedSubAgent] inherits the
-    full state, including private keys.
+    A declarative [`SubAgent`][deepagents.middleware.subagents.SubAgent] fork
+    inherits the full state, including private keys.
     """
 
 
-_SubAgentSpec = SubAgent | ForkedSubAgent | CompiledSubAgent
+_SubAgentSpec = SubAgent | CompiledSubAgent
 
 
 def _validate_subagent_mode(spec: _SubAgentSpec) -> None:
@@ -328,7 +314,7 @@ def _validate_subagent_mode(spec: _SubAgentSpec) -> None:
         msg = f"SubAgent '{spec['name']}' has invalid mode '{mode}'; expected 'handoff' or 'fork'"
         raise ValueError(msg)
     if mode == "fork" and spec.get("skills"):
-        msg = f"ForkedSubAgent '{spec['name']}' cannot set skills; the parent's system message would discard it."
+        msg = f"SubAgent '{spec['name']}' cannot set skills under mode='fork'; the parent's skills are inherited instead."
         raise ValueError(msg)
 
 
@@ -348,16 +334,7 @@ def _validate_unique_subagent_names(subagents: Sequence[_SubAgentSpec]) -> None:
         seen.add(name)
 
 
-def _is_subagent(spec: _SubAgentSpec) -> TypeIs[SubAgent]:
-    """Return whether a spec is an isolated declarative subagent.
-
-    Compiled specs provide a `runnable`; forked declarative specs use
-    `mode="fork"`. All remaining specs are regular `SubAgent` definitions.
-    """
-    return "runnable" not in spec and spec.get("mode") != "fork"
-
-
-def _is_forked_subagent(spec: _SubAgentSpec) -> TypeIs[ForkedSubAgent]:
+def _is_forked_subagent(spec: _SubAgentSpec) -> TypeIs[SubAgent]:
     """Return whether a declarative subagent inherits its parent's state."""
     return "runnable" not in spec and spec.get("mode") == "fork"
 
@@ -638,7 +615,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
     else:
         description = task_description
 
-    def _resolved_declarative_spec(spec: SubAgent | ForkedSubAgent) -> SubAgent:
+    def _resolved_declarative_spec(spec: SubAgent) -> SubAgent:
         """Resolve the inherited prompt for a declarative fork."""
         if not _is_forked_subagent(spec):
             return spec
@@ -926,7 +903,7 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         self,
         *,
         backend: BackendProtocol,
-        subagents: Sequence[SubAgent | ForkedSubAgent | CompiledSubAgent],
+        subagents: Sequence[SubAgent | CompiledSubAgent],
         system_prompt: str | None = None,
         task_description: str | None = None,
         private_state_keys: frozenset[str] | None = None,
@@ -944,7 +921,7 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         self._task_description = task_description
         self._state_schema = state_schema
         if any(_is_forked_subagent(spec) or _is_forked_compiled_subagent(spec) for spec in subagents):
-            warn_beta(name="ForkedSubAgent", obj_type="subagent spec")
+            warn_beta(name="forked subagents", obj_type="feature")
         self.subagent_names: frozenset[str] = frozenset(spec["name"] for spec in subagents)
         """Declared subagent names. Public so streamers can discover them
         without introspecting the `task` tool's closure."""

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -22,7 +22,7 @@ from langchain.agents.structured_output import ResponseFormat
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core._api.beta_decorator import warn_beta
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
@@ -212,8 +212,9 @@ class ForkedSubAgent(_SubAgentBase):
 
     A forked subagent receives the parent's effective conversation history and
     mirrors the parent's prompt-producing middleware, so it rebuilds the same
-    system prompt. It cannot define a separate `system_prompt` or `skills`,
-    since either would diverge from the parent's.
+    system prompt. Its own `system_prompt` is appended to that rather than
+    replacing it. It cannot define `skills`, which would diverge from the
+    parent's.
 
     `tools` isn't restricted the same way -- a forked subagent's own tools
     work normally. The tradeoff is cache misses.
@@ -225,6 +226,9 @@ class ForkedSubAgent(_SubAgentBase):
 
     mode: Literal["fork"]
     """Required discriminator that enables conversation forking."""
+
+    system_prompt: NotRequired[str]
+    """Extra instructions appended to the inherited prompt."""
 
 
 class CompiledSubAgent(TypedDict):
@@ -322,9 +326,6 @@ def _validate_subagent_mode(spec: _SubAgentSpec) -> None:
     mode = spec.get("mode")
     if mode not in (None, "handoff", "fork"):
         msg = f"SubAgent '{spec['name']}' has invalid mode '{mode}'; expected 'handoff' or 'fork'"
-        raise ValueError(msg)
-    if mode == "fork" and spec.get("system_prompt") is not None:
-        msg = f"ForkedSubAgent '{spec['name']}' cannot set system_prompt; it always inherits the parent's."
         raise ValueError(msg)
     if mode == "fork" and spec.get("skills"):
         msg = f"ForkedSubAgent '{spec['name']}' cannot set skills; the parent's system message would discard it."
@@ -602,7 +603,6 @@ def _build_task_tool(  # noqa: C901, PLR0915
     *,
     private_state_keys: frozenset[str] = frozenset(),
     state_schema: type | None = None,
-    parent_system_prompt: str | SystemMessage | None = None,
 ) -> BaseTool:
     """Create a task tool from subagent specs.
 
@@ -613,7 +613,6 @@ def _build_task_tool(  # noqa: C901, PLR0915
         private_state_keys: State keys marked with `PrivateStateAttr` that
             should be stripped from parent state before invoking subagents.
         state_schema: Base graph state schema forwarded to raw subagent specs.
-        parent_system_prompt: Static prompt inherited by declarative forked subagents.
 
     Returns:
         A StructuredTool that can invoke subagents by type.
@@ -643,8 +642,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
         """Resolve the inherited prompt for a declarative fork."""
         if not _is_forked_subagent(spec):
             return spec
-        resolved = {key: value for key, value in spec.items() if key not in {"mode", "system_prompt"}}
-        resolved["system_prompt"] = parent_system_prompt if parent_system_prompt is not None else ""
+        resolved = {key: value for key, value in spec.items() if key != "mode"}
         fork_task_tool = StructuredTool.from_function(
             name="task",
             func=task,
@@ -894,8 +892,6 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
 
             Leave unset to use `create_agent`'s default. `CompiledSubAgent`
             entries are unaffected — callers own those runnables' schemas.
-        parent_system_prompt: Prompt inherited by declarative `ForkedSubAgent`
-            entries. Compiled subagents keep their own prompt.
 
     Example:
         ```python
@@ -935,7 +931,6 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         task_description: str | None = None,
         private_state_keys: frozenset[str] | None = None,
         state_schema: type | None = None,
-        parent_system_prompt: str | SystemMessage | None = None,
     ) -> None:
         """Initialize the `SubAgentMiddleware`."""
         super().__init__()
@@ -948,7 +943,6 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         self._private_state_keys = private_state_keys or frozenset()
         self._task_description = task_description
         self._state_schema = state_schema
-        self._parent_system_prompt = parent_system_prompt
         if any(_is_forked_subagent(spec) or _is_forked_compiled_subagent(spec) for spec in subagents):
             warn_beta(name="ForkedSubAgent", obj_type="subagent spec")
         self.subagent_names: frozenset[str] = frozenset(spec["name"] for spec in subagents)
@@ -960,7 +954,6 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             task_description,
             private_state_keys=self._private_state_keys,
             state_schema=self._state_schema,
-            parent_system_prompt=self._parent_system_prompt,
         )
 
         # Build system prompt with available agents
@@ -992,7 +985,6 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             task_description=self._task_description,
             private_state_keys=value,
             state_schema=self._state_schema,
-            parent_system_prompt=self._parent_system_prompt,
         )
         self.tools = [task_tool]
 

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -139,7 +139,7 @@ filterwarnings = [
     # Unexpected warnings fail the run; see "Warnings are errors" in AGENTS.md.
     "error",
     "ignore:Passing `model=None` to `create_deep_agent`:DeprecationWarning",
-    "ignore:The subagent spec `ForkedSubAgent` is in beta:langchain_core._api.LangChainBetaWarning",
+    "ignore:The feature `forked subagents` is in beta:langchain_core._api.LangChainBetaWarning",
     # `langsmith.sandbox` is alpha upstream; the FutureWarning fires on import.
     "ignore:langsmith.sandbox is in alpha:FutureWarning",
     # pytest-cov complains when invoked with `--no-cov` (used for fast runs).

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -258,7 +258,7 @@ class TestSubagentMiddlewareInit:
         beta_warnings = [w for w in caught if isinstance(w.message, LangChainBetaWarning)]
         assert len(beta_warnings) == expected
         if expected:
-            assert "`ForkedSubAgent` is in beta" in str(beta_warnings[0].message)
+            assert "`forked subagents` is in beta" in str(beta_warnings[0].message)
 
     def test_forked_subagent_history_has_no_dangling_task_call(self) -> None:
         """The spawning `task` call is dropped, so nothing patches a bogus result over it."""

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -151,16 +151,39 @@ class TestSubagentMiddlewareInit:
         with pytest.raises(ValueError, match="invalid mode 'dynamic'"):
             SubAgentMiddleware(backend=StateBackend(), subagents=[invalid_spec])
 
-    def test_rejects_system_prompt_on_forked_subagent(self) -> None:
-        invalid_spec: Any = {
-            "name": "worker",
-            "description": "Does work.",
-            "mode": "fork",
-            "system_prompt": "You are a SQL expert.",
-        }
+    def test_forked_subagent_appends_its_own_system_prompt(self) -> None:
+        """A fork's `system_prompt` is appended to the inherited one, not a replacement."""
+        parent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {"name": "task", "args": {"description": "continue", "subagent_type": "worker"}, "id": "call_worker", "type": "tool_call"}
+                        ],
+                    ),
+                    AIMessage(content="parent done"),
+                ]
+            )
+        )
+        worker_model = GenericFakeChatModel(messages=iter([AIMessage(content="worker done")]))
+        agent = create_deep_agent(
+            model=parent_model,
+            system_prompt="PARENT_PROMPT",
+            subagents=[
+                {
+                    "name": "worker",
+                    "description": "Continues with context.",
+                    "model": worker_model,
+                    "mode": "fork",
+                    "system_prompt": "FORK_EXTRA",
+                }
+            ],
+        )
 
-        with pytest.raises(ValueError, match="cannot set system_prompt"):
-            SubAgentMiddleware(backend=StateBackend(), subagents=[invalid_spec])
+        agent.invoke({"messages": [HumanMessage(content="start")]}, {"recursion_limit": 25})
+
+        assert worker_model.call_history[0]["messages"][0].text == "PARENT_PROMPT\n\nFORK_EXTRA"
 
     def test_rejects_skills_on_forked_subagent(self) -> None:
         invalid_spec: Any = {


### PR DESCRIPTION
Currently:
1. `system_prompt` is forbidden on `ForkedSubAgent` specs
2. `parent_system_prompt` is (usually) required to be passed into SubAgentMiddleware for forked subagents

(In `create_deep_agent`, `parent_system_prompt` specifies the base prompt that is not built by middleware.)

We can avoid introducing a new param by just allowing `system_prompt` on forked subagent specs. So for forked subagents, `create_deep_agent` appends (1) the parent agent system prompt, and (2) any `system_prompt` found in the spec.

Once we do this, we can do away with `ForkedSubAgent` and just have `["handoff", "fork"]` as allowed values for `mode` on SubAgent specs.