### PR TITLE
fix(sdk): rewrite routed glob filters in composite grep

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -482,7 +482,10 @@ class CompositeBackend(BackendProtocol):
                     # Cap already met by earlier routes; skip the rest.
                     truncated = True
                     break
-                grep_result = self._grep_backend(backend, pattern, "/", glob, remaining)
+                routed_glob = (
+                    _strip_route_from_pattern(glob, route_prefix) if glob is not None else None
+                )
+                grep_result = self._grep_backend(backend, pattern, "/", routed_glob, remaining)
                 if grep_result.error:
                     return grep_result
                 all_matches.extend(_remap_grep_path(m, route_prefix) for m in (grep_result.matches or []))
@@ -544,7 +547,10 @@ class CompositeBackend(BackendProtocol):
                     # Cap already met by earlier routes; skip the rest.
                     truncated = True
                     break
-                grep_result = await self._agrep_backend(backend, pattern, "/", glob, remaining)
+                routed_glob = (
+                    _strip_route_from_pattern(glob, route_prefix) if glob is not None else None
+                )
+                grep_result = await self._agrep_backend(backend, pattern, "/", routed_glob, remaining)
                 if grep_result.error:
                     return grep_result
                 all_matches.extend(_remap_grep_path(m, route_prefix) for m in (grep_result.matches or []))

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -1165,6 +1165,22 @@ def test_composite_grep_multiple_matches_per_file(tmp_path: Path) -> None:
     assert line_numbers == [1, 2]
 
 
+def test_composite_root_grep_rewrites_route_qualified_glob() -> None:
+    """Root grep should apply the route prefix to the child backend's glob filter."""
+    mem_store = InMemoryStore()
+    default = StoreBackend(store=mem_store, namespace=lambda _rt: ("default",))
+    routed = StoreBackend(store=mem_store, namespace=lambda _rt: ("routed",))
+    comp = CompositeBackend(default=default, routes={"/memories/": routed})
+
+    comp.write("/memories/readme.md", "needle")
+
+    for pattern in ("/memories/*.md", "memories/*.md"):
+        result = comp.grep("needle", path="/", glob=pattern)
+
+        assert result.error is None
+        assert [match["path"] for match in result.matches or []] == ["/memories/readme.md"]
+
+
 @pytest.mark.xfail(
     reason="StoreBackend instances share the same underlying store when using the same runtime, "
     "causing files written to one route to appear in all routes that use the same backend instance. "

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
@@ -904,6 +904,22 @@ async def test_composite_agrep_multiple_matches_per_file_async(tmp_path: Path) -
     assert line_numbers == [1, 2]
 
 
+async def test_composite_root_agrep_rewrites_route_qualified_glob() -> None:
+    """Root agrep should apply the route prefix to the child backend's glob filter."""
+    mem_store = InMemoryStore()
+    default = StoreBackend(store=mem_store, namespace=lambda _rt: ("default",))
+    routed = StoreBackend(store=mem_store, namespace=lambda _rt: ("routed",))
+    comp = CompositeBackend(default=default, routes={"/memories/": routed})
+
+    await comp.awrite("/memories/readme.md", "needle")
+
+    for pattern in ("/memories/*.md", "memories/*.md"):
+        result = await comp.agrep("needle", path="/", glob=pattern)
+
+        assert result.error is None
+        assert [match["path"] for match in result.matches or []] == ["/memories/readme.md"]
+
+
 @pytest.mark.xfail(
     reason="StoreBackend instances share the same underlying store when using the same runtime, "
     "causing files written to one route to appear in all routes that use the same backend instance. "


### PR DESCRIPTION
## Summary

Fixes #6019.

When CompositeBackend aggregates grep results from the root path, route-qualified glob filters such as /memories/*.md were forwarded unchanged to the routed backend. Because the routed backend sees paths relative to its internal root, the filter returned no matches.

## Changes

- Rewrite route-qualified glob filters before delegating root-level synchronous grep calls.
- Apply the same behavior to asynchronous agrep calls.
- Add regression coverage for both slash-prefixed and bare route-qualified patterns.

## Validation

- Python syntax validation completed locally.
- Added synchronous and asynchronous regression tests; CI should run the full project test suite.