### PR TITLE
fix(talon): persist OAuth token expiry

### DIFF
--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -6,8 +6,10 @@ import asyncio
 import contextlib
 import hashlib
 import json
+import math
 import os
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -152,9 +154,24 @@ class FileTokenStorage:
         raw = data.get("tokens") if data is not None else None
         return OAuthToken.model_validate(raw) if raw is not None else None
 
+    async def get_token_expiry(self) -> float | None:
+        """Return the stored absolute token expiry time."""
+        data = await asyncio.to_thread(self._read)
+        raw = data.get("expires_at") if data is not None else None
+        if raw is None:
+            return None
+        if isinstance(raw, bool) or not isinstance(raw, int | float) or not math.isfinite(raw):
+            msg = f"Invalid MCP credential file: {self.path}"
+            raise TypeError(msg)
+        return float(raw)
+
     async def set_tokens(self, tokens: OAuthToken) -> None:
-        """Persist OAuth tokens."""
-        await asyncio.to_thread(self._update, "tokens", json.loads(tokens.model_dump_json()))
+        """Persist OAuth tokens and their absolute expiry time."""
+        values = {
+            "tokens": json.loads(tokens.model_dump_json()),
+            "expires_at": _token_expiry(tokens),
+        }
+        await asyncio.to_thread(self._update_values, values)
         _mark_authorization_complete()
 
     async def set_tokens_and_client_info(
@@ -165,6 +182,7 @@ class FileTokenStorage:
         """Atomically persist OAuth tokens and their client registration."""
         values = {
             "tokens": json.loads(tokens.model_dump_json()),
+            "expires_at": _token_expiry(tokens),
             "client_info": json.loads(client_info.model_dump_json(exclude_none=True)),
         }
         await asyncio.to_thread(self._update_values, values)
@@ -211,6 +229,10 @@ class FileTokenStorage:
                 os.close(descriptor)
             Path(temporary).unlink(missing_ok=True)
             raise
+
+
+def _token_expiry(tokens: OAuthToken) -> float | None:
+    return time.time() + tokens.expires_in if tokens.expires_in is not None else None
 
 
 def _mark_authorization_complete() -> None:
@@ -586,6 +608,18 @@ def _normalized_url(url: str) -> str:
     return url.rstrip("/")
 
 
+class _PersistedExpiryOAuthProvider(OAuthClientProvider):
+    async def _initialize(self) -> None:
+        storage = self.context.storage
+        if not isinstance(storage, FileTokenStorage):
+            msg = "Talon OAuth requires file token storage"
+            raise TypeError(msg)
+        self.context.current_tokens = await storage.get_tokens()
+        self.context.client_info = await storage.get_client_info()
+        self.context.token_expiry_time = await storage.get_token_expiry()
+        self._initialized = True
+
+
 def build_oauth_provider(
     *,
     server_name: str,
@@ -621,7 +655,7 @@ def build_oauth_provider(
             raise DeviceAuthorizationCompletedError
         await fallback(url)
 
-    provider = OAuthClientProvider(
+    provider = _PersistedExpiryOAuthProvider(
         server_url=server_url,
         client_metadata=_client_metadata(redirect_uri),
         storage=storage,

--- a/libs/talon/tests/test_mcp_auth.py
+++ b/libs/talon/tests/test_mcp_auth.py
@@ -49,6 +49,132 @@ async def test_file_token_storage_round_trip_and_permissions(
     assert stat.S_IMODE(storage.path.parent.stat().st_mode) == 0o700
 
 
+async def test_file_token_storage_persists_absolute_expiry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("deepagents_talon.mcp_auth.time.time", lambda: 1_000.0)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="secret",  # noqa: S106
+            refresh_token="refresh",  # noqa: S106
+            expires_in=60,
+        )
+    )
+
+    assert await storage.get_token_expiry() == 1_060.0
+
+
+async def test_provider_restores_persisted_expiry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("deepagents_talon.mcp_auth.time.time", lambda: 1_000.0)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="secret",  # noqa: S106
+            refresh_token="refresh",  # noqa: S106
+            expires_in=60,
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            redirect_uris=["http://localhost:3000/callback"],
+            client_id="client-id",
+        )
+    )
+    provider = build_oauth_provider(
+        server_name="notion",
+        server_url="https://example.com/mcp",
+        storage=storage,
+        interactive=True,
+    )
+
+    await provider._initialize()
+
+    assert provider.context.token_expiry_time == 1_060.0
+    assert provider.context.can_refresh_token()
+
+
+async def test_provider_refreshes_expired_token_after_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="expired",  # noqa: S106
+            refresh_token="refresh",  # noqa: S106
+            expires_in=-1,
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            redirect_uris=["http://localhost:3000/callback"],
+            client_id="client-id",
+        )
+    )
+    provider = build_oauth_provider(
+        server_name="notion",
+        server_url="https://example.com/mcp",
+        storage=storage,
+        interactive=True,
+    )
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/token":
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "renewed",
+                    "refresh_token": "next-refresh",
+                    "expires_in": 3600,
+                },
+            )
+        return httpx.Response(200)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle), auth=provider) as client:
+        response = await client.get("https://example.com/mcp")
+
+    assert response.status_code == 200
+    assert [request.url.path for request in requests] == ["/token", "/mcp"]
+    assert requests[-1].headers["Authorization"] == "Bearer renewed"
+    tokens = await storage.get_tokens()
+    assert tokens is not None
+    assert tokens.access_token == "renewed"  # noqa: S105
+
+
+async def test_file_token_storage_accepts_legacy_file_without_expiry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+    storage.path.parent.mkdir(parents=True)
+    storage.path.write_text(
+        json.dumps({"tokens": {"access_token": "secret"}}),
+        encoding="utf-8",
+    )
+
+    assert await storage.get_token_expiry() is None
+
+
+async def test_file_token_storage_rejects_invalid_expiry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+    storage.path.parent.mkdir(parents=True)
+    storage.path.write_text(json.dumps({"expires_at": "tomorrow"}), encoding="utf-8")
+
+    with pytest.raises(TypeError, match="Invalid MCP credential file"):
+        await storage.get_token_expiry()
+
+
 async def test_file_token_storage_writes_tokens_and_client_info_together(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -66,6 +192,7 @@ async def test_file_token_storage_writes_tokens_and_client_info_together(
     assert await storage.get_client_info() == client
     assert set(json.loads(storage.path.read_text(encoding="utf-8"))) == {
         "tokens",
+        "expires_at",
         "client_info",
     }
 


### PR DESCRIPTION
Talon now preserves OAuth token expiration across process restarts so expired MCP credentials can refresh seamlessly instead of requiring reauthorization.

---

`FileTokenStorage` stores the absolute expiry alongside each token update, and Talon's OAuth provider restores it when initializing the MCP SDK context. Existing credential files without expiry metadata remain compatible, and malformed metadata is rejected without exposing credentials.

Tests cover persistence, restart-time refresh, legacy files, and invalid expiry data.

Made by [Open SWE](https://openswe.vercel.app/agents/515590ef-34dc-573f-a52c-62defb9f7d9d)