### PR TITLE
fix(code): remove contradictory and invalid system-prompt instructions

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1450,12 +1450,63 @@ _WEB_SEARCH_TOOL_GUIDANCE = (
     "3. NEVER show raw JSON or tool results directly to the user\n"
     "4. Synthesize the information from multiple sources into a coherent answer\n"
     "5. Cite your sources by mentioning page titles or URLs when relevant\n"
-    "6. If the search doesn't find what you need, explain what you found and ask "
-    "clarifying questions\n\n"
-    "The user only sees your text responses - not tool results. Always provide a "
-    "complete, natural language answer after using web_search."
+    "6. If the search doesn't find what you need, explain what you found"
+    "{clarifying_followup}\n\n"
+    "Always provide a complete, natural language answer after using web_search."
 )
 """Usage guidance included only when the Tavily-backed tool is available."""
+
+
+_INTERACTIVE_TOOL_APPROVAL_GUIDANCE = (
+    "### Human-in-the-Loop Tool Approval\n\n"
+    "Some tool calls require user approval before execution. When a tool call is "
+    "rejected by the user:\n\n"
+    "1. Accept their decision immediately - do NOT retry the same command\n"
+    "2. Explain that you understand they rejected the action\n"
+    "3. Suggest an alternative approach or ask for clarification\n"
+    "4. Never attempt the exact same rejected command again\n\n"
+    "Respect the user's decisions and work with them collaboratively."
+)
+"""Tool-approval guidance for sessions with a user available."""
+
+_HEADLESS_TOOL_APPROVAL_GUIDANCE = (
+    "### Tool Approval\n\n"
+    "In non-interactive mode, shell commands may be rejected by the configured "
+    "allow-list policy. If a command is rejected:\n\n"
+    "1. Read the reason in the tool message\n"
+    "2. Do not retry the rejected command\n"
+    "3. Use an allowed command or another approach"
+)
+"""Tool-approval guidance for sessions using programmatic policy decisions."""
+
+
+_INTERACTIVE_ONLY_SECTION_RE = re.compile(
+    r"(?P<prefix>\A|\n)<!-- interactive-only:start -->\n(?P<content>.*?)"
+    r"<!-- interactive-only:end -->(?:"
+    r"\n(?!<!-- interactive-only:start -->)"
+    r"|(?=\n<!-- interactive-only:start -->)|\Z)",
+    re.DOTALL,
+)
+"""Matches prompt sections that require a user who can respond in real time."""
+_INTERACTIVE_ONLY_MARKER_RE = re.compile(r"<!-- interactive-only:[^>]*-->")
+"""Matches any conditional marker left behind after prompt rendering."""
+
+
+def _render_interactive_only_sections(template: str, *, interactive: bool) -> str:
+    """Include marked prompt sections only for interactive sessions.
+
+    Returns:
+        The prompt template with conditional markers removed.
+
+    Raises:
+        ValueError: If the template contains malformed or unpaired markers.
+    """
+    replacement = r"\g<prefix>\g<content>" if interactive else ""
+    rendered = _INTERACTIVE_ONLY_SECTION_RE.sub(replacement, template)
+    if _INTERACTIVE_ONLY_MARKER_RE.search(rendered):
+        msg = "System prompt contains unrendered interactive-only markers"
+        raise ValueError(msg)
+    return rendered
 
 
 def _build_fs_tool_prompt_guidance(fs_tools: list[FsToolName] | None) -> str:
