### PR TITLE
feat(talon): interrupt active turns for new messages

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -8,7 +8,7 @@ Deep Agents Talon is the local runtime host for long-running Deep Agents. It own
 
 Talon currently includes:
 
-- A host process with graceful shutdown, per-conversation serialization, and `/stop` cancellation.
+- A host process with graceful shutdown, per-conversation interrupt-and-continue, and `/stop` cancellation.
 - A generic channel protocol plus WhatsApp, Telegram, and Discord adapters (WhatsApp is backed by a loopback Node bridge).
 - A persistent cron scheduler with agent-facing cron tool helpers.
 - MCP tool loading from explicit config paths or `~/.deepagents/.mcp.json`.
@@ -28,6 +28,10 @@ AGENT_ASSISTANT_ID=local AGENT_MODEL=<provider>:<model-id> uv run deepagents-tal
 If `AGENT_MODEL` is unset, Talon starts with the echo runtime. This is useful for checking host lifecycle and channel wiring without provider credentials.
 
 Assistant state lives under `~/.deepagents/<assistant_id>/` by default. The host creates restrictive state directories for the materialized agent manifest, channel sessions, and cron jobs. The default local execution workspace is the current working directory; set `DEEPAGENTS_TALON_WORKSPACE` to use a different directory. The per-invocation graph recursion limit defaults to `500`; set `DEEPAGENTS_TALON_RECURSION_LIMIT` to tune it.
+
+## Interrupt and Continue
+
+A new message in a conversation cancels the active turn, records an interruption marker after the latest committed graph checkpoint, and starts the new message on the same thread. Partial output from the cancelled turn is not fabricated or delivered. `/stop` and `/new` also recover interrupted state; process shutdown does not. If cancellation does not finish within 30 seconds, Talon leaves the existing run isolated and does not start the new message; restart Talon to recover.
 
 ## Local Agent Activity Logs
 

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -59,6 +59,7 @@ _NEW_CONVERSATION_MESSAGE = "Started a fresh conversation."
 _APPROVE_REPLIES = frozenset({"approve", "approved", "yes", "y"})
 _DENY_REPLIES = frozenset({"deny", "denied", "reject", "rejected", "no", "n"})
 _RESET_THREAD_SEPARATOR = ":talon-reset:"
+_CRON_THREAD_SUFFIX = ":talon-cron"
 _APPROVAL_LOG_RAW_IDS_ENV = "DEEPAGENTS_TALON_APPROVAL_LOG_RAW_IDS"
 _TYPING_REFRESH_SECONDS = 4.0
 _CANCEL_TIMEOUT_SECONDS = 30.0
@@ -92,6 +93,12 @@ class _Turn:
     provider: str | None
     generation: int
     recovery_degraded: bool
+
+
+@dataclass(slots=True)
+class _CronControl:
+    lock: asyncio.Lock
+    users: int = 0
 
 
 @dataclass(slots=True)
@@ -139,6 +146,7 @@ class TalonHost:
         self.scheduler = scheduler
         self.voice_transcriber = voice_transcriber
         self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+        self._cron_controls: dict[str, _CronControl] = {}
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._conversation_tasks: defaultdict[str, set[asyncio.Task[None]]] = defaultdict(set)
         self._generations: defaultdict[str, int] = defaultdict(int)
