### PR TITLE
feat(ci): react to release bot commands

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -74,6 +74,8 @@ To ship without curated notes, add the `release: dangerously skip curated notes`
 
 #### Observing a `@release-bot` run
 
+For a valid manual `draft` or `apply` command, the bot reacts to the command comment with 👀 when processing starts, then replaces it with 🚀 after the command succeeds. A retained 👀 means the command was acknowledged but did not finish successfully; check the bot's failure comment or the workflow logs.
+
 A `@release-bot` comment triggers the "📝 Curate release notes" workflow on the `issue_comment` event, not on the PR's head branch, so it does **not** appear as a PR status check. To watch it:
 
 - Open the repo's **Actions** tab → select "📝 Curate release notes" in the left sidebar → select the run whose title matches your release PR.

--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -573,6 +573,27 @@ async function authenticatedBot(github, appSlug, login, id) {
   return user;
 }
 
+async function acknowledgeCommand({ github, owner, repo, commentId, appSlug, login, id }) {
+  await authenticatedBot(github, appSlug, login, id);
+  const response = await github.rest.reactions.createForIssueComment({
+    owner,
+    repo,
+    comment_id: commentId,
+    content: 'eyes',
+  });
+  return response.data.id;
+}
+
+async function completeCommand({ github, owner, repo, commentId, reactionId, appSlug, login, id }) {
+  await authenticatedBot(github, appSlug, login, id);
+  await github.rest.reactions.deleteForIssueComment({
+    owner, repo, comment_id: commentId, reaction_id: reactionId,
+  });
+  await github.rest.reactions.createForIssueComment({
+    owner, repo, comment_id: commentId, content: 'rocket',
+  });
+}
+
 async function createComment(github, owner, repo, number, body) {
   return github.rest.issues.createComment({ owner, repo, issue_number: number, body });
 }
@@ -733,26 +754,6 @@ async function validateTrigger({ github, context, core, botLogin = null, botId =
         );
       }
       return { shouldRun: false };
-    }
-    // A manual command otherwise passes silently into a queued Actions run,
-    // leaving the maintainer unsure whether it registered at all. Unlike the
-    // rejection replies above this is not gated on `canNotify`: clearing the
-    // write-permission check already proves the commenter is an insider.
-    // Best-effort by design — a createComment failure (e.g. secondary rate
-    // limit) must not fail validation and drop a command that passed every
-    // check. Never include COMMAND_MENTION here, or the ack re-triggers us.
-    try {
-      await createComment(
-        github,
-        owner,
-        repo,
-        number,
-        `Running \`${command}\` for the \`${target.component}\` release PR; the release-notes comment on this PR will be created or updated when the run finishes.`,
-      );
-    } catch (error) {
-      core.warning(
-        `Failed to post acknowledgment comment for ${command} on PR #${number}: ${error instanceof Error ? error.message : String(error)}`,
-      );
     }
   }
 