@@ -1568,7 +1619,9 @@ def get_system_prompt(
         ```
     """
     prompt_dir = Path(__file__).parent
-    template = (prompt_dir / "system_prompt.md").read_text()
+    template = _render_interactive_only_sections(
+        (prompt_dir / "system_prompt.md").read_text(), interactive=interactive
+    )
 
     skills_path = PATHS.display(PATHS.profile.agent_skills_dir(assistant_id))
 
@@ -1576,9 +1629,8 @@ def get_system_prompt(
         mode_description = "an interactive TUI on the user's computer"
         interactive_preamble = (
             "The user sends you messages and you respond with text and tool "
-            "calls. Your tools run on the user's machine. The user can see "
-            "your responses and tool outputs in real time, so keep them "
-            "informed — but don't over-explain."
+            "calls. The user can see your responses and tool outputs in real "
+            "time, so keep them informed — but don't over-explain."
         )
         ambiguity_guidance = (
             "- If the request is ambiguous, ask questions before acting.\n"
@@ -1630,7 +1682,18 @@ def get_system_prompt(
     )
     filesystem_tool_guidance = _build_fs_tool_prompt_guidance(fs_tools)
     tavily_available = credentials.has_tavily if has_tavily is None else has_tavily
-    web_search_tool_guidance = _WEB_SEARCH_TOOL_GUIDANCE if tavily_available else ""
+    web_search_tool_guidance = (
+        _WEB_SEARCH_TOOL_GUIDANCE.format(
+            clarifying_followup=(" and ask clarifying questions" if interactive else "")
+        )
+        if tavily_available
+        else ""
+    )
+    tool_approval_guidance = (
+        _INTERACTIVE_TOOL_APPROVAL_GUIDANCE
+        if interactive
+        else _HEADLESS_TOOL_APPROVAL_GUIDANCE
+    )
 
     # Build working directory section (local vs sandbox)
     if sandbox_type:
@@ -1684,6 +1747,7 @@ def get_system_prompt(
         .replace("{working_dir_section}", working_dir_section)
         .replace("{skills_path}", skills_path)
         .replace("{filesystem_tool_guidance}", filesystem_tool_guidance)
+        .replace("{tool_approval_guidance}", tool_approval_guidance)
         .replace("{web_search_tool_guidance}", web_search_tool_guidance)
     )
 

--- a/libs/code/deepagents_code/system_prompt.md
+++ b/libs/code/deepagents_code/system_prompt.md
@@ -52,6 +52,7 @@ CRITICAL: Match what the user asked for EXACTLY.
 - If steps are repeatedly failing, make note of what's going wrong and share an updated plan with the user.
 - Use tools and dependencies specified by the user or already present in the codebase. Don't substitute without asking.
 
+<!-- interactive-only:start -->
 ## Clarifying Requests
 
 - Do not ask for details the user already supplied.
@@ -60,6 +61,7 @@ CRITICAL: Match what the user asked for EXACTLY.
 - Avoid opening with a long explanation of tool, scheduling, or integration limitations when a concise blocking followup question would move the task forward.
 - Ask domain-defining questions before implementation questions.
 - For monitoring or alerting requests, ask what signals, thresholds, or conditions should trigger an alert.
+<!-- interactive-only:end -->
 
 ## Tool Usage
 
@@ -131,8 +133,6 @@ When something isn't working:
 
 - If you introduce linter errors, fix them if the solution is clear
 - DO NOT loop more than 3 times fixing the same error with the same approach
-- On the third attempt, stop and ask the user what to do
-- If you notice yourself going in circles, stop and ask the user for help
 
 ## Formatting & Pre-Commit Hooks
 
@@ -169,16 +169,6 @@ When referencing code, use format: `file_path:line_number`
 {model_identity_section}{working_dir_section}### Skills Directory
 
 Your skills are stored at: `{skills_path}`
-Skills may contain scripts or supporting files. When executing skill scripts with bash, use the real filesystem path:
-Example: `bash python {skills_path}/web-research/script.py`
+Skills may contain scripts or supporting files.
 
-### Human-in-the-Loop Tool Approval
-
-Some tool calls require user approval before execution. When a tool call is rejected by the user:
-
-1. Accept their decision immediately - do NOT retry the same command
-2. Explain that you understand they rejected the action
-3. Suggest an alternative approach or ask for clarification
-4. Never attempt the exact same rejected command again
-
-Respect the user's decisions and work with them collaboratively.{web_search_tool_guidance}
+{tool_approval_guidance}{web_search_tool_guidance}

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_headless_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_headless_local.md
@@ -1,8 +1,8 @@
 # Deep Agents Code (dcode)
 
-You are a deep agent, an AI assistant running in an interactive TUI on the user's computer. You help with tasks like coding, debugging, research, analysis, and more.
+You are a deep agent, an AI assistant running in non-interactive (headless) mode — there is no human operator monitoring your output in real time. You help with tasks like coding, debugging, research, analysis, and more.
 
-The user sends you messages and you respond with text and tool calls. The user can see your responses and tool outputs in real time, so keep them informed — but don't over-explain.
+You received a single task and must complete it fully and autonomously. There is no human available to answer follow-up questions, so do NOT ask for clarification — make reasonable assumptions and proceed.
 
 # Core Behavior
 
@@ -11,8 +11,9 @@ The user sends you messages and you respond with text and tool calls. The user c
 - Don't say "I'll now do X" — just do it.
 - After working on a file, stop — don't explain what you did unless asked.
 - No time estimates. Focus on what needs to be done, not how long.
-- If the request is ambiguous, ask questions before acting.
-- If asked how to approach something, explain first, then act.
+- Do NOT ask clarifying questions — there is no human to answer them. Make reasonable assumptions and proceed.
+- If you encounter ambiguity, choose the most reasonable interpretation and note your assumption briefly.
+- Always use non-interactive command variants — no human is available to respond to prompts. Examples: `npm init -y` not `npm init`, `apt-get install -y` not `apt-get install`, `yes |` or `--no-input`/`--non-interactive` flags where available. Never run commands that block waiting for stdin.
 - When you run non-trivial bash commands, briefly explain what they do.
 - For longer tasks, give brief progress updates — what you've done, what's next.
 
@@ -52,15 +53,6 @@ CRITICAL: Match what the user asked for EXACTLY.
 - If something fails repeatedly, stop and analyze *why* — don't keep retrying the same approach. Walk through the chain of failures to find the root cause.
 - If steps are repeatedly failing, make note of what's going wrong and share an updated plan with the user.
 - Use tools and dependencies specified by the user or already present in the codebase. Don't substitute without asking.
-
-## Clarifying Requests
-
-- Do not ask for details the user already supplied.
-- Use reasonable defaults when the request clearly implies them.
-- Prioritize missing semantics like content, delivery, detail level, or alert criteria.
-- Avoid opening with a long explanation of tool, scheduling, or integration limitations when a concise blocking followup question would move the task forward.
-- Ask domain-defining questions before implementation questions.
-- For monitoring or alerting requests, ask what signals, thresholds, or conditions should trigger an alert.
 
 ## Tool Usage
 
@@ -190,16 +182,13 @@ The filesystem backend is currently operating in: `/home/user/project`
 Your skills are stored at: `<deepagents_home>/agent/skills`
 Skills may contain scripts or supporting files.
 
-### Human-in-the-Loop Tool Approval
+### Tool Approval
 
-Some tool calls require user approval before execution. When a tool call is rejected by the user:
+In non-interactive mode, shell commands may be rejected by the configured allow-list policy. If a command is rejected:
 
-1. Accept their decision immediately - do NOT retry the same command
-2. Explain that you understand they rejected the action
-3. Suggest an alternative approach or ask for clarification
-4. Never attempt the exact same rejected command again
-
-Respect the user's decisions and work with them collaboratively.
+1. Read the reason in the tool message
+2. Do not retry the rejected command
+3. Use an allowed command or another approach
 
 
 ## Shell paths vs. virtual paths
@@ -216,19 +205,6 @@ Do not assume that a path returned by a file tool can be used directly in a shel
 Host path mappings:
 - `<tmp_path>/dcode-artifacts/conversation_history/` -> `<tmp_path>/.deepagents/conversation_history/` (e.g. `<tmp_path>/dcode-artifacts/conversation_history/dir/x.py` -> `<tmp_path>/.deepagents/conversation_history/dir/x.py`)
 - `/dcode-artifacts-fallback/conversation_history/` -> `<tmp_path>/.deepagents/conversation_history/` (e.g. `/dcode-artifacts-fallback/conversation_history/dir/x.py` -> `<tmp_path>/.deepagents/conversation_history/dir/x.py`)
-
-## `ask_user`
-
-You have access to the `ask_user` tool to ask the user questions when you need clarification or input.
-Use this tool sparingly - only when you genuinely need information from the user that you cannot determine from context.
-
-When using `ask_user`:
-- Be concise and specific with your questions
-- Use multiple choice when there are clear options and exactly one applies
-- Use multi-select when the user may legitimately pick several of the options
-- Use text input when you need free-form responses
-- Group related questions into a single ask_user call rather than making multiple calls
-- Never ask questions you can answer yourself from the available context
 
 <agent_memory>
 (No memory loaded)

--- a/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
+import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langgraph.checkpoint.memory import InMemorySaver
@@ -174,17 +175,27 @@ def _mock_settings(tmp_path: Path) -> Generator[None, None, None]:
             yield
 
 
+@pytest.mark.parametrize(
+    ("interactive", "snapshot_name"),
+    [
+        (True, "system_prompt_interactive_local.md"),
+        (False, "system_prompt_headless_local.md"),
+    ],
+    ids=("interactive", "headless"),
+)
 def test_system_prompt_snapshot(
     tmp_path: Path,
     snapshots_dir: Path,
+    interactive: bool,
+    snapshot_name: str,
     *,
     update_snapshots: bool,
 ) -> None:
-    """Snapshot the full interactive local-mode system prompt.
+    """Snapshot the full local-mode system prompt.
 
     The agent is created with default features (memory, skills, shell) in
-    interactive local mode. A fake model captures the system message from
-    the first model call. The local-context detection script output is
+    interactive or headless mode. A fake model captures the system message
+    from the first model call. The local-context detection script output is
     mocked to keep the snapshot machine-independent.
     """
     model = _SnapshotChatModel(
@@ -198,6 +209,8 @@ def test_system_prompt_snapshot(
             assistant_id="agent",
             checkpointer=InMemorySaver(),
             cwd=_FIXED_CWD,
+            interactive=interactive,
+            enable_ask_user=interactive,
         )
 
         # Mock the local-context detection script so the local-context
@@ -224,7 +237,7 @@ def test_system_prompt_snapshot(
     actual = actual.replace(str(PATHS.profile.root), "<deepagents_home>")
 
     _assert_snapshot(
-        snapshots_dir / "system_prompt_interactive_local.md",
+        snapshots_dir / snapshot_name,
         actual,
         update_snapshots=update_snapshots,
     )

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -41,6 +41,7 @@ from deepagents_code.agent import (
     _format_delete_description,
     _format_execute_description,
     _interrupt_predicate,
+    _render_interactive_only_sections,
     _resolve_retry_owned_model,
     _rubric_grader_system_prompt,
     _sanitize_agent_message_name,
@@ -1242,6 +1243,7 @@ class TestGetSystemPromptModelIdentity:
         expected = PATHS.display(PATHS.profile.agent_skills_dir("test-agent"))
         assert expected in prompt
         assert "~/.deepagents/test-agent/skills" not in prompt
+        assert "bash python" not in prompt
 
     def test_excludes_provider_when_not_set(self) -> None:
         """Test that provider is excluded when model_provider is None."""
@@ -1357,6 +1359,112 @@ class TestGetSystemPromptWebSearch:
 
         assert "### Web Search Tool Usage" in prompt
         assert "When you use the web_search tool:" in prompt
+        assert "explain what you found and ask clarifying questions" in prompt
+        assert "only sees your text responses" not in prompt
+        assert "Always provide a complete, natural language answer" in prompt
+
+    def test_headless_guidance_does_not_request_followup(self) -> None:
+        mock_settings = Mock()
+        runtime_state.model_name = None
+        mock_settings.has_tavily = True
+
+        with patch("deepagents_code.agent.credentials", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=False)
+
+        assert (
+            "6. If the search doesn't find what you need, explain what you found\n\n"
+            in prompt
+        )
+        assert (
+            "6. If the search doesn't find what you need, explain what you found "
+            "and ask clarifying questions" not in prompt
+        )
+
+
+class TestRenderInteractiveOnlySections:
+    """Direct tests for conditional system-prompt sections."""
+
+    _TEMPLATE = (
+        "before\n\n"
+        "<!-- interactive-only:start -->\n"
+        "interactive content\n"
+        "<!-- interactive-only:end -->\n\n"
+        "after"
+    )
+
+    def test_keeps_content_in_interactive_mode(self) -> None:
+        rendered = _render_interactive_only_sections(self._TEMPLATE, interactive=True)
+
+        assert rendered == "before\n\ninteractive content\n\nafter"
+
+    def test_removes_content_and_extra_whitespace_in_headless_mode(self) -> None:
+        rendered = _render_interactive_only_sections(self._TEMPLATE, interactive=False)
+
+        assert rendered == "before\n\nafter"
+        assert "\n\n\n" not in rendered
+
+    def test_renders_section_at_start_of_template(self) -> None:
+        template = (
+            "<!-- interactive-only:start -->\n"
+            "interactive content\n"
+            "<!-- interactive-only:end -->\n"
+            "after"
+        )
+
+        interactive = _render_interactive_only_sections(template, interactive=True)
+        headless = _render_interactive_only_sections(template, interactive=False)
+
+        assert interactive == "interactive content\nafter"
+        assert headless == "after"
+
+    @pytest.mark.parametrize("interactive", [True, False])
+    def test_renders_adjacent_sections(self, *, interactive: bool) -> None:
+        template = (
+            "a\n"
+            "<!-- interactive-only:start -->\n"
+            "X\n"
+            "<!-- interactive-only:end -->\n"
+            "<!-- interactive-only:start -->\n"
+            "Y\n"
+            "<!-- interactive-only:end -->\n"
+            "b"
+        )
+
+        rendered = _render_interactive_only_sections(template, interactive=interactive)
+
+        assert "interactive-only" not in rendered
+        if interactive:
+            assert "X" in rendered
+            assert "Y" in rendered
+        else:
+            assert "X" not in rendered
+            assert "Y" not in rendered
+
+    @pytest.mark.parametrize("interactive", [True, False])
+    def test_accepts_end_marker_at_eof(self, *, interactive: bool) -> None:
+        template = (
+            "before\n"
+            "<!-- interactive-only:start -->\n"
+            "interactive content\n"
+            "<!-- interactive-only:end -->"
+        )
+
+        rendered = _render_interactive_only_sections(template, interactive=interactive)
+
+        expected = "before\ninteractive content\n" if interactive else "before"
+        assert rendered == expected
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "before\n<!-- interactive-only:start -->\ncontent",
+            "before\n<!-- interactive-only:end -->",
+            "before\n<!-- interactive-only:finish -->",
+        ],
+    )
+    def test_rejects_unrendered_markers(self, template: str) -> None:
+        with pytest.raises(ValueError, match="unrendered interactive-only markers"):
+            _render_interactive_only_sections(template, interactive=False)
 
 
 class TestGetSystemPromptNonInteractive:
@@ -1371,6 +1479,7 @@ class TestGetSystemPromptNonInteractive:
 
         assert "interactive TUI" in prompt
         assert "ask questions before acting" in prompt
+        assert "## Clarifying Requests" in prompt
 
     def test_non_interactive_prompt_mentions_headless(self) -> None:
         mock_settings = Mock()
@@ -1389,7 +1498,26 @@ class TestGetSystemPromptNonInteractive:
         with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
 
+        assert "## Clarifying Requests" not in prompt
         assert "ask questions before acting" not in prompt
+        assert "Ask domain-defining questions" not in prompt
+        assert "ask the user what to do" not in prompt
+        assert "ask the user for help" not in prompt
+        assert "DO NOT loop more than 3 times" in prompt
+
+    def test_non_interactive_prompt_describes_policy_rejections(self) -> None:
+        mock_settings = Mock()
+        runtime_state.model_name = None
+
+        with patch("deepagents_code.agent.credentials", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=False)
+
+        assert "shell commands may be rejected" in prompt
+        assert "configured allow-list policy" in prompt
+        assert "Read the reason in the tool message" in prompt
+        assert "Use an allowed command or another approach" in prompt
+        assert "rejected by the user" not in prompt
+        assert "Suggest an alternative approach or ask for clarification" not in prompt
 
     def test_non_interactive_prompt_instructs_autonomous_execution(self) -> None:
         mock_settings = Mock()
@@ -1467,6 +1595,15 @@ class TestGetSystemPromptSandbox:
             prompt = get_system_prompt("test-agent", sandbox_type="modal")
 
         assert "do NOT have access to the user's local filesystem" in prompt
+
+    def test_interactive_sandbox_does_not_claim_tools_run_locally(self) -> None:
+        mock_settings = Mock()
+        runtime_state.model_name = None
+
+        with patch("deepagents_code.agent.credentials", mock_settings):
+            prompt = get_system_prompt("test-agent", sandbox_type="modal")
+
+        assert "tools run on the user's machine" not in prompt
 
     def test_sandbox_includes_working_dir_constraint(self) -> None:
         mock_settings = Mock()


### PR DESCRIPTION
System prompts now reflect the active execution mode, preserve interactive clarification, and let headless runs proceed autonomously or report a blocker.

Fixes #6071

---

Remove the invalid skill-script example and contradictory execution-location and tool-output visibility claims. Use the existing prompt placeholders for mode-specific clarification, failure recovery, web-search follow-ups, and approval guidance.

Headless sessions also use a dedicated memory prompt so middleware does not reintroduce requests for an unavailable user. Memory loading, verified learning, trust boundaries, and the automatic-saving setting remain respected. Interactive clarification and failure escalation remain available.