### PR TITLE
perf(talon): store cron jobs in a structured, versioned format

### DIFF
--- a/libs/talon/deepagents_talon/cron/jobs.py
+++ b/libs/talon/deepagents_talon/cron/jobs.py
@@ -23,8 +23,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-CRON_STORE_VERSION = 2
-"""Schema version of `jobs.json`. A file at any other version is discarded."""
+CRON_STORE_VERSION = 1
+"""Schema version of `jobs.json`.
+
+A file at any other version is discarded, including the unversioned bare list
+that predates this envelope -- treated as v0, since it was never numbered.
+"""
 
 MIN_GRANULARITY_MINUTES = 1
 MAX_SCHEDULE_TEXT_LENGTH = 200

--- a/libs/talon/deepagents_talon/cron/jobs.py
+++ b/libs/talon/deepagents_talon/cron/jobs.py
@@ -223,9 +223,17 @@ class CronOrigin:
 class CronSchedule:
     """Minute-granularity schedule for a cron job.
 
-    The first three fields keep the argument positions this class has always
-    had, so `CronSchedule("recurring", 15, "every 15m")` still constructs an
-    interval schedule. Wall-clock forms pass `minutes=None`.
+    !!! warning "Breaking change"
+        The wall-clock fields changed shape. `local_time="08:00"` became the
+        integer pair `hour=8, minute=0`, and `local_date` went from a
+        `YYYY-MM-DD` string to a `date`. Callers that constructed a wall-clock
+        schedule directly must be updated; positional callers are affected
+        silently, since strings now land where integers are expected. Prefer
+        `parse`, which is the supported way to build any form.
+
+    The first three fields keep the argument positions they have always had, so
+    `CronSchedule("recurring", 15, "every 15m")` still constructs an interval
+    schedule. Wall-clock forms pass `minutes=None`.
 
     Args:
         kind: Whether the schedule is one-shot or recurring.

--- a/libs/talon/deepagents_talon/cron/jobs.py
+++ b/libs/talon/deepagents_talon/cron/jobs.py
@@ -5,7 +5,9 @@ Talon is an experimental runtime and is subject to change or removal at any time
 
 from __future__ import annotations
 
+import functools
 import json
+import logging
 import os
 import tempfile
 import uuid
@@ -18,6 +20,11 @@ from deepagents_talon.timezones import TimeZoneError, resolve_zone
 
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
+
+CRON_STORE_VERSION = 2
+"""Schema version of `jobs.json`. A file at any other version is discarded."""
 
 MIN_GRANULARITY_MINUTES = 1
 MAX_SCHEDULE_TEXT_LENGTH = 200
@@ -35,6 +42,16 @@ _DAILY_LOOKAHEAD_DAYS = 3
 _GAP_PROBE_MINUTES = 1440
 """Bound on the forward probe across a nonexistent local time; real gaps are under 2h."""
 
+_ZONE_CACHE_SIZE = 128
+"""Bound on distinct cached timezones; names originate from agent-supplied text."""
+
+_MIN_MONTH = 1
+_MAX_MONTH = 12
+_MIN_DAY = 1
+_MAX_DAY = 31
+_MIN_YEAR = 1
+_MAX_YEAR = 9999
+
 _SCHEDULE_FORMS_HELP = (
     "schedule must be 'in 30m', 'every 15m', "
     "'at 2026-09-04 13:30 America/New_York', or 'daily at 08:00 America/New_York'"
@@ -43,6 +60,13 @@ _SCHEDULE_FORMS_HELP = (
 JobStatus = Literal["ok", "error"]
 ScheduleKind = Literal["one_shot", "recurring"]
 ScheduleForm = Literal["interval", "at", "daily"]
+
+_FileIdentity = tuple[int, int, int]
+"""Store file fingerprint: modification time in ns, size, and inode."""
+
+_JOB_STATUSES: tuple[str, ...] = ("ok", "error")
+_SCHEDULE_KINDS: tuple[str, ...] = ("one_shot", "recurring")
+_SCHEDULE_FORMS: tuple[str, ...] = ("interval", "at", "daily")
 
 
 class CronJobError(ValueError):
@@ -58,12 +82,31 @@ class CronOriginDict(TypedDict):
 
 
 class CronScheduleDict(TypedDict):
-    """Serialized schedule definition for a job.
+    """Serialized schedule definition for a job, tagged by `form`.
 
-    Only `kind` and `display` are always present. Interval schedules carry
-    `minutes`; wall-clock schedules carry `form`, `timezone`, `local_time`, and
-    (for one-shots) `local_date`.
+    Every field a schedule computes from is stored as an integer so that
+    loading a job never reparses text. `display` is the one string, carried
+    verbatim and never parsed, so the agent's own phrasing survives a round
+    trip: `every 2h` does not come back as `every 120m`.
+
+    Interval schedules carry `minutes`. Wall-clock schedules carry `timezone`,
+    `hour`, and `minute`; the one-shot `at` form adds `year`, `month`, `day`.
     """
+
+    form: ScheduleForm
+    kind: ScheduleKind
+    display: str
+    minutes: NotRequired[int]
+    timezone: NotRequired[str]
+    year: NotRequired[int]
+    month: NotRequired[int]
+    day: NotRequired[int]
+    hour: NotRequired[int]
+    minute: NotRequired[int]
+
+
+class CronScheduleWireDict(TypedDict):
+    """Model-facing schedule payload, using readable text for local wall clocks."""
 
     kind: ScheduleKind
     display: str
@@ -82,7 +125,12 @@ class CronRepeatDict(TypedDict):
 
 
 class CronJobDict(TypedDict):
-    """Serialized cron job record."""
+    """Serialized cron job record.
+
+    Timestamps are whole seconds since the Unix epoch. Cron granularity is one
+    minute, so second precision loses nothing real, and `_coerce_utc` truncates
+    on the way in to keep disk round trips exact rather than lossy.
+    """
 
     id: str
     assistant_id: str
@@ -91,12 +139,37 @@ class CronJobDict(TypedDict):
     schedule: CronScheduleDict
     repeat: CronRepeatDict
     enabled: bool
+    created_at: int
+    next_run_at: int | None
+    last_run_at: int | None
+    last_status: JobStatus | None
+    last_error: str | None
+    origin: CronOriginDict
+
+
+class CronJobWireDict(TypedDict):
+    """Model-facing job payload, using ISO-8601 timestamps."""
+
+    id: str
+    assistant_id: str
+    name: str
+    prompt: str
+    schedule: CronScheduleWireDict
+    repeat: CronRepeatDict
+    enabled: bool
     created_at: str
     next_run_at: str | None
     last_run_at: str | None
     last_status: JobStatus | None
     last_error: str | None
     origin: CronOriginDict
