### PR TITLE
fix(infra): scope release-note redrafts to package changes

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -60,7 +60,7 @@ Keep the release PR in draft while changes are still accumulating. When it is re
 3. After reviewing & finalizing, comment `@release-bot apply`. The bot updates that package's `CHANGELOG.md` (e.g. `libs/code/CHANGELOG.md` for `deepagents-code`) and mirrors the notes to the PR body.
 4. Merge normally after the `curated release notes` CI check passes.
 
-Run `@release-bot draft` to regenerate the draft if the automatic run fails or commits added to `main` after drafting touch that release PR's package directory. Each new draft records its `main` baseline, so a release-please refresh caused only by changes outside the package does not stale the prose. If that unrelated refresh overwrites notes that were already applied, the check asks you to run `@release-bot apply` again; re-drafting is not required.
+Run `@release-bot draft` to regenerate the draft in two cases. The automatic run failed. Or commits added to `main` after drafting touch that release PR's package directory. Each new draft records its `main` baseline, so a release-please refresh caused only by changes outside the package does not invalidate the prose. If that unrelated refresh overwrites notes that were already applied, the check asks you to run `@release-bot apply` again; re-drafting is not required. The bot also asks for a re-draft when it cannot prove what changed: a very large or rewritten `main` history is treated as unknown.
 
 Re-drafting rewrites the original notes comment in place, which GitHub does not surface in the timeline. So that a regenerated draft is not missed, the bot follows an in-place rewrite with a short comment linking back to the refreshed notes — one per re-draft. A first-time draft posts no such pointer, since a brand-new comment is already visible.
 
@@ -282,7 +282,7 @@ Step 3 can be skipped in the situations below. Skipping it holds up only the ref
 
 ### Lockfile Updates
 
-When release-please creates or updates a release PR, the `update-lockfiles` job automatically regenerates `uv.lock` files since release-please updates `pyproject.toml` versions but doesn't regenerate lockfiles. A lockfile-only commit generated on a release branch after an unrelated `main` change does not invalidate that package's curated-note draft.
+When release-please creates or updates a release PR, the `update-lockfiles` job automatically regenerates `uv.lock` files since release-please updates `pyproject.toml` versions but doesn't regenerate lockfiles. A lockfile-only commit generated on a release branch after an unrelated `main` change does not invalidate that package's curated-note draft. This carve-out covers the release branch only. On `main`, every path under the package counts, a lockfile included.
 
 ### Release Pipeline
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -60,7 +60,7 @@ Keep the release PR in draft while changes are still accumulating. When it is re
 3. After reviewing & finalizing, comment `@release-bot apply`. The bot updates that package's `CHANGELOG.md` (e.g. `libs/code/CHANGELOG.md` for `deepagents-code`) and mirrors the notes to the PR body.
 4. Merge normally after the `curated release notes` CI check passes.
 
-Run `@release-bot draft` to regenerate the draft if the automatic run fails or new changes cause release-please to add changelog entries to the release PR. If release-please updates the PR after the notes were applied, the check will fail until you run `draft` and `apply` again.
+Run `@release-bot draft` to regenerate the draft if the automatic run fails or commits added to `main` after drafting touch that release PR's package directory. Each new draft records its `main` baseline, so a release-please refresh caused only by changes outside the package does not stale the prose. If that unrelated refresh overwrites notes that were already applied, the check asks you to run `@release-bot apply` again; re-drafting is not required.
 
 Re-drafting rewrites the original notes comment in place, which GitHub does not surface in the timeline. So that a regenerated draft is not missed, the bot follows an in-place rewrite with a short comment linking back to the refreshed notes — one per re-draft. A first-time draft posts no such pointer, since a brand-new comment is already visible.
 
@@ -282,7 +282,7 @@ Step 3 can be skipped in the situations below. Skipping it holds up only the ref
 
 ### Lockfile Updates
 