@@ -392,29 +400,28 @@ class TalonHost:
         Returns:
             Agent text output for scheduler delivery handling.
         """
-        conversation_root = self._conversation_root(
-            job.origin.channel or "cron",
-            job.origin.conversation_id,
-        )
-        async with self._locks[conversation_root]:
-            conversation_id = self._agent_conversation_id(conversation_root)
-            active = self._tasks.get(conversation_id)
-            if active is not None and not active.done():
-                with contextlib.suppress(asyncio.CancelledError):
-                    await asyncio.shield(active)
-            result = await self._invoke_agent(
-                conversation_id=conversation_id,
-                text=job.prompt,
-                metadata={
-                    "channel": job.origin.channel,
-                    "cron_job_id": job.id,
-                    "cron_job_name": job.name,
-                    "origin_conversation_id": job.origin.conversation_id,
-                    "cron_origin_message_id": job.origin.message_id,
-                    "trigger": "cron",
-                },
-            )
-            return result.text
+        conversation_id = f"{job.id}{_CRON_THREAD_SUFFIX}"
+        control = self._cron_controls.setdefault(job.id, _CronControl(asyncio.Lock()))
+        control.users += 1
+        try:
+            async with control.lock:
+                result = await self._invoke_agent(
+                    conversation_id=conversation_id,
+                    text=job.prompt,
+                    metadata={
+                        "channel": job.origin.channel,
+                        "cron_job_id": job.id,
+                        "cron_job_name": job.name,
+                        "origin_conversation_id": job.origin.conversation_id,
+                        "cron_origin_message_id": job.origin.message_id,
+                        "trigger": "cron",
+                    },
+                )
+                return result.text
+        finally:
+            control.users -= 1
+            if control.users == 0 and self._cron_controls.get(job.id) is control:
+                del self._cron_controls[job.id]
 
     async def deliver_scheduled_result(
         self,
@@ -522,19 +529,19 @@ class TalonHost:
         try:
             done, _ = await asyncio.wait({task}, timeout=_CANCEL_TIMEOUT_SECONDS)
             if not done:
-                return self._mark_cancellation_timeout(conversation_id, task)
+                return self._mark_cancellation_timeout(conversation_id)
             with contextlib.suppress(asyncio.CancelledError):
                 task.result()
             if recover:
                 remaining = deadline - asyncio.get_running_loop().time()
                 if remaining <= 0:
-                    return self._mark_cancellation_timeout(conversation_id, task)
+                    return self._mark_cancellation_timeout(conversation_id)
                 await asyncio.wait_for(
                     self.agent.recover_interrupted(conversation_id),
                     timeout=remaining,
                 )
         except TimeoutError:
-            return self._mark_cancellation_timeout(conversation_id, task)
+            return self._mark_cancellation_timeout(conversation_id)
         except Exception:
             logger.exception(
                 "Failed to recover interrupted conversation %s",
@@ -551,10 +558,8 @@ class TalonHost:
     def _mark_cancellation_timeout(
         self,
         conversation_id: str,
-        task: asyncio.Task[None],
     ) -> _CancelOutcome:
         self._blocked.add(conversation_id)
-        task.add_done_callback(lambda _done: self._blocked.discard(conversation_id))
         log_event(
             logger,
             "agent.interrupt_timeout",

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -13,6 +13,7 @@ import signal
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
+from enum import StrEnum
 from types import FrameType
 from typing import TYPE_CHECKING, cast
 
@@ -60,6 +61,11 @@ _DENY_REPLIES = frozenset({"deny", "denied", "reject", "rejected", "no", "n"})
 _RESET_THREAD_SEPARATOR = ":talon-reset:"
 _APPROVAL_LOG_RAW_IDS_ENV = "DEEPAGENTS_TALON_APPROVAL_LOG_RAW_IDS"
 _TYPING_REFRESH_SECONDS = 4.0
+_CANCEL_TIMEOUT_SECONDS = 30.0
+_CANCEL_TIMEOUT_MESSAGE = (
+    "Could not stop the current run within 30 seconds. Your new message was not started. "
+    "Restart Talon to recover."
+)
 _EMOJI_VARIATION_SELECTOR = "\ufe0f"
 _EMOJI_SKIN_TONES = frozenset(
     {
@@ -70,6 +76,22 @@ _EMOJI_SKIN_TONES = frozenset(
         "\U0001f3ff",
     }
 )
+
+
+class _CancelOutcome(StrEnum):
+    NONE = "none"
+    SUCCESS = "success"
+    TIMEOUT = "timeout"
+    DEGRADED = "degraded"
+
+
+@dataclass(frozen=True, slots=True)
+class _Turn:
+    conversation_root: str
+    conversation_id: str
+    provider: str | None
+    generation: int
+    recovery_degraded: bool
 
 
 @dataclass(slots=True)
@@ -119,6 +141,8 @@ class TalonHost:
         self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._conversation_tasks: defaultdict[str, set[asyncio.Task[None]]] = defaultdict(set)
+        self._generations: defaultdict[str, int] = defaultdict(int)
+        self._blocked: set[str] = set()
         self._conversation_resets: dict[str, int] = {}
         self._pending_tool_approvals: dict[str, _PendingToolApproval] = {}
         self._stopped = asyncio.Event()
@@ -201,34 +225,39 @@ class TalonHost:
             provider or type(channel).__name__,
             channel_conversation_id,
         )
-        agent_conversation_id = self._agent_conversation_id(conversation_root)
+        async with self._locks[conversation_root]:
+            agent_conversation_id = self._agent_conversation_id(conversation_root)
 
-        if command == _NEW_COMMAND:
-            await self._start_new_conversation(
-                channel,
-                channel_conversation_id,
-                conversation_root=conversation_root,
-            )
-            return
+            if command == _NEW_COMMAND:
+                await self._start_new_conversation(
+                    channel,
+                    channel_conversation_id,
+                    conversation_root=conversation_root,
+                )
+                return
 
-        if command == _STOP_COMMAND:
-            await self._cancel_conversation(
+            if command == _STOP_COMMAND:
+                await self._cancel_conversation(
+                    channel,
+                    agent_conversation_id,
+                    reply_conversation_id=channel_conversation_id,
+                )
+                return
+
+            pending = self._pending_tool_approvals.get(agent_conversation_id)
+            if pending is not None:
+                authorized = pending.sender_id is None or message.sender_id == pending.sender_id
+                if not authorized or _parse_tool_approval_reply(message.text) is not None:
+                    await self._handle_tool_approval_reply(channel, message, pending)
+                    return
+
+            await self._replace_agent_turn(
                 channel,
+                message,
+                conversation_root,
                 agent_conversation_id,
-                reply_conversation_id=channel_conversation_id,
+                provider,
             )
-            return
-
-        pending = self._pending_tool_approvals.get(agent_conversation_id)
-        if pending is not None:
-            await self._handle_tool_approval_reply(channel, message, pending)
-            return
-
-        task = asyncio.create_task(
-            self._run_agent_turn(channel, message, agent_conversation_id, provider),
-            name=f"talon:{agent_conversation_id}",
-        )
-        self._track_conversation_task(agent_conversation_id, task)
 
     async def receive_reaction(self, channel: ChannelAdapter, reaction: ChannelReaction) -> None:
         """Handle one inbound channel reaction.
