### PR TITLE
fix(talon): preserve WhatsApp quoted message context

### DIFF
--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -65,6 +65,7 @@ DEFAULT_BOT_HEADER = "deepagents bot"
 DEFAULT_BRIDGE_TOKEN_BYTES = 32
 DEFAULT_WHATSAPP_MAX_MEDIA_BYTES = 64 * 1024 * 1024
 _FAILED_HEALTH_RESTART_THRESHOLD = 3
+_REPLY_CONTEXT_STATUSES = frozenset({"not_reply", "resolved", "lookup_failed"})
 OPEN_EXPOSURE_ACK_ENV = "DEEPAGENTS_TALON_WHATSAPP_OPEN_ACK"
 
 
@@ -545,9 +546,13 @@ class WhatsAppChannel:
                             "whatsapp.inbound.message.dispatching",
                             has_media=bool(checked.metadata.get("has_media")),
                             media_type=checked.metadata.get("media_type"),
+                            quoted_message_id_present=(
+                                checked.metadata.get("quoted_message_id") is not None
+                            ),
                             quoted_participant_present=(
                                 checked.metadata.get("quoted_participant") is not None
                             ),
+                            reply_context_status=checked.metadata.get("reply_context_status"),
                             text_chars=len(checked.text),
                         )
                         await dispatch_message(self._handler, checked, provider="WhatsApp")
@@ -765,6 +770,12 @@ def _parse_message(payload: object) -> ChannelMessage:
     if not isinstance(text, str):
         text = values.get("body")
     has_media = bool(values.get("has_media") or values.get("hasMedia") or media_paths)
+    quoted_participant = optional_str(
+        values.get("quoted_participant") or values.get("quotedParticipant"),
+    )
+    quoted_message_id = optional_str(
+        values.get("quoted_message_id") or values.get("quotedMessageId"),
+    )
     message = ChannelMessage(
         conversation_id=_required_str_any(values, ("chat_id", "chatId")),
         text=text if isinstance(text, str) else "",
@@ -778,8 +789,12 @@ def _parse_message(payload: object) -> ChannelMessage:
             "chat_type": values.get("chat_type") or values.get("chatType"),
             "chat_id_from": values.get("chat_id_from") or values.get("chatIdFrom"),
             "user_name": values.get("user_name") or values.get("senderName"),
-            "quoted_participant": optional_str(
-                values.get("quoted_participant") or values.get("quotedParticipant"),
+            "quoted_participant": quoted_participant,
+            "quoted_message_id": quoted_message_id,
+            "reply_context_status": _reply_context_status(
+                values,
+                quoted_participant=quoted_participant,
+                quoted_message_id=quoted_message_id,
             ),
             "raw_message": values.get("raw_message") or {},
             "from_self": values.get("from_self") is True or values.get("fromSelf") is True,
@@ -792,6 +807,20 @@ def _parse_message(payload: object) -> ChannelMessage:
         mime_types=media_mime_types,
         has_media=has_media,
     )
+
+
+def _reply_context_status(
+    values: Mapping[str, object],
+    *,
+    quoted_participant: str | None,
+    quoted_message_id: str | None,
+) -> str:
+    status = optional_str(values.get("reply_context_status") or values.get("replyContextStatus"))
+    if status in _REPLY_CONTEXT_STATUSES:
+        return status
+    if quoted_participant is not None or quoted_message_id is not None:
+        return "resolved"
+    return "not_reply"
 
 
 def _enforce_inbound_media_cap(message: ChannelMessage, *, max_bytes: int) -> ChannelMessage:

--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -545,6 +545,9 @@ class WhatsAppChannel:
                             "whatsapp.inbound.message.dispatching",
                             has_media=bool(checked.metadata.get("has_media")),
                             media_type=checked.metadata.get("media_type"),
+                            quoted_participant_present=(
+                                checked.metadata.get("quoted_participant") is not None
+                            ),
                             text_chars=len(checked.text),
                         )
                         await dispatch_message(self._handler, checked, provider="WhatsApp")
@@ -775,6 +778,9 @@ def _parse_message(payload: object) -> ChannelMessage:
             "chat_type": values.get("chat_type") or values.get("chatType"),
             "chat_id_from": values.get("chat_id_from") or values.get("chatIdFrom"),
             "user_name": values.get("user_name") or values.get("senderName"),
+            "quoted_participant": optional_str(
+                values.get("quoted_participant") or values.get("quotedParticipant"),
+            ),
             "raw_message": values.get("raw_message") or {},
             "from_self": values.get("from_self") is True or values.get("fromSelf") is True,
             "self_chat": values.get("self_chat") is True or values.get("selfChat") is True,

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
@@ -12,6 +12,7 @@ const {
   createCompatibleClientClass,
   isSelfChat,
   normalizeMessage,
+  quotedMessageContext,
   serializedId,
   widString,
 } = require("./id_compat");
