### PR TITLE
fix(talon): keep the cron ticker alive through a failed tick

### DIFF
--- a/libs/talon/deepagents_talon/cron/scheduler.py
+++ b/libs/talon/deepagents_talon/cron/scheduler.py
@@ -82,8 +82,30 @@ class PersistentCronScheduler:
             await self._run_due_job(job, current)
 
     async def _ticker(self) -> None:
+        """Scan for due jobs until stopped, surviving a failed scan.
+
+        A tick reads the store, consults the clock, and dispatches; an
+        unexpected raise from any of those would otherwise leave the task
+        completed-with-exception, and since nothing awaits it but `stop`, the
+        scheduler would go quiet for the life of the process with no more than
+        an "exception was never retrieved" warning at collection time. Logging
+        and continuing costs one missed scan instead: due jobs stay due, so the
+        next tick picks them up.
+
+        `Exception` rather than `BaseException` is deliberate --
+        `asyncio.CancelledError` derives from the latter, so cancellation still
+        propagates and `stop` keeps working.
+        """
         while not self._stopped.is_set():
-            await self.tick_once()
+            try:
+                await self.tick_once()
+            except Exception as exc:
+                logger.exception("Cron tick failed")
+                # `log_event` JSON-encodes and redacts its fields, so untrusted
+                # text off the store cannot forge a log line.
+                log_event(logger, "cron.tick_failure", error=str(exc))
+            # The wait happens even after a failure, so a persistently broken
+            # tick retries on the normal interval instead of spinning.
             try:
                 await asyncio.wait_for(self._stopped.wait(), timeout=self.tick_seconds)
             except TimeoutError:

--- a/libs/talon/tests/cron/test_scheduler.py
+++ b/libs/talon/tests/cron/test_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime, timedelta
@@ -171,3 +172,77 @@ async def _append(values: list[str], value: str) -> None:
 
 def _event(message: str) -> dict[str, object]:
     return json.loads(message.removeprefix("talon_event "))
+
+
+def _is_event(message: str) -> bool:
+    return message.startswith("talon_event ")
+
+
+async def test_ticker_survives_a_failing_tick(tmp_path, caplog) -> None:
+    now = datetime(2026, 1, 1, 12, tzinfo=UTC)
+    store = _store(tmp_path)
+    job = store.create_job(
+        prompt="check status",
+        schedule=CronSchedule.parse("every 1m"),
+        origin=CronOrigin(conversation_id="chat"),
+        now=now,
+    )
+    ran: list[str] = []
+    failures = 2
+    ticks = 0
+    original_due_jobs = store.due_jobs
+
+    def flaky_due_jobs(*, now: datetime | None = None) -> list[CronJob]:
+        nonlocal ticks
+        ticks += 1
+        if ticks <= failures:
+            msg = "store unavailable"
+            raise RuntimeError(msg)
+        return original_due_jobs(now=now)
+
+    store.due_jobs = flaky_due_jobs  # type: ignore[method-assign]
+
+    scheduler = PersistentCronScheduler(
+        store=store,
+        run_job=lambda claimed: _append_and_return(ran, claimed.id),
+        deliver_result=_deliver_returned_text,
+        tick_seconds=0.01,
+        now=lambda: now + timedelta(minutes=1),
+    )
+
+    with caplog.at_level(logging.INFO, logger="deepagents_talon.cron.scheduler"):
+        await scheduler.start()
+        for _ in range(200):
+            if ran:
+                break
+            await asyncio.sleep(0.01)
+        await scheduler.stop()
+
+    assert ticks > failures, "the ticker must keep scanning after a failed tick"
+    assert ran == [job.id]
+    # `logger.exception` also lands in caplog as plain text, not a talon_event.
+    events = [_event(message)["event"] for message in caplog.messages if _is_event(message)]
+    assert events.count("cron.tick_failure") == failures
+    assert "cron.dispatch" in events
+    assert "Cron tick failed" in caplog.text
+
+
+async def test_stop_still_cancels_a_guarded_ticker(tmp_path) -> None:
+    store = _store(tmp_path)
+    scheduler = PersistentCronScheduler(
+        store=store,
+        run_job=lambda _: _return("done"),
+        deliver_result=_deliver_returned_text,
+        tick_seconds=0.01,
+    )
+
+    await scheduler.start()
+    await asyncio.sleep(0.05)
+    await scheduler.stop()
+
+    assert scheduler._task is None
+
+
+async def _append_and_return(values: list[str], value: str) -> str:
+    values.append(value)
+    return "[SILENT]"


### PR DESCRIPTION
`_ticker` awaited `tick_once` with no handler around it:

```python
while not self._stopped.is_set():
    await self.tick_once()
    try:
        await asyncio.wait_for(self._stopped.wait(), timeout=self.tick_seconds)
    except TimeoutError:
        continue
```

A tick reads the store, consults the clock, and dispatches due jobs. `_run_due_job` already catches failures from the `run_job` and `deliver_result` callbacks, but a raise from any store call or from the clock propagated straight out of the loop. The asyncio task then completed with an exception and **the scheduler went quiet for the life of the process** — no job fired again. Nothing awaits that task except `stop`, so the only trace was an "exception was never retrieved" warning at collection time, if it surfaced at all.

## The fix

Log and continue. The cost is one missed scan: due jobs stay due, so the next tick picks them up.

Two details that aren't incidental:

- **The interval wait still happens after a failure.** Putting the guard around only `tick_once` and leaving the wait outside it means a persistently broken tick retries on the normal cadence instead of spinning hot.
- **`Exception`, not `BaseException`.** `asyncio.CancelledError` derives from the latter, so cancellation still propagates and `stop` keeps working unchanged. There's a test for that specifically, since it's the kind of thing a later "broaden the catch" edit would quietly break.

The failure detail goes out through `log_event`, which runs fields through `_redact_mapping` and then `json.dumps` — so untrusted text read off the store can't forge a log line, and secret-looking keys are redacted. Same shape as the existing `cron.failure` and `cron.delivery_failure` events.

## Testing

Two new tests, 398 pass total. The main one drives the real `start`/`stop` loop with a store whose `due_jobs` raises twice and then recovers, and asserts the ticker kept scanning, emitted exactly two `cron.tick_failure` events, and went on to dispatch the job. I verified it fails against unpatched `scheduler.py` — the raw `RuntimeError` escapes — so it's actually pinning the behavior rather than passing by construction.

`ruff check`, `ruff format --check`, and `ty check` clean.

## Relationship to #6086

Independent — different files, no shared code, merges cleanly in either order. #6086 removed the cron store as a *source* of throws into this loop, which is what surfaced the gap; this PR guards the loop itself, which is still worth doing on its own since the clock, the logging path, and the dispatch calls can all raise too.