@@ -261,21 +290,65 @@ class TalonHost:
             env=self.config.env,
         )
 
+    async def _replace_agent_turn(
+        self,
+        channel: ChannelAdapter,
+        message: ChannelMessage,
+        conversation_root: str,
+        conversation_id: str,
+        provider: str | None,
+    ) -> None:
+        if conversation_id in self._blocked:
+            await send_with_retry(
+                lambda: channel.send_message(message.conversation_id, _CANCEL_TIMEOUT_MESSAGE)
+            )
+            return
+        active = self._tasks.get(conversation_id)
+        recovery_degraded = False
+        if active is not None and not active.done():
+            outcome = await self._cancel_active(conversation_id, active, recover=True)
+            if outcome is _CancelOutcome.TIMEOUT:
+                await send_with_retry(
+                    lambda: channel.send_message(message.conversation_id, _CANCEL_TIMEOUT_MESSAGE)
+                )
+                return
+            recovery_degraded = outcome is _CancelOutcome.DEGRADED
+        generation = self._generations[conversation_id] + 1
+        self._generations[conversation_id] = generation
+        task = asyncio.create_task(
+            self._run_agent_turn(
+                channel,
+                message,
+                _Turn(
+                    conversation_root,
+                    conversation_id,
+                    provider,
+                    generation,
+                    recovery_degraded,
+                ),
+            ),
+            name=f"talon:{conversation_id}",
+        )
+        self._tasks[conversation_id] = task
+        self._track_conversation_task(conversation_id, task)
+
     async def _run_agent_turn(
         self,
         channel: ChannelAdapter,
         message: ChannelMessage,
-        agent_conversation_id: str,
-        provider: str | None,
+        turn: _Turn,
     ) -> None:
+        agent_conversation_id = turn.conversation_id
         message = await transcribe_voice_message(self.voice_transcriber, message)
         message = _prepare_inbound_message(message)
         metadata: dict[str, object] = {
-            "channel": provider,
+            "channel": turn.provider,
             "sender_id": message.sender_id,
             "message_id": message.message_id,
             **message.metadata,
         }
+        if turn.recovery_degraded:
+            metadata["interruption_recovery"] = "failed"
         origin_conversation_id = _origin_conversation_id(message)
         if origin_conversation_id != agent_conversation_id:
             metadata["origin_conversation_id"] = origin_conversation_id
@@ -294,7 +367,7 @@ class TalonHost:
                 approval_handler=lambda approval: self._request_tool_approval(
                     channel,
                     approval,
-                    provider=_channel_key(channel, provider),
+                    provider=_channel_key(channel, turn.provider),
                     reply_conversation_id=message.conversation_id,
                     sender_id=message.sender_id,
                 ),
@@ -303,7 +376,12 @@ class TalonHost:
             typing_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await typing_task
