### PR TITLE
fix(ci): skip repeated runs on curated changelogs

### DIFF
--- a/.github/scripts/checks/curated_apply_only.py
+++ b/.github/scripts/checks/curated_apply_only.py
@@ -1,0 +1,130 @@
+"""Detect a trusted release-bot commit that only updates one managed changelog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path, PurePosixPath
+
+BRANCH_PREFIX = "release-please--branches--main--components--"
+COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a read-only git command."""
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _changelog_path(config_path: Path, component: str) -> str | None:
+    """Resolve one component's changelog from release-please configuration."""
+    config = json.loads(config_path.read_text())
+    if not isinstance(config, dict):
+        return None
+    packages = config.get("packages")
+    if not isinstance(packages, dict):
+        return None
+    matches = []
+    for package_path, metadata in packages.items():
+        if not isinstance(package_path, str) or not isinstance(metadata, dict):
+            return None
+        if metadata.get("component") != component:
+            continue
+        changelog = metadata.get("changelog-path", "CHANGELOG.md")
+        normalized_package = package_path.rstrip("/")
+        if not isinstance(changelog, str) or not normalized_package:
+            return None
+        raw_parts = normalized_package.split("/") + changelog.split("/")
+        if normalized_package.startswith("/") or changelog.startswith("/"):
+            return None
+        if any(part in {"", ".", ".."} for part in raw_parts):
+            return None
+        target = PurePosixPath(normalized_package, changelog)
+        if target.is_absolute() or any(
+            part in {"", ".", ".."} for part in target.parts
+        ):
+            return None
+        matches.append(target.as_posix())
+    return matches[0] if len(matches) == 1 else None
+
+
+def is_curated_apply_only(
+    *,
+    repo: Path,
+    config_path: Path,
+    head: str,
+    branch: str,
+    bot_login: str,
+    bot_id: str,
+) -> bool:
+    """Return whether HEAD is the bot's single-changelog apply commit."""
+    if not branch.startswith(BRANCH_PREFIX) or not bot_id.isdigit():
+        return False
+    component = branch.removeprefix(BRANCH_PREFIX)
+    if not COMPONENT_PATTERN.fullmatch(component):
+        return False
+    changelog = _changelog_path(config_path, component)
+    if changelog is None:
+        return False
+    metadata = (
+        _git(repo, "show", "-s", "--format=%an%x00%ae%x00%P%x00%s", head)
+        .rstrip("\n")
+        .split("\0")
+    )
+    if len(metadata) != 4:
+        return False
+    author, email, parents, subject = metadata
+    if len(parents.split()) != 1:
+        return False
+    expected_email = f"{bot_id}+{bot_login}@users.noreply.github.com"
+    expected_subject = f"chore({component}): apply curated release notes"
+    if (author, email, subject) != (bot_login, expected_email, expected_subject):
+        return False
+    changed = _git(
+        repo, "diff-tree", "--no-commit-id", "--name-only", "-r", head
+    ).splitlines()
+    modified = _git(
+        repo,
+        "diff-tree",
+        "--no-commit-id",
+        "--diff-filter=M",
+        "--name-only",
+        "-r",
+        head,
+    ).splitlines()
+    return changed == [changelog] and modified == [changelog]
+
+
+def main() -> int:
+    """Print a GitHub Actions boolean and fail closed on invalid state."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--bot-login", required=True)
+    parser.add_argument("--bot-id", required=True)
+    args = parser.parse_args()
+    try:
+        result = is_curated_apply_only(
+            repo=args.repo,
+            config_path=args.config,
+            head=args.head,
+            branch=args.branch,
+            bot_login=args.bot_login,
+            bot_id=args.bot_id,
+        )
+    except (OSError, ValueError, json.JSONDecodeError, subprocess.SubprocessError):
+        result = False
+    print(str(result).lower())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/checks/test_curated_apply_only.py
+++ b/.github/scripts/tests/checks/test_curated_apply_only.py
@@ -1,0 +1,118 @@
+"""Tests for changelog-only curated release-note apply detection."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from curated_apply_only import is_curated_apply_only
+
+BOT_LOGIN = "release-bot[bot]"
+BOT_ID = "12345"
+COMPONENT = "example"
+BRANCH = f"release-please--branches--main--components--{COMPONENT}"
+
+
+def _run(repo: Path, *args: str) -> str:
+    env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_NOSYSTEM": "1"}
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+
+
+def _commit(repo: Path, message: str, *, bot: bool = True) -> str:
+    if bot:
+        _run(repo, "config", "user.name", BOT_LOGIN)
+        _run(
+            repo,
+            "config",
+            "user.email",
+            f"{BOT_ID}+{BOT_LOGIN}@users.noreply.github.com",
+        )
+    else:
+        _run(repo, "config", "user.name", "Maintainer")
+        _run(repo, "config", "user.email", "maintainer@example.com")
+    _run(repo, "add", ".")
+    _run(repo, "commit", "-m", message)
+    return _run(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    _run(repository, "init", "-b", "main")
+    _run(repository, "config", "user.name", "Maintainer")
+    _run(repository, "config", "user.email", "maintainer@example.com")
+    (repository / "pkg").mkdir()
+    (repository / "pkg" / "CHANGELOG.md").write_text("generated\n")
+    (repository / "pkg" / "source.py").write_text("value = 1\n")
+    (repository / "release-please-config.json").write_text(
+        json.dumps({"packages": {"pkg": {"component": COMPONENT}}})
+    )
+    _commit(repository, "initial", bot=False)
+    return repository
+
+
+def _detect(repo: Path, head: str) -> bool:
+    return is_curated_apply_only(
+        repo=repo,
+        config_path=repo / "release-please-config.json",
+        head=head,
+        branch=BRANCH,
+        bot_login=BOT_LOGIN,
+        bot_id=BOT_ID,
+    )
+
+
+def test_accepts_bot_apply_that_only_modifies_managed_changelog(repo: Path) -> None:
+    (repo / "pkg" / "CHANGELOG.md").write_text("curated\n")
+    head = _commit(repo, f"chore({COMPONENT}): apply curated release notes")
+
+    assert _detect(repo, head) is True
+
+
+@pytest.mark.parametrize(
+    "failure", ["message", "author", "extra-file", "added-changelog"]
+)
+def test_rejects_untrusted_or_non_changelog_only_commits(
+    repo: Path, failure: str
+) -> None:
+    if failure == "added-changelog":
+        (repo / "pkg" / "CHANGELOG.md").unlink()
+        _commit(repo, "remove changelog", bot=False)
+    (repo / "pkg" / "CHANGELOG.md").write_text("curated\n")
+    if failure == "extra-file":
+        (repo / "pkg" / "source.py").write_text("value = 2\n")
+    message = (
+        "not an apply"
+        if failure == "message"
+        else f"chore({COMPONENT}): apply curated release notes"
+    )
+    head = _commit(repo, message, bot=failure != "author")
+
+    assert _detect(repo, head) is False
+
+
+def test_rejects_configured_path_traversal(repo: Path) -> None:
+    (repo / "release-please-config.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "pkg": {"component": COMPONENT, "changelog-path": "../source.py"}
+                }
+            }
+        )
+    )
+    _commit(repo, "malformed config", bot=False)
+    (repo / "pkg" / "CHANGELOG.md").write_text("curated\n")
+    head = _commit(repo, f"chore({COMPONENT}): apply curated release notes")
+
+    assert _detect(repo, head) is False

