### PR TITLE
fix(code): resolve project policy per workspace

### DIFF
--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from deepagents_code.project_utils import ProjectContext
 
 
-_SESSION_WORKSPACE_FIELDS = frozenset(
+SESSION_WORKSPACE_FIELDS = frozenset(
     {
         "allow_fs_tools",
         "assistant_id",
@@ -48,7 +48,7 @@ _SESSION_WORKSPACE_FIELDS = frozenset(
         "shell_allow_list",
     }
 )
-_PROJECT_WORKSPACE_FIELDS = frozenset(
+PROJECT_WORKSPACE_FIELDS = frozenset(
     {
         "extension_paths",
         "mcp_config_path",
@@ -57,31 +57,6 @@ _PROJECT_WORKSPACE_FIELDS = frozenset(
         "trust_project_mcp",
     }
 )
-
-
-def workspace_claim_fields() -> frozenset[str]:
-    """Return the exact workspace policy keys clients may claim.
-
-    Returns:
-        The session-scoped workspace field names.
-    """
-    return _SESSION_WORKSPACE_FIELDS
-
-
-def project_workspace_fields() -> frozenset[str]:
-    """Return the exact workspace policy keys resolved per project.
-
-    Returns:
-        The project-scoped workspace field names.
-    """
-    return _PROJECT_WORKSPACE_FIELDS
-
-
-def _fingerprint(value: object) -> str:
-    import hashlib
-
-    serialized = json.dumps(value, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(serialized.encode()).hexdigest()
 
 
 def _same_workspace_project(first: str | None, second: str) -> bool:
@@ -519,13 +494,25 @@ class ServerConfig:
             "extension_paths": list(self.extension_paths),
         }
 
-    def to_session_workspace_claim(self) -> dict[str, Any]:
-        """Return the command-scoped policy a managed client may claim."""
+    def _workspace_subset(self, fields: frozenset[str]) -> dict[str, Any]:
+        """Return the *fields* subset of the full workspace policy.
+
+        Returns:
+            The requested subset of `to_workspace_payload()`.
+        """
         return {
             key: value
             for key, value in self.to_workspace_payload().items()
-            if key in _SESSION_WORKSPACE_FIELDS
+            if key in fields
         }
+
+    def to_session_workspace_claim(self) -> dict[str, Any]:
+        """Return the command-scoped policy a managed client may claim.
+
+        Returns:
+            The session-scoped subset of the workspace policy.
+        """
+        return self._workspace_subset(SESSION_WORKSPACE_FIELDS)
 
     def to_project_workspace_policy(self) -> dict[str, Any]:
         """Return policy that must be resolved for each project directory.
@@ -533,11 +520,7 @@ class ServerConfig:
         Returns:
             The project-scoped subset of the workspace policy.
         """
-        return {
-            key: value
-            for key, value in self.to_workspace_payload().items()
-            if key in _PROJECT_WORKSPACE_FIELDS
-        }
+        return self._workspace_subset(PROJECT_WORKSPACE_FIELDS)
 
     def session_workspace_fingerprint(self) -> str:
         """Fingerprint the exact client-claimable session policy.
@@ -545,7 +528,9 @@ class ServerConfig:
         Returns:
             The canonical SHA-256 fingerprint.
         """
-        return _fingerprint(self.to_session_workspace_claim())
+        from deepagents_code.workspace import canonical_fingerprint
+
+        return canonical_fingerprint(self.to_session_workspace_claim())
 
     def resolve_workspace(
         self,
@@ -583,7 +568,9 @@ class ServerConfig:
         values = self.to_env()
         values.pop("CWD")
         values.pop("PROJECT_ROOT")
-        return _fingerprint(values)
+        from deepagents_code.workspace import canonical_fingerprint
+
+        return canonical_fingerprint(values)
 
     def __post_init__(self) -> None:
         """Normalize fields and validate invariants.

--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -24,6 +24,73 @@ if TYPE_CHECKING:
     from deepagents import FsToolName
 
     from deepagents_code.project_utils import ProjectContext
+
+
+_SESSION_WORKSPACE_FIELDS = frozenset(
+    {
+        "allow_fs_tools",
+        "assistant_id",
+        "auto_approve",
+        "enable_ask_user",
+        "enable_interpreter",
+        "enable_memory",
+        "enable_shell",
+        "enable_skills",
+        "interactive",
+        "interpreter_ptc",
+        "interpreter_ptc_acknowledge_unsafe",
+        "interrupt_shell_only",
+        "no_mcp",
+        "recursion_limit",
+        "sandbox_id",
+        "sandbox_snapshot_name",
+        "sandbox_type",
+        "shell_allow_list",
+    }
+)
+_PROJECT_WORKSPACE_FIELDS = frozenset(
+    {
+        "extension_paths",
+        "mcp_config_path",
+        "sandbox_setup",
+        "trust_project_extensions",
+        "trust_project_mcp",
+    }
+)
+
+
+def workspace_claim_fields() -> frozenset[str]:
+    """Return the exact workspace policy keys clients may claim.
+
+    Returns:
+        The session-scoped workspace field names.
+    """
+    return _SESSION_WORKSPACE_FIELDS
+
+
+def project_workspace_fields() -> frozenset[str]:
+    """Return the exact workspace policy keys resolved per project.
+
+    Returns:
+        The project-scoped workspace field names.
+    """
+    return _PROJECT_WORKSPACE_FIELDS
+
+
+def _fingerprint(value: object) -> str:
+    import hashlib
+
+    serialized = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def _same_workspace_project(first: str | None, second: str) -> bool:
+    if first is None:
+        return False
+    try:
+        return Path(first).resolve(strict=True) == Path(second).resolve(strict=True)
+    except (OSError, RuntimeError):
+        return False
 
 
 def _read_env_bool(suffix: str, *, default: bool = False) -> bool:
@@ -452,19 +519,71 @@ class ServerConfig:
             "extension_paths": list(self.extension_paths),
         }
 
-    def workspace_fingerprint(self) -> str:
-        """Fingerprint the full effective config without persisting its contents.
+    def to_session_workspace_claim(self) -> dict[str, Any]:
+        """Return the command-scoped policy a managed client may claim."""
+        return {
+            key: value
+            for key, value in self.to_workspace_payload().items()
+            if key in _SESSION_WORKSPACE_FIELDS
+        }
+
+    def to_project_workspace_policy(self) -> dict[str, Any]:
+        """Return policy that must be resolved for each project directory.
+
+        Returns:
+            The project-scoped subset of the workspace policy.
+        """
+        return {
+            key: value
+            for key, value in self.to_workspace_payload().items()
+            if key in _PROJECT_WORKSPACE_FIELDS
+        }
+
+    def session_workspace_fingerprint(self) -> str:
+        """Fingerprint the exact client-claimable session policy.
 
         Returns:
             The canonical SHA-256 fingerprint.
         """
-        import hashlib
+        return _fingerprint(self.to_session_workspace_claim())
 
+    def resolve_workspace(
+        self,
+        cwd: str,
+        project_root: str | None,
+    ) -> ServerConfig:
+        """Resolve directory-bound policy for one server workspace.
+
+        Returns:
+            A config bound to the target workspace's project policy.
+        """
+        launch_root = self.project_root or self.cwd
+        target_root = project_root or cwd
+        if _same_workspace_project(launch_root, target_root):
+            return replace(self, cwd=cwd, project_root=project_root)
+        from deepagents_code.extensions.trust import is_project_extensions_trusted
+
+        return replace(
+            self,
+            cwd=cwd,
+            project_root=project_root,
+            sandbox_setup=None,
+            mcp_config_path=None,
+            trust_project_mcp=None,
+            trust_project_extensions=is_project_extensions_trusted(target_root),
+            extension_paths=(),
+        )
+
+    def workspace_fingerprint(self) -> str:
+        """Fingerprint the resolved runtime config except workspace identity.
+
+        Returns:
+            The canonical SHA-256 fingerprint.
+        """
         values = self.to_env()
         values.pop("CWD")
         values.pop("PROJECT_ROOT")
-        serialized = json.dumps(values, sort_keys=True, separators=(",", ":"))
-        return hashlib.sha256(serialized.encode()).hexdigest()
+        return _fingerprint(values)
 
     def __post_init__(self) -> None:
         """Normalize fields and validate invariants.

--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -591,12 +591,16 @@ class ServerConfig:
         Args:
             cwd: Absolute, canonical working directory for the workspace.
             project_root: Canonical project root, or `None` when the workspace
-                has none. Extension trust is then keyed on `cwd`.
+                has none. The launch cwd uses the server's explicit root when
+                configured. Otherwise, extension trust is keyed on `cwd` when
+                no root exists.
 
         Returns:
             A config whose session policy is unchanged and whose project policy
             is either the launch project's or empty.
         """
+        if self.project_root is not None and _same_workspace_project(self.cwd, cwd):
+            project_root = str(Path(self.project_root).expanduser().resolve())
         launch_root = self.project_root or self.cwd
         target_root = project_root or cwd
         if _same_workspace_project(launch_root, target_root):

--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -79,20 +79,24 @@ decision.
 
 
 def _same_workspace_project(first: str | None, second: str) -> bool:
-    """Whether two paths name the same existing project directory.
+    """Whether two paths name the same project directory.
 
-    Fails closed: an unset launch root, or a path that no longer resolves,
-    counts as *different*, so the caller drops project policy rather than
-    carrying it across an unverified boundary.
+    Fails closed: an unset launch root, a missing path, or an undecidable
+    comparison counts as *different*, so the caller drops project policy rather
+    than carrying it across an unverified boundary. `_same_directory` compares
+    by device and inode, so a symlinked or differently cased spelling of one
+    directory still compares equal.
 
     Returns:
-        `True` only when both paths resolve to the same real directory.
+        `True` only when both paths name the same directory.
     """
     if first is None:
         return False
+    from deepagents_code._paths import DeepAgentsHomeError, _same_directory
+
     try:
-        return Path(first).resolve(strict=True) == Path(second).resolve(strict=True)
-    except (OSError, RuntimeError):
+        return _same_directory(Path(first), Path(second))
+    except DeepAgentsHomeError:
         logger.warning(
             "Could not compare project directories %s and %s; treating as "
             "separate projects, so project-scoped policy will not apply",
@@ -529,25 +533,17 @@ class ServerConfig:
             "extension_paths": list(self.extension_paths),
         }
 
-    def _workspace_subset(self, fields: frozenset[str]) -> dict[str, Any]:
-        """Return the *fields* subset of the full workspace policy.
-
-        Returns:
-            The requested subset of `to_workspace_payload()`.
-        """
-        return {
-            key: value
-            for key, value in self.to_workspace_payload().items()
-            if key in fields
-        }
-
     def to_session_workspace_claim(self) -> dict[str, Any]:
         """Return the command-scoped policy a managed client may claim.
 
         Returns:
             The session-scoped subset of the workspace policy.
         """
-        return self._workspace_subset(SESSION_WORKSPACE_FIELDS)
+        return {
+            key: value
+            for key, value in self.to_workspace_payload().items()
+            if key in SESSION_WORKSPACE_FIELDS
+        }
 
     def to_project_workspace_policy(self) -> dict[str, Any]:
         """Return policy that must be resolved for each project directory.
@@ -555,7 +551,11 @@ class ServerConfig:
         Returns:
             The project-scoped subset of the workspace policy.
         """
-        return self._workspace_subset(PROJECT_WORKSPACE_FIELDS)
+        return {
+            key: value
+            for key, value in self.to_workspace_payload().items()
+            if key in PROJECT_WORKSPACE_FIELDS
+        }
 
     def session_workspace_fingerprint(self) -> str:
         """Fingerprint the exact client-claimable session policy.

--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -22,6 +22,8 @@ from deepagents_code._constants import DEFAULT_AGENT_NAME as DEFAULT_ASSISTANT_I
 from deepagents_code._env_vars import SERVER_ENV_PREFIX
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from deepagents import FsToolName
 
     from deepagents_code.project_utils import ProjectContext
@@ -611,6 +613,24 @@ class ServerConfig:
             trust_project_extensions=is_project_extensions_trusted(target_root),
             extension_paths=(),
         )
+
+    def preserve_bound_extension_trust(
+        self, bound_policy: Mapping[str, object]
+    ) -> ServerConfig:
+        """Keep an existing thread's extension trust when a new grant appears.
+
+        Args:
+            bound_policy: Server policy persisted when the thread was bound.
+
+        Returns:
+            A config that defers new grants to new threads. Revocations remain
+            visible so binding and runtime validation can reject them.
+        """
+        if bound_policy.get("trust_project_extensions") is False and (
+            self.trust_project_extensions is True
+        ):
+            return replace(self, trust_project_extensions=False)
+        return self
 
     def workspace_fingerprint(self) -> str:
         """Fingerprint the resolved runtime config except workspace identity.

--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -12,6 +12,7 @@ with `from_env()`.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -24,6 +25,8 @@ if TYPE_CHECKING:
     from deepagents import FsToolName
 
     from deepagents_code.project_utils import ProjectContext
+
+logger = logging.getLogger(__name__)
 
 
 SESSION_WORKSPACE_FIELDS = frozenset(
@@ -48,6 +51,15 @@ SESSION_WORKSPACE_FIELDS = frozenset(
         "shell_allow_list",
     }
 )
+"""Policy a managed client may claim for its own command invocation.
+
+These come from the client's own CLI flags, so the client already knows them
+and claiming them proves only that both sides agree. Together with
+`PROJECT_WORKSPACE_FIELDS` this must partition `to_workspace_payload()`
+exactly: a payload field in neither set is never verified against a client
+claim and never checked for project drift.
+`test_workspace_claim_partitions_every_policy_field` pins that.
+"""
 PROJECT_WORKSPACE_FIELDS = frozenset(
     {
         "extension_paths",
@@ -57,14 +69,37 @@ PROJECT_WORKSPACE_FIELDS = frozenset(
         "trust_project_mcp",
     }
 )
+"""Policy the server must resolve per project directory, never accept.
+
+Each of these grants code execution scoped to a checkout -- MCP servers,
+sandbox setup commands, Python extensions. A client that could claim them could
+execute one directory's configuration against another directory's trust
+decision.
+"""
 
 
 def _same_workspace_project(first: str | None, second: str) -> bool:
+    """Whether two paths name the same existing project directory.
+
+    Fails closed: an unset launch root, or a path that no longer resolves,
+    counts as *different*, so the caller drops project policy rather than
+    carrying it across an unverified boundary.
+
+    Returns:
+        `True` only when both paths resolve to the same real directory.
+    """
     if first is None:
         return False
     try:
         return Path(first).resolve(strict=True) == Path(second).resolve(strict=True)
     except (OSError, RuntimeError):
+        logger.warning(
+            "Could not compare project directories %s and %s; treating as "
+            "separate projects, so project-scoped policy will not apply",
+            first,
+            second,
+            exc_info=True,
+        )
         return False
 
 
@@ -539,8 +574,26 @@ class ServerConfig:
     ) -> ServerConfig:
         """Resolve directory-bound policy for one server workspace.
 
+        Project-scoped policy (`PROJECT_WORKSPACE_FIELDS`) is valid only for
+        the directory it was resolved against: it came from the launch-time CLI
+        and that project's trust decisions. Reusing it for another directory
+        would apply one project's MCP servers, sandbox setup, and extensions to
+        a different, possibly untrusted, checkout.
+
+        So the launch project keeps its policy verbatim, and any other project
+        starts from nothing: MCP and sandbox setup are *dropped* rather than
+        rediscovered, and extension trust is re-read from the trust store for
+        that project. `_same_workspace_project` fails closed, so an
+        unresolvable path also takes the drop branch.
+
+        Args:
+            cwd: Absolute, canonical working directory for the workspace.
+            project_root: Canonical project root, or `None` when the workspace
+                has none. Extension trust is then keyed on `cwd`.
+
         Returns:
-            A config bound to the target workspace's project policy.
+            A config whose session policy is unchanged and whose project policy
+            is either the launch project's or empty.
         """
         launch_root = self.project_root or self.cwd
         target_root = project_root or cwd

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import inspect
 import logging
-import os
 import re
 import shutil
 import warnings
@@ -108,6 +107,7 @@ from deepagents_code.config import (
     _INHERITED_PYTHONPATH_ENV,
     DEFAULT_MODEL_RETRIES,
     _ShellAllowAll,
+    active_environment,
     console,
     credentials,
     get_default_coding_instructions,
@@ -1606,26 +1606,19 @@ def get_system_prompt(
         )
 
     if model_result is not None:
-        model_identity = (
+        model_identity_section = build_model_identity_section(
             model_result.model_name,
-            model_result.provider,
-            model_result.context_limit,
-            model_result.unsupported_modalities,
+            provider=model_result.provider,
+            context_limit=model_result.context_limit,
+            unsupported_modalities=model_result.unsupported_modalities,
         )
     else:
-        model_identity = (
+        model_identity_section = build_model_identity_section(
             runtime_state.model_name,
-            runtime_state.model_provider,
-            runtime_state.model_context_limit,
-            runtime_state.model_unsupported_modalities,
+            provider=runtime_state.model_provider,
+            context_limit=runtime_state.model_context_limit,
+            unsupported_modalities=runtime_state.model_unsupported_modalities,
         )
-    model_name, model_provider, model_context_limit, model_modalities = model_identity
-    model_identity_section = build_model_identity_section(
-        model_name,
-        provider=model_provider,
-        context_limit=model_context_limit,
-        unsupported_modalities=model_modalities,
-    )
     filesystem_tool_guidance = _build_fs_tool_prompt_guidance(fs_tools)
     tavily_available = credentials.has_tavily if has_tavily is None else has_tavily
     web_search_tool_guidance = _WEB_SEARCH_TOOL_GUIDANCE if tavily_available else ""
@@ -2647,7 +2640,7 @@ def create_cli_agent(
             a prebuilt `BaseChatModel` came from a path that already checked.
     """  # noqa: DOC502 - propagates from `ModelConfig.require_model_allowed`
     tools = list(tools or [])
-    environment = os.environ if environ is None else environ
+    environment = active_environment() if environ is None else environ
     runtime_credentials = (
         credentials if credentials_snapshot is None else credentials_snapshot
     )

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4638,8 +4638,8 @@ class DeepAgentsApp(App):
         config = ServerConfig.from_env()
         agent.set_workspace(
             self._cwd,
-            config.to_workspace_payload(),
-            config_fingerprint=config.workspace_fingerprint(),
+            config.to_session_workspace_claim(),
+            config_fingerprint=config.session_workspace_fingerprint(),
         )
         return agent
 

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -616,7 +616,12 @@ def _redact_remote(value: str) -> str:
 def _known_credential_values(
     environ: Mapping[str, str] | None = None,
 ) -> tuple[str, ...]:
-    source = os.environ if environ is None else environ
+    from deepagents_code.config import (
+        active_environment,
+        relayed_user_tracing_secrets,
+    )
+
+    source = active_environment() if environ is None else environ
     values: set[str] = set()
     for name, value in source.items():
         if _SECRET_KEY_RE.search(name) and len(value) >= _MIN_SECRET_LENGTH:
@@ -624,8 +629,6 @@ def _known_credential_values(
     # The caller's relayed tracing key is what `execute` commands actually run
     # under, but it reaches this process inside a carrier whose name does not
     # match `_SECRET_KEY_RE`, so the name scan above cannot see it.
-    from deepagents_code.config import relayed_user_tracing_secrets
-
     values.update(
         value
         for value in relayed_user_tracing_secrets(source)

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -616,10 +616,21 @@ def _redact_remote(value: str) -> str:
 def _known_credential_values(
     environ: Mapping[str, str] | None = None,
 ) -> tuple[str, ...]:
+    source = os.environ if environ is None else environ
     values: set[str] = set()
-    for name, value in (os.environ if environ is None else environ).items():
+    for name, value in source.items():
         if _SECRET_KEY_RE.search(name) and len(value) >= _MIN_SECRET_LENGTH:
             values.add(value)
+    # The caller's relayed tracing key is what `execute` commands actually run
+    # under, but it reaches this process inside a carrier whose name does not
+    # match `_SECRET_KEY_RE`, so the name scan above cannot see it.
+    from deepagents_code.config import relayed_user_tracing_secrets
+
+    values.update(
+        value
+        for value in relayed_user_tracing_secrets(source)
+        if len(value) >= _MIN_SECRET_LENGTH
+    )
     try:
         from deepagents_code.auth_store import load_credentials
 

--- a/libs/code/deepagents_code/client/launch/server_manager.py
+++ b/libs/code/deepagents_code/client/launch/server_manager.py
@@ -454,8 +454,8 @@ async def start_server_and_get_agent(
             raise RuntimeError(msg)
         agent.set_workspace(
             str(project_context.user_cwd),
-            config.to_workspace_payload(),
-            config_fingerprint=config.workspace_fingerprint(),
+            config.to_session_workspace_claim(),
+            config_fingerprint=config.session_workspace_fingerprint(),
         )
         started = True
         return agent, server, None

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -1423,6 +1423,27 @@ def _decode_user_langsmith_env(
     return (launch, user) if launch is not None and user is not None else None
 
 
+def relayed_user_tracing_secrets(environ: Mapping[str, str]) -> tuple[str, ...]:
+    """Extract caller API keys from the validated LangSmith settings carrier.
+
+    Args:
+        environ: Environment containing the client-to-server carrier.
+
+    Returns:
+        Launch and user-command API keys for Auto mode output redaction.
+    """
+    encoded = environ.get(_USER_LANGSMITH_ENV_CARRIER)
+    decoded = _decode_user_langsmith_env(encoded) if encoded else None
+    if decoded is None:
+        return ()
+    return tuple(
+        value
+        for mapping in decoded
+        for var in _TRACING_API_KEY_ENV_VARS
+        if isinstance(value := mapping.get(var), str) and value
+    )
+
+
 def _encode_user_langsmith_env() -> str:
     """Encode the trusted user-command LangSmith environment for the server.
 

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -591,9 +591,15 @@ def _dotenv_values_from(
     from dotenv.main import DotEnv
     from dotenv.variables import parse_variables
 
+    # `DotEnv` defaults `encoding` to `None` (the locale encoding, cp1252 on
+    # Windows) where the `dotenv_values` helper this replaced defaulted to
+    # UTF-8. Without this, a `.env` holding non-ASCII bytes raises
+    # `UnicodeDecodeError` -- a `ValueError` the caller swallows -- and the
+    # whole file is dropped.
     parsed = DotEnv(
         dotenv_path=str(dotenv_path),
         interpolate=False,
+        encoding="utf-8",
     ).dict()
     resolved: dict[str, str | None] = {}
     # Built once: `resolved` only grows, and each new key is folded in below, so

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -724,9 +724,21 @@ def _dotenv_environment(
             if raw is not None:
                 global_toggle[READ_PROJECT_DOTENV] = raw
     except (OSError, ValueError):
+        # Fail closed. `resolve_read_project_dotenv` defaults to true, so an
+        # unreadable global file would silently discard the user's opt-out and
+        # load the untrusted project `.env` instead. Skipping the project file
+        # costs the user a startup value; honoring it costs them the trust
+        # decision they made. This occupies the global-dotenv tier only, so
+        # managed policy and a shell export still win -- a user who opts in
+        # through a trusted surface keeps project `.env` loading.
+        global_toggle[READ_PROJECT_DOTENV] = "false"
         logger.warning(
-            "Could not read global dotenv at %s; global defaults may be incomplete",
+            "Could not read the trusted global dotenv at %s. Skipping the "
+            "project .env for %s rather than assuming "
+            "startup.read_project_dotenv is true. Fix that file's permissions "
+            "to restore project .env loading.",
             _GLOBAL_DOTENV_PATH,
+            start_path or "cwd",
             exc_info=True,
         )
 

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -1436,6 +1436,29 @@ def _decode_user_langsmith_env(
     return (launch, user) if launch is not None and user is not None else None
 
 
+def _decode_relayed_tracing(raw: str | None) -> dict[str, Any] | None:
+    """Decode the relayed caller tracing carrier into its original values.
+
+    The carrier is the one serialized blob that becomes shell environment, so
+    its parse and shape contract has a single definition: both the redaction
+    set and the shell environment restore read it through here.
+
+    Args:
+        raw: Serialized carrier value, or `None` when absent.
+
+    Returns:
+        The decoded mapping, or `None` when the carrier is absent, unparsable,
+        or not an object.
+    """
+    if not raw:
+        return None
+    try:
+        originals = json.loads(raw)
+    except ValueError:
+        return None
+    return originals if isinstance(originals, dict) else None
+
+
 def relayed_user_tracing_secrets(environ: Mapping[str, str]) -> tuple[str, ...]:
     """Extract caller API keys from the validated LangSmith settings carrier.
 

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -770,6 +770,19 @@ def _dotenv_environment(
     return env
 
 
+def strip_loaded_dotenv_values(env: MutableMapping[str, str]) -> None:
+    """Remove values this process's dotenv loader injected into *env*.
+
+    A value is loader-owned only while it still matches what was injected, so a
+    later override by the shell or by managed policy survives the strip. This is
+    the single definition of that rule; both the dotenv preview and the server
+    subprocess environment depend on it.
+    """
+    for key, value in _dotenv_loaded_values.items():
+        if env.get(key) == value:
+            env.pop(key)
+
+
 def _preview_dotenv_environ(*, start_path: Path | None = None) -> dict[str, str]:
     """Return the effective dotenv environment without mutating `os.environ`.
 
@@ -4355,6 +4368,7 @@ def get_langsmith_project_name() -> str | None:
     Returns:
         Project name string when LangSmith tracing is active, None otherwise.
     """
+    from deepagents_code._env_vars import LANGSMITH_PROJECT
     from deepagents_code.config_manifest import LANGSMITH_PROJECT_DEFAULT
     from deepagents_code.model_config import resolve_env_var
 
@@ -5892,12 +5906,9 @@ def _apply_provider_sdk_environment(
     if provider == "azure_openai":
         _apply_azure_sdk_endpoint(kwargs)
 
-    table = {
-        argument: env_names
-        for argument, env_names in _PROVIDER_SDK_ENV_KWARGS.get(provider, {}).items()
-        if argument not in kwargs
-    }
-    kwargs.update(resolve_env_kwargs(table, resolve_env_var))
+    table = _PROVIDER_SDK_ENV_KWARGS.get(provider, {})
+    for argument, value in resolve_env_kwargs(table, resolve_env_var).items():
+        kwargs.setdefault(argument, value)
 
 
 def _get_provider_kwargs(
@@ -5977,6 +5988,48 @@ def _get_provider_kwargs(
 
     _apply_provider_sdk_environment(provider, result)
     return result
+
+
+def _apply_scoped_endpoint(
+    provider: str,
+    kwargs: dict[str, Any],
+    extra_kwargs: dict[str, Any] | None,
+) -> None:
+    """Pair the resolved key with its endpoint on the workspace-scoped path.
+
+    `apply_stored_credentials` is skipped while an environment is bound, so this
+    is the only thing keeping a gateway key from reaching an endpoint that key
+    was not issued for.
+    """
+    if not (extra_kwargs and "api_key" in extra_kwargs):
+        _apply_scoped_stored_endpoint(provider, kwargs)
+        if extra_kwargs and "base_url" in extra_kwargs:
+            kwargs["base_url"] = extra_kwargs["base_url"]
+        return
+    if "base_url" in extra_kwargs:
+        return
+
+    from deepagents_code.model_config import auth_store
+
+    try:
+        stored_base_url = auth_store.get_stored_base_url(provider)
+    except RuntimeError:
+        # The caller passed an explicit `api_key` with no `base_url`. Without
+        # the store we cannot tell whether the inherited endpoint was paired
+        # with the *stored* key, so fail closed and drop it: sending an
+        # explicitly supplied key to a gateway it was not issued for is the
+        # worse outcome.
+        logger.warning(
+            "Could not read the stored endpoint for %r; the credential file "
+            "may be corrupt. Dropping the inherited base URL so the explicitly "
+            "supplied key is not sent to it. Pass `base_url` via "
+            "`--model-params` to target an endpoint explicitly.",
+            provider,
+        )
+        kwargs.pop("base_url", None)
+        return
+    if stored_base_url and kwargs.get("base_url") == stored_base_url:
+        kwargs.pop("base_url", None)
 
 
 def _apply_scoped_stored_endpoint(provider: str, kwargs: dict[str, Any]) -> None:
@@ -6571,7 +6624,7 @@ def create_model(
 
     # Provider-specific kwargs (with per-model overrides)
     kwargs = _get_provider_kwargs(provider, model_name=model_name)
-    if provider and stored_credential and provider != "google_anthropic_vertex":
+    if stored_credential and provider != "google_anthropic_vertex":
         kwargs["api_key"] = stored_credential
 
     # Compose under existing kwargs: profile < config.toml < --model-params
@@ -6614,35 +6667,7 @@ def create_model(
         reasoning_override = extra_kwargs.get("reasoning")
         kwargs.update(extra_kwargs)
     if provider and scoped_environment:
-        if extra_kwargs and "api_key" in extra_kwargs:
-            if "base_url" not in extra_kwargs:
-                from deepagents_code.model_config import auth_store
-
-                try:
-                    stored_base_url = auth_store.get_stored_base_url(provider)
-                except RuntimeError:
-                    # The caller passed an explicit `api_key` with no
-                    # `base_url`. Without the store we cannot tell whether the
-                    # inherited endpoint was paired with the *stored* key, so
-                    # fail closed and drop it: sending an explicitly supplied
-                    # key to a gateway it was not issued for is the worse
-                    # outcome.
-                    logger.warning(
-                        "Could not read the stored endpoint for %r; the "
-                        "credential file may be corrupt. Dropping the "
-                        "inherited base URL so the explicitly supplied key is "
-                        "not sent to it. Pass `base_url` via `--model-params` "
-                        "to target an endpoint explicitly.",
-                        provider,
-                    )
-                    kwargs.pop("base_url", None)
-                else:
-                    if stored_base_url and kwargs.get("base_url") == stored_base_url:
-                        kwargs.pop("base_url", None)
-        else:
-            _apply_scoped_stored_endpoint(provider, kwargs)
-            if extra_kwargs and "base_url" in extra_kwargs:
-                kwargs["base_url"] = extra_kwargs["base_url"]
+        _apply_scoped_endpoint(provider, kwargs, extra_kwargs)
     kwargs = _compose_openai_reasoning_effort(
         provider,
         kwargs,

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -770,19 +770,6 @@ def _dotenv_environment(
     return env
 
 
-def strip_loaded_dotenv_values(env: MutableMapping[str, str]) -> None:
-    """Remove values this process's dotenv loader injected into *env*.
-
-    A value is loader-owned only while it still matches what was injected, so a
-    later override by the shell or by managed policy survives the strip. This is
-    the single definition of that rule; both the dotenv preview and the server
-    subprocess environment depend on it.
-    """
-    for key, value in _dotenv_loaded_values.items():
-        if env.get(key) == value:
-            env.pop(key)
-
-
 def _preview_dotenv_environ(*, start_path: Path | None = None) -> dict[str, str]:
     """Return the effective dotenv environment without mutating `os.environ`.
 
@@ -1434,29 +1421,6 @@ def _decode_user_langsmith_env(
     launch = _validate_user_langsmith_env(decoded["launch"])
     user = _validate_user_langsmith_env(decoded["user"])
     return (launch, user) if launch is not None and user is not None else None
-
-
-def _decode_relayed_tracing(raw: str | None) -> dict[str, Any] | None:
-    """Decode the relayed caller tracing carrier into its original values.
-
-    The carrier is the one serialized blob that becomes shell environment, so
-    its parse and shape contract has a single definition: both the redaction
-    set and the shell environment restore read it through here.
-
-    Args:
-        raw: Serialized carrier value, or `None` when absent.
-
-    Returns:
-        The decoded mapping, or `None` when the carrier is absent, unparsable,
-        or not an object.
-    """
-    if not raw:
-        return None
-    try:
-        originals = json.loads(raw)
-    except ValueError:
-        return None
-    return originals if isinstance(originals, dict) else None
 
 
 def relayed_user_tracing_secrets(environ: Mapping[str, str]) -> tuple[str, ...]:
@@ -4391,7 +4355,6 @@ def get_langsmith_project_name() -> str | None:
     Returns:
         Project name string when LangSmith tracing is active, None otherwise.
     """
-    from deepagents_code._env_vars import LANGSMITH_PROJECT
     from deepagents_code.config_manifest import LANGSMITH_PROJECT_DEFAULT
     from deepagents_code.model_config import resolve_env_var
 

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -543,6 +543,14 @@ class _ModalProvider(SandboxProvider):
     """Modal sandbox provider — lifecycle management for Modal sandboxes."""
 
     def __init__(self) -> None:
+        """Initialize the Modal provider.
+
+        Raises:
+            ValueError: If the resolved Modal credentials are invalid, or if
+                only one half of the `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`
+                pair resolves. Delegating to default Modal authentication
+                there would be a silent privilege substitution.
+        """
         self._modal = _import_provider_module(
             "modal",
             provider="modal",
@@ -567,12 +575,18 @@ class _ModalProvider(SandboxProvider):
                 )
                 raise ValueError(msg) from exc
         elif token_id or token_secret:
-            logger.warning(
-                "Only one of MODAL_TOKEN_ID / MODAL_TOKEN_SECRET is set; "
-                "both are required for explicit credential auth. "
-                "Falling back to default Modal authentication.",
+            # Fail closed rather than warn and delegate: a `None` client makes
+            # `App.lookup` resolve credentials from the server process, so a
+            # workspace that pinned a restricted token would silently run its
+            # sandbox under the server's broader Modal identity.
+            missing = "MODAL_TOKEN_SECRET" if token_id else "MODAL_TOKEN_ID"
+            msg = (
+                "The workspace Modal configuration is incomplete: "
+                f"{missing} is not set. Set MODAL_TOKEN_ID and "
+                "MODAL_TOKEN_SECRET together, or unset both to fall back to "
+                "default Modal authentication."
             )
-            self._client = None
+            raise ValueError(msg)
         else:
             self._client = None
 

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -961,6 +961,7 @@ class _VercelProvider(SandboxProvider):
     """Vercel Sandbox provider implementation."""
 
     def __init__(self) -> None:
+        """Initialize the provider, resolving workspace Vercel credentials."""
         self._sdk_kwargs = self._resolve_sdk_kwargs()
 
     @classmethod
@@ -969,12 +970,18 @@ class _VercelProvider(SandboxProvider):
 
         Each value resolves prefixed-first then canonical via `resolve_env_var`,
         against the bound workspace environment. Credentials stay SDK-managed
-        (OIDC, or `VERCEL_*` in the server's own environment) only when the
-        workspace configured none of them.
+        (OIDC, or `VERCEL_*` in the server's own environment) only when none of
+        the three variables resolves for this workspace.
 
         Returns:
             Explicit SDK credential arguments, or an empty mapping to delegate
             credential resolution to the Vercel SDK.
+
+        Raises:
+            ValueError: If only part of the `VERCEL_TOKEN` / `VERCEL_PROJECT_ID`
+                / `VERCEL_TEAM_ID` set resolves. Delegating to the SDK there
+                would authenticate the sandbox with the server's own Vercel
+                identity instead of the credentials this workspace pinned.
         """
         from deepagents_code.model_config import resolve_env_var
 
@@ -990,15 +997,24 @@ class _VercelProvider(SandboxProvider):
         # read -- gating on the prefix alone silently discarded it.
         if not any(values.values()):
             return {}
-        missing = sorted(key for key, value in values.items() if not value)
+        missing = sorted(
+            f"VERCEL_{key.upper()}" for key, value in values.items() if not value
+        )
         if missing:
-            logger.warning(
-                "Incomplete explicit Vercel credentials; VERCEL_TOKEN, "
-                "VERCEL_PROJECT_ID, and VERCEL_TEAM_ID are all required. "
-                "Falling back to default Vercel authentication. Missing: %s",
-                ", ".join(missing),
+            # Fail closed rather than warn and delegate: an empty mapping hands
+            # auth back to the Vercel SDK, which resolves credentials from the
+            # server process (`VERCEL_*` in its own environment, or its OIDC
+            # identity). A workspace that pinned a restricted token would then
+            # silently run its sandbox under the server's broader identity.
+            msg = (
+                "The workspace Vercel configuration is incomplete: "
+                f"{', '.join(missing)} not set. Set VERCEL_TOKEN, "
+                "VERCEL_PROJECT_ID, and VERCEL_TEAM_ID together, or unset all "
+                "three to fall back to default Vercel authentication."
             )
-            return {}
+            raise ValueError(msg)
+        # `missing` is empty, so every value is a non-empty string here; the
+        # comprehension re-states that for the type checker.
         return {key: value for key, value in values.items() if value}
 
     def get_or_create(

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -1031,18 +1031,19 @@ class _VercelProvider(SandboxProvider):
 
         Each value resolves prefixed-first then canonical via `resolve_env_var`,
         against the bound workspace environment. Credentials stay SDK-managed
-        when none of the three variables resolves, or when token-free OIDC
-        settings match the server environment that the SDK reads.
+        when none of the three variables resolves, and when every resolved
+        value matches the server environment the SDK reads for itself -- there
+        is no workspace identity to protect in either case.
 
         Returns:
             Explicit SDK credential arguments, or an empty mapping to delegate
             credential resolution to the Vercel SDK.
 
         Raises:
-            ValueError: If only part of the `VERCEL_TOKEN` / `VERCEL_PROJECT_ID`
-                / `VERCEL_TEAM_ID` set resolves and SDK-managed OIDC cannot
-                preserve the workspace settings. Delegating there would use
-                the server's identity instead of the workspace credentials.
+            ValueError: If the workspace overrides part of the `VERCEL_TOKEN` /
+                `VERCEL_PROJECT_ID` / `VERCEL_TEAM_ID` set but not all of it.
+                Delegating there would use the server's identity instead of
+                the credentials the workspace pinned.
         """
         from deepagents_code.model_config import resolve_env_var
 
@@ -1058,16 +1059,18 @@ class _VercelProvider(SandboxProvider):
         # read -- gating on the prefix alone silently discarded it.
         if not any(values.values()):
             return {}
-        # OIDC can coexist with inherited project/team IDs without an API
-        # token. Delegate only if the SDK sees the same settings; otherwise
-        # workspace overrides would silently be discarded.
-        if (
-            not values["token"]
-            and os.environ.get("VERCEL_OIDC_TOKEN")
-            and all(
-                value == (os.environ.get(f"VERCEL_{key.upper()}") or None)
-                for key, value in values.items()
-            )
+        # Nothing here came from the workspace: `resolve_env_var` reads
+        # `active_environment()`, which falls back to `os.environ`, so the
+        # server's own `VERCEL_*` resolve identically. There is no workspace
+        # identity to protect and the SDK resolves exactly these values, so
+        # delegate instead of demanding the full set. That covers inherited
+        # token-free OIDC, and a personal-scope token, where `VERCEL_TEAM_ID`
+        # is optional and demanding it turned a working setup into a startup
+        # failure. A workspace override differs from the server, so it still
+        # takes the fail-closed path below.
+        if all(
+            value == (os.environ.get(f"VERCEL_{key.upper()}") or None)
+            for key, value in values.items()
         ):
             return {}
         missing = sorted(

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -6,6 +6,7 @@ import contextlib
 import importlib
 import importlib.util
 import logging
+import os
 import shlex
 import string
 import time
@@ -970,8 +971,8 @@ class _VercelProvider(SandboxProvider):
 
         Each value resolves prefixed-first then canonical via `resolve_env_var`,
         against the bound workspace environment. Credentials stay SDK-managed
-        (OIDC, or `VERCEL_*` in the server's own environment) only when none of
-        the three variables resolves for this workspace.
+        when none of the three variables resolves, or when token-free OIDC
+        settings match the server environment that the SDK reads.
 
         Returns:
             Explicit SDK credential arguments, or an empty mapping to delegate
@@ -979,9 +980,9 @@ class _VercelProvider(SandboxProvider):
 
         Raises:
             ValueError: If only part of the `VERCEL_TOKEN` / `VERCEL_PROJECT_ID`
-                / `VERCEL_TEAM_ID` set resolves. Delegating to the SDK there
-                would authenticate the sandbox with the server's own Vercel
-                identity instead of the credentials this workspace pinned.
+                / `VERCEL_TEAM_ID` set resolves and SDK-managed OIDC cannot
+                preserve the workspace settings. Delegating there would use
+                the server's identity instead of the workspace credentials.
         """
         from deepagents_code.model_config import resolve_env_var
 
@@ -996,6 +997,18 @@ class _VercelProvider(SandboxProvider):
         # `resolve_env_var` but no longer reaches the SDK's own `os.environ`
         # read -- gating on the prefix alone silently discarded it.
         if not any(values.values()):
+            return {}
+        # OIDC can coexist with inherited project/team IDs without an API
+        # token. Delegate only if the SDK sees the same settings; otherwise
+        # workspace overrides would silently be discarded.
+        if (
+            not values["token"]
+            and os.environ.get("VERCEL_OIDC_TOKEN")
+            and all(
+                value == (os.environ.get(f"VERCEL_{key.upper()}") or None)
+                for key, value in values.items()
+            )
+        ):
             return {}
         missing = sorted(
             f"VERCEL_{key.upper()}" for key, value in values.items() if not value

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -773,10 +773,9 @@ def _aws_session_kwargs() -> dict[str, str]:
         Populated boto3 session keyword arguments.
 
     Raises:
-        ValueError: If the resolved credentials are incomplete or express two
-            mutually exclusive intents. Checked before boto3 is touched so the
-            error names the variable at fault; boto3's own
-            `PartialCredentialsError` names neither.
+        ValueError: If the resolved credentials are incomplete. Checked before
+            boto3 is touched so the error names the variable at fault; boto3's
+            own `PartialCredentialsError` names neither.
     """
     from deepagents_code.model_config import resolve_env_var
 

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -1046,9 +1046,9 @@ class _VercelProvider(SandboxProvider):
 
         Each value resolves prefixed-first then canonical via `resolve_env_var`,
         against the bound workspace environment. Credentials stay SDK-managed
-        when none of the three variables resolves, and when every resolved
-        value matches the server environment the SDK reads for itself -- there
-        is no workspace identity to protect in either case.
+        when every resolved value matches the server environment the SDK reads
+        for itself. Explicit credentials must come entirely from the workspace
+        or entirely from the server, never a mixture of the two.
 
         Returns:
             Explicit SDK credential arguments, or an empty mapping to delegate
@@ -1066,13 +1066,6 @@ class _VercelProvider(SandboxProvider):
             key: resolve_env_var(name)
             for key, name in cls._CREDENTIAL_ENV_NAMES.items()
         }
-        # Gate on the resolved values, not on the presence of a prefixed name.
-        # `_build_server_env` strips the client's project `.env` from the server
-        # process, so an unprefixed `VERCEL_TOKEN` in a workspace `.env` reaches
-        # `resolve_env_var` but no longer reaches the SDK's own `os.environ`
-        # read -- gating on the prefix alone silently discarded it.
-        if not any(values.values()):
-            return {}
         # Nothing here came from the workspace: `resolve_env_var` reads
         # `active_environment()`, which falls back to `os.environ`, so the
         # server's own `VERCEL_*` resolve identically. There is no workspace
@@ -1104,9 +1097,37 @@ class _VercelProvider(SandboxProvider):
                 "unset all three to fall back to default Vercel authentication."
             )
             raise ValueError(msg)
+        cls._validate_credential_sources(values)
         # `missing` is empty, so every value is a non-empty string here; the
         # comprehension re-states that for the type checker.
         return {key: value for key, value in values.items() if value}
+
+    @classmethod
+    def _validate_credential_sources(cls, values: Mapping[str, str | None]) -> None:
+        """Reject a workspace credential set completed by inherited fields.
+
+        Compare the selected variable names as well as their values: an
+        explicit prefixed workspace ID may equal the server's canonical ID.
+
+        Raises:
+            ValueError: If only part of the credential set is inherited.
+        """
+        from deepagents_code.model_config import resolved_env_var_name
+
+        inherited = [
+            name
+            for key, name in cls._CREDENTIAL_ENV_NAMES.items()
+            if values[key] == os.environ.get(resolved_env_var_name(name))
+        ]
+        if inherited and len(inherited) != len(values):
+            msg = (
+                "The Vercel configuration mixes workspace and server credentials: "
+                f"{', '.join(inherited)} inherited from the server. "
+                "Set VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID together "
+                "using workspace overrides, or remove the workspace overrides "
+                "to use default Vercel authentication."
+            )
+            raise ValueError(msg)
 
     def get_or_create(
         self,

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -910,42 +910,22 @@ class _VercelSandboxHandle(Protocol):
 class _VercelProvider(SandboxProvider):
     """Vercel Sandbox provider implementation."""
 
-    _CREDENTIAL_ENV_NAMES = (
-        "VERCEL_TOKEN",
-        "VERCEL_PROJECT_ID",
-        "VERCEL_TEAM_ID",
-    )
-
     def __init__(self) -> None:
         self._sdk_kwargs = self._resolve_sdk_kwargs()
 
     @classmethod
     def _resolve_sdk_kwargs(cls) -> dict[str, str]:
-        """Resolve explicit Vercel credentials when a prefixed override is set.
+        """Resolve explicit Vercel credentials configured for this workspace.
 
-        Credentials stay SDK-managed (canonical `VERCEL_*` variables or OIDC)
-        unless at least one of the prefixed overrides
-        `DEEPAGENTS_CODE_VERCEL_TOKEN`, `DEEPAGENTS_CODE_VERCEL_PROJECT_ID`, or
-        `DEEPAGENTS_CODE_VERCEL_TEAM_ID` is present. When triggered, each value
-        still resolves prefixed-first then canonical via `resolve_env_var`.
+        Each value resolves prefixed-first then canonical via `resolve_env_var`,
+        against the bound workspace environment. Credentials stay SDK-managed
+        (OIDC, or `VERCEL_*` in the server's own environment) only when the
+        workspace configured none of them.
 
         Returns:
             Explicit SDK credential arguments, or an empty mapping to delegate
             credential resolution to the Vercel SDK.
         """
-        from deepagents_code.model_config import _ENV_PREFIX
-
-        prefix = _ENV_PREFIX
-        # Gate against the same mapping `resolve_env_var` resolves from. Reading
-        # `os.environ` here would miss a prefixed override that came from the
-        # workspace `.env`, silently falling back to default Vercel auth.
-        environment = active_environment()
-        has_override = any(
-            f"{prefix}{name}" in environment for name in cls._CREDENTIAL_ENV_NAMES
-        )
-        if not has_override:
-            return {}
-
         from deepagents_code.model_config import resolve_env_var
 
         values = {
@@ -953,6 +933,13 @@ class _VercelProvider(SandboxProvider):
             "project_id": resolve_env_var("VERCEL_PROJECT_ID"),
             "team_id": resolve_env_var("VERCEL_TEAM_ID"),
         }
+        # Gate on the resolved values, not on the presence of a prefixed name.
+        # `_build_server_env` strips the client's project `.env` from the server
+        # process, so an unprefixed `VERCEL_TOKEN` in a workspace `.env` reaches
+        # `resolve_env_var` but no longer reaches the SDK's own `os.environ`
+        # read -- gating on the prefix alone silently discarded it.
+        if not any(values.values()):
+            return {}
         missing = sorted(key for key, value in values.items() if not value)
         if missing:
             logger.warning(

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -720,6 +720,40 @@ class _RunloopProvider(SandboxProvider):
         self._provider.delete(sandbox_id=sandbox_id)
 
 
+def _aws_session_kwargs() -> dict[str, str]:
+    """Translate the bound workspace environment into boto3 session arguments.
+
+    Resolves through `resolve_env_var` so a `DEEPAGENTS_CODE_`-prefixed
+    override is honored here exactly as it is on the model path. Both paths
+    share `AWS_CREDENTIAL_ENV_SOURCES`; sharing the table alone left the
+    *lookup* free to drift, so a prefixed value applied to the model and was
+    dropped for the sandbox.
+
+    Returns:
+        Populated boto3 session keyword arguments.
+
+    Raises:
+        ValueError: If exactly one half of the access-key pair resolves.
+            boto3 would raise `PartialCredentialsError`, which the caller
+            turns into a silent fallback to the server's own credentials.
+    """
+    from deepagents_code.model_config import resolve_env_var
+
+    resolved = resolve_env_kwargs(AWS_CREDENTIAL_ENV_SOURCES, resolve_env_var)
+    key_id = resolved.get("aws_access_key_id")
+    secret = resolved.get("aws_secret_access_key")
+    if bool(key_id) != bool(secret):
+        missing = "AWS_SECRET_ACCESS_KEY" if key_id else "AWS_ACCESS_KEY_ID"
+        msg = (
+            f"The workspace AWS configuration is incomplete: {missing} is not "
+            f"set. Set both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in "
+            f"this workspace's .env, or unset both to use AWS_PROFILE or the "
+            f"server's default credentials."
+        )
+        raise ValueError(msg)
+    return resolved
+
+
 class _AgentCoreProvider(SandboxProvider):
     """AgentCore Code Interpreter sandbox provider.
 
@@ -735,8 +769,11 @@ class _AgentCoreProvider(SandboxProvider):
                 `AWS_DEFAULT_REGION` / `us-west-2`).
 
         Raises:
-            ValueError: If boto3 is installed and AWS credentials cannot
-                be resolved.
+            ValueError: If boto3 is installed and AWS credentials cannot be
+                resolved, or if the workspace scoped the sandbox to specific
+                AWS credentials that turn out to be invalid or incomplete.
+                Falling back to the server's own credentials there would be a
+                silent privilege substitution.
         """
         environment = active_environment()
         # Region resolves through the same table-driven helper as the
@@ -749,10 +786,12 @@ class _AgentCoreProvider(SandboxProvider):
         self._session: Any = None
 
         # Validate AWS credentials early for a clear error message.
+        session_kwargs: dict[str, str] = {}
         try:
             import boto3  # ty: ignore[unresolved-import]
 
-            session_kwargs = {**aws_kwargs, "region_name": self._region}
+            session_kwargs = _aws_session_kwargs()
+            session_kwargs["region_name"] = self._region
             self._session = boto3.Session(**session_kwargs)
             credentials = self._session.get_credentials()
             if credentials is None:
@@ -766,10 +805,27 @@ class _AgentCoreProvider(SandboxProvider):
             logger.debug("boto3 not installed; skipping credential pre-check")
         except ValueError:
             raise
-        except Exception:
-            # Say what the failure costs, not just that it happened: without a
-            # session the interpreter resolves credentials itself, from the
-            # process environment rather than this workspace's.
+        except Exception as exc:
+            # Without a session the interpreter resolves credentials itself,
+            # from the server process rather than this workspace. That is the
+            # right default when the workspace scoped nothing, and a privilege
+            # substitution when it did -- a workspace pinned to a restricted
+            # profile would silently run under the server's broader identity.
+            scoped = {
+                key: value
+                for key, value in session_kwargs.items()
+                if key != "region_name"
+            }
+            if scoped:
+                msg = (
+                    f"The workspace AWS configuration is invalid: {exc}. This "
+                    f"workspace scoped its sandbox to specific AWS credentials "
+                    f"({', '.join(sorted(scoped))}), so the server's own "
+                    f"credentials are not substituted. Fix AWS_PROFILE / "
+                    f"AWS_ACCESS_KEY_ID in this workspace's .env, or unset "
+                    f"them to use the server's default credentials."
+                )
+                raise ValueError(msg) from exc
             logger.warning(
                 "Could not build an AWS session from the workspace environment "
                 "(region=%s). The sandbox will NOT use workspace AWS "

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -735,6 +735,26 @@ class _RunloopProvider(SandboxProvider):
         self._provider.delete(sandbox_id=sandbox_id)
 
 
+def _server_aws_session_kwargs() -> dict[str, str]:
+    """Resolve boto3 session arguments from the server's own environment.
+
+    The workspace resolution reads `active_environment()`, which falls back to
+    `os.environ`, so a plain `AWS_PROFILE` exported in the server's shell is
+    indistinguishable from one a workspace pinned. Resolving the same table
+    against `os.environ` explicitly gives the caller a baseline to compare
+    against.
+
+    Returns:
+        The boto3 session arguments the server would resolve on its own.
+    """
+    from deepagents_code.config import _resolve_env_var_from
+
+    return resolve_env_kwargs(
+        AWS_CREDENTIAL_ENV_SOURCES,
+        lambda name: _resolve_env_var_from(os.environ, name),
+    )
+
+
 def _aws_session_kwargs() -> dict[str, str]:
     """Translate the bound workspace environment into boto3 session arguments.
 
@@ -744,13 +764,19 @@ def _aws_session_kwargs() -> dict[str, str]:
     *lookup* free to drift, so a prefixed value applied to the model and was
     dropped for the sandbox.
 
+    Validates the resolved set as a whole. A pair check alone let a session
+    token with neither key half through, and botocore then declines the
+    explicit credential provider and falls through to the server's own
+    credentials -- so the workspace's token is silently ignored.
+
     Returns:
         Populated boto3 session keyword arguments.
 
     Raises:
-        ValueError: If exactly one half of the access-key pair resolves.
-            boto3 would raise `PartialCredentialsError`, which the caller
-            turns into a silent fallback to the server's own credentials.
+        ValueError: If the resolved credentials are incomplete or express two
+            mutually exclusive intents. Checked before boto3 is touched so the
+            error names the variable at fault; boto3's own
+            `PartialCredentialsError` names neither.
     """
     from deepagents_code.model_config import resolve_env_var
 
@@ -766,6 +792,20 @@ def _aws_session_kwargs() -> dict[str, str]:
             f"server's default credentials."
         )
         raise ValueError(msg)
+    if resolved.get("aws_session_token") and not key_id:
+        msg = (
+            "The workspace AWS configuration is incomplete: AWS_SESSION_TOKEN "
+            "is set without AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. Set "
+            "all three together, or unset AWS_SESSION_TOKEN to use AWS_PROFILE "
+            "or the server's default credentials."
+        )
+        raise ValueError(msg)
+    # `AWS_PROFILE` alongside explicit keys is left alone deliberately. boto3's
+    # precedence is documented and deterministic, and because
+    # `active_environment()` layers the workspace over the server's own
+    # environment, an exported profile plus workspace keys is an ordinary
+    # combination rather than a mistake. Rejecting it would turn a working
+    # setup into a startup failure.
     return resolved
 
 
@@ -825,7 +865,13 @@ class _AgentCoreProvider(SandboxProvider):
             # right default when the workspace scoped nothing, and a privilege
             # substitution when it did -- a workspace pinned to a restricted
             # profile would silently run under the server's broader identity.
-            if credential_kwargs:
+            #
+            # Compare against what the server resolves on its own: a plain
+            # `AWS_PROFILE` exported in the server's shell reaches
+            # `active_environment()` too, and treating that as workspace-pinned
+            # turned a stale server-level profile into a startup failure whose
+            # message blamed a workspace `.env` that never set it.
+            if credential_kwargs and credential_kwargs != _server_aws_session_kwargs():
                 msg = (
                     f"The workspace AWS configuration is invalid: {exc}. This "
                     f"workspace scoped its sandbox to specific AWS credentials "

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -786,13 +786,12 @@ class _AgentCoreProvider(SandboxProvider):
         self._session: Any = None
 
         # Validate AWS credentials early for a clear error message.
-        session_kwargs: dict[str, str] = {}
+        credential_kwargs: dict[str, str] = {}
         try:
             import boto3  # ty: ignore[unresolved-import]
 
-            session_kwargs = _aws_session_kwargs()
-            session_kwargs["region_name"] = self._region
-            self._session = boto3.Session(**session_kwargs)
+            credential_kwargs = _aws_session_kwargs()
+            self._session = boto3.Session(region_name=self._region, **credential_kwargs)
             credentials = self._session.get_credentials()
             if credentials is None:
                 msg = (
@@ -811,16 +810,11 @@ class _AgentCoreProvider(SandboxProvider):
             # right default when the workspace scoped nothing, and a privilege
             # substitution when it did -- a workspace pinned to a restricted
             # profile would silently run under the server's broader identity.
-            scoped = {
-                key: value
-                for key, value in session_kwargs.items()
-                if key != "region_name"
-            }
-            if scoped:
+            if credential_kwargs:
                 msg = (
                     f"The workspace AWS configuration is invalid: {exc}. This "
                     f"workspace scoped its sandbox to specific AWS credentials "
-                    f"({', '.join(sorted(scoped))}), so the server's own "
+                    f"({', '.join(sorted(credential_kwargs))}), so the server's own "
                     f"credentials are not substituted. Fix AWS_PROFILE / "
                     f"AWS_ACCESS_KEY_ID in this workspace's .env, or unset "
                     f"them to use the server's default credentials."

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -13,7 +13,7 @@ import time
 from contextlib import contextmanager
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol
 
 from rich.markup import escape as escape_markup
 
@@ -33,7 +33,7 @@ from deepagents_code.integrations.sandbox_provider import (
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Mapping
     from types import ModuleType
 
     from deepagents.backends.protocol import SandboxBackendProtocol
@@ -735,23 +735,26 @@ class _RunloopProvider(SandboxProvider):
         self._provider.delete(sandbox_id=sandbox_id)
 
 
-def _server_aws_session_kwargs() -> dict[str, str]:
-    """Resolve boto3 session arguments from the server's own environment.
+def _server_env_kwargs(table: Mapping[str, tuple[str, ...]]) -> dict[str, str]:
+    """Resolve a credential table against the server's own environment.
 
-    The workspace resolution reads `active_environment()`, which falls back to
-    `os.environ`, so a plain `AWS_PROFILE` exported in the server's shell is
-    indistinguishable from one a workspace pinned. Resolving the same table
-    against `os.environ` explicitly gives the caller a baseline to compare
-    against.
+    Workspace resolution reads `active_environment()`, which falls back to
+    `os.environ`, so a plain `AWS_PROFILE` or `VERCEL_TOKEN` exported in the
+    server's shell is indistinguishable from one a workspace pinned. Resolving
+    the same table against `os.environ` explicitly gives the caller a baseline
+    to compare against: an equal result means the workspace pinned nothing of
+    its own, so there is no workspace identity to protect.
+
+    Args:
+        table: Constructor argument name mapped to candidate env var names.
 
     Returns:
-        The boto3 session arguments the server would resolve on its own.
+        The arguments the server would resolve on its own.
     """
     from deepagents_code.config import _resolve_env_var_from
 
     return resolve_env_kwargs(
-        AWS_CREDENTIAL_ENV_SOURCES,
-        lambda name: _resolve_env_var_from(os.environ, name),
+        table, lambda name: _resolve_env_var_from(os.environ, name)
     )
 
 
@@ -870,7 +873,8 @@ class _AgentCoreProvider(SandboxProvider):
             # `active_environment()` too, and treating that as workspace-pinned
             # turned a stale server-level profile into a startup failure whose
             # message blamed a workspace `.env` that never set it.
-            if credential_kwargs and credential_kwargs != _server_aws_session_kwargs():
+            server_kwargs = _server_env_kwargs(AWS_CREDENTIAL_ENV_SOURCES)
+            if credential_kwargs and credential_kwargs != server_kwargs:
                 msg = (
                     f"The workspace AWS configuration is invalid: {exc}. This "
                     f"workspace scoped its sandbox to specific AWS credentials "
@@ -1020,6 +1024,18 @@ class _VercelSandboxHandle(Protocol):
 class _VercelProvider(SandboxProvider):
     """Vercel Sandbox provider implementation."""
 
+    _CREDENTIAL_ENV_NAMES: ClassVar[dict[str, str]] = {
+        "token": "VERCEL_TOKEN",
+        "project_id": "VERCEL_PROJECT_ID",
+        "team_id": "VERCEL_TEAM_ID",
+    }
+    """SDK credential argument mapped to the env var that supplies it.
+
+    One table drives the lookup, the server-environment baseline, and the
+    incomplete-set error, so a renamed argument cannot desynchronize the error
+    message from what was actually read.
+    """
+
     def __init__(self) -> None:
         """Initialize the provider, resolving workspace Vercel credentials."""
         self._sdk_kwargs = self._resolve_sdk_kwargs()
@@ -1047,9 +1063,8 @@ class _VercelProvider(SandboxProvider):
         from deepagents_code.model_config import resolve_env_var
 
         values = {
-            "token": resolve_env_var("VERCEL_TOKEN"),
-            "project_id": resolve_env_var("VERCEL_PROJECT_ID"),
-            "team_id": resolve_env_var("VERCEL_TEAM_ID"),
+            key: resolve_env_var(name)
+            for key, name in cls._CREDENTIAL_ENV_NAMES.items()
         }
         # Gate on the resolved values, not on the presence of a prefixed name.
         # `_build_server_env` strips the client's project `.env` from the server
@@ -1068,12 +1083,12 @@ class _VercelProvider(SandboxProvider):
         # failure. A workspace override differs from the server, so it still
         # takes the fail-closed path below.
         if all(
-            value == (os.environ.get(f"VERCEL_{key.upper()}") or None)
+            value == (os.environ.get(cls._CREDENTIAL_ENV_NAMES[key]) or None)
             for key, value in values.items()
         ):
             return {}
         missing = sorted(
-            f"VERCEL_{key.upper()}" for key, value in values.items() if not value
+            name for key, name in cls._CREDENTIAL_ENV_NAMES.items() if not values[key]
         )
         if missing:
             # Fail closed rather than warn and delegate: an empty mapping hands
@@ -1081,11 +1096,12 @@ class _VercelProvider(SandboxProvider):
             # server process (`VERCEL_*` in its own environment, or its OIDC
             # identity). A workspace that pinned a restricted token would then
             # silently run its sandbox under the server's broader identity.
+            names = list(cls._CREDENTIAL_ENV_NAMES.values())
+            required = f"{', '.join(names[:-1])}, and {names[-1]}"
             msg = (
                 "The workspace Vercel configuration is incomplete: "
-                f"{', '.join(missing)} not set. Set VERCEL_TOKEN, "
-                "VERCEL_PROJECT_ID, and VERCEL_TEAM_ID together, or unset all "
-                "three to fall back to default Vercel authentication."
+                f"{', '.join(missing)} not set. Set {required} together, or "
+                "unset all three to fall back to default Vercel authentication."
             )
             raise ValueError(msg)
         # `missing` is empty, so every value is a non-empty string here; the

--- a/libs/code/deepagents_code/mcp_config.py
+++ b/libs/code/deepagents_code/mcp_config.py
@@ -47,13 +47,14 @@ def _interpolate_env(value: str, *, field: str) -> str:
         RuntimeError: If a required environment variable is unset, or the
             string contains a malformed `${...}` reference.
     """
+    from deepagents_code.config import active_environment
+
+    environ = active_environment()
 
     def replace(match: re.Match[str]) -> str:
         name = match.group(1)
         default = match.group(2)
-        from deepagents_code.config import active_environment
-
-        resolved = active_environment().get(name)
+        resolved = environ.get(name)
         # A non-empty value always wins, for both `${VAR}` and `${VAR:-default}`.
         if resolved:
             return resolved

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -36,7 +36,6 @@ from deepagents_code.server_graph import _workspace_runtime as get_server_runtim
 from deepagents_code.workspace import (
     WorkspaceConflictError,
     bind_thread_workspace,
-    canonical_workspace_config,
     require_thread_workspace,
 )
 
@@ -202,19 +201,45 @@ async def workspace(request: Request) -> JSONResponse:
             {"detail": "request body must be an object"}, status_code=422
         )
     try:
-        from deepagents_code._server_config import ServerConfig
+        from deepagents_code._server_config import (
+            ServerConfig,
+            project_workspace_fields,
+            workspace_claim_fields,
+        )
+        from deepagents_code.workspace import resolve_workspace
 
-        server_config = ServerConfig.from_env()
-        trusted_config = server_config.to_workspace_payload()
-        if "workspace_config" in body or "config_fingerprint" in body:
-            _, trusted_policy_fingerprint = canonical_workspace_config(trusted_config)
-            _, claimed_policy_fingerprint = canonical_workspace_config(
-                body.get("workspace_config")
+        allowed_request_keys = {"config_fingerprint", "cwd", "workspace_config"}
+        if unknown := body.keys() - allowed_request_keys:
+            names = ", ".join(sorted(unknown))
+            return JSONResponse(
+                {"detail": f"unknown workspace request field(s): {names}"},
+                status_code=422,
             )
+        server_config = ServerConfig.from_env()
+        identity = await asyncio.to_thread(resolve_workspace, body.get("cwd"))
+        trusted = server_config.resolve_workspace(identity.cwd, identity.project_root)
+        if "workspace_config" in body or "config_fingerprint" in body:
+            claim = body.get("workspace_config")
+            if not isinstance(claim, dict):
+                return JSONResponse(
+                    {"detail": "workspace_config must be an object"},
+                    status_code=422,
+                )
+            keys = set(claim)
+            if keys & project_workspace_fields():
+                return JSONResponse(
+                    {"detail": "clients cannot claim project workspace policy"},
+                    status_code=409,
+                )
+            if keys != workspace_claim_fields():
+                return JSONResponse(
+                    {"detail": "workspace configuration does not match server policy"},
+                    status_code=409,
+                )
             claimed_config_fingerprint = body.get("config_fingerprint")
             if (
-                claimed_policy_fingerprint != trusted_policy_fingerprint
-                or claimed_config_fingerprint != server_config.workspace_fingerprint()
+                claimed_config_fingerprint != trusted.session_workspace_fingerprint()
+                or claim != trusted.to_session_workspace_claim()
             ):
                 return JSONResponse(
                     {"detail": "workspace configuration does not match server policy"},
@@ -222,9 +247,9 @@ async def workspace(request: Request) -> JSONResponse:
                 )
         binding = await bind_thread_workspace(
             thread_id,
-            body.get("cwd"),
-            trusted_config,
-            config_fingerprint=server_config.workspace_fingerprint(),
+            identity.cwd,
+            trusted.to_workspace_payload(),
+            config_fingerprint=trusted.workspace_fingerprint(),
         )
     except (TypeError, ValueError) as exc:
         return JSONResponse({"detail": str(exc)}, status_code=422)

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -217,7 +217,11 @@ async def workspace(request: Request) -> JSONResponse:
             )
         server_config = ServerConfig.from_env()
         identity = await asyncio.to_thread(resolve_workspace, body.get("cwd"))
-        trusted = server_config.resolve_workspace(identity.cwd, identity.project_root)
+        trusted = await asyncio.to_thread(
+            server_config.resolve_workspace,
+            identity.cwd,
+            identity.project_root,
+        )
         if "workspace_config" in body or "config_fingerprint" in body:
             claim = body.get("workspace_config")
             if not isinstance(claim, dict):

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -43,12 +43,14 @@ if TYPE_CHECKING:
     from langchain_core.runnables import RunnableConfig
     from starlette.requests import Request
 
+    from deepagents_code._server_config import ServerConfig
     from deepagents_code.cost_tracking import PreparedOperationCost
     from deepagents_code.offload_middleware import (
         OffloadExecution,
         OffloadResponse,
         _OffloadState,
     )
+    from deepagents_code.workspace import WorkspaceBinding
 
 logger = logging.getLogger(__name__)
 
@@ -202,9 +204,8 @@ async def workspace(request: Request) -> JSONResponse:
         )
     try:
         from deepagents_code._server_config import (
+            PROJECT_WORKSPACE_FIELDS,
             ServerConfig,
-            project_workspace_fields,
-            workspace_claim_fields,
         )
         from deepagents_code.workspace import resolve_workspace
 
@@ -216,12 +217,15 @@ async def workspace(request: Request) -> JSONResponse:
                 status_code=422,
             )
         server_config = ServerConfig.from_env()
-        identity = await asyncio.to_thread(resolve_workspace, body.get("cwd"))
-        trusted = await asyncio.to_thread(
-            server_config.resolve_workspace,
-            identity.cwd,
-            identity.project_root,
-        )
+
+        def _resolve() -> tuple[WorkspaceBinding, ServerConfig]:
+            identity = resolve_workspace(body.get("cwd"))
+            return identity, server_config.resolve_workspace(
+                identity.cwd,
+                identity.project_root,
+            )
+
+        identity, trusted = await asyncio.to_thread(_resolve)
         if "workspace_config" in body or "config_fingerprint" in body:
             claim = body.get("workspace_config")
             if not isinstance(claim, dict):
@@ -229,15 +233,9 @@ async def workspace(request: Request) -> JSONResponse:
                     {"detail": "workspace_config must be an object"},
                     status_code=422,
                 )
-            keys = set(claim)
-            if keys & project_workspace_fields():
+            if claim.keys() & PROJECT_WORKSPACE_FIELDS:
                 return JSONResponse(
                     {"detail": "clients cannot claim project workspace policy"},
-                    status_code=409,
-                )
-            if keys != workspace_claim_fields():
-                return JSONResponse(
-                    {"detail": "workspace configuration does not match server policy"},
                     status_code=409,
                 )
             claimed_config_fingerprint = body.get("config_fingerprint")

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -36,6 +36,7 @@ from deepagents_code.server_graph import _workspace_runtime as get_server_runtim
 from deepagents_code.workspace import (
     WorkspaceConflictError,
     bind_thread_workspace,
+    get_thread_workspace,
     require_thread_workspace,
 )
 
@@ -254,6 +255,11 @@ async def workspace(request: Request) -> JSONResponse:
                     {"detail": "workspace configuration does not match server policy"},
                     status_code=409,
                 )
+        existing = await get_thread_workspace(thread_id)
+        if existing is not None and existing.workspace_id == identity.workspace_id:
+            trusted = trusted.preserve_bound_extension_trust(
+                existing.workspace_config()
+            )
         binding = await bind_thread_workspace(
             thread_id,
             identity.cwd,

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -83,6 +83,14 @@ _TRACE_FLUSH_TIMEOUT = 2.0
 """Seconds allowed for the shutdown trace flush."""
 _TRACE_FLUSH_POLL_INTERVAL = 0.05
 """Seconds between completion checks while the daemon flush thread runs."""
+_WORKSPACE_REQUEST_FIELDS = frozenset({"config_fingerprint", "cwd", "workspace_config"})
+"""Every field a workspace bind request may carry.
+
+One of the allowlists that gate this trust boundary; an unknown key is rejected
+rather than ignored, so a client cannot smuggle policy past the claim check.
+Declared here, beside the other request-shape constants, so the set of gates is
+visible in one place.
+"""
 
 
 def _run_trace_flush(done: threading.Event, failures: list[BaseException]) -> None:
@@ -209,8 +217,7 @@ async def workspace(request: Request) -> JSONResponse:
         )
         from deepagents_code.workspace import resolve_workspace
 
-        allowed_request_keys = {"config_fingerprint", "cwd", "workspace_config"}
-        if unknown := body.keys() - allowed_request_keys:
+        if unknown := body.keys() - _WORKSPACE_REQUEST_FIELDS:
             names = ", ".join(sorted(unknown))
             return JSONResponse(
                 {"detail": f"unknown workspace request field(s): {names}"},

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -35,7 +35,13 @@ from deepagents_code._startup_error import (
 from deepagents_code.configuration.interpreter import InterpreterConfig
 from deepagents_code.configuration.resolver import get_config_resolver
 from deepagents_code.project_utils import ProjectContext, get_server_project_context
-from deepagents_code.workspace import WorkspaceConflictError, resolve_workspace
+from deepagents_code.workspace import (
+    PROJECT_POLICY_DRIFT_REASON,
+    SERVER_CONFIG_DRIFT_REASON,
+    WorkspaceConflictError,
+    project_policy_differs,
+    resolve_workspace,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping
@@ -132,7 +138,7 @@ async def _build_tools(
     project_context: ProjectContext | None,
     *,
     tavily_api_key: str | None,
-) -> tuple[list[Any], list[Any] | None, list[Any]]:
+) -> tuple[list[Any], list[Any] | None, list[Any], list[Any]]:
     """Assemble the tool list based on server config.
 
     Loads built-in tools (conditionally including web search when Tavily is
@@ -155,7 +161,10 @@ async def _build_tools(
             reports the key as unconfigured.
 
     Returns:
-        Tuple of `(tools, mcp_server_info, mcp_tools)`.
+        Tuple of `(tools, mcp_server_info, mcp_tools, read_only_builtins)`. The
+        last element is the exact built-in tool objects that are safe to expose
+        to criteria drafting and rubric grading; read-only-ness is known here,
+        at construction, so no consumer has to re-derive it.
 
     Raises:
         FileNotFoundError: If the MCP config file is not found.
@@ -168,8 +177,11 @@ async def _build_tools(
     )
 
     tools: list[Any] = [fetch_url, get_current_thread_id]
+    read_only_builtins: list[Any] = [fetch_url]
     if tavily_api_key is not None:
-        tools.append(create_web_search_tool(tavily_api_key))
+        search_tool = create_web_search_tool(tavily_api_key)
+        tools.append(search_tool)
+        read_only_builtins.append(search_tool)
 
     mcp_server_info: list[Any] | None = None
     mcp_tools: list[Any] = []
@@ -211,28 +223,28 @@ async def _build_tools(
         if mcp_tools:
             logger.info("Loaded %d MCP tool(s)", len(mcp_tools))
 
-    return tools, mcp_server_info, mcp_tools
+    return tools, mcp_server_info, mcp_tools, read_only_builtins
 
 
 def _criteria_context_tools(
     tools: list[Any],
     mcp_tools: list[Any],
+    read_only_builtins: list[Any],
 ) -> list[Any]:
     """Select read-only external tools for criteria drafting and rubric grading.
 
     Args:
         tools: Main agent tools in execution order.
         mcp_tools: Exact tool objects returned by MCP discovery.
+        read_only_builtins: Built-in tool objects `_build_tools` created and
+            marked read-only.
 
     Returns:
         External context tools available to criteria generation and grading.
         MCP tools are included only when their protocol annotations explicitly
         declare them read-only.
     """
-    from deepagents_code.tools import fetch_url, is_web_search_tool
-
-    allowed_ids = {id(fetch_url)}
-    allowed_ids.update(id(tool) for tool in tools if is_web_search_tool(tool))
+    allowed_ids = {id(tool) for tool in read_only_builtins}
     allowed_ids.update(
         id(tool) for tool in mcp_tools if _mcp_tool_is_explicitly_read_only(tool)
     )
@@ -413,12 +425,14 @@ async def _make_graphs_in_environment(
     )
     result.apply_to_runtime_state()
 
-    tools, mcp_server_info, mcp_tools = await _build_tools(
+    tools, mcp_server_info, mcp_tools, read_only_builtins = await _build_tools(
         config,
         project_context,
         tavily_api_key=workspace_credentials.tavily_api_key,
     )
-    read_only_context_tools = _criteria_context_tools(tools, mcp_tools)
+    read_only_context_tools = _criteria_context_tools(
+        tools, mcp_tools, read_only_builtins
+    )
 
     # Create sandbox backend if a sandbox provider is configured.
     # The context manager is created here in the factory, but its reference is
@@ -724,18 +738,17 @@ async def _default_workspace_binding(config: ServerConfig) -> WorkspaceBinding |
     """
     if config.cwd is None:
         return None
-    identity = await asyncio.to_thread(resolve_workspace, config.cwd)
-    resolved = await asyncio.to_thread(
-        config.resolve_workspace,
-        identity.cwd,
-        identity.project_root,
-    )
-    return await asyncio.to_thread(
-        resolve_workspace,
-        identity.cwd,
-        resolved.to_workspace_payload(),
-        config_fingerprint=resolved.workspace_fingerprint(),
-    )
+
+    def _bind() -> WorkspaceBinding:
+        identity = resolve_workspace(config.cwd)
+        resolved = config.resolve_workspace(identity.cwd, identity.project_root)
+        return resolve_workspace(
+            identity.cwd,
+            resolved.to_workspace_payload(),
+            config_fingerprint=resolved.workspace_fingerprint(),
+        )
+
+    return await asyncio.to_thread(_bind)
 
 
 def _resolve_bound_workspace_config(binding: WorkspaceBinding) -> ServerConfig:
@@ -746,18 +759,14 @@ def _resolve_bound_workspace_config(binding: WorkspaceBinding) -> ServerConfig:
     """
     config = ServerConfig.from_env()
     current_config = config.resolve_workspace(binding.cwd, binding.project_root)
-    bound_policy = binding.workspace_config()
-    project_policy = current_config.to_project_workspace_policy()
-    if any(bound_policy.get(key) != value for key, value in project_policy.items()):
-        reason = (
-            "the project's resolved policy differs from the policy recorded "
-            "when this workspace was bound"
-        )
-        conflict = WorkspaceConflictError.from_reason(reason)
+    if project_policy_differs(
+        binding.workspace_config(),
+        current_config.to_project_workspace_policy(),
+    ):
+        conflict = WorkspaceConflictError.from_reason(PROJECT_POLICY_DRIFT_REASON)
         raise conflict
     if current_config.workspace_fingerprint() != binding.config_fingerprint:
-        reason = "the server configuration changed after this workspace was bound"
-        conflict = WorkspaceConflictError.from_reason(reason)
+        conflict = WorkspaceConflictError.from_reason(SERVER_CONFIG_DRIFT_REASON)
         raise conflict
     return current_config
 
@@ -768,15 +777,11 @@ async def _workspace_runtime(binding: WorkspaceBinding) -> ServerRuntime:
     Returns:
         The runtime selected by the binding's immutable resource key.
     """
-    await asyncio.to_thread(_resolve_bound_workspace_config, binding)
+    current_config = await asyncio.to_thread(_resolve_bound_workspace_config, binding)
     cached = _cached_workspace_runtime(binding)
     if cached is not None:
         return cached
     async with _workspace_runtime_lock:
-        current_config = await asyncio.to_thread(
-            _resolve_bound_workspace_config,
-            binding,
-        )
         cached = _cached_workspace_runtime(binding)
         if cached is not None:
             return cached

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -743,16 +743,9 @@ async def _default_workspace_binding(config: ServerConfig) -> WorkspaceBinding |
         # First pass resolves identity only (cwd plus project root); its
         # fingerprints are digests of an empty policy and are discarded.
         identity = resolve_workspace(config.cwd)
-        # Resolve policy against the root the runtime will actually use.
-        # `resolve_workspace` always derives it with `find_project_root`, while
-        # `get_server_project_context` prefers an explicit
-        # `DEEPAGENTS_CODE_SERVER_PROJECT_ROOT`. Where those disagree, using the
-        # derived root made this binding record scrubbed project policy while
-        # `_get_runtime()` -- which takes no override -- kept the launch
-        # project's MCP servers and extensions live.
-        resolved = config.resolve_workspace(
-            identity.cwd, config.project_root or identity.project_root
-        )
+        # The shared policy resolver honors the explicit launch root while
+        # keeping the durable identity consistent with workspace validation.
+        resolved = config.resolve_workspace(identity.cwd, identity.project_root)
         return resolve_workspace(
             identity.cwd,
             resolved.to_workspace_payload(),
@@ -818,7 +811,11 @@ async def _workspace_runtime(binding: WorkspaceBinding) -> ServerRuntime:
         _claim_sandbox_workspace(current_config.sandbox_type, binding)
         project_context = ProjectContext(
             user_cwd=Path(binding.cwd),
-            project_root=Path(binding.project_root) if binding.project_root else None,
+            project_root=(
+                Path(current_config.project_root)
+                if current_config.project_root
+                else None
+            ),
         )
         runtime = await _make_graphs(
             config_override=current_config,

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -741,8 +741,19 @@ async def _default_workspace_binding(config: ServerConfig) -> WorkspaceBinding |
         return None
 
     def _bind() -> WorkspaceBinding:
+        # First pass resolves identity only (cwd plus project root); its
+        # fingerprints are digests of an empty policy and are discarded.
         identity = resolve_workspace(config.cwd)
-        resolved = config.resolve_workspace(identity.cwd, identity.project_root)
+        # Resolve policy against the root the runtime will actually use.
+        # `resolve_workspace` always derives it with `find_project_root`, while
+        # `get_server_project_context` prefers an explicit
+        # `DEEPAGENTS_CODE_SERVER_PROJECT_ROOT`. Where those disagree, using the
+        # derived root made this binding record scrubbed project policy while
+        # `_get_runtime()` -- which takes no override -- kept the launch
+        # project's MCP servers and extensions live.
+        resolved = config.resolve_workspace(
+            identity.cwd, config.project_root or identity.project_root
+        )
         return resolve_workspace(
             identity.cwd,
             resolved.to_workspace_payload(),

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -16,6 +16,7 @@ import atexit
 import logging
 import sys
 from collections import OrderedDict
+from dataclasses import replace
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -39,7 +40,7 @@ from deepagents_code.workspace import (
     PROJECT_POLICY_DRIFT_REASON,
     SERVER_CONFIG_DRIFT_REASON,
     WorkspaceConflictError,
-    project_policy_differs,
+    drifted_project_fields,
     resolve_workspace,
 )
 
@@ -754,18 +755,44 @@ async def _default_workspace_binding(config: ServerConfig) -> WorkspaceBinding |
 def _resolve_bound_workspace_config(binding: WorkspaceBinding) -> ServerConfig:
     """Resolve current workspace policy and reject drift from its binding.
 
+    Refusals name the fields that drifted. This runs on every request, and it
+    reads the extension trust store each time, so a transient read failure
+    reports as a policy change; without the field names that refusal is not
+    diagnosable. The values are paths and booleans, never secrets.
+
     Returns:
         The current server configuration resolved for the workspace.
     """
     config = ServerConfig.from_env()
     current_config = config.resolve_workspace(binding.cwd, binding.project_root)
-    if project_policy_differs(
-        binding.workspace_config(),
-        current_config.to_project_workspace_policy(),
+    bound_policy = binding.workspace_config()
+    # Extension trust is resolved from a mutable on-disk store, so granting it
+    # in another session looks exactly like drift. A grant is user-authorized
+    # and only ever adds privilege, so pin the bound value instead of refusing:
+    # the thread keeps the trust it was bound with, and the grant takes effect
+    # on the next binding. A revocation still has to refuse, immediately.
+    if bound_policy.get("trust_project_extensions") is False and (
+        current_config.trust_project_extensions is True
     ):
-        conflict = WorkspaceConflictError.from_reason(PROJECT_POLICY_DRIFT_REASON)
+        current_config = replace(current_config, trust_project_extensions=False)
+    drifted = drifted_project_fields(
+        bound_policy, current_config.to_project_workspace_policy()
+    )
+    if drifted:
+        logger.warning(
+            "Workspace %s project policy drifted since binding: %s",
+            binding.cwd,
+            ", ".join(drifted),
+        )
+        conflict = WorkspaceConflictError.from_reason(
+            f"{PROJECT_POLICY_DRIFT_REASON} ({', '.join(drifted)})"
+        )
         raise conflict
     if current_config.workspace_fingerprint() != binding.config_fingerprint:
+        logger.warning(
+            "Workspace %s server config fingerprint changed since binding",
+            binding.cwd,
+        )
         conflict = WorkspaceConflictError.from_reason(SERVER_CONFIG_DRIFT_REASON)
         raise conflict
     return current_config

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -725,7 +725,11 @@ async def _default_workspace_binding(config: ServerConfig) -> WorkspaceBinding |
     if config.cwd is None:
         return None
     identity = await asyncio.to_thread(resolve_workspace, config.cwd)
-    resolved = config.resolve_workspace(identity.cwd, identity.project_root)
+    resolved = await asyncio.to_thread(
+        config.resolve_workspace,
+        identity.cwd,
+        identity.project_root,
+    )
     return await asyncio.to_thread(
         resolve_workspace,
         identity.cwd,
@@ -764,12 +768,15 @@ async def _workspace_runtime(binding: WorkspaceBinding) -> ServerRuntime:
     Returns:
         The runtime selected by the binding's immutable resource key.
     """
-    _resolve_bound_workspace_config(binding)
+    await asyncio.to_thread(_resolve_bound_workspace_config, binding)
     cached = _cached_workspace_runtime(binding)
     if cached is not None:
         return cached
     async with _workspace_runtime_lock:
-        current_config = _resolve_bound_workspace_config(binding)
+        current_config = await asyncio.to_thread(
+            _resolve_bound_workspace_config,
+            binding,
+        )
         cached = _cached_workspace_runtime(binding)
         if cached is not None:
             return cached

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -790,13 +790,14 @@ def _resolve_bound_workspace_config(binding: WorkspaceBinding) -> ServerConfig:
         bound_policy, current_config.to_project_workspace_policy()
     )
     if drifted:
+        fields = ", ".join(drifted)
         logger.warning(
             "Workspace %s project policy drifted since binding: %s",
             binding.cwd,
-            ", ".join(drifted),
+            fields,
         )
         conflict = WorkspaceConflictError.from_reason(
-            f"{PROJECT_POLICY_DRIFT_REASON} ({', '.join(drifted)})"
+            f"{PROJECT_POLICY_DRIFT_REASON} ({fields})"
         )
         raise conflict
     if current_config.workspace_fingerprint() != binding.config_fingerprint:

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -16,7 +16,6 @@ import atexit
 import logging
 import sys
 from collections import OrderedDict
-from dataclasses import replace
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -777,15 +776,7 @@ def _resolve_bound_workspace_config(binding: WorkspaceBinding) -> ServerConfig:
     config = ServerConfig.from_env()
     current_config = config.resolve_workspace(binding.cwd, binding.project_root)
     bound_policy = binding.workspace_config()
-    # Extension trust is resolved from a mutable on-disk store, so granting it
-    # in another session looks exactly like drift. A grant is user-authorized
-    # and only ever adds privilege, so pin the bound value instead of refusing:
-    # the thread keeps the trust it was bound with, and the grant takes effect
-    # on the next binding. A revocation still has to refuse, immediately.
-    if bound_policy.get("trust_project_extensions") is False and (
-        current_config.trust_project_extensions is True
-    ):
-        current_config = replace(current_config, trust_project_extensions=False)
+    current_config = current_config.preserve_bound_extension_trust(bound_policy)
     drifted = drifted_project_fields(
         bound_policy, current_config.to_project_workspace_policy()
     )

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -734,40 +734,45 @@ async def _default_workspace_binding(config: ServerConfig) -> WorkspaceBinding |
     )
 
 
+def _resolve_bound_workspace_config(binding: WorkspaceBinding) -> ServerConfig:
+    """Resolve current workspace policy and reject drift from its binding.
+
+    Returns:
+        The current server configuration resolved for the workspace.
+    """
+    config = ServerConfig.from_env()
+    current_config = config.resolve_workspace(binding.cwd, binding.project_root)
+    bound_policy = binding.workspace_config()
+    project_policy = current_config.to_project_workspace_policy()
+    if any(bound_policy.get(key) != value for key, value in project_policy.items()):
+        reason = (
+            "the project's resolved policy differs from the policy recorded "
+            "when this workspace was bound"
+        )
+        conflict = WorkspaceConflictError.from_reason(reason)
+        raise conflict
+    if current_config.workspace_fingerprint() != binding.config_fingerprint:
+        reason = "the server configuration changed after this workspace was bound"
+        conflict = WorkspaceConflictError.from_reason(reason)
+        raise conflict
+    return current_config
+
+
 async def _workspace_runtime(binding: WorkspaceBinding) -> ServerRuntime:
     """Build or reuse a runtime from the persisted workspace resource policy.
 
     Returns:
         The runtime selected by the binding's immutable resource key.
     """
+    _resolve_bound_workspace_config(binding)
     cached = _cached_workspace_runtime(binding)
     if cached is not None:
         return cached
     async with _workspace_runtime_lock:
+        current_config = _resolve_bound_workspace_config(binding)
         cached = _cached_workspace_runtime(binding)
         if cached is not None:
             return cached
-        config = ServerConfig.from_env()
-        current_config = config.resolve_workspace(
-            binding.cwd,
-            binding.project_root,
-        )
-        bound_policy = binding.workspace_config()
-        if any(
-            bound_policy.get(key)
-            != current_config.to_project_workspace_policy().get(key)
-            for key in current_config.to_project_workspace_policy()
-        ):
-            reason = (
-                "the project's resolved policy differs from the policy recorded "
-                "when this workspace was bound"
-            )
-            conflict = WorkspaceConflictError.from_reason(reason)
-            raise conflict
-        if current_config.workspace_fingerprint() != binding.config_fingerprint:
-            reason = "the server configuration changed after this workspace was bound"
-            conflict = WorkspaceConflictError.from_reason(reason)
-            raise conflict
         _claim_sandbox_workspace(current_config.sandbox_type, binding)
         project_context = ProjectContext(
             user_cwd=Path(binding.cwd),

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import atexit
-import dataclasses
 import logging
 import sys
 from collections import OrderedDict
@@ -725,11 +724,13 @@ async def _default_workspace_binding(config: ServerConfig) -> WorkspaceBinding |
     """
     if config.cwd is None:
         return None
+    identity = await asyncio.to_thread(resolve_workspace, config.cwd)
+    resolved = config.resolve_workspace(identity.cwd, identity.project_root)
     return await asyncio.to_thread(
         resolve_workspace,
-        config.cwd,
-        config.to_workspace_payload(),
-        config_fingerprint=config.workspace_fingerprint(),
+        identity.cwd,
+        resolved.to_workspace_payload(),
+        config_fingerprint=resolved.workspace_fingerprint(),
     )
 
 
@@ -747,18 +748,24 @@ async def _workspace_runtime(binding: WorkspaceBinding) -> ServerRuntime:
         if cached is not None:
             return cached
         config = ServerConfig.from_env()
-        current_config = dataclasses.replace(
-            config,
-            cwd=binding.cwd,
-            project_root=binding.project_root,
+        current_config = config.resolve_workspace(
+            binding.cwd,
+            binding.project_root,
         )
-        if (
-            current_config.workspace_fingerprint() != binding.config_fingerprint
-            or current_config.to_workspace_payload() != binding.workspace_config()
+        bound_policy = binding.workspace_config()
+        if any(
+            bound_policy.get(key)
+            != current_config.to_project_workspace_policy().get(key)
+            for key in current_config.to_project_workspace_policy()
         ):
+            reason = (
+                "the project's resolved policy differs from the policy recorded "
+                "when this workspace was bound"
+            )
+            conflict = WorkspaceConflictError.from_reason(reason)
+            raise conflict
+        if current_config.workspace_fingerprint() != binding.config_fingerprint:
             reason = "the server configuration changed after this workspace was bound"
-            # Built into a local first: `raise X.from_reason(...)` reads as a
-            # `from_reason` raise to ruff's DOC501.
             conflict = WorkspaceConflictError.from_reason(reason)
             raise conflict
         _claim_sandbox_workspace(current_config.sandbox_type, binding)

--- a/libs/code/deepagents_code/workspace.py
+++ b/libs/code/deepagents_code/workspace.py
@@ -9,9 +9,12 @@ import os
 import sqlite3
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePath
-from typing import Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from deepagents_code._env_vars import SERVER_ENV_PREFIX
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 _SCHEMA_VERSION = 2
 _MAX_PATH_LENGTH = 4096
@@ -127,7 +130,15 @@ def canonical_workspace_config(value: object | None) -> tuple[str, str]:
     return serialized, hashlib.sha256(serialized.encode()).hexdigest()
 
 
-def _fingerprint(value: object) -> str:
+def canonical_fingerprint(value: object) -> str:
+    """Fingerprint *value* with the canonical workspace serialization.
+
+    This is the single definition of the fingerprint wire format that client
+    claims and server verification must agree on.
+
+    Returns:
+        The SHA-256 hex digest of the canonical JSON encoding.
+    """
     serialized = json.dumps(value, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(serialized.encode()).hexdigest()
 
@@ -151,13 +162,13 @@ def resolve_workspace(
     project_root = find_project_root(canonical_cwd)
     if project_root is not None:
         project_root = _canonical_directory(str(project_root), field="project_root")
-    workspace_id = _fingerprint(
+    workspace_id = canonical_fingerprint(
         {
             "cwd": str(canonical_cwd),
             "project_root": str(project_root) if project_root else None,
         }
     )
-    resource_key = _fingerprint(
+    resource_key = canonical_fingerprint(
         {"workspace_id": workspace_id, "config_fingerprint": config_fingerprint}
     )
     return WorkspaceBinding(
@@ -225,6 +236,32 @@ def _binding_differs(existing: WorkspaceBinding, proposed: WorkspaceBinding) -> 
     )
 
 
+PROJECT_POLICY_DRIFT_REASON = (
+    "the project's resolved policy differs from the policy recorded "
+    "when this workspace was bound"
+)
+SERVER_CONFIG_DRIFT_REASON = (
+    "the server configuration changed after this workspace was bound"
+)
+
+
+def project_policy_differs(
+    bound_config: Mapping[str, Any],
+    current_config: Mapping[str, Any],
+) -> bool:
+    """Report whether the project-scoped policy drifted from its binding.
+
+    Returns:
+        `True` when any project-scoped field differs between the two policies.
+    """
+    from deepagents_code._server_config import PROJECT_WORKSPACE_FIELDS
+
+    return any(
+        bound_config.get(key) != current_config.get(key)
+        for key in PROJECT_WORKSPACE_FIELDS
+    )
+
+
 def _binding_conflict(
     thread_id: str,
     existing: WorkspaceBinding,
@@ -234,18 +271,11 @@ def _binding_conflict(
         return WorkspaceConflictError(
             f"thread {thread_id} is already bound to a different workspace"
         )
-    from deepagents_code._server_config import project_workspace_fields
-
-    fields = project_workspace_fields()
-    old = existing.workspace_config()
-    new = proposed.workspace_config()
-    if any(old.get(key) != new.get(key) for key in fields):
-        reason = (
-            "the project's resolved policy differs from the policy recorded "
-            "when this workspace was bound"
-        )
-    else:
-        reason = "the server configuration changed after this workspace was bound"
+    drifted = project_policy_differs(
+        existing.workspace_config(),
+        proposed.workspace_config(),
+    )
+    reason = PROJECT_POLICY_DRIFT_REASON if drifted else SERVER_CONFIG_DRIFT_REASON
     return WorkspaceConflictError.from_reason(reason)
 
 

--- a/libs/code/deepagents_code/workspace.py
+++ b/libs/code/deepagents_code/workspace.py
@@ -225,6 +225,30 @@ def _binding_differs(existing: WorkspaceBinding, proposed: WorkspaceBinding) -> 
     )
 
 
+def _binding_conflict(
+    thread_id: str,
+    existing: WorkspaceBinding,
+    proposed: WorkspaceBinding,
+) -> WorkspaceConflictError:
+    if existing.workspace_id != proposed.workspace_id:
+        return WorkspaceConflictError(
+            f"thread {thread_id} is already bound to a different workspace"
+        )
+    from deepagents_code._server_config import project_workspace_fields
+
+    fields = project_workspace_fields()
+    old = existing.workspace_config()
+    new = proposed.workspace_config()
+    if any(old.get(key) != new.get(key) for key in fields):
+        reason = (
+            "the project's resolved policy differs from the policy recorded "
+            "when this workspace was bound"
+        )
+    else:
+        reason = "the server configuration changed after this workspace was bound"
+    return WorkspaceConflictError.from_reason(reason)
+
+
 def _bind(thread_id: str, proposed: WorkspaceBinding) -> WorkspaceBinding:
     with sqlite3.connect(_database_path(), timeout=5) as conn:
         conn.row_factory = sqlite3.Row
@@ -258,8 +282,7 @@ def _bind(thread_id: str, proposed: WorkspaceBinding) -> WorkspaceBinding:
             raise RuntimeError(msg)
         existing = _row_binding(row)
         if _binding_differs(existing, proposed):
-            msg = f"thread {thread_id} is already bound to a different workspace"
-            raise WorkspaceConflictError(msg)
+            raise _binding_conflict(thread_id, existing, proposed)
         if not existing.config_fingerprint:
             conn.execute(
                 """

--- a/libs/code/deepagents_code/workspace.py
+++ b/libs/code/deepagents_code/workspace.py
@@ -20,13 +20,11 @@ if TYPE_CHECKING:
 _SCHEMA_VERSION = 3
 """Binding schema generation.
 
-Bumped to 3 when project-scoped policy became per-workspace. Before that,
-`offload_api` bound every workspace with the launch config's fingerprint, so a
-version-2 row for a directory outside the launch project holds a fingerprint
-over a different field set. Comparing it against a resolved fingerprint is
-meaningless, and treating the mismatch as drift left those threads refusing
-every request with no way to re-bind. `_binding_differs` therefore compares
-the stored session policy for stale rows and `_bind` migrates them in place.
+Version 3 resolves project policy per workspace. Version 2 used the launch
+config's fingerprint for every directory, so its project policy values may
+differ from the newly resolved ones. After checking workspace identity and
+session policy, `_bind` migrates old rows instead of rejecting that mismatch
+as configuration drift.
 """
 _MAX_PATH_LENGTH = 4096
 _MAX_CONFIG_LENGTH = 64_000
@@ -142,14 +140,7 @@ def canonical_workspace_config(value: object | None) -> tuple[str, str]:
 
 
 def _canonical_json(value: object) -> str:
-    """Serialize *value* in the one wire format this module fingerprints.
-
-    Client claims and server verification must agree on this encoding, so it
-    has a single definition rather than a copy per caller.
-
-    Returns:
-        Canonical JSON with sorted keys and no insignificant whitespace.
-    """
+    """Return JSON with consistent key ordering and spacing for fingerprinting."""
     return json.dumps(value, sort_keys=True, separators=(",", ":"))
 
 
@@ -255,10 +246,9 @@ def _row_binding(row: sqlite3.Row) -> WorkspaceBinding:
 def _is_migratable(existing: WorkspaceBinding) -> bool:
     """Whether a row's recorded policy predates the current schema.
 
-    A stale row's fingerprint was computed over a different field set, so it
-    cannot be compared against a freshly resolved one. Workspace identity is
-    still compared, so migrating only ever rewrites policy for the same
-    directory.
+    Older rows may contain launch-project policy instead of workspace policy.
+    `_binding_differs` checks workspace identity and recorded session policy
+    before allowing migration.
 
     Returns:
         `True` when the row has no fingerprint yet, or an older schema.

--- a/libs/code/deepagents_code/workspace.py
+++ b/libs/code/deepagents_code/workspace.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import sqlite3
+from contextlib import closing
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Any, TypedDict, cast
@@ -24,8 +25,8 @@ Bumped to 3 when project-scoped policy became per-workspace. Before that,
 version-2 row for a directory outside the launch project holds a fingerprint
 over a different field set. Comparing it against a resolved fingerprint is
 meaningless, and treating the mismatch as drift left those threads refusing
-every request with no way to re-bind. `_binding_differs` therefore skips the
-fingerprint check for a stale row and `_bind` migrates it in place.
+every request with no way to re-bind. `_binding_differs` therefore compares
+the stored session policy for stale rows and `_bind` migrates them in place.
 """
 _MAX_PATH_LENGTH = 4096
 _MAX_CONFIG_LENGTH = 64_000
@@ -266,9 +267,20 @@ def _is_migratable(existing: WorkspaceBinding) -> bool:
 
 
 def _binding_differs(existing: WorkspaceBinding, proposed: WorkspaceBinding) -> bool:
-    return existing.workspace_id != proposed.workspace_id or (
-        not _is_migratable(existing)
-        and existing.config_fingerprint != proposed.config_fingerprint
+    if existing.workspace_id != proposed.workspace_id:
+        return True
+    if not _is_migratable(existing):
+        return existing.config_fingerprint != proposed.config_fingerprint
+    if not existing.config_fingerprint:
+        # Pre-fingerprint rows have no recorded policy to preserve.
+        return False
+    from deepagents_code._server_config import SESSION_WORKSPACE_FIELDS
+
+    bound_policy = existing.workspace_config()
+    proposed_policy = proposed.workspace_config()
+    return any(
+        bound_policy.get(key) != proposed_policy.get(key)
+        for key in SESSION_WORKSPACE_FIELDS
     )
 
 
@@ -313,6 +325,8 @@ def _binding_conflict(
         return WorkspaceConflictError(
             f"thread {thread_id} is already bound to a different workspace"
         )
+    if _is_migratable(existing):
+        return WorkspaceConflictError.from_reason(SERVER_CONFIG_DRIFT_REASON)
     drifted = drifted_project_fields(
         existing.workspace_config(),
         proposed.workspace_config(),
@@ -322,7 +336,7 @@ def _binding_conflict(
 
 
 def _bind(thread_id: str, proposed: WorkspaceBinding) -> WorkspaceBinding:
-    with sqlite3.connect(_database_path(), timeout=5) as conn:
+    with closing(sqlite3.connect(_database_path(), timeout=5)) as conn, conn:
         conn.row_factory = sqlite3.Row
         conn.execute("BEGIN IMMEDIATE")
         _initialize(conn)
@@ -379,7 +393,7 @@ def _bind(thread_id: str, proposed: WorkspaceBinding) -> WorkspaceBinding:
 
 
 def _read(thread_id: str) -> WorkspaceBinding | None:
-    with sqlite3.connect(_database_path(), timeout=5) as conn:
+    with closing(sqlite3.connect(_database_path(), timeout=5)) as conn, conn:
         conn.row_factory = sqlite3.Row
         conn.execute("BEGIN IMMEDIATE")
         _initialize(conn)
@@ -453,7 +467,7 @@ async def require_thread_workspace(
         _, claimed_fingerprint = canonical_workspace_config(workspace_config)
 
     def _require() -> WorkspaceBinding:
-        with sqlite3.connect(_database_path(), timeout=5) as conn:
+        with closing(sqlite3.connect(_database_path(), timeout=5)) as conn, conn:
             conn.row_factory = sqlite3.Row
             conn.execute("BEGIN IMMEDIATE")
             _initialize(conn)

--- a/libs/code/deepagents_code/workspace.py
+++ b/libs/code/deepagents_code/workspace.py
@@ -269,6 +269,29 @@ SERVER_CONFIG_DRIFT_REASON = (
 )
 
 
+def drifted_project_fields(
+    bound_config: Mapping[str, Any],
+    current_config: Mapping[str, Any],
+) -> list[str]:
+    """Name the project-scoped fields that drifted from their binding.
+
+    The refusal these feed is safe either way, but it is not diagnosable
+    without the field names: the resolution reads the extension trust store on
+    every call, so a transient read failure reports as a policy change. These
+    values are paths and booleans, never secrets, so naming them is safe.
+
+    Returns:
+        The drifted field names, sorted; empty when the policy is unchanged.
+    """
+    from deepagents_code._server_config import PROJECT_WORKSPACE_FIELDS
+
+    return sorted(
+        key
+        for key in PROJECT_WORKSPACE_FIELDS
+        if bound_config.get(key) != current_config.get(key)
+    )
+
+
 def project_policy_differs(
     bound_config: Mapping[str, Any],
     current_config: Mapping[str, Any],
@@ -278,12 +301,7 @@ def project_policy_differs(
     Returns:
         `True` when any project-scoped field differs between the two policies.
     """
-    from deepagents_code._server_config import PROJECT_WORKSPACE_FIELDS
-
-    return any(
-        bound_config.get(key) != current_config.get(key)
-        for key in PROJECT_WORKSPACE_FIELDS
-    )
+    return bool(drifted_project_fields(bound_config, current_config))
 
 
 def _binding_conflict(

--- a/libs/code/deepagents_code/workspace.py
+++ b/libs/code/deepagents_code/workspace.py
@@ -16,7 +16,17 @@ from deepagents_code._env_vars import SERVER_ENV_PREFIX
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-_SCHEMA_VERSION = 2
+_SCHEMA_VERSION = 3
+"""Binding schema generation.
+
+Bumped to 3 when project-scoped policy became per-workspace. Before that,
+`offload_api` bound every workspace with the launch config's fingerprint, so a
+version-2 row for a directory outside the launch project holds a fingerprint
+over a different field set. Comparing it against a resolved fingerprint is
+meaningless, and treating the mismatch as drift left those threads refusing
+every request with no way to re-bind. `_binding_differs` therefore skips the
+fingerprint check for a stale row and `_bind` migrates it in place.
+"""
 _MAX_PATH_LENGTH = 4096
 _MAX_CONFIG_LENGTH = 64_000
 
@@ -229,9 +239,23 @@ def _row_binding(row: sqlite3.Row) -> WorkspaceBinding:
     )
 
 
+def _is_migratable(existing: WorkspaceBinding) -> bool:
+    """Whether a row's recorded policy predates the current schema.
+
+    A stale row's fingerprint was computed over a different field set, so it
+    cannot be compared against a freshly resolved one. Workspace identity is
+    still compared, so migrating only ever rewrites policy for the same
+    directory.
+
+    Returns:
+        `True` when the row has no fingerprint yet, or an older schema.
+    """
+    return not existing.config_fingerprint or existing.schema_version < _SCHEMA_VERSION
+
+
 def _binding_differs(existing: WorkspaceBinding, proposed: WorkspaceBinding) -> bool:
     return existing.workspace_id != proposed.workspace_id or (
-        bool(existing.config_fingerprint)
+        not _is_migratable(existing)
         and existing.config_fingerprint != proposed.config_fingerprint
     )
 
@@ -313,13 +337,15 @@ def _bind(thread_id: str, proposed: WorkspaceBinding) -> WorkspaceBinding:
         existing = _row_binding(row)
         if _binding_differs(existing, proposed):
             raise _binding_conflict(thread_id, existing, proposed)
-        if not existing.config_fingerprint:
+        if _is_migratable(existing):
+            # Guard on the fingerprint this transaction actually read, so a
+            # concurrent migration cannot be overwritten after the fact.
             conn.execute(
                 """
                 UPDATE dcode_thread_workspaces
                 SET schema_version = ?, resource_key = ?, config_fingerprint = ?,
                     workspace_config_json = ?
-                WHERE thread_id = ? AND config_fingerprint = ''
+                WHERE thread_id = ? AND config_fingerprint = ?
                 """,
                 (
                     proposed.schema_version,
@@ -327,6 +353,7 @@ def _bind(thread_id: str, proposed: WorkspaceBinding) -> WorkspaceBinding:
                     proposed.config_fingerprint,
                     proposed.workspace_config_json,
                     thread_id,
+                    existing.config_fingerprint,
                 ),
             )
             return proposed

--- a/libs/code/deepagents_code/workspace.py
+++ b/libs/code/deepagents_code/workspace.py
@@ -130,7 +130,7 @@ def canonical_workspace_config(value: object | None) -> tuple[str, str]:
         msg = "workspace_config must be an object"
         raise TypeError(msg)
     try:
-        serialized = json.dumps(value, sort_keys=True, separators=(",", ":"))
+        serialized = _canonical_json(value)
     except (TypeError, ValueError) as exc:
         msg = "workspace configuration must be JSON serializable"
         raise ValueError(msg) from exc
@@ -140,18 +140,25 @@ def canonical_workspace_config(value: object | None) -> tuple[str, str]:
     return serialized, hashlib.sha256(serialized.encode()).hexdigest()
 
 
+def _canonical_json(value: object) -> str:
+    """Serialize *value* in the one wire format this module fingerprints.
+
+    Client claims and server verification must agree on this encoding, so it
+    has a single definition rather than a copy per caller.
+
+    Returns:
+        Canonical JSON with sorted keys and no insignificant whitespace.
+    """
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
 def canonical_fingerprint(value: object) -> str:
     """Fingerprint `value` with the canonical workspace serialization.
-
-    Client claims and server verification must agree on this wire format.
-    `canonical_workspace_config` applies the same encoding to a bounded policy
-    object and returns its digest alongside the serialized form.
 
     Returns:
         The SHA-256 hex digest of the canonical JSON encoding.
     """
-    serialized = json.dumps(value, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(serialized.encode()).hexdigest()
+    return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
 
 
 def resolve_workspace(
@@ -297,18 +304,6 @@ def drifted_project_fields(
     )
 
 
-def project_policy_differs(
-    bound_config: Mapping[str, Any],
-    current_config: Mapping[str, Any],
-) -> bool:
-    """Report whether the project-scoped policy drifted from its binding.
-
-    Returns:
-        `True` when any project-scoped field differs between the two policies.
-    """
-    return bool(drifted_project_fields(bound_config, current_config))
-
-
 def _binding_conflict(
     thread_id: str,
     existing: WorkspaceBinding,
@@ -318,7 +313,7 @@ def _binding_conflict(
         return WorkspaceConflictError(
             f"thread {thread_id} is already bound to a different workspace"
         )
-    drifted = project_policy_differs(
+    drifted = drifted_project_fields(
         existing.workspace_config(),
         proposed.workspace_config(),
     )

--- a/libs/code/deepagents_code/workspace.py
+++ b/libs/code/deepagents_code/workspace.py
@@ -141,10 +141,11 @@ def canonical_workspace_config(value: object | None) -> tuple[str, str]:
 
 
 def canonical_fingerprint(value: object) -> str:
-    """Fingerprint *value* with the canonical workspace serialization.
+    """Fingerprint `value` with the canonical workspace serialization.
 
-    This is the single definition of the fingerprint wire format that client
-    claims and server verification must agree on.
+    Client claims and server verification must agree on this wire format.
+    `canonical_workspace_config` applies the same encoding to a bounded policy
+    object and returns its digest alongside the serialized form.
 
     Returns:
         The SHA-256 hex digest of the canonical JSON encoding.
@@ -159,7 +160,11 @@ def resolve_workspace(
     *,
     config_fingerprint: str | None = None,
 ) -> WorkspaceBinding:
-    """Resolve and validate a client workspace claim.
+    """Resolve a client-supplied cwd into a canonical workspace binding.
+
+    `cwd` is untrusted and is validated here. `workspace_config` is not: every
+    caller passes server-resolved policy. A client claim is verified against
+    server policy in `offload_api.workspace` and never reaches this function.
 
     Returns:
         A canonical, fingerprinted binding including the resource policy.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -14060,6 +14060,34 @@ class TestFetchThreadHistoryData:
 class TestRemoteAgent:
     """Tests for configuring external agents."""
 
+    def test_managed_agent_claims_only_session_policy(self, tmp_path) -> None:
+        from deepagents_code._server_config import ServerConfig
+        from deepagents_code.client.remote_client import RemoteAgent
+
+        app = DeepAgentsApp(cwd=tmp_path)
+        app._server_kwargs = {}
+        agent = RemoteAgent("http://test:0")
+        config = ServerConfig(
+            trust_project_mcp=True,
+            mcp_config_path="/tmp/mcp.json",
+            no_mcp=True,
+        )
+        with (
+            patch.object(agent, "set_workspace") as set_workspace,
+            patch.object(ServerConfig, "from_env", return_value=config),
+        ):
+            app._configure_remote_agent(agent)
+
+        set_workspace.assert_called_once_with(
+            str(tmp_path),
+            config.to_session_workspace_claim(),
+            config_fingerprint=config.session_workspace_fingerprint(),
+        )
+        claim = set_workspace.call_args.args[1]
+        assert "trust_project_mcp" not in claim
+        assert "mcp_config_path" not in claim
+        assert claim["no_mcp"] is True
+
     def test_external_agent_defers_policy_to_server(self, tmp_path) -> None:
         from deepagents_code.client.remote_client import RemoteAgent
 

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -1108,6 +1108,42 @@ def test_workspace_credentials_are_known_secrets(tmp_path: Path) -> None:
     assert "workspace-secret-value" in middleware._known_secrets
 
 
+def test_relayed_caller_tracing_key_is_a_known_secret(tmp_path: Path) -> None:
+    """The key `execute` actually runs under must be redactable.
+
+    `restore_user_langsmith_env` writes the caller's relayed LangSmith key
+    into the shell environment, but it arrives inside a carrier whose name does
+    not match the secret-name scan, so it would otherwise be the one credential
+    never redacted from command output.
+    """
+    from deepagents_code.config import (
+        _USER_LANGSMITH_ENV_CARRIER,
+        _USER_LANGSMITH_ENV_VARS,
+    )
+
+    selectors = dict.fromkeys(_USER_LANGSMITH_ENV_VARS)
+    selectors["LANGSMITH_API_KEY"] = "lsv2-caller-relayed-key"
+
+    config: InterruptOnConfig = {"allowed_decisions": ["approve", "reject"]}
+    middleware = AutoModeHITLMiddleware(
+        {"execute": config},
+        worktree_root=tmp_path,
+        environ={
+            _USER_LANGSMITH_ENV_CARRIER: json.dumps(
+                {"launch": selectors, "user": selectors}
+            ),
+            "LANGSMITH_API_KEY": "lsv2-agent-session-key",
+        },
+    )
+
+    assert "lsv2-caller-relayed-key" in middleware._known_secrets
+    # The agent's own key stays covered by the name scan.
+    assert "lsv2-agent-session-key" in middleware._known_secrets
+    # The carrier itself is not a credential; it must not become a redaction
+    # pattern that blanks whole command outputs.
+    assert not any(value.startswith("{") for value in middleware._known_secrets)
+
+
 def test_sanitize_auto_reason_redacts_secrets_urls_and_control_text() -> None:
     reason = (
         "TOKEN=supersecret https://user:pass@example.com/path?q=value\x1b[31m\n"

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -4124,6 +4124,36 @@ class TestGetProviderKwargsConfigFallback:
             kwargs = _get_provider_kwargs("google_genai")
             assert kwargs == {}
 
+    def test_azure_env_endpoint_does_not_replace_configured_azure_endpoint(
+        self, tmp_path: Path
+    ) -> None:
+        """`AZURE_OPENAI_ENDPOINT` fills in but never replaces `azure_endpoint`.
+
+        A `config.toml` `[models.providers.azure_openai.params]` literal reaches
+        `_apply_azure_sdk_endpoint` before the environment default is applied,
+        so an explicit endpoint must win over the env var just as the other
+        SDK environment defaults in `_apply_provider_sdk_environment` use
+        `setdefault`. The `base_url` -> `azure_endpoint` translation still runs
+        when the env var matches a configured `base_url`.
+        """
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.azure_openai.params]
+azure_endpoint = "https://configured.openai.azure.com/"
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict(
+                "os.environ",
+                {"AZURE_OPENAI_ENDPOINT": "https://env.openai.azure.com/"},
+                clear=True,
+            ),
+        ):
+            kwargs = _get_provider_kwargs("azure_openai")
+
+        assert kwargs["azure_endpoint"] == "https://configured.openai.azure.com/"
+        assert "base_url" not in kwargs
+
     def test_merges_config_params(self, tmp_path: Path) -> None:
         """Merges params from config with base_url and api_key."""
         config_path = tmp_path / "config.toml"

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -635,6 +635,51 @@ class TestWorkspaceDotenvEnvironment:
         assert recorded["encoding"] == "utf-8"
         assert values["PROXY_USER"] == "café"
 
+    def test_global_dotenv_does_not_interpolate_project_values(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cloned repo cannot steer the trusted global file's references."""
+        import deepagents_code.config as config_mod
+
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".env").write_text("GATEWAY_HOST=https://evil\n", encoding="utf-8")
+        global_dotenv = tmp_path / "global.env"
+        global_dotenv.write_text(
+            "ANTHROPIC_BASE_URL=${GATEWAY_HOST}/v1\n", encoding="utf-8"
+        )
+        monkeypatch.delenv("GATEWAY_HOST", raising=False)
+        monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+        monkeypatch.setattr(config_mod, "_GLOBAL_DOTENV_PATH", global_dotenv)
+
+        env = config_mod._preview_dotenv_environ(start_path=project)
+
+        # The project value still lands in the environment; it just must not
+        # be visible to the global file's interpolation.
+        assert env["GATEWAY_HOST"] == "https://evil"
+        assert env["ANTHROPIC_BASE_URL"] == "/v1"
+
+    def test_global_dotenv_still_interpolates_shell_values(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The baseline keeps trusted shell values available to the global file."""
+        import deepagents_code.config as config_mod
+
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".env").write_text("PROJECT_VALUE=project\n", encoding="utf-8")
+        global_dotenv = tmp_path / "global.env"
+        global_dotenv.write_text(
+            "ANTHROPIC_BASE_URL=${GATEWAY_HOST}/v1\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("GATEWAY_HOST", "https://trusted")
+        monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+        monkeypatch.setattr(config_mod, "_GLOBAL_DOTENV_PATH", global_dotenv)
+
+        env = config_mod._preview_dotenv_environ(start_path=project)
+
+        assert env["ANTHROPIC_BASE_URL"] == "https://trusted/v1"
+
     def test_unreadable_global_dotenv_skips_the_project_dotenv(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -5,7 +5,7 @@ import logging
 import subprocess
 import sys
 import warnings
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, ClassVar
@@ -634,6 +634,73 @@ class TestWorkspaceDotenvEnvironment:
 
         assert recorded["encoding"] == "utf-8"
         assert values["PROXY_USER"] == "café"
+
+    def test_unreadable_global_dotenv_skips_the_project_dotenv(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unreadable global file must not resurrect the project `.env`.
+
+        `resolve_read_project_dotenv` defaults to true, so failing open here
+        would discard the user's opt-out on every workspace construction.
+        """
+        import deepagents_code.config as config_mod
+
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".env").write_text("PROJECT_VALUE=project\n", encoding="utf-8")
+        global_dotenv = tmp_path / "global.env"
+        global_dotenv.write_text("GLOBAL_VALUE=global\n", encoding="utf-8")
+        monkeypatch.delenv("PROJECT_VALUE", raising=False)
+        monkeypatch.delenv("GLOBAL_VALUE", raising=False)
+        monkeypatch.setattr(config_mod, "_GLOBAL_DOTENV_PATH", global_dotenv)
+
+        real_values_from = config_mod._dotenv_values_from
+
+        def _fail_on_global(
+            dotenv_path: Path, environ: Mapping[str, str]
+        ) -> dict[str, str | None]:
+            if dotenv_path == global_dotenv:
+                msg = "permission denied"
+                raise OSError(msg)
+            return real_values_from(dotenv_path, environ)
+
+        monkeypatch.setattr(config_mod, "_dotenv_values_from", _fail_on_global)
+
+        env = config_mod._preview_dotenv_environ(start_path=project)
+
+        assert "PROJECT_VALUE" not in env
+
+    def test_unreadable_global_dotenv_yields_to_a_trusted_opt_in(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Failing closed occupies the global tier, so a shell export wins."""
+        import deepagents_code.config as config_mod
+
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".env").write_text("PROJECT_VALUE=project\n", encoding="utf-8")
+        global_dotenv = tmp_path / "global.env"
+        global_dotenv.write_text("GLOBAL_VALUE=global\n", encoding="utf-8")
+        monkeypatch.delenv("PROJECT_VALUE", raising=False)
+        monkeypatch.setenv("DEEPAGENTS_CODE_READ_PROJECT_DOTENV", "true")
+
+        monkeypatch.setattr(config_mod, "_GLOBAL_DOTENV_PATH", global_dotenv)
+
+        real_values_from = config_mod._dotenv_values_from
+
+        def _fail_on_global(
+            dotenv_path: Path, environ: Mapping[str, str]
+        ) -> dict[str, str | None]:
+            if dotenv_path == global_dotenv:
+                msg = "permission denied"
+                raise OSError(msg)
+            return real_values_from(dotenv_path, environ)
+
+        monkeypatch.setattr(config_mod, "_dotenv_values_from", _fail_on_global)
+
+        env = config_mod._preview_dotenv_environ(start_path=project)
+
+        assert env["PROJECT_VALUE"] == "project"
 
 
 class TestProjectDotenvDeniedKeys:

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -1583,6 +1583,123 @@ class TestWorkspaceStoredCredentials:
         assert kwargs["base_url"] == "https://api.anthropic.com"
         assert kwargs["default_headers"] == {}
 
+    @patch("langchain.chat_models.init_chat_model")
+    def test_corrupt_store_drops_the_inherited_endpoint(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An unreadable store must not let a resolved key reach a gateway.
+
+        `_apply_scoped_stored_endpoint` is the only thing enforcing the
+        key/endpoint pairing on the scoped path, and `resolve_provider_credential`
+        still falls back to the environment key. Keeping `base_url` would send
+        that key to a gateway a workspace `.env` chose.
+        """
+        from deepagents_code.config import create_model, use_environment
+
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+
+        def _corrupt(_provider: str) -> str | None:
+            msg = "credential file is corrupt"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_key", _corrupt
+        )
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_base_url", _corrupt
+        )
+
+        with use_environment(
+            {
+                "OPENAI_API_KEY": "workspace-key",
+                "OPENAI_BASE_URL": "https://attacker.example/v1",
+            }
+        ):
+            create_model("openai:gpt-5.5")
+
+        kwargs = mock_init_chat_model.call_args.kwargs
+        assert kwargs.get("base_url") != "https://attacker.example/v1"
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_corrupt_store_drops_the_endpoint_for_an_explicit_key(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without the store, an explicit key's endpoint pairing is unknowable."""
+        from deepagents_code.config import create_model, use_environment
+
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+
+        def _corrupt(_provider: str) -> str | None:
+            msg = "credential file is corrupt"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_base_url", _corrupt
+        )
+
+        with use_environment(
+            {
+                "OPENAI_API_KEY": "workspace-key",
+                "OPENAI_BASE_URL": "https://attacker.example/v1",
+            }
+        ):
+            create_model("openai:gpt-5.5", extra_kwargs={"api_key": "caller-key"})
+
+        kwargs = mock_init_chat_model.call_args.kwargs
+        assert kwargs["api_key"] == "caller-key"
+        assert "base_url" not in kwargs
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_corrupt_store_falls_back_to_adc_project_inference(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Vertex stores the GCP project in the key slot; a read failure warns.
+
+        The provider uses implicit auth, so the early credential check never
+        fires and a corrupt store would otherwise surface only as an opaque
+        ADC project-inference error.
+        """
+        import logging
+
+        from deepagents_code.config import create_model, use_environment
+
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+
+        def _corrupt(_provider: str) -> str | None:
+            msg = "credential file is corrupt"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(
+            "deepagents_code.model_config.auth_store.get_stored_key", _corrupt
+        )
+
+        with (
+            caplog.at_level(logging.WARNING, logger="deepagents_code.config"),
+            use_environment({"GOOGLE_CLOUD_LOCATION": "us-east5"}),
+        ):
+            create_model("google_anthropic_vertex:claude-sonnet-4-6")
+
+        kwargs = mock_init_chat_model.call_args.kwargs
+        assert "project" not in kwargs
+        assert kwargs["location"] == "us-east5"
+        assert any(
+            "Could not read the stored Google Cloud project" in record.message
+            for record in caplog.records
+        )
+
     def test_bare_claude_provider_uses_workspace_credentials(self) -> None:
         """Bare model inference reads the active workspace snapshot."""
         from deepagents_code.config import detect_provider, use_environment

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -606,6 +606,35 @@ class TestWorkspaceDotenvEnvironment:
         assert env["PROJECT_VALUE"] == "project"
         assert env["GLOBAL_VALUE"] == "global"
 
+    def test_dotenv_is_read_as_utf8_regardless_of_locale(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `.env` holding non-ASCII bytes decodes on any platform locale.
+
+        The value round-trips on a UTF-8 host either way, so this asserts the
+        explicit encoding reaches `DotEnv`: its own default is the locale
+        encoding (cp1252 on Windows), which mis-decodes or raises.
+        """
+        import dotenv.main
+
+        import deepagents_code.config as config_mod
+
+        dotenv_path = tmp_path / ".env"
+        dotenv_path.write_text("PROXY_USER=café\n", encoding="utf-8")
+        recorded: dict[str, Any] = {}
+        real_dotenv = dotenv.main.DotEnv
+
+        def _record(**kwargs: Any) -> dotenv.main.DotEnv:
+            recorded.update(kwargs)
+            return real_dotenv(**kwargs)
+
+        monkeypatch.setattr(dotenv.main, "DotEnv", _record)
+
+        values = config_mod._dotenv_values_from(dotenv_path, {})
+
+        assert recorded["encoding"] == "utf-8"
+        assert values["PROXY_USER"] == "café"
+
 
 class TestProjectDotenvDeniedKeys:
     """A cloned repo must not set user-level environment values."""

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -680,14 +680,14 @@ class TestWorkspaceDotenvEnvironment:
 
         assert env["ANTHROPIC_BASE_URL"] == "https://trusted/v1"
 
-    def test_unreadable_global_dotenv_skips_the_project_dotenv(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize("trusted_opt_in", [False, True])
+    def test_unreadable_global_dotenv_requires_trusted_opt_in(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        trusted_opt_in: bool,
     ) -> None:
-        """An unreadable global file must not resurrect the project `.env`.
-
-        `resolve_read_project_dotenv` defaults to true, so failing open here
-        would discard the user's opt-out on every workspace construction.
-        """
+        """An unreadable global dotenv blocks the project unless the shell opts in."""
         import deepagents_code.config as config_mod
 
         project = tmp_path / "project"
@@ -697,6 +697,9 @@ class TestWorkspaceDotenvEnvironment:
         global_dotenv.write_text("GLOBAL_VALUE=global\n", encoding="utf-8")
         monkeypatch.delenv("PROJECT_VALUE", raising=False)
         monkeypatch.delenv("GLOBAL_VALUE", raising=False)
+        monkeypatch.delenv("DEEPAGENTS_CODE_READ_PROJECT_DOTENV", raising=False)
+        if trusted_opt_in:
+            monkeypatch.setenv("DEEPAGENTS_CODE_READ_PROJECT_DOTENV", "true")
         monkeypatch.setattr(config_mod, "_GLOBAL_DOTENV_PATH", global_dotenv)
 
         real_values_from = config_mod._dotenv_values_from
@@ -713,39 +716,10 @@ class TestWorkspaceDotenvEnvironment:
 
         env = config_mod._preview_dotenv_environ(start_path=project)
 
-        assert "PROJECT_VALUE" not in env
-
-    def test_unreadable_global_dotenv_yields_to_a_trusted_opt_in(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Failing closed occupies the global tier, so a shell export wins."""
-        import deepagents_code.config as config_mod
-
-        project = tmp_path / "project"
-        project.mkdir()
-        (project / ".env").write_text("PROJECT_VALUE=project\n", encoding="utf-8")
-        global_dotenv = tmp_path / "global.env"
-        global_dotenv.write_text("GLOBAL_VALUE=global\n", encoding="utf-8")
-        monkeypatch.delenv("PROJECT_VALUE", raising=False)
-        monkeypatch.setenv("DEEPAGENTS_CODE_READ_PROJECT_DOTENV", "true")
-
-        monkeypatch.setattr(config_mod, "_GLOBAL_DOTENV_PATH", global_dotenv)
-
-        real_values_from = config_mod._dotenv_values_from
-
-        def _fail_on_global(
-            dotenv_path: Path, environ: Mapping[str, str]
-        ) -> dict[str, str | None]:
-            if dotenv_path == global_dotenv:
-                msg = "permission denied"
-                raise OSError(msg)
-            return real_values_from(dotenv_path, environ)
-
-        monkeypatch.setattr(config_mod, "_dotenv_values_from", _fail_on_global)
-
-        env = config_mod._preview_dotenv_environ(start_path=project)
-
-        assert env["PROJECT_VALUE"] == "project"
+        if trusted_opt_in:
+            assert env["PROJECT_VALUE"] == "project"
+        else:
+            assert "PROJECT_VALUE" not in env
 
 
 class TestProjectDotenvDeniedKeys:

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -119,11 +119,12 @@ class TestWorkspaceRoute:
             response = await offload_api.workspace(cast("Any", request))
 
         assert response.status_code == 200
+        resolved = server_config.resolve_workspace(str(tmp_path), None)
         bind.assert_awaited_once_with(
             "thread-1",
             str(tmp_path),
-            server_config.to_workspace_payload(),
-            config_fingerprint=server_config.workspace_fingerprint(),
+            resolved.to_workspace_payload(),
+            config_fingerprint=resolved.workspace_fingerprint(),
         )
         runtime.assert_awaited_once_with(binding)
 
@@ -203,6 +204,47 @@ class TestWorkspaceRoute:
 
         assert response.status_code == 409
         from_env.assert_called_once_with()
+
+    async def test_rejects_client_project_policy_claim(self, tmp_path) -> None:
+        from deepagents_code import offload_api
+        from deepagents_code._server_config import ServerConfig
+
+        config = ServerConfig()
+        claim = config.to_session_workspace_claim()
+        claim["trust_project_mcp"] = True
+        request = SimpleNamespace(
+            path_params={"thread_id": "thread-1"},
+            json=AsyncMock(
+                return_value={
+                    "cwd": str(tmp_path),
+                    "workspace_config": claim,
+                    "config_fingerprint": config.session_workspace_fingerprint(),
+                }
+            ),
+        )
+
+        with patch.object(ServerConfig, "from_env", return_value=config):
+            response = await offload_api.workspace(cast("Any", request))
+
+        assert response.status_code == 409
+        assert response.body == (
+            b'{"detail":"clients cannot claim project workspace policy"}'
+        )
+
+    async def test_rejects_unknown_workspace_request_field(self, tmp_path) -> None:
+        from deepagents_code import offload_api
+
+        request = SimpleNamespace(
+            path_params={"thread_id": "thread-1"},
+            json=AsyncMock(
+                return_value={"cwd": str(tmp_path), "trust_project_mcp": True}
+            ),
+        )
+
+        response = await offload_api.workspace(cast("Any", request))
+
+        assert response.status_code == 422
+        assert b"trust_project_mcp" in response.body
 
     async def test_malformed_policy_is_a_client_error(self, tmp_path) -> None:
         """A non-object policy returns 422 instead of escaping as a 500."""

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
+from blockbuster import blockbuster_ctx
 
 from deepagents_code.offload_middleware import OffloadExecution, OffloadResult
 
@@ -115,6 +116,7 @@ class TestWorkspaceRoute:
                 "_thread_client",
                 return_value=SimpleNamespace(threads=threads),
             ),
+            blockbuster_ctx(scanned_modules=offload_api),
         ):
             response = await offload_api.workspace(cast("Any", request))
 

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -84,6 +84,66 @@ async def _workspace_route_client(
 
 
 class TestWorkspaceRoute:
+    @pytest.fixture(autouse=True)
+    def workspace_database(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "DEEPAGENTS_CODE_SERVER_DB_PATH", str(tmp_path / "sessions.db")
+        )
+
+    @pytest.mark.parametrize("initial_trust", [False, True])
+    async def test_reconnect_after_extension_trust_changes(
+        self, tmp_path, initial_trust: bool
+    ) -> None:
+        from httpx import ASGITransport, AsyncClient
+
+        from deepagents_code import offload_api
+        from deepagents_code._server_config import ServerConfig
+        from deepagents_code.workspace import get_thread_workspace
+
+        launch = tmp_path / "launch"
+        other = tmp_path / "other"
+        launch.mkdir()
+        other.mkdir()
+        config = ServerConfig(cwd=str(launch), project_root=str(launch))
+        threads = SimpleNamespace(create=AsyncMock(), update=AsyncMock())
+        with (
+            patch.object(ServerConfig, "from_env", return_value=config),
+            patch.object(offload_api, "get_server_runtime", new=AsyncMock()),
+            patch.object(
+                offload_api,
+                "_thread_client",
+                return_value=SimpleNamespace(threads=threads),
+            ),
+            patch(
+                "deepagents_code.extensions.trust.is_project_extensions_trusted",
+                return_value=initial_trust,
+            ) as trust,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=offload_api.app), base_url="http://test"
+            ) as client:
+                url = "/dcode/threads/thread-1/workspace"
+                first = await client.post(url, json={"cwd": str(other)})
+                assert first.status_code == 200
+                original = await get_thread_workspace("thread-1")
+
+                trust.return_value = not initial_trust
+                resumed = await client.post(url, json={"cwd": str(other)})
+                assert resumed.status_code == (409 if initial_trust else 200)
+                if not initial_trust:
+                    assert resumed.json() == first.json()
+                assert await get_thread_workspace("thread-1") == original
+
+                fresh = await client.post(
+                    "/dcode/threads/thread-2/workspace", json={"cwd": str(other)}
+                )
+                assert fresh.status_code == 200
+                binding = await get_thread_workspace("thread-2")
+                assert binding is not None
+                assert binding.workspace_config()["trust_project_extensions"] is (
+                    not initial_trust
+                )
+
     async def test_server_supplies_policy_when_client_omits_claim(
         self, tmp_path
     ) -> None:

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -94,7 +94,17 @@ class TestWorkspaceRoute:
             path_params={"thread_id": "thread-1"},
             json=AsyncMock(return_value={"cwd": str(tmp_path)}),
         )
-        server_config = ServerConfig(auto_approve=True)
+        launch = tmp_path / "launch"
+        launch.mkdir()
+        server_config = ServerConfig(
+            auto_approve=True,
+            cwd=str(launch),
+            project_root=str(launch),
+            mcp_config_path="/launch/.mcp.json",
+            sandbox_setup="/launch/setup.sh",
+            trust_project_mcp=True,
+            extension_paths=("/launch/ext.py",),
+        )
         binding = SimpleNamespace(
             cwd=str(tmp_path),
             workspace_id="workspace-1",
@@ -121,13 +131,19 @@ class TestWorkspaceRoute:
             response = await offload_api.workspace(cast("Any", request))
 
         assert response.status_code == 200
-        resolved = server_config.resolve_workspace(str(tmp_path), None)
-        bind.assert_awaited_once_with(
-            "thread-1",
-            str(tmp_path),
-            resolved.to_workspace_payload(),
-            config_fingerprint=resolved.workspace_fingerprint(),
-        )
+        # Assert the literal policy, not `resolve_workspace(...)` re-run here:
+        # comparing against the method under test passes even if it stops
+        # stripping anything.
+        bind.assert_awaited_once()
+        bind_call = bind.await_args
+        assert bind_call is not None
+        bound_policy = bind_call.args[2]
+        assert bound_policy["mcp_config_path"] is None
+        assert bound_policy["sandbox_setup"] is None
+        assert bound_policy["trust_project_mcp"] is None
+        assert bound_policy["extension_paths"] == []
+        # Session policy is the client's own and survives.
+        assert bound_policy["auto_approve"] is True
         runtime.assert_awaited_once_with(binding)
 
     async def test_runtime_conflict_returns_409_before_thread_creation(

--- a/libs/code/tests/unit_tests/test_offload_api.py
+++ b/libs/code/tests/unit_tests/test_offload_api.py
@@ -8,6 +8,7 @@ import logging
 import re
 import threading
 import time
+from collections import OrderedDict
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
@@ -19,6 +20,7 @@ from deepagents_code.offload_middleware import OffloadExecution, OffloadResult
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
+    from pathlib import Path
 
     from deepagents_code.offload_middleware import _PendingArchive
 
@@ -89,6 +91,75 @@ class TestWorkspaceRoute:
         monkeypatch.setenv(
             "DEEPAGENTS_CODE_SERVER_DB_PATH", str(tmp_path / "sessions.db")
         )
+
+    @pytest.mark.parametrize("cached", [False, True])
+    @pytest.mark.parametrize("git_workspace", [False, True])
+    async def test_explicit_launch_root_preserves_policy_and_runtime(
+        self, tmp_path: Path, cached: bool, git_workspace: bool
+    ) -> None:
+        from httpx import ASGITransport, AsyncClient
+
+        from deepagents_code import offload_api, server_graph
+        from deepagents_code._server_config import ServerConfig
+        from deepagents_code.workspace import require_thread_workspace
+
+        root = tmp_path / "project"
+        workdir = root / "workdir"
+        workdir.mkdir(parents=True)
+        if git_workspace:
+            (workdir / ".git").mkdir()
+        config = ServerConfig(
+            cwd=str(workdir),
+            project_root=str(root),
+            mcp_config_path=str(root / ".mcp.json"),
+            sandbox_setup=str(root / "setup.sh"),
+            trust_project_mcp=True,
+            trust_project_extensions=True,
+            extension_paths=(str(root / "ext.py"),),
+        )
+        runtime = create_autospec(server_graph.ServerRuntime, instance=True)
+        threads = SimpleNamespace(create=AsyncMock(), update=AsyncMock())
+        with (
+            patch.object(ServerConfig, "from_env", return_value=config),
+            patch.object(server_graph, "_workspace_runtimes", OrderedDict()),
+            patch.object(
+                server_graph, "_get_runtime", new=AsyncMock(return_value=runtime)
+            ),
+            patch.object(
+                server_graph, "_make_graphs", new=AsyncMock(return_value=runtime)
+            ) as make,
+            patch.object(
+                offload_api, "get_server_runtime", server_graph._workspace_runtime
+            ),
+            patch.object(
+                offload_api,
+                "_thread_client",
+                return_value=SimpleNamespace(threads=threads),
+            ),
+        ):
+            if cached:
+                assert await server_graph.get_server_runtime() is runtime
+            async with AsyncClient(
+                transport=ASGITransport(app=offload_api.app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/dcode/threads/thread-1/workspace", json={"cwd": str(workdir)}
+                )
+            assert response.status_code == 200, response.text
+            binding = await require_thread_workspace(
+                "thread-1", response.json()["workspace"]
+            )
+            assert binding.workspace_config() == config.to_workspace_payload()
+            assert await server_graph._workspace_runtime(binding) is runtime
+            if cached:
+                make.assert_not_awaited()
+            else:
+                make.assert_awaited_once()
+                assert make.await_args is not None
+                built = make.await_args.kwargs["config_override"]
+                context = make.await_args.kwargs["project_context_override"]
+                assert built.project_root == str(root)
+                assert context.project_root == root
 
     @pytest.mark.parametrize("initial_trust", [False, True])
     async def test_reconnect_after_extension_trust_changes(

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -530,7 +530,12 @@ class TestReloadFromEnvironment:
         tmp_path: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """OSError reading global `.env` should log a warning and continue."""
+        """OSError reading global `.env` warns and skips the project `.env`.
+
+        The global file carries the trusted `startup.read_project_dotenv`
+        opt-out. Loading the project file anyway would discard that decision
+        because the option defaults to true.
+        """
         credentials = Credentials.from_environment(start_path=tmp_path)
 
         broken = MagicMock()
@@ -538,17 +543,20 @@ class TestReloadFromEnvironment:
         broken.is_file.side_effect = OSError(msg)
         monkeypatch.setattr("deepagents_code.config._GLOBAL_DOTENV_PATH", broken)
 
-        # Should not raise — project .env still loads
         project_env = tmp_path / ".env"
         project_env.write_text("OPENAI_API_KEY=sk-fallback\n")
 
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("DEEPAGENTS_CODE_READ_PROJECT_DOTENV", raising=False)
 
         with caplog.at_level(logging.WARNING, logger="deepagents_code.config"):
             credentials.reload_from_environment(start_path=tmp_path)
 
-        assert any("Could not read global dotenv" in r.message for r in caplog.records)
-        assert os.environ["OPENAI_API_KEY"] == "sk-fallback"
+        assert any(
+            "Could not read the trusted global dotenv" in r.message
+            for r in caplog.records
+        )
+        assert "OPENAI_API_KEY" not in os.environ
 
     def test_global_dotenv_values_raises_oserror(
         self,
@@ -588,13 +596,14 @@ class TestReloadFromEnvironment:
         with caplog.at_level(logging.WARNING, logger="deepagents_code.config"):
             credentials.reload_from_environment(start_path=tmp_path)
 
-        # Asserting a count here would mirror the implementation: memoizing the
-        # global read is a valid optimization that must not fail this test. What
-        # matters is that the unreadable global file was attempted, and that the
-        # project value still applied.
+        # The unreadable global file must be attempted before project loading.
         assert global_calls >= 1
-        assert os.environ["OPENAI_API_KEY"] == "sk-ok"
-        assert any("Could not read global dotenv" in r.message for r in caplog.records)
+        # The failed pre-check fails closed, so the project file is skipped.
+        assert "OPENAI_API_KEY" not in os.environ
+        assert any(
+            "Could not read the trusted global dotenv" in r.message
+            for r in caplog.records
+        )
 
     def test_project_dotenv_denies_environment_hijack_keys(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -709,6 +709,48 @@ def test_vercel_delegates_when_the_workspace_configured_nothing() -> None:
         assert _VercelProvider._resolve_sdk_kwargs() == {}
 
 
+def test_vercel_fails_closed_on_a_partial_workspace_credential_set() -> None:
+    """A partial set must not fall back to the server's Vercel identity.
+
+    An empty mapping hands auth back to the Vercel SDK, which resolves
+    credentials from the server process (`VERCEL_*` in its own environment,
+    or its OIDC identity). A workspace that pinned a restricted token would
+    then silently run its sandbox under the server's broader identity.
+    """
+    environment = {
+        "DEEPAGENTS_CODE_VERCEL_TOKEN": "workspace-token",
+    }
+    with (
+        patch(f"{_FACTORY}.active_environment", return_value=environment),
+        patch(
+            "deepagents_code.model_config.resolve_env_var",
+            side_effect=lambda name: environment.get(f"DEEPAGENTS_CODE_{name}"),
+        ),
+        patch.dict("os.environ", {}, clear=True),
+        pytest.raises(ValueError, match="VERCEL_PROJECT_ID, and VERCEL_TEAM_ID"),
+    ):
+        _VercelProvider._resolve_sdk_kwargs()
+
+
+def test_vercel_get_provider_fails_closed_on_a_partial_set() -> None:
+    """The constructor propagates the partial-set failure.
+
+    `create_sandbox` surfaces `ValueError` as a startup error, so the server
+    refuses the sandbox rather than running it under substituted credentials.
+    """
+    with (
+        _bind_environment(
+            {
+                "DEEPAGENTS_CODE_VERCEL_TOKEN": "workspace-token",
+                "DEEPAGENTS_CODE_VERCEL_TEAM_ID": "workspace-team",
+            }
+        ),
+        patch.dict("os.environ", {}, clear=True),
+        pytest.raises(ValueError, match="workspace Vercel configuration"),
+    ):
+        _get_provider("vercel")
+
+
 def test_agentcore_omits_session_when_it_could_not_be_built() -> None:
     """A failed session must not masquerade as an applied workspace session."""
     mock_boto3 = MagicMock()

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -641,6 +641,47 @@ def test_vercel_override_gate_reads_workspace_environment() -> None:
     }
 
 
+def test_vercel_uses_an_unprefixed_workspace_credential() -> None:
+    """Canonical `VERCEL_*` names from a workspace `.env` must not be dropped.
+
+    `_build_server_env` strips the client's project `.env` from the server
+    process, so these never reach the SDK's own `os.environ` read.
+    """
+    environment = {
+        "VERCEL_TOKEN": "workspace-token",
+        "VERCEL_PROJECT_ID": "workspace-project",
+        "VERCEL_TEAM_ID": "workspace-team",
+    }
+    with (
+        patch(f"{_FACTORY}.active_environment", return_value=environment),
+        patch(
+            "deepagents_code.model_config.resolve_env_var",
+            side_effect=environment.get,
+        ),
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        kwargs = _VercelProvider._resolve_sdk_kwargs()
+
+    assert kwargs == {
+        "token": "workspace-token",
+        "project_id": "workspace-project",
+        "team_id": "workspace-team",
+    }
+
+
+def test_vercel_delegates_when_the_workspace_configured_nothing() -> None:
+    """With no resolved credential the SDK keeps owning auth (OIDC)."""
+    with (
+        patch(f"{_FACTORY}.active_environment", return_value={}),
+        patch(
+            "deepagents_code.model_config.resolve_env_var",
+            return_value=None,
+        ),
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        assert _VercelProvider._resolve_sdk_kwargs() == {}
+
+
 def test_agentcore_omits_session_when_it_could_not_be_built() -> None:
     """A failed session must not masquerade as an applied workspace session."""
     mock_boto3 = MagicMock()

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import sys
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,7 +21,32 @@ from deepagents_code.integrations.sandbox_factory import (
 )
 from deepagents_code.integrations.sandbox_registry import SandboxRegistry
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
 _FACTORY = "deepagents_code.integrations.sandbox_factory"
+
+
+@contextlib.contextmanager
+def _bind_environment(environment: Mapping[str, str]) -> Iterator[None]:
+    """Bind one workspace environment everywhere the factory reads it.
+
+    `sandbox_factory` aliases `active_environment` at import, while
+    `resolve_env_var` calls it through `deepagents_code.config`. Both resolve
+    to the same binding in production, so a test that patches only the alias
+    lets the two disagree.
+
+    Yields:
+        `None`, with both references bound to `environment`.
+    """
+    with (
+        patch(f"{_FACTORY}.active_environment", return_value=environment),
+        patch(
+            "deepagents_code.config.active_environment",
+            return_value=environment,
+        ),
+    ):
+        yield
 
 
 def _registry_with(config: SandboxConfig) -> SandboxRegistry:
@@ -198,7 +225,7 @@ def test_agentcore_uses_workspace_aws_session() -> None:
     backend_module.AgentCoreSandbox.return_value.id = "sandbox-id"
 
     with (
-        patch(f"{_FACTORY}.active_environment", return_value=environment),
+        _bind_environment(environment),
         patch.dict(sys.modules, {"boto3": mock_boto3}),
     ):
         provider = _AgentCoreProvider()
@@ -693,9 +720,7 @@ def test_agentcore_omits_session_when_it_could_not_be_built() -> None:
     backend_module.AgentCoreSandbox.return_value.id = "sandbox-id"
 
     with (
-        patch(
-            f"{_FACTORY}.active_environment", return_value={"AWS_REGION": "us-test-1"}
-        ),
+        _bind_environment({"AWS_REGION": "us-test-1"}),
         patch.dict(sys.modules, {"boto3": mock_boto3}),
     ):
         provider = _AgentCoreProvider()
@@ -711,3 +736,64 @@ def test_agentcore_omits_session_when_it_could_not_be_built() -> None:
         integration_source="deepagents-code",
     )
     assert "session" not in client_module.CodeInterpreter.call_args.kwargs
+
+
+def test_agentcore_refuses_to_substitute_server_aws_credentials() -> None:
+    """A workspace that scoped its credentials must not silently fall back.
+
+    Omitting `session` lets the SDK resolve from the server process, so a
+    workspace pinned to a restricted profile would run under the server's
+    broader identity.
+    """
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.side_effect = RuntimeError("ProfileNotFound: typo")
+
+    with (
+        _bind_environment(
+            {"AWS_REGION": "us-test-1", "AWS_PROFILE": "restricted-profile"}
+        ),
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+        pytest.raises(ValueError, match="not substituted"),
+    ):
+        _AgentCoreProvider()
+
+
+def test_agentcore_rejects_a_half_set_access_key_pair() -> None:
+    """boto3 would raise `PartialCredentialsError` into the silent fallback."""
+    mock_boto3 = MagicMock()
+
+    with (
+        _bind_environment(
+            {"AWS_REGION": "us-test-1", "AWS_ACCESS_KEY_ID": "only-the-id"}
+        ),
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+        pytest.raises(ValueError, match="AWS_SECRET_ACCESS_KEY is not set"),
+    ):
+        _AgentCoreProvider()
+
+    mock_boto3.Session.assert_not_called()
+
+
+def test_agentcore_honors_a_prefixed_aws_credential_override() -> None:
+    """The sandbox path must read the prefix exactly as the model path does."""
+    session = MagicMock()
+    session.get_credentials.return_value = MagicMock()
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value = session
+
+    with (
+        _bind_environment(
+            {
+                "AWS_REGION": "us-test-1",
+                "AWS_PROFILE": "canonical-profile",
+                "DEEPAGENTS_CODE_AWS_PROFILE": "prefixed-profile",
+            }
+        ),
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+    ):
+        _AgentCoreProvider()
+
+    mock_boto3.Session.assert_called_once_with(
+        profile_name="prefixed-profile",
+        region_name="us-test-1",
+    )

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -885,7 +885,7 @@ def test_agentcore_refuses_to_substitute_server_aws_credentials() -> None:
 
 
 def test_agentcore_rejects_a_half_set_access_key_pair() -> None:
-    """boto3 would raise `PartialCredentialsError` into the silent fallback."""
+    """A half pair is rejected before any boto3 session is built."""
     mock_boto3 = MagicMock()
 
     with (

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -14,6 +14,7 @@ from deepagents_code.integrations.sandbox_factory import (
     _VERCEL_SANDBOX_TIMEOUT,
     _AgentCoreProvider,
     _get_provider,
+    _ModalProvider,
     _VercelProvider,
     create_sandbox,
     get_default_working_dir,
@@ -855,6 +856,48 @@ def test_agentcore_rejects_a_half_set_access_key_pair() -> None:
         _AgentCoreProvider()
 
     mock_boto3.Session.assert_not_called()
+
+
+def test_modal_rejects_a_half_set_token_pair() -> None:
+    """A `None` client resolves the server's Modal identity, not the workspace's."""
+    mock_modal = MagicMock()
+
+    with (
+        _bind_environment({"MODAL_TOKEN_ID": "only-the-id"}),
+        patch.dict(sys.modules, {"modal": mock_modal}),
+        pytest.raises(ValueError, match="MODAL_TOKEN_SECRET is not set"),
+    ):
+        _ModalProvider()
+
+    mock_modal.App.lookup.assert_not_called()
+    mock_modal.Client.from_credentials.assert_not_called()
+
+
+def test_modal_rejects_a_half_set_token_pair_missing_the_id() -> None:
+    """The mirrored arm must name the other variable."""
+    mock_modal = MagicMock()
+
+    with (
+        _bind_environment({"MODAL_TOKEN_SECRET": "only-the-secret"}),
+        patch.dict(sys.modules, {"modal": mock_modal}),
+        pytest.raises(ValueError, match="MODAL_TOKEN_ID is not set"),
+    ):
+        _ModalProvider()
+
+    mock_modal.App.lookup.assert_not_called()
+
+
+def test_modal_delegates_when_no_token_resolves() -> None:
+    """No workspace Modal credentials at all still uses default auth."""
+    mock_modal = MagicMock()
+
+    with (
+        _bind_environment({}),
+        patch.dict(sys.modules, {"modal": mock_modal}),
+    ):
+        _ModalProvider()
+
+    assert "client" not in mock_modal.App.lookup.call_args.kwargs
 
 
 def test_agentcore_honors_a_prefixed_aws_credential_override() -> None:

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -698,57 +698,42 @@ def test_vercel_uses_an_unprefixed_workspace_credential() -> None:
     }
 
 
-def test_vercel_delegates_when_the_workspace_configured_nothing() -> None:
-    """With no resolved credential the SDK keeps owning auth (OIDC)."""
-    with (
-        patch(f"{_FACTORY}.active_environment", return_value={}),
-        patch(
-            "deepagents_code.model_config.resolve_env_var",
-            return_value=None,
-        ),
-        patch.dict("os.environ", {}, clear=True),
-    ):
-        assert _VercelProvider._resolve_sdk_kwargs() == {}
-
-
-@pytest.mark.parametrize(
-    "identifiers",
-    [
-        {"VERCEL_PROJECT_ID": "server-project"},
-        {"VERCEL_TEAM_ID": "server-team"},
-        {"VERCEL_PROJECT_ID": "server-project", "VERCEL_TEAM_ID": "server-team"},
-    ],
-)
-def test_vercel_delegates_inherited_oidc_with_identifiers(
-    identifiers: dict[str, str],
-) -> None:
-    """Inherited project/team IDs do not disable the SDK's OIDC auth."""
-    environment = {"VERCEL_OIDC_TOKEN": "test-oidc-token", **identifiers}
-    with (
-        _bind_environment(environment),
-        patch.dict("os.environ", environment, clear=True),
-    ):
-        assert _VercelProvider._resolve_sdk_kwargs() == {}
-
-
 @pytest.mark.parametrize(
     "server",
     [
-        {"VERCEL_TOKEN": "personal-token", "VERCEL_PROJECT_ID": "prj_1"},
-        {"VERCEL_TOKEN": "personal-token"},
-        {"VERCEL_PROJECT_ID": "prj_1", "VERCEL_TEAM_ID": "team_1"},
+        pytest.param({}, id="empty"),
+        pytest.param(
+            {
+                "VERCEL_OIDC_TOKEN": "test-oidc-token",
+                "VERCEL_PROJECT_ID": "server-project",
+            },
+            id="oidc-project",
+        ),
+        pytest.param(
+            {"VERCEL_OIDC_TOKEN": "test-oidc-token", "VERCEL_TEAM_ID": "server-team"},
+            id="oidc-team",
+        ),
+        pytest.param(
+            {
+                "VERCEL_OIDC_TOKEN": "test-oidc-token",
+                "VERCEL_PROJECT_ID": "server-project",
+                "VERCEL_TEAM_ID": "server-team",
+            },
+            id="oidc-project-and-team",
+        ),
+        pytest.param(
+            {"VERCEL_TOKEN": "personal-token", "VERCEL_PROJECT_ID": "prj_1"},
+            id="personal-token-and-project",
+        ),
+        pytest.param({"VERCEL_TOKEN": "personal-token"}, id="personal-token"),
+        pytest.param(
+            {"VERCEL_PROJECT_ID": "prj_1", "VERCEL_TEAM_ID": "team_1"},
+            id="project-and-team",
+        ),
     ],
 )
-def test_vercel_delegates_an_incomplete_set_inherited_from_the_server(
-    server: dict[str, str],
-) -> None:
-    """An incomplete set the workspace did not pin is the server's own config.
-
-    Personal-scope Vercel accounts leave `VERCEL_TEAM_ID` unset, so demanding
-    the full set turned a working server-level configuration into a startup
-    failure. There is no workspace identity to protect here -- the SDK resolves
-    exactly these values.
-    """
+def test_vercel_delegates_unchanged_server_credentials(server: dict[str, str]) -> None:
+    """Inherited credentials remain SDK-managed, including partial sets and OIDC."""
     with (
         _bind_environment(server),
         patch.dict("os.environ", server, clear=True),
@@ -923,52 +908,23 @@ def test_agentcore_omits_session_when_it_could_not_be_built() -> None:
     assert "session" not in client_module.CodeInterpreter.call_args.kwargs
 
 
-def test_agentcore_refuses_to_substitute_server_aws_credentials() -> None:
-    """A workspace that scoped its credentials must not silently fall back.
-
-    Omitting `session` lets the SDK resolve from the server process, so a
-    workspace pinned to a restricted profile would run under the server's
-    broader identity.
-    """
-    mock_boto3 = MagicMock()
-    mock_boto3.Session.side_effect = RuntimeError("ProfileNotFound: typo")
-
-    with (
-        _bind_environment(
-            {"AWS_REGION": "us-test-1", "AWS_PROFILE": "restricted-profile"}
-        ),
-        patch.dict(sys.modules, {"boto3": mock_boto3}),
-        pytest.raises(ValueError, match="not substituted"),
-    ):
-        _AgentCoreProvider()
-
-
-def test_agentcore_rejects_a_half_set_access_key_pair() -> None:
-    """A half pair is rejected before any boto3 session is built."""
+@pytest.mark.parametrize(
+    ("present", "missing"),
+    [
+        ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
+        ("AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY_ID"),
+    ],
+)
+def test_agentcore_rejects_a_half_set_access_key_pair(
+    present: str, missing: str
+) -> None:
+    """Either missing credential is named before any boto3 session is built."""
     mock_boto3 = MagicMock()
 
     with (
-        _bind_environment(
-            {"AWS_REGION": "us-test-1", "AWS_ACCESS_KEY_ID": "only-the-id"}
-        ),
+        _bind_environment({"AWS_REGION": "us-test-1", present: "workspace-value"}),
         patch.dict(sys.modules, {"boto3": mock_boto3}),
-        pytest.raises(ValueError, match="AWS_SECRET_ACCESS_KEY is not set"),
-    ):
-        _AgentCoreProvider()
-
-    mock_boto3.Session.assert_not_called()
-
-
-def test_agentcore_rejects_a_half_set_access_key_pair_missing_the_id() -> None:
-    """The mirrored arm must name the other variable."""
-    mock_boto3 = MagicMock()
-
-    with (
-        _bind_environment(
-            {"AWS_REGION": "us-test-1", "AWS_SECRET_ACCESS_KEY": "only-the-secret"}
-        ),
-        patch.dict(sys.modules, {"boto3": mock_boto3}),
-        pytest.raises(ValueError, match="AWS_ACCESS_KEY_ID is not set"),
+        pytest.raises(ValueError, match=f"{missing} is not set"),
     ):
         _AgentCoreProvider()
 
@@ -1023,33 +979,26 @@ def test_agentcore_blames_the_workspace_for_a_workspace_only_profile() -> None:
         _AgentCoreProvider()
 
 
-def test_modal_rejects_a_half_set_token_pair() -> None:
-    """A `None` client resolves the server's Modal identity, not the workspace's."""
+@pytest.mark.parametrize(
+    ("present", "missing"),
+    [
+        ("MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"),
+        ("MODAL_TOKEN_SECRET", "MODAL_TOKEN_ID"),
+    ],
+)
+def test_modal_rejects_a_half_set_token_pair(present: str, missing: str) -> None:
+    """An incomplete pair cannot fall back to the server's Modal identity."""
     mock_modal = MagicMock()
 
     with (
-        _bind_environment({"MODAL_TOKEN_ID": "only-the-id"}),
+        _bind_environment({present: "workspace-value"}),
         patch.dict(sys.modules, {"modal": mock_modal}),
-        pytest.raises(ValueError, match="MODAL_TOKEN_SECRET is not set"),
+        pytest.raises(ValueError, match=f"{missing} is not set"),
     ):
         _ModalProvider()
 
     mock_modal.App.lookup.assert_not_called()
     mock_modal.Client.from_credentials.assert_not_called()
-
-
-def test_modal_rejects_a_half_set_token_pair_missing_the_id() -> None:
-    """The mirrored arm must name the other variable."""
-    mock_modal = MagicMock()
-
-    with (
-        _bind_environment({"MODAL_TOKEN_SECRET": "only-the-secret"}),
-        patch.dict(sys.modules, {"modal": mock_modal}),
-        pytest.raises(ValueError, match="MODAL_TOKEN_ID is not set"),
-    ):
-        _ModalProvider()
-
-    mock_modal.App.lookup.assert_not_called()
 
 
 def test_modal_delegates_when_no_token_resolves() -> None:

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -835,6 +835,65 @@ def test_vercel_get_provider_fails_closed_on_a_partial_set() -> None:
         _get_provider("vercel")
 
 
+@pytest.mark.parametrize("prefix", ["", "DEEPAGENTS_CODE_"])
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        ("TOKEN",),
+        ("PROJECT_ID",),
+        ("TEAM_ID",),
+        ("TOKEN", "PROJECT_ID"),
+        ("TOKEN", "TEAM_ID"),
+        ("PROJECT_ID", "TEAM_ID"),
+    ],
+)
+def test_vercel_rejects_mixed_workspace_and_server_credentials(
+    prefix: str, overrides: tuple[str, ...]
+) -> None:
+    """A complete merged mapping can still contain two credential identities."""
+    server = {
+        f"VERCEL_{key}": f"server-{key}" for key in ("TOKEN", "PROJECT_ID", "TEAM_ID")
+    }
+    environment = {
+        **server,
+        **{f"{prefix}VERCEL_{key}": f"workspace-{key}" for key in overrides},
+    }
+    with (
+        _bind_environment(environment),
+        patch.dict("os.environ", server, clear=True),
+        pytest.raises(ValueError, match="mixes workspace and server"),
+    ):
+        _get_provider("vercel")
+
+
+def test_vercel_empty_workspace_overrides_cannot_restore_server_auth() -> None:
+    """Explicitly clearing every credential must not reactivate ambient auth."""
+    server = {"VERCEL_TOKEN": "server-token"}
+    with (
+        _bind_environment({**server, "DEEPAGENTS_CODE_VERCEL_TOKEN": ""}),
+        patch.dict("os.environ", server, clear=True),
+        pytest.raises(ValueError, match="workspace Vercel configuration is incomplete"),
+    ):
+        _get_provider("vercel")
+
+
+def test_vercel_complete_prefixed_set_can_share_server_identifiers() -> None:
+    """Explicit workspace IDs remain scoped even when their values match."""
+    server = {"VERCEL_PROJECT_ID": "shared-project", "VERCEL_TEAM_ID": "shared-team"}
+    environment = {
+        **server,
+        "DEEPAGENTS_CODE_VERCEL_TOKEN": "workspace-token",
+        "DEEPAGENTS_CODE_VERCEL_PROJECT_ID": "shared-project",
+        "DEEPAGENTS_CODE_VERCEL_TEAM_ID": "shared-team",
+    }
+    with _bind_environment(environment), patch.dict("os.environ", server, clear=True):
+        assert _VercelProvider._resolve_sdk_kwargs() == {
+            "token": "workspace-token",
+            "project_id": "shared-project",
+            "team_id": "shared-team",
+        }
+
+
 def test_agentcore_omits_session_when_it_could_not_be_built() -> None:
     """A failed session must not masquerade as an applied workspace session."""
     mock_boto3 = MagicMock()

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -731,6 +731,47 @@ def test_vercel_delegates_inherited_oidc_with_identifiers(
         assert _VercelProvider._resolve_sdk_kwargs() == {}
 
 
+@pytest.mark.parametrize(
+    "server",
+    [
+        {"VERCEL_TOKEN": "personal-token", "VERCEL_PROJECT_ID": "prj_1"},
+        {"VERCEL_TOKEN": "personal-token"},
+        {"VERCEL_PROJECT_ID": "prj_1", "VERCEL_TEAM_ID": "team_1"},
+    ],
+)
+def test_vercel_delegates_an_incomplete_set_inherited_from_the_server(
+    server: dict[str, str],
+) -> None:
+    """An incomplete set the workspace did not pin is the server's own config.
+
+    Personal-scope Vercel accounts leave `VERCEL_TEAM_ID` unset, so demanding
+    the full set turned a working server-level configuration into a startup
+    failure. There is no workspace identity to protect here -- the SDK resolves
+    exactly these values.
+    """
+    with (
+        _bind_environment(server),
+        patch.dict("os.environ", server, clear=True),
+    ):
+        assert _VercelProvider._resolve_sdk_kwargs() == {}
+
+
+def test_vercel_fails_closed_when_the_workspace_overrides_part_of_the_set() -> None:
+    """A workspace override differs from the server, so it must not delegate."""
+    with (
+        _bind_environment(
+            {"VERCEL_TOKEN": "workspace-token", "VERCEL_PROJECT_ID": "prj_1"}
+        ),
+        patch.dict(
+            "os.environ",
+            {"VERCEL_TOKEN": "server-token", "VERCEL_PROJECT_ID": "prj_1"},
+            clear=True,
+        ),
+        pytest.raises(ValueError, match="VERCEL_TEAM_ID not set"),
+    ):
+        _VercelProvider._resolve_sdk_kwargs()
+
+
 @pytest.mark.parametrize("server_oidc", [False, True])
 def test_vercel_oidc_does_not_discard_workspace_identifiers(
     server_oidc: bool,

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import sys
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -856,6 +857,70 @@ def test_agentcore_rejects_a_half_set_access_key_pair() -> None:
         _AgentCoreProvider()
 
     mock_boto3.Session.assert_not_called()
+
+
+def test_agentcore_rejects_a_half_set_access_key_pair_missing_the_id() -> None:
+    """The mirrored arm must name the other variable."""
+    mock_boto3 = MagicMock()
+
+    with (
+        _bind_environment(
+            {"AWS_REGION": "us-test-1", "AWS_SECRET_ACCESS_KEY": "only-the-secret"}
+        ),
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+        pytest.raises(ValueError, match="AWS_ACCESS_KEY_ID is not set"),
+    ):
+        _AgentCoreProvider()
+
+    mock_boto3.Session.assert_not_called()
+
+
+def test_agentcore_rejects_a_session_token_without_the_key_pair() -> None:
+    """Botocore declines the explicit provider and falls through to the server."""
+    mock_boto3 = MagicMock()
+
+    with (
+        _bind_environment(
+            {"AWS_REGION": "us-test-1", "AWS_SESSION_TOKEN": "only-the-token"}
+        ),
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+        pytest.raises(ValueError, match="AWS_SESSION_TOKEN is set without"),
+    ):
+        _AgentCoreProvider()
+
+    mock_boto3.Session.assert_not_called()
+
+
+def test_agentcore_does_not_blame_the_workspace_for_a_server_level_profile() -> None:
+    """A stale profile from the server's own shell must not be a startup failure."""
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.side_effect = RuntimeError("ProfileNotFound: stale")
+    environment = {"AWS_REGION": "us-test-1", "AWS_PROFILE": "stale-server-profile"}
+
+    with (
+        _bind_environment(environment),
+        patch.dict(os.environ, environment, clear=True),
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+    ):
+        provider = _AgentCoreProvider()
+
+    assert provider._session is None
+
+
+def test_agentcore_blames_the_workspace_for_a_workspace_only_profile() -> None:
+    """A profile the workspace pinned, and the server did not, still fails closed."""
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.side_effect = RuntimeError("ProfileNotFound: pinned")
+
+    with (
+        _bind_environment(
+            {"AWS_REGION": "us-test-1", "AWS_PROFILE": "workspace-pinned"}
+        ),
+        patch.dict(os.environ, {"AWS_REGION": "us-test-1"}, clear=True),
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+        pytest.raises(ValueError, match="workspace scoped its sandbox"),
+    ):
+        _AgentCoreProvider()
 
 
 def test_modal_rejects_a_half_set_token_pair() -> None:

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -709,7 +709,50 @@ def test_vercel_delegates_when_the_workspace_configured_nothing() -> None:
         assert _VercelProvider._resolve_sdk_kwargs() == {}
 
 
-def test_vercel_fails_closed_on_a_partial_workspace_credential_set() -> None:
+@pytest.mark.parametrize(
+    "identifiers",
+    [
+        {"VERCEL_PROJECT_ID": "server-project"},
+        {"VERCEL_TEAM_ID": "server-team"},
+        {"VERCEL_PROJECT_ID": "server-project", "VERCEL_TEAM_ID": "server-team"},
+    ],
+)
+def test_vercel_delegates_inherited_oidc_with_identifiers(
+    identifiers: dict[str, str],
+) -> None:
+    """Inherited project/team IDs do not disable the SDK's OIDC auth."""
+    environment = {"VERCEL_OIDC_TOKEN": "test-oidc-token", **identifiers}
+    with (
+        _bind_environment(environment),
+        patch.dict("os.environ", environment, clear=True),
+    ):
+        assert _VercelProvider._resolve_sdk_kwargs() == {}
+
+
+@pytest.mark.parametrize("server_oidc", [False, True])
+def test_vercel_oidc_does_not_discard_workspace_identifiers(
+    server_oidc: bool,
+) -> None:
+    """Delegating cannot drop workspace settings the SDK cannot read."""
+    environment = {
+        "VERCEL_OIDC_TOKEN": "test-oidc-token",
+        "VERCEL_PROJECT_ID": "workspace-project",
+    }
+    server = {"VERCEL_OIDC_TOKEN": "test-oidc-token"} if server_oidc else {}
+    with (
+        _bind_environment(environment),
+        patch.dict("os.environ", server, clear=True),
+        pytest.raises(ValueError, match="workspace Vercel configuration"),
+    ):
+        _VercelProvider._resolve_sdk_kwargs()
+
+
+@pytest.mark.parametrize("oidc", [None, "test-oidc-token"])
+@pytest.mark.parametrize("prefix", ["", "DEEPAGENTS_CODE_"])
+def test_vercel_fails_closed_on_a_partial_workspace_credential_set(
+    oidc: str | None,
+    prefix: str,
+) -> None:
     """A partial set must not fall back to the server's Vercel identity.
 
     An empty mapping hands auth back to the Vercel SDK, which resolves
@@ -718,15 +761,13 @@ def test_vercel_fails_closed_on_a_partial_workspace_credential_set() -> None:
     then silently run its sandbox under the server's broader identity.
     """
     environment = {
-        "DEEPAGENTS_CODE_VERCEL_TOKEN": "workspace-token",
+        f"{prefix}VERCEL_TOKEN": "workspace-token",
     }
     with (
-        patch(f"{_FACTORY}.active_environment", return_value=environment),
-        patch(
-            "deepagents_code.model_config.resolve_env_var",
-            side_effect=lambda name: environment.get(f"DEEPAGENTS_CODE_{name}"),
+        _bind_environment(environment),
+        patch.dict(
+            "os.environ", {"VERCEL_OIDC_TOKEN": oidc} if oidc else {}, clear=True
         ),
-        patch.dict("os.environ", {}, clear=True),
         pytest.raises(ValueError, match="VERCEL_PROJECT_ID, and VERCEL_TEAM_ID"),
     ):
         _VercelProvider._resolve_sdk_kwargs()

--- a/libs/code/tests/unit_tests/test_server_config.py
+++ b/libs/code/tests/unit_tests/test_server_config.py
@@ -199,6 +199,105 @@ class TestServerConfigEdgeCases:
             enable_interpreter=None, sandbox_type="daytona", local_default=True
         )
 
+    def test_workspace_claim_partitions_every_policy_field(self) -> None:
+        config = ServerConfig()
+
+        assert set(config.to_workspace_payload()) == set(
+            config.to_session_workspace_claim()
+        ) | set(config.to_project_workspace_policy())
+        assert not (
+            set(config.to_session_workspace_claim())
+            & set(config.to_project_workspace_policy())
+        )
+        assert {"no_mcp", "allow_fs_tools"} <= set(config.to_session_workspace_claim())
+
+    def test_session_fingerprint_excludes_every_project_field(self) -> None:
+        baseline = ServerConfig()
+        project_changed = ServerConfig(
+            extension_paths=("/tmp/extension.py",),
+            mcp_config_path="/tmp/mcp.json",
+            sandbox_setup="/tmp/setup.sh",
+            trust_project_extensions=True,
+            trust_project_mcp=True,
+        )
+
+        assert (
+            baseline.session_workspace_fingerprint()
+            == project_changed.session_workspace_fingerprint()
+        )
+        assert (
+            baseline.workspace_fingerprint() != project_changed.workspace_fingerprint()
+        )
+        assert (
+            baseline.session_workspace_fingerprint()
+            != ServerConfig(no_mcp=True).session_workspace_fingerprint()
+        )
+        assert (
+            baseline.session_workspace_fingerprint()
+            != ServerConfig(
+                allow_fs_tools=["read_file"]
+            ).session_workspace_fingerprint()
+        )
+
+    def test_second_project_drops_launch_project_grants(self, tmp_path: Path) -> None:
+        launch = tmp_path / "launch"
+        other = tmp_path / "other"
+        launch.mkdir()
+        other.mkdir()
+        config = ServerConfig(
+            cwd=str(launch),
+            project_root=str(launch),
+            trust_project_mcp=True,
+            trust_project_extensions=True,
+            mcp_config_path=str(launch / "mcp.json"),
+            sandbox_setup=str(launch / "setup.sh"),
+            extension_paths=(str(launch / "extension.py"),),
+            no_mcp=True,
+            allow_fs_tools=["read_file"],
+        )
+
+        launch_config = config.resolve_workspace(str(launch), str(launch))
+        with patch(
+            "deepagents_code.extensions.trust.is_project_extensions_trusted",
+            return_value=False,
+        ):
+            other_config = config.resolve_workspace(str(other), str(other))
+
+        assert launch_config.to_project_workspace_policy() == (
+            config.to_project_workspace_policy()
+        )
+        assert other_config.to_project_workspace_policy() == {
+            "extension_paths": [],
+            "mcp_config_path": None,
+            "sandbox_setup": None,
+            "trust_project_extensions": False,
+            "trust_project_mcp": None,
+        }
+        assert other_config.no_mcp is True
+        assert other_config.allow_fs_tools == ["read_file"]
+
+    def test_second_project_resolves_its_persisted_extension_trust(
+        self, tmp_path: Path
+    ) -> None:
+        launch = tmp_path / "launch"
+        other = tmp_path / "other"
+        launch.mkdir()
+        other.mkdir()
+        config = ServerConfig(
+            cwd=str(launch),
+            project_root=str(launch),
+            trust_project_extensions=False,
+        )
+
+        with patch(
+            "deepagents_code.extensions.trust.is_project_extensions_trusted",
+            return_value=True,
+        ) as trusted:
+            resolved = config.resolve_workspace(str(other), str(other))
+
+        assert resolved.trust_project_extensions is True
+        trusted.assert_called_once_with(str(other))
+
     def test_trust_project_mcp_false_round_trips(self) -> None:
         """False must survive round-trip (not collapse to None)."""
         original = ServerConfig(trust_project_mcp=False)

--- a/libs/code/tests/unit_tests/test_server_config.py
+++ b/libs/code/tests/unit_tests/test_server_config.py
@@ -239,43 +239,6 @@ class TestServerConfigEdgeCases:
             ).session_workspace_fingerprint()
         )
 
-    def test_second_project_drops_launch_project_grants(self, tmp_path: Path) -> None:
-        launch = tmp_path / "launch"
-        other = tmp_path / "other"
-        launch.mkdir()
-        other.mkdir()
-        config = ServerConfig(
-            cwd=str(launch),
-            project_root=str(launch),
-            trust_project_mcp=True,
-            trust_project_extensions=True,
-            mcp_config_path=str(launch / "mcp.json"),
-            sandbox_setup=str(launch / "setup.sh"),
-            extension_paths=(str(launch / "extension.py"),),
-            no_mcp=True,
-            allow_fs_tools=["read_file"],
-        )
-
-        launch_config = config.resolve_workspace(str(launch), str(launch))
-        with patch(
-            "deepagents_code.extensions.trust.is_project_extensions_trusted",
-            return_value=False,
-        ):
-            other_config = config.resolve_workspace(str(other), str(other))
-
-        assert launch_config.to_project_workspace_policy() == (
-            config.to_project_workspace_policy()
-        )
-        assert other_config.to_project_workspace_policy() == {
-            "extension_paths": [],
-            "mcp_config_path": None,
-            "sandbox_setup": None,
-            "trust_project_extensions": False,
-            "trust_project_mcp": None,
-        }
-        assert other_config.no_mcp is True
-        assert other_config.allow_fs_tools == ["read_file"]
-
     def test_second_project_resolves_its_persisted_extension_trust(
         self, tmp_path: Path
     ) -> None:

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -777,6 +777,77 @@ class TestWorkspaceRuntime:
 
         make.assert_awaited_once()
 
+    async def test_cached_runtime_survives_a_granted_extension_trust(
+        self, tmp_path
+    ) -> None:
+        """Granting trust elsewhere must not brick an already-bound thread.
+
+        Trust is resolved from a mutable on-disk store, so a grant in another
+        session looked exactly like drift -- and because the check runs before
+        the cache lookup, every request on the thread refused with no way to
+        recover. A grant only adds privilege, so the bound value is pinned and
+        takes effect on the next binding instead.
+        """
+        module = _import_fresh_server_graph()
+        launch = tmp_path / "launch"
+        other = tmp_path / "other"
+        launch.mkdir()
+        other.mkdir()
+        launch_config = ServerConfig(cwd=str(launch), project_root=str(launch))
+        runtime = module.ServerRuntime(object(), object(), object())
+        make = AsyncMock(return_value=runtime)
+        trust = "deepagents_code.extensions.trust.is_project_extensions_trusted"
+
+        with patch(trust, return_value=False):
+            binding = _bind(launch_config, other)
+
+        with (
+            patch(trust, return_value=False),
+            patch.object(ServerConfig, "from_env", return_value=launch_config),
+            patch.object(module, "_make_graphs", new=make),
+        ):
+            assert await module._workspace_runtime(binding) is runtime
+
+        # The user grants trust for this project in another session.
+        with (
+            patch(trust, return_value=True),
+            patch.object(ServerConfig, "from_env", return_value=launch_config),
+            patch.object(module, "_make_graphs", new=make),
+        ):
+            assert await module._workspace_runtime(binding) is runtime
+
+        # The thread keeps the trust it was bound with, not the new grant.
+        make.assert_awaited_once()
+        call = make.await_args
+        assert call is not None
+        assert call.kwargs["config_override"].trust_project_extensions is False
+
+    async def test_project_policy_drift_names_the_drifted_fields(
+        self, tmp_path
+    ) -> None:
+        """An opaque refusal cannot be told apart from a trust-store read failure."""
+        from deepagents_code.workspace import WorkspaceConflictError
+
+        module = _import_fresh_server_graph()
+        launch = tmp_path / "launch"
+        other = tmp_path / "other"
+        launch.mkdir()
+        other.mkdir()
+        launch_config = ServerConfig(cwd=str(launch), project_root=str(launch))
+        trust = "deepagents_code.extensions.trust.is_project_extensions_trusted"
+
+        with patch(trust, return_value=True):
+            binding = _bind(launch_config, other)
+
+        with (
+            patch(trust, return_value=False),
+            patch.object(ServerConfig, "from_env", return_value=launch_config),
+            pytest.raises(
+                WorkspaceConflictError, match=r"\(trust_project_extensions\)"
+            ),
+        ):
+            await module._workspace_runtime(binding)
+
     async def test_rejects_server_config_drift(self, tmp_path) -> None:
         from deepagents_code.workspace import WorkspaceConflictError
 

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -777,6 +777,38 @@ class TestWorkspaceRuntime:
 
         make.assert_awaited_once()
 
+    async def test_launch_binding_uses_the_explicit_server_project_root(
+        self, tmp_path
+    ) -> None:
+        """The binding must agree with the config `_get_runtime()` builds from.
+
+        `resolve_workspace` derives the project root with `find_project_root`,
+        but `get_server_project_context` prefers an explicit
+        `DEEPAGENTS_CODE_SERVER_PROJECT_ROOT`. Where they disagreed, the launch
+        binding recorded scrubbed project policy while the process-wide runtime
+        kept the launch project's MCP servers and extensions live.
+        """
+        module = _import_fresh_server_graph()
+        # `explicit` is not a project root by discovery, so `find_project_root`
+        # cannot return it -- only the explicit setting can.
+        workdir = tmp_path / "workdir"
+        explicit = tmp_path / "explicit"
+        workdir.mkdir()
+        explicit.mkdir()
+        config = ServerConfig(
+            cwd=str(workdir),
+            project_root=str(explicit),
+            mcp_config_path="/launch/.mcp.json",
+            sandbox_setup="/launch/setup.sh",
+        )
+
+        binding = await module._default_workspace_binding(config)
+
+        assert binding is not None
+        policy = binding.workspace_config()
+        assert policy["mcp_config_path"] == "/launch/.mcp.json"
+        assert policy["sandbox_setup"] == "/launch/setup.sh"
+
     async def test_cached_runtime_survives_a_granted_extension_trust(
         self, tmp_path
     ) -> None:

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -408,6 +408,93 @@ asyncio.run(main())
         }
 
 
+class TestWorkspaceEnvironmentBinding:
+    """The workspace snapshot must actually be bound around construction.
+
+    Every other `_make_graphs` test stubs `deepagents_code.config`, including
+    `use_environment`, while each consumer test patches `active_environment`
+    directly. Both ends are mocked, so nothing exercises the wire between them:
+    dropping the `with use_environment(...)` block leaves `active_environment()`
+    falling back to `os.environ` with no error and no failing test, and sandbox
+    setup would expand the server's own secrets.
+    """
+
+    async def test_consumers_read_the_workspace_env_during_construction(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The real config module binds the workspace `.env` for consumers."""
+        import deepagents_code.agent as agent_mod
+        import deepagents_code.config as config_mod
+        import deepagents_code.integrations.sandbox_factory as sandbox_mod
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / ".env").write_text(
+            "WORKSPACE_ONLY=from-workspace-dotenv\n", encoding="utf-8"
+        )
+        monkeypatch.delenv("WORKSPACE_ONLY", raising=False)
+        monkeypatch.setenv("SERVER_ONLY", "from-server-process")
+        monkeypatch.setattr(
+            config_mod, "_GLOBAL_DOTENV_PATH", tmp_path / "missing-global.env"
+        )
+
+        seen: dict[str, object] = {}
+
+        def _record(label: str) -> None:
+            environment = config_mod.active_environment()
+            seen[label] = environment.get("WORKSPACE_ONLY")
+            seen[f"{label}_server_leak"] = environment.get("SERVER_ONLY")
+
+        graph_obj = object()
+
+        def _create_cli_agent(**_kwargs: object) -> tuple[object, object]:
+            _record("agent")
+            return graph_obj, _backend_with_offload(object())
+
+        def _create_model(*_args: object, **_kwargs: object) -> object:
+            _record("model")
+            return SimpleNamespace(
+                model=object(),
+                provider="openai",
+                apply_to_runtime_state=lambda: None,
+                model_retries=5,
+                cli_max_retries=None,
+            )
+
+        def _create_sandbox(*_args: object, **_kwargs: object) -> object:
+            _record("sandbox")
+            return MagicMock()
+
+        module = _import_fresh_server_graph()
+        config = ServerConfig(
+            no_mcp=True,
+            cwd=str(workspace),
+            project_root=str(workspace),
+            sandbox_type="vercel",
+        )
+
+        with (
+            patch.object(agent_mod, "create_cli_agent", _create_cli_agent),
+            patch.object(agent_mod, "load_async_subagents", lambda **_: None),
+            patch.object(config_mod, "create_model", _create_model),
+            patch.object(sandbox_mod, "create_sandbox", _create_sandbox),
+            patch.object(
+                module, "_criteria_context_tools", lambda *_args, **_kwargs: []
+            ),
+        ):
+            runtime = await module._make_graphs(config_override=config)
+
+        assert runtime.agent is graph_obj
+        # Each consumer read the workspace `.env`, not the server process env.
+        assert seen["model"] == "from-workspace-dotenv"
+        assert seen["agent"] == "from-workspace-dotenv"
+        assert seen["sandbox"] == "from-workspace-dotenv"
+        # The server's own environment still shows through where unshadowed.
+        assert seen["agent_server_leak"] == "from-server-process"
+        # And the workspace value never reached the process.
+        assert "WORKSPACE_ONLY" not in os.environ
+
+
 def _bind(config: ServerConfig, cwd: Any) -> Any:  # noqa: ANN401
     """Resolve a workspace binding for `cwd`, creating the directory first."""
     from deepagents_code.workspace import resolve_workspace

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -198,14 +198,14 @@ asyncio.run(main())
         assert result == [fetch_url, readonly, web_search]
 
     @pytest.mark.parametrize("read_only", [False, None, True])
-    def test_mcp_search_marker_cannot_bypass_read_only_gate(
+    async def test_mcp_search_marker_cannot_bypass_read_only_gate(
         self, read_only: bool | None
     ) -> None:
         """Server-controlled annotation extras cannot grant criteria access."""
         from langchain_mcp_adapters.tools import convert_mcp_tool_to_langchain_tool
         from mcp.types import Tool, ToolAnnotations
 
-        from deepagents_code.tools import create_web_search_tool
+        from deepagents_code.tools import fetch_url
 
         module = _import_fresh_server_graph()
         remote = convert_mcp_tool_to_langchain_tool(
@@ -223,9 +223,15 @@ asyncio.run(main())
             ),
             connection={"transport": "stdio", "command": "unused", "args": []},
         )
-        search = create_web_search_tool("")
+        tools, _, _, read_only_builtins = await module._build_tools(
+            ServerConfig(no_mcp=True), None, tavily_api_key=""
+        )
+        tools.append(remote)
+        selected = module._criteria_context_tools(tools, [remote], read_only_builtins)
 
-        assert module._criteria_context_tools([remote, search], [remote]) == [search]
+        assert remote not in selected
+        assert fetch_url in selected
+        assert any(getattr(tool, "name", None) == "web_search" for tool in selected)
 
     async def test_make_graph_emits_marker_and_exits_on_failure(
         self, capsys: pytest.CaptureFixture[str]
@@ -279,17 +285,14 @@ asyncio.run(main())
         module = _import_fresh_server_graph()
         from deepagents_code.tools import fetch_url, get_current_thread_id
 
-        _, _, _, read_only_builtins = await module._build_tools(
-            ServerConfig(no_mcp=True),
-            None,
-            workspace_credentials=SimpleNamespace(
-                has_tavily=False,
-                tavily_api_key=None,
-            ),
+        tools, _, mcp_tools, read_only_builtins = await module._build_tools(
+            ServerConfig(no_mcp=True), None, tavily_api_key=None
         )
+        selected = module._criteria_context_tools(tools, mcp_tools, read_only_builtins)
 
-        assert read_only_builtins == [fetch_url]
-        assert get_current_thread_id not in read_only_builtins
+        assert selected == [fetch_url]
+        assert get_current_thread_id in tools
+        assert get_current_thread_id not in selected
 
     async def test_build_tools_skips_mcp_when_disabled(self) -> None:
         """`no_mcp=True` should not call the MCP resolver at all."""

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -539,29 +539,6 @@ def _bind(config: ServerConfig, cwd: Any) -> Any:  # noqa: ANN401
 class TestWorkspaceRuntime:
     """Workspace runtimes retain trusted server-only configuration."""
 
-    async def test_default_binding_preserves_launch_project_policy(
-        self, tmp_path
-    ) -> None:
-        module = _import_fresh_server_graph()
-        project = tmp_path / "project"
-        project.mkdir()
-        config = ServerConfig(
-            cwd=str(project),
-            project_root=str(project),
-            trust_project_mcp=True,
-            mcp_config_path=str(project / "mcp.json"),
-        )
-
-        with blockbuster_ctx(scanned_modules=module):
-            binding = await module._default_workspace_binding(config)
-
-        assert binding is not None
-        assert binding.workspace_config()["trust_project_mcp"] is True
-        assert binding.workspace_config()["mcp_config_path"] == str(
-            project / "mcp.json"
-        )
-        assert binding.config_fingerprint == config.workspace_fingerprint()
-
     async def test_cached_runtime_resolves_policy_off_event_loop(
         self, tmp_path
     ) -> None:
@@ -810,14 +787,7 @@ class TestWorkspaceRuntime:
     async def test_second_project_runtime_is_built_without_launch_grants(
         self, tmp_path
     ) -> None:
-        """The strip has to reach the config the runtime is built from.
-
-        `resolve_workspace` is tested in isolation and the drift check is
-        tested, but nothing asserted that `_make_graphs` receives the scrubbed
-        policy -- so returning the unresolved config here, or losing one of the
-        five strips, would leave every test green while the second workspace
-        executed the launch project's trusted extensions and MCP servers.
-        """
+        """Second-project runtimes drop launch grants and retain session policy."""
         module = _import_fresh_server_graph()
         launch = tmp_path / "launch"
         other = tmp_path / "other"
@@ -829,9 +799,11 @@ class TestWorkspaceRuntime:
             mcp_config_path="/launch/.mcp.json",
             sandbox_setup="/launch/setup.sh",
             trust_project_mcp=True,
+            trust_project_extensions=True,
             extension_paths=("/launch/ext.py",),
             no_mcp=True,
             auto_approve=True,
+            allow_fs_tools=["read_file"],
         )
         runtime = module.ServerRuntime(object(), object(), object())
         make = AsyncMock(return_value=runtime)
@@ -858,6 +830,7 @@ class TestWorkspaceRuntime:
         # Session policy belongs to the command, not the project, and survives.
         assert built.no_mcp is True
         assert built.auto_approve is True
+        assert built.allow_fs_tools == ["read_file"]
         assert built.cwd == binding.cwd
 
     async def test_launch_binding_uses_the_explicit_server_project_root(
@@ -885,12 +858,14 @@ class TestWorkspaceRuntime:
             sandbox_setup="/launch/setup.sh",
         )
 
-        binding = await module._default_workspace_binding(config)
+        with blockbuster_ctx(scanned_modules=module):
+            binding = await module._default_workspace_binding(config)
 
         assert binding is not None
         policy = binding.workspace_config()
         assert policy["mcp_config_path"] == "/launch/.mcp.json"
         assert policy["sandbox_setup"] == "/launch/setup.sh"
+        assert binding.config_fingerprint == config.workspace_fingerprint()
 
     async def test_cached_runtime_survives_a_granted_extension_trust(
         self, tmp_path

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -411,15 +411,39 @@ def _bind(config: ServerConfig, cwd: Any) -> Any:  # noqa: ANN401
     from deepagents_code.workspace import resolve_workspace
 
     cwd.mkdir(exist_ok=True)
+    identity = resolve_workspace(str(cwd))
+    resolved = config.resolve_workspace(identity.cwd, identity.project_root)
     return resolve_workspace(
-        str(cwd),
-        config.to_workspace_payload(),
-        config_fingerprint=config.workspace_fingerprint(),
+        identity.cwd,
+        resolved.to_workspace_payload(),
+        config_fingerprint=resolved.workspace_fingerprint(),
     )
 
 
 class TestWorkspaceRuntime:
     """Workspace runtimes retain trusted server-only configuration."""
+
+    async def test_default_binding_preserves_launch_project_policy(
+        self, tmp_path
+    ) -> None:
+        module = _import_fresh_server_graph()
+        project = tmp_path / "project"
+        project.mkdir()
+        config = ServerConfig(
+            cwd=str(project),
+            project_root=str(project),
+            trust_project_mcp=True,
+            mcp_config_path=str(project / "mcp.json"),
+        )
+
+        binding = await module._default_workspace_binding(config)
+
+        assert binding is not None
+        assert binding.workspace_config()["trust_project_mcp"] is True
+        assert binding.workspace_config()["mcp_config_path"] == str(
+            project / "mcp.json"
+        )
+        assert binding.config_fingerprint == config.workspace_fingerprint()
 
     async def test_uses_full_server_config_and_replaces_only_workspace_paths(
         self, tmp_path
@@ -547,6 +571,31 @@ class TestWorkspaceRuntime:
             ] == (runtimes)
 
         assert make.await_count == 2
+
+    async def test_rejects_resolved_project_policy_divergence(self, tmp_path) -> None:
+        from deepagents_code.workspace import WorkspaceConflictError
+
+        module = _import_fresh_server_graph()
+        project = tmp_path / "project"
+        bound_config = ServerConfig(
+            cwd=str(project),
+            project_root=str(project),
+            trust_project_mcp=False,
+        )
+        binding = _bind(bound_config, project)
+        changed = ServerConfig(
+            cwd=str(project),
+            project_root=str(project),
+            trust_project_mcp=True,
+        )
+        with (
+            patch.object(ServerConfig, "from_env", return_value=changed),
+            patch.object(module, "_make_graphs", new=AsyncMock()) as make,
+            pytest.raises(WorkspaceConflictError, match="project's resolved policy"),
+        ):
+            await module._workspace_runtime(binding)
+
+        make.assert_not_awaited()
 
     async def test_rejects_server_config_drift(self, tmp_path) -> None:
         from deepagents_code.workspace import WorkspaceConflictError

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -646,6 +646,50 @@ class TestWorkspaceRuntime:
 
         make.assert_awaited_once()
 
+    async def test_cached_runtime_rejects_revoked_extension_trust(
+        self, tmp_path
+    ) -> None:
+        """Revoking trust must invalidate a runtime built while it was granted.
+
+        `trust_project_extensions` is the one project policy field not derived
+        from the environment: `resolve_workspace` re-reads it from the
+        persisted trust store. `ServerConfig.from_env()` is identical across
+        both calls here, so the server-config fingerprint check cannot fire and
+        only the project-policy comparison can catch the revocation. Without
+        it, a runtime keeps executing project Python the user has untrusted.
+        """
+        from deepagents_code.workspace import WorkspaceConflictError
+
+        module = _import_fresh_server_graph()
+        launch = tmp_path / "launch"
+        other = tmp_path / "other"
+        launch.mkdir()
+        other.mkdir()
+        launch_config = ServerConfig(cwd=str(launch), project_root=str(launch))
+        runtime = module.ServerRuntime(object(), object(), object())
+        make = AsyncMock(return_value=runtime)
+        trust = "deepagents_code.extensions.trust.is_project_extensions_trusted"
+
+        with patch(trust, return_value=True):
+            binding = _bind(launch_config, other)
+
+        with (
+            patch(trust, return_value=True),
+            patch.object(ServerConfig, "from_env", return_value=launch_config),
+            patch.object(module, "_make_graphs", new=make),
+        ):
+            assert await module._workspace_runtime(binding) is runtime
+
+        # The user revokes trust. Nothing about the environment changes.
+        with (
+            patch(trust, return_value=False),
+            patch.object(ServerConfig, "from_env", return_value=launch_config),
+            pytest.raises(WorkspaceConflictError, match="project's resolved policy"),
+        ):
+            await module._workspace_runtime(binding)
+
+        make.assert_awaited_once()
+
     async def test_rejects_server_config_drift(self, tmp_path) -> None:
         from deepagents_code.workspace import WorkspaceConflictError
 

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import importlib
 import os
 import subprocess
@@ -596,6 +597,37 @@ class TestWorkspaceRuntime:
             await module._workspace_runtime(binding)
 
         make.assert_not_awaited()
+
+    async def test_cached_runtime_rejects_project_policy_divergence(
+        self, tmp_path
+    ) -> None:
+        from deepagents_code.workspace import WorkspaceConflictError
+
+        module = _import_fresh_server_graph()
+        project = tmp_path / "project"
+        bound_config = ServerConfig(
+            cwd=str(project),
+            project_root=str(project),
+            trust_project_mcp=True,
+        )
+        binding = _bind(bound_config, project)
+        runtime = module.ServerRuntime(object(), object(), object())
+        make = AsyncMock(return_value=runtime)
+
+        with (
+            patch.object(ServerConfig, "from_env", return_value=bound_config),
+            patch.object(module, "_make_graphs", new=make),
+        ):
+            assert await module._workspace_runtime(binding) is runtime
+
+        changed = dataclasses.replace(bound_config, trust_project_mcp=False)
+        with (
+            patch.object(ServerConfig, "from_env", return_value=changed),
+            pytest.raises(WorkspaceConflictError, match="project's resolved policy"),
+        ):
+            await module._workspace_runtime(binding)
+
+        make.assert_awaited_once()
 
     async def test_rejects_server_config_drift(self, tmp_path) -> None:
         from deepagents_code.workspace import WorkspaceConflictError

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -153,6 +153,7 @@ asyncio.run(main())
                 fetch_url,
             ],
             [mcp_tool],
+            [fetch_url, web_search],
         )
 
         assert len(result) == 3
@@ -191,6 +192,7 @@ asyncio.run(main())
         result = module._criteria_context_tools(
             [mutating, fetch_url, readonly, unannotated, web_search, ambiguous],
             [readonly, mutating, unannotated, ambiguous],
+            [fetch_url, web_search],
         )
 
         assert result == [fetch_url, readonly, web_search]
@@ -256,7 +258,7 @@ asyncio.run(main())
             "deepagents_code.tools.create_web_search_tool",
             return_value=bound_tool,
         ) as create:
-            tools, _, _ = await module._build_tools(
+            tools, _, _, _ = await module._build_tools(
                 ServerConfig(no_mcp=True),
                 None,
                 tavily_api_key="workspace-key",
@@ -280,7 +282,6 @@ asyncio.run(main())
             create_web_search_tool=Mock(),
             fetch_url=fetch_tool,
             get_current_thread_id=thread_tool,
-            is_web_search_tool=lambda _tool: False,
             web_search=object(),
         )
         mcp_module = _module_with_attrs(
@@ -297,7 +298,7 @@ asyncio.run(main())
             },
         ):
             module = _import_fresh_server_graph()
-            tools, mcp_server_info, mcp_tools = await module._build_tools(
+            tools, mcp_server_info, mcp_tools, _ = await module._build_tools(
                 ServerConfig(no_mcp=True),
                 None,
                 tavily_api_key=None,
@@ -367,7 +368,6 @@ asyncio.run(main())
             create_web_search_tool=Mock(),
             fetch_url=object(),
             get_current_thread_id=object(),
-            is_web_search_tool=lambda _tool: False,
             web_search=object(),
         )
         config = ServerConfig(

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -258,14 +258,38 @@ asyncio.run(main())
             "deepagents_code.tools.create_web_search_tool",
             return_value=bound_tool,
         ) as create:
-            tools, _, _, _ = await module._build_tools(
+            tools, _, _, read_only_builtins = await module._build_tools(
                 ServerConfig(no_mcp=True),
                 None,
                 tavily_api_key="workspace-key",
             )
 
         assert bound_tool in tools
+        # The read-only allowlist is a security control, and the
+        # `_criteria_context_tools` tests are handed it as an argument, so this
+        # is the only place its contents are actually checked.
+        from deepagents_code.tools import fetch_url, get_current_thread_id
+
+        assert read_only_builtins == [fetch_url, bound_tool]
+        assert get_current_thread_id not in read_only_builtins
         create.assert_called_once_with("workspace-key")
+
+    async def test_build_tools_read_only_allowlist_without_web_search(self) -> None:
+        """With no Tavily key the allowlist holds `fetch_url` alone."""
+        module = _import_fresh_server_graph()
+        from deepagents_code.tools import fetch_url, get_current_thread_id
+
+        _, _, _, read_only_builtins = await module._build_tools(
+            ServerConfig(no_mcp=True),
+            None,
+            workspace_credentials=SimpleNamespace(
+                has_tavily=False,
+                tavily_api_key=None,
+            ),
+        )
+
+        assert read_only_builtins == [fetch_url]
+        assert get_current_thread_id not in read_only_builtins
 
     async def test_build_tools_skips_mcp_when_disabled(self) -> None:
         """`no_mcp=True` should not call the MCP resolver at all."""
@@ -776,6 +800,59 @@ class TestWorkspaceRuntime:
             await module._workspace_runtime(binding)
 
         make.assert_awaited_once()
+
+    async def test_second_project_runtime_is_built_without_launch_grants(
+        self, tmp_path
+    ) -> None:
+        """The strip has to reach the config the runtime is built from.
+
+        `resolve_workspace` is tested in isolation and the drift check is
+        tested, but nothing asserted that `_make_graphs` receives the scrubbed
+        policy -- so returning the unresolved config here, or losing one of the
+        five strips, would leave every test green while the second workspace
+        executed the launch project's trusted extensions and MCP servers.
+        """
+        module = _import_fresh_server_graph()
+        launch = tmp_path / "launch"
+        other = tmp_path / "other"
+        launch.mkdir()
+        other.mkdir()
+        launch_config = ServerConfig(
+            cwd=str(launch),
+            project_root=str(launch),
+            mcp_config_path="/launch/.mcp.json",
+            sandbox_setup="/launch/setup.sh",
+            trust_project_mcp=True,
+            extension_paths=("/launch/ext.py",),
+            no_mcp=True,
+            auto_approve=True,
+        )
+        runtime = module.ServerRuntime(object(), object(), object())
+        make = AsyncMock(return_value=runtime)
+        trust = "deepagents_code.extensions.trust.is_project_extensions_trusted"
+
+        with patch(trust, return_value=False):
+            binding = _bind(launch_config, other)
+
+        with (
+            patch(trust, return_value=False),
+            patch.object(ServerConfig, "from_env", return_value=launch_config),
+            patch.object(module, "_make_graphs", new=make),
+        ):
+            assert await module._workspace_runtime(binding) is runtime
+
+        call = make.await_args
+        assert call is not None
+        built = call.kwargs["config_override"]
+        assert built.mcp_config_path is None
+        assert built.sandbox_setup is None
+        assert built.trust_project_mcp is None
+        assert built.extension_paths == ()
+        assert built.trust_project_extensions is False
+        # Session policy belongs to the command, not the project, and survives.
+        assert built.no_mcp is True
+        assert built.auto_approve is True
+        assert built.cwd == binding.cwd
 
     async def test_launch_binding_uses_the_explicit_server_project_root(
         self, tmp_path

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from blockbuster import blockbuster_ctx
 
 from deepagents_code._env_vars import SERVER_ENV_PREFIX
 from deepagents_code._server_config import ServerConfig
@@ -437,7 +438,8 @@ class TestWorkspaceRuntime:
             mcp_config_path=str(project / "mcp.json"),
         )
 
-        binding = await module._default_workspace_binding(config)
+        with blockbuster_ctx(scanned_modules=module):
+            binding = await module._default_workspace_binding(config)
 
         assert binding is not None
         assert binding.workspace_config()["trust_project_mcp"] is True
@@ -445,6 +447,21 @@ class TestWorkspaceRuntime:
             project / "mcp.json"
         )
         assert binding.config_fingerprint == config.workspace_fingerprint()
+
+    async def test_cached_runtime_resolves_policy_off_event_loop(
+        self, tmp_path
+    ) -> None:
+        module = _import_fresh_server_graph()
+        config = ServerConfig()
+        binding = _bind(config, tmp_path)
+        runtime = module.ServerRuntime(object(), object(), object())
+        module._remember_workspace_runtime(binding, runtime)
+
+        with (
+            patch.object(ServerConfig, "from_env", return_value=config),
+            blockbuster_ctx(scanned_modules=module),
+        ):
+            assert await module._workspace_runtime(binding) is runtime
 
     async def test_uses_full_server_config_and_replaces_only_workspace_paths(
         self, tmp_path

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -795,7 +795,10 @@ class TestWorkspaceRuntime:
         with (
             patch(trust, return_value=False),
             patch.object(ServerConfig, "from_env", return_value=launch_config),
-            pytest.raises(WorkspaceConflictError, match="project's resolved policy"),
+            pytest.raises(
+                WorkspaceConflictError,
+                match=r"project's resolved policy.*\(trust_project_extensions\)",
+            ),
         ):
             await module._workspace_runtime(binding)
 
@@ -930,32 +933,6 @@ class TestWorkspaceRuntime:
         call = make.await_args
         assert call is not None
         assert call.kwargs["config_override"].trust_project_extensions is False
-
-    async def test_project_policy_drift_names_the_drifted_fields(
-        self, tmp_path
-    ) -> None:
-        """An opaque refusal cannot be told apart from a trust-store read failure."""
-        from deepagents_code.workspace import WorkspaceConflictError
-
-        module = _import_fresh_server_graph()
-        launch = tmp_path / "launch"
-        other = tmp_path / "other"
-        launch.mkdir()
-        other.mkdir()
-        launch_config = ServerConfig(cwd=str(launch), project_root=str(launch))
-        trust = "deepagents_code.extensions.trust.is_project_extensions_trusted"
-
-        with patch(trust, return_value=True):
-            binding = _bind(launch_config, other)
-
-        with (
-            patch(trust, return_value=False),
-            patch.object(ServerConfig, "from_env", return_value=launch_config),
-            pytest.raises(
-                WorkspaceConflictError, match=r"\(trust_project_extensions\)"
-            ),
-        ):
-            await module._workspace_runtime(binding)
 
     async def test_rejects_server_config_drift(self, tmp_path) -> None:
         from deepagents_code.workspace import WorkspaceConflictError

--- a/libs/code/tests/unit_tests/test_server_manager.py
+++ b/libs/code/tests/unit_tests/test_server_manager.py
@@ -173,6 +173,58 @@ class TestStartServerAndGetAgent:
 
         assert mock_server_process.call_args.kwargs["scaffold"] is mock_scaffold
 
+    async def test_managed_client_claims_only_session_policy(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        monkeypatch.chdir(project_root)
+        work_dir = tmp_path / "runtime"
+        work_dir.mkdir()
+        mcp_config = project_root / "mcp.json"
+        mcp_config.write_text('{"mcpServers": {"test": {"command": "echo"}}}')
+        server = MagicMock(
+            start=AsyncMock(),
+            wait_for_graph_ready=AsyncMock(),
+            url="http://127.0.0.1:2024",
+        )
+        agent = MagicMock()
+        captured: list[ServerConfig] = []
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch(
+                "deepagents_code.client.launch.server_manager.tempfile.mkdtemp",
+                return_value=str(work_dir),
+            ),
+            patch("deepagents_code.client.launch.server_manager._scaffold_workspace"),
+            patch(
+                "deepagents_code.client.launch.server_manager._apply_server_config",
+                side_effect=captured.append,
+            ),
+            patch(
+                "deepagents_code.client.launch.server.ServerProcess",
+                return_value=server,
+            ),
+            patch(
+                "deepagents_code.client.remote_client.RemoteAgent", return_value=agent
+            ),
+        ):
+            await start_server_and_get_agent(
+                assistant_id="agent",
+                mcp_config_path=str(mcp_config),
+                trust_project_mcp=True,
+                allow_fs_tools=["read_file"],
+            )
+
+        claim = agent.set_workspace.call_args.args[1]
+        assert "mcp_config_path" not in claim
+        assert "trust_project_mcp" not in claim
+        assert claim["allow_fs_tools"] == ["read_file"]
+        assert agent.set_workspace.call_args.kwargs["config_fingerprint"] == (
+            captured[0].session_workspace_fingerprint()
+        )
+
     def test_builtin_server_registers_only_the_agent_graph(
         self, tmp_path: Path
     ) -> None:

--- a/libs/code/tests/unit_tests/test_workspace.py
+++ b/libs/code/tests/unit_tests/test_workspace.py
@@ -85,7 +85,7 @@ async def test_binding_rejects_resource_policy_change(tmp_path) -> None:
         config_fingerprint="config-a",
     )
 
-    with pytest.raises(WorkspaceConflictError, match="already bound"):
+    with pytest.raises(WorkspaceConflictError, match="configuration changed"):
         await bind_thread_workspace(
             "thread-1",
             str(tmp_path),
@@ -96,6 +96,30 @@ async def test_binding_rejects_resource_policy_change(tmp_path) -> None:
         await require_thread_workspace(
             "thread-1", binding.to_payload(), config_fingerprint="config-b"
         )
+
+
+async def test_binding_rejects_resolved_project_policy_change(tmp_path) -> None:
+    binding = await bind_thread_workspace(
+        "thread-1",
+        str(tmp_path),
+        {"trust_project_mcp": False},
+        config_fingerprint="config-a",
+    )
+
+    expected = (
+        "Cannot host this workspace because the project's resolved policy differs "
+        "from the policy recorded when this workspace was bound."
+    )
+    with pytest.raises(WorkspaceConflictError) as exc_info:
+        await bind_thread_workspace(
+            "thread-1",
+            str(tmp_path),
+            {"trust_project_mcp": True},
+            config_fingerprint="config-b",
+        )
+
+    assert str(exc_info.value) == expected
+    assert binding.workspace_config()["trust_project_mcp"] is False
 
 
 async def test_binding_persists_only_non_secret_policy(

--- a/libs/code/tests/unit_tests/test_workspace.py
+++ b/libs/code/tests/unit_tests/test_workspace.py
@@ -164,7 +164,7 @@ async def test_current_schema_migrates_on_reopen(tmp_path, workspace_database) -
     config = {"enable_shell": True}
     binding = await bind_thread_workspace("thread-1", str(tmp_path), config)
 
-    assert binding.schema_version == 2
+    assert binding.schema_version == 3
     assert binding.config_fingerprint
     assert (await require_thread_workspace("thread-1", binding.to_payload())) == binding
     with sqlite3.connect(workspace_database) as conn:
@@ -172,7 +172,44 @@ async def test_current_schema_migrates_on_reopen(tmp_path, workspace_database) -
             "SELECT schema_version FROM dcode_thread_workspaces WHERE thread_id = ?",
             ("thread-1",),
         ).fetchone()[0]
-    assert stored_version == 2
+    assert stored_version == 3
+
+
+async def test_a_stale_schema_row_rebinds_instead_of_conflicting(
+    tmp_path, workspace_database
+) -> None:
+    """A version-2 row's fingerprint spanned a different field set.
+
+    Those rows were bound with the launch config's fingerprint regardless of
+    directory, so comparing one against a resolved fingerprint reported drift
+    forever and the thread could never re-bind.
+    """
+    binding = await bind_thread_workspace("thread-1", str(tmp_path), {"no_mcp": True})
+    with sqlite3.connect(workspace_database) as conn:
+        conn.execute(
+            """
+            UPDATE dcode_thread_workspaces
+            SET schema_version = 2, config_fingerprint = 'stale-launch-fingerprint'
+            WHERE thread_id = ?
+            """,
+            ("thread-1",),
+        )
+
+    rebound = await bind_thread_workspace("thread-1", str(tmp_path), {"no_mcp": False})
+
+    assert rebound.schema_version == 3
+    assert rebound.workspace_config()["no_mcp"] is False
+    assert rebound.config_fingerprint != "stale-launch-fingerprint"
+    assert (await require_thread_workspace("thread-1", rebound.to_payload())) == rebound
+    assert rebound.workspace_id == binding.workspace_id
+
+
+async def test_a_current_schema_row_still_conflicts_on_drift(tmp_path) -> None:
+    """Migration must not become a general-purpose rebind."""
+    await bind_thread_workspace("thread-1", str(tmp_path), {"no_mcp": True})
+
+    with pytest.raises(WorkspaceConflictError):
+        await bind_thread_workspace("thread-1", str(tmp_path), {"no_mcp": False})
 
 
 def test_relative_workspace_is_rejected() -> None:

--- a/libs/code/tests/unit_tests/test_workspace.py
+++ b/libs/code/tests/unit_tests/test_workspace.py
@@ -180,7 +180,7 @@ async def test_current_schema_migrates_on_reopen(tmp_path, workspace_database) -
 async def test_a_stale_schema_row_rebinds_instead_of_conflicting(
     tmp_path, workspace_database
 ) -> None:
-    """A version-2 row's fingerprint spanned a different field set.
+    """A version-2 row's fingerprint used launch-project policy values.
 
     Those rows were bound with the launch config's fingerprint regardless of
     directory, so comparing one against a resolved fingerprint reported drift

--- a/libs/code/tests/unit_tests/test_workspace.py
+++ b/libs/code/tests/unit_tests/test_workspace.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+from contextlib import closing
 
 import pytest
 
 from deepagents_code.workspace import (
     WorkspaceConflictError,
     bind_thread_workspace,
+    get_thread_workspace,
     require_thread_workspace,
 )
 
@@ -135,7 +137,7 @@ async def test_binding_persists_only_non_secret_policy(
     ).to_workspace_payload()
     binding = await bind_thread_workspace("thread-1", str(tmp_path), config)
 
-    with sqlite3.connect(workspace_database) as conn:
+    with closing(sqlite3.connect(workspace_database)) as conn, conn:
         stored = conn.execute(
             "SELECT workspace_config_json FROM dcode_thread_workspaces"
         ).fetchone()[0]
@@ -146,7 +148,7 @@ async def test_binding_persists_only_non_secret_policy(
 
 async def test_current_schema_migrates_on_reopen(tmp_path, workspace_database) -> None:
     """Databases created before policy fingerprinting upgrade in place."""
-    with sqlite3.connect(workspace_database) as conn:
+    with closing(sqlite3.connect(workspace_database)) as conn, conn:
         conn.execute(
             """
             CREATE TABLE dcode_thread_workspaces (
@@ -167,7 +169,7 @@ async def test_current_schema_migrates_on_reopen(tmp_path, workspace_database) -
     assert binding.schema_version == 3
     assert binding.config_fingerprint
     assert (await require_thread_workspace("thread-1", binding.to_payload())) == binding
-    with sqlite3.connect(workspace_database) as conn:
+    with closing(sqlite3.connect(workspace_database)) as conn, conn:
         stored_version = conn.execute(
             "SELECT schema_version FROM dcode_thread_workspaces WHERE thread_id = ?",
             ("thread-1",),
@@ -184,8 +186,10 @@ async def test_a_stale_schema_row_rebinds_instead_of_conflicting(
     directory, so comparing one against a resolved fingerprint reported drift
     forever and the thread could never re-bind.
     """
-    binding = await bind_thread_workspace("thread-1", str(tmp_path), {"no_mcp": True})
-    with sqlite3.connect(workspace_database) as conn:
+    binding = await bind_thread_workspace(
+        "thread-1", str(tmp_path), {"trust_project_mcp": True}
+    )
+    with closing(sqlite3.connect(workspace_database)) as conn, conn:
         conn.execute(
             """
             UPDATE dcode_thread_workspaces
@@ -195,13 +199,41 @@ async def test_a_stale_schema_row_rebinds_instead_of_conflicting(
             ("thread-1",),
         )
 
-    rebound = await bind_thread_workspace("thread-1", str(tmp_path), {"no_mcp": False})
+    rebound = await bind_thread_workspace(
+        "thread-1", str(tmp_path), {"trust_project_mcp": False}
+    )
 
     assert rebound.schema_version == 3
-    assert rebound.workspace_config()["no_mcp"] is False
+    assert rebound.workspace_config()["trust_project_mcp"] is False
     assert rebound.config_fingerprint != "stale-launch-fingerprint"
     assert (await require_thread_workspace("thread-1", rebound.to_payload())) == rebound
     assert rebound.workspace_id == binding.workspace_id
+
+
+@pytest.mark.parametrize(
+    ("original", "changed"),
+    [
+        ({"auto_approve": False}, {"auto_approve": True}),
+        ({"shell_allow_list": ["ls"]}, {"shell_allow_list": ["*"]}),
+        ({"allow_fs_tools": ["read_file"]}, {"allow_fs_tools": None}),
+        ({"no_mcp": True}, {"no_mcp": False}),
+    ],
+)
+async def test_migration_rejects_session_policy_drift(
+    tmp_path, workspace_database, original, changed
+) -> None:
+    """Project migration cannot replace a thread's recorded session controls."""
+    original["trust_project_mcp"] = True
+    changed["trust_project_mcp"] = False
+    await bind_thread_workspace("thread-1", str(tmp_path), original)
+    with closing(sqlite3.connect(workspace_database)) as conn, conn:
+        conn.execute("UPDATE dcode_thread_workspaces SET schema_version = 2")
+    stored = await get_thread_workspace("thread-1")
+
+    with pytest.raises(WorkspaceConflictError, match="server configuration changed"):
+        await bind_thread_workspace("thread-1", str(tmp_path), changed)
+
+    assert await get_thread_workspace("thread-1") == stored
 
 
 async def test_a_current_schema_row_still_conflicts_on_drift(tmp_path) -> None:

--- a/libs/code/tests/unit_tests/test_workspace.py
+++ b/libs/code/tests/unit_tests/test_workspace.py
@@ -236,14 +236,6 @@ async def test_migration_rejects_session_policy_drift(
     assert await get_thread_workspace("thread-1") == stored
 
 
-async def test_a_current_schema_row_still_conflicts_on_drift(tmp_path) -> None:
-    """Migration must not become a general-purpose rebind."""
-    await bind_thread_workspace("thread-1", str(tmp_path), {"no_mcp": True})
-
-    with pytest.raises(WorkspaceConflictError):
-        await bind_thread_workspace("thread-1", str(tmp_path), {"no_mcp": False})
-
-
 def test_relative_workspace_is_rejected() -> None:
     """Client-controlled relative paths never inherit the server cwd."""
     from deepagents_code.workspace import resolve_workspace


### PR DESCRIPTION
Each server workspace now uses the project policy for its own directory instead of inheriting policy from the directory that launched the server.

---

`dcode` has two parts: a terminal client that displays the conversation and collects input, and a separate server process that runs the agent and its tools. One server can host conversations working in different directories. Here, a **workspace** identifies a conversation's working directory and its project root, if one is found. The server records that association together with the settings and permissions the conversation is allowed to use; this is its workspace binding.

Previously, every workspace inherited the project settings captured when the server started. For example, start the server in project A, where the user has approved an MCP configuration (external tools available to the agent), then use that server for a conversation in project B. B could inherit A's MCP trust, MCP configuration path, sandbox setup script, or Python extensions, even though the user approved them only for A. These settings can load or execute code, so carrying them into another project carries permissions across a project boundary.

The server now separates shared launch settings, such as approval mode and enabled tools, from project-specific paths and trust decisions. It resolves project policy for the requested directory itself. The launch project keeps its explicit settings; another project does not inherit those paths or the launch project's whole-config MCP approval. That project's own saved extension trust and scoped MCP approvals still apply. Clients can confirm shared launch settings, but cannot supply project paths or grant project trust.

The change also covers the lifecycle and configuration cases needed around this behavior:

- Check recorded policy before reusing an already-created agent runtime, so cached tools cannot bypass a revoked project approval. Conflicting policy returns HTTP 409, including after a server restart. Granting extension trust does not prevent reconnecting: existing conversations keep their recorded trust, new conversations receive the grant, and revocations still block existing conversations.
- Honor an explicitly configured launch project root during HTTP workspace binding and runtime validation, even when Git discovery identifies a different root or finds none. This preserves the launch project's MCP settings, sandbox setup, and extensions when reusing or rebuilding its runtime.
- Migrate older workspace bindings while preserving their recorded session restrictions, so the new policy format does not leave existing conversations unusable.
- Reject incomplete or mixed workspace credential configurations for sandbox providers where they could silently substitute the server's identity. This includes AWS, Modal, and Vercel handling.
- Fix related dotenv loading and endpoint precedence cases, and redact relayed tracing keys from Auto mode output.

Made by [Open SWE](https://openswe.vercel.app/agents/f4a11b04-d023-5192-8a54-e75562c2fe53)