@@ -1524,6 +1525,7 @@ async function checkCuratedState({
 
 module.exports = {
   BYPASS_LABEL,
+  acknowledgeCommand,
   comparisonLeavesPackageUnchanged,
   pathIsInPackage,
   COMMAND_MENTION,
@@ -1537,6 +1539,7 @@ module.exports = {
   commandFromComment,
   componentFromBranch,
   componentRegistry,
+  completeCommand,
   createApplyCommit,
   exactSha256,
   extractPreviewSection,

--- a/.github/scripts/tests/release/release-notes.test.js
+++ b/.github/scripts/tests/release/release-notes.test.js
@@ -132,6 +132,7 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
     getContent: [],
     getRef: [],
     graphql: [],
+    reactionEvents: [],
     updateComment: [],
     updatePr: [],
     updateRef: [],
@@ -176,6 +177,16 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
             comment.updated_at = APPLIED_UPDATED_AT;
           }
           return { data: comment ?? { id: params.comment_id, updated_at: APPLIED_UPDATED_AT, user: BOT, body: params.body } };
+        },
+      },
+      reactions: {
+        createForIssueComment: async params => {
+          calls.reactionEvents.push({ action: 'create', params });
+          return { data: { id: 501 } };
+        },
+        deleteForIssueComment: async params => {
+          calls.reactionEvents.push({ action: 'delete', params });
+          return { status: 204 };
         },
       },
       repos: {
@@ -433,7 +444,7 @@ test('manual commands ignore comments authored by the configured bot', async () 
   assert.equal(run.calls.createComment.length, 0);
 });
 
-test('an accepted manual command is acknowledged immediately', async () => {
+test('an accepted manual command defers acknowledgment to the privileged job', async () => {
   const context = {
     eventName: 'issue_comment',
     repo: { owner: 'langchain-ai', repo: 'deepagents' },
@@ -447,40 +458,7 @@ test('an accepted manual command is acknowledged immediately', async () => {
   const result = await releaseNotes.validateTrigger({ github: run.github, context, core: makeCore() });
   assert.equal(result.shouldRun, true);
   assert.equal(result.command, 'draft');
-  assert.equal(run.calls.createComment.length, 1);
-  assert.match(run.calls.createComment[0].body, /Running `draft` for the `deepagents-code` release PR/);
-  // The ack must land on the PR that carried the command, not merely somewhere.
-  assert.equal(run.calls.createComment[0].owner, 'langchain-ai');
-  assert.equal(run.calls.createComment[0].repo, 'deepagents');
-  assert.equal(run.calls.createComment[0].issue_number, 123);
-  // A mention would make the ack re-trigger the workflow on itself.
-  assert.doesNotMatch(run.calls.createComment[0].body, /@release-bot/);
-});
-
-test('a failed acknowledgment still runs the command', async () => {
-  const context = {
-    eventName: 'issue_comment',
-    repo: { owner: 'langchain-ai', repo: 'deepagents' },
-    payload: {
-      action: 'created',
-      issue: { number: 123, pull_request: {} },
-      comment: { body: '@release-bot apply', user: { login: 'maintainer' }, author_association: 'MEMBER' },
-    },
-  };
-  // A non-Error rejection is the sharp case: reading `.message` off it unguarded
-  // throws out of the catch and drops a command that passed every gate.
-  for (const thrown of [new Error('secondary rate limit'), 'secondary rate limit']) {
-    const run = makeGithub({
-      permission: 'write',
-      onCreateComment: () => { throw thrown; },
-    });
-    const core = makeCore();
-    const result = await releaseNotes.validateTrigger({ github: run.github, context, core });
-    assert.equal(result.shouldRun, true);
-    assert.equal(result.command, 'apply');
-    assert.equal(core.warnings.length, 1);
-    assert.match(core.warnings[0], /Failed to post acknowledgment comment for apply on PR #123: secondary rate limit/);
-  }
+  assert.equal(run.calls.createComment.length, 0);
 });
 
 test('ready_for_review automatically validates as draft command', async () => {
@@ -1363,6 +1341,58 @@ test('postDraft fails when the installation App is not the configured bot', asyn
   assert.equal(wrongUser.calls.updateComment.length, 0);
 });
 
+test('command reactions move from eyes to rocket after successful work', async () => {
+  const { github, calls } = makeGithub();
+  const params = {
+    github,
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    commentId: 77,
+    ...BOT_AUTH,
+  };
+
+  const reactionId = await releaseNotes.acknowledgeCommand(params);
+  assert.equal(reactionId, 501);
+  await releaseNotes.completeCommand({ ...params, reactionId });
+
+  assert.deepEqual(calls.reactionEvents, [
+    {
+      action: 'create',
+      params: {
+        owner: 'langchain-ai', repo: 'deepagents', comment_id: 77, content: 'eyes',
+      },
+    },
+    {
+      action: 'delete',
+      params: {
+        owner: 'langchain-ai', repo: 'deepagents', comment_id: 77, reaction_id: 501,
+      },
+    },
+    {
+      action: 'create',
+      params: {
+        owner: 'langchain-ai', repo: 'deepagents', comment_id: 77, content: 'rocket',
+      },
+    },
+  ]);
+});
+
+test('command reactions reject a token minted for another App', async () => {
+  const { github, calls } = makeGithub();
+  await assert.rejects(
+    releaseNotes.acknowledgeCommand({
+      github,
+      owner: 'langchain-ai',
+      repo: 'deepagents',
+      commentId: 77,
+      ...BOT_AUTH,
+      appSlug: 'someone-else',
+    }),
+    /token was minted for someone-else\[bot\]/,
+  );
+  assert.deepEqual(calls.reactionEvents, []);
+});
+
 test('required check fails when curated draft or applied metadata is missing', async () => {
   const { github } = makeGithub({ comments: [] });
   const core = makeCore();
@@ -1864,10 +1894,7 @@ test('manual commands run for maintainers and admins', async () => {
   const maintainResult = await releaseNotes.validateTrigger({ github: maintain.github, context, core: makeCore() });
   assert.equal(maintainResult.shouldRun, true);
   assert.equal(maintainResult.command, 'apply');
-  // This payload carries no `author_association`, so `canNotify` is false: the
-  // ack fires on write permission alone, unlike every rejection reply.
-  assert.equal(maintain.calls.createComment.length, 1);
-  assert.match(maintain.calls.createComment[0].body, /Running `apply`/);
+  assert.equal(maintain.calls.createComment.length, 0);
 
   // The admin flag grants access even when the permission string is not in the set.
   const admin = makeGithub({ permission: 'read', adminFlag: true });
@@ -1896,11 +1923,7 @@ test('validateTrigger surfaces draft instructions and drops apply instructions',
   assert.equal(draftResult.shouldRun, true);
   assert.equal(draftResult.command, 'draft');
   assert.equal(draftResult.instructions, 'emphasize the breaking SDK change');
-  // The ack is a plain reply; instructions ride along in the result, not the
-  // comment, so untrusted text never gets echoed back onto the PR.
-  assert.equal(draftRun.calls.createComment.length, 1);
-  assert.match(draftRun.calls.createComment[0].body, /Running `draft`/);
-  assert.doesNotMatch(draftRun.calls.createComment[0].body, /emphasize the breaking SDK change/);
+  assert.equal(draftRun.calls.createComment.length, 0);
 
   // Instructions after `apply` never reach the workflow: apply republishes the
   // stored draft, so the gate reports no instructions for it.

--- a/.github/scripts/tests/release/test_release_notes.py
+++ b/.github/scripts/tests/release/test_release_notes.py
@@ -239,6 +239,40 @@ def test_mutation_workflow_commands_are_target_only() -> None:
             for step in privileged_steps
         )
 
+        acknowledge = next(
+            step for step in job["steps"] if step.get("id") == "acknowledge"
+        )
+        assert acknowledge["if"] == "github.event_name == 'issue_comment'"
+        assert acknowledge["continue-on-error"] is True
+        assert acknowledge["with"]["retries"] == 3
+        assert "acknowledgeCommand" in acknowledge["with"]["script"]
+        assert "core.setOutput('reaction-id', reactionId)" in acknowledge["with"][
+            "script"
+        ]
+
+        complete = next(
+            step
+            for step in job["steps"]
+            if step.get("name") == "Mark manual command complete"
+        )
+        terminal_step = "post" if job_name == "draft" else "publish"
+        assert "github.event_name == 'issue_comment'" in complete["if"]
+        assert "steps.acknowledge.outcome == 'success'" in complete["if"]
+        assert f"steps.{terminal_step}.outcome == 'success'" in complete["if"]
+        assert complete["continue-on-error"] is True
+        assert complete["with"]["retries"] == 3
+        assert complete["env"]["REACTION_ID"] == (
+            "${{ steps.acknowledge.outputs.reaction-id }}"
+        )
+        assert "completeCommand" in complete["with"]["script"]
+
+        step_names = [step.get("name") for step in job["steps"]]
+        assert step_names.index("Acknowledge manual command") < step_names.index(
+            "Prepare isolated drafting input"
+            if job_name == "draft"
+            else "Validate override and prepare changelog/body edits"
+        )
+
     # No long-lived bot PAT: repository mutations go through short-lived App tokens.
     # This also covers the old DCODE_RELEASE_BOT_TOKEN name as a substring.
     assert "RELEASE_BOT_TOKEN" not in automation

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -133,6 +133,30 @@ jobs:
           path: trusted-source
           persist-credentials: false
 
+      - name: Acknowledge manual command
+        id: acknowledge
+        if: github.event_name == 'issue_comment'
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          BOT_LOGIN: ${{ vars.RELEASE_BOT_LOGIN }}
+          BOT_ID: ${{ vars.RELEASE_BOT_ID }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          retries: 3
+          script: |
+            const { acknowledgeCommand } = require('./trusted-source/.github/scripts/release/release-notes.js');
+            const reactionId = await acknowledgeCommand({
+              github,
+              ...context.repo,
+              commentId: context.payload.comment.id,
+              appSlug: process.env.APP_SLUG,
+              login: process.env.BOT_LOGIN,
+              id: process.env.BOT_ID,
+            });
+            core.setOutput('reaction-id', reactionId);
+
       - name: Prepare isolated drafting input
         id: prepare
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -244,6 +268,30 @@ jobs:
               throw error;
             }
 
+      - name: Mark manual command complete
+        if: ${{ github.event_name == 'issue_comment' && steps.acknowledge.outcome == 'success' && steps.post.outcome == 'success' }}
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          BOT_LOGIN: ${{ vars.RELEASE_BOT_LOGIN }}
+          BOT_ID: ${{ vars.RELEASE_BOT_ID }}
+          REACTION_ID: ${{ steps.acknowledge.outputs.reaction-id }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          retries: 3
+          script: |
+            const { completeCommand } = require('./trusted-source/.github/scripts/release/release-notes.js');
+            await completeCommand({
+              github,
+              ...context.repo,
+              commentId: context.payload.comment.id,
+              reactionId: Number(process.env.REACTION_ID),
+              appSlug: process.env.APP_SLUG,
+              login: process.env.BOT_LOGIN,
+              id: process.env.BOT_ID,
+            });
+
       # Runs for any non-success in prepare/agent/post, including a hard failure in
       # `prepare` (which would otherwise skip a plain `success()`-gated step and
       # leave the maintainer with no PR feedback). `!cancelled()` keeps it firing
@@ -329,11 +377,36 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout trusted automation
+        id: checkout-trusted
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           path: trusted-source
           persist-credentials: false
+
+      - name: Acknowledge manual command
+        id: acknowledge
+        if: github.event_name == 'issue_comment'
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          BOT_LOGIN: ${{ vars.RELEASE_BOT_LOGIN }}
+          BOT_ID: ${{ vars.RELEASE_BOT_ID }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          retries: 3
+          script: |
+            const { acknowledgeCommand } = require('./trusted-source/.github/scripts/release/release-notes.js');
+            const reactionId = await acknowledgeCommand({
+              github,
+              ...context.repo,
+              commentId: context.payload.comment.id,
+              appSlug: process.env.APP_SLUG,
+              login: process.env.BOT_LOGIN,
+              id: process.env.BOT_ID,
+            });
+            core.setOutput('reaction-id', reactionId);
 
       - name: Validate override and prepare changelog/body edits
         id: prepare-apply
@@ -428,11 +501,35 @@ jobs:
               throw error;
             }
 
-      # The apply steps have no continue-on-error, so any failure reds the job;
-      # this mirrors the draft job's failure comment so a maintainer who ran
-      # `apply` sees the reason on the PR instead of only a red Actions run.
+      - name: Mark manual command complete
+        if: ${{ github.event_name == 'issue_comment' && steps.acknowledge.outcome == 'success' && steps.publish.outcome == 'success' }}
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          BOT_LOGIN: ${{ vars.RELEASE_BOT_LOGIN }}
+          BOT_ID: ${{ vars.RELEASE_BOT_ID }}
+          REACTION_ID: ${{ steps.acknowledge.outputs.reaction-id }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          retries: 3
+          script: |
+            const { completeCommand } = require('./trusted-source/.github/scripts/release/release-notes.js');
+            await completeCommand({
+              github,
+              ...context.repo,
+              commentId: context.payload.comment.id,
+              reactionId: Number(process.env.REACTION_ID),
+              appSlug: process.env.APP_SLUG,
+              login: process.env.BOT_LOGIN,
+              id: process.env.BOT_ID,
+            });
+
+      # Only an apply-operation failure should publish this notice. Reaction
+      # updates are best-effort and must not turn a successful apply into a
+      # misleading apply-failure comment.
       - name: Comment on apply failure
-        if: failure()
+        if: ${{ !cancelled() && (steps.prepare-apply.outcome != 'success' || steps.commit.outcome != 'success' || steps.publish.outcome != 'success') }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ needs.validate.outputs.number }}


### PR DESCRIPTION
Release-bot `draft` and `apply` commands now show `👀` while running and `🚀` after successful completion.

---

The previous acknowledgement reply added timeline noise without showing whether processing had completed. This replaces that reply with identity-checked reactions on the triggering comment. Reaction calls use the existing short-lived GitHub App token, retry transient failures, and remain best-effort so they cannot invalidate a successful release-note operation. Failed commands retain `👀` for visibility.