### PR TITLE
fix(ci): hide superseded release-note warnings

### DIFF
--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -1207,15 +1207,15 @@ async function warnForNewEntries({ github, owner, repo, number, comments, head, 
     comment.user?.type === 'Bot' &&
     (comment.body ?? '').startsWith(`${STALE_MARKER}\n`),
   );
-  let current = warnings.find(comment => (comment.body ?? '').startsWith(marker));
+  const newest = [...warnings]
+    .sort((left, right) => Number(right.id) - Number(left.id))[0];
+  let current = newest && (newest.body ?? '').startsWith(marker) ? newest : null;
   if (!current) {
     const response = await createComment(github, owner, repo, number, newEntriesWarningBody(marker));
     current = response.data;
   }
-  const newest = [...warnings, current]
-    .sort((left, right) => Number(right.id) - Number(left.id))[0];
   for (const warning of warnings) {
-    if (warning.id !== newest.id) await minimizeComment(github, warning);
+    if (warning.id !== current.id) await minimizeComment(github, warning);
   }
 }
 

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -16,6 +16,7 @@ const DEFAULT_CHANGELOG = 'CHANGELOG.md';
 const COMPONENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const BYPASS_LABEL = 'release: dangerously skip curated notes';
 const COMMAND_MENTION = '@release-bot';
+const WORKFLOW_BOT_LOGIN = 'github-actions[bot]';
 const OVERRIDE_MARKER = 'release-notes-override';
 const APPLIED_MARKER = 'release-notes-applied';
 // GitHub's compare response lists at most 300 changed files and does not
@@ -1195,16 +1196,54 @@ async function draftCoversCurrentPackage({ github, owner, repo, override, pr, pa
   return comparisonLeavesPackageUnchanged(response.data, packagePath);
 }
 
+// A changed head/fingerprint needs a fresh timeline entry, but older notices no
+// longer need to compete for attention. Preserve them as an audit trail and mark
+// them outdated through GitHub's Hide API. The author checks are load-bearing:
+// contributor-authored copies of the marker must never become mutation targets.
 async function warnForNewEntries({ github, owner, repo, number, comments, head, fingerprint }) {
   const marker = `${STALE_MARKER}\nhead: ${head}\nchangelog-fingerprint: ${fingerprint}\n-->`;
-  if (comments.some(comment => (comment.body ?? '').startsWith(marker))) return;
-  await createComment(
-    github,
-    owner,
-    repo,
-    number,
-    `${marker}\nNew generated release entries appeared; please re-run \`${COMMAND_MENTION} draft\` and then \`${COMMAND_MENTION} apply\`.`,
+  const warnings = comments.filter(comment =>
+    comment.user?.login === WORKFLOW_BOT_LOGIN &&
+    comment.user?.type === 'Bot' &&
+    (comment.body ?? '').startsWith(`${STALE_MARKER}\n`),
   );
+  let current = warnings.find(comment => (comment.body ?? '').startsWith(marker));
+  if (!current) {
+    const response = await createComment(github, owner, repo, number, newEntriesWarningBody(marker));
+    current = response.data;
+  }
+  const newest = [...warnings, current]
+    .sort((left, right) => Number(right.id) - Number(left.id))[0];
+  for (const warning of warnings) {
+    if (warning.id !== newest.id) await minimizeComment(github, warning);
+  }
+}
+
+function newEntriesWarningBody(marker) {
+  return [
+    marker,
+    'New generated release entries appeared; please re-run:',
+    '',
+    '```',
+    `${COMMAND_MENTION} draft`,
+    '```',
+    '',
+    'and then:',
+    '',
+    '```',
+    `${COMMAND_MENTION} apply`,
+    '```',
+  ].join('\n');
+}
+
+async function minimizeComment(github, comment) {
+  await github.graphql(`
+    mutation($id: ID!) {
+      minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+        minimizedComment { isMinimized }
+      }
+    }
+  `, { id: comment.node_id });
 }
 
 // Surface (logs only) bot-authored comments that carry a curated-notes marker
@@ -1393,7 +1432,7 @@ async function checkCuratedState({
         }
       }
     }
-    core.warning(`Could not post the new-entries warning comment: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+    core.warning(`Could not update the new-entries warning comments: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
   };
   if (!applied) {
     await maybeWarnNewEntries();

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -1282,6 +1282,35 @@ test('the newest new-entries warning hides prior bot warnings and uses copyable 
   }
 });
 