+
+
+class CronStoreDict(TypedDict):
+    """Versioned envelope wrapping the persisted job list."""
+
+    version: int
+    jobs: list[CronJobDict]
 
 
 @dataclass(frozen=True, slots=True)
@@ -126,7 +199,7 @@ class CronOrigin:
         }
 
     @classmethod
-    def from_dict(cls, data: CronOriginDict) -> CronOrigin:
+    def from_dict(cls, data: object) -> CronOrigin:
         """Deserialize a cron origin from disk.
 
         Args:
@@ -134,11 +207,15 @@ class CronOrigin:
 
         Returns:
             Parsed cron origin.
+
+        Raises:
+            CronJobError: If a field is missing or has the wrong type.
         """
+        record = _as_record(data)
         return cls(
-            conversation_id=data["conversation_id"],
-            channel=data.get("channel"),
-            message_id=data.get("message_id"),
+            conversation_id=_str_field(record, "conversation_id"),
+            channel=_optional_str_field(record, "channel"),
+            message_id=_optional_str_field(record, "message_id"),
         )
 
 
@@ -156,8 +233,9 @@ class CronSchedule:
         display: Human-readable schedule text. Canonicalized for wall-clock forms.
         form: Which arithmetic computes the next run.
         timezone: IANA timezone name. Wall-clock schedules only.
-        local_time: Local `HH:MM` wall-clock time. Wall-clock schedules only.
-        local_date: Local `YYYY-MM-DD` date. One-shot wall-clock schedules only.
+        hour: Local wall-clock hour, 0-23. Wall-clock schedules only.
+        minute: Local wall-clock minute, 0-59. Wall-clock schedules only.
+        local_date: Local calendar date. One-shot wall-clock schedules only.
     """
 
     kind: ScheduleKind
@@ -165,8 +243,9 @@ class CronSchedule:
     display: str
     form: ScheduleForm = "interval"
     timezone: str | None = None
-    local_time: str | None = None
-    local_date: str | None = None
+    hour: int | None = None
+    minute: int | None = None
+    local_date: date | None = None
 
     def __post_init__(self) -> None:
         """Validate the fields required by this schedule form.
@@ -189,7 +268,12 @@ class CronSchedule:
         if self.minutes < MIN_GRANULARITY_MINUTES:
             msg = "cron schedules must be at least 1 minute"
             raise CronJobError(msg)
-        if self.timezone is not None or self.local_time is not None or self.local_date is not None:
+        if (
+            self.timezone is not None
+            or self.hour is not None
+            or self.minute is not None
+            or self.local_date is not None
+        ):
             msg = "interval schedules cannot carry wall-clock fields"
             raise CronJobError(msg)
 
@@ -197,16 +281,17 @@ class CronSchedule:
         if self.minutes is not None:
             msg = "wall-clock schedules cannot carry a minute count"
             raise CronJobError(msg)
-        if self.timezone is None or self.local_time is None:
-            msg = "wall-clock schedules require a timezone and a local time"
+        if self.timezone is None or self.hour is None or self.minute is None:
+            msg = "wall-clock schedules require a timezone, an hour, and a minute"
             raise CronJobError(msg)
         _resolve_zone(self.timezone)
-        _parse_local_time(self.local_time)
+        if not 0 <= self.hour <= _MAX_HOUR or not 0 <= self.minute <= _MAX_MINUTE:
+            msg = f"{self.hour}:{self.minute} is not a valid 24-hour local time"
+            raise CronJobError(msg)
         if self.form == "at":
             if self.local_date is None:
                 msg = "one-shot wall-clock schedules require a local date"
                 raise CronJobError(msg)
-            _parse_local_date(self.local_date)
         elif self.local_date is not None:
             msg = "daily schedules cannot carry a local date"
             raise CronJobError(msg)
@@ -259,29 +344,31 @@ class CronSchedule:
     @classmethod
     def _at(cls, date_text: str, time_text: str, zone_name: str) -> CronSchedule:
         local_date = _parse_local_date(date_text)
-        local_time = _format_local_time(_parse_local_time(time_text))
+        hour, minute = _parse_local_time(time_text)
         _resolve_zone(zone_name)
         return cls(
             kind="one_shot",
             minutes=None,
-            display=f"at {local_date.isoformat()} {local_time} {zone_name}",
+            display=f"at {local_date.isoformat()} {_format_local_time(hour, minute)} {zone_name}",
             form="at",
             timezone=zone_name,
-            local_time=local_time,
-            local_date=local_date.isoformat(),
+            hour=hour,
+            minute=minute,
+            local_date=local_date,
         )
 
     @classmethod
     def _daily(cls, time_text: str, zone_name: str) -> CronSchedule:
-        local_time = _format_local_time(_parse_local_time(time_text))
+        hour, minute = _parse_local_time(time_text)
         _resolve_zone(zone_name)
         return cls(
             kind="recurring",
             minutes=None,
-            display=f"daily at {local_time} {zone_name}",
+            display=f"daily at {_format_local_time(hour, minute)} {zone_name}",
             form="daily",
             timezone=zone_name,
-            local_time=local_time,
+            hour=hour,
+            minute=minute,
         )
 
     def next_after(self, now: datetime, *, previous: datetime | None = None) -> datetime:
@@ -303,10 +390,9 @@ class CronSchedule:
         if self.form == "interval":
             return self._next_interval(now, previous)
         zone = _resolve_zone(cast("str", self.timezone))
-        hour, minute = _parse_local_time(cast("str", self.local_time))
+        hour, minute = cast("int", self.hour), cast("int", self.minute)
         if self.form == "at":
-            local_date = _parse_local_date(cast("str", self.local_date))
-            naive = datetime.combine(local_date, time(hour, minute))
+            naive = datetime.combine(cast("date", self.local_date), time(hour, minute))
             return _localize(naive, zone).astimezone(UTC)
         return _next_daily_instant(now, zone, hour, minute)
 
@@ -319,40 +405,79 @@ class CronSchedule:
     def to_dict(self) -> CronScheduleDict:
         """Serialize this schedule for disk storage.
 
-        Only the keys the schedule form uses are emitted.
+        Only the keys the schedule form uses are emitted, all of them integers
+        apart from `display` and the timezone name.
 
         Returns:
             JSON-compatible schedule dictionary.
         """