--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -210,6 +210,42 @@ def test_ci_success_builds_named_results_from_needs_object() -> None:
     assert "talon-failure-advisory" not in workflow["jobs"]["ci_success"]["needs"]
 
 
+def test_curated_apply_only_requires_bot_commit_and_green_parent_ci() -> None:
+    workflow = _load_workflow(CI_WORKFLOW)
+    changes = workflow["jobs"]["changes"]
+    step = _find_step(
+        workflow,
+        job="changes",
+        name="📝 Detect a changelog-only curated-notes apply",
+    )
+
+    assert changes["outputs"]["curated-apply-only"] == (
+        "${{ steps.curated-apply.outputs.only || 'false' }}"
+    )
+    assert workflow["concurrency"]["cancel-in-progress"] == (
+        "${{ !startsWith(github.head_ref, "
+        "'release-please--branches--main--components--') }}"
+    )
+    assert "github.actor == vars.RELEASE_BOT_LOGIN" in step["if"]
+    assert "head.repo.full_name == github.repository" in step["if"]
+    assert "curated_apply_only.py" in step["run"]
+    assert "commits/$parent/check-runs" in step["run"]
+    assert "✅ CI Success" in step["run"]
+    assert "success|failure" in step["run"]
+
+    gate = _find_step(workflow, job="ci_success", name="🎉 All Checks Passed")
+    assert gate["env"]["CURATED_APPLY_ONLY"] == (
+        "${{ needs.changes.outputs.curated-apply-only }}"
+    )
+    assert 'if [ "$CURATED_APPLY_ONLY" = true ]' in gate["run"]
+    assert 'if [ "$CURATED_APPLY_PARENT_CONCLUSION" = success ]' in gate["run"]
+
+    helper_job = workflow["jobs"]["check-release-options"]
+    assert helper_job["needs"] == "changes"
+    assert helper_job["if"] == "needs.changes.outputs.curated-apply-only != 'true'"
+    assert workflow["jobs"]["ci_success"]["if"] == "always()"
+
+
 def test_ci_success_runs_gate_script_from_trusted_base_ref() -> None:
     """The gate script must not come from the untrusted PR checkout.
 

--- a/.github/scripts/tests/workflows/test_ci_workflow.py
+++ b/.github/scripts/tests/workflows/test_ci_workflow.py
@@ -222,13 +222,31 @@ def test_curated_apply_only_requires_bot_commit_and_green_parent_ci() -> None:
     assert changes["outputs"]["curated-apply-only"] == (
         "${{ steps.curated-apply.outputs.only || 'false' }}"
     )
-    assert workflow["concurrency"]["cancel-in-progress"] == (
-        "${{ !startsWith(github.head_ref, "
-        "'release-please--branches--main--components--') }}"
-    )
+    cancellation = workflow["concurrency"]["cancel-in-progress"]
+    assert "github.event_name != 'pull_request'" in cancellation
+    assert "github.actor != vars.RELEASE_BOT_LOGIN" in cancellation
+    assert "head.repo.full_name != github.repository" in cancellation
+    assert "!startsWith(github.head_ref" in cancellation
     assert "github.actor == vars.RELEASE_BOT_LOGIN" in step["if"]
     assert "head.repo.full_name == github.repository" in step["if"]
-    assert "curated_apply_only.py" in step["run"]
+
+    checkout = _find_step(
+        workflow, job="changes", name="📋 Checkout detector from trusted base ref"
+    )
+    assert checkout["with"]["ref"] == "${{ github.base_ref }}"
+    assert checkout["with"]["path"] == ".curated-apply-base"
+    assert checkout["with"]["persist-credentials"] is False
+    assert (
+        ".github/scripts/checks/curated_apply_only.py"
+        in checkout["with"]["sparse-checkout"]
+    )
+    assert "release-please-config.json" in checkout["with"]["sparse-checkout"]
+    assert (
+        ".curated-apply-base/.github/scripts/checks/curated_apply_only.py"
+        in step["run"]
+    )
+    assert '--repo "$GITHUB_WORKSPACE"' in step["run"]
+    assert "--config .curated-apply-base/release-please-config.json" in step["run"]
     assert "commits/$parent/check-runs" in step["run"]
     assert "✅ CI Success" in step["run"]
     assert "success|failure" in step["run"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,17 @@ on:
   pull_request:
   merge_group:
 
-# Cancel redundant workflow runs
+# Cancel redundant workflow runs, except trusted release-bot PR updates whose
+# new head may need to inspect the prior run before it finishes.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.head_ref, 'release-please--branches--main--components--') }}
+  cancel-in-progress: >-
+    ${{
+      github.event_name != 'pull_request' ||
+      github.actor != vars.RELEASE_BOT_LOGIN ||
+      github.event.pull_request.head.repo.full_name != github.repository ||
+      !startsWith(github.head_ref, 'release-please--branches--main--components--')
+    }}
 
 # `pull-requests: read` lets the called `_test.yml` reusable workflow read live
 # PR labels (re-runs replay the original event payload, so the API is the only
@@ -62,6 +69,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: "📋 Checkout detector from trusted base ref"
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor == vars.RELEASE_BOT_LOGIN &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'release-please--branches--main--components--')
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.base_ref }}
+          path: .curated-apply-base
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts/checks/curated_apply_only.py
+            release-please-config.json
+
       - name: "📝 Detect a changelog-only curated-notes apply"
         id: curated-apply
         if: >-
@@ -76,8 +98,9 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          only="$(python3 .github/scripts/checks/curated_apply_only.py \
-            --config release-please-config.json \
+          only="$(python3 .curated-apply-base/.github/scripts/checks/curated_apply_only.py \
+            --repo "$GITHUB_WORKSPACE" \
+            --config .curated-apply-base/release-please-config.json \
             --head "$HEAD_SHA" \
             --branch "$HEAD_REF" \
             --bot-login "$BOT_LOGIN" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
 # Cancel redundant workflow runs
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !startsWith(github.head_ref, 'release-please--branches--main--components--') }}
 
 # `pull-requests: read` lets the called `_test.yml` reusable workflow read live
 # PR labels (re-runs replay the original event payload, so the API is the only
@@ -26,6 +26,7 @@ concurrency:
 # The issues labels endpoint it uses accepts either `issues: read` or
 # `pull-requests: read`, so no `issues` grant is needed here.
 permissions:
+  checks: read
   contents: read
   pull-requests: read
 
@@ -38,26 +39,67 @@ jobs:
     name: "🔍 Detect Changes"
     runs-on: ubuntu-latest
     outputs:
-      deepagents: ${{ steps.filter.outputs.deepagents }}
-      code: ${{ steps.filter.outputs.code }}
-      talon: ${{ steps.filter.outputs.talon }}
+      deepagents: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.deepagents == 'true' }}
+      code: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.code == 'true' }}
+      talon: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.talon == 'true' }}
       # `talon-src` tracks only libs/talon/** so the `ci_success` waiver and
       # the advisory job can tell "PR touches talon sources" apart from
       # "talon CI runs" (the broad `talon` filter above also matches
       # libs/code and libs/deepagents because talon editable-installs them).
-      talon-src: ${{ steps.filter.outputs.talon-src }}
-      evals: ${{ steps.filter.outputs.evals }}
-      acp: ${{ steps.filter.outputs.acp }}
-      daytona: ${{ steps.filter.outputs.daytona }}
-      modal: ${{ steps.filter.outputs.modal }}
-      runloop: ${{ steps.filter.outputs.runloop }}
-      vercel: ${{ steps.filter.outputs.vercel }}
-      quickjs: ${{ steps.filter.outputs.quickjs }}
+      talon-src: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.talon-src == 'true' }}
+      evals: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.evals == 'true' }}
+      acp: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.acp == 'true' }}
+      daytona: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.daytona == 'true' }}
+      modal: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.modal == 'true' }}
+      runloop: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.runloop == 'true' }}
+      vercel: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.vercel == 'true' }}
+      quickjs: ${{ steps.curated-apply.outputs.only != 'true' && steps.filter.outputs.quickjs == 'true' }}
+      curated-apply-only: ${{ steps.curated-apply.outputs.only || 'false' }}
+      curated-apply-parent-conclusion: ${{ steps.curated-apply.outputs.prior-conclusion }}
     steps:
       - name: "📋 Checkout Code"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+
+      - name: "📝 Detect a changelog-only curated-notes apply"
+        id: curated-apply
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor == vars.RELEASE_BOT_LOGIN &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'release-please--branches--main--components--')
+        env:
+          BOT_LOGIN: ${{ vars.RELEASE_BOT_LOGIN }}
+          BOT_ID: ${{ vars.RELEASE_BOT_ID }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          only="$(python3 .github/scripts/checks/curated_apply_only.py \
+            --config release-please-config.json \
+            --head "$HEAD_SHA" \
+            --branch "$HEAD_REF" \
+            --bot-login "$BOT_LOGIN" \
+            --bot-id "$BOT_ID")"
+          if [ "$only" = true ]; then
+            parent="$(git rev-parse "$HEAD_SHA^")"
+            conclusion="$(gh api \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/$GITHUB_REPOSITORY/commits/$parent/check-runs?check_name=%E2%9C%85%20CI%20Success&filter=latest&per_page=100" \
+              --jq '[.check_runs[] | select(.name == "✅ CI Success")] | if length == 1 then .[0].conclusion else "" end' \
+              2>/dev/null || true)"
+            case "$conclusion" in
+              success|failure) ;;
+              *)
+                only=false
+                conclusion=''
+                echo "Prior CI is not conclusive; running the normal package jobs."
+                ;;
+            esac
+          fi
+          echo "only=$only" >> "$GITHUB_OUTPUT"
+          echo "prior-conclusion=${conclusion:-}" >> "$GITHUB_OUTPUT"
 
       - name: "🔍 Check for changes"
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
@@ -483,6 +525,8 @@ jobs:
   # are kept for branch-protection compatibility; rename only with a coordinated PR.
   check-release-options:
     name: "Validate Release Options"
+    needs: changes
+    if: needs.changes.outputs.curated-apply-only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -512,7 +556,11 @@ jobs:
   talon-failure-advisory:
     name: "⚠️ talon failure advisory"
     needs: [changes, lint-talon, test-talon]
-    if: always() && github.event_name == 'pull_request' && needs.changes.outputs.talon-src != 'true'
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.curated-apply-only != 'true' &&
+      needs.changes.outputs.talon-src != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -691,6 +739,8 @@ jobs:
       - name: "🎉 All Checks Passed"
         env:
           EVENT_NAME: ${{ github.event_name }}
+          CURATED_APPLY_ONLY: ${{ needs.changes.outputs.curated-apply-only }}
+          CURATED_APPLY_PARENT_CONCLUSION: ${{ needs.changes.outputs.curated-apply-parent-conclusion }}
           # Full needs context: the wildcard `toJSON(needs.*.result)` form
           # loses job names (it yields a bare array of result strings), so
           # the name -> result map is rebuilt from each entry below. Skipped
@@ -699,6 +749,14 @@ jobs:
           TALON_CHANGED: ${{ needs.changes.outputs.talon-src }}
         run: |
           set -euo pipefail
+          if [ "$CURATED_APPLY_ONLY" = true ]; then
+            if [ "$CURATED_APPLY_PARENT_CONCLUSION" = success ]; then
+              echo "The release-bot commit only updates the managed changelog; prior-head CI passed."
+              exit 0
+            fi
+            echo "Prior-head CI failed; refusing to pass the changelog-only apply commit."
+            exit 1
+          fi
           # Get all job results (excluding 'changes' which always succeeds)
           results="$(printf '%s' "$NEEDS" | python3 -c '
           import json


### PR DESCRIPTION
Curated release-note applies no longer rerun unchanged package CI after the prior release head has passed.

---

A bot-authored `apply curated release notes` commit only changes the managed package `CHANGELOG.md`, but it currently restarts package CI and cancels the in-flight run it depends on.

Queue CI runs for release-please branches, recognize only the trusted bot's exact single-changelog apply commit, and carry forward the completed parent `CI Success` result. Any identity, path, commit-shape, configuration, or parent-check mismatch fails closed to normal CI.

Made by [Open SWE](https://openswe.vercel.app/agents/b0abb0d0-8090-5c48-a575-f888f4f8ee06)