-        await self._deliver_agent_result(channel, message.conversation_id, result)
+        async with self._locks[turn.conversation_root]:
+            if (
+                self._agent_conversation_id(turn.conversation_root) == agent_conversation_id
+                and self._generations[agent_conversation_id] == turn.generation
+            ):
+                await self._deliver_agent_result(channel, message.conversation_id, result)
 
     async def run_scheduled_job(self, job: CronJob) -> str:
         """Invoke the agent for one scheduled job.
@@ -318,20 +396,25 @@ class TalonHost:
             job.origin.channel or "cron",
             job.origin.conversation_id,
         )
-        conversation_id = self._agent_conversation_id(conversation_root)
-        result = await self._invoke_agent(
-            conversation_id=conversation_id,
-            text=job.prompt,
-            metadata={
-                "channel": job.origin.channel,
-                "cron_job_id": job.id,
-                "cron_job_name": job.name,
-                "origin_conversation_id": job.origin.conversation_id,
-                "cron_origin_message_id": job.origin.message_id,
-                "trigger": "cron",
-            },
-        )
-        return result.text
+        async with self._locks[conversation_root]:
+            conversation_id = self._agent_conversation_id(conversation_root)
+            active = self._tasks.get(conversation_id)
+            if active is not None and not active.done():
+                with contextlib.suppress(asyncio.CancelledError):
+                    await asyncio.shield(active)
+            result = await self._invoke_agent(
+                conversation_id=conversation_id,
+                text=job.prompt,
+                metadata={
+                    "channel": job.origin.channel,
+                    "cron_job_id": job.id,
+                    "cron_job_name": job.name,
+                    "origin_conversation_id": job.origin.conversation_id,
+                    "cron_origin_message_id": job.origin.message_id,
+                    "trigger": "cron",
+                },
+            )
+            return result.text
 
     async def deliver_scheduled_result(
         self,
@@ -357,38 +440,29 @@ class TalonHost:
         approval_handler: Callable[[ToolApprovalRequest], Awaitable[ToolApprovalDecision]]
         | None = None,
     ) -> AgentResult:
-        lock = self._locks[conversation_id]
-        async with lock:
-            task = asyncio.current_task()
-            if task is not None:
-                self._tasks[conversation_id] = task
-
-            try:
-                with langsmith_trace_context(
-                    self.config.env,
-                    assistant_id=self.config.assistant_id,
-                    conversation_id=conversation_id,
-                    metadata=metadata,
-                ):
-                    return await self.agent.invoke(
-                        AgentRequest(
-                            conversation_id=conversation_id,
-                            text=text,
-                            metadata=metadata,
-                            approval_handler=approval_handler,
-                        ),
-                    )
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.exception(
-                    "Unhandled agent error in conversation %s",
-                    conversation_id,
+        try:
+            with langsmith_trace_context(
+                self.config.env,
+                assistant_id=self.config.assistant_id,
+                conversation_id=conversation_id,
+                metadata=metadata,
+            ):
+                return await self.agent.invoke(
+                    AgentRequest(
+                        conversation_id=conversation_id,
+                        text=text,
+                        metadata=metadata,
+                        approval_handler=approval_handler,
+                    ),
                 )
-                raise
-            finally:
-                if self._tasks.get(conversation_id) is task:
-                    del self._tasks[conversation_id]
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                "Unhandled agent error in conversation %s",
+                conversation_id,
+            )
+            raise
 
     async def _start_new_conversation(
         self,
@@ -398,7 +472,12 @@ class TalonHost:
         conversation_root: str,
     ) -> None:
         current_conversation_id = self._agent_conversation_id(conversation_root)
-        await self._cancel_conversation_tasks(current_conversation_id)
+        outcome = await self._cancel_conversation_tasks(current_conversation_id)
+        if outcome is _CancelOutcome.TIMEOUT:
+            await send_with_retry(
+                lambda: channel.send_message(conversation_id, _CANCEL_TIMEOUT_MESSAGE)
+            )
+            return
         next_reset = self._conversation_resets.get(conversation_root, 0) + 1
         self._conversation_resets[conversation_root] = next_reset
         await send_with_retry(
@@ -413,33 +492,75 @@ class TalonHost:
         reply_conversation_id: str | None = None,
     ) -> None:
         target_conversation_id = reply_conversation_id or conversation_id
-        cancelled = await self._cancel_conversation_tasks(conversation_id)
-        if not cancelled:
-            await send_with_retry(
-                lambda: channel.send_message(target_conversation_id, "No in-flight run to stop.")
+        outcome = await self._cancel_conversation_tasks(conversation_id)
+        if outcome is _CancelOutcome.NONE:
+            message = "No in-flight run to stop."
+        elif outcome is _CancelOutcome.TIMEOUT:
+            message = _CANCEL_TIMEOUT_MESSAGE
+        elif outcome is _CancelOutcome.DEGRADED:
+            message = "Stopped current run."
+        else:
+            message = "Stopped current run."
+        await send_with_retry(lambda: channel.send_message(target_conversation_id, message))
+
+    async def _cancel_conversation_tasks(self, conversation_id: str) -> _CancelOutcome:
+        task = self._tasks.get(conversation_id)
+        if task is None or task.done():
+            return _CancelOutcome.NONE
+        return await self._cancel_active(conversation_id, task, recover=True)
+
+    async def _cancel_active(
+        self,
+        conversation_id: str,
+        task: asyncio.Task[None],
+        *,
+        recover: bool,
+    ) -> _CancelOutcome:
+        self._generations[conversation_id] += 1
+        task.cancel()
+        deadline = asyncio.get_running_loop().time() + _CANCEL_TIMEOUT_SECONDS
+        try:
+            done, _ = await asyncio.wait({task}, timeout=_CANCEL_TIMEOUT_SECONDS)
+            if not done:
+                return self._mark_cancellation_timeout(conversation_id, task)
+            with contextlib.suppress(asyncio.CancelledError):
+                task.result()
+            if recover:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    return self._mark_cancellation_timeout(conversation_id, task)
+                await asyncio.wait_for(
+                    self.agent.recover_interrupted(conversation_id),
+                    timeout=remaining,
+                )
+        except TimeoutError:
+            return self._mark_cancellation_timeout(conversation_id, task)
+        except Exception:
+            logger.exception(
+                "Failed to recover interrupted conversation %s",
+                stable_log_ref(conversation_id),
             )
-            return
-
-        await send_with_retry(
-            lambda: channel.send_message(target_conversation_id, "Stopped current run.")
+            return _CancelOutcome.DEGRADED
+        log_event(
+            logger,
+            "agent.interrupted",
+            conversation_ref=stable_log_ref(conversation_id),
         )
+        return _CancelOutcome.SUCCESS
 
-    async def _cancel_conversation_tasks(self, conversation_id: str) -> bool:
-        tasks = {
-            task
-            for task in {
-                *self._conversation_tasks.get(conversation_id, set()),
-                self._tasks.get(conversation_id),
-            }
-            if task is not None and not task.done()
-        }
-        if not tasks:
-            return False
-
-        for task in tasks:
-            task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
-        return True
+    def _mark_cancellation_timeout(
+        self,
+        conversation_id: str,
+        task: asyncio.Task[None],
+    ) -> _CancelOutcome:
+        self._blocked.add(conversation_id)
+        task.add_done_callback(lambda _done: self._blocked.discard(conversation_id))
+        log_event(
+            logger,
+            "agent.interrupt_timeout",
+            conversation_ref=stable_log_ref(conversation_id),
+        )
+        return _CancelOutcome.TIMEOUT
 
     def _agent_conversation_id(self, conversation_id: str) -> str:
         reset = self._conversation_resets.get(conversation_id, 0)

--- a/libs/talon/deepagents_talon/interfaces.py
+++ b/libs/talon/deepagents_talon/interfaces.py
@@ -261,3 +261,6 @@ class AgentRuntime(Protocol):
         Returns:
             Agent output for the host to route back to the trigger.
         """
