### PR TITLE
fix(sdk): rename `handoff` subagent mode to `isolated`

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -90,8 +90,8 @@ class SubAgent(TypedDict):
         system_prompt: Instructions for the subagent.
 
             Appended to the inherited prompt under `mode="fork"`.
-        mode: `handoff` (default) for an isolated subagent, or `fork` to
-            continue the parent's conversation.
+        mode: `isolated` (default) for a subagent that only sees the
+            delegated task, or `fork` to continue the parent's conversation.
         tools: Tools the subagent can use.
 
             If not specified, inherits tools from the main agent
@@ -206,8 +206,8 @@ class SubAgent(TypedDict):
     replacing it.
     """
 
-    mode: NotRequired[Literal["handoff", "fork"]]
-    """Context mode. Defaults to `handoff`, an isolated subagent.
+    mode: NotRequired[Literal["isolated", "fork"]]
+    """Context mode. Defaults to `isolated`, where the subagent only sees the delegated task.
 
     Under `fork`, the subagent receives the parent's effective conversation
     history and state, and mirrors the parent's prompt-producing middleware so
@@ -296,7 +296,7 @@ class CompiledSubAgent(TypedDict):
     results back to the main agent.
     """
 
-    mode: NotRequired[Literal["handoff", "fork"]]
+    mode: NotRequired[Literal["isolated", "fork"]]
     """Use `fork` to inherit the parent's conversation without changing the runnable prompt.
 
     A declarative [`SubAgent`][deepagents.middleware.subagents.SubAgent] fork
@@ -310,8 +310,8 @@ _SubAgentSpec = SubAgent | CompiledSubAgent
 def _validate_subagent_mode(spec: _SubAgentSpec) -> None:
     """Reject unsupported context modes before a subagent can run."""
     mode = spec.get("mode")
-    if mode not in (None, "handoff", "fork"):
-        msg = f"SubAgent '{spec['name']}' has invalid mode '{mode}'; expected 'handoff' or 'fork'"
+    if mode not in (None, "isolated", "fork", "handoff"):  # "handoff" is legacy alias for "isolated"
+        msg = f"SubAgent '{spec['name']}' has invalid mode '{mode}'; expected 'isolated' or 'fork'"
         raise ValueError(msg)
     if mode == "fork" and spec.get("skills"):
         msg = f"SubAgent '{spec['name']}' cannot set skills under mode='fork'; the parent's skills are inherited instead."

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -31,6 +31,8 @@ from deepagents.middleware.subagents import (
     SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY,
     SubAgentMiddleware,
     _build_task_tool,
+    _is_forked_compiled_subagent,
+    _is_forked_subagent,
     create_sub_agent,
 )
 from tests.unit_tests.chat_model import GenericFakeChatModel
@@ -150,6 +152,21 @@ class TestSubagentMiddlewareInit:
 
         with pytest.raises(ValueError, match="invalid mode 'dynamic'"):
             SubAgentMiddleware(backend=StateBackend(), subagents=[invalid_spec])
+
+    @pytest.mark.parametrize("mode", ["isolated", "handoff"])
+    def test_accepts_isolated_subagent_mode(self, mode: str) -> None:
+        """`handoff` is a legacy alias for `isolated`; neither forks the parent."""
+        spec: Any = {
+            "name": "worker",
+            "description": "Does work.",
+            "runnable": RunnableLambda(lambda _state: {"messages": [AIMessage(content="done")]}),
+            "mode": mode,
+        }
+
+        SubAgentMiddleware(backend=StateBackend(), subagents=[spec])
+
+        assert not _is_forked_subagent(spec)
+        assert not _is_forked_compiled_subagent(spec)
 
     def test_forked_subagent_appends_its_own_system_prompt(self) -> None:
         """A fork's `system_prompt` is appended to the inherited one, not a replacement."""
@@ -976,7 +993,7 @@ class TestSubagentMiddlewareInit:
                 ],
             )
 
-    def test_handoff_subagent_receives_only_task_description(self) -> None:
+    def test_isolated_subagent_receives_only_task_description(self) -> None:
         captured: dict[str, object] = {}
 
         class _Runnable:


### PR DESCRIPTION
Kept backward compatibility, although this feature is not yet documented or announced.