### PR TITLE
feat(talon): support Slack MCP OAuth login

### DIFF
--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass
 from enum import StrEnum
 from types import FrameType
 from typing import TYPE_CHECKING, cast
-from urllib.parse import parse_qs, urlparse
 
 from deepagents_talon.authorization import (
     AuthorizationBinding,
@@ -41,6 +40,7 @@ from deepagents_talon.interfaces import (
     ToolApprovalDecision,
     ToolApprovalRequest,
 )
+from deepagents_talon.mcp_auth import extract_oauth_callback_url
 from deepagents_talon.media import (
     MarkdownMediaRef,
     build_inbound_text,
@@ -1063,16 +1063,7 @@ def _prepare_inbound_message(message: ChannelMessage) -> ChannelMessage:
 
 
 def _callback_url(text: str) -> str | None:
-    candidate = text.strip()
-    if candidate.startswith("<") and candidate.endswith(">"):
-        candidate = candidate[1:-1].strip()
-    parsed = urlparse(candidate)
-    if parsed.scheme != "http" or parsed.netloc != "localhost:3000" or parsed.path != "/callback":
-        return None
-    query = parse_qs(parsed.query)
-    if not query.get("state") or not (query.get("code") or query.get("error")):
-        return None
-    return candidate
+    return extract_oauth_callback_url(text)
 
 
 def _command_name(text: str) -> str | None:

--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -40,6 +40,7 @@ from deepagents_talon.mcp_auth import (
     MCPAuthorizationError,
     build_oauth_provider,
     format_login_error,
+    prepare_oauth_login,
 )
 
 if TYPE_CHECKING:
@@ -758,11 +759,17 @@ async def _remote_connection(  # noqa: PLR0913  # keeps distinct OAuth modes exp
         if not interactive and not channel_authorization and await storage.get_tokens() is None:
             msg = f"MCP server {name!r} needs authentication; run deepagents-talon mcp login {name}"
             raise _MCPLoginRequiredError(msg)
+        slack_team_id = await prepare_oauth_login(
+            server_url=url,
+            storage=storage,
+            interactive=interactive,
+        )
         connection["auth"] = build_oauth_provider(
             server_name=name,
             server_url=url,
             storage=storage,
             interactive=interactive,
+            slack_team_id=slack_team_id,
         )
     elif server.get("auth") is not None:
         msg = f"MCP server {name!r} uses unsupported auth {server['auth']!r}"

--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -759,17 +759,12 @@ async def _remote_connection(  # noqa: PLR0913  # keeps distinct OAuth modes exp
         if not interactive and not channel_authorization and await storage.get_tokens() is None:
             msg = f"MCP server {name!r} needs authentication; run deepagents-talon mcp login {name}"
             raise _MCPLoginRequiredError(msg)
-        slack_team_id = await prepare_oauth_login(
-            server_url=url,
-            storage=storage,
-            interactive=interactive,
-        )
+        await prepare_oauth_login(server_url=url, storage=storage)
         connection["auth"] = build_oauth_provider(
             server_name=name,
             server_url=url,
             storage=storage,
             interactive=interactive,
-            slack_team_id=slack_team_id,
         )
     elif server.get("auth") is not None:
         msg = f"MCP server {name!r} uses unsupported auth {server['auth']!r}"

--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -10,7 +10,7 @@ import os
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qs, urlparse
 
 from mcp.client.auth import OAuthClientProvider
 from mcp.shared.auth import AnyUrl, OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
@@ -68,7 +68,6 @@ class FileTokenStorage:
         digest = hashlib.sha256(server_url.encode()).hexdigest()[:12]
         self.path = Path.home() / _TOKEN_DIR / f"{server_name}-{digest}.json"
         self._force_authorization = force_authorization
-        self._pending_slack_team_id: str | None = None
 
     async def get_tokens(self) -> OAuthToken | None:
         """Return stored OAuth tokens."""
@@ -81,11 +80,7 @@ class FileTokenStorage:
 
     async def set_tokens(self, tokens: OAuthToken) -> None:
         """Persist OAuth tokens."""
-        values: dict[str, object] = {"tokens": json.loads(tokens.model_dump_json())}
-        if self._pending_slack_team_id is not None:
-            values["slack_team_id"] = self._pending_slack_team_id
-        await asyncio.to_thread(self._update, values)
-        self._pending_slack_team_id = None
+        await asyncio.to_thread(self._update, "tokens", json.loads(tokens.model_dump_json()))
         attempt = current_authorization_attempt()
         if attempt is not None and attempt.binding is not None:
             attempt.completed = True
@@ -99,20 +94,7 @@ class FileTokenStorage:
     async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
         """Persist OAuth client registration."""
         value = json.loads(client_info.model_dump_json(exclude_none=True))
-        await asyncio.to_thread(self._update, {"client_info": value})
-
-    async def get_slack_team_id(self) -> str | None:
-        """Return the Slack team ID associated with a successful login."""
-        data = await asyncio.to_thread(self._read)
-        raw = data.get("slack_team_id") if data is not None else None
-        if raw is not None and not isinstance(raw, str):
-            msg = f"Invalid Slack team ID in MCP credential file: {self.path}"
-            raise TypeError(msg)
-        return raw
-
-    def store_slack_team_id_with_tokens(self, team_id: str) -> None:
-        """Stage a Slack team ID for the next successful token write."""
-        self._pending_slack_team_id = team_id
+        await asyncio.to_thread(self._update, "client_info", value)
 
     def _read(self) -> dict[str, object] | None:
         try:
@@ -124,12 +106,12 @@ class FileTokenStorage:
             raise TypeError(msg)
         return raw
 
-    def _update(self, values: dict[str, object]) -> None:
+    def _update(self, key: str, value: object) -> None:
         directory = self.path.parent
         directory.mkdir(mode=0o700, parents=True, exist_ok=True)
         directory.chmod(0o700)
         data = self._read() or {}
-        data.update(values)
+        data[key] = value
         descriptor, temporary = tempfile.mkstemp(dir=directory, prefix=".tokens-", text=True)
         try:
             os.fchmod(descriptor, 0o600)
@@ -149,7 +131,6 @@ def build_oauth_provider(
     server_url: str,
     storage: FileTokenStorage,
     interactive: bool,
-    slack_team_id: str | None = None,
 ) -> OAuthClientProvider:
     """Build an MCP SDK OAuth provider for Talon.
 
@@ -158,7 +139,6 @@ def build_oauth_provider(
         server_url: Remote MCP endpoint URL.
         storage: Credential storage bound to the server identity.
         interactive: Whether to use terminal instead of channel authorization.
-        slack_team_id: Optional Slack workspace to select during authorization.
 
     Returns:
         A configured MCP SDK OAuth provider.
@@ -169,8 +149,6 @@ def build_oauth_provider(
         redirect, callback = _interactive_handlers(redirect_uri)
     else:
         redirect, callback = _channel_handlers(server_name, redirect_uri)
-    if is_slack and slack_team_id is not None:
-        redirect = _with_slack_team(redirect, slack_team_id)
     return OAuthClientProvider(
         server_url=server_url,
         client_metadata=_client_metadata(redirect_uri),
@@ -180,29 +158,15 @@ def build_oauth_provider(
     )
 
 
-async def prepare_oauth_login(
-    *, server_url: str, storage: FileTokenStorage, interactive: bool
-) -> str | None:
-    """Prepare provider-specific OAuth state before creating the SDK provider.
+async def prepare_oauth_login(*, server_url: str, storage: FileTokenStorage) -> None:
+    """Preseed provider-specific OAuth client information when required.
 
     Args:
         server_url: Remote MCP endpoint URL.
         storage: Credential storage bound to the server identity.
-        interactive: Whether terminal prompts are available.
-
-    Returns:
-        The cached or newly entered Slack team ID for Slack, otherwise `None`.
     """
-    if not _is_slack_mcp_url(server_url):
-        return None
-    await _preseed_slack_client_info(storage)
-    team_id = await storage.get_slack_team_id()
-    if team_id is not None or not interactive:
-        return team_id
-    team_id = await _prompt_slack_team_id()
-    if team_id is not None:
-        storage.store_slack_team_id_with_tokens(team_id)
-    return team_id
+    if _is_slack_mcp_url(server_url):
+        await _preseed_slack_client_info(storage)
 
 
 def _interactive_handlers(
@@ -342,34 +306,6 @@ async def _preseed_slack_client_info(storage: FileTokenStorage) -> None:
         token_endpoint_auth_method="none",  # noqa: S106
     )
     await storage.set_client_info(client_info)
-
-
-async def _prompt_slack_team_id() -> str | None:
-    try:
-        raw = await asyncio.to_thread(
-            input,
-            "Slack team ID to install the app into "
-            "(e.g. T01234567 — leave blank to pick on Slack's page): ",
-        )
-    except EOFError:
-        return None
-    return raw.strip() or None
-
-
-def _with_slack_team(
-    redirect: Callable[[str], Awaitable[None]], team_id: str
-) -> Callable[[str], Awaitable[None]]:
-    async def wrapped(url: str) -> None:
-        parsed = urlparse(url)
-        query = [
-            (key, value)
-            for key, value in parse_qsl(parsed.query, keep_blank_values=True)
-            if key != "team"
-        ]
-        query.append(("team", team_id))
-        await redirect(urlunparse(parsed._replace(query=urlencode(query))))
-
-    return wrapped
 
 
 def format_login_error(exc: BaseException) -> str:

--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -10,10 +10,10 @@ import os
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunparse
 
 from mcp.client.auth import OAuthClientProvider
-from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+from mcp.shared.auth import AnyUrl, OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 from pydantic import ValidationError
 
 from deepagents_talon.authorization import (
@@ -29,8 +29,18 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
 _REDIRECT_URI = "http://localhost:3000/callback"
+_SLACK_MCP_CLIENT_ID = "4518649543379.10944517634130"
+_SLACK_REDIRECT_URI = "http://localhost:3118/callback"
+_OAUTH_CALLBACK_ENDPOINTS = frozenset(
+    {
+        ("http", "localhost:3000", "/callback"),
+        ("http", "localhost:3118", "/callback"),
+    }
+)
 _TOKEN_DIR = Path(".deepagents/mcp-tokens")
 _AUTHORIZATION_TIMEOUT_SECONDS = 10 * 60
+_ASCII_CONTROL_LIMIT = 32
+_ASCII_DELETE = 127
 
 
 class MCPAuthorizationError(RuntimeError):
@@ -58,6 +68,7 @@ class FileTokenStorage:
         digest = hashlib.sha256(server_url.encode()).hexdigest()[:12]
         self.path = Path.home() / _TOKEN_DIR / f"{server_name}-{digest}.json"
         self._force_authorization = force_authorization
+        self._pending_slack_team_id: str | None = None
 
     async def get_tokens(self) -> OAuthToken | None:
         """Return stored OAuth tokens."""
@@ -70,7 +81,11 @@ class FileTokenStorage:
 
     async def set_tokens(self, tokens: OAuthToken) -> None:
         """Persist OAuth tokens."""
-        await asyncio.to_thread(self._update, "tokens", json.loads(tokens.model_dump_json()))
+        values: dict[str, object] = {"tokens": json.loads(tokens.model_dump_json())}
+        if self._pending_slack_team_id is not None:
+            values["slack_team_id"] = self._pending_slack_team_id
+        await asyncio.to_thread(self._update, values)
+        self._pending_slack_team_id = None
         attempt = current_authorization_attempt()
         if attempt is not None and attempt.binding is not None:
             attempt.completed = True
@@ -84,7 +99,20 @@ class FileTokenStorage:
     async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
         """Persist OAuth client registration."""
         value = json.loads(client_info.model_dump_json(exclude_none=True))
-        await asyncio.to_thread(self._update, "client_info", value)
+        await asyncio.to_thread(self._update, {"client_info": value})
+
+    async def get_slack_team_id(self) -> str | None:
+        """Return the Slack team ID associated with a successful login."""
+        data = await asyncio.to_thread(self._read)
+        raw = data.get("slack_team_id") if data is not None else None
+        if raw is not None and not isinstance(raw, str):
+            msg = f"Invalid Slack team ID in MCP credential file: {self.path}"
+            raise TypeError(msg)
+        return raw
+
+    def store_slack_team_id_with_tokens(self, team_id: str) -> None:
+        """Stage a Slack team ID for the next successful token write."""
+        self._pending_slack_team_id = team_id
 
     def _read(self) -> dict[str, object] | None:
         try:
@@ -96,12 +124,12 @@ class FileTokenStorage:
             raise TypeError(msg)
         return raw
 
-    def _update(self, key: str, value: object) -> None:
+    def _update(self, values: dict[str, object]) -> None:
         directory = self.path.parent
         directory.mkdir(mode=0o700, parents=True, exist_ok=True)
         directory.chmod(0o700)
         data = self._read() or {}
-        data[key] = value
+        data.update(values)
         descriptor, temporary = tempfile.mkstemp(dir=directory, prefix=".tokens-", text=True)
         try:
             os.fchmod(descriptor, 0o600)
@@ -116,28 +144,70 @@ class FileTokenStorage:
 
 
 def build_oauth_provider(
-    *, server_name: str, server_url: str, storage: FileTokenStorage, interactive: bool
+    *,
+    server_name: str,
+    server_url: str,
+    storage: FileTokenStorage,
+    interactive: bool,
+    slack_team_id: str | None = None,
 ) -> OAuthClientProvider:
-    """Build an MCP SDK OAuth provider for Talon."""
-    redirect, callback = _interactive_handlers() if interactive else _channel_handlers(server_name)
+    """Build an MCP SDK OAuth provider for Talon.
+
+    Args:
+        server_name: Configured MCP server name.
+        server_url: Remote MCP endpoint URL.
+        storage: Credential storage bound to the server identity.
+        interactive: Whether to use terminal instead of channel authorization.
+        slack_team_id: Optional Slack workspace to select during authorization.
+
+    Returns:
+        A configured MCP SDK OAuth provider.
+    """
+    is_slack = _is_slack_mcp_url(server_url)
+    redirect_uri = _SLACK_REDIRECT_URI if is_slack else _REDIRECT_URI
+    if interactive:
+        redirect, callback = _interactive_handlers(redirect_uri)
+    else:
+        redirect, callback = _channel_handlers(server_name, redirect_uri)
+    if is_slack and slack_team_id is not None:
+        redirect = _with_slack_team(redirect, slack_team_id)
     return OAuthClientProvider(
         server_url=server_url,
-        client_metadata=OAuthClientMetadata(
-            redirect_uris=[_REDIRECT_URI],
-            client_name="Deep Agents Talon",
-            grant_types=["authorization_code", "refresh_token"],
-            response_types=["code"],
-            token_endpoint_auth_method="none",  # noqa: S106
-        ),
+        client_metadata=_client_metadata(redirect_uri),
         storage=storage,
         redirect_handler=redirect,
         callback_handler=callback,
     )
 
 
-def _interactive_handlers() -> tuple[
-    Callable[[str], Awaitable[None]], Callable[[], Awaitable[tuple[str, str | None]]]
-]:
+async def prepare_oauth_login(
+    *, server_url: str, storage: FileTokenStorage, interactive: bool
+) -> str | None:
+    """Prepare provider-specific OAuth state before creating the SDK provider.
+
+    Args:
+        server_url: Remote MCP endpoint URL.
+        storage: Credential storage bound to the server identity.
+        interactive: Whether terminal prompts are available.
+
+    Returns:
+        The cached or newly entered Slack team ID for Slack, otherwise `None`.
+    """
+    if not _is_slack_mcp_url(server_url):
+        return None
+    await _preseed_slack_client_info(storage)
+    team_id = await storage.get_slack_team_id()
+    if team_id is not None or not interactive:
+        return team_id
+    team_id = await _prompt_slack_team_id()
+    if team_id is not None:
+        storage.store_slack_team_id_with_tokens(team_id)
+    return team_id
+
+
+def _interactive_handlers(
+    redirect_uri: str,
+) -> tuple[Callable[[str], Awaitable[None]], Callable[[], Awaitable[tuple[str, str | None]]]]:
     async def redirect(url: str) -> None:
         print("Open this URL in a browser and approve access:\n")  # noqa: T201
         print(f"  {url}\n")  # noqa: T201
@@ -148,13 +218,13 @@ def _interactive_handlers() -> tuple[
         except EOFError as exc:
             msg = "No callback URL received; re-run the login command."
             raise RuntimeError(msg) from exc
-        return _parse_callback_url(raw)
+        return _parse_callback_url(raw, redirect_uri)
 
     return redirect, callback
 
 
 def _channel_handlers(
-    server_name: str,
+    server_name: str, redirect_uri: str
 ) -> tuple[Callable[[str], Awaitable[None]], Callable[[], Awaitable[tuple[str, str | None]]]]:
     async def redirect(url: str) -> None:
         handler = current_authorization_handler()
@@ -182,14 +252,14 @@ def _channel_handlers(
         if not isinstance(raw, str):
             msg = "MCP authorization callback was not received"
             raise MCPAuthorizationError(msg)
-        return _parse_callback_url(raw)
+        return _parse_callback_url(raw, redirect_uri)
 
     return redirect, callback
 
 
-def _parse_callback_url(raw: str) -> tuple[str, str | None]:
+def _parse_callback_url(raw: str, redirect_uri: str = _REDIRECT_URI) -> tuple[str, str | None]:
     parsed = urlparse(raw.strip())
-    expected = urlparse(_REDIRECT_URI)
+    expected = urlparse(redirect_uri)
     if (parsed.scheme, parsed.netloc, parsed.path) != (
         expected.scheme,
         expected.netloc,
@@ -209,6 +279,99 @@ def _parse_callback_url(raw: str) -> tuple[str, str | None]:
     return code, state
 
 
+def extract_oauth_callback_url(text: str) -> str | None:
+    """Return a recognized Talon OAuth callback URL from a channel message.
+
+    Args:
+        text: Raw channel message text.
+
+    Returns:
+        The normalized callback URL, or `None` when the message is not a
+        recognized callback.
+    """
+    candidate = text.strip()
+    if candidate.startswith("<") and candidate.endswith(">"):
+        candidate = candidate[1:-1].strip()
+    if any(
+        ord(character) < _ASCII_CONTROL_LIMIT or ord(character) == _ASCII_DELETE
+        for character in candidate
+    ):
+        return None
+    try:
+        parsed = urlparse(candidate)
+    except ValueError:
+        return None
+    if (parsed.scheme, parsed.netloc, parsed.path) not in _OAUTH_CALLBACK_ENDPOINTS:
+        return None
+    query = parse_qs(parsed.query)
+    if not query.get("state") or not (query.get("code") or query.get("error")):
+        return None
+    return candidate
+
+
+def _is_slack_mcp_url(url: str) -> bool:
+    host = urlparse(url).hostname or ""
+    return host == "slack.com" or host.endswith(".slack.com")
+
+
+def _client_metadata(redirect_uri: str) -> OAuthClientMetadata:
+    return OAuthClientMetadata(
+        redirect_uris=[AnyUrl(redirect_uri)],
+        client_name="Deep Agents Talon",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method="none",  # noqa: S106
+    )
+
+
+async def _preseed_slack_client_info(storage: FileTokenStorage) -> None:
+    existing = await storage.get_client_info()
+    redirect_uris = existing.redirect_uris if existing is not None else None
+    current_redirect = str(redirect_uris[0]) if redirect_uris else None
+    if (
+        existing is not None
+        and existing.client_id == _SLACK_MCP_CLIENT_ID
+        and current_redirect == _SLACK_REDIRECT_URI
+    ):
+        return
+    client_info = OAuthClientInformationFull(
+        client_id=_SLACK_MCP_CLIENT_ID,
+        redirect_uris=[AnyUrl(_SLACK_REDIRECT_URI)],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method="none",  # noqa: S106
+    )
+    await storage.set_client_info(client_info)
+
+
+async def _prompt_slack_team_id() -> str | None:
+    try:
+        raw = await asyncio.to_thread(
+            input,
+            "Slack team ID to install the app into "
+            "(e.g. T01234567 — leave blank to pick on Slack's page): ",
+        )
+    except EOFError:
+        return None
+    return raw.strip() or None
+
+
+def _with_slack_team(
+    redirect: Callable[[str], Awaitable[None]], team_id: str
+) -> Callable[[str], Awaitable[None]]:
+    async def wrapped(url: str) -> None:
+        parsed = urlparse(url)
+        query = [
+            (key, value)
+            for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+            if key != "team"
+        ]
+        query.append(("team", team_id))
+        await redirect(urlunparse(parsed._replace(query=urlencode(query))))
+
+    return wrapped
+
+
 def format_login_error(exc: BaseException) -> str:
     """Return a credential-safe OAuth failure message."""
     if isinstance(exc, (OSError, ValidationError, TypeError, ValueError)):
@@ -220,5 +383,7 @@ __all__ = [
     "FileTokenStorage",
     "MCPAuthorizationError",
     "build_oauth_provider",
+    "extract_oauth_callback_url",
     "format_login_error",
+    "prepare_oauth_login",
 ]

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -249,7 +249,7 @@ async def test_channel_authorization_intercepts_bound_callback_outside_model(
         ChannelMessage(conversation_id="chat", text="login", sender_id="operator"),
     )
     await _wait_for_sent_count(channel, 1)
-    callback = "http://localhost:3000/callback?code=sensitive-code&state=sensitive-state"
+    callback = "http://localhost:3118/callback?code=sensitive-code&state=sensitive-state"
     await host.receive_message(
         channel,
         ChannelMessage(conversation_id="chat", text=callback, sender_id="attacker"),

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, ClassVar, Self
 
 import pytest
 from langchain_mcp_adapters.interceptors import MCPToolCallRequest
-from mcp.client.auth import OAuthFlowError
+from mcp.client.auth import OAuthClientProvider, OAuthFlowError
 from mcp.shared.auth import OAuthToken
 from mcp.types import CallToolResult
 
@@ -245,6 +245,34 @@ async def test_mcp_interceptor_resumes_same_bound_invocation_without_secret_outp
     assert isinstance(events[-1], AuthorizationCompleted)
     assert "secret-state" not in repr(events[0])
     assert "secret-code" not in repr(events)
+
+
+async def test_slack_connection_reuses_team_after_successful_login(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "T01234567")
+    output: list[str] = []
+    monkeypatch.setattr(
+        "builtins.print",
+        lambda *values, **_kwargs: output.extend(str(value) for value in values),
+    )
+
+    connection, _transport = await _connection(
+        "slack",
+        {"url": "https://slack.com/mcp", "auth": "oauth"},
+        interactive=True,
+    )
+    provider = connection["auth"]
+    assert isinstance(provider, OAuthClientProvider)
+    redirect = provider.context.redirect_handler
+    assert redirect is not None
+    await redirect("https://slack.com/oauth/v2/authorize?state=opaque")
+    assert any("team=T01234567" in line for line in output)
+
+    await provider.context.storage.set_tokens(_oauth_token())
+    stored = FileTokenStorage("slack", server_url="https://slack.com/mcp")
+    assert await stored.get_slack_team_id() == "T01234567"
 
 
 def test_normalize_mcp_arguments_omits_only_optional_empty_strings() -> None:

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, ClassVar, Self
 
 import pytest
 from langchain_mcp_adapters.interceptors import MCPToolCallRequest
-from mcp.client.auth import OAuthClientProvider, OAuthFlowError
+from mcp.client.auth import OAuthFlowError
 from mcp.shared.auth import OAuthToken
 from mcp.types import CallToolResult
 
@@ -245,34 +245,6 @@ async def test_mcp_interceptor_resumes_same_bound_invocation_without_secret_outp
     assert isinstance(events[-1], AuthorizationCompleted)
     assert "secret-state" not in repr(events[0])
     assert "secret-code" not in repr(events)
-
-
-async def test_slack_connection_reuses_team_after_successful_login(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
-    monkeypatch.setattr("builtins.input", lambda _prompt: "T01234567")
-    output: list[str] = []
-    monkeypatch.setattr(
-        "builtins.print",
-        lambda *values, **_kwargs: output.extend(str(value) for value in values),
-    )
-
-    connection, _transport = await _connection(
-        "slack",
-        {"url": "https://slack.com/mcp", "auth": "oauth"},
-        interactive=True,
-    )
-    provider = connection["auth"]
-    assert isinstance(provider, OAuthClientProvider)
-    redirect = provider.context.redirect_handler
-    assert redirect is not None
-    await redirect("https://slack.com/oauth/v2/authorize?state=opaque")
-    assert any("team=T01234567" in line for line in output)
-
-    await provider.context.storage.set_tokens(_oauth_token())
-    stored = FileTokenStorage("slack", server_url="https://slack.com/mcp")
-    assert await stored.get_slack_team_id() == "T01234567"
 
 
 def test_normalize_mcp_arguments_omits_only_optional_empty_strings() -> None:

--- a/libs/talon/tests/test_mcp_auth.py
+++ b/libs/talon/tests/test_mcp_auth.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import stat
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
@@ -11,7 +10,6 @@ from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from deepagents_talon.mcp_auth import (
     FileTokenStorage,
     MCPAuthorizationError,
-    _with_slack_team,
     build_oauth_provider,
     extract_oauth_callback_url,
     prepare_oauth_login,
@@ -122,71 +120,18 @@ def test_slack_provider_selection_requires_slack_hostname() -> None:
     ]
 
 
-async def test_slack_login_preseeds_public_client_and_persists_team_with_tokens(
+async def test_slack_login_preseeds_public_client(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
-    monkeypatch.setattr("builtins.input", lambda _prompt: "  T01234567  ")
     storage = FileTokenStorage("slack", server_url="https://slack.com/mcp")
 
-    team_id = await prepare_oauth_login(
-        server_url="https://slack.com/mcp",
-        storage=storage,
-        interactive=True,
-    )
+    await prepare_oauth_login(server_url="https://slack.com/mcp", storage=storage)
 
     client = await storage.get_client_info()
     assert client is not None
     assert client.client_id == "4518649543379.10944517634130"
     assert [str(uri) for uri in client.redirect_uris or []] == ["http://localhost:3118/callback"]
-    assert team_id == "T01234567"
-    assert await storage.get_slack_team_id() is None
-    assert "slack_team_id" not in json.loads(storage.path.read_text(encoding="utf-8"))
-
-    await storage.set_tokens(OAuthToken(access_token="secret"))  # noqa: S106
-
-    assert await storage.get_slack_team_id() == "T01234567"
-
-
-async def test_slack_login_reuses_team_without_prompt_or_rewriting_client(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
-    storage = FileTokenStorage("slack", server_url="https://slack.com/mcp")
-    storage.store_slack_team_id_with_tokens("T01234567")
-    await storage.set_tokens(OAuthToken(access_token="secret"))  # noqa: S106
-    await prepare_oauth_login(
-        server_url="https://slack.com/mcp",
-        storage=storage,
-        interactive=False,
-    )
-    modified_at = storage.path.stat().st_mtime_ns
-    monkeypatch.setattr(
-        "builtins.input",
-        lambda _prompt: pytest.fail("cached Slack team ID should skip the prompt"),
-    )
-
-    team_id = await prepare_oauth_login(
-        server_url="https://slack.com/mcp",
-        storage=storage,
-        interactive=True,
-    )
-
-    assert team_id == "T01234567"
-    assert storage.path.stat().st_mtime_ns == modified_at
-
-
-async def test_slack_team_query_is_encoded_and_replaces_existing_value() -> None:
-    urls: list[str] = []
-
-    async def capture(url: str) -> None:
-        urls.append(url)
-
-    redirect = _with_slack_team(capture, "T01 &")
-    await redirect("https://slack.com/oauth?state=opaque&team=old")
-
-    assert len(urls) == 1
-    assert parse_qs(urlparse(urls[0]).query) == {"state": ["opaque"], "team": ["T01 &"]}
 
 
 async def test_slack_provider_validates_registered_callback(

--- a/libs/talon/tests/test_mcp_auth.py
+++ b/libs/talon/tests/test_mcp_auth.py
@@ -3,11 +3,19 @@ from __future__ import annotations
 import json
 import stat
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
-from deepagents_talon.mcp_auth import FileTokenStorage, build_oauth_provider
+from deepagents_talon.mcp_auth import (
+    FileTokenStorage,
+    MCPAuthorizationError,
+    _with_slack_team,
+    build_oauth_provider,
+    extract_oauth_callback_url,
+    prepare_oauth_login,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -89,6 +97,143 @@ async def test_interactive_provider_validates_callback_state(
     code, state = await provider.context.callback_handler()
 
     assert (code, state) == ("abc", "state")
+
+
+def test_slack_provider_selection_requires_slack_hostname() -> None:
+    storage = FileTokenStorage("slack", server_url="https://slack.com/mcp")
+    slack = build_oauth_provider(
+        server_name="slack",
+        server_url="https://slack.com/mcp",
+        storage=storage,
+        interactive=True,
+    )
+    lookalike = build_oauth_provider(
+        server_name="lookalike",
+        server_url="https://slack.com.attacker.example/mcp",
+        storage=storage,
+        interactive=True,
+    )
+
+    assert [str(uri) for uri in slack.context.client_metadata.redirect_uris or []] == [
+        "http://localhost:3118/callback"
+    ]
+    assert [str(uri) for uri in lookalike.context.client_metadata.redirect_uris or []] == [
+        "http://localhost:3000/callback"
+    ]
+
+
+async def test_slack_login_preseeds_public_client_and_persists_team_with_tokens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "  T01234567  ")
+    storage = FileTokenStorage("slack", server_url="https://slack.com/mcp")
+
+    team_id = await prepare_oauth_login(
+        server_url="https://slack.com/mcp",
+        storage=storage,
+        interactive=True,
+    )
+
+    client = await storage.get_client_info()
+    assert client is not None
+    assert client.client_id == "4518649543379.10944517634130"
+    assert [str(uri) for uri in client.redirect_uris or []] == ["http://localhost:3118/callback"]
+    assert team_id == "T01234567"
+    assert await storage.get_slack_team_id() is None
+    assert "slack_team_id" not in json.loads(storage.path.read_text(encoding="utf-8"))
+
+    await storage.set_tokens(OAuthToken(access_token="secret"))  # noqa: S106
+
+    assert await storage.get_slack_team_id() == "T01234567"
+
+
+async def test_slack_login_reuses_team_without_prompt_or_rewriting_client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    storage = FileTokenStorage("slack", server_url="https://slack.com/mcp")
+    storage.store_slack_team_id_with_tokens("T01234567")
+    await storage.set_tokens(OAuthToken(access_token="secret"))  # noqa: S106
+    await prepare_oauth_login(
+        server_url="https://slack.com/mcp",
+        storage=storage,
+        interactive=False,
+    )
+    modified_at = storage.path.stat().st_mtime_ns
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt: pytest.fail("cached Slack team ID should skip the prompt"),
+    )
+
+    team_id = await prepare_oauth_login(
+        server_url="https://slack.com/mcp",
+        storage=storage,
+        interactive=True,
+    )
+
+    assert team_id == "T01234567"
+    assert storage.path.stat().st_mtime_ns == modified_at
+
+
+async def test_slack_team_query_is_encoded_and_replaces_existing_value() -> None:
+    urls: list[str] = []
+
+    async def capture(url: str) -> None:
+        urls.append(url)
+
+    redirect = _with_slack_team(capture, "T01 &")
+    await redirect("https://slack.com/oauth?state=opaque&team=old")
+
+    assert len(urls) == 1
+    assert parse_qs(urlparse(urls[0]).query) == {"state": ["opaque"], "team": ["T01 &"]}
+
+
+async def test_slack_provider_validates_registered_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = FileTokenStorage("slack", server_url="https://slack.com/mcp")
+    provider = build_oauth_provider(
+        server_name="slack",
+        server_url="https://slack.com/mcp",
+        storage=storage,
+        interactive=True,
+    )
+    callback = provider.context.callback_handler
+    assert callback is not None
+    callbacks = iter(
+        [
+            "http://localhost:3118/callback?code=abc&state=state",
+            "http://localhost:3000/callback?code=abc&state=state",
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(callbacks))
+
+    assert await callback() == ("abc", "state")
+    with pytest.raises(MCPAuthorizationError, match="callback is invalid"):
+        await callback()
+
+
+@pytest.mark.parametrize("port", [3000, 3118])
+def test_extract_oauth_callback_url_accepts_registered_ports(port: int) -> None:
+    callback = f"http://localhost:{port}/callback?code=secret&state=opaque"
+
+    assert extract_oauth_callback_url(f"<{callback}>") == callback
+
+
+@pytest.mark.parametrize(
+    "callback",
+    [
+        "http://localhost:3119/callback?code=secret&state=opaque",
+        "http://localhost:3118/other?code=secret&state=opaque",
+        "http://attacker.example/callback?code=secret&state=opaque",
+        "http://localhost:3118/callback?code=secret&state=opaque\nextra",
+    ],
+)
+def test_extract_oauth_callback_url_rejects_unregistered_or_unsafe_urls(
+    callback: str,
+) -> None:
+    assert extract_oauth_callback_url(callback) is None
 
 
 async def test_malformed_credential_file_does_not_expose_contents(


### PR DESCRIPTION
Talon can now authenticate Slack's hosted MCP server while leaving workspace selection to Slack on every authorization.

---

Slack's hosted MCP endpoint uses a public client and a pre-registered callback that differ from the generic MCP OAuth flow. This adds the provider-specific client metadata and recognizes Slack's callback port without storing or injecting a workspace ID.

Channel callback routing recognizes both exact Talon callback endpoints while provider and state validation remain authoritative.

Tests cover provider selection, callback validation, and callback routing.

Made by [Open SWE](https://openswe.vercel.app/agents/6e7f7ae4-3119-5ba0-b16a-683539d47998)