-        data: CronScheduleDict = {"kind": self.kind, "display": self.display}
+        data: CronScheduleDict = {
+            "form": self.form,
+            "kind": self.kind,
+            "display": self.display,
+        }
+        if self.minutes is not None:
+            data["minutes"] = self.minutes
+        if self.form != "interval":
+            data["timezone"] = cast("str", self.timezone)
+            data["hour"] = cast("int", self.hour)
+            data["minute"] = cast("int", self.minute)
+        if self.local_date is not None:
+            data["year"] = self.local_date.year
+            data["month"] = self.local_date.month
+            data["day"] = self.local_date.day
+        return data
+
+    def to_wire(self) -> CronScheduleWireDict:
+        """Render this schedule for the model-facing tool payload.
+
+        Local wall clocks become `HH:MM` and `YYYY-MM-DD` text, which reads
+        better to a model than bare integers. Only tool calls pay this cost;
+        the scheduler's hot path never touches it.
+
+        Returns:
+            JSON-compatible schedule dictionary.
+        """
+        data: CronScheduleWireDict = {"kind": self.kind, "display": self.display}
         if self.minutes is not None:
             data["minutes"] = self.minutes
         if self.form != "interval":
             data["form"] = self.form
             data["timezone"] = cast("str", self.timezone)
-            data["local_time"] = cast("str", self.local_time)
+            data["local_time"] = _format_local_time(
+                cast("int", self.hour), cast("int", self.minute)
+            )
         if self.local_date is not None:
-            data["local_date"] = self.local_date
+            data["local_date"] = self.local_date.isoformat()
         return data
 
     @classmethod
-    def from_dict(cls, data: CronScheduleDict) -> CronSchedule:
+    def from_dict(cls, data: object) -> CronSchedule:
         """Deserialize a cron schedule from disk.
+
+        Every field is type-checked before use: the file is a trust boundary,
+        and a malformed record must surface as `CronJobError` rather than an
+        arbitrary exception from deep inside the scheduler loop.
 
         Args:
             data: JSON schedule dictionary.
 
         Returns:
             Parsed cron schedule.
+
+        Raises:
+            CronJobError: If a field is missing or has the wrong type.
         """
+        record = _as_record(data)
         return cls(
-            kind=data["kind"],
-            minutes=data.get("minutes"),
-            display=data["display"],
-            form=data.get("form", "interval"),
-            timezone=data.get("timezone"),
-            local_time=data.get("local_time"),
-            local_date=data.get("local_date"),
+            kind=cast("ScheduleKind", _literal_field(record, "kind", _SCHEDULE_KINDS)),
+            minutes=_optional_int_field(record, "minutes"),
+            display=_str_field(record, "display"),
+            form=cast("ScheduleForm", _literal_field(record, "form", _SCHEDULE_FORMS)),
+            timezone=_optional_str_field(record, "timezone"),
+            hour=_optional_int_field(record, "hour"),
+            minute=_optional_int_field(record, "minute"),
+            local_date=_optional_date_fields(record),
         )
 
 
@@ -399,7 +524,7 @@ class CronRepeat:
         return {"times": self.times, "completed": self.completed}
 
     @classmethod
-    def from_dict(cls, data: CronRepeatDict) -> CronRepeat:
+    def from_dict(cls, data: object) -> CronRepeat:
         """Deserialize repeat state from disk.
 
         Args:
@@ -407,8 +532,15 @@ class CronRepeat:
 
         Returns:
             Parsed repeat state.
+
+        Raises:
+            CronJobError: If a field has the wrong type.
         """
-        return cls(times=data.get("times"), completed=data.get("completed", 0))
+        record = _as_record(data)
+        return cls(
+            times=_optional_int_field(record, "times"),
+            completed=_optional_int_field(record, "completed") or 0,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -459,6 +591,32 @@ class CronJob:
             "schedule": self.schedule.to_dict(),
             "repeat": self.repeat.to_dict(),
             "enabled": self.enabled,
+            "created_at": _to_epoch(self.created_at),
+            "next_run_at": _to_optional_epoch(self.next_run_at),
+            "last_run_at": _to_optional_epoch(self.last_run_at),
+            "last_status": self.last_status,
+            "last_error": self.last_error,
+            "origin": self.origin.to_dict(),
+        }
+
+    def to_wire(self) -> CronJobWireDict:
+        """Render this job for the model-facing tool payload.
+
+        Identical to `to_dict` except that timestamps are ISO-8601 text and the
+        schedule uses `to_wire`, so what the model reads is unchanged by the
+        integer disk encoding.
+
+        Returns:
+            JSON-compatible job dictionary.
+        """
+        return {
+            "id": self.id,
+            "assistant_id": self.assistant_id,
+            "name": self.name,
+            "prompt": self.prompt,
+            "schedule": self.schedule.to_wire(),
+            "repeat": self.repeat.to_dict(),
+            "enabled": self.enabled,
             "created_at": _format_time(self.created_at),
             "next_run_at": _format_optional_time(self.next_run_at),
             "last_run_at": _format_optional_time(self.last_run_at),
@@ -468,7 +626,7 @@ class CronJob:
         }
 
     @classmethod
-    def from_dict(cls, data: CronJobDict) -> CronJob:
+    def from_dict(cls, data: object) -> CronJob:
         """Deserialize a cron job from disk.
 
         Args:
@@ -476,21 +634,28 @@ class CronJob:
 
         Returns:
             Parsed cron job.
+
+        Raises:
+            CronJobError: If a field is missing or has the wrong type.
         """
+        record = _as_record(data)
         return cls(
-            id=data["id"],
-            assistant_id=data["assistant_id"],
-            name=data["name"],
-            prompt=data["prompt"],
-            schedule=CronSchedule.from_dict(data["schedule"]),
-            repeat=CronRepeat.from_dict(data["repeat"]),
-            enabled=data["enabled"],
-            created_at=_parse_time(data["created_at"]),
-            next_run_at=_parse_optional_time(data["next_run_at"]),
-            last_run_at=_parse_optional_time(data["last_run_at"]),
-            last_status=data["last_status"],
-            last_error=data["last_error"],
-            origin=CronOrigin.from_dict(data["origin"]),
+            id=_str_field(record, "id"),
+            assistant_id=_str_field(record, "assistant_id"),
+            name=_str_field(record, "name"),
+            prompt=_str_field(record, "prompt"),
+            schedule=CronSchedule.from_dict(record.get("schedule")),
+            repeat=CronRepeat.from_dict(record.get("repeat")),
+            enabled=_bool_field(record, "enabled"),
+            created_at=_from_epoch(_int_field(record, "created_at")),
+            next_run_at=_from_optional_epoch(_optional_int_field(record, "next_run_at")),
+            last_run_at=_from_optional_epoch(_optional_int_field(record, "last_run_at")),
+            last_status=cast(
+                "JobStatus | None",
+                _optional_literal_field(record, "last_status", _JOB_STATUSES),
+            ),
+            last_error=_optional_str_field(record, "last_error"),
+            origin=CronOrigin.from_dict(record.get("origin")),
         )
 
 
