### PR TITLE
fix(code): bound transcript tail reconciliation

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -19792,7 +19792,8 @@ class DeepAgentsApp(App):
             return True
 
         await self._ensure_transcript_spacers(messages)
-        await self._move_transcript_window_to_tail(messages)
+        if not await self._move_transcript_window_to_tail(messages):
+            return False
 
         # Eagerly fold tool calls into a single live summary so they are
         # collapsed from the moment they start, rather than rendering verbose
@@ -19871,13 +19872,22 @@ class DeepAgentsApp(App):
 
     async def _move_transcript_window_to_tail(
         self, messages_container: Container
-    ) -> None:
-        """Replace an outdated mounted window with the bounded transcript tail."""
+    ) -> bool:
+        """Replace an outdated mounted window with the bounded transcript tail.
+
+        Returns:
+            Whether the mounted window reached the store tail.
+        """
         if not self._message_store.has_messages_below:
-            return
+            return True
         tail = self._message_store.get_tail_window(self._message_store.WINDOW_SIZE)
         if tail is None:
-            return
+            while self._message_store.has_messages_below:
+                before = self._message_store.get_visible_range()[1]
+                await self._hydrate_messages("below")
+                if self._message_store.get_visible_range()[1] == before:
+                    return False
+            return True
 
         generation = self._transcript_generation
         mounted_ids = {data.id for data in self._message_store.get_visible_messages()}
@@ -19904,9 +19914,9 @@ class DeepAgentsApp(App):
             entries,
             generation=generation,
         ):
-            return
+            return False
         if generation != self._transcript_generation:
-            return
+            return False
 
         moved = self._message_store.move_visible_window_to_tail(
             self._message_store.WINDOW_SIZE
@@ -19918,11 +19928,12 @@ class DeepAgentsApp(App):
                 for node in ((widget, footer) if footer is not None else (widget,))
             ]
             await messages_container.remove_children(hydrated_nodes)
-            return
+            return False
         await messages_container.remove_children(obsolete)
         self._schedule_message_height_measurements([data.id for data in moved])
         self._sync_transcript_spacers(messages_container)
         await self._regroup_completed_tools()