+test('returning to an older warned state creates a fresh visible warning', async () => {
+  const newGenerated = GENERATED_SECTION.replace('useful feature', 'new generated entry');
+  const changedHead = 'd'.repeat(40);
+  const fingerprint = releaseNotes.changelogFingerprint(newGenerated);
+  const pr = releasePr({
+    head: { ...releasePr().head, sha: changedHead },
+    body: `Release notes preview\n\n${newGenerated}\n_End release notes preview._\n`,
+  });
+  const comments = [
+    overrideComment(),
+    staleWarningComment({ id: 30, head: changedHead, fingerprint }),
+    staleWarningComment({ id: 31, head: 'e'.repeat(40), fingerprint: 'newer-state' }),
+  ];
+  const files = new Map([[changedHead, changelog(newGenerated)]]);
+  const { github, calls } = makeGithub({ pr, comments, commentUser: WORKFLOW_BOT, files });
+
+  await releaseNotes.checkCuratedState({
+    github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core: makeCore(),
+    number: 123,
+    ...BOT_AUTH,
+  });
+
+  assert.equal(calls.createComment.length, 1);
+  assert.match(calls.createComment[0].body, new RegExp(`^<!-- release-notes-stale\\nhead: ${changedHead}\\nchangelog-fingerprint: ${fingerprint}\\n-->`));
+  assert.deepEqual(calls.graphql.map(call => call.variables.id), ['IC_30', 'IC_31']);
+});
+
 test('draft, unmanaged branch, and bypass label pass without metadata', async () => {
   for (const pr of [
     releasePr({ draft: true }),

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -10,6 +10,7 @@ const releaseNotes = require('../../release/release-notes.js');
 
 const APP_SLUG = 'release-notes-bot';
 const BOT = { login: `${APP_SLUG}[bot]`, id: 42 };
+const WORKFLOW_BOT = { login: 'github-actions[bot]', id: 41898282, type: 'Bot' };
 const BOT_AUTH = { appSlug: APP_SLUG, login: BOT.login, id: BOT.id };
 const COMPONENT = 'deepagents-code';
 const RELEASE_BRANCH = `${releaseNotes.RELEASE_BRANCH_PREFIX}${COMPONENT}`;
@@ -94,6 +95,21 @@ function appliedComment({ id = 20, overrideId = 10, overrideUpdatedAt = OVERRIDE
   };
 }
 
+function staleWarningComment({ id, head, fingerprint, user = WORKFLOW_BOT }) {
+  return {
+    id,
+    node_id: `IC_${id}`,
+    user,
+    body: [
+      '<!-- release-notes-stale',
+      `head: ${head}`,
+      `changelog-fingerprint: ${fingerprint}`,
+      '-->',
+      'New generated release entries appeared.',
+    ].join('\n'),
+  };
+}
+
 function makeCore() {
   return {
     failed: null,
@@ -105,7 +121,7 @@ function makeCore() {
   };
 }
 
-function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adminFlag = permission === 'admin', appUser = BOT, files = new Map(), comparison = 'ahead', changedFiles = [], malformedContent = false, onGetPr = null, onListComments = null, onCreateComment = null } = {}) {
+function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adminFlag = permission === 'admin', appUser = BOT, commentUser = BOT, files = new Map(), comparison = 'ahead', changedFiles = [], malformedContent = false, onGetPr = null, onListComments = null, onCreateComment = null } = {}) {
   const calls = {
     createBlob: [],
     createComment: [],
@@ -115,6 +131,7 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
     getCommit: [],
     getContent: [],
     getRef: [],
+    graphql: [],
     updateComment: [],
     updatePr: [],
     updateRef: [],
@@ -146,7 +163,8 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
         createComment: async params => {
           calls.createComment.push(params);
           if (onCreateComment) onCreateComment({ count: calls.createComment.length, params });
-          const comment = { id: 100 + calls.createComment.length, updated_at: APPLIED_UPDATED_AT, user: BOT, body: params.body };
+          const id = 100 + calls.createComment.length;
+          const comment = { id, node_id: `IC_${id}`, updated_at: APPLIED_UPDATED_AT, user: commentUser, body: params.body };
           comments.push(comment);
           return { data: comment };
         },
@@ -219,6 +237,10 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
           return { data: appUser };
         },
       },
+    },
+    graphql: async (query, variables) => {
+      calls.graphql.push({ query, variables });
+      return { minimizeComment: { minimizedComment: { isMinimized: true } } };
     },
     paginate: async (method, params) => (await method(params)).data,
   };
@@ -1080,7 +1102,12 @@ test('required check fails after override edit and after release-please overwrit
     body: `Release notes preview\n\n${newGenerated}\n_End release notes preview._\n`,
   });
   const files = new Map([[overwrittenPr.head.sha, changelog(newGenerated)]]);
-  const overwritten = makeGithub({ pr: overwrittenPr, comments: [overrideComment(), appliedComment()], files });
+  const overwritten = makeGithub({
+    pr: overwrittenPr,
+    comments: [overrideComment(), appliedComment()],
+    commentUser: WORKFLOW_BOT,
+    files,
+  });
   const overwrittenCore = makeCore();
   await releaseNotes.checkCuratedState({ github: overwritten.github, context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } }, core: overwrittenCore, number: 123, ...BOT_AUTH });
   assert.match(overwrittenCore.failed, /changelog does not contain/);
