### PR TITLE
fix(store): report file sizes in bytes

### DIFF
--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -27,6 +27,7 @@ from deepagents.backends.utils import (
     _get_backend_read_file_type,
     _glob_search_files,
     create_file_data,
+    file_data_size,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
@@ -156,7 +157,7 @@ class StateBackend(BackendProtocol):
                 continue
 
             # This is a file directly in the current directory
-            size = len(file_data_to_string(fd))
+            size = file_data_size(fd)
             infos.append(
                 {
                     "path": k,
@@ -308,7 +309,7 @@ class StateBackend(BackendProtocol):
         infos: list[FileInfo] = []
         for p in paths:
             fd = files.get(p)
-            size = len(file_data_to_string(fd)) if fd else 0
+            size = file_data_size(fd) if fd else 0
             infos.append(
                 {
                     "path": p,

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -28,6 +28,7 @@ from deepagents.backends.utils import (
     _get_backend_read_file_type,
     _glob_search_files,
     create_file_data,
+    file_data_size,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
@@ -347,7 +348,7 @@ class StoreBackend(BackendProtocol):
                 fd = self._convert_store_item_to_file_data(item)
             except ValueError:
                 continue
-            size = len(file_data_to_string(fd))
+            size = file_data_size(fd)
             infos.append(
                 {
                     "path": item.key,
@@ -641,7 +642,7 @@ class StoreBackend(BackendProtocol):
         infos: list[FileInfo] = []
         for p in paths:
             fd = files.get(p)
-            size = len(file_data_to_string(fd)) if fd else 0
+            size = file_data_size(fd) if fd else 0
             infos.append(
                 {
                     "path": p,

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -5,6 +5,7 @@ helpers used by backends and the composite router. Structured helpers
 enable composition without fragile string parsing.
 """
 
+import base64
 import functools
 import logging
 import os
@@ -331,6 +332,21 @@ def file_data_to_string(file_data: FileData) -> str:
         TypeError: If content is neither a string nor a legacy list of strings.
     """
     return _normalize_content(file_data)
+
+
+def file_data_size(file_data: FileData) -> int:
+    """Return the file content size in bytes.
+
+    Args:
+        file_data: File content and its storage encoding.
+
+    Returns:
+        Byte count of UTF-8 text or decoded base64 content.
+    """
+    content = file_data_to_string(file_data)
+    if file_data.get("encoding") == "base64":
+        return len(base64.standard_b64decode(content))
+    return len(content.encode("utf-8"))
 
 
 def create_file_data(

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
@@ -83,6 +83,18 @@ def test_state_backend_reads_legacy_list_content(monkeypatch: pytest.MonkeyPatch
     assert files["/legacy.txt"]["content"] == legacy_content
 
 
+def test_state_backend_reports_utf8_file_size_in_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`ls` and `glob` report UTF-8 byte sizes rather than character counts."""
+    backend = StateBackend()
+    content = "hello 😀 €"
+    files = {"/unicode.txt": {"content": content, "encoding": "utf-8"}}
+    monkeypatch.setattr(backend, "_read_files", lambda: files)
+    expected_size = len(content.encode("utf-8"))
+
+    assert backend.ls("/").entries[0]["size"] == expected_size
+    assert backend.glob("*.txt", path="/").matches[0]["size"] == expected_size
+
+
 def test_state_backend_reads_legacy_list_content_for_non_text_path(monkeypatch: pytest.MonkeyPatch) -> None:
     backend = StateBackend()
     legacy_content = ["aGVsbG8="]

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -46,6 +46,19 @@ def test_store_backend_crud_and_search():
     assert {i["path"] for i in g} == {i["path"] for i in g2}
 
 
+def test_store_backend_reports_utf8_file_size_in_bytes() -> None:
+    """`ls` and `glob` report UTF-8 byte sizes rather than character counts."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    content = "hello 😀 €"
+    expected_size = len(content.encode("utf-8"))
+
+    be.write("/unicode.txt", content)
+
+    assert be.ls("/").entries[0]["size"] == expected_size
+    assert be.glob("*.txt", path="/").matches[0]["size"] == expected_size
+
+
 def test_store_backend_read_surfaces_pagination_metadata():
     """`StoreBackend.read` propagates the pagination metadata from `slice_read_response`."""
     mem_store = InMemoryStore()


### PR DESCRIPTION
Fixes #6042

Report UTF-8 and base64-backed file sizes in bytes across state and store backends.

---

`FileInfo.size` is defined as an approximate byte count, but `StateBackend` and `StoreBackend` counted Unicode characters. This aligns their `ls` and `glob` results with the backend protocol and filesystem-backed implementations.