+        return True
 
     async def _prune_messages(
         self,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -19792,7 +19792,7 @@ class DeepAgentsApp(App):
             return True
 
         await self._ensure_transcript_spacers(messages)
-        await self._hydrate_all_messages_below()
+        await self._move_transcript_window_to_tail(messages)
 
         # Eagerly fold tool calls into a single live summary so they are
         # collapsed from the moment they start, rather than rendering verbose
@@ -19869,14 +19869,60 @@ class DeepAgentsApp(App):
 
         return True
 
-    async def _hydrate_all_messages_below(self) -> None:
-        """Mount any hidden tail before appending fresh transcript output."""
-        while self._message_store.has_messages_below:
-            before = self._message_store.get_visible_range()[1]
-            await self._hydrate_messages("below")
-            after = self._message_store.get_visible_range()[1]
-            if after == before:
-                break
+    async def _move_transcript_window_to_tail(
+        self, messages_container: Container
+    ) -> None:
+        """Replace an outdated mounted window with the bounded transcript tail."""
+        if not self._message_store.has_messages_below:
+            return
+        tail = self._message_store.get_tail_window(self._message_store.WINDOW_SIZE)
+        if tail is None:
+            return
+
+        generation = self._transcript_generation
+        mounted_ids = {data.id for data in self._message_store.get_visible_messages()}
+        tail_ids = {data.id for data in tail}
+        entries = [
+            self._build_hydration_entry(data)
+            for data in tail
+            if data.id not in mounted_ids
+        ]
+        obsolete_ids = mounted_ids - tail_ids
+        obsolete_footer_ids = {
+            _message_timestamp_footer_id(message_id) for message_id in obsolete_ids
+        }
+        obsolete = [
+            child
+            for child in messages_container.children
+            if child.id in obsolete_ids
+            or child.id in obsolete_footer_ids
+            or isinstance(child, ToolGroupSummary)
+        ]
+
+        if not await self._mount_hydration_batch(
+            messages_container,
+            entries,
+            generation=generation,
+        ):
+            return
+        if generation != self._transcript_generation:
+            return
+
+        moved = self._message_store.move_visible_window_to_tail(
+            self._message_store.WINDOW_SIZE
+        )
+        if moved is None:
+            hydrated_nodes = [
+                node
+                for widget, _data, footer in entries
+                for node in ((widget, footer) if footer is not None else (widget,))
+            ]
+            await messages_container.remove_children(hydrated_nodes)
+            return
+        await messages_container.remove_children(obsolete)
+        self._schedule_message_height_measurements([data.id for data in moved])
+        self._sync_transcript_spacers(messages_container)
+        await self._regroup_completed_tools()
 
     async def _prune_messages(
         self,

--- a/libs/code/deepagents_code/tui/widgets/message_store.py
+++ b/libs/code/deepagents_code/tui/widgets/message_store.py
@@ -1069,6 +1069,30 @@ class MessageStore:
         """
         self._visible_end = min(len(self._messages), self._visible_end + count)
 
+    def get_tail_window(self, count: int) -> list[MessageData] | None:
+        """Return a bounded tail window when moving there preserves live rows.
+
+        Returns:
+            The tail rows, or None when the move would archive a protected row.
+        """
+        start = max(0, len(self._messages) - max(0, count))
+        if any(self.is_protected(message.id) for message in self._messages[:start]):
+            return None
+        return self._messages[start:]
+
+    def move_visible_window_to_tail(self, count: int) -> list[MessageData] | None:
+        """Move the visible range directly to a bounded protected-safe tail.
+
+        Returns:
+            The new visible tail, or None when a protected row blocks the move.
+        """
+        tail = self.get_tail_window(count)
+        if tail is None:
+            return None
+        self._visible_end = len(self._messages)
+        self._visible_start = self._visible_end - len(tail)
+        return tail
+
     def should_hydrate_above(
         self,
         scroll_position: float,

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -11153,47 +11153,87 @@ class TestMessageTimestampFooters:
                 app.query_one("#spacer-0", UserMessage)
             assert app.query_one("#spacer-4", UserMessage)
 
-    async def test_mount_message_hydrates_hidden_tail_before_append(
+    async def test_mount_message_moves_directly_to_bounded_tail(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """New live output should not skip messages hidden below the window."""
-        from deepagents_code.tui.widgets.message_store import MessageType
+        """New live output should mount only the bounded tail before appending."""
+        from deepagents_code.tui.widgets.message_store import MessageData, MessageType
 
         app = DeepAgentsApp()
 
         async with app.run_test() as pilot:
             await pilot.pause()
-            for index in range(5):
-                await app._mount_message(UserMessage(f"m{index}", id=f"tail-{index}"))
-            await pilot.pause()
-
             monkeypatch.setattr(app._message_store, "WINDOW_SIZE", 3)
+            archived = [
+                MessageData(
+                    type=MessageType.USER,
+                    content=f"m{index}",
+                    id=f"tail-{index}",
+                )
+                for index in range(100)
+            ]
+            app._message_store.bulk_load(archived)
+            entries = [
+                app._build_hydration_entry(data)
+                for data in app._message_store.get_visible_messages()
+            ]
             messages = app.query_one("#messages", Container)
-            await app._prune_messages("below", messages)
+            assert await app._mount_hydration_batch(
+                messages,
+                entries,
+                generation=app._transcript_generation,
+            )
+            await app._ensure_transcript_spacers(messages)
+            app._message_store._visible_start = 10
+            app._message_store._visible_end = 13
+            tail_nodes = [
+                child
+                for child in messages.children
+                if child.id
+                and any(
+                    child.id.startswith(f"tail-{index}") for index in range(97, 100)
+                )
+            ]
+            await messages.remove_children(tail_nodes)
+            middle_entries = [
+                app._build_hydration_entry(data)
+                for data in app._message_store.get_visible_messages()
+            ]
+            assert await app._mount_hydration_batch(
+                messages,
+                middle_entries,
+                generation=app._transcript_generation,
+            )
             await pilot.pause()
 
-            assert app._message_store.has_messages_below
-            with pytest.raises(NoMatches):
-                app.query_one("#tail-3", UserMessage)
+            hydrate_calls = 0
 
+            async def count_hydration(
+                direction: Literal["above", "below"], *, count: int | None = None
+            ) -> int:
+                nonlocal hydrate_calls
+                hydrate_calls += 1
+                await asyncio.sleep(0)
+                assert direction in {"above", "below"}
+                assert count is None or count >= 0
+                return 0
+
+            monkeypatch.setattr(app, "_hydrate_messages", count_hydration)
             await app._mount_message(UserMessage("new", id="tail-new"))
             await pilot.pause()
 
-            assert not app._message_store.has_messages_below
+            assert hydrate_calls == 0
+            assert app._message_store.get_visible_range() == (97, 101)
             assert [
                 msg.id
                 for msg in app._message_store.get_all_messages()
                 if msg.type is MessageType.USER
-            ] == [
-                "tail-0",
-                "tail-1",
-                "tail-2",
-                "tail-3",
-                "tail-4",
-                "tail-new",
-            ]
-            for message_id in ["tail-3", "tail-4", "tail-new"]:
+            ] == [*[f"tail-{index}" for index in range(100)], "tail-new"]
+            for message_id in ["tail-97", "tail-98", "tail-99", "tail-new"]:
                 assert app.query_one(f"#{message_id}", UserMessage)
+            for message_id in ["tail-10", "tail-11", "tail-12", "tail-50"]:
+                with pytest.raises(NoMatches):
+                    app.query_one(f"#{message_id}", UserMessage)
 
     async def test_hydrate_below_replaces_unbuildable_message(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -11235,6 +11235,81 @@ class TestMessageTimestampFooters:
                 with pytest.raises(NoMatches):
                     app.query_one(f"#{message_id}", UserMessage)
 
+    async def test_mount_message_hydrates_tail_blocked_by_protected_row(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A protected old row keeps the store and mounted append in sync."""
+        from deepagents_code.tui.widgets.message_store import MessageData, MessageType
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            monkeypatch.setattr(app._message_store, "WINDOW_SIZE", 3)
+            monkeypatch.setattr(app, "_schedule_transcript_prune", lambda *_args: None)
+            app._message_store.bulk_load(
+                [
+                    MessageData(
+                        type=MessageType.USER,
+                        content=f"m{index}",
+                        id=f"blocked-{index}",
+                    )
+                    for index in range(10)
+                ]
+            )
+            messages = app.query_one("#messages", Container)
+            tail_entries = [
+                app._build_hydration_entry(data)
+                for data in app._message_store.get_visible_messages()
+            ]
+            assert await app._mount_hydration_batch(
+                messages,
+                tail_entries,
+                generation=app._transcript_generation,
+            )
+            await app._ensure_transcript_spacers(messages)
+            await messages.remove_children(
+                [
+                    child
+                    for child in messages.children
+                    if child.id
+                    and any(
+                        child.id.startswith(f"blocked-{index}")
+                        for index in range(7, 10)
+                    )
+                ]
+            )
+            app._message_store._visible_start = 1
+            app._message_store._visible_end = 3
+            middle_entries = [
+                app._build_hydration_entry(data)
+                for data in app._message_store.get_visible_messages()
+            ]
+            assert await app._mount_hydration_batch(
+                messages,
+                middle_entries,
+                generation=app._transcript_generation,
+            )
+            app._message_store.protect_message("blocked-2")
+
+            assert await app._mount_message(UserMessage("new", id="blocked-new"))
+            await pilot.pause()
+
+            visible_ids = {
+                data.id for data in app._message_store.get_visible_messages()
+            }
+            mounted_ids = {
+                child.id
+                for child in messages.children
+                if child.id
+                in {
+                    *{f"blocked-{index}" for index in range(10)},
+                    "blocked-new",
+                }
+            }
+            assert app._message_store.get_visible_range() == (1, 11)
+            assert mounted_ids == visible_ids
+            assert len(app.query("#blocked-new")) == 1
+
     async def test_hydrate_below_replaces_unbuildable_message(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_message_store.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_message_store.py
@@ -129,6 +129,54 @@ class TestMessageStore:
         # Active at position 0 -> break immediately -> nothing pruned
         assert len(to_prune) == 0
 
+    def test_move_visible_window_to_tail_is_bounded(self):
+        """Moving to the tail skips intermediate archived rows."""
+        store = MessageStore()
+        for i in range(10):
+            store.append(
+                MessageData(type=MessageType.USER, content=f"msg{i}", id=f"id-{i}")
+            )
+        store._visible_start = 1
+        store._visible_end = 3
+
+        tail = store.move_visible_window_to_tail(3)
+
+        assert [message.id for message in tail or []] == ["id-7", "id-8", "id-9"]
+        assert store.get_visible_range() == (7, 10)
+        assert [message.id for message in store.get_all_messages()] == [
+            f"id-{i}" for i in range(10)
+        ]
+
+    def test_move_visible_window_to_tail_preserves_protected_rows(self):
+        """A protected row outside the target tail blocks the range change."""
+        store = MessageStore()
+        for i in range(10):
+            store.append(
+                MessageData(type=MessageType.USER, content=f"msg{i}", id=f"id-{i}")
+            )
+        store._visible_start = 1
+        store._visible_end = 3
+        store.protect_message("id-2")
+
+        assert store.move_visible_window_to_tail(3) is None
+        assert store.get_visible_range() == (1, 3)
+
+    def test_move_visible_window_to_tail_keeps_protected_tail_rows(self):
+        """Protected rows already inside the bounded tail remain mounted."""
+        store = MessageStore()
+        for i in range(10):
+            store.append(
+                MessageData(type=MessageType.USER, content=f"msg{i}", id=f"id-{i}")
+            )
+        store._visible_start = 1
+        store._visible_end = 3
+        store.protect_message("id-8")
+
+        tail = store.move_visible_window_to_tail(3)
+
+        assert [message.id for message in tail or []] == ["id-7", "id-8", "id-9"]
+        assert store.get_visible_range() == (7, 10)
+
     def test_should_hydrate_above_uses_top_spacer_boundary(self):
         """Hydration starts before the viewport reaches the mounted window."""
         store = MessageStore()


### PR DESCRIPTION
Appending output to a long transcript now renders only a bounded tail instead of replaying all hidden messages.

---

When messages below the visible transcript window had been dropped from view, every new real row synchronously hydrated the entire hidden tail before mounting. Assistant and reasoning rows also re-rendered markdown during that pass, making append latency grow with conversation length.

This changes append-time reconciliation to jump directly to a protected-safe tail window, mount only missing tail rows, remove obsolete mounted rows, and preserve out-of-view history in the store and spacers. If an active streaming or live-tool row would be virtualized, reconciliation safely stays on the current window.

Made by [Open SWE](https://openswe.vercel.app/agents/28e9d0e1-2487-5a1c-a67d-1930117ced4d)
