### PR TITLE
fix(code): surface the LangSmith credential in `dcode config`

### DIFF
--- a/libs/code/deepagents_code/_constants.py
+++ b/libs/code/deepagents_code/_constants.py
@@ -44,6 +44,12 @@ is the drift guard that fails when the two diverge.
 FIREWORKS_PROVIDER_ID_PREFIX: Final[str] = "accounts/fireworks/"
 """Prefix used to infer Fireworks from fully-qualified IDs."""
 
+LANGSMITH_API_KEY_ENV_VARS: Final[tuple[str, ...]] = (
+    "LANGSMITH_API_KEY",
+    "LANGCHAIN_API_KEY",
+)
+"""Env vars LangSmith tracing reads for its API key, in precedence order."""
+
 FIREWORKS_MODEL_ID_PREFIXES: Final[tuple[str, ...]] = (
     "accounts/fireworks/models/",
     "accounts/fireworks/routers/",

--- a/libs/code/deepagents_code/_constants.py
+++ b/libs/code/deepagents_code/_constants.py
@@ -56,9 +56,7 @@ LANGSMITH_API_KEY_ENV_VARS: Final[tuple[str, ...]] = (
 )
 """Env vars LangSmith reads for its API key, in precedence order.
 
-Mirrors the SDK's own `LANGSMITH_`-then-`LANGCHAIN_` lookup. Drives both the
-tracing bootstrap in `config.py` and the `/auth` credential surface, so it is
-no longer tracing-specific.
+Mirrors the SDK's own `LANGSMITH_`-then-`LANGCHAIN_` lookup.
 """
 
 FIREWORKS_MODEL_ID_PREFIXES: Final[tuple[str, ...]] = (

--- a/libs/code/deepagents_code/_constants.py
+++ b/libs/code/deepagents_code/_constants.py
@@ -44,11 +44,22 @@ is the drift guard that fails when the two diverge.
 FIREWORKS_PROVIDER_ID_PREFIX: Final[str] = "accounts/fireworks/"
 """Prefix used to infer Fireworks from fully-qualified IDs."""
 
+LANGSMITH_API_KEY_ENV: Final[str] = "LANGSMITH_API_KEY"
+"""Primary env var the LangSmith SDK reads for its API key."""
+
+LANGSMITH_API_KEY_FALLBACK_ENV_VARS: Final[tuple[str, ...]] = ("LANGCHAIN_API_KEY",)
+"""Legacy env vars the LangSmith SDK accepts after `LANGSMITH_API_KEY_ENV`."""
+
 LANGSMITH_API_KEY_ENV_VARS: Final[tuple[str, ...]] = (
-    "LANGSMITH_API_KEY",
-    "LANGCHAIN_API_KEY",
+    LANGSMITH_API_KEY_ENV,
+    *LANGSMITH_API_KEY_FALLBACK_ENV_VARS,
 )
-"""Env vars LangSmith tracing reads for its API key, in precedence order."""
+"""Env vars LangSmith reads for its API key, in precedence order.
+
+Mirrors the SDK's own `LANGSMITH_`-then-`LANGCHAIN_` lookup. Drives both the
+tracing bootstrap in `config.py` and the `/auth` credential surface, so it is
+no longer tracing-specific.
+"""
 
 FIREWORKS_MODEL_ID_PREFIXES: Final[tuple[str, ...]] = (
     "accounts/fireworks/models/",

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -31,7 +31,7 @@ from urllib.request import url2pathname
 
 from deepagents_code._constants import (
     FIREWORKS_PROVIDER_ID_PREFIX,
-    LANGSMITH_API_KEY_ENV_VARS,
+    LANGSMITH_API_KEY_ENV_VARS as _TRACING_API_KEY_ENV_VARS,
 )
 from deepagents_code._env_vars import (
     AUTO_CLASSIFIER_MODEL,
@@ -885,15 +885,6 @@ def _load_dotenv(
         _bootstrap_state.user_langsmith_env = _langsmith_selectors_from(project)
     return bool(effective.keys() - baseline.keys())
 
-
-_TRACING_API_KEY_ENV_VARS = LANGSMITH_API_KEY_ENV_VARS
-"""Env vars that hold the LangSmith API key used for trace ingestion.
-
-Alias of `LANGSMITH_API_KEY_ENV_VARS`, kept as a local name so the tracing
-bootstrap reads it alongside `_TRACING_ENABLE_ENV_VARS` and
-`_TRACING_ENDPOINT_ENV_VARS`. The shared constant also drives the `/auth`
-credential surface, so edit it there rather than here.
-"""
 
 _TRACING_BRIDGED_ENABLE_ENV_VARS = ("LANGSMITH_TRACING", "LANGCHAIN_TRACING_V2")
 """Tracing flags bootstrap propagates from a `DEEPAGENTS_CODE_` prefix.

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -29,7 +29,10 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
-from deepagents_code._constants import FIREWORKS_PROVIDER_ID_PREFIX
+from deepagents_code._constants import (
+    FIREWORKS_PROVIDER_ID_PREFIX,
+    LANGSMITH_API_KEY_ENV_VARS,
+)
 from deepagents_code._env_vars import (
     AUTO_CLASSIFIER_MODEL,
     AUTO_CLASSIFIER_TIMEOUT,
@@ -883,7 +886,7 @@ def _load_dotenv(
     return bool(effective.keys() - baseline.keys())
 
 
-_TRACING_API_KEY_ENV_VARS = ("LANGSMITH_API_KEY", "LANGCHAIN_API_KEY")
+_TRACING_API_KEY_ENV_VARS = LANGSMITH_API_KEY_ENV_VARS
 """Env vars that hold the LangSmith API key used for trace ingestion."""
 
 _TRACING_BRIDGED_ENABLE_ENV_VARS = ("LANGSMITH_TRACING", "LANGCHAIN_TRACING_V2")

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -887,7 +887,13 @@ def _load_dotenv(
 
 
 _TRACING_API_KEY_ENV_VARS = LANGSMITH_API_KEY_ENV_VARS
-"""Env vars that hold the LangSmith API key used for trace ingestion."""
+"""Env vars that hold the LangSmith API key used for trace ingestion.
+
+Alias of `LANGSMITH_API_KEY_ENV_VARS`, kept as a local name so the tracing
+bootstrap reads it alongside `_TRACING_ENABLE_ENV_VARS` and
+`_TRACING_ENDPOINT_ENV_VARS`. The shared constant also drives the `/auth`
+credential surface, so edit it there rather than here.
+"""
 
 _TRACING_BRIDGED_ENABLE_ENV_VARS = ("LANGSMITH_TRACING", "LANGCHAIN_TRACING_V2")
 """Tracing flags bootstrap propagates from a `DEEPAGENTS_CODE_` prefix.

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1862,12 +1862,6 @@ def resolve_recursion_limit(
 
 # --- Option definitions -----------------------------------------------------
 
-# Search credentials that are not provider API keys live outside
-# `PROVIDER_API_KEY_ENV`, so they are declared explicitly.
-_EXTRA_CREDENTIAL_ENV: dict[str, str] = {
-    "tavily": "TAVILY_API_KEY",
-}
-
 _SECRET_NAME_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "APIKEY")
 
 _PROVIDER_DEPENDENCIES: dict[str, tuple[str, str]] = {
@@ -1983,18 +1977,21 @@ def _is_secret_env(name: str) -> bool:
 def _credential_options() -> tuple[ConfigOption[object], ...]:
     """Build credential options from the canonical provider/key registries.
 
-    Generating these from `PROVIDER_API_KEY_ENV` (rather than hand-listing
-    them) guarantees every provider the app knows how to authenticate has a
-    manifest entry, so new providers can never silently miss the config
-    surface.
+    Generating these from the provider and service registries guarantees every
+    credential the app knows how to authenticate has a manifest entry, so new
+    providers and services can never silently miss the config surface.
 
     Returns:
         One credential `ConfigOption` per known provider/key env var.
     """
-    from deepagents_code.model_config import PROVIDER_API_KEY_ENV
+    from deepagents_code.model_config import (
+        PROVIDER_API_KEY_ENV,
+        SERVICE_API_KEY_ENV,
+        SERVICE_API_KEY_FALLBACK_ENV_VARS,
+    )
 
     options: list[ConfigOption[object]] = []
-    sources = {**PROVIDER_API_KEY_ENV, **_EXTRA_CREDENTIAL_ENV}
+    sources = {**PROVIDER_API_KEY_ENV, **SERVICE_API_KEY_ENV}
     for name, env_var in sorted(sources.items()):
         redacted = _is_secret_env(env_var)
         summary = (
@@ -2010,6 +2007,7 @@ def _credential_options() -> tuple[ConfigOption[object], ...]:
                 summary=summary,
                 kind=OptionKind.STR,
                 env_var=env_var,
+                fallback_env_vars=SERVICE_API_KEY_FALLBACK_ENV_VARS.get(name, ()),
                 redacted=redacted,
                 provider=name,
                 dependency_module=dependency[0] if dependency else None,

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1974,6 +1974,26 @@ def _is_secret_env(name: str) -> bool:
     return any(marker in upper for marker in _SECRET_NAME_MARKERS)
 
 
+def _prefix_aware_fallbacks(names: tuple[str, ...]) -> tuple[str, ...]:
+    """Expand canonical fallbacks in `resolve_env_var` lookup order.
+
+    Args:
+        names: Canonical fallback environment variable names.
+
+    Returns:
+        Prefixed and canonical spellings for each fallback, in precedence order.
+    """
+    return tuple(
+        candidate
+        for name in names
+        for candidate in (
+            (name,)
+            if name.startswith("DEEPAGENTS_CODE_")
+            else (f"DEEPAGENTS_CODE_{name}", name)
+        )
+    )
+
+
 def _credential_options() -> tuple[ConfigOption[object], ...]:
     """Build credential options from the canonical provider/key registries.
 
@@ -2007,7 +2027,9 @@ def _credential_options() -> tuple[ConfigOption[object], ...]:
                 summary=summary,
                 kind=OptionKind.STR,
                 env_var=env_var,
-                fallback_env_vars=SERVICE_API_KEY_FALLBACK_ENV_VARS.get(name, ()),
+                fallback_env_vars=_prefix_aware_fallbacks(
+                    SERVICE_API_KEY_FALLBACK_ENV_VARS.get(name, ())
+                ),
                 redacted=redacted,
                 provider=name,
                 dependency_module=dependency[0] if dependency else None,

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -433,9 +433,10 @@ class ConfigOption[T]:
     fallback_env_vars: tuple[str, ...] = ()
     """Secondary env vars read (in order) when `env_var` is unset.
 
-    Read literally — no `DEEPAGENTS_CODE_` prefix logic — so `config`/`config get`
-    mirror runtime fallbacks such as `get_langsmith_project_name` reading bare
-    `LANGSMITH_PROJECT`.
+    Credential fallbacks apply `DEEPAGENTS_CODE_` prefix overrides dynamically,
+    including empty-prefix shadowing. Other fallbacks are read literally so
+    `config`/`config get` mirror runtime fallbacks such as
+    `get_langsmith_project_name` reading bare `LANGSMITH_PROJECT`.
     """
 
     toml_keys: tuple[str, ...] | None = None
@@ -1974,26 +1975,6 @@ def _is_secret_env(name: str) -> bool:
     return any(marker in upper for marker in _SECRET_NAME_MARKERS)
 
 
-def _prefix_aware_fallbacks(names: tuple[str, ...]) -> tuple[str, ...]:
-    """Expand canonical fallbacks in `resolve_env_var` lookup order.
-
-    Args:
-        names: Canonical fallback environment variable names.
-
-    Returns:
-        Prefixed and canonical spellings for each fallback, in precedence order.
-    """
-    return tuple(
-        candidate
-        for name in names
-        for candidate in (
-            (name,)
-            if name.startswith("DEEPAGENTS_CODE_")
-            else (f"DEEPAGENTS_CODE_{name}", name)
-        )
-    )
-
-
 def _credential_options() -> tuple[ConfigOption[object], ...]:
     """Build credential options from the canonical provider/key registries.
 
@@ -2027,9 +2008,7 @@ def _credential_options() -> tuple[ConfigOption[object], ...]:
                 summary=summary,
                 kind=OptionKind.STR,
                 env_var=env_var,
-                fallback_env_vars=_prefix_aware_fallbacks(
-                    SERVICE_API_KEY_FALLBACK_ENV_VARS.get(name, ())
-                ),
+                fallback_env_vars=SERVICE_API_KEY_FALLBACK_ENV_VARS.get(name, ()),
                 redacted=redacted,
                 provider=name,
                 dependency_module=dependency[0] if dependency else None,

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1983,7 +1983,9 @@ def _credential_options() -> tuple[ConfigOption[object], ...]:
     providers and services can never silently miss the config surface.
 
     Returns:
-        One credential `ConfigOption` per known provider/key env var.
+        One credential `ConfigOption` per provider in `PROVIDER_API_KEY_ENV`
+            and per service in `SERVICE_API_KEY_ENV`. Service entries win on a
+            name collision.
     """
     from deepagents_code.model_config import (
         PROVIDER_API_KEY_ENV,

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -357,6 +357,7 @@ class _CommonFields(TypedDict):
     summary: str
     env_var: NotRequired[str | None]
     fallback_env_vars: NotRequired[tuple[str, ...]]
+    prefix_aware_fallbacks: NotRequired[bool]
     toml_keys: NotRequired[tuple[str, ...] | None]
     invert_toml_bool: NotRequired[bool]
     cli_flag: NotRequired[str | None]
@@ -433,10 +434,18 @@ class ConfigOption[T]:
     fallback_env_vars: tuple[str, ...] = ()
     """Secondary env vars read (in order) when `env_var` is unset.
 
-    Credential fallbacks apply `DEEPAGENTS_CODE_` prefix overrides dynamically,
-    including empty-prefix shadowing. Other fallbacks are read literally so
-    `config`/`config get` mirror runtime fallbacks such as
-    `get_langsmith_project_name` reading bare `LANGSMITH_PROJECT`.
+    Read literally unless `prefix_aware_fallbacks` is set, so `config`/`config
+    get` mirror runtime fallbacks such as `get_langsmith_project_name` reading
+    bare `LANGSMITH_PROJECT`.
+    """
+
+    prefix_aware_fallbacks: bool = False
+    """Whether `fallback_env_vars` honor `DEEPAGENTS_CODE_` prefix overrides.
+
+    Set for credentials, whose runtime lookup routes every accepted name
+    through `resolve_env_var` -- including empty-prefix shadowing. Left off for
+    fallbacks the runtime reads literally, where applying the override would
+    let an empty prefixed variable shadow a set canonical one.
     """
 
     toml_keys: tuple[str, ...] | None = None
@@ -2011,6 +2020,7 @@ def _credential_options() -> tuple[ConfigOption[object], ...]:
                 kind=OptionKind.STR,
                 env_var=env_var,
                 fallback_env_vars=SERVICE_API_KEY_FALLBACK_ENV_VARS.get(name, ()),
+                prefix_aware_fallbacks=True,
                 redacted=redacted,
                 provider=name,
                 dependency_module=dependency[0] if dependency else None,

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -448,12 +448,16 @@ def ranked_environment_value[T](
     names: list[str] = []
     if option.env_var:
         names.append(_prefix_aware_env_name(option.env_var, environ))
-    if option.group == "Credentials":
-        names.extend(
-            _prefix_aware_env_name(name, environ) for name in option.fallback_env_vars
+    for fallback in option.fallback_env_vars:
+        name = (
+            _prefix_aware_env_name(fallback, environ)
+            if option.prefix_aware_fallbacks
+            else fallback
         )
-    else:
-        names.extend(option.fallback_env_vars)
+        # A prefix-aware fallback can resolve to a name the primary already
+        # selected; reading it twice would emit a duplicate diagnostic.
+        if name not in names:
+            names.append(name)
 
     status = ProviderStatus("environment", None, ProviderHealth.OK)
     last_invalid: Invalid | None = None

--- a/libs/code/deepagents_code/configuration/providers.py
+++ b/libs/code/deepagents_code/configuration/providers.py
@@ -411,6 +411,22 @@ def ranked_toml_value[T](
     return RankedProviderValue(rank, durable, status, result)
 
 
+def _prefix_aware_env_name(name: str, environ: Mapping[str, str]) -> str:
+    """Select a prefix override by presence, including an explicitly empty one.
+
+    Args:
+        name: Canonical environment variable name.
+        environ: Environment mapping being resolved.
+
+    Returns:
+        The prefixed name when present, otherwise the canonical name.
+    """
+    prefixed = (
+        name if name.startswith("DEEPAGENTS_CODE_") else f"DEEPAGENTS_CODE_{name}"
+    )
+    return prefixed if prefixed in environ else name
+
+
 def ranked_environment_value[T](
     option: ConfigOption[T],
     environ: Mapping[str, str],
@@ -431,14 +447,13 @@ def ranked_environment_value[T](
 
     names: list[str] = []
     if option.env_var:
-        canonical = option.env_var
-        prefixed = (
-            canonical
-            if canonical.startswith("DEEPAGENTS_CODE_")
-            else f"DEEPAGENTS_CODE_{canonical}"
+        names.append(_prefix_aware_env_name(option.env_var, environ))
+    if option.group == "Credentials":
+        names.extend(
+            _prefix_aware_env_name(name, environ) for name in option.fallback_env_vars
         )
-        names.append(prefixed if prefixed in environ else canonical)
-    names.extend(option.fallback_env_vars)
+    else:
+        names.extend(option.fallback_env_vars)
 
     status = ProviderStatus("environment", None, ProviderHealth.OK)
     last_invalid: Invalid | None = None

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -26,6 +26,7 @@ from urllib.parse import urlparse
 import tomli_w
 
 from deepagents_code import _env_vars, auth_store
+from deepagents_code._constants import LANGSMITH_API_KEY_ENV_VARS
 from deepagents_code._git import find_git_common_dir
 from deepagents_code._paths import PATHS
 from deepagents_code.configuration.writer import USER_CONFIG_WRITE_LOCK
@@ -978,6 +979,11 @@ model as model providers, so they appear in the `/auth` manager and can be
 entered directly in the TUI instead of being exported as environment variables
 before launch.
 """
+
+SERVICE_API_KEY_FALLBACK_ENV_VARS: dict[str, tuple[str, ...]] = {
+    LANGSMITH_SERVICE: LANGSMITH_API_KEY_ENV_VARS[1:],
+}
+"""Ordered fallback env vars accepted by each non-model service runtime."""
 
 CODEX_PROVIDER = "openai_codex"
 """Provider name for `_ChatOpenAICodex` models authenticated via ChatGPT OAuth.
@@ -2805,9 +2811,31 @@ def get_service_auth_status(service: str) -> ProviderAuthStatus:
         `CONFIGURED` when a stored or env credential is set, else `MISSING`.
     """
     env_var = SERVICE_API_KEY_ENV[service]
-    configured = _resolve_configured(service, env_var)
-    if configured:
-        return configured
+    if _has_stored_credential(service):
+        return ProviderAuthStatus(
+            state=ProviderAuthState.CONFIGURED,
+            provider=service,
+            env_var=env_var,
+            source=ProviderAuthSource.STORED,
+            detail="stored credential",
+        )
+    if resolve_env_var(env_var):
+        return ProviderAuthStatus(
+            state=ProviderAuthState.CONFIGURED,
+            provider=service,
+            env_var=resolved_env_var_name(env_var),
+            source=ProviderAuthSource.ENV,
+            detail="credentials set",
+        )
+    for fallback_env_var in SERVICE_API_KEY_FALLBACK_ENV_VARS.get(service, ()):
+        if resolve_env_var(fallback_env_var):
+            return ProviderAuthStatus(
+                state=ProviderAuthState.CONFIGURED,
+                provider=service,
+                env_var=resolved_env_var_name(fallback_env_var),
+                source=ProviderAuthSource.ENV,
+                detail="credentials set",
+            )
     return ProviderAuthStatus(
         state=ProviderAuthState.MISSING,
         provider=service,

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -2446,7 +2446,11 @@ def _resolve_gateway_configured(provider: str) -> ProviderAuthStatus | None:
     )
 
 
-def _resolve_configured(provider: str, env_var: str) -> ProviderAuthStatus | None:
+def _resolve_configured(
+    provider: str,
+    env_var: str,
+    fallback_env_vars: tuple[str, ...] = (),
+) -> ProviderAuthStatus | None:
     """Return a `CONFIGURED` status if a stored or env credential is set.
 
     Stored credentials beat env vars (matches `resolve_provider_credential`).
@@ -2455,9 +2459,11 @@ def _resolve_configured(provider: str, env_var: str) -> ProviderAuthStatus | Non
         provider: Provider name (e.g., `"anthropic"`).
         env_var: Canonical env var name to check when no stored credential
             exists. Recorded on the returned status either way.
+        fallback_env_vars: Canonical env vars read, in order, when `env_var`
+            is unset. The one that resolves is recorded on the status.
 
     Returns:
-        A `CONFIGURED` status, or `None` when neither source is set.
+        A `CONFIGURED` status, or `None` when no source is set.
     """
     if _has_stored_credential(provider):
         return ProviderAuthStatus(
@@ -2467,14 +2473,15 @@ def _resolve_configured(provider: str, env_var: str) -> ProviderAuthStatus | Non
             source=ProviderAuthSource.STORED,
             detail="stored credential",
         )
-    if resolve_env_var(env_var):
-        return ProviderAuthStatus(
-            state=ProviderAuthState.CONFIGURED,
-            provider=provider,
-            env_var=env_var,
-            source=ProviderAuthSource.ENV,
-            detail="credentials set",
-        )
+    for candidate in (env_var, *fallback_env_vars):
+        if resolve_env_var(candidate):
+            return ProviderAuthStatus(
+                state=ProviderAuthState.CONFIGURED,
+                provider=provider,
+                env_var=candidate,
+                source=ProviderAuthSource.ENV,
+                detail="credentials set",
+            )
     return None
 
 
@@ -2811,31 +2818,11 @@ def get_service_auth_status(service: str) -> ProviderAuthStatus:
         `CONFIGURED` when a stored or env credential is set, else `MISSING`.
     """
     env_var = SERVICE_API_KEY_ENV[service]
-    if _has_stored_credential(service):
-        return ProviderAuthStatus(
-            state=ProviderAuthState.CONFIGURED,
-            provider=service,
-            env_var=env_var,
-            source=ProviderAuthSource.STORED,
-            detail="stored credential",
-        )
-    if resolve_env_var(env_var):
-        return ProviderAuthStatus(
-            state=ProviderAuthState.CONFIGURED,
-            provider=service,
-            env_var=env_var,
-            source=ProviderAuthSource.ENV,
-            detail="credentials set",
-        )
-    for fallback_env_var in SERVICE_API_KEY_FALLBACK_ENV_VARS.get(service, ()):
-        if resolve_env_var(fallback_env_var):
-            return ProviderAuthStatus(
-                state=ProviderAuthState.CONFIGURED,
-                provider=service,
-                env_var=fallback_env_var,
-                source=ProviderAuthSource.ENV,
-                detail="credentials set",
-            )
+    configured = _resolve_configured(
+        service, env_var, SERVICE_API_KEY_FALLBACK_ENV_VARS.get(service, ())
+    )
+    if configured:
+        return configured
     return ProviderAuthStatus(
         state=ProviderAuthState.MISSING,
         provider=service,

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -2480,12 +2480,14 @@ def _resolve_configured(
     provider: str,
     env_var: str,
     fallback_env_vars: tuple[str, ...] = (),
+    *,
+    allow_stored: bool = True,
 ) -> ProviderAuthStatus | None:
     """Return a `CONFIGURED` status if a stored or env credential is set.
 
     Stored credentials beat env vars (matches `resolve_provider_credential`),
-    except where `stored_key_reaches_runtime` says a prefixed override has
-    already displaced the store.
+    unless the service caller disables stored credentials because a prefixed
+    override prevents them from reaching the runtime.
 
     Args:
         provider: Provider name (e.g., `"anthropic"`).
@@ -2493,13 +2495,12 @@ def _resolve_configured(
             exists. Recorded on the returned status either way.
         fallback_env_vars: Canonical env vars read, in order, when `env_var`
             is unset. The one that resolves is recorded on the status.
+        allow_stored: Whether a stored credential can reach the runtime.
 
     Returns:
         A `CONFIGURED` status, or `None` when no source is set.
     """
-    # Reporting STORED when a prefixed override stands in the way would promise
-    # a credential the app never reads.
-    if stored_key_reaches_runtime(env_var) and _has_stored_credential(provider):
+    if allow_stored and _has_stored_credential(provider):
         return ProviderAuthStatus(
             state=ProviderAuthState.CONFIGURED,
             provider=provider,
@@ -2843,7 +2844,8 @@ def get_service_auth_status(service: str) -> ProviderAuthStatus:
 
     Checks a stored key, then `SERVICE_API_KEY_ENV[service]`, then each entry in
     `SERVICE_API_KEY_FALLBACK_ENV_VARS[service]` in order. Mirrors
-    `get_provider_auth_status`, so a stored key beats the env vars and the
+    `get_provider_auth_status`, except a prefixed override suppresses the stored
+    service key. Otherwise a stored key beats the env vars, and the
     `/auth` manager can render the same `[stored]` / `[env: ...]` / `[missing]`
     badges. Recorded env var names stay canonical; callers resolve the
     `DEEPAGENTS_CODE_` spelling at display time.
@@ -2857,7 +2859,9 @@ def get_service_auth_status(service: str) -> ProviderAuthStatus:
     """
     env_var = SERVICE_API_KEY_ENV[service]
     fallbacks = SERVICE_API_KEY_FALLBACK_ENV_VARS.get(service, ())
-    configured = _resolve_configured(service, env_var, fallbacks)
+    configured = _resolve_configured(
+        service, env_var, fallbacks, allow_stored=stored_key_reaches_runtime(env_var)
+    )
     if configured:
         return configured
     accepted = " or ".join((env_var, *fallbacks))

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -2813,15 +2813,19 @@ def is_langsmith(name: str) -> bool:
 def get_service_auth_status(service: str) -> ProviderAuthStatus:
     """Return credential readiness for a non-model service (e.g. `"tavily"`).
 
-    Mirrors `get_provider_auth_status` but is scoped to `SERVICE_API_KEY_ENV`,
-    so a stored key beats the env var and the `/auth` manager can render the
-    same `[stored]` / `[env: ...]` / `[missing]` badges.
+    Checks a stored key, then `SERVICE_API_KEY_ENV[service]`, then each entry in
+    `SERVICE_API_KEY_FALLBACK_ENV_VARS[service]` in order. Mirrors
+    `get_provider_auth_status`, so a stored key beats the env vars and the
+    `/auth` manager can render the same `[stored]` / `[env: ...]` / `[missing]`
+    badges. Recorded env var names stay canonical; callers resolve the
+    `DEEPAGENTS_CODE_` spelling at display time.
 
     Args:
         service: Service name (e.g. `"tavily"`).
 
     Returns:
-        `CONFIGURED` when a stored or env credential is set, else `MISSING`.
+        `CONFIGURED` when a stored, env, or fallback env credential is set,
+            else `MISSING`.
     """
     env_var = SERVICE_API_KEY_ENV[service]
     configured = _resolve_configured(
@@ -2829,11 +2833,14 @@ def get_service_auth_status(service: str) -> ProviderAuthStatus:
     )
     if configured:
         return configured
+    accepted = " or ".join(
+        (env_var, *SERVICE_API_KEY_FALLBACK_ENV_VARS.get(service, ()))
+    )
     return ProviderAuthStatus(
         state=ProviderAuthState.MISSING,
         provider=service,
         env_var=env_var,
-        detail=f"{env_var} is not set or is empty",
+        detail=f"{accepted} is not set or is empty",
     )
 
 

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -2823,7 +2823,7 @@ def get_service_auth_status(service: str) -> ProviderAuthStatus:
         return ProviderAuthStatus(
             state=ProviderAuthState.CONFIGURED,
             provider=service,
-            env_var=resolved_env_var_name(env_var),
+            env_var=env_var,
             source=ProviderAuthSource.ENV,
             detail="credentials set",
         )
@@ -2832,7 +2832,7 @@ def get_service_auth_status(service: str) -> ProviderAuthStatus:
             return ProviderAuthStatus(
                 state=ProviderAuthState.CONFIGURED,
                 provider=service,
-                env_var=resolved_env_var_name(fallback_env_var),
+                env_var=fallback_env_var,
                 source=ProviderAuthSource.ENV,
                 detail="credentials set",
             )

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -56,6 +56,25 @@ def reset_env_resolution_log() -> None:
         _resolved_env_var_log_names.clear()
 
 
+def stored_key_reaches_runtime(env_var: str) -> bool:
+    """Whether a stored credential copied onto `env_var` would be read.
+
+    A present `DEEPAGENTS_CODE_` override outranks the store: the apply pass
+    skips the copy outright, and the canonical name it would have written is
+    then ignored by `resolve_env_var`. That holds even when the override is
+    empty, which suppresses the canonical name entirely.
+
+    Args:
+        env_var: Canonical env var name the store would be copied onto.
+
+    Returns:
+        `True` when no prefixed override stands in the way.
+    """
+    if env_var.startswith(_ENV_PREFIX):
+        return True
+    return f"{_ENV_PREFIX}{env_var}" not in os.environ
+
+
 def resolved_env_var_name(canonical: str) -> str:
     """Return whichever env var name actually carries the resolved value.
 
@@ -417,11 +436,16 @@ class ProviderAuthStatus:
         return True
 
     def missing_detail(self) -> str:
-        """Return a user-facing reason for a missing-credential status."""
-        if self.env_var:
-            return f"{self.env_var} is not set or is empty"
+        """Return a user-facing reason for a missing-credential status.
+
+        `detail` wins over the `env_var` template because a status that names
+        several accepted variables (a service with fallbacks) has already
+        spelled the fuller sentence there.
+        """
         if self.detail:
             return self.detail
+        if self.env_var:
+            return f"{self.env_var} is not set or is empty"
         return (
             f"provider '{self.provider}' is not recognized. "
             f"Add it to {PATHS.display(PATHS.profile.config_file)} with an "
@@ -2459,7 +2483,9 @@ def _resolve_configured(
 ) -> ProviderAuthStatus | None:
     """Return a `CONFIGURED` status if a stored or env credential is set.
 
-    Stored credentials beat env vars (matches `resolve_provider_credential`).
+    Stored credentials beat env vars (matches `resolve_provider_credential`),
+    except where `stored_key_reaches_runtime` says a prefixed override has
+    already displaced the store.
 
     Args:
         provider: Provider name (e.g., `"anthropic"`).
@@ -2471,17 +2497,9 @@ def _resolve_configured(
     Returns:
         A `CONFIGURED` status, or `None` when no source is set.
     """
-    # A present `DEEPAGENTS_CODE_` override outranks the store at runtime:
-    # `apply_stored_service_credentials` skips the copy outright, and
-    # `apply_stored_credentials` writes only the canonical name, which
-    # `resolve_env_var` then ignores. Reporting STORED here would promise a
-    # credential the app never reads -- including when the override is empty,
-    # which suppresses the canonical name entirely.
-    prefixed = f"{_ENV_PREFIX}{env_var}"
-    stored_is_authoritative = env_var.startswith(_ENV_PREFIX) or (
-        prefixed not in os.environ
-    )
-    if stored_is_authoritative and _has_stored_credential(provider):
+    # Reporting STORED when a prefixed override stands in the way would promise
+    # a credential the app never reads.
+    if stored_key_reaches_runtime(env_var) and _has_stored_credential(provider):
         return ProviderAuthStatus(
             state=ProviderAuthState.CONFIGURED,
             provider=provider,
@@ -2838,14 +2856,11 @@ def get_service_auth_status(service: str) -> ProviderAuthStatus:
             else `MISSING`.
     """
     env_var = SERVICE_API_KEY_ENV[service]
-    configured = _resolve_configured(
-        service, env_var, SERVICE_API_KEY_FALLBACK_ENV_VARS.get(service, ())
-    )
+    fallbacks = SERVICE_API_KEY_FALLBACK_ENV_VARS.get(service, ())
+    configured = _resolve_configured(service, env_var, fallbacks)
     if configured:
         return configured
-    accepted = " or ".join(
-        (env_var, *SERVICE_API_KEY_FALLBACK_ENV_VARS.get(service, ()))
-    )
+    accepted = " or ".join((env_var, *fallbacks))
     return ProviderAuthStatus(
         state=ProviderAuthState.MISSING,
         provider=service,
@@ -2876,8 +2891,7 @@ def apply_stored_service_credentials() -> None:
             continue
         if not stored:
             continue
-        prefixed = f"{_ENV_PREFIX}{env_var}"
-        if prefixed in os.environ:
+        if not stored_key_reaches_runtime(env_var):
             continue
         if os.environ.get(env_var) != stored:
             os.environ[env_var] = stored

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -26,7 +26,10 @@ from urllib.parse import urlparse
 import tomli_w
 
 from deepagents_code import _env_vars, auth_store
-from deepagents_code._constants import LANGSMITH_API_KEY_ENV_VARS
+from deepagents_code._constants import (
+    LANGSMITH_API_KEY_ENV,
+    LANGSMITH_API_KEY_FALLBACK_ENV_VARS,
+)
 from deepagents_code._git import find_git_common_dir
 from deepagents_code._paths import PATHS
 from deepagents_code.configuration.writer import USER_CONFIG_WRITE_LOCK
@@ -968,7 +971,7 @@ constant is the single name its `/auth` handling compares against.
 """
 
 SERVICE_API_KEY_ENV: dict[str, str] = {
-    LANGSMITH_SERVICE: "LANGSMITH_API_KEY",
+    LANGSMITH_SERVICE: LANGSMITH_API_KEY_ENV,
     TAVILY_SERVICE: "TAVILY_API_KEY",
 }
 """Non-model services configurable via `/auth`, mapped to their API-key env var.
@@ -981,9 +984,12 @@ before launch.
 """
 
 SERVICE_API_KEY_FALLBACK_ENV_VARS: dict[str, tuple[str, ...]] = {
-    LANGSMITH_SERVICE: LANGSMITH_API_KEY_ENV_VARS[1:],
+    LANGSMITH_SERVICE: LANGSMITH_API_KEY_FALLBACK_ENV_VARS,
 }
-"""Ordered fallback env vars accepted by each non-model service runtime."""
+"""Fallback env vars per non-model service, tried after its primary env var.
+
+A service absent from this map has no fallbacks.
+"""
 
 CODEX_PROVIDER = "openai_codex"
 """Provider name for `_ChatOpenAICodex` models authenticated via ChatGPT OAuth.

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -2471,7 +2471,17 @@ def _resolve_configured(
     Returns:
         A `CONFIGURED` status, or `None` when no source is set.
     """
-    if _has_stored_credential(provider):
+    # A present `DEEPAGENTS_CODE_` override outranks the store at runtime:
+    # `apply_stored_service_credentials` skips the copy outright, and
+    # `apply_stored_credentials` writes only the canonical name, which
+    # `resolve_env_var` then ignores. Reporting STORED here would promise a
+    # credential the app never reads -- including when the override is empty,
+    # which suppresses the canonical name entirely.
+    prefixed = f"{_ENV_PREFIX}{env_var}"
+    stored_is_authoritative = env_var.startswith(_ENV_PREFIX) or (
+        prefixed not in os.environ
+    )
+    if stored_is_authoritative and _has_stored_credential(provider):
         return ProviderAuthStatus(
             state=ProviderAuthState.CONFIGURED,
             provider=provider,

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -1430,11 +1430,13 @@ class TestWorkspaceStoredCredentials:
         assert kwargs["aws_session_token"] == "test-session-token"
         assert all(name not in os.environ for name in aws_environment)
 
+    @pytest.mark.parametrize("override", [None, "", "from-prefix"])
     @patch("langchain.chat_models.init_chat_model")
     def test_stored_key_and_endpoint_do_not_mutate_process_environment(
         self,
         mock_init_chat_model: Mock,
         monkeypatch: pytest.MonkeyPatch,
+        override: str | None,
     ) -> None:
         """Scoped model creation passes stored auth explicitly."""
         import os
@@ -1457,7 +1459,10 @@ class TestWorkspaceStoredCredentials:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
-        with use_environment({}):
+        environment = (
+            {} if override is None else {"DEEPAGENTS_CODE_OPENAI_API_KEY": override}
+        )
+        with use_environment(environment):
             create_model("openai:gpt-5.5")
 
         kwargs = mock_init_chat_model.call_args.kwargs

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -688,7 +688,10 @@ def test_resolve_langsmith_service_prefers_stored(monkeypatch):
     option = get_option("credentials.langsmith")
     assert option is not None
     assert option.redacted is True
-    assert option.fallback_env_vars == ("LANGCHAIN_API_KEY",)
+    assert option.fallback_env_vars == (
+        "DEEPAGENTS_CODE_LANGCHAIN_API_KEY",
+        "LANGCHAIN_API_KEY",
+    )
     is_set, source, value = _resolve(option, {}, managed_toml_data={})
     assert is_set is True
     assert source == "stored"
@@ -714,6 +717,7 @@ def test_resolve_langsmith_falls_back_to_langchain_api_key(monkeypatch):
     """LangSmith credential display reports the runtime fallback source."""
     monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
     monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", raising=False)
     monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
     option = get_option("credentials.langsmith")
     assert option is not None
@@ -723,9 +727,24 @@ def test_resolve_langsmith_falls_back_to_langchain_api_key(monkeypatch):
     assert value == "from-fallback"
 
 
+def test_resolve_langsmith_falls_back_to_prefixed_langchain_api_key(monkeypatch):
+    """LangSmith credential display honors the prefixed runtime fallback."""
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", raising=False)
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
+    monkeypatch.setenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", "from-prefix")
+    option = get_option("credentials.langsmith")
+    assert option is not None
+    is_set, source, value = _resolve(option, {}, managed_toml_data={})
+    assert is_set is True
+    assert source == "env (DEEPAGENTS_CODE_LANGCHAIN_API_KEY)"
+    assert value == "from-prefix"
+
+
 def test_resolve_langsmith_primary_env_wins_over_fallback(monkeypatch):
     """The primary LangSmith env var retains precedence over its fallback."""
     monkeypatch.setenv("LANGSMITH_API_KEY", "from-primary")
+    monkeypatch.setenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", "from-prefix")
     monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
     option = get_option("credentials.langsmith")
     assert option is not None

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -30,7 +30,11 @@ from deepagents_code.config_manifest import (
     get_option,
     options_with_key_prefix,
 )
-from deepagents_code.model_config import DEFAULT_STARTUP_MODE, PROVIDER_API_KEY_ENV
+from deepagents_code.model_config import (
+    DEFAULT_STARTUP_MODE,
+    PROVIDER_API_KEY_ENV,
+    SERVICE_API_KEY_ENV,
+)
 from unit_tests.conftest import resolve_option_for_test
 
 if TYPE_CHECKING:
@@ -68,6 +72,15 @@ def test_manifest_covers_every_provider_credential() -> None:
     missing = set(PROVIDER_API_KEY_ENV.values()) - manifest_env_vars
     assert not missing, (
         f"Provider credential env vars without a manifest entry: {sorted(missing)}."
+    )
+
+
+def test_manifest_covers_every_service_credential() -> None:
+    """Every service in `SERVICE_API_KEY_ENV` must have a credential option."""
+    manifest_env_vars = {opt.env_var for opt in get_config_options() if opt.env_var}
+    missing = set(SERVICE_API_KEY_ENV.values()) - manifest_env_vars
+    assert not missing, (
+        f"Service credential env vars without a manifest entry: {sorted(missing)}."
     )
 
 
@@ -661,6 +674,65 @@ def test_resolve_non_credential_ignores_store():
     assert option is not None
     _, source, _ = _resolve(option, {}, managed_toml_data={})
     assert source != "stored"
+
+
+@pytest.mark.usefixtures("stored_auth_dir")
+def test_resolve_langsmith_service_prefers_stored(monkeypatch):
+    """A stored LangSmith key resolves with a stored source."""
+    from deepagents_code import auth_store
+
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    auth_store.set_stored_key("langsmith", "from-store")
+    option = get_option("credentials.langsmith")
+    assert option is not None
+    assert option.redacted is True
+    assert option.fallback_env_vars == ("LANGCHAIN_API_KEY",)
+    is_set, source, value = _resolve(option, {}, managed_toml_data={})
+    assert is_set is True
+    assert source == "stored"
+    assert value == "from-store"
+
+
+@pytest.mark.usefixtures("stored_auth_dir")
+def test_resolve_langsmith_prefixed_env_overrides_stored(monkeypatch):
+    """A prefixed LangSmith env var wins over the stored key."""
+    from deepagents_code import auth_store
+
+    monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "from-prefix")
+    auth_store.set_stored_key("langsmith", "from-store")
+    option = get_option("credentials.langsmith")
+    assert option is not None
+    is_set, source, value = _resolve(option, {}, managed_toml_data={})
+    assert is_set is True
+    assert source == "env (DEEPAGENTS_CODE_LANGSMITH_API_KEY)"
+    assert value == "from-prefix"
+
+
+def test_resolve_langsmith_falls_back_to_langchain_api_key(monkeypatch):
+    """LangSmith credential display reports the runtime fallback source."""
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", raising=False)
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
+    option = get_option("credentials.langsmith")
+    assert option is not None
+    is_set, source, value = _resolve(option, {}, managed_toml_data={})
+    assert is_set is True
+    assert source == "env (LANGCHAIN_API_KEY)"
+    assert value == "from-fallback"
+
+
+def test_resolve_langsmith_primary_env_wins_over_fallback(monkeypatch):
+    """The primary LangSmith env var retains precedence over its fallback."""
+    monkeypatch.setenv("LANGSMITH_API_KEY", "from-primary")
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
+    option = get_option("credentials.langsmith")
+    assert option is not None
+    is_set, source, value = _resolve(option, {}, managed_toml_data={})
+    assert is_set is True
+    assert source == "env (LANGSMITH_API_KEY)"
+    assert value == "from-primary"
 
 
 @pytest.mark.usefixtures("stored_auth_dir")

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -709,6 +709,7 @@ def test_resolve_langsmith_prefixed_env_overrides_stored(monkeypatch):
     assert value == "from-prefix"
 
 
+@pytest.mark.usefixtures("stored_auth_dir")
 def test_resolve_langsmith_falls_back_to_langchain_api_key(monkeypatch):
     """LangSmith credential display reports the runtime fallback source."""
     monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
@@ -723,6 +724,7 @@ def test_resolve_langsmith_falls_back_to_langchain_api_key(monkeypatch):
     assert value == "from-fallback"
 
 
+@pytest.mark.usefixtures("stored_auth_dir")
 def test_resolve_langsmith_falls_back_to_prefixed_langchain_api_key(monkeypatch):
     """LangSmith credential display honors the prefixed runtime fallback."""
     monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
@@ -770,6 +772,7 @@ def test_resolve_langsmith_empty_prefixed_fallback_shadows_canonical(
     )
 
 
+@pytest.mark.usefixtures("stored_auth_dir")
 def test_resolve_langsmith_primary_env_wins_over_fallback(monkeypatch):
     """The primary LangSmith env var retains precedence over its fallback."""
     monkeypatch.setenv("LANGSMITH_API_KEY", "from-primary")

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -30,11 +30,7 @@ from deepagents_code.config_manifest import (
     get_option,
     options_with_key_prefix,
 )
-from deepagents_code.model_config import (
-    DEFAULT_STARTUP_MODE,
-    PROVIDER_API_KEY_ENV,
-    SERVICE_API_KEY_ENV,
-)
+from deepagents_code.model_config import DEFAULT_STARTUP_MODE, PROVIDER_API_KEY_ENV
 from unit_tests.conftest import resolve_option_for_test
 
 if TYPE_CHECKING:
@@ -66,16 +62,12 @@ def _resolve_manifest_option(
 # --- Drift / coverage -------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    ("label", "registry"),
-    [("Provider", PROVIDER_API_KEY_ENV), ("Service", SERVICE_API_KEY_ENV)],
-)
-def test_manifest_covers_every_credential(label: str, registry: dict[str, str]) -> None:
-    """Every provider and service credential must have a manifest option."""
+def test_manifest_covers_every_provider_credential() -> None:
+    """Every provider in `PROVIDER_API_KEY_ENV` must have a credential option."""
     manifest_env_vars = {opt.env_var for opt in get_config_options() if opt.env_var}
-    missing = set(registry.values()) - manifest_env_vars
+    missing = set(PROVIDER_API_KEY_ENV.values()) - manifest_env_vars
     assert not missing, (
-        f"{label} credential env vars without a manifest entry: {sorted(missing)}."
+        f"Provider credential env vars without a manifest entry: {sorted(missing)}."
     )
 
 
@@ -701,33 +693,6 @@ def test_resolve_langsmith_service_prefers_stored():
     assert is_set is True
     assert source == "stored"
     assert value == "from-store"
-
-
-@pytest.mark.usefixtures("stored_auth_dir", "clear_langsmith_env")
-def test_resolve_langsmith_prefixed_env_overrides_stored(monkeypatch):
-    """A prefixed LangSmith env var wins over the stored key."""
-    from deepagents_code import auth_store
-
-    monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "from-prefix")
-    auth_store.set_stored_key("langsmith", "from-store")
-    option = get_option("credentials.langsmith")
-    assert option is not None
-    is_set, source, value = _resolve(option, {}, managed_toml_data={})
-    assert is_set is True
-    assert source == "env (DEEPAGENTS_CODE_LANGSMITH_API_KEY)"
-    assert value == "from-prefix"
-
-
-@pytest.mark.usefixtures("stored_auth_dir", "clear_langsmith_env")
-def test_resolve_langsmith_falls_back_to_langchain_api_key(monkeypatch):
-    """LangSmith credential display reports the runtime fallback source."""
-    monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
-    option = get_option("credentials.langsmith")
-    assert option is not None
-    is_set, source, value = _resolve(option, {}, managed_toml_data={})
-    assert is_set is True
-    assert source == "env (LANGCHAIN_API_KEY)"
-    assert value == "from-fallback"
 
 
 @pytest.mark.usefixtures("stored_auth_dir", "clear_langsmith_env")

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -66,21 +66,16 @@ def _resolve_manifest_option(
 # --- Drift / coverage -------------------------------------------------------
 
 
-def test_manifest_covers_every_provider_credential() -> None:
-    """Every provider in `PROVIDER_API_KEY_ENV` must have a credential option."""
+@pytest.mark.parametrize(
+    ("label", "registry"),
+    [("Provider", PROVIDER_API_KEY_ENV), ("Service", SERVICE_API_KEY_ENV)],
+)
+def test_manifest_covers_every_credential(label: str, registry: dict[str, str]) -> None:
+    """Every provider and service credential must have a manifest option."""
     manifest_env_vars = {opt.env_var for opt in get_config_options() if opt.env_var}
-    missing = set(PROVIDER_API_KEY_ENV.values()) - manifest_env_vars
+    missing = set(registry.values()) - manifest_env_vars
     assert not missing, (
-        f"Provider credential env vars without a manifest entry: {sorted(missing)}."
-    )
-
-
-def test_manifest_covers_every_service_credential() -> None:
-    """Every service in `SERVICE_API_KEY_ENV` must have a credential option."""
-    manifest_env_vars = {opt.env_var for opt in get_config_options() if opt.env_var}
-    missing = set(SERVICE_API_KEY_ENV.values()) - manifest_env_vars
-    assert not missing, (
-        f"Service credential env vars without a manifest entry: {sorted(missing)}."
+        f"{label} credential env vars without a manifest entry: {sorted(missing)}."
     )
 
 
@@ -676,14 +671,28 @@ def test_resolve_non_credential_ignores_store():
     assert source != "stored"
 
 
-@pytest.mark.usefixtures("stored_auth_dir")
-def test_resolve_langsmith_service_prefers_stored(monkeypatch):
+@pytest.fixture
+def clear_langsmith_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every LangSmith key name so each test declares its own state.
+
+    Not autouse: these are module-level functions, so it would leak into
+    unrelated tests. Sharing it keeps the four names from drifting apart
+    test-by-test.
+    """
+    for var in (
+        "LANGSMITH_API_KEY",
+        "DEEPAGENTS_CODE_LANGSMITH_API_KEY",
+        "LANGCHAIN_API_KEY",
+        "DEEPAGENTS_CODE_LANGCHAIN_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.usefixtures("stored_auth_dir", "clear_langsmith_env")
+def test_resolve_langsmith_service_prefers_stored():
     """A stored LangSmith key resolves with a stored source."""
     from deepagents_code import auth_store
 
-    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
-    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", raising=False)
-    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
     auth_store.set_stored_key("langsmith", "from-store")
     option = get_option("credentials.langsmith")
     assert option is not None
@@ -694,7 +703,7 @@ def test_resolve_langsmith_service_prefers_stored(monkeypatch):
     assert value == "from-store"
 
 
-@pytest.mark.usefixtures("stored_auth_dir")
+@pytest.mark.usefixtures("stored_auth_dir", "clear_langsmith_env")
 def test_resolve_langsmith_prefixed_env_overrides_stored(monkeypatch):
     """A prefixed LangSmith env var wins over the stored key."""
     from deepagents_code import auth_store
@@ -709,12 +718,9 @@ def test_resolve_langsmith_prefixed_env_overrides_stored(monkeypatch):
     assert value == "from-prefix"
 
 
-@pytest.mark.usefixtures("stored_auth_dir")
+@pytest.mark.usefixtures("stored_auth_dir", "clear_langsmith_env")
 def test_resolve_langsmith_falls_back_to_langchain_api_key(monkeypatch):
     """LangSmith credential display reports the runtime fallback source."""
-    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
-    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", raising=False)
-    monkeypatch.delenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", raising=False)
     monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
     option = get_option("credentials.langsmith")
     assert option is not None
@@ -724,11 +730,9 @@ def test_resolve_langsmith_falls_back_to_langchain_api_key(monkeypatch):
     assert value == "from-fallback"
 
 
-@pytest.mark.usefixtures("stored_auth_dir")
+@pytest.mark.usefixtures("stored_auth_dir", "clear_langsmith_env")
 def test_resolve_langsmith_falls_back_to_prefixed_langchain_api_key(monkeypatch):
     """LangSmith credential display honors the prefixed runtime fallback."""
-    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
-    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", raising=False)
     monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
     monkeypatch.setenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", "from-prefix")
     option = get_option("credentials.langsmith")
@@ -739,7 +743,7 @@ def test_resolve_langsmith_falls_back_to_prefixed_langchain_api_key(monkeypatch)
     assert value == "from-prefix"
 
 
-@pytest.mark.usefixtures("stored_auth_dir")
+@pytest.mark.usefixtures("stored_auth_dir", "clear_langsmith_env")
 def test_resolve_langsmith_empty_prefixed_fallback_shadows_canonical(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -749,15 +753,10 @@ def test_resolve_langsmith_empty_prefixed_fallback_shadows_canonical(
         get_service_auth_status,
     )
 
-    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
-    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", raising=False)
-    monkeypatch.delenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", raising=False)
     monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
     option = get_option("credentials.langsmith")
     assert option is not None
-    assert _resolve(option, {}, managed_toml_data={})[0] is True
 
-    # Reuse the manifest entry so prefix selection must happen at resolution.
     monkeypatch.setenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", "")
     assert get_service_auth_status("langsmith").state is ProviderAuthState.MISSING
     is_set, _, value = _resolve(option, {}, managed_toml_data={})
@@ -772,7 +771,7 @@ def test_resolve_langsmith_empty_prefixed_fallback_shadows_canonical(
     )
 
 
-@pytest.mark.usefixtures("stored_auth_dir")
+@pytest.mark.usefixtures("stored_auth_dir", "clear_langsmith_env")
 def test_stored_key_with_empty_prefixed_primary_agrees_across_surfaces(monkeypatch):
     """`config` and `auth status` agree once a fallback can outrank the store."""
     from deepagents_code import auth_store
@@ -784,8 +783,6 @@ def test_stored_key_with_empty_prefixed_primary_agrees_across_surfaces(monkeypat
 
     auth_store.set_stored_key("langsmith", "from-store")
     monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "")
-    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
-    monkeypatch.delenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", raising=False)
     monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
 
     option = get_option("credentials.langsmith")
@@ -802,7 +799,7 @@ def test_stored_key_with_empty_prefixed_primary_agrees_across_surfaces(monkeypat
     assert status.env_var == "LANGCHAIN_API_KEY"
 
 
-@pytest.mark.usefixtures("stored_auth_dir")
+@pytest.mark.usefixtures("stored_auth_dir", "clear_langsmith_env")
 def test_resolve_langsmith_primary_env_wins_over_fallback(monkeypatch):
     """The primary LangSmith env var retains precedence over its fallback."""
     monkeypatch.setenv("LANGSMITH_API_KEY", "from-primary")

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -773,6 +773,36 @@ def test_resolve_langsmith_empty_prefixed_fallback_shadows_canonical(
 
 
 @pytest.mark.usefixtures("stored_auth_dir")
+def test_stored_key_with_empty_prefixed_primary_agrees_across_surfaces(monkeypatch):
+    """`config` and `auth status` agree once a fallback can outrank the store."""
+    from deepagents_code import auth_store
+    from deepagents_code.model_config import (
+        ProviderAuthSource,
+        ProviderAuthState,
+        get_service_auth_status,
+    )
+
+    auth_store.set_stored_key("langsmith", "from-store")
+    monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "")
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
+
+    option = get_option("credentials.langsmith")
+    assert option is not None
+    assert _resolve(option, {}, managed_toml_data={}) == (
+        True,
+        "env (LANGCHAIN_API_KEY)",
+        "from-fallback",
+    )
+
+    status = get_service_auth_status("langsmith")
+    assert status.state is ProviderAuthState.CONFIGURED
+    assert status.source is ProviderAuthSource.ENV
+    assert status.env_var == "LANGCHAIN_API_KEY"
+
+
+@pytest.mark.usefixtures("stored_auth_dir")
 def test_resolve_langsmith_primary_env_wins_over_fallback(monkeypatch):
     """The primary LangSmith env var retains precedence over its fallback."""
     monkeypatch.setenv("LANGSMITH_API_KEY", "from-primary")

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -688,10 +688,6 @@ def test_resolve_langsmith_service_prefers_stored(monkeypatch):
     option = get_option("credentials.langsmith")
     assert option is not None
     assert option.redacted is True
-    assert option.fallback_env_vars == (
-        "DEEPAGENTS_CODE_LANGCHAIN_API_KEY",
-        "LANGCHAIN_API_KEY",
-    )
     is_set, source, value = _resolve(option, {}, managed_toml_data={})
     assert is_set is True
     assert source == "stored"
@@ -739,6 +735,39 @@ def test_resolve_langsmith_falls_back_to_prefixed_langchain_api_key(monkeypatch)
     assert is_set is True
     assert source == "env (DEEPAGENTS_CODE_LANGCHAIN_API_KEY)"
     assert value == "from-prefix"
+
+
+@pytest.mark.usefixtures("stored_auth_dir")
+def test_resolve_langsmith_empty_prefixed_fallback_shadows_canonical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty fallback override keeps config display aligned with runtime."""
+    from deepagents_code.model_config import (
+        ProviderAuthState,
+        get_service_auth_status,
+    )
+
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
+    option = get_option("credentials.langsmith")
+    assert option is not None
+    assert _resolve(option, {}, managed_toml_data={})[0] is True
+
+    # Reuse the manifest entry so prefix selection must happen at resolution.
+    monkeypatch.setenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", "")
+    assert get_service_auth_status("langsmith").state is ProviderAuthState.MISSING
+    is_set, _, value = _resolve(option, {}, managed_toml_data={})
+    assert is_set is False
+    assert value is None
+
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY")
+    assert _resolve(option, {}, managed_toml_data={}) == (
+        True,
+        "env (LANGCHAIN_API_KEY)",
+        "from-fallback",
+    )
 
 
 def test_resolve_langsmith_primary_env_wins_over_fallback(monkeypatch):

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -841,9 +841,16 @@ class TestServiceCredentials:
     """Non-model services (e.g. Tavily) resolve and apply stored keys."""
 
     @pytest.fixture(autouse=True)
-    def _clear_tavily_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Strip Tavily env vars so each test controls its own state."""
-        for var in ("TAVILY_API_KEY", "DEEPAGENTS_CODE_TAVILY_API_KEY"):
+    def _clear_service_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Strip service env vars so each test controls its own state."""
+        for var in (
+            "TAVILY_API_KEY",
+            "DEEPAGENTS_CODE_TAVILY_API_KEY",
+            "LANGSMITH_API_KEY",
+            "DEEPAGENTS_CODE_LANGSMITH_API_KEY",
+            "LANGCHAIN_API_KEY",
+            "DEEPAGENTS_CODE_LANGCHAIN_API_KEY",
+        ):
             monkeypatch.delenv(var, raising=False)
 
     def test_apply_exports_stored_langsmith_key(
@@ -885,6 +892,35 @@ class TestServiceCredentials:
         status = get_service_auth_status("tavily")
         assert status.state is ProviderAuthState.CONFIGURED
         assert status.source is ProviderAuthSource.ENV
+
+    def test_langsmith_status_uses_langchain_fallback(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """LangSmith status reports the runtime's fallback env var."""
+        from deepagents_code.model_config import get_service_auth_status
+
+        monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
+        status = get_service_auth_status("langsmith")
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.source is ProviderAuthSource.ENV
+        assert status.env_var == "LANGCHAIN_API_KEY"
+
+    def test_langsmith_status_primary_wins_over_fallback(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """LangSmith status reports its primary env var when both are set."""
+        from deepagents_code.model_config import get_service_auth_status
+
+        monkeypatch.setenv("LANGSMITH_API_KEY", "from-primary")
+        monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
+        status = get_service_auth_status("langsmith")
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.source is ProviderAuthSource.ENV
+        assert status.env_var == "LANGSMITH_API_KEY"
 
     def test_status_configured_from_store(
         self,

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -922,6 +922,28 @@ class TestServiceCredentials:
         assert status.source is ProviderAuthSource.ENV
         assert status.env_var == "LANGSMITH_API_KEY"
 
+    def test_service_fallbacks_key_off_known_services(self) -> None:
+        """Every fallback entry names a service that actually exists.
+
+        Both readers use `.get(service, ())`, so a renamed or misspelled key
+        degrades to "no fallbacks" indistinguishably from "none configured".
+        """
+        from deepagents_code.model_config import (
+            SERVICE_API_KEY_ENV,
+            SERVICE_API_KEY_FALLBACK_ENV_VARS,
+        )
+
+        unknown = set(SERVICE_API_KEY_FALLBACK_ENV_VARS) - set(SERVICE_API_KEY_ENV)
+        assert not unknown, f"Fallbacks for unknown services: {sorted(unknown)}."
+
+    def test_service_without_fallbacks_declares_none(self) -> None:
+        """Tavily has no fallback, so its option must not inherit LangSmith's."""
+        from deepagents_code.config_manifest import get_option
+
+        option = get_option("credentials.tavily")
+        assert option is not None
+        assert option.fallback_env_vars == ()
+
     def test_service_status_env_var_stays_canonical(
         self,
         fake_state_dir: Path,  # noqa: ARG002

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -490,15 +490,19 @@ class TestStoredCredentials:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         assert resolve_provider_credential("totally-unknown") is None
 
+    @pytest.mark.parametrize("override", [None, "", "from-prefix"])
     def test_status_reports_stored_credential(
         self,
         fake_state_dir: Path,  # noqa: ARG002
         monkeypatch: pytest.MonkeyPatch,
+        override: str | None,
     ) -> None:
         """A stored key flips status to CONFIGURED with a stored detail."""
         from deepagents_code import auth_store
 
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        if override is not None:
+            monkeypatch.setenv("DEEPAGENTS_CODE_ANTHROPIC_API_KEY", override)
         auth_store.set_stored_key("anthropic", "from-store")
 
         status = get_provider_auth_status("anthropic")

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -922,6 +922,40 @@ class TestServiceCredentials:
         assert status.source is ProviderAuthSource.ENV
         assert status.env_var == "LANGSMITH_API_KEY"
 
+    def test_prefixed_override_outranks_stored_service_key(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A prefixed override reports ENV, because the store never applies."""
+        from deepagents_code import auth_store
+        from deepagents_code.model_config import get_service_auth_status
+
+        auth_store.set_stored_key("langsmith", "from-store")
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "from-prefix")
+        status = get_service_auth_status("langsmith")
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.source is ProviderAuthSource.ENV
+        assert status.env_var == "LANGSMITH_API_KEY"
+
+    def test_empty_prefixed_override_hides_stored_service_key(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An empty override suppresses the store, matching the runtime.
+
+        `apply_stored_service_credentials` skips the copy whenever the prefixed
+        name is present, so the stored key never reaches the SDK. Reporting it
+        as configured would be a promise the app cannot keep.
+        """
+        from deepagents_code import auth_store
+        from deepagents_code.model_config import get_service_auth_status
+
+        auth_store.set_stored_key("langsmith", "from-store")
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "")
+        assert get_service_auth_status("langsmith").state is ProviderAuthState.MISSING
+
     def test_missing_langsmith_detail_names_the_fallback(
         self,
         fake_state_dir: Path,  # noqa: ARG002

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -898,20 +898,6 @@ class TestServiceCredentials:
         assert status.state is ProviderAuthState.CONFIGURED
         assert status.source is ProviderAuthSource.ENV
 
-    def test_langsmith_status_uses_langchain_fallback(
-        self,
-        fake_state_dir: Path,  # noqa: ARG002
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """LangSmith status reports the runtime's fallback env var."""
-        from deepagents_code.model_config import get_service_auth_status
-
-        monkeypatch.setenv("LANGCHAIN_API_KEY", "from-fallback")
-        status = get_service_auth_status("langsmith")
-        assert status.state is ProviderAuthState.CONFIGURED
-        assert status.source is ProviderAuthSource.ENV
-        assert status.env_var == "LANGCHAIN_API_KEY"
-
     def test_langsmith_status_primary_wins_over_fallback(
         self,
         fake_state_dir: Path,  # noqa: ARG002
@@ -972,30 +958,6 @@ class TestServiceCredentials:
         assert status.state is ProviderAuthState.MISSING
         assert status.detail == (
             "LANGSMITH_API_KEY or LANGCHAIN_API_KEY is not set or is empty"
-        )
-
-    def test_service_status_env_var_stays_canonical(
-        self,
-        fake_state_dir: Path,  # noqa: ARG002
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Status carries canonical names; display resolves the prefix.
-
-        `get_provider_auth_status` records canonical names too, so keeping the
-        service path identical stops the two surfaces drifting apart. Every
-        caller renders the label through `resolved_env_var_name`, so the
-        prefixed spelling still reaches the user.
-        """
-        from deepagents_code.model_config import (
-            get_service_auth_status,
-            resolved_env_var_name,
-        )
-
-        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "from-prefix")
-        status = get_service_auth_status("langsmith")
-        assert status.env_var == "LANGSMITH_API_KEY"
-        assert (
-            resolved_env_var_name(status.env_var) == "DEEPAGENTS_CODE_LANGSMITH_API_KEY"
         )
 
     def test_service_fallback_status_env_var_stays_canonical(

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -922,6 +922,48 @@ class TestServiceCredentials:
         assert status.source is ProviderAuthSource.ENV
         assert status.env_var == "LANGSMITH_API_KEY"
 
+    def test_service_status_env_var_stays_canonical(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Status carries canonical names; display resolves the prefix.
+
+        `get_provider_auth_status` records canonical names too, so keeping the
+        service path identical stops the two surfaces drifting apart. Every
+        caller renders the label through `resolved_env_var_name`, so the
+        prefixed spelling still reaches the user.
+        """
+        from deepagents_code.model_config import (
+            get_service_auth_status,
+            resolved_env_var_name,
+        )
+
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "from-prefix")
+        status = get_service_auth_status("langsmith")
+        assert status.env_var == "LANGSMITH_API_KEY"
+        assert (
+            resolved_env_var_name(status.env_var) == "DEEPAGENTS_CODE_LANGSMITH_API_KEY"
+        )
+
+    def test_service_fallback_status_env_var_stays_canonical(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A prefixed fallback also records its canonical spelling."""
+        from deepagents_code.model_config import (
+            get_service_auth_status,
+            resolved_env_var_name,
+        )
+
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGCHAIN_API_KEY", "from-prefix")
+        status = get_service_auth_status("langsmith")
+        assert status.env_var == "LANGCHAIN_API_KEY"
+        assert (
+            resolved_env_var_name(status.env_var) == "DEEPAGENTS_CODE_LANGCHAIN_API_KEY"
+        )
+
     def test_status_configured_from_store(
         self,
         fake_state_dir: Path,  # noqa: ARG002

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -922,6 +922,30 @@ class TestServiceCredentials:
         assert status.source is ProviderAuthSource.ENV
         assert status.env_var == "LANGSMITH_API_KEY"
 
+    def test_missing_langsmith_detail_names_the_fallback(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+    ) -> None:
+        """The MISSING message names every env var that would have worked."""
+        from deepagents_code.model_config import get_service_auth_status
+
+        status = get_service_auth_status("langsmith")
+        assert status.state is ProviderAuthState.MISSING
+        assert status.detail == (
+            "LANGSMITH_API_KEY or LANGCHAIN_API_KEY is not set or is empty"
+        )
+
+    def test_missing_tavily_detail_names_only_its_env_var(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+    ) -> None:
+        """A service without fallbacks keeps a single-variable message."""
+        from deepagents_code.model_config import get_service_auth_status
+
+        status = get_service_auth_status("tavily")
+        assert status.state is ProviderAuthState.MISSING
+        assert status.detail == "TAVILY_API_KEY is not set or is empty"
+
     def test_service_fallbacks_key_off_known_services(self) -> None:
         """Every fallback entry names a service that actually exists.
 

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -879,6 +879,7 @@ class TestServiceCredentials:
         status = get_service_auth_status("tavily")
         assert status.state is ProviderAuthState.MISSING
         assert status.env_var == "TAVILY_API_KEY"
+        assert status.detail == "TAVILY_API_KEY is not set or is empty"
 
     def test_status_configured_from_env(
         self,
@@ -968,39 +969,6 @@ class TestServiceCredentials:
         assert status.detail == (
             "LANGSMITH_API_KEY or LANGCHAIN_API_KEY is not set or is empty"
         )
-
-    def test_missing_tavily_detail_names_only_its_env_var(
-        self,
-        fake_state_dir: Path,  # noqa: ARG002
-    ) -> None:
-        """A service without fallbacks keeps a single-variable message."""
-        from deepagents_code.model_config import get_service_auth_status
-
-        status = get_service_auth_status("tavily")
-        assert status.state is ProviderAuthState.MISSING
-        assert status.detail == "TAVILY_API_KEY is not set or is empty"
-
-    def test_service_fallbacks_key_off_known_services(self) -> None:
-        """Every fallback entry names a service that actually exists.
-
-        Both readers use `.get(service, ())`, so a renamed or misspelled key
-        degrades to "no fallbacks" indistinguishably from "none configured".
-        """
-        from deepagents_code.model_config import (
-            SERVICE_API_KEY_ENV,
-            SERVICE_API_KEY_FALLBACK_ENV_VARS,
-        )
-
-        unknown = set(SERVICE_API_KEY_FALLBACK_ENV_VARS) - set(SERVICE_API_KEY_ENV)
-        assert not unknown, f"Fallbacks for unknown services: {sorted(unknown)}."
-
-    def test_service_without_fallbacks_declares_none(self) -> None:
-        """Tavily has no fallback, so its option must not inherit LangSmith's."""
-        from deepagents_code.config_manifest import get_option
-
-        option = get_option("credentials.tavily")
-        assert option is not None
-        assert option.fallback_env_vars == ()
 
     def test_service_status_env_var_stays_canonical(
         self,


### PR DESCRIPTION
`credentials.langsmith` now appears in `dcode config` with configured/not-configured status and the credential source.

---

`dcode auth ls` and `dcode config` disagreed about which credentials exist, so users could not tell from `config` whether their LangSmith key was picked up.

Credential rows now come from both `PROVIDER_API_KEY_ENV` and `SERVICE_API_KEY_ENV`, removing the hand-maintained Tavily-only list. A service-registry drift test ensures future service credentials cannot silently miss the config surface.

Both `dcode config` and `dcode auth status langsmith` now report the `LANGCHAIN_API_KEY` fallback used by the runtime while preserving `LANGSMITH_API_KEY` precedence and secret redaction.

Made by [Open SWE](https://openswe.vercel.app/agents/8fd3dda1-eaf7-5721-8647-3faa45a690a7)