### PR TITLE
feat(talon): persist LangGraph checkpoints

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -27,7 +27,7 @@ AGENT_ASSISTANT_ID=local AGENT_MODEL=<provider>:<model-id> uv run deepagents-tal
 
 If `AGENT_MODEL` is unset, Talon starts with the echo runtime. This is useful for checking host lifecycle and channel wiring without provider credentials.
 
-Assistant state lives under `~/.deepagents/<assistant_id>/` by default. The host creates restrictive state directories for the materialized agent manifest, channel sessions, and cron jobs. The default local execution workspace is the current working directory; set `DEEPAGENTS_TALON_WORKSPACE` to use a different directory. The per-invocation graph recursion limit defaults to `500`; set `DEEPAGENTS_TALON_RECURSION_LIMIT` to tune it.
+Assistant state lives under `~/.deepagents/<assistant_id>/` by default. The host creates restrictive state directories for the materialized agent manifest, channel sessions, and cron jobs, and persists conversation checkpoints in `checkpoints.sqlite` so chat history survives restarts. The default local execution workspace is the current working directory; set `DEEPAGENTS_TALON_WORKSPACE` to use a different directory. The per-invocation graph recursion limit defaults to `500`; set `DEEPAGENTS_TALON_RECURSION_LIMIT` to tune it.
 
 ## Interrupt and Continue
 

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -192,15 +192,28 @@ async def _run_host(
     config: TalonConfig,
     cron_store: CronJobStore,
     channels: Sequence[ChannelAdapter],
+    *,
+    checkpointer: Checkpointer | None = None,
 ) -> None:
-    from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver  # noqa: PLC0415
-
     if config.model is None:
         await _run_host_with_agent(args, config, cron_store, channels, await _agent_runtime(config))
         return
-    async with AsyncSqliteSaver.from_conn_string(str(config.checkpoint_path)) as checkpointer:
-        await checkpointer.setup()
+    if checkpointer is not None:
         agent = await _agent_runtime(config, cron_store=cron_store, checkpointer=checkpointer)
+        await _run_host_with_agent(args, config, cron_store, channels, agent)
+        return
+
+    from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver  # noqa: PLC0415
+
+    async with AsyncSqliteSaver.from_conn_string(
+        str(config.checkpoint_path)
+    ) as sqlite_checkpointer:
+        await sqlite_checkpointer.setup()
+        agent = await _agent_runtime(
+            config,
+            cron_store=cron_store,
+            checkpointer=sqlite_checkpointer,
+        )
         await _run_host_with_agent(args, config, cron_store, channels, agent)
 
 

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -32,6 +32,8 @@ from deepagents_talon.speech import build_voice_transcriber
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
+    from langgraph.types import Checkpointer
+
     from deepagents_talon.cron import CronJob
     from deepagents_talon.interfaces import AgentRuntime, ChannelAdapter
 
@@ -97,24 +99,7 @@ def main() -> None:
         telegram=args.telegram,
         discord=args.discord,
     )
