### PR TITLE
fix(talon): omit empty optional MCP arguments

### DIFF
--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -14,6 +14,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal, cast
 
@@ -320,11 +321,18 @@ async def load_mcp_tools(config: TalonConfig) -> MCPTools:
     infos: list[MCPServerInfo] = []
     for name, server in servers.items():
         transport = _transport_label(server)
+        input_schemas: dict[str, dict[str, object]] = {}
         try:
             connection, transport = await _connection(name, server)
             client = MultiServerMCPClient(
                 {name: connection},
-                tool_interceptors=[_authorization_interceptor],
+                tool_interceptors=[
+                    _authorization_interceptor,
+                    partial(
+                        _argument_normalization_interceptor,
+                        input_schemas=input_schemas,
+                    ),
+                ],
                 tool_name_prefix=True,
                 handle_tool_errors=True,
             )
@@ -333,6 +341,14 @@ async def load_mcp_tools(config: TalonConfig) -> MCPTools:
                 timeout=_MCP_LOAD_TIMEOUT_SECONDS,
             )
             loaded = _filter_tools(name, server, loaded)
+            prefix = f"{name}_"
+            input_schemas.update(
+                {
+                    tool.name.removeprefix(prefix): tool.args_schema
+                    for tool in loaded
+                    if isinstance(tool.args_schema, dict)
+                }
+            )
         except (
             ExceptionGroup,
             HTTPError,
@@ -439,6 +455,48 @@ async def _authorization_interceptor(
     invocation_id = getattr(request.runtime, "tool_call_id", None)
     normalized_id = invocation_id if isinstance(invocation_id, str) and invocation_id else None
     return await _run_authorized(normalized_id, lambda: handler(request))
+
+
+async def _argument_normalization_interceptor(
+    request: MCPToolCallRequest,
+    handler: Callable[[MCPToolCallRequest], Awaitable[MCPToolCallResult]],
+    *,
+    input_schemas: Mapping[str, dict[str, object]],
+) -> MCPToolCallResult:
+    schema = input_schemas.get(request.name)
+    arguments = _normalize_mcp_arguments(request.args, schema)
+    normalized = request if arguments == request.args else request.override(args=arguments)
+    return await handler(normalized)
+
+
+def _normalize_mcp_arguments(
+    arguments: Mapping[str, object], input_schema: object
+) -> dict[str, object]:
+    """Omit empty strings for optional string-like MCP arguments."""
+    if not isinstance(input_schema, dict):
+        return dict(arguments)
+    raw_required = input_schema.get("required")
+    required = (
+        {item for item in raw_required if isinstance(item, str)}
+        if isinstance(raw_required, list)
+        else set()
+    )
+    raw_properties = input_schema.get("properties")
+    properties = raw_properties if isinstance(raw_properties, dict) else {}
+    return {
+        name: value
+        for name, value in arguments.items()
+        if value != "" or name in required or _is_explicitly_non_string(properties.get(name))
+    }
+
+
+def _is_explicitly_non_string(property_schema: object) -> bool:
+    if not isinstance(property_schema, dict):
+        return False
+    property_type = property_schema.get("type")
+    if property_type is None or property_type == "string":
+        return False
+    return not (isinstance(property_type, list) and "string" in property_type)
 
 
 async def _run_authorized[AuthorizedResult](

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -28,8 +28,10 @@ from deepagents_talon.mcp import (
     MCPServerInfo,
     MCPToolInfo,
     MCPToolProvider,
+    _argument_normalization_interceptor,
     _authorization_interceptor,
     _connection,
+    _normalize_mcp_arguments,
     load_mcp_tools,
     login_mcp_server,
     mcp_config_path,
@@ -243,6 +245,56 @@ async def test_mcp_interceptor_resumes_same_bound_invocation_without_secret_outp
     assert isinstance(events[-1], AuthorizationCompleted)
     assert "secret-state" not in repr(events[0])
     assert "secret-code" not in repr(events)
+
+
+def test_normalize_mcp_arguments_omits_only_optional_empty_strings() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "integrationId": {"type": "string"},
+            "fetchMode": {"type": "object"},
+        },
+        "required": ["query"],
+    }
+
+    arguments = _normalize_mcp_arguments(
+        {"query": "", "integrationId": "", "fetchMode": {}}, schema
+    )
+
+    assert arguments == {"query": "", "fetchMode": {}}
+
+
+async def test_argument_normalization_interceptor_overrides_request_arguments() -> None:
+    request = MCPToolCallRequest(
+        name="listVulnerabilities",
+        args={"severity": "CRITICAL", "integrationId": ""},
+        server_name="vanta",
+    )
+    received: list[MCPToolCallRequest] = []
+    expected = CallToolResult(content=[])
+
+    async def execute(normalized: MCPToolCallRequest) -> CallToolResult:
+        received.append(normalized)
+        return expected
+
+    result = await _argument_normalization_interceptor(
+        request,
+        execute,
+        input_schemas={
+            "listVulnerabilities": {
+                "type": "object",
+                "properties": {
+                    "severity": {"type": "string"},
+                    "integrationId": {"type": "string"},
+                },
+            }
+        },
+    )
+
+    assert result is expected
+    assert received[0].args == {"severity": "CRITICAL"}
+    assert request.args == {"severity": "CRITICAL", "integrationId": ""}
 
 
 async def test_mcp_tool_provider_exposes_only_configured_server_authentication(


### PR DESCRIPTION
Talon omits empty optional string arguments before sending MCP tool calls, preventing servers from treating placeholder empty IDs as real identifiers.

---

Some models include empty strings for optional MCP arguments. Talon forwarded them verbatim, which caused Vanta to reject calls such as listVulnerabilities with an empty integrationId.

This adds schema-aware normalization at the MCP interceptor boundary. It preserves required arguments and explicitly non-string fields while leaving structured MCP results and errors unchanged.

Tests: make lint; make test.