### PR TITLE
fix(quickjs): isolate forked subagent runtimes

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -43,6 +43,9 @@ from deepagents.middleware.summarization import (
 SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY = "__deepagents_subagent_response_format"
 """Configurable key used by task-tool callers to request dynamic response format."""
 
+SUBAGENT_INVOCATION_CONFIG_KEY = "__deepagents_subagent_invocation"
+"""Configurable key identifying one subagent invocation's private runtime."""
+
 _FORK_EXCLUDED_STATE_KEYS = frozenset({"structured_response", SUMMARIZATION_EVENT_KEY, SUMMARIZATION_SESSION_ID_KEY})
 """State a fork must not resume.
 
@@ -574,6 +577,19 @@ def _get_subagent_response_format(
     return value
 
 
+def _subagent_config(runtime: ToolRuntime) -> RunnableConfig:
+    """Build child config with a private invocation identity."""
+    if not runtime.tool_call_id:
+        msg = "Tool call ID is required for subagent invocation"
+        raise ValueError(msg)
+    return {
+        "configurable": {
+            "ls_agent_type": "subagent",
+            SUBAGENT_INVOCATION_CONFIG_KEY: runtime.tool_call_id,
+        }
+    }
+
+
 def _build_task_tool(  # noqa: C901, PLR0915
     subagents: Sequence[_SubAgentSpec],
     task_description: str | None = None,
@@ -787,8 +803,9 @@ def _build_task_tool(  # noqa: C901, PLR0915
         # the subagent's bound config still wins collisions (e.g. `lc_agent_name`,
         # `recursion_limit`) and parent metadata propagates (deepagents#3634).
         # Forwarding those keys explicitly would double-count under the merge
-        # (e.g. duplicate `tags`), so we only stamp the subagent tracing tag.
-        subagent_config: RunnableConfig = {"configurable": {"ls_agent_type": "subagent"}}
+        # (e.g. duplicate `tags`); the private invocation key lets inherited
+        # middleware isolate this child agent's in-process resources.
+        subagent_config = _subagent_config(runtime)
         with _subagent_tracing_context():
             result = subagent.invoke(subagent_state, subagent_config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
@@ -817,8 +834,9 @@ def _build_task_tool(  # noqa: C901, PLR0915
         # the subagent's bound config still wins collisions (e.g. `lc_agent_name`,
         # `recursion_limit`) and parent metadata propagates (deepagents#3634).
         # Forwarding those keys explicitly would double-count under the merge
-        # (e.g. duplicate `tags`), so we only stamp the subagent tracing tag.
-        subagent_config: RunnableConfig = {"configurable": {"ls_agent_type": "subagent"}}
+        # (e.g. duplicate `tags`); the private invocation key lets inherited
+        # middleware isolate this child agent's in-process resources.
+        subagent_config = _subagent_config(runtime)
         with _subagent_tracing_context():
             result = await subagent.ainvoke(subagent_state, subagent_config)
         return _return_command_with_state_update(result, runtime.tool_call_id)

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -35,8 +35,32 @@ from pydantic import BaseModel, Field
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.graph import create_deep_agent
 from deepagents.middleware.skills import SkillsMiddleware
-from deepagents.middleware.subagents import CompiledSubAgent, SubAgent
+from deepagents.middleware.subagents import (
+    SUBAGENT_INVOCATION_CONFIG_KEY,
+    CompiledSubAgent,
+    SubAgent,
+    _subagent_config,
+)
 from tests.unit_tests.chat_model import GenericFakeChatModel
+
+
+def test_subagent_config_scopes_invocation() -> None:
+    runtime = ToolRuntime(
+        state={},
+        context={},
+        config={"configurable": {}},
+        stream_writer=lambda _chunk: None,
+        tools=[],
+        tool_call_id="call-1",
+        store=None,
+    )
+
+    assert _subagent_config(runtime) == {
+        "configurable": {
+            "ls_agent_type": "subagent",
+            SUBAGENT_INVOCATION_CONFIG_KEY: "call-1",
+        }
+    }
 
 
 def _make_skill_content(name: str, description: str) -> str:

--- a/libs/partners/quickjs/langchain_quickjs/_subagent.py
+++ b/libs/partners/quickjs/langchain_quickjs/_subagent.py
@@ -15,8 +15,12 @@ from langgraph.errors import GraphInterrupt
 from langchain_quickjs._format import coerce_tool_output_for_ptc
 
 try:
-    from deepagents.middleware.subagents import SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY
+    from deepagents.middleware.subagents import (
+        SUBAGENT_INVOCATION_CONFIG_KEY,
+        SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY,
+    )
 except ImportError:  # pragma: no cover - compatibility with older deepagents
+    SUBAGENT_INVOCATION_CONFIG_KEY = "__deepagents_subagent_invocation"
     SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY = "__deepagents_subagent_response_format"
 
 

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -50,7 +50,10 @@ from langchain_quickjs._snapshot import (
     sign_snapshot,
     verify_snapshot,
 )
-from langchain_quickjs._subagent import find_subagent_task_tool
+from langchain_quickjs._subagent import (
+    SUBAGENT_INVOCATION_CONFIG_KEY,
+    find_subagent_task_tool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -105,25 +108,26 @@ def _resolve_mode(
 
 
 def _resolve_thread_id(fallback: str) -> str:
-    """Extract `thread_id` from langgraph config or use `fallback`.
+    """Extract a QuickJS slot identity from LangGraph config or use `fallback`.
 
-    The fallback is a middleware-instance-scoped id: when the caller
-    didn't configure a `thread_id` (common for ad-hoc
-    `agent.invoke(...)` in tests or single-shot scripts), we still need
-    all resolver calls within one CodeInterpreterMiddleware lifetime to return the
-    same id — otherwise `wrap_model_call` installs tools on one REPL
-    and the eval tool looks up a different one, and the model sees
-    `ReferenceError: tools is not defined`.
+    The fallback is middleware-instance-scoped, keeping model-call preparation
+    and eval on the same REPL when no LangGraph `thread_id` is configured. A
+    subagent invocation adds a private suffix so inherited middleware cannot
+    share or evict its parent's in-process QuickJS slot.
     """
     try:
         config = get_config()
     except RuntimeError:
         # Not running inside a Runnable — test / bare-call path.
         return fallback
-    thread_id = config.get("configurable", {}).get("thread_id") if config else None
-    if thread_id is not None:
-        return str(thread_id)
-    return fallback
+    configurable = config.get("configurable", {}) if config else {}
+    if not isinstance(configurable, dict):
+        configurable = {}
+    thread_id = str(configurable.get("thread_id", fallback))
+    invocation_id = configurable.get(SUBAGENT_INVOCATION_CONFIG_KEY)
+    if invocation_id is not None:
+        return f"{thread_id}::subagent:{invocation_id}"
+    return thread_id
 
 
 @beta()

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -35,6 +35,7 @@ from langchain_quickjs._subagent import (
     _runtime_with_response_format,
     call_subagent_task_tool,
 )
+from langchain_quickjs.middleware import _resolve_thread_id
 
 if TYPE_CHECKING:
     from langchain_core.callbacks import CallbackManagerForLLMRun
@@ -280,6 +281,42 @@ def test_system_prompt_mentions_mode_call() -> None:
     base_prompt = mw._base_prompt(ptc_attached=False)
     assert "fresh sandboxed REPL for each invocation" in base_prompt
     assert "does not persist across tool calls" in base_prompt
+
+
+def test_subagent_invocation_scopes_repl_identity() -> None:
+    with patch(
+        "langchain_quickjs.middleware.get_config",
+        return_value={
+            "configurable": {
+                "thread_id": "thread-1",
+                "__deepagents_subagent_invocation": "call-1",
+            }
+        },
+    ):
+        assert _resolve_thread_id("fallback") == "thread-1::subagent:call-1"
+
+
+async def test_subagent_cleanup_preserves_parent_and_sibling_slots() -> None:
+    middleware = CodeInterpreterMiddleware(mode="turn")
+    try:
+        parent = middleware._registry.get("thread")
+        sibling = middleware._registry.get("thread::subagent:call-2")
+        middleware._registry.get("thread::subagent:call-1")
+        with patch(
+            "langchain_quickjs.middleware.get_config",
+            return_value={
+                "configurable": {
+                    "thread_id": "thread",
+                    "__deepagents_subagent_invocation": "call-1",
+                }
+            },
+        ):
+            await middleware.aafter_agent(state={}, runtime=MagicMock())
+        assert middleware._registry.get_if_exists("thread") is parent
+        assert middleware._registry.get_if_exists("thread::subagent:call-2") is sibling
+        assert middleware._registry.get_if_exists("thread::subagent:call-1") is None
+    finally:
+        middleware._registry.close()
 
 
 def test_default_mode_is_thread() -> None:


### PR DESCRIPTION
Forked subagents now use private QuickJS slots, so finishing a child cannot close the parent or a sibling's REPL.

---

Forked subagents inherit the parent checkpoint `thread_id` and middleware stack. The task tool now stamps each invocation with an opaque private runtime identity; QuickJS uses it only for its in-process registry key, leaving checkpoint identity unchanged. Child cleanup therefore evicts only the child slot.

Tests: `make test TEST_FILE=tests/unit_tests/test_repl_middleware.py` (78 passed); `make test TEST_FILE=tests/unit_tests/test_subagents.py` (38 passed, 1 expected failure); `make lint` in `libs/deepagents` and `libs/partners/quickjs`.

Made by [Open SWE](https://openswe.vercel.app/agents/104c511d-33d7-5fa8-b919-0e94a10e4635)