-    host = TalonHost(
-        config=config,
-        agent=asyncio.run(_agent_runtime(config, cron_store)),
-        channels=channels,
-        voice_transcriber=build_voice_transcriber(config),
-    )
-    if channels:
-        host.scheduler = PersistentCronScheduler(
-            store=cron_store,
-            run_job=host.run_scheduled_job,
-            deliver_result=lambda job, text: _deliver_cron_result(host, channels, job, text),
-        )
-
-    if args.once:
-        asyncio.run(_run_once(host))
-        return
-
-    asyncio.run(host.run_until_stopped())
+    asyncio.run(_run_host(args, config, cron_store, channels))
 
 
 def _add_import_fleet_parser(
@@ -202,9 +187,52 @@ def _has_configured_assistant_id(env: Mapping[str, str]) -> bool:
     return "DEEPAGENTS_TALON_ASSISTANT_ID" in env or "AGENT_ASSISTANT_ID" in env
 
 
-async def _agent_runtime(
+async def _run_host(
+    args: argparse.Namespace,
     config: TalonConfig,
     cron_store: CronJobStore,
+    channels: Sequence[ChannelAdapter],
+) -> None:
+    from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver  # noqa: PLC0415
+
+    if config.model is None:
+        await _run_host_with_agent(args, config, cron_store, channels, await _agent_runtime(config))
+        return
+    async with AsyncSqliteSaver.from_conn_string(str(config.checkpoint_path)) as checkpointer:
+        await checkpointer.setup()
+        agent = await _agent_runtime(config, cron_store=cron_store, checkpointer=checkpointer)
+        await _run_host_with_agent(args, config, cron_store, channels, agent)
+
+
+async def _run_host_with_agent(
+    args: argparse.Namespace,
+    config: TalonConfig,
+    cron_store: CronJobStore,
+    channels: Sequence[ChannelAdapter],
+    agent: AgentRuntime,
+) -> None:
+    host = TalonHost(
+        config=config,
+        agent=agent,
+        channels=channels,
+        voice_transcriber=build_voice_transcriber(config),
+    )
+    if channels:
+        host.scheduler = PersistentCronScheduler(
+            store=cron_store,
+            run_job=host.run_scheduled_job,
+            deliver_result=lambda job, text: _deliver_cron_result(host, channels, job, text),
+        )
+    if args.once:
+        await _run_once(host)
+    else:
+        await host.run_until_stopped()
+
+
+async def _agent_runtime(
+    config: TalonConfig,
+    cron_store: CronJobStore | None = None,
+    checkpointer: Checkpointer | None = None,
 ) -> AgentRuntime:
     from deepagents_talon.runtime import (  # noqa: PLC0415
         DeepAgentRuntime,
@@ -233,6 +261,7 @@ async def _agent_runtime(
         subagents=async_subagents or None,
         cron_store=cron_store,
         interrupt_on=interrupt_on_with_env_overlay(None, env),
+        checkpointer=checkpointer,
         env=env,
     )
 

--- a/libs/talon/deepagents_talon/config.py
+++ b/libs/talon/deepagents_talon/config.py
@@ -128,13 +128,21 @@ class TalonConfig:
     @property
     def checkpoint_path(self) -> Path:
         """SQLite database used for persistent LangGraph checkpoints."""
+        return self._state_path("checkpoints.sqlite", "checkpoint database")
+
+    @property
+    def conversation_state_path(self) -> Path:
+        """JSON file used for active conversation generations."""
+        return self._state_path("conversations.json", "conversation state")
+
+    def _state_path(self, name: str, description: str) -> Path:
         home = self.home.resolve()
         expected_home = self.home.parent.resolve() / self.home.name
-        checkpoint_path = (home / "checkpoints.sqlite").resolve()
-        if home != expected_home or checkpoint_path.parent != home:
-            msg = "checkpoint database must remain inside the assistant home"
+        state_path = (home / name).resolve()
+        if home != expected_home or state_path.parent != home:
+            msg = f"{description} must remain inside the assistant home"
             raise TalonConfigError(msg)
-        return checkpoint_path
+        return state_path
 
     @property
     def inbound_media_dir(self) -> Path:

--- a/libs/talon/deepagents_talon/config.py
+++ b/libs/talon/deepagents_talon/config.py
@@ -126,6 +126,17 @@ class TalonConfig:
         return self.home / "channels"
 
     @property
+    def checkpoint_path(self) -> Path:
+        """SQLite database used for persistent LangGraph checkpoints."""
+        home = self.home.resolve()
+        expected_home = self.home.parent.resolve() / self.home.name
+        checkpoint_path = (home / "checkpoints.sqlite").resolve()
+        if home != expected_home or checkpoint_path.parent != home:
+            msg = "checkpoint database must remain inside the assistant home"
+            raise TalonConfigError(msg)
+        return checkpoint_path
+
+    @property
     def inbound_media_dir(self) -> Path:
         """Directory reserved for downloaded inbound channel media."""
         return self.home / "media" / "inbound"

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -9,11 +9,14 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 import signal
+import tempfile
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
+from pathlib import Path
 from types import FrameType
 from typing import TYPE_CHECKING, cast
 
@@ -54,7 +57,6 @@ from deepagents_talon.speech import transcribe_voice_message
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from pathlib import Path
 
     from deepagents_talon.config import TalonConfig
     from deepagents_talon.cron.jobs import CronJob
@@ -184,7 +186,7 @@ class TalonHost:
         self._conversation_tasks: defaultdict[str, set[asyncio.Task[None]]] = defaultdict(set)
         self._generations: defaultdict[str, int] = defaultdict(int)
         self._blocked: set[str] = set()
-        self._conversation_resets: dict[str, int] = {}
+        self._conversation_resets = _load_conversation_resets(config.conversation_state_path)
         self._pending_tool_approvals: dict[str, _PendingToolApproval] = {}
         self._pending_authorizations: dict[str, _PendingAuthorization] = {}
         self._authorization_flows: dict[str, _AuthorizationFlow] = {}
@@ -564,8 +566,12 @@ class TalonHost:
                 lambda: channel.send_message(conversation_id, _CANCEL_TIMEOUT_MESSAGE)
             )
             return
-        next_reset = self._conversation_resets.get(conversation_root, 0) + 1
-        self._conversation_resets[conversation_root] = next_reset
+        next_resets = {
+            **self._conversation_resets,
+            conversation_root: self._conversation_resets.get(conversation_root, 0) + 1,
+        }
+        _save_conversation_resets(self.config.conversation_state_path, next_resets)
+        self._conversation_resets = next_resets
         await send_with_retry(
             lambda: channel.send_message(conversation_id, _NEW_CONVERSATION_MESSAGE)
         )
@@ -1280,6 +1286,44 @@ def _json_preview(value: object) -> str:
         return json.dumps(value, sort_keys=True, default=str)
     except (TypeError, ValueError):
         return str(value)
+
+
+def _load_conversation_resets(path: Path) -> dict[str, int]:
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        msg = f"failed to load conversation state from {path}"
+        raise RuntimeError(msg) from exc
+    if not isinstance(state, dict) or any(
+        not isinstance(key, str)
+        or not isinstance(reset, int)
+        or isinstance(reset, bool)
+        or reset < 1
+        for key, reset in state.items()
+    ):
+        msg = f"invalid conversation state in {path}"
+        raise RuntimeError(msg)
+    return state
+
+
+def _save_conversation_resets(path: Path, resets: Mapping[str, int]) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            json.dump(resets, file, sort_keys=True)
+            file.flush()
+            os.fsync(file.fileno())
+        temporary_path.replace(path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.close(descriptor)
+        with contextlib.suppress(OSError):
+            temporary_path.unlink()
+        raise
 
 
 def _parse_tool_approval_reply(text: str) -> ToolApprovalDecision | None:

--- a/libs/talon/pyproject.toml
+++ b/libs/talon/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "deepagents-code>=0.1.30,<1.0.0",
     "discord.py>=2.4.0,<3.0.0",
     "langchain-mcp-adapters>=0.3.2,<1.0.0",
+    "langgraph-checkpoint-sqlite>=3.1.1,<4.0.0",
     "tzdata>=2025.2",
 ]
 

--- a/libs/talon/tests/test_config.py
+++ b/libs/talon/tests/test_config.py
@@ -33,6 +33,7 @@ def test_from_env_creates_assistant_home(tmp_path: Path) -> None:
     assert config.cron_dir.stat().st_mode & 0o777 == 0o700
     assert config.channel_dir.stat().st_mode & 0o777 == 0o700
     assert config.checkpoint_path == config.home / "checkpoints.sqlite"
+    assert config.conversation_state_path == config.home / "conversations.json"
     assert config.inbound_media_dir.stat().st_mode & 0o777 == 0o700
 
 

--- a/libs/talon/tests/test_config.py
+++ b/libs/talon/tests/test_config.py
@@ -32,7 +32,19 @@ def test_from_env_creates_assistant_home(tmp_path: Path) -> None:
     assert config.agents_dir.stat().st_mode & 0o777 == 0o700
     assert config.cron_dir.stat().st_mode & 0o777 == 0o700
     assert config.channel_dir.stat().st_mode & 0o777 == 0o700
+    assert config.checkpoint_path == config.home / "checkpoints.sqlite"
     assert config.inbound_media_dir.stat().st_mode & 0o777 == 0o700
+
+
+def test_checkpoint_path_rejects_symlinked_assistant_home(tmp_path: Path) -> None:
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    linked_home = tmp_path / "assistant-1"
+    linked_home.symlink_to(real_home, target_is_directory=True)
+    config = TalonConfig(assistant_id="assistant-1", home=linked_home)
+
+    with pytest.raises(TalonConfigError, match="checkpoint database"):
+        _ = config.checkpoint_path
 
 
 def test_from_env_defaults_to_deepagents_home(

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -582,6 +582,37 @@ async def test_new_command_starts_fresh_conversation_thread(tmp_path: Path) -> N
     ]
 
 
+async def test_new_command_remains_active_after_restart(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    channel = RecordingChannel()
+    first_agent = HistoryAgent()
+    first_host = TalonHost(config=config, agent=first_agent, channels=[channel])
+    await first_host.start()
+
+    await first_host.receive_message(channel, ChannelMessage(conversation_id="chat", text="first"))
+    await _wait_for_sent_count(channel, 1)
+    await first_host.receive_message(channel, ChannelMessage(conversation_id="chat", text="/new"))
+    await first_host.stop()
+
+    restarted_channel = RecordingChannel()
+    restarted_agent = HistoryAgent()
+    restarted_host = TalonHost(
+        config=config,
+        agent=restarted_agent,
+        channels=[restarted_channel],
+    )
+    await restarted_host.start()
+    await restarted_host.receive_message(
+        restarted_channel,
+        ChannelMessage(conversation_id="chat", text="second"),
+    )
+    await _wait_for_sent_count(restarted_channel, 1)
+    await restarted_host.stop()
+
+    assert restarted_agent.requests[0].conversation_id.startswith("chat:talon-reset:")
+    assert restarted_channel.sent == [("chat", "seen:0")]
+
+
 async def test_new_command_accepts_telegram_bot_command_suffix(tmp_path: Path) -> None:
     channel = RecordingChannel()
     agent = HistoryAgent()

--- a/libs/talon/tests/test_main.py
+++ b/libs/talon/tests/test_main.py
@@ -1,10 +1,55 @@
 from __future__ import annotations
 
+import argparse
 import logging
+from typing import Any
 
 import pytest
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
-from deepagents_talon.__main__ import _channel_log_level, _configure_logging
+from deepagents_talon.__main__ import (
+    _channel_log_level,
+    _configure_logging,
+    _run_host,
+)
+from deepagents_talon.config import TalonConfig
+from deepagents_talon.cron import CronJobStore
+
+
+async def test_run_host_persists_langgraph_checkpoints(tmp_path, monkeypatch) -> None:
+    config = TalonConfig.from_env(
+        {"AGENT_ASSISTANT_ID": "assistant-1", "AGENT_MODEL": "test:model"},
+        base_home=tmp_path,
+    )
+    config.ensure_home()
+    cron_store = CronJobStore(assistant_id=config.assistant_id, cron_dir=config.cron_dir)
+    captured: dict[str, Any] = {}
+
+    async def fake_agent_runtime(_config, cron_store=None, checkpointer=None):
+        captured["cron_store"] = cron_store
+        captured["checkpointer"] = checkpointer
+        return object()
+
+    async def fake_run_host_with_agent(*_args: object) -> None:
+        await captured["checkpointer"].aput(
+            {"configurable": {"thread_id": "conversation", "checkpoint_ns": ""}},
+            {"id": "checkpoint", "ts": "2026-09-04T00:00:00Z", "channel_values": {}},
+            {},
+            {},
+        )
+
+    monkeypatch.setattr("deepagents_talon.__main__._agent_runtime", fake_agent_runtime)
+    monkeypatch.setattr("deepagents_talon.__main__._run_host_with_agent", fake_run_host_with_agent)
+
+    await _run_host(argparse.Namespace(once=True), config, cron_store, ())
+
+    assert config.checkpoint_path.is_file()
+    async with AsyncSqliteSaver.from_conn_string(str(config.checkpoint_path)) as checkpointer:
+        checkpoint = await checkpointer.aget(
+            {"configurable": {"thread_id": "conversation", "checkpoint_ns": ""}}
+        )
+    assert checkpoint is not None
+    assert checkpoint["id"] == "checkpoint"
 
 
 @pytest.mark.parametrize(

--- a/libs/talon/tests/test_main.py
+++ b/libs/talon/tests/test_main.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 import pytest
+from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 from deepagents_talon.__main__ import (
@@ -14,6 +15,41 @@ from deepagents_talon.__main__ import (
 )
 from deepagents_talon.config import TalonConfig
 from deepagents_talon.cron import CronJobStore
+
+
+async def test_run_host_uses_configured_checkpointer(tmp_path, monkeypatch) -> None:
+    config = TalonConfig.from_env(
+        {"AGENT_ASSISTANT_ID": "assistant-1", "AGENT_MODEL": "test:model"},
+        base_home=tmp_path,
+    )
+    cron_store = CronJobStore(assistant_id=config.assistant_id, cron_dir=config.cron_dir)
+    configured_checkpointer = InMemorySaver()
+    captured: dict[str, object] = {}
+
+    async def fake_agent_runtime(_config, cron_store=None, checkpointer=None):
+        captured["cron_store"] = cron_store
+        captured["checkpointer"] = checkpointer
+        return object()
+
+    async def fake_run_host_with_agent(*_args: object) -> None:
+        return None
+
+    monkeypatch.setattr("deepagents_talon.__main__._agent_runtime", fake_agent_runtime)
+    monkeypatch.setattr("deepagents_talon.__main__._run_host_with_agent", fake_run_host_with_agent)
+
+    await _run_host(
+        argparse.Namespace(once=True),
+        config,
+        cron_store,
+        (),
+        checkpointer=configured_checkpointer,
+    )
+
+    assert captured == {
+        "cron_store": cron_store,
+        "checkpointer": configured_checkpointer,
+    }
+    assert not config.checkpoint_path.exists()
 
 
 async def test_run_host_persists_langgraph_checkpoints(tmp_path, monkeypatch) -> None:

--- a/libs/talon/uv.lock
+++ b/libs/talon/uv.lock
@@ -1011,6 +1011,7 @@ dependencies = [
     { name = "deepagents-code" },
     { name = "discord-py" },
     { name = "langchain-mcp-adapters" },
+    { name = "langgraph-checkpoint-sqlite" },
     { name = "tzdata" },
 ]
 
@@ -1044,6 +1045,7 @@ requires-dist = [
     { name = "deepagents-code", extras = ["media"], marker = "extra == 'media'", editable = "../code" },
     { name = "discord-py", specifier = ">=2.4.0,<3.0.0" },
     { name = "langchain-mcp-adapters", specifier = ">=0.3.2,<1.0.0" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.1,<4.0.0" },
     { name = "librosa", marker = "extra == 'media'", specifier = ">=0.11.0,<1.0.0" },
     { name = "numpy", marker = "extra == 'media'", specifier = ">=2.4.6,<3.0.0" },
     { name = "phonemizer", marker = "extra == 'media'", specifier = ">=3.3.0,<4.0.0" },


### PR DESCRIPTION
Talon now persists conversation checkpoints so chat history survives process restarts.

---

The host owns an async SQLite checkpointer for the lifetime of a model-backed runtime and stores it inside the validated per-assistant home. Explicitly injected checkpointers remain supported for embedded runtimes and tests.

The direct `langgraph-checkpoint-sqlite>=3.1.1,<4.0.0` dependency provides LangGraph's supported async SQLite saver. It is MIT-licensed, actively maintained by LangChain, already present transitively through `deepagents-code`, and the locked 3.1.1 release has no known advisory. The alternatives were non-persistent in-memory state or custom checkpoint storage.

Validation:
- `make -C libs/talon format_diff`
- `make -C libs/talon lint_diff`
- `uv run --directory libs/talon --group test pytest -q tests/test_runtime.py tests/test_main.py tests/test_config.py --no-header --no-summary --disable-socket --allow-unix-socket --timeout 10` (67 passed)

Depends on https://github.com/langchain-ai/deepagents/pull/6085
Related: JKB-71

Made by [Open SWE](https://openswe.vercel.app/agents/2aa8c4f9-8625-5d1f-a04d-0ff0110d4ea0)