@@ -1100,7 +1127,7 @@ test('required check warns when generated entries change after draft before appl
   });
   const comments = [overrideComment()];
   const files = new Map([[changedHead, changelog(newGenerated)]]);
-  const { github, calls } = makeGithub({ pr, comments, files });
+  const { github, calls } = makeGithub({ pr, comments, commentUser: WORKFLOW_BOT, files });
 
   const core = makeCore();
   const result = await releaseNotes.checkCuratedState({ github, context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } }, core, number: 123, ...BOT_AUTH });
@@ -1142,7 +1169,7 @@ test('a failed new-entries warning comment does not mask the actionable gate rea
   });
   assert.equal(result.status, 'missing');
   assert.match(core.failed, /draft and then/);
-  assert.ok(core.warnings.some(message => /Could not post the new-entries warning comment/.test(message)));
+  assert.ok(core.warnings.some(message => /Could not update the new-entries warning comments/.test(message)));
 });
 
 test('the new-entries warning comment retries a transient post failure', async () => {
@@ -1176,7 +1203,7 @@ test('the new-entries warning comment retries a transient post failure', async (
   });
   assert.equal(result.status, 'missing');
   assert.equal(createCommentAttempts, 2);
-  assert.ok(!core.warnings.some(message => /Could not post the new-entries warning comment/.test(message)));
+  assert.ok(!core.warnings.some(message => /Could not update the new-entries warning comments/.test(message)));
 });
 
 test('the new-entries warning retry does not duplicate a comment the server already accepted', async () => {
@@ -1194,7 +1221,8 @@ test('the new-entries warning retry does not duplicate a comment the server alre
   // snapshot would post the identical warning again; the retry must re-read
   // comments, see the marker, and stop after one POST.
   github.rest.issues.createComment = async params => {
-    comments.push({ id: 100 + comments.length, updated_at: APPLIED_UPDATED_AT, user: BOT, body: params.body });
+    const id = 100 + comments.length;
+    comments.push({ id, node_id: `IC_${id}`, updated_at: APPLIED_UPDATED_AT, user: WORKFLOW_BOT, body: params.body });
     calls.createComment.push(params);
     throw new Error('request timed out');
   };
@@ -1211,7 +1239,47 @@ test('the new-entries warning retry does not duplicate a comment the server alre
   });
   assert.equal(result.status, 'missing');
   assert.equal(calls.createComment.length, 1);
-  assert.ok(!core.warnings.some(message => /Could not post the new-entries warning comment/.test(message)));
+  assert.ok(!core.warnings.some(message => /Could not update the new-entries warning comments/.test(message)));
+});
+
+test('the newest new-entries warning hides prior bot warnings and uses copyable command blocks', async () => {
+  const newGenerated = GENERATED_SECTION.replace('useful feature', 'new generated entry');
+  const changedHead = 'd'.repeat(40);
+  const pr = releasePr({
+    head: { ...releasePr().head, sha: changedHead },
+    body: `Release notes preview\n\n${newGenerated}\n_End release notes preview._\n`,
+  });
+  const comments = [
+    overrideComment(),
+    staleWarningComment({ id: 30, head: 'b'.repeat(40), fingerprint: 'old-1' }),
+    staleWarningComment({ id: 31, head: 'c'.repeat(40), fingerprint: 'old-2' }),
+    staleWarningComment({
+      id: 32,
+      head: 'c'.repeat(40),
+      fingerprint: 'contributor-copy',
+      user: { login: 'contributor', id: 7, type: 'User' },
+    }),
+  ];
+  const files = new Map([[changedHead, changelog(newGenerated)]]);
+  const { github, calls } = makeGithub({ pr, comments, commentUser: WORKFLOW_BOT, files });
+
+  await releaseNotes.checkCuratedState({
+    github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core: makeCore(),
+    number: 123,
+    ...BOT_AUTH,
+  });
+
+  assert.equal(calls.createComment.length, 1);
+  assert.match(
+    calls.createComment[0].body,
+    /please re-run:\n\n```\n@release-bot draft\n```\n\nand then:\n\n```\n@release-bot apply\n```$/,
+  );
+  assert.deepEqual(calls.graphql.map(call => call.variables.id), ['IC_30', 'IC_31']);
+  for (const { query } of calls.graphql) {
+    assert.match(query, /minimizeComment\(input: \{subjectId: \$id, classifier: OUTDATED\}\)/);
+  }
 });
 
 test('draft, unmanaged branch, and bypass label pass without metadata', async () => {


### PR DESCRIPTION
Release PRs now keep only the newest generated-entry warning visible and provide copyable release-bot commands.

---

Repeated release-please refreshes can produce a new stale-entry warning for each head and fingerprint, leaving old notices visible and obscuring the current action.

After publishing the current warning, this minimizes older workflow-authored marker comments as `OUTDATED` through GitHub GraphQL `minimizeComment`. Contributor-authored marker copies are excluded. It also renders `@release-bot draft` and `@release-bot apply` in separate fenced blocks so either command can be copied without creating an ambiguous two-command comment.