-When release-please creates or updates a release PR, the `update-lockfiles` job automatically regenerates `uv.lock` files since release-please updates `pyproject.toml` versions but doesn't regenerate lockfiles.
+When release-please creates or updates a release PR, the `update-lockfiles` job automatically regenerates `uv.lock` files since release-please updates `pyproject.toml` versions but doesn't regenerate lockfiles. A lockfile-only commit generated on a release branch after an unrelated `main` change does not invalidate that package's curated-note draft.
 
 ### Release Pipeline
 

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -964,7 +964,13 @@ async function validateApplySnapshot({ github, owner, repo, state, login, id, ex
     target.component !== state.component ||
     target.version !== state.version ||
     pr.draft ||
-    pr.base?.sha !== state.baseHead ||
+    // GitHub recomputes base.sha to main's tip whenever the release branch is
+    // synchronized, and the apply commit is itself such a push. So this field
+    // legitimately moves between the pre-push check and the post-push one, for
+    // the same reason expectedHead does. Bind it to the same flag: before the
+    // push it guards the prepare/commit window, after the push a main advance
+    // is not grounds to withhold the metadata for a commit that already landed.
+    (checkPrHead && pr.base?.sha !== state.baseHead) ||
     (checkPrHead && pr.head.sha !== expectedHead) ||
     exactSha256(pr.body ?? '') !== state.originalBodyHash
   ) {

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -119,7 +119,12 @@ function loadComponentRegistry(configPath = RELEASE_PLEASE_CONFIG) {
     const changelog = typeof meta['changelog-path'] === 'string' && meta['changelog-path']
       ? meta['changelog-path']
       : DEFAULT_CHANGELOG;
-    const changelogPath = `${packagePath.replace(/\/+$/, '')}/${changelog}`;
+    // A release-please config key may legally end in `/`. Strip it once here so
+    // every consumer sees the same shape: pathIsInPackage compares this prefix
+    // against compare-API filenames, and a stored `libs/code/` would match no
+    // file at all, reporting every package change as unrelated.
+    const normalizedPackagePath = packagePath.replace(/\/+$/, '');
+    const changelogPath = `${normalizedPackagePath}/${changelog}`;
     // The apply commit writes this path via the Git Data API. Refuse anything that
     // could escape the package directory even if the config is wrong.
     if (changelogPath.split('/').some(segment => segment === '' || segment === '.' || segment === '..')) {
@@ -127,7 +132,7 @@ function loadComponentRegistry(configPath = RELEASE_PLEASE_CONFIG) {
     }
     registry.set(component, {
       component,
-      packagePath,
+      packagePath: normalizedPackagePath,
       changelogPath,
       releaseBranch: `${RELEASE_BRANCH_PREFIX}${component}`,
     });

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -18,6 +18,9 @@ const BYPASS_LABEL = 'release: dangerously skip curated notes';
 const COMMAND_MENTION = '@release-bot';
 const OVERRIDE_MARKER = 'release-notes-override';
 const APPLIED_MARKER = 'release-notes-applied';
+// GitHub's compare endpoint returns at most 300 changed files. Treat a full page
+// as indeterminate so a package path beyond the response cannot be missed.
+const COMPARE_FILES_LIMIT = 300;
 const CONTENT_START = '<!-- release-notes-content-start -->';
 const CONTENT_END = '<!-- release-notes-content-end -->';
 const STALE_MARKER = '<!-- release-notes-stale';
@@ -42,10 +45,10 @@ const PERMITTED_ROLES = new Set(['admin', 'maintain', 'write']);
 const FEEDBACK_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
 
 // These field sets are a strict, bidirectional contract with overrideBody/
-// appliedBody: parseMetadata rejects a comment missing any listed field or
-// carrying any field not listed. Adding a field to a *Body writer without adding
-// it here (or vice versa) makes every such comment unparseable, which fails the
-// merge gate "missing" with no obvious cause. Keep them in lockstep.
+// appliedBody: parseMetadata rejects a comment missing any required field or
+// carrying a field not listed. `release-main-head` is optional only so drafts
+// created before package-scoped freshness was introduced remain usable; every
+// new draft records it. Keep these in lockstep with the body writers.
 const OVERRIDE_FIELDS = new Set([
   'package',
   'version',
@@ -54,6 +57,7 @@ const OVERRIDE_FIELDS = new Set([
   'changelog-fingerprint',
   'state',
 ]);
+const OVERRIDE_OPTIONAL_FIELDS = new Set(['release-main-head']);
 const APPLIED_FIELDS = new Set([
   'package',
   'version',
@@ -249,6 +253,11 @@ function changelogFingerprint(section) {
   return sha256(text.slice(text.indexOf('\n') + 1));
 }
 
+function withHeading(section, heading) {
+  const text = canonical(section);
+  return `${heading}${text.slice(text.indexOf('\n'))}`;
+}
+
 function extractPreviewSection(document, version) {
   const { text, start, end } = sectionRange(document, version, PREVIEW_TERMINATOR);
   return canonical(text.slice(start, end));
@@ -274,7 +283,7 @@ function replacePreviewSection(document, version, replacement) {
 // line, duplicate key, or missing field yields null (untrusted). Callers treat
 // null as "not a valid bot comment", so loosening this weakens the trust
 // boundary. See OVERRIDE_FIELDS/APPLIED_FIELDS.
-function parseMetadata(body, marker, allowedFields) {
+function parseMetadata(body, marker, requiredFields, optionalFields = new Set()) {
   const text = normalize(body ?? '');
   const prefix = `<!-- ${marker}\n`;
   if (!text.startsWith(prefix)) return null;
@@ -283,19 +292,20 @@ function parseMetadata(body, marker, allowedFields) {
   if (close < 0) return null;
   const metadataText = text.slice(prefix.length, close);
   const metadata = {};
+  const allowedFields = new Set([...requiredFields, ...optionalFields]);
   for (const line of metadataText.split('\n')) {
     const match = /^([a-z0-9-]+): (.+)$/.exec(line);
     if (!match || !allowedFields.has(match[1]) || metadata[match[1]] !== undefined) return null;
     metadata[match[1]] = match[2];
   }
-  if ([...allowedFields].some(field => metadata[field] === undefined)) return null;
+  if ([...requiredFields].some(field => metadata[field] === undefined)) return null;
   let remainderStart = close + closeMarker.length;
   if (text[remainderStart] === '\n') remainderStart += 1;
   return { metadata, remainder: text.slice(remainderStart) };
 }
 
 function parseOverrideComment(comment) {
-  const parsed = parseMetadata(comment.body, OVERRIDE_MARKER, OVERRIDE_FIELDS);
+  const parsed = parseMetadata(comment.body, OVERRIDE_MARKER, OVERRIDE_FIELDS, OVERRIDE_OPTIONAL_FIELDS);
   if (!parsed || parsed.metadata.state !== 'draft') return null;
   const start = parsed.remainder.indexOf(CONTENT_START);
   const end = parsed.remainder.indexOf(CONTENT_END);
@@ -431,12 +441,13 @@ function instructionsFromComment(body) {
   return parseCommand(body).instructions;
 }
 
-function overrideBody({ component, version, head, headingHash, fingerprint, section, instructions = '' }) {
+function overrideBody({ component, version, head, mainHead, headingHash, fingerprint, section, instructions = '' }) {
   return [
     `<!-- ${OVERRIDE_MARKER}`,
     `package: ${component}`,
     `version: ${version}`,
     `release-pr-head: ${head}`,
+    ...(mainHead ? [`release-main-head: ${mainHead}`] : []),
     `release-heading-hash: ${headingHash}`,
     `changelog-fingerprint: ${fingerprint}`,
     'state: draft',
@@ -727,7 +738,7 @@ function writeJson(file, value) {
 async function prepareDraft({ github, owner, repo, number, expectedHead, runnerTemp, instructions = '' }) {
   const pr = await getPr(github, owner, repo, number);
   const target = releaseTarget(pr);
-  if (!target || pr.draft || pr.head.sha !== expectedHead) {
+  if (!target || pr.draft || pr.head.sha !== expectedHead || !pr.base?.sha) {
     throw new Error('Release PR changed before drafting started; re-run the draft command');
   }
   const version = target.version;
@@ -765,6 +776,7 @@ async function prepareDraft({ github, owner, repo, number, expectedHead, runnerT
     component: target.component,
     version,
     head: pr.head.sha,
+    mainHead: pr.base.sha,
     fingerprint,
     heading: section.split('\n')[0],
     instructions: guidance,
@@ -821,6 +833,7 @@ async function postDraft({ github, owner, repo, stateFile, outputFile, appSlug, 
       component: state.component,
       version: state.version,
       head: state.head,
+      mainHead: state.mainHead,
       headingHash: sha256(state.heading),
       fingerprint: state.fingerprint,
       section,
@@ -876,7 +889,7 @@ async function prepareApply({ github, owner, repo, number, expectedHead, changel
   await authenticatedBot(github, appSlug, login, id);
   const pr = await getPr(github, owner, repo, number);
   const target = releaseTarget(pr);
-  if (!target || pr.draft || pr.head.sha !== expectedHead) {
+  if (!target || pr.draft || pr.head.sha !== expectedHead || !pr.base?.sha) {
     throw new Error('Release PR changed before apply started; re-run the command');
   }
   const { component, version } = target;
@@ -884,8 +897,11 @@ async function prepareApply({ github, owner, repo, number, expectedHead, changel
   const override = latestOverride({ comments, login, id, component, version });
   if (!override) throw new Error('No valid bot-authored curated release-note draft exists');
   if (!override.comment.updated_at) throw new Error('Curated release-note draft is missing its GitHub revision');
-  if (!(await isDescendant(github, owner, repo, override.metadata['release-pr-head'], pr.head.sha))) {
-    throw new Error(`Release PR was rewritten after drafting; run ${COMMAND_MENTION} draft before apply`);
+  if (!(await draftCoversCurrentPackage({ github, owner, repo, override, pr, packagePath: target.packagePath }))) {
+    const reason = override.metadata['release-main-head']
+      ? `The draft no longer covers current ${component} changes on main`
+      : 'Release PR was rewritten after drafting';
+    throw new Error(`${reason}; run ${COMMAND_MENTION} draft before apply`);
   }
 
   const changelog = await fetchChangelog(github, owner, repo, pr.head.sha, target.changelogPath);
@@ -895,24 +911,32 @@ async function prepareApply({ github, owner, repo, number, expectedHead, changel
   if (sha256(overrideHeading) !== override.metadata['release-heading-hash']) {
     throw new Error('Keep the generated release version heading unchanged');
   }
-  const alreadyApplied = currentSection === override.section;
-  if (!alreadyApplied && overrideHeading !== currentHeading) {
+  // release-please may update the date/comparison URL in the generated heading
+  // while refreshing a branch for an unrelated main commit. Preserve that current
+  // generated heading without making the maintainer regenerate unchanged prose.
+  const scopedDraft = Boolean(override.metadata['release-main-head']);
+  if (!scopedDraft && overrideHeading !== currentHeading) {
     throw new Error('Keep the generated release version heading unchanged');
   }
+  const curatedSection = scopedDraft
+    ? withHeading(override.section, currentHeading)
+    : override.section;
+  const alreadyApplied = currentSection === curatedSection;
   if (!alreadyApplied && changelogFingerprint(currentSection) !== override.metadata['changelog-fingerprint']) {
     throw new Error(`New generated release entries appeared; run ${COMMAND_MENTION} draft before apply`);
   }
 
   const updatedChangelog = alreadyApplied
     ? changelog
-    : replaceVersionSection(changelog, version, override.section);
+    : replaceVersionSection(changelog, version, curatedSection);
   fs.writeFileSync(changelogFile, updatedChangelog, { encoding: 'utf8', mode: 0o600 });
-  const body = replacePreviewSection(pr.body ?? '', version, override.section);
+  const body = replacePreviewSection(pr.body ?? '', version, curatedSection);
   writeJson(stateFile, {
     number,
     component,
     version,
     sourceHead: pr.head.sha,
+    baseHead: pr.base.sha,
     fingerprint: override.metadata['changelog-fingerprint'],
     overrideId: String(override.comment.id),
     overrideUpdatedAt: override.comment.updated_at,
@@ -935,6 +959,7 @@ async function validateApplySnapshot({ github, owner, repo, state, login, id, ex
     target.component !== state.component ||
     target.version !== state.version ||
     pr.draft ||
+    pr.base?.sha !== state.baseHead ||
     (checkPrHead && pr.head.sha !== expectedHead) ||
     exactSha256(pr.body ?? '') !== state.originalBodyHash
   ) {
@@ -1067,6 +1092,44 @@ async function isDescendant(github, owner, repo, base, head) {
   return response.data.status === 'ahead' || response.data.status === 'identical';
 }
 
+function pathIsInPackage(filename, packagePath) {
+  return filename === packagePath || filename.startsWith(`${packagePath}/`);
+}
+
+function comparisonLeavesPackageUnchanged(comparison, packagePath) {
+  if (comparison.status === 'identical') return true;
+  if (comparison.status !== 'ahead') return false;
+  const changedFiles = comparison.files;
+  if (!Array.isArray(changedFiles) || changedFiles.length >= COMPARE_FILES_LIMIT) return false;
+  return !changedFiles.some(file => {
+    if (typeof file?.filename !== 'string') return true;
+    return pathIsInPackage(file.filename, packagePath)
+      || (typeof file.previous_filename === 'string' && pathIsInPackage(file.previous_filename, packagePath));
+  });
+}
+
+// New drafts bind freshness to the package delta on main, not to release-please's
+// generated branch history. release-please may rebuild that branch after an
+// unrelated merge and the lockfile updater then advances it again; neither event
+// changes the notes being curated. Legacy drafts have no main baseline, so retain
+// the prior ancestry check until they are regenerated.
+async function draftCoversCurrentPackage({ github, owner, repo, override, pr, packagePath }) {
+  const draftMainHead = override.metadata['release-main-head'];
+  if (!draftMainHead) {
+    return isDescendant(github, owner, repo, override.metadata['release-pr-head'], pr.head.sha);
+  }
+  const currentMainHead = pr.base?.sha;
+  if (!currentMainHead) return false;
+  if (draftMainHead === currentMainHead) return true;
+
+  const response = await github.rest.repos.compareCommitsWithBasehead({
+    owner,
+    repo,
+    basehead: `${draftMainHead}...${currentMainHead}`,
+  });
+  return comparisonLeavesPackageUnchanged(response.data, packagePath);
+}
+
 async function warnForNewEntries({ github, owner, repo, number, comments, head, fingerprint }) {
   const marker = `${STALE_MARKER}\nhead: ${head}\nchangelog-fingerprint: ${fingerprint}\n-->`;
   if (comments.some(comment => (comment.body ?? '').startsWith(marker))) return;
@@ -1127,7 +1190,8 @@ async function checkCuratedState({
     core.setFailed(`The ${component} release PR title does not match the required \`release(${component}): <version>\` title`);
     return { status: 'invalid-title' };
   }
-  const { changelogPath } = targetForComponent(component);
+  const target = targetForComponent(component);
+  const { changelogPath } = target;
 
   const labelNames = value => (value.labels ?? [])
     .map(label => typeof label === 'string' ? label : label.name)
@@ -1139,6 +1203,7 @@ async function checkCuratedState({
   // re-read, so a mid-check edit can't slip past a stale snapshot.
   const prSnapshotChanged = live =>
     live.head.sha !== pr.head.sha ||
+    live.base?.sha !== pr.base?.sha ||
     live.body !== pr.body ||
     live.draft !== pr.draft ||
     live.title !== pr.title ||
@@ -1209,11 +1274,29 @@ async function checkCuratedState({
   const changelog = await fetchChangelog(github, owner, repo, pr.head.sha, changelogPath);
   const currentSection = extractVersionSection(changelog, version);
   const currentFingerprint = changelogFingerprint(currentSection);
+  const currentHeading = currentSection.split('\n')[0];
+  const overrideHeading = override.section.split('\n')[0];
+  const overrideHeadingValid = sha256(overrideHeading) === override.metadata['release-heading-hash'];
+  const scopedDraft = Boolean(override.metadata['release-main-head']);
+  const legacyHeadingChanged = !scopedDraft
+    && currentSection !== override.section
+    && overrideHeading !== currentHeading;
+  const expectedSection = scopedDraft
+    ? withHeading(override.section, currentHeading)
+    : override.section;
+  const draftCoversPackage = await draftCoversCurrentPackage({
+    github,
+    owner,
+    repo,
+    override,
+    pr,
+    packagePath: target.packagePath,
+  });
   // True when the generated changelog has drifted from the curated override.
   // Reused for the new-entries warning below and for the missing-vs-unapplied
   // split in the !applied branch.
   const generatedEntriesChanged =
-    currentSection !== override.section &&
+    currentSection !== expectedSection &&
     currentFingerprint !== override.metadata['changelog-fingerprint'];
   // Warn (idempotently; deduped by head+fingerprint) when the changelog has moved
   // away from the curated override. Invoked at both the pre-applied miss and the
@@ -1252,21 +1335,7 @@ async function checkCuratedState({
   };
   if (!applied) {
     await maybeWarnNewEntries();
-    let draftMetadataChanged = false;
-    if (!generatedEntriesChanged) {
-      const currentHeading = currentSection.split('\n')[0];
-      const overrideHeading = override.section.split('\n')[0];
-      const headingChanged =
-        sha256(overrideHeading) !== override.metadata['release-heading-hash'] ||
-        (currentSection !== override.section && overrideHeading !== currentHeading);
-      draftMetadataChanged = headingChanged || !(await isDescendant(
-        github,
-        owner,
-        repo,
-        override.metadata['release-pr-head'],
-        pr.head.sha,
-      ));
-    }
+    const draftMetadataChanged = !overrideHeadingValid || legacyHeadingChanged || !draftCoversPackage;
     if (generatedEntriesChanged || draftMetadataChanged) {
       core.setFailed(`Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply before merging`);
       return { status: 'missing', component, version };
@@ -1279,15 +1348,28 @@ async function checkCuratedState({
 
   const appliedMetadata = applied.metadata;
   const failures = [];
+  let draftRequired = generatedEntriesChanged
+    || !overrideHeadingValid
+    || legacyHeadingChanged
+    || !draftCoversPackage;
 
   if (appliedMetadata['override-comment-id'] !== String(override.comment.id)) failures.push('applied metadata references an older override comment');
   if (appliedMetadata['override-comment-updated-at'] !== override.comment.updated_at) failures.push('the curated override was revised after apply');
-  if (!(await isDescendant(github, owner, repo, override.metadata['release-pr-head'], appliedMetadata['source-head']))) {
+  if (!overrideHeadingValid) failures.push('the generated release heading in the curated override changed');
+  if (!draftCoversPackage) failures.push(`the draft does not cover the current ${target.packagePath} state on main`);
+  if (!override.metadata['release-main-head'] && !(await isDescendant(
+    github,
+    owner,
+    repo,
+    override.metadata['release-pr-head'],
+    appliedMetadata['source-head'],
+  ))) {
     failures.push('the applied draft is not based on the latest curated draft');
+    draftRequired = true;
   }
   if (appliedMetadata['changelog-fingerprint'] !== override.metadata['changelog-fingerprint']) failures.push('applied and override fingerprints differ');
   if (appliedMetadata['override-content-hash'] !== sha256(override.section)) failures.push('the curated override changed after apply');
-  if (currentSection !== override.section) failures.push('the changelog does not contain the curated override');
+  if (currentSection !== expectedSection) failures.push('the changelog does not contain the curated override');
 
   let preview = null;
   try {
@@ -1295,7 +1377,7 @@ async function checkCuratedState({
   } catch (error) {
     failures.push(error.message);
   }
-  if (preview !== null && preview !== override.section) failures.push('the release PR body does not mirror the curated changelog section');
+  if (preview !== null && preview !== expectedSection) failures.push('the release PR body does not mirror the curated changelog section');
 
   if (!(await isDescendant(github, owner, repo, appliedMetadata['applied-head'], pr.head.sha))) {
     failures.push('the applied commit is not an ancestor of the current release PR head');
@@ -1332,8 +1414,11 @@ async function checkCuratedState({
     // Prefix the target so the annotation GitHub surfaces from setFailed names the
     // package and version being gated; bare reason strings are ambiguous across the
     // many open release PRs this check covers.
-    const target = `for ${component} ${version}`;
-    core.setFailed(`${target}: ${failures.join('; ')}. Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply.`);
+    const release = `for ${component} ${version}`;
+    const remediation = draftRequired
+      ? `Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply.`
+      : `Run ${COMMAND_MENTION} apply.`;
+    core.setFailed(`${release}: ${failures.join('; ')}. ${remediation}`);
     return { status: 'failed', failures, component, version };
   }
   core.info(`Curated release notes are current for ${component} ${version}`);

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -51,9 +51,8 @@ const FEEDBACK_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
 
 // These field sets are a strict, bidirectional contract with overrideBody/
 // appliedBody: parseMetadata rejects a comment missing any required field or
-// carrying a field not listed. `release-main-head` is optional only so drafts
-// created before package-scoped freshness was introduced remain usable; every
-// new draft records it. Keep these in lockstep with the body writers.
+// carrying a field outside the allowed set. Keep these in lockstep with the body
+// writers.
 const OVERRIDE_FIELDS = new Set([
   'package',
   'version',
@@ -62,7 +61,9 @@ const OVERRIDE_FIELDS = new Set([
   'changelog-fingerprint',
   'state',
 ]);
-const OVERRIDE_OPTIONAL_FIELDS = new Set(['release-main-head']);
+// Optional only so drafts created before package-scoped freshness remain usable;
+// every new draft records `release-main-head`.
+const OVERRIDE_ALLOWED_FIELDS = new Set([...OVERRIDE_FIELDS, 'release-main-head']);
 const APPLIED_FIELDS = new Set([
   'package',
   'version',
@@ -263,9 +264,33 @@ function changelogFingerprint(section) {
   return sha256(text.slice(text.indexOf('\n') + 1));
 }
 
+function sectionHeading(section) {
+  return section.split('\n')[0];
+}
+
 function withHeading(section, heading) {
   const text = canonical(section);
   return `${heading}${text.slice(text.indexOf('\n'))}`;
+}
+
+// The single definition of "what the changelog and PR body must contain". Both
+// the writer (prepareApply) and the verifier (checkCuratedState) call it, so the
+// bytes one writes are by construction the bytes the other expects. A scoped
+// draft accepts release-please's current generated heading, since a branch
+// refresh for an unrelated main commit may restyle the date or comparison URL
+// without touching the curated prose.
+function curatedSectionFor(override, currentHeading) {
+  return override.mainHead ? withHeading(override.section, currentHeading) : override.section;
+}
+
+// Names the cause behind a draftCoversCurrentPackage miss. The helper answers a
+// different question per draft kind — a package delta on main for scoped drafts,
+// release-branch ancestry for legacy ones — so the reason is produced here, once,
+// rather than reconstructed by each caller.
+function staleDraftReason(override, packagePath) {
+  return override.mainHead
+    ? `main has new ${packagePath} changes since this draft`
+    : 'the release branch was rewritten after drafting';
 }
 
 function extractPreviewSection(document, version) {
@@ -293,7 +318,7 @@ function replacePreviewSection(document, version, replacement) {
 // line, duplicate key, or missing field yields null (untrusted). Callers treat
 // null as "not a valid bot comment", so loosening this weakens the trust
 // boundary. See OVERRIDE_FIELDS/APPLIED_FIELDS.
-function parseMetadata(body, marker, requiredFields, optionalFields = new Set()) {
+function parseMetadata(body, marker, requiredFields, allowedFields = requiredFields) {
   const text = normalize(body ?? '');
   const prefix = `<!-- ${marker}\n`;
   if (!text.startsWith(prefix)) return null;
@@ -302,7 +327,6 @@ function parseMetadata(body, marker, requiredFields, optionalFields = new Set())
   if (close < 0) return null;
   const metadataText = text.slice(prefix.length, close);
   const metadata = {};
-  const allowedFields = new Set([...requiredFields, ...optionalFields]);
   for (const line of metadataText.split('\n')) {
     const match = /^([a-z0-9-]+): (.+)$/.exec(line);
     if (!match || !allowedFields.has(match[1]) || metadata[match[1]] !== undefined) return null;
@@ -315,7 +339,7 @@ function parseMetadata(body, marker, requiredFields, optionalFields = new Set())
 }
 
 function parseOverrideComment(comment) {
-  const parsed = parseMetadata(comment.body, OVERRIDE_MARKER, OVERRIDE_FIELDS, OVERRIDE_OPTIONAL_FIELDS);
+  const parsed = parseMetadata(comment.body, OVERRIDE_MARKER, OVERRIDE_FIELDS, OVERRIDE_ALLOWED_FIELDS);
   if (!parsed || parsed.metadata.state !== 'draft') return null;
   const start = parsed.remainder.indexOf(CONTENT_START);
   const end = parsed.remainder.indexOf(CONTENT_END);
@@ -335,7 +359,11 @@ function parseOverrideComment(comment) {
     }
     throw error;
   }
-  return { comment, metadata: parsed.metadata, section };
+  // Resolve the scoped-vs-legacy discriminant once, here, so no consumer has to
+  // re-probe the raw metadata key: a draft carrying a main baseline is scoped to
+  // its package delta, one without it predates that scoping.
+  const mainHead = parsed.metadata['release-main-head'] ?? null;
+  return { comment, metadata: parsed.metadata, section, mainHead };
 }
 
 function parseAppliedComment(comment) {
@@ -788,7 +816,7 @@ async function prepareDraft({ github, owner, repo, number, expectedHead, runnerT
     head: pr.head.sha,
     mainHead: pr.base.sha,
     fingerprint,
-    heading: section.split('\n')[0],
+    heading: sectionHeading(section),
     instructions: guidance,
   });
   return { work, input, output, state };
@@ -908,29 +936,22 @@ async function prepareApply({ github, owner, repo, number, expectedHead, changel
   if (!override) throw new Error('No valid bot-authored curated release-note draft exists');
   if (!override.comment.updated_at) throw new Error('Curated release-note draft is missing its GitHub revision');
   if (!(await draftCoversCurrentPackage({ github, owner, repo, override, pr, packagePath: target.packagePath }))) {
-    const reason = override.metadata['release-main-head']
-      ? `main has new ${target.packagePath} changes since this draft`
-      : 'The release PR was rewritten after drafting';
-    throw new Error(`${reason}; run ${COMMAND_MENTION} draft before apply`);
+    throw new Error(
+      `${staleDraftReason(override, target.packagePath)}; run ${COMMAND_MENTION} draft before apply`,
+    );
   }
 
   const changelog = await fetchChangelog(github, owner, repo, pr.head.sha, target.changelogPath);
   const currentSection = extractVersionSection(changelog, version);
-  const currentHeading = currentSection.split('\n')[0];
-  const overrideHeading = override.section.split('\n')[0];
-  if (sha256(overrideHeading) !== override.metadata['release-heading-hash']) {
+  const currentHeading = sectionHeading(currentSection);
+  const overrideHeading = sectionHeading(override.section);
+  // A legacy draft must still match the generated heading byte for byte; only a
+  // scoped draft tolerates release-please restyling it (see curatedSectionFor).
+  if (sha256(overrideHeading) !== override.metadata['release-heading-hash']
+    || (!override.mainHead && overrideHeading !== currentHeading)) {
     throw new Error('Keep the generated release version heading unchanged');
   }
-  // release-please may update the date/comparison URL in the generated heading
-  // while refreshing a branch for an unrelated main commit. Preserve that current
-  // generated heading without making the maintainer regenerate unchanged prose.
-  const scopedDraft = Boolean(override.metadata['release-main-head']);
-  if (!scopedDraft && overrideHeading !== currentHeading) {
-    throw new Error('Keep the generated release version heading unchanged');
-  }
-  const curatedSection = scopedDraft
-    ? withHeading(override.section, currentHeading)
-    : override.section;
+  const curatedSection = curatedSectionFor(override, currentHeading);
   const alreadyApplied = currentSection === curatedSection;
   if (!alreadyApplied && changelogFingerprint(currentSection) !== override.metadata['changelog-fingerprint']) {
     throw new Error(`New generated release entries appeared; run ${COMMAND_MENTION} draft before apply`);
@@ -975,8 +996,7 @@ async function validateApplySnapshot({ github, owner, repo, state, login, id, ex
     // the same reason expectedHead does. Bind it to the same flag: before the
     // push it guards the prepare/commit window, after the push a main advance
     // is not grounds to withhold the metadata for a commit that already landed.
-    (checkPrHead && pr.base?.sha !== state.baseHead) ||
-    (checkPrHead && pr.head.sha !== expectedHead) ||
+    (checkPrHead && (pr.base?.sha !== state.baseHead || pr.head.sha !== expectedHead)) ||
     exactSha256(pr.body ?? '') !== state.originalBodyHash
   ) {
     throw new Error('Release PR changed while apply was preparing; refusing to publish stale metadata');
@@ -1143,7 +1163,7 @@ function comparisonLeavesPackageUnchanged(comparison, packagePath) {
 // changes the notes being curated. Legacy drafts have no main baseline, so retain
 // the prior ancestry check until they are regenerated.
 async function draftCoversCurrentPackage({ github, owner, repo, override, pr, packagePath }) {
-  const draftMainHead = override.metadata['release-main-head'];
+  const draftMainHead = override.mainHead;
   if (!draftMainHead) {
     return isDescendant(github, owner, repo, override.metadata['release-pr-head'], pr.head.sha);
   }
@@ -1235,8 +1255,7 @@ async function checkCuratedState({
     core.setFailed(`The ${component} release PR title does not match the required \`release(${component}): <version>\` title`);
     return { status: 'invalid-title' };
   }
-  const target = targetForComponent(component);
-  const { changelogPath } = target;
+  const { changelogPath, packagePath } = targetForComponent(component);
 
   const labelNames = value => (value.labels ?? [])
     .map(label => typeof label === 'string' ? label : label.name)
@@ -1316,27 +1335,25 @@ async function checkCuratedState({
     return { status: 'missing', component, version };
   }
 
-  const changelog = await fetchChangelog(github, owner, repo, pr.head.sha, changelogPath);
+  // Independent round-trips: the comparison needs only the override and the PR,
+  // both settled above, so it must not queue behind the changelog fetch.
+  const [changelog, draftCoversPackage] = await Promise.all([
+    fetchChangelog(github, owner, repo, pr.head.sha, changelogPath),
+    draftCoversCurrentPackage({ github, owner, repo, override, pr, packagePath }),
+  ]);
   const currentSection = extractVersionSection(changelog, version);
   const currentFingerprint = changelogFingerprint(currentSection);
-  const currentHeading = currentSection.split('\n')[0];
-  const overrideHeading = override.section.split('\n')[0];
+  const currentHeading = sectionHeading(currentSection);
+  const overrideHeading = sectionHeading(override.section);
   const overrideHeadingValid = sha256(overrideHeading) === override.metadata['release-heading-hash'];
-  const scopedDraft = Boolean(override.metadata['release-main-head']);
-  const legacyHeadingChanged = !scopedDraft
+  const legacyHeadingChanged = !override.mainHead
     && currentSection !== override.section
     && overrideHeading !== currentHeading;
-  const expectedSection = scopedDraft
-    ? withHeading(override.section, currentHeading)
-    : override.section;
-  const draftCoversPackage = await draftCoversCurrentPackage({
-    github,
-    owner,
-    repo,
-    override,
-    pr,
-    packagePath: target.packagePath,
-  });
+  const expectedSection = curatedSectionFor(override, currentHeading);
+  // The one definition of "a re-draft is required", shared by the unapplied and
+  // applied branches below so they cannot prescribe different remedies for the
+  // same state.
+  const draftMetadataChanged = !overrideHeadingValid || legacyHeadingChanged || !draftCoversPackage;
   // True when the generated changelog has drifted from the curated override.
   // Reused for the new-entries warning below and for the missing-vs-unapplied
   // split in the !applied branch.
@@ -1380,7 +1397,6 @@ async function checkCuratedState({
   };
   if (!applied) {
     await maybeWarnNewEntries();
-    const draftMetadataChanged = !overrideHeadingValid || legacyHeadingChanged || !draftCoversPackage;
     if (generatedEntriesChanged || draftMetadataChanged) {
       core.setFailed(`Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply before merging`);
       return { status: 'missing', component, version };
@@ -1393,24 +1409,13 @@ async function checkCuratedState({
 
   const appliedMetadata = applied.metadata;
   const failures = [];
-  let draftRequired = generatedEntriesChanged
-    || !overrideHeadingValid
-    || legacyHeadingChanged
-    || !draftCoversPackage;
+  let draftRequired = generatedEntriesChanged || draftMetadataChanged;
 
   if (appliedMetadata['override-comment-id'] !== String(override.comment.id)) failures.push('applied metadata references an older override comment');
   if (appliedMetadata['override-comment-updated-at'] !== override.comment.updated_at) failures.push('the curated override was revised after apply');
   if (!overrideHeadingValid) failures.push('the generated release heading in the curated override changed');
-  // draftCoversCurrentPackage answers a different question per draft kind: a
-  // package delta on main for scoped drafts, release-branch ancestry for legacy
-  // ones. Name the cause that actually applies; a force-pushed legacy branch
-  // moves no main commit at all.
-  if (!draftCoversPackage) {
-    failures.push(override.metadata['release-main-head']
-      ? `main has new ${target.packagePath} changes since this draft`
-      : 'the release branch was rewritten after drafting');
-  }
-  if (!override.metadata['release-main-head'] && !(await isDescendant(
+  if (!draftCoversPackage) failures.push(staleDraftReason(override, packagePath));
+  if (!override.mainHead && !(await isDescendant(
     github,
     owner,
     repo,
@@ -1467,11 +1472,11 @@ async function checkCuratedState({
     // Prefix the target so the annotation GitHub surfaces from setFailed names the
     // package and version being gated; bare reason strings are ambiguous across the
     // many open release PRs this check covers.
-    const release = `for ${component} ${version}`;
+    const target = `for ${component} ${version}`;
     const remediation = draftRequired
       ? `Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply.`
       : `Run ${COMMAND_MENTION} apply.`;
-    core.setFailed(`${release}: ${failures.join('; ')}. ${remediation}`);
+    core.setFailed(`${target}: ${failures.join('; ')}. ${remediation}`);
     return { status: 'failed', failures, component, version };
   }
   core.info(`Curated release notes are current for ${component} ${version}`);

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -904,8 +904,8 @@ async function prepareApply({ github, owner, repo, number, expectedHead, changel
   if (!override.comment.updated_at) throw new Error('Curated release-note draft is missing its GitHub revision');
   if (!(await draftCoversCurrentPackage({ github, owner, repo, override, pr, packagePath: target.packagePath }))) {
     const reason = override.metadata['release-main-head']
-      ? `The draft no longer covers current ${component} changes on main`
-      : 'Release PR was rewritten after drafting';
+      ? `main has new ${target.packagePath} changes since this draft`
+      : 'The release PR was rewritten after drafting';
     throw new Error(`${reason}; run ${COMMAND_MENTION} draft before apply`);
   }
 
@@ -1361,7 +1361,15 @@ async function checkCuratedState({
   if (appliedMetadata['override-comment-id'] !== String(override.comment.id)) failures.push('applied metadata references an older override comment');
   if (appliedMetadata['override-comment-updated-at'] !== override.comment.updated_at) failures.push('the curated override was revised after apply');
   if (!overrideHeadingValid) failures.push('the generated release heading in the curated override changed');
-  if (!draftCoversPackage) failures.push(`the draft does not cover the current ${target.packagePath} state on main`);
+  // draftCoversCurrentPackage answers a different question per draft kind: a
+  // package delta on main for scoped drafts, release-branch ancestry for legacy
+  // ones. Name the cause that actually applies; a force-pushed legacy branch
+  // moves no main commit at all.
+  if (!draftCoversPackage) {
+    failures.push(override.metadata['release-main-head']
+      ? `main has new ${target.packagePath} changes since this draft`
+      : 'the release branch was rewritten after drafting');
+  }
   if (!override.metadata['release-main-head'] && !(await isDescendant(
     github,
     owner,

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -18,9 +18,14 @@ const BYPASS_LABEL = 'release: dangerously skip curated notes';
 const COMMAND_MENTION = '@release-bot';
 const OVERRIDE_MARKER = 'release-notes-override';
 const APPLIED_MARKER = 'release-notes-applied';
-// GitHub's compare endpoint returns at most 300 changed files. Treat a full page
-// as indeterminate so a package path beyond the response cannot be missed.
+// GitHub's compare response lists at most 300 changed files and does not
+// paginate them. A response at that cap may omit a package path, so treat it as
+// unknown and require a re-draft.
 const COMPARE_FILES_LIMIT = 300;
+// The same response carries at most one page of commits. When it holds fewer
+// than total_commits, the range is truncated and the file list describes only
+// part of it, so the "no package file moved" answer is not trustworthy.
+const COMPARE_COMMITS_PER_PAGE = 100;
 const CONTENT_START = '<!-- release-notes-content-start -->';
 const CONTENT_END = '<!-- release-notes-content-end -->';
 const STALE_MARKER = '<!-- release-notes-stale';
@@ -1107,13 +1112,26 @@ function pathIsInPackage(filename, packagePath) {
   return filename === packagePath || filename.startsWith(`${packagePath}/`);
 }
 
+// Returns true only when the comparison positively proves that no path inside
+// the package moved. Every ambiguous, truncated, or malformed response counts as
+// changed: the cost of a needless re-draft is a maintainer command, and the cost
+// of a wrong "unchanged" is shipping stale curated prose behind a green gate.
 function comparisonLeavesPackageUnchanged(comparison, packagePath) {
   if (comparison.status === 'identical') return true;
+  // Anything else (behind, diverged, absent) means main was rewritten or moved
+  // backwards, and the file list no longer describes the drift.
   if (comparison.status !== 'ahead') return false;
+  // A truncated commit list yields a partial file list that still looks
+  // well-formed, so it must be rejected before the file list is trusted.
+  const { total_commits: totalCommits, commits } = comparison;
+  if (typeof totalCommits !== 'number' || !Array.isArray(commits)) return false;
+  if (commits.length < totalCommits) return false;
   const changedFiles = comparison.files;
   if (!Array.isArray(changedFiles) || changedFiles.length >= COMPARE_FILES_LIMIT) return false;
   return !changedFiles.some(file => {
+    // A malformed entry could be the package path; count it as touching.
     if (typeof file?.filename !== 'string') return true;
+    // A rename out of the package is a package change that `filename` alone hides.
     return pathIsInPackage(file.filename, packagePath)
       || (typeof file.previous_filename === 'string' && pathIsInPackage(file.previous_filename, packagePath));
   });
@@ -1133,11 +1151,27 @@ async function draftCoversCurrentPackage({ github, owner, repo, override, pr, pa
   if (!currentMainHead) return false;
   if (draftMainHead === currentMainHead) return true;
 
-  const response = await github.rest.repos.compareCommitsWithBasehead({
-    owner,
-    repo,
-    basehead: `${draftMainHead}...${currentMainHead}`,
-  });
+  const basehead = `${draftMainHead}...${currentMainHead}`;
+  let response;
+  try {
+    response = await github.rest.repos.compareCommitsWithBasehead({
+      owner,
+      repo,
+      basehead,
+      per_page: COMPARE_COMMITS_PER_PAGE,
+    });
+  } catch (error) {
+    // A recorded main SHA can become unreachable after a history rewrite, and
+    // the endpoint also refuses ranges whose diff is too large. Both are
+    // expected here, so name the comparison and the remedy instead of letting a
+    // bare Octokit message reach the maintainer.
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Could not compare ${basehead} to scope ${packagePath} changes for the curated draft (${detail}); `
+      + `run ${COMMAND_MENTION} draft`,
+      { cause: error },
+    );
+  }
   return comparisonLeavesPackageUnchanged(response.data, packagePath);
 }
 
@@ -1446,6 +1480,8 @@ async function checkCuratedState({
 
 module.exports = {
   BYPASS_LABEL,
+  comparisonLeavesPackageUnchanged,
+  pathIsInPackage,
   COMMAND_MENTION,
   CONTENT_END,
   CONTENT_START,

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -16,6 +16,8 @@ const RELEASE_BRANCH = `${releaseNotes.RELEASE_BRANCH_PREFIX}${COMPONENT}`;
 const CHANGELOG_PATH = 'libs/code/CHANGELOG.md';
 const HEAD = 'a'.repeat(40);
 const APPLIED_HEAD = 'b'.repeat(40);
+const MAIN_HEAD = '0'.repeat(40);
+const NEXT_MAIN_HEAD = '1'.repeat(40);
 const VERSION = '0.1.35';
 const OVERRIDE_UPDATED_AT = '2026-07-09T12:00:00Z';
 const APPLIED_UPDATED_AT = '2026-07-09T12:05:00Z';
@@ -39,13 +41,13 @@ function releasePr(overrides = {}) {
       sha: HEAD,
       repo: { full_name: 'langchain-ai/deepagents' },
     },
-    base: { ref: 'main', repo: { full_name: 'langchain-ai/deepagents' } },
+    base: { ref: 'main', sha: MAIN_HEAD, repo: { full_name: 'langchain-ai/deepagents' } },
     labels: [],
     ...overrides,
   };
 }
 
-function overrideComment({ id = 10, section = CURATED_SECTION, fingerprint = releaseNotes.changelogFingerprint(GENERATED_SECTION), head = HEAD, updatedAt = OVERRIDE_UPDATED_AT, htmlUrl = null } = {}) {
+function overrideComment({ id = 10, section = CURATED_SECTION, fingerprint = releaseNotes.changelogFingerprint(GENERATED_SECTION), head = HEAD, mainHead = null, updatedAt = OVERRIDE_UPDATED_AT, htmlUrl = null } = {}) {
   return {
     id,
     updated_at: updatedAt,
@@ -58,6 +60,7 @@ function overrideComment({ id = 10, section = CURATED_SECTION, fingerprint = rel
       'package: deepagents-code',
       `version: ${VERSION}`,
       `release-pr-head: ${head}`,
+      ...(mainHead === null ? [] : [`release-main-head: ${mainHead}`]),
       `release-heading-hash: ${releaseNotes.sha256(HEADING)}`,
       `changelog-fingerprint: ${fingerprint}`,
       'state: draft',
@@ -102,7 +105,7 @@ function makeCore() {
   };
 }
 
-function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adminFlag = permission === 'admin', appUser = BOT, files = new Map(), comparison = 'ahead', malformedContent = false, onGetPr = null, onListComments = null, onCreateComment = null } = {}) {
+function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adminFlag = permission === 'admin', appUser = BOT, files = new Map(), comparison = 'ahead', changedFiles = [], malformedContent = false, onGetPr = null, onListComments = null, onCreateComment = null } = {}) {
   const calls = {
     createBlob: [],
     createComment: [],
@@ -166,7 +169,11 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
           const content = files.get(params.ref) ?? fallback;
           return { data: { type: 'file', encoding: 'base64', content: Buffer.from(content).toString('base64') } };
         },
-        compareCommitsWithBasehead: async () => ({ data: { status: comparison } }),
+        compareCommitsWithBasehead: async params => ({
+          data: typeof comparison === 'function'
+            ? comparison(params)
+            : { status: comparison, files: changedFiles },
+        }),
       },
       git: {
         getCommit: async params => {
@@ -483,7 +490,9 @@ test('prepares agent input from the exact validated head', async t => {
     runnerTemp,
   });
   assert.match(fs.readFileSync(prepared.input, 'utf8'), /untrusted source material/);
-  assert.equal(JSON.parse(fs.readFileSync(prepared.state, 'utf8')).fingerprint, releaseNotes.changelogFingerprint(GENERATED_SECTION));
+  const state = JSON.parse(fs.readFileSync(prepared.state, 'utf8'));
+  assert.equal(state.fingerprint, releaseNotes.changelogFingerprint(GENERATED_SECTION));
+  assert.equal(state.mainHead, MAIN_HEAD);
   // The trusted state file must live outside `work` (the agent's only writable dir)
   // so a compromised agent can't overwrite what postDraft re-validates against.
   assert.ok(!prepared.state.startsWith(prepared.work));
@@ -532,13 +541,14 @@ test('posts a bot-authored draft and refuses stale agent output', async t => {
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const state = path.join(dir, 'state.json');
   const output = path.join(dir, 'output.md');
-  fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
+  fs.writeFileSync(state, JSON.stringify({ number: 123, component: COMPONENT, version: VERSION, head: HEAD, mainHead: MAIN_HEAD, fingerprint: releaseNotes.changelogFingerprint(GENERATED_SECTION), heading: HEADING }));
   fs.writeFileSync(output, '### Features\n\n* Add a useful feature.\n');
   const { github, calls } = makeGithub();
   await releaseNotes.postDraft({ github, owner: 'langchain-ai', repo: 'deepagents', stateFile: state, outputFile: output, core: makeCore(), ...BOT_AUTH });
   assert.deepEqual(calls.getByUsername, [{ username: BOT.login }]);
   assert.equal(calls.createComment.length, 1);
   assert.match(calls.createComment[0].body, /changelog-fingerprint:/);
+  assert.match(calls.createComment[0].body, new RegExp(`release-main-head: ${MAIN_HEAD}`));
   assert.match(calls.createComment[0].body, /---\n<!-- release-notes-content-start -->/);
   assert.match(calls.createComment[0].body, /<!-- release-notes-content-end -->\n---/);
   assert.match(calls.createComment[0].body, /```\n@release-bot apply\n```/);
@@ -613,6 +623,7 @@ test('prepare apply replaces only the changelog section and records immutable ha
   assert.equal(state.overrideId, '10');
   assert.equal(state.overrideUpdatedAt, OVERRIDE_UPDATED_AT);
   assert.equal(state.contentHash, releaseNotes.sha256(CURATED_SECTION));
+  assert.equal(state.baseHead, MAIN_HEAD);
   assert.equal(state.originalBodyHash, releaseNotes.exactSha256(releasePr().body));
   assert.match(state.body, /\* Add a useful feature/);
 });
@@ -649,6 +660,38 @@ test('apply rejects concurrent PR-body and override revisions', async t => {
     releaseNotes.publishAppliedState({ github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile, appliedHead: APPLIED_HEAD, ...BOT_AUTH }),
     /draft changed while apply was preparing/,
   );
+});
+
+test('apply rejects main advancing after its package-scope snapshot', async t => {
+  const workspace = tempWorkspace();
+  t.after(() => fs.rmSync(workspace.root, { recursive: true, force: true }));
+  const stateFile = path.join(workspace.root, 'apply.json');
+  const run = makeGithub({ comments: [overrideComment()] });
+  await releaseNotes.prepareApply({
+    github: run.github,
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    number: 123,
+    expectedHead: HEAD,
+    changelogFile: workspace.file,
+    stateFile,
+    ...BOT_AUTH,
+  });
+  run.setPr(releasePr({ base: { ...releasePr().base, sha: NEXT_MAIN_HEAD } }));
+
+  await assert.rejects(
+    releaseNotes.createApplyCommit({
+      github: run.github,
+      owner: 'langchain-ai',
+      repo: 'deepagents',
+      stateFile,
+      changelogFile: workspace.file,
+      ...BOT_AUTH,
+    }),
+    /Release PR changed while apply was preparing/,
+  );
+  assert.equal(run.calls.createCommit.length, 0);
+  assert.equal(run.calls.updateRef.length, 0);
 });
 
 test('prepare apply preserves the generated release heading', async t => {
@@ -692,6 +735,73 @@ test('prepare apply rejects a draft from a rewritten release branch with unchang
   );
 });
 
+test('prepare apply keeps a scoped draft after unrelated main changes rewrite the release branch', async t => {
+  const rewrittenHead = 'c'.repeat(40);
+  const workspace = tempWorkspace();
+  t.after(() => fs.rmSync(workspace.root, { recursive: true, force: true }));
+  const currentHeading = HEADING.replace('(2026-07-09)', '(2026-07-10)');
+  const generated = GENERATED_SECTION.replace(HEADING, currentHeading);
+  const pr = releasePr({
+    head: { ...releasePr().head, sha: rewrittenHead },
+    base: { ...releasePr().base, sha: NEXT_MAIN_HEAD },
+    body: `Release notes preview\n\n${generated}\n_End release notes preview._\n`,
+  });
+  const files = new Map([[rewrittenHead, changelog(generated)]]);
+  const { github } = makeGithub({
+    pr,
+    comments: [overrideComment({ mainHead: MAIN_HEAD })],
+    files,
+    changedFiles: [{ filename: '.github/workflows/ci.yml' }],
+  });
+
+  const state = await releaseNotes.prepareApply({
+    github,
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    number: 123,
+    expectedHead: rewrittenHead,
+    changelogFile: workspace.file,
+    stateFile: path.join(workspace.root, 'state.json'),
+    ...BOT_AUTH,
+  });
+
+  const appliedSection = releaseNotes.extractVersionSection(fs.readFileSync(workspace.file, 'utf8'), VERSION);
+  assert.equal(appliedSection.split('\n')[0], currentHeading);
+  assert.match(appliedSection, /\* Add a useful feature/);
+  assert.equal(state.contentHash, releaseNotes.sha256(CURATED_SECTION));
+});
+
+test('prepare apply requires a new scoped draft when main changed the package', async t => {
+  const rewrittenHead = 'c'.repeat(40);
+  const workspace = tempWorkspace();
+  t.after(() => fs.rmSync(workspace.root, { recursive: true, force: true }));
+  const pr = releasePr({
+    head: { ...releasePr().head, sha: rewrittenHead },
+    base: { ...releasePr().base, sha: NEXT_MAIN_HEAD },
+  });
+  const files = new Map([[rewrittenHead, changelog(GENERATED_SECTION)]]);
+  const { github } = makeGithub({
+    pr,
+    comments: [overrideComment({ mainHead: MAIN_HEAD })],
+    files,
+    changedFiles: [{ filename: 'libs/code/deepagents_cli/app.py' }],
+  });
+
+  await assert.rejects(
+    releaseNotes.prepareApply({
+      github,
+      owner: 'langchain-ai',
+      repo: 'deepagents',
+      number: 123,
+      expectedHead: rewrittenHead,
+      changelogFile: workspace.file,
+      stateFile: path.join(workspace.root, 'state.json'),
+      ...BOT_AUTH,
+    }),
+    /draft no longer covers current deepagents-code changes on main; run @release-bot draft before apply/,
+  );
+});
+
 test('required check passes only when applied metadata, changelog, body, and ancestry match', async () => {
   const pr = releasePr({
     head: { ...releasePr().head, sha: APPLIED_HEAD },
@@ -731,6 +841,92 @@ test('required check accepts apply after unrelated branch advancement', async ()
   });
   assert.equal(result.status, 'passed', core.failed);
   assert.equal(core.failed, null);
+});
+
+test('required check asks only for apply after an unrelated main change rewrites a scoped release', async () => {
+  const rewrittenHead = 'c'.repeat(40);
+  const pr = releasePr({
+    head: { ...releasePr().head, sha: rewrittenHead },
+    base: { ...releasePr().base, sha: NEXT_MAIN_HEAD },
+  });
+  const files = new Map([[rewrittenHead, changelog(GENERATED_SECTION)]]);
+  const comparison = ({ basehead }) => basehead === `${MAIN_HEAD}...${NEXT_MAIN_HEAD}`
+    ? { status: 'ahead', files: [{ filename: '.github/workflows/ci.yml' }] }
+    : { status: 'diverged', files: [] };
+  const { github } = makeGithub({
+    pr,
+    comments: [overrideComment({ mainHead: MAIN_HEAD }), appliedComment()],
+    files,
+    comparison,
+  });
+  const core = makeCore();
+
+  const result = await releaseNotes.checkCuratedState({
+    github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    ...BOT_AUTH,
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.match(core.failed, /Run @release-bot apply\.$/);
+  assert.doesNotMatch(core.failed, /draft and then/);
+});
+
+test('required check accepts a scoped draft re-applied with release-please refreshed heading metadata', async () => {
+  const currentHeading = HEADING.replace('(2026-07-09)', '(2026-07-10)');
+  const curated = CURATED_SECTION.replace(HEADING, currentHeading);
+  const pr = releasePr({
+    head: { ...releasePr().head, sha: APPLIED_HEAD },
+    base: { ...releasePr().base, sha: NEXT_MAIN_HEAD },
+    body: `Release notes preview\n\n${curated}\n_End release notes preview._\n`,
+  });
+  const files = new Map([[APPLIED_HEAD, changelog(curated)]]);
+  const { github } = makeGithub({
+    pr,
+    comments: [overrideComment({ mainHead: MAIN_HEAD }), appliedComment()],
+    files,
+    changedFiles: [{ filename: '.github/workflows/ci.yml' }],
+  });
+  const core = makeCore();
+
+  const result = await releaseNotes.checkCuratedState({
+    github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    ...BOT_AUTH,
+  });
+
+  assert.equal(result.status, 'passed', core.failed);
+});
+
+test('required check requires a fresh scoped draft after a package change on main', async () => {
+  const rewrittenHead = 'c'.repeat(40);
+  const pr = releasePr({
+    head: { ...releasePr().head, sha: rewrittenHead },
+    base: { ...releasePr().base, sha: NEXT_MAIN_HEAD },
+  });
+  const files = new Map([[rewrittenHead, changelog(GENERATED_SECTION)]]);
+  const { github } = makeGithub({
+    pr,
+    comments: [overrideComment({ mainHead: MAIN_HEAD })],
+    files,
+    changedFiles: [{ filename: 'libs/code/uv.lock' }],
+  });
+  const core = makeCore();
+
+  const result = await releaseNotes.checkCuratedState({
+    github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    ...BOT_AUTH,
+  });
+
+  assert.equal(result.status, 'missing');
+  assert.match(core.failed, /draft and then @release-bot apply/);
 });
 
 test('required check accepts an identical-ancestry comparison as a descendant', async () => {
@@ -1261,6 +1457,10 @@ test('required check fails when the applied commit is not an ancestor of the hea
 test('parseMetadata rejects malformed, unknown, duplicate, and missing-field comments', () => {
   const valid = overrideComment();
   assert.ok(releaseNotes.parseOverrideComment(valid));
+  assert.equal(
+    releaseNotes.parseOverrideComment(overrideComment({ mainHead: MAIN_HEAD })).metadata['release-main-head'],
+    MAIN_HEAD,
+  );
 
   // Missing prefix: body does not start with the marker at byte 0.
   assert.equal(releaseNotes.parseOverrideComment({ ...valid, body: `noise\n${valid.body}` }), null);

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -731,7 +731,7 @@ test('prepare apply rejects a draft from a rewritten release branch with unchang
 
   await assert.rejects(
     releaseNotes.prepareApply({ github, owner: 'langchain-ai', repo: 'deepagents', number: 123, expectedHead: rewrittenHead, changelogFile: workspace.file, stateFile: path.join(workspace.root, 'state.json'), ...BOT_AUTH }),
-    /Release PR was rewritten after drafting; run @release-bot draft before apply/,
+    /The release PR was rewritten after drafting; run @release-bot draft before apply/,
   );
 });
 
@@ -798,7 +798,7 @@ test('prepare apply requires a new scoped draft when main changed the package', 
       stateFile: path.join(workspace.root, 'state.json'),
       ...BOT_AUTH,
     }),
-    /draft no longer covers current deepagents-code changes on main; run @release-bot draft before apply/,
+    /main has new libs\/code changes since this draft; run @release-bot draft before apply/,
   );
 });
 
@@ -1439,6 +1439,10 @@ test('required check fails when the applied draft is not based on the latest ove
   const core = makeCore();
   await releaseNotes.checkCuratedState({ github, context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } }, core, number: 123, ...BOT_AUTH });
   assert.match(core.failed, /not based on the latest curated draft/);
+  // This is a legacy draft, so the coverage failure is release-branch ancestry.
+  // main never moved here; it must not be blamed for the staleness.
+  assert.match(core.failed, /the release branch was rewritten after drafting/);
+  assert.doesNotMatch(core.failed, /main has new/);
 });
 
 test('required check fails when the applied commit is not an ancestor of the head', async () => {

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -169,11 +169,22 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
           const content = files.get(params.ref) ?? fallback;
           return { data: { type: 'file', encoding: 'base64', content: Buffer.from(content).toString('base64') } };
         },
-        compareCommitsWithBasehead: async params => ({
-          data: typeof comparison === 'function'
+        compareCommitsWithBasehead: async params => {
+          const raw = typeof comparison === 'function'
             ? comparison(params)
-            : { status: comparison, files: changedFiles },
-        }),
+            : { status: comparison, files: changedFiles };
+          // Fixtures that only pin status/files still have to satisfy the
+          // truncation guard, so default them to a complete commit list. An
+          // explicit total_commits/commits in the fixture wins.
+          const count = Math.max(1, (raw.files ?? []).length);
+          return {
+            data: {
+              total_commits: count,
+              commits: Array.from({ length: count }, (_, index) => ({ sha: `commit-${index}` })),
+              ...raw,
+            },
+          };
+        },
       },
       git: {
         getCommit: async params => {
@@ -2541,4 +2552,88 @@ test('the component registry fails closed on a malformed release-please config',
   }));
   assert.equal(slashed.get('x').packagePath, 'libs/x');
   assert.equal(slashed.get('x').changelogPath, 'libs/x/CHANGELOG.md');
+});
+
+// comparisonLeavesPackageUnchanged decides whether a curated draft still covers
+// main. Its wrong answer is silent: a false "unchanged" ships stale prose behind
+// a green gate, so each fail-closed branch is pinned individually here rather
+// than reached incidentally through the apply and check flows.
+test('comparisonLeavesPackageUnchanged proves unchanged only for a complete, in-range comparison', () => {
+  const unchanged = releaseNotes.comparisonLeavesPackageUnchanged;
+  const complete = (files, extra = {}) => ({
+    status: 'ahead',
+    total_commits: 2,
+    commits: [{ sha: 'a' }, { sha: 'b' }],
+    files,
+    ...extra,
+  });
+
+  // Positive case: a complete comparison touching nothing in the package.
+  assert.equal(unchanged(complete([{ filename: 'libs/other/app.py' }]), 'libs/code'), true);
+  assert.equal(unchanged(complete([]), 'libs/code'), true);
+  // An identical comparison short-circuits before any file inspection.
+  assert.equal(unchanged({ status: 'identical' }, 'libs/code'), true);
+
+  // A file inside the package, including the package directory itself.
+  assert.equal(unchanged(complete([{ filename: 'libs/code/app.py' }]), 'libs/code'), false);
+  assert.equal(unchanged(complete([{ filename: 'libs/code' }]), 'libs/code'), false);
+  // A sibling sharing the name as a prefix is a different package.
+  assert.equal(unchanged(complete([{ filename: 'libs/code-server/app.py' }]), 'libs/code'), true);
+
+  // A rename out of the package is invisible via `filename` alone.
+  assert.equal(
+    unchanged(complete([{ filename: 'libs/other/app.py', previous_filename: 'libs/code/app.py' }]), 'libs/code'),
+    false,
+  );
+
+  // Non-ahead statuses mean main moved backwards or was rewritten.
+  for (const status of ['diverged', 'behind', undefined]) {
+    assert.equal(unchanged(complete([], { status }), 'libs/code'), false, `status ${status}`);
+  }
+
+  // Truncated commit list: the file list describes only part of the range.
+  assert.equal(
+    unchanged({ status: 'ahead', total_commits: 250, commits: [{ sha: 'a' }], files: [] }, 'libs/code'),
+    false,
+  );
+  assert.equal(unchanged({ status: 'ahead', commits: [{ sha: 'a' }], files: [] }, 'libs/code'), false);
+  assert.equal(unchanged({ status: 'ahead', total_commits: 1, files: [] }, 'libs/code'), false);
+
+  // File list at GitHub's cap may omit a package path.
+  const capped = Array.from({ length: 300 }, (_, index) => ({ filename: `libs/other/f${index}.py` }));
+  assert.equal(unchanged(complete(capped), 'libs/code'), false);
+  assert.equal(unchanged(complete(capped.slice(0, 299)), 'libs/code'), true);
+
+  // Missing or malformed file entries cannot be ruled out as the package path.
+  assert.equal(unchanged(complete(undefined), 'libs/code'), false);
+  assert.equal(unchanged(complete([{}]), 'libs/code'), false);
+  assert.equal(unchanged(complete([{ filename: null }]), 'libs/code'), false);
+});
+
+test('a failed package comparison names the comparison and the remedy', async () => {
+  const pr = releasePr({ base: { ...releasePr().base, sha: NEXT_MAIN_HEAD } });
+  const comparison = () => { throw new Error('Not Found'); };
+  const { github } = makeGithub({
+    pr,
+    comments: [overrideComment({ mainHead: MAIN_HEAD }), appliedComment()],
+    comparison,
+  });
+  const core = makeCore();
+  await assert.rejects(
+    releaseNotes.checkCuratedState({
+      github,
+      context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+      core,
+      number: 123,
+      ...BOT_AUTH,
+    }),
+    error => {
+      assert.match(error.message, /Could not compare/);
+      assert.match(error.message, new RegExp(`${MAIN_HEAD}\\.\\.\\.${NEXT_MAIN_HEAD}`));
+      assert.match(error.message, /libs\/code/);
+      assert.match(error.message, /Not Found/);
+      assert.match(error.message, /@release-bot draft/);
+      return true;
+    },
+  );
 });

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -2481,4 +2481,13 @@ test('the component registry fails closed on a malformed release-please config',
     packages: { 'libs/x': { component: 'x' } },
   }));
   assert.equal(registry.get('x').changelogPath, 'libs/x/CHANGELOG.md');
+  assert.equal(registry.get('x').packagePath, 'libs/x');
+  // A trailing slash in the config key must not survive into packagePath. An
+  // unnormalized `libs/x/` prefix matches no compare-API filename, so every
+  // package change would read as unrelated and no draft would ever go stale.
+  const slashed = releaseNotes.loadComponentRegistry(write('slash.json', {
+    packages: { 'libs/x/': { component: 'x' } },
+  }));
+  assert.equal(slashed.get('x').packagePath, 'libs/x');
+  assert.equal(slashed.get('x').changelogPath, 'libs/x/CHANGELOG.md');
 });

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -694,6 +694,53 @@ test('apply rejects main advancing after its package-scope snapshot', async t =>
   assert.equal(run.calls.updateRef.length, 0);
 });
 
+test('apply publishes its metadata when main advances after the commit landed', async t => {
+  const workspace = tempWorkspace();
+  t.after(() => fs.rmSync(workspace.root, { recursive: true, force: true }));
+  const stateFile = path.join(workspace.root, 'apply.json');
+  const run = makeGithub({ comments: [overrideComment()] });
+  await releaseNotes.prepareApply({
+    github: run.github,
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    number: 123,
+    expectedHead: HEAD,
+    changelogFile: workspace.file,
+    stateFile,
+    ...BOT_AUTH,
+  });
+  await releaseNotes.createApplyCommit({
+    github: run.github,
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    stateFile,
+    changelogFile: workspace.file,
+    ...BOT_AUTH,
+  });
+  assert.equal(run.calls.updateRef.length, 1);
+  // The apply commit is a branch push, so GitHub snaps base.sha to main's tip.
+  // The changelog commit has already landed; withholding the applied comment and
+  // the body mirror here would strand it and fail the gate for no defect.
+  run.setPr(releasePr({
+    head: { ...releasePr().head, sha: APPLIED_HEAD },
+    base: { ...releasePr().base, sha: NEXT_MAIN_HEAD },
+  }));
+
+  await releaseNotes.publishAppliedState({
+    github: run.github,
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    stateFile,
+    appliedHead: APPLIED_HEAD,
+    ...BOT_AUTH,
+  });
+  assert.equal(run.calls.updatePr.length, 1);
+  assert.equal(run.calls.createComment.length, 1);
+  const parsed = releaseNotes.parseAppliedComment({ body: run.calls.createComment[0].body });
+  assert.ok(parsed, 'applied comment should parse');
+  assert.equal(parsed.metadata['applied-head'], APPLIED_HEAD);
+});
+
 test('prepare apply preserves the generated release heading', async t => {
   const workspace = tempWorkspace();
   t.after(() => fs.rmSync(workspace.root, { recursive: true, force: true }));

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -174,13 +174,12 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
             ? comparison(params)
             : { status: comparison, files: changedFiles };
           // Fixtures that only pin status/files still have to satisfy the
-          // truncation guard, so default them to a complete commit list. An
+          // truncation guard, so default them to a complete one-commit list. An
           // explicit total_commits/commits in the fixture wins.
-          const count = Math.max(1, (raw.files ?? []).length);
           return {
             data: {
-              total_commits: count,
-              commits: Array.from({ length: count }, (_, index) => ({ sha: `commit-${index}` })),
+              total_commits: 1,
+              commits: [{ sha: 'commit-0' }],
               ...raw,
             },
           };
@@ -789,7 +788,7 @@ test('prepare apply rejects a draft from a rewritten release branch with unchang
 
   await assert.rejects(
     releaseNotes.prepareApply({ github, owner: 'langchain-ai', repo: 'deepagents', number: 123, expectedHead: rewrittenHead, changelogFile: workspace.file, stateFile: path.join(workspace.root, 'state.json'), ...BOT_AUTH }),
-    /The release PR was rewritten after drafting; run @release-bot draft before apply/,
+    /the release branch was rewritten after drafting; run @release-bot draft before apply/,
   );
 });
 


### PR DESCRIPTION
Curated release-note drafts now remain valid when new `main` commits do not touch the package being released.

---

Release-please refreshes every open release PR after changes land on `main`, and the lockfile updater can advance those branches even when the released package is unaffected. Binding draft freshness only to release-branch ancestry therefore forces maintainers to regenerate unchanged prose.

Record the `main` SHA in each new draft and compare later `main` changes against the package directory. Package changes still require `draft` and `apply`; unrelated refreshes require only `apply` if they overwrite already-applied notes. Legacy drafts retain the ancestry check, and incomplete or oversized comparisons fail closed.