@@ -209,6 +210,7 @@ async function enqueueMessage(message, fromSelf) {
   const chatName = (chat && chat.name) || data.chatName || chatId;
   const isGroup =
     chat && typeof chat.isGroup === "boolean" ? chat.isGroup : chatId.endsWith("@g.us");
+  const quote = await quotedMessageContext(message);
 
   const entry = {
     text: message.body || "",
@@ -249,7 +251,12 @@ async function enqueueMessage(message, fromSelf) {
     selfChat,
     mentionedIds: normalizeIds(message.mentionedIds || []),
     botIds,
-    quotedParticipant: await quotedParticipant(message),
+    quoted_participant: quote.participant,
+    quotedParticipant: quote.participant,
+    quoted_message_id: quote.messageId,
+    quotedMessageId: quote.messageId,
+    reply_context_status: quote.status,
+    replyContextStatus: quote.status,
     raw_message: {
       from: messageFrom,
       to: messageTo,
@@ -342,18 +349,6 @@ async function safeGetContact(message) {
     return await message.getContact();
   } catch (_error) {
     console.log("[bridge] getContact failed (non-fatal)");
-    return null;
-  }
-}
-
-async function quotedParticipant(message) {
-  if (!message.hasQuotedMsg) {
-    return null;
-  }
-  try {
-    const quoted = await message.getQuotedMessage();
-    return quoted.author || quoted.from || null;
-  } catch (_error) {
     return null;
   }
 }

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/id_compat.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/id_compat.js
@@ -47,6 +47,22 @@ function serializedId(value) {
   return typeof value.id === "string" && value.id ? value.id : null;
 }
 
+async function quotedMessageContext(message) {
+  if (!message.hasQuotedMsg) {
+    return { participant: null, messageId: null, status: "not_reply" };
+  }
+  try {
+    const quoted = await message.getQuotedMessage();
+    return {
+      participant: widString(quoted.author) || widString(quoted.from),
+      messageId: serializedId(quoted.id),
+      status: "resolved",
+    };
+  } catch (_error) {
+    return { participant: null, messageId: null, status: "lookup_failed" };
+  }
+}
+
 function normalizeId(value) {
   if (!value || typeof value !== "object" || value._serialized) {
     return value;
@@ -257,6 +273,7 @@ module.exports = {
   isSelfChat,
   normalizeId,
   normalizeMessage,
+  quotedMessageContext,
   serializedId,
   widString,
 };

--- a/libs/talon/tests/channels/test_whatsapp.py
+++ b/libs/talon/tests/channels/test_whatsapp.py
@@ -264,7 +264,11 @@ def test_config_accepts_open_exposure_with_acknowledgement(tmp_path: Path) -> No
     assert whatsapp.exposure.mode == ExposureMode.OPEN
 
 
-async def test_channel_polls_and_dispatches_allowed_messages(tmp_path: Path) -> None:
+async def test_channel_polls_and_dispatches_allowed_messages(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    quoted_participant = "quoted-user@s.whatsapp.net"
     transport = RecordingTransport(
         messages=[
             {
@@ -273,6 +277,7 @@ async def test_channel_polls_and_dispatches_allowed_messages(tmp_path: Path) -> 
                 "user_id": "operator",
                 "message_id": "message-1",
                 "message_type": "chat",
+                "quotedParticipant": quoted_participant,
             },
             {
                 "text": "blocked",
@@ -299,12 +304,16 @@ async def test_channel_polls_and_dispatches_allowed_messages(tmp_path: Path) -> 
 
     channel.set_message_handler(record)
 
-    await channel.start()
-    await asyncio.sleep(0)
-    await channel.stop()
+    with caplog.at_level(logging.DEBUG, logger="deepagents_talon.channels.whatsapp"):
+        await channel.start()
+        await asyncio.sleep(0)
+        await channel.stop()
 
     assert [message.text for message in received] == ["allowed"]
     assert received[0].metadata["provider"] == "whatsapp"
+    assert received[0].metadata["quoted_participant"] == quoted_participant
+    assert '"quoted_participant_present": true' in caplog.text
+    assert quoted_participant not in caplog.text
 
 
 async def test_channel_rejects_truthy_non_boolean_self_markers(tmp_path: Path) -> None:

--- a/libs/talon/tests/channels/test_whatsapp.py
+++ b/libs/talon/tests/channels/test_whatsapp.py
@@ -22,6 +22,7 @@ from deepagents_talon.channels.whatsapp import (
     WhatsAppChannelConfig,
     _bridge_script_path,
     _BridgeTransport,
+    _parse_message,
     _WhatsAppBridgeError,
 )
 from deepagents_talon.config import TalonConfig
@@ -264,11 +265,29 @@ def test_config_accepts_open_exposure_with_acknowledgement(tmp_path: Path) -> No
     assert whatsapp.exposure.mode == ExposureMode.OPEN
 
 
+@pytest.mark.parametrize(
+    ("reply_metadata", "expected_status"),
+    [
+        ({"quotedParticipant": "quoted-user@lid"}, "resolved"),
+        ({"replyContextStatus": "lookup_failed"}, "lookup_failed"),
+        ({"replyContextStatus": "untrusted-value"}, "not_reply"),
+    ],
+)
+def test_channel_normalizes_reply_context_status(
+    reply_metadata: dict[str, object],
+    expected_status: str,
+) -> None:
+    message = _parse_message({"text": "message", "chat_id": "chat", **reply_metadata})
+
+    assert message.metadata["reply_context_status"] == expected_status
+
+
 async def test_channel_polls_and_dispatches_allowed_messages(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     quoted_participant = "quoted-user@s.whatsapp.net"
+    quoted_message_id = "false_chat@lid_ABC"
     transport = RecordingTransport(
         messages=[
             {
@@ -277,7 +296,9 @@ async def test_channel_polls_and_dispatches_allowed_messages(
                 "user_id": "operator",
                 "message_id": "message-1",
                 "message_type": "chat",
+                "quotedMessageId": quoted_message_id,
                 "quotedParticipant": quoted_participant,
+                "replyContextStatus": "resolved",
             },
             {
                 "text": "blocked",
@@ -311,8 +332,13 @@ async def test_channel_polls_and_dispatches_allowed_messages(
 
     assert [message.text for message in received] == ["allowed"]
     assert received[0].metadata["provider"] == "whatsapp"
+    assert received[0].metadata["quoted_message_id"] == quoted_message_id
     assert received[0].metadata["quoted_participant"] == quoted_participant
+    assert received[0].metadata["reply_context_status"] == "resolved"
+    assert '"quoted_message_id_present": true' in caplog.text
     assert '"quoted_participant_present": true' in caplog.text
+    assert '"reply_context_status": "resolved"' in caplog.text
+    assert quoted_message_id not in caplog.text
     assert quoted_participant not in caplog.text
 
 

--- a/libs/talon/tests/channels/whatsapp_bridge/id_compat.test.js
+++ b/libs/talon/tests/channels/whatsapp_bridge/id_compat.test.js
@@ -13,6 +13,7 @@ const {
   isSelfChat,
   normalizeId,
   normalizeMessage,
+  quotedMessageContext,
   serializedId,
   widString,
 } = require("../../../deepagents_talon/channels/whatsapp_bridge/id_compat");
@@ -25,6 +26,45 @@ test("reads legacy, renamed, and component WhatsApp IDs", () => {
     serializedId({ fromMe: true, remote: { user: "123", server: "lid" }, id: "ABC" }),
     "true_123@lid_ABC",
   );
+});
+
+test("classifies messages without quoted context", async () => {
+  assert.deepEqual(await quotedMessageContext({ hasQuotedMsg: false }), {
+    participant: null,
+    messageId: null,
+    status: "not_reply",
+  });
+});
+
+test("resolves quoted message context", async () => {
+  const context = await quotedMessageContext({
+    hasQuotedMsg: true,
+    getQuotedMessage: async () => ({
+      author: { user: "quoted-user", server: "lid" },
+      id: { fromMe: false, remote: "chat@lid", id: "ABC" },
+    }),
+  });
+
+  assert.deepEqual(context, {
+    participant: "quoted-user@lid",
+    messageId: "false_chat@lid_ABC",
+    status: "resolved",
+  });
+});
+
+test("reports quoted message lookup failures", async () => {
+  const context = await quotedMessageContext({
+    hasQuotedMsg: true,
+    getQuotedMessage: async () => {
+      throw new Error("private provider failure");
+    },
+  });
+
+  assert.deepEqual(context, {
+    participant: null,
+    messageId: null,
+    status: "lookup_failed",
+  });
 });
 
 test("collects the paired account phone and LID aliases", () => {


### PR DESCRIPTION
WhatsApp reply metadata now preserves quoted-message context for downstream debugging without exposing raw identifiers in logs.

---

The WhatsApp bridge previously emitted only quotedParticipant, and the Python adapter discarded it. This change carries normalized quoted participant and message IDs through the bridge, records whether context was not present, resolved, or failed lookup, and emits only status and presence booleans at DEBUG. Focused bridge and Python coverage verifies all status paths, backward-compatible normalization, and log privacy.