### PR TITLE
feat(talon): reload MCP configuration without restarting

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -178,6 +178,11 @@ turn after login completes.
 Run `deepagents-talon mcp config` to print the resolved config path. The terminal-only
 `deepagents-talon mcp login <server>` flow remains available as an alternative.
 
+After editing the configuration, send `/mcp-reload` through an authorized channel to
+reload it without restarting Talon. The agent can also call
+`reload_mcp_configuration` autonomously; that schedules the same reload before the
+next agent turn.
+
 Fleet zip exports can be materialized into a Talon-local agent directory before
 starting the host:
 

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -228,6 +228,7 @@ async def _agent_runtime(
         model=config.model,
         tools=mcp.tools,
         refresh_tools=mcp_provider.refresh_if_needed,
+        reload_tools=mcp_provider.reload,
         assistant_dir=config.manifest_dir,
         subagents=async_subagents or None,
         cron_store=cron_store,

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -37,6 +37,7 @@ from deepagents_talon.interfaces import (
     ChannelMessage,
     ChannelReaction,
     CronScheduler,
+    MCPReloadableRuntime,
     ReactionChannelAdapter,
     ToolApprovalDecision,
     ToolApprovalRequest,
@@ -65,7 +66,11 @@ logger = logging.getLogger(__name__)
 
 _STOP_COMMAND = "/stop"
 _NEW_COMMAND = "/new"
+_MCP_RELOAD_COMMAND = "/mcp-reload"
 _NEW_CONVERSATION_MESSAGE = "Started a fresh conversation."
+_MCP_RELOAD_SUCCESS_MESSAGE = "Reloaded MCP configuration."
+_MCP_RELOAD_FAILURE_MESSAGE = "Could not reload MCP configuration. Check Talon logs."
+_MCP_RELOAD_UNAVAILABLE_MESSAGE = "MCP configuration reload is unavailable."
 _APPROVE_REPLIES = frozenset({"approve", "approved", "yes", "y"})
 _DENY_REPLIES = frozenset({"deny", "denied", "reject", "rejected", "no", "n"})
 _RESET_THREAD_SEPARATOR = ":talon-reset:"
@@ -275,6 +280,10 @@ class TalonHost:
                 )
                 return
 
+            if command == _MCP_RELOAD_COMMAND:
+                await self._reload_mcp_configuration(channel, channel_conversation_id)
+                return
+
             pending = self._pending_tool_approvals.get(agent_conversation_id)
             if pending is not None:
                 authorized = pending.sender_id is None or message.sender_id == pending.sender_id
@@ -297,6 +306,23 @@ class TalonHost:
                 agent_conversation_id,
                 provider,
             )