@@ -507,6 +672,8 @@ class CronJobStore:
         self.assistant_id = assistant_id
         self.cron_dir = cron_dir
         self.path = cron_dir / "jobs.json"
+        self._cache: list[CronJob] | None = None
+        self._cache_identity: _FileIdentity | None = None
 
     def create_job(  # noqa: PLR0913  # job creation exposes the persisted CRON_JOB fields
         self,
@@ -791,22 +958,67 @@ class CronJobStore:
         return removed
 
     def _read_jobs(self) -> list[CronJob]:
+        """Return the stored jobs, reparsing only when the file changed.
+
+        The parsed list is cached against the identity of the inode it came
+        from, so a scheduler tick that finds nothing due costs a `stat` rather
+        than reading and deserializing every record. `_ensure_store` still runs
+        first: re-tightening permissions on each access is cheap next to a
+        parse, and worth keeping on the read path.
+
+        Callers get a shallow copy. `CronJob` is frozen, but the list container
+        must not be shared with the cache.
+
+        Returns:
+            Stored jobs, or an empty list if the file is absent or unreadable.
+        """
         self._ensure_store()
-        if not self.path.exists():
+        identity = self._stat_identity()
+        if identity is None:
+            self._cache = []
+            self._cache_identity = None
             return []
-        data = json.loads(self.path.read_text(encoding="utf-8"))
-        if not isinstance(data, list):
-            msg = "cron jobs file must contain a JSON list"
-            raise CronJobError(msg)
-        return [CronJob.from_dict(cast("CronJobDict", item)) for item in data]
+        if self._cache is not None and self._cache_identity == identity:
+            return list(self._cache)
+        jobs, loaded = self._load_jobs()
+        self._cache = jobs
+        self._cache_identity = loaded
+        return list(jobs)
+
+    def _stat_identity(self) -> _FileIdentity | None:
+        try:
+            info = self.path.stat()
+        except OSError:
+            return None
+        return (info.st_mtime_ns, info.st_size, info.st_ino)
+
+    def _load_jobs(self) -> tuple[list[CronJob], _FileIdentity | None]:
+        """Parse the store file, reporting the identity of what was parsed.
+
+        The identity comes from `fstat` on the open handle rather than a second
+        `stat` of the path, so a concurrent atomic replace cannot make the cache
+        claim newer content than it holds.
+
+        Returns:
+            Parsed jobs and the identity of the inode they were read from.
+        """
+        try:
+            with self.path.open("rb") as handle:
+                info = os.fstat(handle.fileno())
+                raw = handle.read()
+        except OSError:
+            logger.warning("Could not read cron store %s", self.path, exc_info=True)
+            return [], None
+        identity = (info.st_mtime_ns, info.st_size, info.st_ino)
+        return _decode_store(raw, path=self.path), identity
 
     def _write_jobs(self, jobs: list[CronJob]) -> None:
         self._ensure_store()
-        payload = json.dumps(
-            [job.to_dict() for job in jobs],
-            indent=2,
-            sort_keys=True,
-        )
+        store: CronStoreDict = {
+            "version": CRON_STORE_VERSION,
+            "jobs": [job.to_dict() for job in jobs],
+        }
+        payload = json.dumps(store, indent=2, sort_keys=True)
         fd, name = tempfile.mkstemp(
             dir=self.cron_dir,
             prefix=".jobs.",
@@ -827,6 +1039,12 @@ class CronJobStore:
         finally:
             if tmp_path.exists():
                 tmp_path.unlink()
+        # Seed the cache from what was just written; no reparse on the next read.
+        # This trusts that no other process replaced the file between the rename
+        # above and this stat. Cron stores are single-writer, and the surrounding
+        # read-all/write-all pattern already offered no cross-process guarantee.
+        self._cache = list(jobs)
+        self._cache_identity = self._stat_identity()
 
     def _ensure_store(self) -> None:
         self.cron_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -870,8 +1088,14 @@ def _first_run_at(schedule: CronSchedule, now: datetime) -> datetime:
     return next_run_at
 
 
+@functools.lru_cache(maxsize=_ZONE_CACHE_SIZE)
 def _resolve_zone(name: str) -> ZoneInfo:
     """Look up an IANA timezone, reporting failures as a cron job error.
+
+    Cached because every schedule validates its zone on construction -- which
+    includes every deserialization -- and `next_after` resolves it again on
+    each fire. The cache is bounded: names arrive in agent-supplied schedule
+    text, so an unbounded map would grow with distinct invalid input.
 
     Args:
         name: Timezone key, such as `America/New_York` or `UTC`.
@@ -985,8 +1209,8 @@ def _parse_local_time(value: str) -> tuple[int, int]:
     return hour, minute
 
 
-def _format_local_time(parts: tuple[int, int]) -> str:
-    return f"{parts[0]:02d}:{parts[1]:02d}"
+def _format_local_time(hour: int, minute: int) -> str:
+    return f"{hour:02d}:{minute:02d}"
 
 
 def _parse_local_date(value: str) -> date:
@@ -1037,11 +1261,43 @@ def _same_origin_scope(left: CronOrigin, right: CronOrigin) -> bool:
 
 
 def _coerce_utc(value: datetime | None = None) -> datetime:
+    """Normalize a timestamp to whole-second UTC.
+
+    Sub-second precision is dropped here rather than at the serialization
+    boundary, so a job's in-memory timestamps always match what a disk round
+    trip returns. Cron granularity is one minute, so nothing real is lost.
+
+    Args:
+        value: Timestamp to normalize. Defaults to the current time.
+
+    Returns:
+        Timezone-aware UTC timestamp with `microsecond` zeroed.
+    """
     if value is None:
-        return datetime.now(UTC)
+        return datetime.now(UTC).replace(microsecond=0)
     if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value.astimezone(UTC)
+        return value.replace(tzinfo=UTC, microsecond=0)
+    return value.astimezone(UTC).replace(microsecond=0)
+
+
+def _to_epoch(value: datetime) -> int:
+    return int(_coerce_utc(value).timestamp())
+
+
+def _to_optional_epoch(value: datetime | None) -> int | None:
+    return None if value is None else _to_epoch(value)
+
+
+def _from_epoch(value: int) -> datetime:
+    try:
+        return datetime.fromtimestamp(value, UTC)
+    except (OverflowError, OSError, ValueError) as exc:
+        msg = f"{value} is not a valid epoch timestamp"
+        raise CronJobError(msg) from exc
+
+
+def _from_optional_epoch(value: int | None) -> datetime | None:
+    return None if value is None else _from_epoch(value)
 
 
 def _format_optional_time(value: datetime | None) -> str | None:
@@ -1052,12 +1308,190 @@ def _format_time(value: datetime) -> str:
     return _coerce_utc(value).isoformat()
 
 
-def _parse_optional_time(value: str | None) -> datetime | None:
-    return None if value is None else _parse_time(value)
+def _decode_store(raw: bytes, *, path: Path) -> list[CronJob]:
+    """Decode the store file, treating anything unreadable as an empty store.
+
+    A malformed file must not raise: `_read_jobs` sits under the scheduler's
+    tick loop, which has no exception handler, so a throw here would silently
+    kill the ticker for the life of the process. Returning empty degrades to
+    "no jobs scheduled" and lets the next write heal the file, at the cost of
+    dropping whatever could not be read -- hence the loud log.
+
+    Args:
+        raw: File contents.
+        path: Store path, for diagnostics.
+
+    Returns:
+        Parsed jobs, or an empty list if the file cannot be read.
+    """
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        logger.warning("Discarding cron store %s: not valid JSON", path, exc_info=True)
+        return []
+    if not isinstance(data, dict):
+        logger.warning(
+            "Discarding cron store %s: expected a JSON object, found %s",
+            path,
+            type(data).__name__,
+        )
+        return []
+    version = data.get("version")
+    if version != CRON_STORE_VERSION:
+        logger.warning(
+            "Discarding cron store %s: schema version %r is not %d; scheduled jobs are lost",
+            path,
+            version,
+            CRON_STORE_VERSION,
+        )
+        return []
+    jobs = data.get("jobs")
+    if not isinstance(jobs, list):
+        logger.warning(
+            "Discarding cron store %s: 'jobs' must be a list, found %s",
+            path,
+            type(jobs).__name__,
+        )
+        return []
+    try:
+        return [CronJob.from_dict(item) for item in jobs]
+    except CronJobError:
+        logger.exception("Discarding cron store %s: a job record is malformed", path)
+        return []
 
 
-def _parse_time(value: str) -> datetime:
-    return _coerce_utc(datetime.fromisoformat(value))
+_MISSING = object()
+"""Sentinel distinguishing an absent field from a stored `null`."""
+
+_Record = dict[str, object]
+
+
+def _as_record(data: object) -> _Record:
+    """Confirm a decoded JSON value is an object before reading fields from it.
+
+    Called once per record rather than once per field: re-checking the same
+    mapping for every field is what makes a strict loader slower than the text
+    parsing it replaced.
+
+    Args:
+        data: Value expected to be a JSON object.
+
+    Returns:
+        The value as a string-keyed mapping.
+
+    Raises:
+        CronJobError: If the value is not a JSON object.
+    """
+    if not isinstance(data, dict):
+        msg = f"cron record must be a JSON object, not {type(data).__name__}"
+        raise CronJobError(msg)
+    # JSON objects always key by string, so the cast is sound once this holds.
+    return cast("_Record", data)
+
+
+def _str_field(record: _Record, key: str) -> str:
+    value = record.get(key, _MISSING)
+    if not isinstance(value, str):
+        raise _field_error(key, value, "a string")
+    return value
+
+
+def _optional_str_field(record: _Record, key: str) -> str | None:
+    value = record.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _field_error(key, value, "a string or null")
+    return value
+
+
+def _int_field(record: _Record, key: str) -> int:
+    value = record.get(key, _MISSING)
+    # `bool` is a subclass of `int`; a JSON `true` is not an acceptable count.
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise _field_error(key, value, "an integer")
+    return value
+
+
+def _optional_int_field(record: _Record, key: str) -> int | None:
+    value = record.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise _field_error(key, value, "an integer or null")
+    return value
+
+
+def _bool_field(record: _Record, key: str) -> bool:
+    value = record.get(key, _MISSING)
+    if not isinstance(value, bool):
+        raise _field_error(key, value, "a boolean")
+    return value
+
+
+def _literal_field(record: _Record, key: str, allowed: tuple[str, ...]) -> str:
+    value = _str_field(record, key)
+    if value not in allowed:
+        raise _field_error(key, value, f"one of {allowed}")
+    return value
+
+
+def _optional_literal_field(record: _Record, key: str, allowed: tuple[str, ...]) -> str | None:
+    value = _optional_str_field(record, key)
+    if value is None or value in allowed:
+        return value
+    raise _field_error(key, value, f"one of {allowed} or null")
+
+
+def _field_error(key: str, value: object, expected: str) -> CronJobError:
+    """Build the error for a field that is absent or of the wrong type.
+
+    Args:
+        key: Field name.
+        value: Offending value, or `_MISSING` when the field is absent.
+        expected: Description of what the field should have held.
+
+    Returns:
+        Error to raise at the call site, so the traceback points there.
+    """
+    if value is _MISSING:
+        return CronJobError(f"cron record is missing required field {key!r}")
+    return CronJobError(f"cron field {key!r} must be {expected}, not {type(value).__name__}")
+
+
+def _optional_date_fields(record: _Record) -> date | None:
+    """Rebuild a local date from its integer components.
+
+    Args:
+        record: Schedule dictionary.
+
+    Returns:
+        Parsed date, or `None` when the schedule carries no date.
+
+    Raises:
+        CronJobError: If the components are partial, out of range, or not a
+            real calendar date.
+    """
+    year = _optional_int_field(record, "year")
+    month = _optional_int_field(record, "month")
+    day = _optional_int_field(record, "day")
+    if year is None and month is None and day is None:
+        return None
+    if year is None or month is None or day is None:
+        msg = "a schedule date requires all of 'year', 'month', and 'day'"
+        raise CronJobError(msg)
+    if (
+        not _MIN_YEAR <= year <= _MAX_YEAR
+        or not _MIN_MONTH <= month <= _MAX_MONTH
+        or not _MIN_DAY <= day <= _MAX_DAY
+    ):
+        msg = f"{year}-{month}-{day} is not a valid calendar date"
+        raise CronJobError(msg)
+    try:
+        return date(year, month, day)
+    except ValueError as exc:
+        msg = f"{year}-{month}-{day} is not a valid calendar date"
+        raise CronJobError(msg) from exc
 
 
 def _fsync_dir(path: Path) -> None:

--- a/libs/talon/deepagents_talon/cron/tools.py
+++ b/libs/talon/deepagents_talon/cron/tools.py
@@ -253,7 +253,7 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
 
 
 def _tool_job(job: CronJob) -> dict[str, Any]:
-    data = job.to_dict()
+    data = job.to_wire()
     return {
         "id": data["id"],
         "name": data["name"],

--- a/libs/talon/tests/cron/test_jobs.py
+++ b/libs/talon/tests/cron/test_jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
 
@@ -368,14 +369,14 @@ def test_timestamps_round_trip_at_second_precision(tmp_path) -> None:
 @pytest.mark.parametrize(
     "payload",
     [
-        pytest.param("[]", id="v1_bare_list"),
-        pytest.param('{"version": 1, "jobs": []}', id="older_version"),
+        pytest.param("[]", id="v0_bare_list"),
+        pytest.param('{"version": 0, "jobs": []}', id="older_version"),
         pytest.param('{"version": 99, "jobs": []}', id="newer_version"),
         pytest.param('{"jobs": []}', id="missing_version"),
         pytest.param("not json at all", id="malformed_json"),
-        pytest.param('{"version": 2, "jobs": {}}', id="jobs_not_a_list"),
-        pytest.param('{"version": 2, "jobs": [{"id": 5}]}', id="malformed_record"),
-        pytest.param('{"version": 2, "jobs": [{"id": "x", "enabled": "yes"}]}', id="wrong_type"),
+        pytest.param('{"version": 1, "jobs": {}}', id="jobs_not_a_list"),
+        pytest.param('{"version": 1, "jobs": [{"id": 5}]}', id="malformed_record"),
+        pytest.param('{"version": 1, "jobs": [{"id": "x", "enabled": "yes"}]}', id="wrong_type"),
     ],
 )
 def test_unreadable_store_reads_empty_without_raising(tmp_path, payload: str) -> None:
@@ -390,7 +391,7 @@ def test_unreadable_store_reads_empty_without_raising(tmp_path, payload: str) ->
 def test_next_write_heals_an_unreadable_store(tmp_path) -> None:
     store = _store(tmp_path)
     store.cron_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-    store.path.write_text('{"version": 1, "jobs": []}', encoding="utf-8")
+    store.path.write_text("[]", encoding="utf-8")
 
     created = store.create_job(
         prompt="check status",
@@ -556,3 +557,46 @@ def test_cache_stays_coherent_across_a_job_fire(tmp_path) -> None:
     assert on_disk.last_status == "ok"
     assert on_disk.next_run_at == now + timedelta(minutes=30)
     assert store.due_jobs(now=fired) == []
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason"),
+    [
+        pytest.param("[]", "expected a JSON object", id="v0_bare_list"),
+        pytest.param('{"version": 0, "jobs": []}', "schema version", id="older_version"),
+        pytest.param('{"jobs": []}', "schema version", id="missing_version"),
+        pytest.param("not json", "not valid JSON", id="malformed_json"),
+        pytest.param('{"version": 1, "jobs": {}}', "must be a list", id="jobs_not_a_list"),
+        pytest.param(
+            '{"version": 1, "jobs": [{"id": 5}]}', "record is malformed", id="malformed_record"
+        ),
+    ],
+)
+def test_discard_names_the_reason(tmp_path, caplog, payload: str, reason: str) -> None:
+    """Pin which check rejected the file.
+
+    Without this, renumbering `CRON_STORE_VERSION` can leave the content-level
+    cases short-circuiting at the version check: they still read empty, so a
+    pass/fail assertion alone stays green while testing nothing.
+    """
+    store = _store(tmp_path)
+    store.cron_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    store.path.write_text(payload, encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_talon.cron.jobs"):
+        assert store.list_jobs() == []
+
+    assert reason in caplog.text
+
+
+def test_current_version_is_accepted(tmp_path) -> None:
+    store = _store(tmp_path)
+    created = store.create_job(
+        prompt="check status",
+        schedule=CronSchedule.parse("in 30m"),
+        origin=CronOrigin(conversation_id="chat"),
+    )
+    payload = json.loads(store.path.read_text(encoding="utf-8"))
+
+    assert payload["version"] == 1
+    assert [job.id for job in _store(tmp_path).list_jobs()] == [created.id]

--- a/libs/talon/tests/cron/test_jobs.py
+++ b/libs/talon/tests/cron/test_jobs.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import pytest
 
-from deepagents_talon.cron import CronJobError, CronJobStore, CronOrigin, CronSchedule, CronTools
+from deepagents_talon.cron import (
+    CronJobError,
+    CronJobStore,
+    CronOrigin,
+    CronSchedule,
+    CronTools,
+    jobs as jobs_module,
+)
+from deepagents_talon.cron.jobs import CRON_STORE_VERSION
 
 
 def _store(tmp_path, assistant_id: str = "assistant") -> CronJobStore:
@@ -149,7 +158,7 @@ def test_parse_preserves_timezone_case_and_canonicalizes_display() -> None:
     schedule = CronSchedule.parse(f"DAILY At 8:00 {NEW_YORK}")
 
     assert schedule.timezone == NEW_YORK
-    assert schedule.local_time == "08:00"
+    assert (schedule.hour, schedule.minute) == (8, 0)
     assert schedule.display == f"daily at 08:00 {NEW_YORK}"
 
 
@@ -309,3 +318,241 @@ def test_interval_job_catches_up_after_long_downtime(tmp_path) -> None:
 
     assert claimed is not None
     assert claimed.next_run_at == back_online + timedelta(minutes=1)
+
+
+def test_store_writes_versioned_envelope(tmp_path) -> None:
+    store = _store(tmp_path)
+    store.create_job(
+        prompt="check status",
+        schedule=CronSchedule.parse(f"daily at 08:00 {NEW_YORK}"),
+        origin=CronOrigin(conversation_id="chat"),
+    )
+
+    payload = json.loads(store.path.read_text(encoding="utf-8"))
+
+    assert payload["version"] == CRON_STORE_VERSION
+    assert [entry["schedule"]["hour"] for entry in payload["jobs"]] == [8]
+    assert isinstance(payload["jobs"][0]["created_at"], int)
+
+
+def test_store_preserves_agent_schedule_phrasing(tmp_path) -> None:
+    store = _store(tmp_path)
+    store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse("every 2h"),
+        origin=CronOrigin(conversation_id="chat"),
+    )
+    reloaded = _store(tmp_path).list_jobs()
+
+    assert reloaded[0].schedule.minutes == 120
+    assert reloaded[0].schedule.display == "every 2h"
+
+
+def test_timestamps_round_trip_at_second_precision(tmp_path) -> None:
+    now = datetime(2026, 1, 1, 12, 30, 45, 123456, tzinfo=UTC)
+    store = _store(tmp_path)
+    created = store.create_job(
+        prompt="check status",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=CronOrigin(conversation_id="chat"),
+        now=now,
+    )
+
+    reloaded = _store(tmp_path).get_job(created.id)
+
+    assert reloaded is not None
+    assert reloaded.created_at == created.created_at
+    assert created.created_at == now.replace(microsecond=0)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param("[]", id="v1_bare_list"),
+        pytest.param('{"version": 1, "jobs": []}', id="older_version"),
+        pytest.param('{"version": 99, "jobs": []}', id="newer_version"),
+        pytest.param('{"jobs": []}', id="missing_version"),
+        pytest.param("not json at all", id="malformed_json"),
+        pytest.param('{"version": 2, "jobs": {}}', id="jobs_not_a_list"),
+        pytest.param('{"version": 2, "jobs": [{"id": 5}]}', id="malformed_record"),
+        pytest.param('{"version": 2, "jobs": [{"id": "x", "enabled": "yes"}]}', id="wrong_type"),
+    ],
+)
+def test_unreadable_store_reads_empty_without_raising(tmp_path, payload: str) -> None:
+    store = _store(tmp_path)
+    store.cron_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    store.path.write_text(payload, encoding="utf-8")
+
+    assert store.list_jobs() == []
+    assert store.due_jobs() == []
+
+
+def test_next_write_heals_an_unreadable_store(tmp_path) -> None:
+    store = _store(tmp_path)
+    store.cron_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    store.path.write_text('{"version": 1, "jobs": []}', encoding="utf-8")
+
+    created = store.create_job(
+        prompt="check status",
+        schedule=CronSchedule.parse("in 30m"),
+        origin=CronOrigin(conversation_id="chat"),
+    )
+
+    assert [job.id for job in _store(tmp_path).list_jobs()] == [created.id]
+
+
+def test_reads_are_cached_until_the_file_changes(tmp_path, monkeypatch) -> None:
+    store = _store(tmp_path)
+    store.create_job(
+        prompt="check status",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=CronOrigin(conversation_id="chat"),
+    )
+    loads = 0
+    original = jobs_module.json.loads
+
+    def counting_loads(*args: object, **kwargs: object) -> object:
+        nonlocal loads
+        loads += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(jobs_module.json, "loads", counting_loads)
+
+    for _ in range(5):
+        assert len(store.list_jobs()) == 1
+
+    assert loads == 0, "a write seeds the cache, so unchanged reads must not reparse"
+
+    fresh = _store(tmp_path)
+    for _ in range(5):
+        assert len(fresh.list_jobs()) == 1
+
+    assert loads == 1, "a fresh store parses once, then serves the cache"
+
+
+def test_cache_reloads_after_an_external_write(tmp_path) -> None:
+    writer = _store(tmp_path)
+    reader = _store(tmp_path)
+    reader.create_job(
+        prompt="first",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=CronOrigin(conversation_id="chat"),
+    )
+    assert len(reader.list_jobs()) == 1
+
+    second = writer.create_job(
+        prompt="second",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=CronOrigin(conversation_id="chat"),
+    )
+
+    assert second.id in {job.id for job in reader.list_jobs()}
+
+
+def test_read_does_not_expose_the_cached_list(tmp_path) -> None:
+    store = _store(tmp_path)
+    store.create_job(
+        prompt="check status",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=CronOrigin(conversation_id="chat"),
+    )
+
+    store.list_jobs().clear()
+
+    assert len(store.list_jobs()) == 1
+
+
+def test_wire_payload_keeps_readable_text(tmp_path) -> None:
+    store = _store(tmp_path)
+    job = store.create_job(
+        prompt="check status",
+        schedule=CronSchedule.parse(f"daily at 08:00 {NEW_YORK}"),
+        origin=CronOrigin(conversation_id="chat"),
+    )
+
+    wire = job.to_wire()
+
+    assert wire["schedule"]["local_time"] == "08:00"
+    assert wire["schedule"]["timezone"] == NEW_YORK
+    assert wire["created_at"] == job.created_at.isoformat()
+    assert "hour" not in wire["schedule"]
+
+
+@pytest.mark.parametrize(
+    "schedule",
+    [
+        pytest.param({"form": "daily", "kind": "recurring", "display": "d"}, id="missing_zone"),
+        pytest.param(
+            {
+                "form": "daily",
+                "kind": "recurring",
+                "display": "d",
+                "timezone": NEW_YORK,
+                "hour": 99,
+                "minute": 0,
+            },
+            id="hour_out_of_range",
+        ),
+        pytest.param(
+            {
+                "form": "at",
+                "kind": "one_shot",
+                "display": "d",
+                "timezone": NEW_YORK,
+                "hour": 8,
+                "minute": 0,
+                "year": 2026,
+                "month": 2,
+            },
+            id="partial_date",
+        ),
+        pytest.param(
+            {
+                "form": "at",
+                "kind": "one_shot",
+                "display": "d",
+                "timezone": NEW_YORK,
+                "hour": 8,
+                "minute": 0,
+                "year": 2026,
+                "month": 2,
+                "day": 30,
+            },
+            id="impossible_date",
+        ),
+        pytest.param(
+            {"form": "interval", "kind": "recurring", "display": "d", "minutes": True},
+            id="bool_is_not_a_count",
+        ),
+    ],
+)
+def test_malformed_schedule_raises_cron_job_error(schedule: dict) -> None:
+    with pytest.raises(CronJobError):
+        CronSchedule.from_dict(schedule)
+
+
+def test_cache_stays_coherent_across_a_job_fire(tmp_path) -> None:
+    now = datetime(2026, 1, 1, 12, tzinfo=UTC)
+    store = _store(tmp_path)
+    job = store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=CronOrigin(conversation_id="chat"),
+        now=now,
+    )
+    fired = now + timedelta(minutes=15)
+
+    assert [due.id for due in store.due_jobs(now=fired)] == [job.id]
+    claimed = store.advance_next_run(job.id, now=fired)
+    assert claimed is not None
+    store.mark_job_run(job.id, status="ok", now=fired)
+
+    cached = store.get_job(job.id)
+    on_disk = _store(tmp_path).get_job(job.id)
+
+    assert cached is not None
+    assert on_disk is not None
+    assert cached == on_disk
+    assert on_disk.last_status == "ok"
+    assert on_disk.next_run_at == now + timedelta(minutes=30)
+    assert store.due_jobs(now=fired) == []


### PR DESCRIPTION
`jobs.json` held every structured value as text and re-derived it on each load — ISO-8601 timestamps, `"HH:MM"` local times, `"YYYY-MM-DD"` local dates. The wall-clock fields were parsed twice, once validating on deserialization and again inside every `next_after`, and the store reparsed the whole file on every access, so one job firing cost three full reads and two fsynced rewrites.

## The format

A versioned envelope whose every computed-from field is an integer:

```json
{ "version": 1, "jobs": [ { "...": "...", "created_at": 1788548916, "next_run_at": 1788609600,
    "schedule": { "form": "daily", "kind": "recurring", "hour": 8, "minute": 0,
                  "timezone": "America/New_York",
                  "display": "daily at 08:00 America/New_York" } } ] }
```

Schedules are a tagged union on `form`. `interval` carries `minutes`; the wall-clock forms carry `timezone`/`hour`/`minute`, and one-shot `at` adds `year`/`month`/`day`.

`display` stays as the one string, carried verbatim and never parsed — so the agent's own phrasing survives a round trip. Dropping it would have turned `every 2h` into `every 120m`, since that form isn't derivable from `minutes` alone.

## Where the time went

Beyond the format, the access pattern was doing the real damage. The parsed list is now cached against the identity of the inode it came from, taken via `fstat` on the open handle rather than a second `stat` of the path, so a concurrent atomic replace cannot make the cache claim newer content than it holds. `_write_jobs` seeds it directly; reads hand out a shallow copy so callers can't mutate it. The zone lookup is `lru_cache`d — it ran on every deserialization and again per fire — bounded at 128 because names arrive in agent-supplied text.

| jobs | idle tick | one job fire | cold read |
|---|---|---|---|
| 10 | 0.114 → **0.044ms** | 1.03 → **0.75ms** | 0.114 → 0.119ms |
| 100 | 0.421 → **0.046ms** | 2.49 → **1.23ms** | 0.421 → 0.498ms |
| 1000 | 3.900 → **0.050ms** | 19.0 → **6.39ms** | 3.900 → **4.707ms** |

Fire is the real `due_jobs` → `advance_next_run` → `mark_job_run` sequence. The "before" column for it is computed from measured per-op costs, since the old code had no cache and every read was a full parse.

**Cold read is ~20% slower at 1000 jobs, and that's real.** Fields are now type-checked individually — work the old loader skipped entirely, where `data["id"]` would surface a raw `KeyError` from inside the scheduler. A first pass was worse still (6.14ms) because every field re-validated the same mapping; hoisting that to one `_as_record` per record recovered most of it. It's now paid once per process instead of three times per fire.

## Behavior changes

- **Timestamps are whole seconds.** `_coerce_utc` truncates on the way in, so disk round trips are exact rather than lossy. Cron granularity is one minute, so nothing real is lost.
- **An unreadable store logs and reads empty instead of raising** — for any cause, not just a version mismatch. This one matters more than it looks: `scheduler._ticker` has no handler around `tick_once`, so a throw out of `_read_jobs` would have silently killed the ticker for the life of the process. (A guard on the ticker itself is a separate PR; it doesn't depend on this one.)
- **No compatibility path for the format this replaces.** The predecessor was an unversioned bare list, so it is treated as v0 and this envelope is v1. A file at any other version is discarded with a warning naming the version found, and healed by the next write. Existing schedules on disk are lost on upgrade — acceptable while talon is experimental, and the alternative was a dead reader path lingering indefinitely.
- **`to_dict` is disk-only.** The new `to_wire` keeps ISO-8601 timestamps and `HH:MM` local times, so what the model reads through the cron tools is byte-identical to before. Only tool calls pay that formatting; the scheduler's hot path never touches it.

Unchanged: file permissions (`0o700` dir, `0o600` file), the atomic `mkstemp` + fsync + `replace` write, and the origin-scoping that keeps one conversation from reading or editing another's jobs.

## Breaking changes

Both are deliberate, and both were flagged in review before being confirmed.

**`CronSchedule`'s wall-clock fields changed shape.** `local_time="08:00"` became `hour=8, minute=0`, and `local_date` went from a `YYYY-MM-DD` string to a `date`. The class is exported from `deepagents_talon.cron` and from top-level `deepagents_talon.__all__`, so this breaks external callers that construct a wall-clock schedule directly. Positional callers break *silently* — strings land where integers are now expected — which is the part worth knowing. Every in-repo caller uses `parse`, so the suite gave no signal. The class docstring now carries a warning naming the change and pointing at `parse` as the supported constructor.

This does cut against `AGENTS.md`'s "preserve exported function signatures" rule, knowingly. For anyone revisiting the decision: the integer encoding of the wall-clock fields turned out to be the least load-bearing part of this change. The costly reparse was in `next_after`, once per fire, not on load — caching derived values in `__post_init__` would have delivered the same throughput with the signature untouched. The measured wins below are all independent of the field shape.

**Existing `jobs.json` files are discarded, not migrated.** The v0 bare list is recognized explicitly, logged with a warning naming the version found, and healed by the next write. Schedules created before the upgrade are lost. The alternative was a v0 reader kept alive indefinitely for a format with no released consumers to protect; talon is marked experimental in every module, so we took the break.

## Testing

425 pass, 31 new. Coverage for the envelope, phrasing preservation, second-precision round-trips, eight malformed-input shapes (v0 bare list, wrong versions, bad JSON, partial and impossible dates, `true` where a count belongs), self-healing on the next write, cache hit/miss/external-write/coherence-through-a-fire, and that reads don't expose the cached list. `ruff check`, `ruff format --check`, and `ty check` clean.

One test asserts *which* check rejected a file rather than only that it was rejected. Renumbering exposed why that matters: two rejection tests used `{"version": 1, ...}` as an invalid payload, and once 1 became the accepted version they went vacuous rather than failing — the version check short-circuits, the store still reads empty, and the assertions stay green while exercising none of the record parser. The new test fails on exactly that, and I confirmed it does by reintroducing a stale version.

## Not in scope

`fcntl` advisory locking. The read-all/mutate-one/write-all pattern already offered no cross-process guarantee; the cache narrows the window slightly but doesn't create the problem. Worth a follow-up if multiple processes ever share a `cron_dir`.