+
+    async def recover_interrupted(self, conversation_id: str) -> None:
+        """Record an interrupted turn after its latest committed checkpoint."""

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, TypeGuard, cast
 
 from deepagents import create_deep_agent
 from deepagents.backends import LocalShellBackend
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from deepagents.middleware.summarization import (
     SummarizationToolMiddleware,
     create_summarization_tool_middleware,
@@ -48,7 +49,7 @@ if TYPE_CHECKING:
     from deepagents.backends.protocol import BackendProtocol
     from deepagents.middleware.async_subagents import AsyncSubAgent
     from deepagents.middleware.subagents import CompiledSubAgent, SubAgent
-    from langchain.agents.middleware import InterruptOnConfig
+    from langchain.agents.middleware import AgentState, InterruptOnConfig
     from langchain.agents.middleware.types import AgentMiddleware
     from langchain_core.language_models import BaseChatModel
     from langchain_core.tools import BaseTool
@@ -335,9 +336,12 @@ class DeepAgentRuntime:
             raise TypeError(msg)
         snapshot = await get_state(config)
         checkpoint_config = getattr(snapshot, "config", None) or config
+        values = cast("AgentState[Any]", getattr(snapshot, "values", {}))
+        repair = PatchToolCallsMiddleware().before_agent(values, cast("Any", None))
+        messages = [] if repair is None else repair.get("messages", [])
         await update_state(
             checkpoint_config,
-            {"messages": [HumanMessage(content=_INTERRUPTED_MESSAGE)]},
+            {"messages": [*messages, HumanMessage(content=_INTERRUPTED_MESSAGE)]},
         )
 
     async def invoke(self, request: AgentRequest) -> AgentResult:

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -24,6 +24,7 @@ from deepagents.middleware.summarization import (
 )
 from deepagents.profiles.provider.provider_profiles import apply_provider_profile
 from langchain.chat_models import init_chat_model
+from langchain_core.messages import HumanMessage
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.types import Command
 
@@ -161,6 +162,7 @@ _CRON_AUTO_DENY_MESSAGE = (
 _CHANNEL_AUTO_DENY_MESSAGE = (
     "Tool approval is unavailable on this channel; skipped the gated tool call."
 )
+_INTERRUPTED_MESSAGE = "[SYSTEM] Task interrupted by user. Previous operation was cancelled."
 _LOCAL_SUBAGENT_NAME_PATTERN = re.compile(r"[A-Za-z0-9_.-]{1,128}")
 
 _CRON_ORIGIN: contextvars.ContextVar[CronOrigin | None] = contextvars.ContextVar(
@@ -177,6 +179,9 @@ class EchoAgentRuntime:
 
     async def stop(self) -> None:
         """Release placeholder runtime resources."""
+
+    async def recover_interrupted(self, conversation_id: str) -> None:
+        """Leave placeholder conversation state unchanged."""
 
     async def invoke(self, request: AgentRequest) -> AgentResult:
         """Return the request text as a trivial agent response.
@@ -316,6 +321,24 @@ class DeepAgentRuntime:
             result = cleanup()
             if isinstance(result, Awaitable):
                 await result
+
+    async def recover_interrupted(self, conversation_id: str) -> None:
+        """Append an interruption marker after the latest committed checkpoint."""
+        if self._graph is None:
+            msg = "DeepAgentRuntime must be started before recovery"
+            raise RuntimeError(msg)
+        config = {"configurable": {"thread_id": conversation_id}}
+        get_state = getattr(self._graph, "aget_state", None)
+        update_state = getattr(self._graph, "aupdate_state", None)
+        if not callable(get_state) or not callable(update_state):
+            msg = "Deep Agents graph does not expose async state recovery"
+            raise TypeError(msg)
+        snapshot = await get_state(config)
+        checkpoint_config = getattr(snapshot, "config", None) or config
+        await update_state(
+            checkpoint_config,
+            {"messages": [HumanMessage(content=_INTERRUPTED_MESSAGE)]},
+        )
 
     async def invoke(self, request: AgentRequest) -> AgentResult:
         """Invoke the Deep Agents graph for one Talon request.

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -40,6 +40,7 @@ class BlockingAgent:
         self.started = False
         self.stopped = False
         self.requests: list[AgentRequest] = []
+        self.recoveries: list[str] = []
         self.released = asyncio.Event()
 
     async def start(self) -> None:
@@ -48,10 +49,32 @@ class BlockingAgent:
     async def stop(self) -> None:
         self.stopped = True
 
+    async def recover_interrupted(self, conversation_id: str) -> None:
+        self.recoveries.append(conversation_id)
+
     async def invoke(self, request: AgentRequest) -> AgentResult:
         self.requests.append(request)
         if request.text == "block":
             await self.released.wait()
+        return AgentResult(text=f"reply:{request.text}")
+
+
+class FailingRecoveryAgent(BlockingAgent):
+    async def recover_interrupted(self, conversation_id: str) -> None:
+        self.recoveries.append(conversation_id)
+        message = "persistence failed"
+        raise RuntimeError(message)
+
+
+class CancellationResistantAgent(BlockingAgent):
+    async def invoke(self, request: AgentRequest) -> AgentResult:
+        self.requests.append(request)
+        if request.text == "block":
+            try:
+                await self.released.wait()
+            except asyncio.CancelledError:
+                asyncio.current_task().uncancel()
+                await self.released.wait()
         return AgentResult(text=f"reply:{request.text}")
 
 
@@ -65,6 +88,9 @@ class HistoryAgent:
 
     async def stop(self) -> None:
         pass
+
+    async def recover_interrupted(self, conversation_id: str) -> None:
+        self.history.setdefault(conversation_id, []).append("[recovered]")
 
     async def invoke(self, request: AgentRequest) -> AgentResult:
         self.requests.append(request)
@@ -137,7 +163,7 @@ async def test_host_starts_and_stops_components(tmp_path: Path) -> None:
     assert channel.handler is not None
 
 
-async def test_host_serializes_messages_per_conversation(tmp_path: Path) -> None:
+async def test_host_interrupts_active_turn_and_continues_same_conversation(tmp_path: Path) -> None:
     channel = RecordingChannel()
     agent = BlockingAgent()
     host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
@@ -146,17 +172,13 @@ async def test_host_serializes_messages_per_conversation(tmp_path: Path) -> None
     await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
     await _wait_for_request(agent, "block")
     await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="second"))
-    await asyncio.sleep(0)
-
-    assert [request.text for request in agent.requests] == ["block"]
-
-    agent.released.set()
     await _wait_for_request(agent, "second")
-    await _wait_for_sent_count(channel, 2)
+    await _wait_for_sent_count(channel, 1)
     await host.stop()
 
     assert [request.text for request in agent.requests] == ["block", "second"]
-    assert channel.sent == [("chat", "reply:block"), ("chat", "reply:second")]
+    assert agent.recoveries == ["chat"]
+    assert channel.sent == [("chat", "reply:second")]
 
 
 async def test_typing_indicator_refreshes_during_long_agent_turn(
@@ -194,6 +216,22 @@ async def test_stop_cancels_in_flight_conversation(tmp_path: Path) -> None:
     await host.stop()
 
     assert channel.sent == [("chat", "Stopped current run.")]
+
+
+async def test_stop_keeps_ack_when_recovery_fails(tmp_path: Path, caplog) -> None:
+    channel = RecordingChannel()
+    agent = FailingRecoveryAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+    await _wait_for_request(agent, "block")
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="/stop"))
+    await host.stop()
+
+    assert agent.recoveries == ["chat"]
+    assert channel.sent == [("chat", "Stopped current run.")]
+    assert "Failed to recover interrupted conversation" in caplog.text
 
 
 async def test_new_command_starts_fresh_conversation_thread(tmp_path: Path) -> None:
@@ -257,6 +295,64 @@ async def test_new_command_cancels_in_flight_conversation(tmp_path: Path) -> Non
         ("chat", "Started a fresh conversation."),
         ("chat", "reply:second"),
     ]
+
+
+async def test_new_recovers_old_thread_before_reset(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+    await _wait_for_request(agent, "block")
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="/new"))
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="second"))
+    await _wait_for_request(agent, "second")
+    await host.stop()
+
+    assert agent.recoveries == ["chat"]
+    assert agent.requests[1].conversation_id.startswith("chat:talon-reset:")
+
+
+async def test_recovery_failure_starts_replacement_with_metadata(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = FailingRecoveryAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+    await _wait_for_request(agent, "block")
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="second"))
+    await _wait_for_request(agent, "second")
+    await host.stop()
+
+    assert agent.requests[1].metadata["interruption_recovery"] == "failed"
+
+
+async def test_cancellation_timeout_blocks_until_task_exits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deepagents_talon.host._CANCEL_TIMEOUT_SECONDS", 0.01)
+    channel = RecordingChannel()
+    agent = CancellationResistantAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+    await _wait_for_request(agent, "block")
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="second"))
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="third"))
+    assert [request.text for request in agent.requests] == ["block"]
+    assert len(channel.sent) == 2
+
+    agent.released.set()
+    for _ in range(100):
+        if "chat" not in host._blocked:
+            break
+        await asyncio.sleep(0)
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="fourth"))
+    await _wait_for_request(agent, "fourth")
+    await host.stop()
 
 
 async def test_host_sends_markdown_media_refs_as_channel_media(tmp_path: Path) -> None:
@@ -462,15 +558,13 @@ async def test_host_keeps_tool_approval_scoped_to_original_sender(tmp_path: Path
     await _wait_for_sent_count(channel, 4)
     await host.stop()
 
-    assert len(agent.requests) == 1
+    assert [request.text for request in agent.requests] == ["run", "maybe"]
+    assert agent.recoveries == ["chat"]
     assert channel.sent[1] == (
         "chat",
         "Only the operator who started this run can approve or deny it.",
     )
-    assert channel.sent[2] == (
-        "chat",
-        "Reply `approve` to run the tool call or `deny` to skip it.",
-    )
+    assert "Tool approval required." in channel.sent[2][1]
     assert channel.sent[3] == ("chat", "decision:reject")
 
 

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -73,7 +73,9 @@ class CancellationResistantAgent(BlockingAgent):
             try:
                 await self.released.wait()
             except asyncio.CancelledError:
-                asyncio.current_task().uncancel()
+                task = asyncio.current_task()
+                assert task is not None
+                task.uncancel()
                 await self.released.wait()
         return AgentResult(text=f"reply:{request.text}")
 
@@ -329,7 +331,7 @@ async def test_recovery_failure_starts_replacement_with_metadata(tmp_path: Path)
     assert agent.requests[1].metadata["interruption_recovery"] == "failed"
 
 
-async def test_cancellation_timeout_blocks_until_task_exits(
+async def test_cancellation_timeout_blocks_until_host_restart(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr("deepagents_talon.host._CANCEL_TIMEOUT_SECONDS", 0.01)
@@ -346,12 +348,11 @@ async def test_cancellation_timeout_blocks_until_task_exits(
     assert len(channel.sent) == 2
 
     agent.released.set()
-    for _ in range(100):
-        if "chat" not in host._blocked:
-            break
-        await asyncio.sleep(0)
+    await asyncio.sleep(0)
     await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="fourth"))
-    await _wait_for_request(agent, "fourth")
+    assert [request.text for request in agent.requests] == ["block"]
+    assert len(channel.sent) == 3
+    assert "chat" in host._blocked
     await host.stop()
 
 
@@ -913,6 +914,32 @@ async def test_host_runs_scheduled_job_and_delivers_result(tmp_path: Path) -> No
     assert [request.text for request in agent.requests] == ["scheduled prompt"]
     assert agent.requests[0].metadata["trigger"] == "cron"
     assert channel.sent == [("chat", "reply:scheduled prompt")]
+
+
+async def test_scheduled_job_runs_while_interactive_turn_remains_active(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    store = CronJobStore(assistant_id="test", cron_dir=tmp_path / "test" / "cron")
+    job = store.create_job(
+        prompt="scheduled prompt",
+        schedule=CronSchedule.parse("in 5m"),
+        origin=CronOrigin(conversation_id="chat"),
+    )
+    await host.start()
+
+    await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+    await _wait_for_request(agent, "block")
+    text = await asyncio.wait_for(host.run_scheduled_job(job), timeout=1)
+
+    assert text == "reply:scheduled prompt"
+    assert [request.text for request in agent.requests] == ["block", "scheduled prompt"]
+    assert agent.recoveries == []
+    assert agent.requests[0].conversation_id == "chat"
+    assert agent.requests[1].conversation_id == f"{job.id}:talon-cron"
+    assert not host._tasks["chat"].done()
+    agent.released.set()
+    await host.stop()
 
 
 async def test_host_transcribes_voice_before_agent(tmp_path: Path) -> None:

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 import pytest
 from deepagents.backends import LocalShellBackend
 from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import AIMessage, RemoveMessage, ToolMessage
 
 from deepagents_talon.cron import CronJobStore
 from deepagents_talon.interfaces import (
@@ -54,13 +55,14 @@ class RecordingGraph:
 
 
 class RecoverableGraph:
-    def __init__(self) -> None:
+    def __init__(self, messages: list[object] | None = None) -> None:
         self.config = {"configurable": {"thread_id": "chat", "checkpoint_id": "latest"}}
+        self.values = {"messages": messages or []}
         self.update: tuple[dict[str, Any], dict[str, Any]] | None = None
 
     async def aget_state(self, config: dict[str, Any]) -> SimpleNamespace:
         assert config == {"configurable": {"thread_id": "chat"}}
-        return SimpleNamespace(config=self.config)
+        return SimpleNamespace(config=self.config, values=self.values)
 
     async def aupdate_state(self, config: dict[str, Any], values: dict[str, Any]) -> None:
         self.update = (config, values)
@@ -902,6 +904,30 @@ async def test_runtime_recovers_with_exact_human_message_after_latest_checkpoint
     assert len(messages) == 1
     assert messages[0].type == "human"
     assert messages[0].content == (
+        "[SYSTEM] Task interrupted by user. Previous operation was cancelled."
+    )
+
+
+async def test_runtime_repairs_dangling_tool_call_before_interruption_marker() -> None:
+    tool_call = {"name": "search", "args": {"query": "test"}, "id": "call-1"}
+    graph = RecoverableGraph([AIMessage(content="", tool_calls=[tool_call])])
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+    runtime._graph = graph
+
+    await runtime.recover_interrupted("chat")
+
+    assert graph.update is not None
+    messages = graph.update[1]["messages"]
+    assert isinstance(messages[0], RemoveMessage)
+    assert isinstance(messages[-2], ToolMessage)
+    assert messages[-2].tool_call_id == "call-1"
+    assert messages[-1].type == "human"
+    assert messages[-1].content == (
         "[SYSTEM] Task interrupted by user. Previous operation was cancelled."
     )
 

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -53,6 +53,19 @@ class RecordingGraph:
         return {"messages": list(messages)}
 
 
+class RecoverableGraph:
+    def __init__(self) -> None:
+        self.config = {"configurable": {"thread_id": "chat", "checkpoint_id": "latest"}}
+        self.update: tuple[dict[str, Any], dict[str, Any]] | None = None
+
+    async def aget_state(self, config: dict[str, Any]) -> SimpleNamespace:
+        assert config == {"configurable": {"thread_id": "chat"}}
+        return SimpleNamespace(config=self.config)
+
+    async def aupdate_state(self, config: dict[str, Any], values: dict[str, Any]) -> None:
+        self.update = (config, values)
+
+
 class CronCallingGraph:
     def __init__(self, create_job: InvokableTool) -> None:
         self.create_job = create_job
@@ -868,6 +881,29 @@ async def test_runtime_rejects_invalid_recursion_limit_env() -> None:
             memory=(),
             env={"DEEPAGENTS_TALON_RECURSION_LIMIT": "0"},
         )
+
+
+async def test_runtime_recovers_with_exact_human_message_after_latest_checkpoint() -> None:
+    graph = RecoverableGraph()
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+    runtime._graph = graph
+
+    await runtime.recover_interrupted("chat")
+
+    assert graph.update is not None
+    config, values = graph.update
+    assert config is graph.config
+    messages = values["messages"]
+    assert len(messages) == 1
+    assert messages[0].type == "human"
+    assert messages[0].content == (
+        "[SYSTEM] Task interrupted by user. Previous operation was cancelled."
+    )
 
 
 async def test_runtime_preserves_conversation_thread_across_turns(


### PR DESCRIPTION
New Talon messages now interrupt active work and continue with committed context on the same conversation.

---

Talon previously queued corrections behind the active turn, allowing superseded work to continue. This adds per-conversation turn ownership, bounded cancellation and state-only recovery with the canonical interruption marker. It also suppresses stale results, preserves approval ownership and scheduled-job serialization, and applies the same recovery behavior to `/stop` and `/new`.

Validation:
- `uv run --group test pytest -q tests/test_host.py tests/test_runtime.py`
- `make format_diff`
- `make lint_diff`

Made by [Open SWE](https://openswe.vercel.app/agents/16febf98-7c50-5c1f-948a-0e410239775f)