+
+    async def _reload_mcp_configuration(
+        self,
+        channel: ChannelAdapter,
+        conversation_id: str,
+    ) -> None:
+        if not isinstance(self.agent, MCPReloadableRuntime):
+            message = _MCP_RELOAD_UNAVAILABLE_MESSAGE
+        else:
+            try:
+                await self.agent.reload_mcp_configuration()
+            except Exception:  # noqa: BLE001  # Do not disclose config or transport errors.
+                logger.warning("MCP configuration reload failed", exc_info=True)
+                message = _MCP_RELOAD_FAILURE_MESSAGE
+            else:
+                message = _MCP_RELOAD_SUCCESS_MESSAGE
+        await send_with_retry(lambda: channel.send_message(conversation_id, message))
 
     async def receive_reaction(self, channel: ChannelAdapter, reaction: ChannelReaction) -> None:
         """Handle one inbound channel reaction.

--- a/libs/talon/deepagents_talon/interfaces.py
+++ b/libs/talon/deepagents_talon/interfaces.py
@@ -274,3 +274,11 @@ class AgentRuntime(Protocol):
 
     async def recover_interrupted(self, conversation_id: str) -> None:
         """Record an interrupted turn after its latest committed checkpoint."""
+
+
+@runtime_checkable
+class MCPReloadableRuntime(Protocol):
+    """Optional runtime capability for reloading MCP configuration."""
+
+    async def reload_mcp_configuration(self) -> None:
+        """Reload MCP tools without restarting the runtime."""

--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -198,9 +198,14 @@ class MCPToolProvider:
             if not force and revision == self._applied_revision:
                 return None
             try:
-                return (await self.load()).tools
-            finally:
+                tools = (await self.load()).tools
+            except asyncio.CancelledError:
+                raise
+            except BaseException:
                 self._applied_revision = revision
+                raise
+            self._applied_revision = revision
+            return tools
 
     def _reload_tool(self) -> BaseTool:
         @tool(

--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -152,13 +152,14 @@ class MCPTools:
 
 
 class MCPToolProvider:
-    """Load MCP tools and refresh them after first-time channel authorization."""
+    """Load MCP tools and refresh them when their availability changes."""
 
     def __init__(self, config: TalonConfig) -> None:
         """Bind the provider to one Talon configuration."""
         self._config = config
         self._oauth_servers: frozenset[str] = frozenset()
-        self._dirty = False
+        self._refresh_revision = 0
+        self._applied_revision = 0
         self._lock = asyncio.Lock()
 
     async def load(self) -> MCPTools:
@@ -172,18 +173,48 @@ class MCPToolProvider:
             tools = (*tools, self._status_tool(loaded.servers))
         if self._oauth_servers:
             tools = (*tools, self._authorization_tool())
+        tools = (*tools, self._reload_tool())
         return MCPTools(tools=tools, servers=loaded.servers)
 
     async def refresh_if_needed(self) -> Sequence[BaseTool] | None:
-        """Reload MCP schemas once after an authorization changes credentials."""
-        if not self._dirty:
-            return None
+        """Reload MCP schemas once after their availability changes."""
+        return await self._reload(force=False)
+
+    async def reload(self) -> Sequence[BaseTool]:
+        """Reload MCP tools from the configured path."""
+        refreshed = await self._reload(force=True)
+        if refreshed is None:
+            msg = "forced MCP reload did not produce tools"
+            raise RuntimeError(msg)
+        return refreshed
+
+    def request_refresh(self) -> None:
+        """Schedule an MCP configuration reload before the next agent turn."""
+        self._refresh_revision += 1
+
+    async def _reload(self, *, force: bool) -> Sequence[BaseTool] | None:
         async with self._lock:
-            if not self._dirty:
+            revision = self._refresh_revision
+            if not force and revision == self._applied_revision:
                 return None
-            tools = (await self.load()).tools
-            self._dirty = False
-            return tools
+            try:
+                return (await self.load()).tools
+            finally:
+                self._applied_revision = revision
+
+    def _reload_tool(self) -> BaseTool:
+        @tool(
+            "reload_mcp_configuration",
+            description=(
+                "Reload Talon's configured MCP servers before the next agent turn. "
+                "Use after the operator changes the MCP configuration."
+            ),
+        )
+        def reload_mcp_configuration() -> dict[str, str]:
+            self.request_refresh()
+            return {"status": "scheduled", "available": "next_turn"}
+
+        return reload_mcp_configuration
 
     def _status_tool(self, servers: Sequence[MCPServerInfo]) -> BaseTool:
         statuses: tuple[dict[str, object], ...] = tuple(
@@ -268,7 +299,7 @@ class MCPToolProvider:
             )
         except asyncio.CancelledError:
             if attempt.completed:
-                self._dirty = True
+                self._refresh_revision += 1
             raise
         except (
             HTTPError,
@@ -300,7 +331,7 @@ class MCPToolProvider:
             if attempt.binding is None
             else "failed"
         )
-        self._dirty = self._dirty or attempt.completed
+        self._refresh_revision += int(attempt.completed)
         return {"status": status, "server_name": server_name}
 
 

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -304,6 +304,10 @@ class DeepAgentRuntime:
         self.max_retries = max_retries
         self.max_continuations = max_continuations
         self._graph: object | None = None
+        self._invocation_graph: contextvars.ContextVar[object | None] = contextvars.ContextVar(
+            "talon_invocation_graph",
+            default=None,
+        )
         self._tools_lock = asyncio.Lock()
 
     async def start(self) -> None:
@@ -384,6 +388,7 @@ class DeepAgentRuntime:
             raise RuntimeError(msg)
 
         await self._refresh_runtime_tools()
+        graph_token = self._invocation_graph.set(self._graph)
         activity = self._activity_callback(request)
         if activity is not None:
             activity.run_started(request.metadata.get("trigger"))
@@ -398,6 +403,7 @@ class DeepAgentRuntime:
         finally:
             reset_authorization_handler(authorization_token)
             _CRON_ORIGIN.reset(token)
+            self._invocation_graph.reset(graph_token)
         if activity is not None:
             activity.run_completed(text)
         return AgentResult(text=text)
@@ -531,7 +537,10 @@ class DeepAgentRuntime:
         raise RuntimeError(msg)
 
     def _graph_invoke(self) -> Callable[..., Awaitable[object]]:
-        ainvoke = getattr(self._graph, "ainvoke", None)
+        graph = self._invocation_graph.get()
+        if graph is None:
+            graph = self._graph
+        ainvoke = getattr(graph, "ainvoke", None)
         if not callable(ainvoke):
             msg = "Deep Agents graph does not expose async invocation"
             raise TypeError(msg)

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -219,6 +219,7 @@ class DeepAgentRuntime:
             web, and cron tools.
         refresh_tools: Optional callback that supplies replacement runtime tools
             after an external authorization changes their availability.
+        reload_tools: Optional callback that reloads runtime tools on demand.
         system_prompt: Optional system prompt. When omitted and `assistant_dir`
             is supplied, `AGENTS.md` is loaded from that directory.
         subagents: Optional subagent specs available to the main agent.
@@ -250,6 +251,8 @@ class DeepAgentRuntime:
         model: str,
         tools: Sequence[BaseTool | Callable[..., object]] = (),
         refresh_tools: Callable[[], Awaitable[Sequence[BaseTool | Callable[..., object]] | None]]
+        | None = None,
+        reload_tools: Callable[[], Awaitable[Sequence[BaseTool | Callable[..., object]]]]
         | None = None,
         system_prompt: str | None = None,
         subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
@@ -283,6 +286,7 @@ class DeepAgentRuntime:
         self.model = model
         self.tools = tuple(tools)
         self.refresh_tools = refresh_tools
+        self.reload_tools = reload_tools
         self.system_prompt = system_prompt
         self.subagents = tuple(subagents) if subagents is not None else None
         self._has_async_subagents = _has_async_subagents(self.subagents)
@@ -300,13 +304,17 @@ class DeepAgentRuntime:
         self.max_retries = max_retries
         self.max_continuations = max_continuations
         self._graph: object | None = None
+        self._tools_lock = asyncio.Lock()
 
     async def start(self) -> None:
         """Construct the Deep Agents graph."""
         self._graph = self._create_graph()
 
-    def _create_graph(self) -> object:
-        tools = self._build_tools()
+    def _create_graph(
+        self,
+        runtime_tools: Sequence[BaseTool | Callable[..., object]] | None = None,
+    ) -> object:
+        tools = self._build_tools(runtime_tools)
         context_size = _context_size_from_env(self.env)
         model = _resolve_model_from_env(self.model, self.env, context_size=context_size)
         middleware = list(self.middleware)
@@ -397,25 +405,44 @@ class DeepAgentRuntime:
     async def _refresh_runtime_tools(self) -> None:
         if self.refresh_tools is None:
             return
-        refreshed = await self.refresh_tools()
-        if refreshed is None:
-            return
-        self.tools = tuple(refreshed)
-        self._graph = self._create_graph()
+        async with self._tools_lock:
+            refreshed = await self.refresh_tools()
+            if refreshed is not None:
+                self._replace_runtime_tools(refreshed)
+
+    async def reload_mcp_configuration(self) -> None:
+        """Reload MCP tools without restarting the Talon runtime."""
+        if self.reload_tools is None:
+            msg = "MCP configuration reload is unavailable"
+            raise RuntimeError(msg)
+        async with self._tools_lock:
+            self._replace_runtime_tools(await self.reload_tools())
+
+    def _replace_runtime_tools(
+        self,
+        tools: Sequence[BaseTool | Callable[..., object]],
+    ) -> None:
+        replacement = tuple(tools)
+        graph = self._create_graph(replacement)
+        self.tools = replacement
+        self._graph = graph
 
     def _activity_callback(self, request: AgentRequest) -> AgentActivityCallback | None:
         if not agent_activity_logging_enabled(self.env):
             return None
         return AgentActivityCallback(logger, request.conversation_id)
 
-    def _build_tools(self) -> list[BaseTool | Callable[..., object]]:
+    def _build_tools(
+        self,
+        runtime_tools: Sequence[BaseTool | Callable[..., object]] | None = None,
+    ) -> list[BaseTool | Callable[..., object]]:
         tools: list[BaseTool | Callable[..., object]] = [current_time]
         if self.include_web_tools:
             tools.extend([fetch_url, web_search])
         if self.cron_store is not None:
             cron = CronTools(store=self.cron_store, origin=_current_cron_origin)
             tools.extend(cron.as_langchain_tools())
-        tools.extend(self.tools)
+        tools.extend(self.tools if runtime_tools is None else runtime_tools)
         return tools
 
     async def _invoke_until_text(

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -74,6 +74,19 @@ class FailingRecoveryAgent(BlockingAgent):
         raise RuntimeError(message)
 
 
+class ReloadableAgent(BlockingAgent):
+    def __init__(self, *, fail_reload: bool = False) -> None:
+        super().__init__()
+        self.fail_reload = fail_reload
+        self.reloads = 0
+
+    async def reload_mcp_configuration(self) -> None:
+        self.reloads += 1
+        if self.fail_reload:
+            message = "sensitive reload failure"
+            raise RuntimeError(message)
+
+
 class CancellationResistantAgent(BlockingAgent):
     async def invoke(self, request: AgentRequest) -> AgentResult:
         self.requests.append(request)
@@ -543,6 +556,61 @@ async def test_new_command_cancels_in_flight_conversation(tmp_path: Path) -> Non
         ("chat", "Started a fresh conversation."),
         ("chat", "reply:second"),
     ]
+
+
+async def test_mcp_reload_command_reloads_without_invoking_agent(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = ReloadableAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    await host.receive_message(
+        channel,
+        ChannelMessage(conversation_id="chat", text="/mcp-reload@TestBot"),
+    )
+    await host.stop()
+
+    assert agent.reloads == 1
+    assert agent.requests == []
+    assert channel.sent == [("chat", "Reloaded MCP configuration.")]
+
+
+async def test_mcp_reload_command_hides_reload_errors(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    channel = RecordingChannel()
+    agent = ReloadableAgent(fail_reload=True)
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    await host.receive_message(
+        channel,
+        ChannelMessage(conversation_id="chat", text="/mcp-reload"),
+    )
+    await host.stop()
+
+    assert channel.sent == [
+        ("chat", "Could not reload MCP configuration. Check Talon logs."),
+    ]
+    assert "MCP configuration reload failed" in caplog.text
+    assert "sensitive reload failure" not in channel.sent[0][1]
+
+
+async def test_mcp_reload_command_reports_unavailable_runtime(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    await host.receive_message(
+        channel,
+        ChannelMessage(conversation_id="chat", text="/mcp-reload"),
+    )
+    await host.stop()
+
+    assert agent.requests == []
+    assert channel.sent == [("chat", "MCP configuration reload is unavailable.")]
 
 
 async def test_new_recovers_old_thread_before_reset(tmp_path: Path) -> None:

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -99,6 +99,19 @@ def _config(tmp_path: Path, env: dict[str, str] | None = None) -> TalonConfig:
     )
 
 
+async def _assert_refresh_scheduled(
+    provider: MCPToolProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def load() -> SimpleNamespace:
+        return SimpleNamespace(tools=(DummyTool("refreshed"),))
+
+    monkeypatch.setattr(provider, "load", load)
+    refreshed = await provider.refresh_if_needed()
+    assert refreshed is not None
+    assert [tool.name for tool in refreshed] == ["refreshed"]
+
+
 def test_mcp_metadata_contracts_are_talon_owned() -> None:
     tool = MCPToolInfo(
         name="search",
@@ -317,6 +330,7 @@ async def test_mcp_tool_provider_exposes_only_configured_server_authentication(
     assert [tool.name for tool in loaded.tools] == [
         "get_mcp_server_status",
         "authenticate_mcp_server",
+        "reload_mcp_configuration",
     ]
     status_tool = loaded.tools[0]
     assert status_tool.description == (
@@ -343,12 +357,38 @@ async def test_mcp_tool_provider_exposes_only_configured_server_authentication(
     assert await provider._authenticate("unconfigured", "tool-call") == {"status": "failed"}
 
 
+async def test_mcp_reload_tool_schedules_refresh_without_configuration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = MCPToolProvider(
+        _config(
+            tmp_path,
+            {"DEEPAGENTS_TALON_MCP_CONFIG": str(tmp_path / "missing.json")},
+        )
+    )
+    reload_tool = (await provider.load()).tools[0]
+
+    result = reload_tool.invoke({})
+
+    assert reload_tool.name == "reload_mcp_configuration"
+    assert result == {"status": "scheduled", "available": "next_turn"}
+
+    async def load() -> SimpleNamespace:
+        return SimpleNamespace(tools=(DummyTool("refreshed"),))
+
+    monkeypatch.setattr(provider, "load", load)
+    refreshed = await provider.refresh_if_needed()
+    assert refreshed is not None
+    assert [tool.name for tool in refreshed] == ["refreshed"]
+
+
 async def test_mcp_tool_provider_serializes_concurrent_refreshes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = MCPToolProvider(_config(tmp_path))
-    provider._dirty = True
+    provider.request_refresh()
     load_started = asyncio.Event()
     release_load = asyncio.Event()
 
@@ -373,6 +413,58 @@ async def test_mcp_tool_provider_serializes_concurrent_refreshes(
     assert second_result is None
 
 
+async def test_mcp_tool_provider_preserves_refresh_requested_during_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = MCPToolProvider(_config(tmp_path))
+    provider.request_refresh()
+    load_started = asyncio.Event()
+    release_load = asyncio.Event()
+    loads = 0
+
+    async def load() -> SimpleNamespace:
+        nonlocal loads
+        loads += 1
+        if loads == 1:
+            load_started.set()
+            await release_load.wait()
+        return SimpleNamespace(tools=(DummyTool(f"refreshed-{loads}"),))
+
+    monkeypatch.setattr(provider, "load", load)
+    first = asyncio.create_task(provider.refresh_if_needed())
+    await load_started.wait()
+    provider.request_refresh()
+    release_load.set()
+
+    first_result = await first
+    second_result = await provider.refresh_if_needed()
+
+    assert first_result is not None
+    assert second_result is not None
+    assert [tool.name for tool in first_result] == ["refreshed-1"]
+    assert [tool.name for tool in second_result] == ["refreshed-2"]
+
+
+async def test_mcp_tool_provider_does_not_retry_failed_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = MCPToolProvider(_config(tmp_path))
+    provider.request_refresh()
+
+    async def load() -> SimpleNamespace:
+        message = "invalid MCP configuration"
+        raise MCPConfigError(message)
+
+    monkeypatch.setattr(provider, "load", load)
+
+    with pytest.raises(MCPConfigError, match="invalid MCP configuration"):
+        await provider.refresh_if_needed()
+
+    assert await provider.refresh_if_needed() is None
+
+
 async def test_mcp_tool_provider_reports_existing_authorization_without_refresh(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -393,7 +485,7 @@ async def test_mcp_tool_provider_reports_existing_authorization_without_refresh(
     result = await provider._authenticate("notion", "tool-call")
 
     assert result == {"status": "already_authenticated", "server_name": "notion"}
-    assert provider._dirty is False
+    assert await provider.refresh_if_needed() is None
 
 
 async def test_mcp_tool_provider_forces_explicit_reauthentication(
@@ -437,7 +529,7 @@ async def test_mcp_tool_provider_forces_explicit_reauthentication(
 
     assert forced == [True]
     assert result == {"status": "completed", "server_name": "notion"}
-    assert provider._dirty is True
+    await _assert_refresh_scheduled(provider, monkeypatch)
 
 
 def _provider_with_post_persistence_error(
@@ -488,7 +580,7 @@ async def test_mcp_tool_provider_refreshes_after_credentials_persist(
         reset_authorization_handler(token)
 
     assert result == {"status": "completed", "server_name": "notion"}
-    assert provider._dirty is True
+    await _assert_refresh_scheduled(provider, monkeypatch)
     assert [type(event) for event in events] == [AuthorizationCompleted]
     assert isinstance(events[0], AuthorizationCompleted)
     assert events[0].terminal is True
@@ -516,7 +608,7 @@ async def test_mcp_tool_provider_propagates_cancellation_after_credentials_persi
     finally:
         reset_authorization_handler(token)
 
-    assert provider._dirty is True
+    await _assert_refresh_scheduled(provider, monkeypatch)
     assert [type(event) for event in events] == [AuthorizationCompleted]
 
 

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -446,6 +446,37 @@ async def test_mcp_tool_provider_preserves_refresh_requested_during_load(
     assert [tool.name for tool in second_result] == ["refreshed-2"]
 
 
+async def test_mcp_tool_provider_retries_cancelled_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = MCPToolProvider(_config(tmp_path))
+    provider.request_refresh()
+    load_started = asyncio.Event()
+    release_load = asyncio.Event()
+    loads = 0
+
+    async def load() -> SimpleNamespace:
+        nonlocal loads
+        loads += 1
+        if loads == 1:
+            load_started.set()
+            await release_load.wait()
+        return SimpleNamespace(tools=(DummyTool("refreshed"),))
+
+    monkeypatch.setattr(provider, "load", load)
+    refresh = asyncio.create_task(provider.refresh_if_needed())
+    await load_started.wait()
+    refresh.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await refresh
+
+    refreshed = await provider.refresh_if_needed()
+    assert refreshed is not None
+    assert [tool.name for tool in refreshed] == ["refreshed"]
+
+
 async def test_mcp_tool_provider_does_not_retry_failed_refresh(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from types import SimpleNamespace
@@ -1123,6 +1124,48 @@ async def test_runtime_approves_tool_interrupt_with_channel_handler() -> None:
     assert approvals[0].conversation_id == "chat"
     assert approvals[0].interrupt_id == "interrupt-1"
     assert approvals[0].action_requests[0]["name"] == "dangerous_tool"
+
+
+async def test_runtime_keeps_graph_stable_while_waiting_for_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = InterruptingGraph()
+    replacement = RecordingGraph()
+    approval_started = asyncio.Event()
+    release_approval = asyncio.Event()
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+    runtime._graph = graph
+
+    async def approve(_request: ToolApprovalRequest) -> ToolApprovalDecision:
+        approval_started.set()
+        await release_approval.wait()
+        return "approve"
+
+    invocation = asyncio.create_task(
+        runtime.invoke(
+            AgentRequest(
+                conversation_id="chat",
+                text="run",
+                approval_handler=approve,
+            )
+        )
+    )
+    await approval_started.wait()
+    monkeypatch.setattr(runtime, "_create_graph", lambda _tools: replacement)
+    runtime._replace_runtime_tools(())
+    release_approval.set()
+
+    result = await invocation
+
+    assert result.text == "approved"
+    assert graph.executed is True
+    assert runtime._graph is replacement
+    assert replacement.calls == []
 
 
 async def test_runtime_logs_tool_approval_without_argument_values(

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -194,6 +194,46 @@ async def test_runtime_refreshes_tools_between_turns_and_binds_authorization_han
     assert current_authorization_handler() is None
 
 
+async def test_runtime_reloads_mcp_tools_transactionally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[RecordingGraph] = []
+
+    def fake_create_deep_agent(**_kwargs: Any) -> RecordingGraph:
+        graph = RecordingGraph()
+        created.append(graph)
+        if len(created) == 3:
+            msg = "invalid replacement graph"
+            raise RuntimeError(msg)
+        return graph
+
+    async def reload_tools() -> list[Callable[..., object]]:
+        return [refreshed_tool]
+
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        tools=[custom_tool],
+        reload_tools=reload_tools,
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+    await runtime.start()
+
+    await runtime.reload_mcp_configuration()
+
+    assert runtime.tools == (refreshed_tool,)
+    assert runtime._graph is created[1]
+
+    previous_graph = runtime._graph
+    with pytest.raises(RuntimeError, match="invalid replacement graph"):
+        await runtime.reload_mcp_configuration()
+
+    assert runtime.tools == (refreshed_tool,)
+    assert runtime._graph is previous_graph
+
+
 async def test_runtime_wires_backend_checkpointer_tools_skills_and_memory(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Talon can now reload its MCP configuration from an authorized channel or autonomously between agent turns without restarting the host.

---

MCP tools were previously refreshed only after channel OAuth authorization. This extends the existing provider refresh path with two entry points:

- `/mcp-reload` reloads immediately outside the model loop.
- `reload_mcp_configuration` lets the agent schedule a reload before its next turn.

Reloads are serialized and graph replacement is transactional, so failed configuration loads retain the previous runtime graph. Channel responses use fixed messages while detailed failures remain in operator logs.

## Testing

- `make test` in `libs/talon` (403 Python tests and 14 WhatsApp bridge tests)
- `make lint` in `libs/talon`

Made by [Open SWE](https://openswe.vercel.app/agents/184abe13-b9fe-5219-884c-006641104838)
