### PR TITLE
feat(talon): add MCP configuration tools with default approval

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -178,7 +178,39 @@ turn after login completes.
 Run `deepagents-talon mcp config` to print the resolved config path. The terminal-only
 `deepagents-talon mcp login <server>` flow remains available as an alternative.
 
-After editing the configuration, send `/mcp-reload` through an authorized channel to
+Ask Talon through Telegram, Discord, or another authorized channel to inspect or
+change MCP settings. `get_mcp_configuration` reads the operator-selected file;
+`update_mcp_server` adds, replaces, or removes one server. Neither tool accepts a
+file path. Updates require human approval by default, using the channel's existing
+approval flow. Scheduled runs and channels without approval support cannot apply
+updates under this default.
+
+The view masks stored strings as `<redacted>`, including URLs, commands, arguments,
+headers, and environment values. Only transport/authentication enums and exact
+`${ENV_VAR}` references remain visible; references are never expanded. An update
+can copy `<redacted>` at the same field to preserve the stored value. It supplies
+a complete server object (omitted fields are removed), or `null` to remove the
+server. Other servers and top-level settings are preserved. Use environment
+references for new credentials; do not send secrets through chat.
+
+Each update requires the revision returned by the view. If the file changes while
+approval is pending, Talon rejects the stale update and must read it again. Writes
+are atomic, use owner-only permissions, and schedule a reload before the next turn.
+These tools require a POSIX host (Linux or macOS) and reject symlink configuration
+files.
+
+Set `DEEPAGENTS_TALON_MCP_CONFIG_AUTO_APPROVE=true` in the **host environment** to
+disable the default MCP update approval. Other values keep approval enabled.
+Explicit gating through `DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS` still applies. This
+opt-out trusts the agent to change commands, destinations, and credential use:
+MCP configuration can launch processes or send credentials to remote servers.
+
+Keep the file outside the workspace using `DEEPAGENTS_TALON_MCP_CONFIG` when your
+deployment restricts the agent's filesystem access. These tools do not create a
+sandbox: Talon's default local shell backend can access host files outside the
+workspace. Enforce that boundary in the backend or deployment if required.
+
+After editing the configuration manually, send `/mcp-reload` through an authorized channel to
 reload it without restarting Talon. The agent can also call
 `reload_mcp_configuration` autonomously; that schedules the same reload before the
 next agent turn.

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -178,37 +178,15 @@ turn after login completes.
 Run `deepagents-talon mcp config` to print the resolved config path. The terminal-only
 `deepagents-talon mcp login <server>` flow remains available as an alternative.
 
-Ask Talon through Telegram, Discord, or another authorized channel to inspect or
-change MCP settings. `get_mcp_configuration` reads the operator-selected file;
-`update_mcp_server` adds, replaces, or removes one server. Neither tool accepts a
-file path. Updates require human approval by default, using the channel's existing
-approval flow. Scheduled runs and channels without approval support cannot apply
-updates under this default.
+On Linux/macOS, Talon can manage its MCP configuration through chat using
+`get_mcp_configuration` (redacted view) and `update_mcp_server` (add, replace, or
+remove one server). Updates require human approval by default and reload before
+the next turn. Set `DEEPAGENTS_TALON_MCP_CONFIG_AUTO_APPROVE=true` in the host
+environment to opt out; explicit tool approval policies still apply.
 
-The view masks stored strings as `<redacted>`, including URLs, commands, arguments,
-headers, and environment values. Only transport/authentication enums and exact
-`${ENV_VAR}` references remain visible; references are never expanded. An update
-can copy `<redacted>` at the same field to preserve the stored value. It supplies
-a complete server object (omitted fields are removed), or `null` to remove the
-server. Other servers and top-level settings are preserved. Use environment
-references for new credentials; do not send secrets through chat.
-
-Each update requires the revision returned by the view. If the file changes while
-approval is pending, Talon rejects the stale update and must read it again. Writes
-are atomic, use owner-only permissions, and schedule a reload before the next turn.
-These tools require a POSIX host (Linux or macOS) and reject symlink configuration
-files.
-
-Set `DEEPAGENTS_TALON_MCP_CONFIG_AUTO_APPROVE=true` in the **host environment** to
-disable the default MCP update approval. Other values keep approval enabled.
-Explicit gating through `DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS` still applies. This
-opt-out trusts the agent to change commands, destinations, and credential use:
-MCP configuration can launch processes or send credentials to remote servers.
-
-Keep the file outside the workspace using `DEEPAGENTS_TALON_MCP_CONFIG` when your
-deployment restricts the agent's filesystem access. These tools do not create a
-sandbox: Talon's default local shell backend can access host files outside the
-workspace. Enforce that boundary in the backend or deployment if required.
+Use `${ENV_VAR}` references for credentials. Set `DEEPAGENTS_TALON_MCP_CONFIG`
+to keep the file outside the workspace. These tools do not sandbox Talon's local
+shell backend; deployments must enforce filesystem isolation separately.
 
 After editing the configuration manually, send `/mcp-reload` through an authorized channel to
 reload it without restarting Talon. The agent can also call

--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -43,6 +43,7 @@ from deepagents_talon.mcp_auth import (
     format_login_error,
     prepare_oauth_login,
 )
+from deepagents_talon.mcp_config import MCPConfigStore
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping, Sequence
@@ -163,6 +164,7 @@ class MCPToolProvider:
         self._refresh_revision = 0
         self._applied_revision = 0
         self._lock = asyncio.Lock()
+        self._config_store = MCPConfigStore(mcp_config_path(config), self.request_refresh)
 
     async def load(self) -> MCPTools:
         """Load tools and include the narrow proactive authorization capability."""
@@ -175,7 +177,10 @@ class MCPToolProvider:
             tools = (*tools, self._status_tool(loaded.servers))
         if self._oauth_servers:
             tools = (*tools, self._authorization_tool())
-        tools = (*tools, self._reload_tool())
+        tools = (*tools, self._reload_tool(), *self._config_store.tools())
+        if len({tool.name for tool in tools}) != len(tools):
+            msg = "MCP tool names conflict with Talon management tools"
+            raise MCPConfigError(msg)
         return MCPTools(tools=tools, servers=loaded.servers)
 
     async def refresh_if_needed(self) -> Sequence[BaseTool] | None:

--- a/libs/talon/deepagents_talon/mcp_config.py
+++ b/libs/talon/deepagents_talon/mcp_config.py
@@ -1,0 +1,299 @@
+"""Narrow, redacted access to Talon's operator-selected MCP configuration."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import stat
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from langchain_core.tools import tool
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from langchain_core.tools import BaseTool
+
+MCP_CONFIG_AUTO_APPROVE_ENV = "DEEPAGENTS_TALON_MCP_CONFIG_AUTO_APPROVE"
+MCP_CONFIG_UPDATE_TOOL = "update_mcp_server"
+_REDACTED = "<redacted>"
+_REFERENCE = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*\}")
+_NAME = re.compile(r"[A-Za-z0-9_-]+")
+_FIELDS = frozenset(
+    {
+        "transport",
+        "type",
+        "command",
+        "args",
+        "env",
+        "url",
+        "headers",
+        "auth",
+        "allowedTools",
+        "disabledTools",
+    }
+)
+_ENUMS = {
+    "transport": {"stdio", "http", "sse", "streamable_http", "streamable-http"},
+    "type": {"stdio", "http", "sse", "streamable_http", "streamable-http"},
+    "auth": {"oauth"},
+}
+
+
+class MCPConfigStore:
+    """Manage one fixed file without exposing stored credentials to tools.
+
+    Args:
+        path: Operator-selected configuration path, outside the agent workspace.
+        on_update: Schedule a reload after a successful write.
+    """
+
+    def __init__(self, path: Path, on_update: Callable[[], None]) -> None:
+        """Capture the operator path and a process-local revision key."""
+        self._path = path.parent.resolve() / path.name
+        self._on_update = on_update
+        self._revision_key = secrets.token_bytes(32)
+
+    def tools(self) -> tuple[BaseTool, BaseTool]:
+        """Return the read and single-server update capabilities."""
+
+        @tool
+        def get_mcp_configuration() -> dict[str, object]:
+            """View MCP server configuration and its revision without reading files.
+
+            Stored strings are <redacted>, except transport/auth enums and exact
+            ${ENV_VAR} references. Values are never expanded. Use this revision
+            with update_mcp_server; do not use filesystem tools for MCP settings.
+            """
+            return self._view()
+
+        @tool
+        def update_mcp_server(
+            server_name: str, server: dict[str, object] | None, expected_revision: str
+        ) -> dict[str, str]:
+            """Add, replace, or remove one MCP server; normally requires approval.
+
+            Args:
+                server_name: Server name from mcpServers, or a new name.
+                server: Complete replacement settings, or null to remove. Copy
+                    <redacted> at the same field to preserve its stored value.
+                    Omitted fields are removed. Use ${ENV_VAR} references for
+                    credentials; never request or include literal secrets.
+                expected_revision: Revision returned by get_mcp_configuration.
+
+            Changes can execute commands or send credentials to configured URLs.
+            Successful changes become available on the next agent turn.
+            """
+            return self._update(server_name, server, expected_revision)
+
+        return get_mcp_configuration, update_mcp_server
+
+    def _revision(self, raw: bytes | None) -> str:
+        return hmac.new(
+            self._revision_key, b"missing" if raw is None else b"file:" + raw, hashlib.sha256
+        ).hexdigest()
+
+    def _read(self) -> tuple[bytes | None, dict[str, object]]:
+        _require_posix()
+        try:
+            descriptor = os.open(self._path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+        except FileNotFoundError:
+            return None, {"mcpServers": {}}
+        with os.fdopen(descriptor, "rb") as stream:
+            if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
+                msg = "MCP configuration must be a regular file"
+                raise ValueError(msg)
+            raw = stream.read()
+        document = json.loads(raw)
+        if not isinstance(document, dict) or not isinstance(document.get("mcpServers"), dict):
+            msg = "Invalid MCP configuration"
+            raise TypeError(msg)
+        return raw, document
+
+    def _view(self) -> dict[str, object]:
+        try:
+            raw, document = self._read()
+            servers = cast("dict[str, object]", document["mcpServers"])
+            return {
+                "revision": self._revision(raw),
+                "mcpServers": {name: _redact_server(server) for name, server in servers.items()},
+            }
+        except (OSError, ValueError, TypeError, RecursionError):
+            return {"status": "error", "message": "Cannot read MCP configuration."}
+
+    def _update(self, name: str, server: dict[str, object] | None, revision: str) -> dict[str, str]:
+        try:
+            if not _NAME.fullmatch(name):
+                return {"status": "error", "message": "Invalid server name."}
+            with self._locked():
+                raw, document = self._read()
+                if not hmac.compare_digest(self._revision(raw), revision):
+                    return {"status": "conflict", "message": "Read the configuration again."}
+                self._replace_server(document, name, server)
+                _atomic_write(self._path, document)
+        except (OSError, ValueError, TypeError, RecursionError):
+            return {
+                "status": "error",
+                "message": "Cannot update MCP configuration; check settings.",
+            }
+        self._on_update()
+        return {"status": "updated", "available": "next_turn"}
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        _require_posix()
+        import fcntl  # noqa: PLC0415  # Keep Talon importable on non-POSIX hosts.
+
+        self._path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        descriptor = os.open(
+            self._path.with_name(self._path.name + ".lock"),
+            os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW,
+            0o600,
+        )
+        with os.fdopen(descriptor, "rb") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock, fcntl.LOCK_UN)
+
+    def _replace_server(
+        self, document: dict[str, object], name: str, server: dict[str, object] | None
+    ) -> None:
+        servers = cast("dict[str, object]", document["mcpServers"])
+        if server is None:
+            servers.pop(name, None)
+            return
+        replacement = cast("dict[str, object]", _restore(server, servers.get(name)))
+        _validate_server(replacement)
+        servers[name] = replacement
+
+
+def _require_posix() -> None:
+    if os.name != "posix":
+        msg = "MCP configuration management requires POSIX file locking"
+        raise OSError(msg)
+
+
+def _redact_server(server: object) -> object:
+    if not isinstance(server, dict):
+        return _redact(server)
+    return {
+        key: value if isinstance(value, str) and value in _ENUMS.get(key, set()) else _redact(value)
+        for key, value in server.items()
+    }
+
+
+def _redact(value: object) -> object:
+    if isinstance(value, dict):
+        return {key: _redact(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, str):
+        return value if _REFERENCE.fullmatch(value) else _REDACTED
+    return value
+
+
+def _restore(value: object, previous: object) -> object:
+    if value == _REDACTED:
+        if not isinstance(previous, str):
+            msg = "No stored value for redacted field"
+            raise ValueError(msg)
+        return previous
+    if isinstance(value, dict):
+        old = previous if isinstance(previous, dict) else {}
+        return {key: _restore(item, old.get(key)) for key, item in value.items()}
+    if isinstance(value, list):
+        old_list = previous if isinstance(previous, list) else []
+        return [
+            _restore(item, old_list[i] if i < len(old_list) else None)
+            for i, item in enumerate(value)
+        ]
+    return value
+
+
+def _validate_server(server: dict[str, object]) -> None:
+    # Reuse pure loader validation; never resolve environment values or open sessions.
+    from deepagents_talon.mcp import _filter_tools, _stdio_connection  # noqa: PLC0415
+
+    if server.keys() - _FIELDS:
+        msg = "Unsupported MCP settings"
+        raise ValueError(msg)
+    _validate_fields(server)
+    _validate_references(server)
+    transport = server.get(
+        "transport", server.get("type", "stdio" if "command" in server else "http")
+    )
+    for field, choices in _ENUMS.items():
+        if field in server and server[field] not in choices:
+            msg = "Invalid MCP transport or authentication"
+            raise ValueError(msg)
+    if transport == "stdio":
+        _stdio_connection("server", server)
+    else:
+        _validate_remote(server)
+    _filter_tools("server", server, ())
+
+
+def _validate_fields(server: dict[str, object]) -> None:
+    for field in ("command", "url", "auth"):
+        if field in server and not isinstance(server[field], str):
+            msg = "MCP settings must contain strings"
+            raise TypeError(msg)
+    args = server.get("args", [])
+    if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
+        msg = "MCP args must contain strings"
+        raise TypeError(msg)
+    for field in ("env", "headers"):
+        values = server.get(field, {})
+        if not isinstance(values, dict) or not all(
+            isinstance(key, str) and isinstance(value, str) for key, value in values.items()
+        ):
+            msg = "MCP environment and headers must contain strings"
+            raise TypeError(msg)
+
+
+def _validate_references(server: dict[str, object]) -> None:
+    from deepagents_talon.mcp import _ENV_REF  # noqa: PLC0415  # Avoid a module import cycle.
+
+    values = [server.get(field, "") for field in ("command", "url")]
+    values.extend(cast("list[str]", server.get("args", [])))
+    for field in ("env", "headers"):
+        values.extend(cast("dict[str, str]", server.get(field, {})).values())
+    if any(isinstance(value, str) and "${" in _ENV_REF.sub("", value) for value in values):
+        msg = "Malformed MCP environment reference"
+        raise ValueError(msg)
+
+
+def _validate_remote(server: dict[str, object]) -> None:
+    url = server.get("url")
+    headers = cast("dict[str, str]", server.get("headers", {}))
+    if not isinstance(url, str) or not url:
+        msg = "Remote MCP server requires a URL"
+        raise ValueError(msg)
+    if server.get("auth") == "oauth" and any(key.lower() == "authorization" for key in headers):
+        msg = "OAuth cannot be combined with an Authorization header"
+        raise ValueError(msg)
+
+
+def _atomic_write(path: Path, document: dict[str, object]) -> None:
+    descriptor, temporary = tempfile.mkstemp(prefix=".mcp-", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(document, stream, indent=2, allow_nan=False)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        if path.is_symlink():
+            msg = "MCP configuration must not be a symlink"
+            raise ValueError(msg)
+        Path(temporary).replace(path)
+    finally:
+        Path(temporary).unlink(missing_ok=True)

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -43,6 +43,7 @@ from deepagents_talon.interfaces import (
     ToolApprovalHandler,
     ToolApprovalRequest,
 )
+from deepagents_talon.mcp_config import MCP_CONFIG_AUTO_APPROVE_ENV, MCP_CONFIG_UPDATE_TOOL
 from deepagents_talon.observability import (
     AgentActivityCallback,
     agent_activity_logging_enabled,
@@ -319,6 +320,7 @@ class DeepAgentRuntime:
         runtime_tools: Sequence[BaseTool | Callable[..., object]] | None = None,
     ) -> object:
         tools = self._build_tools(runtime_tools)
+        interrupt_on = _interrupt_on_with_mcp_config(self.interrupt_on, self.env, tools)
         context_size = _context_size_from_env(self.env)
         model = _resolve_model_from_env(self.model, self.env, context_size=context_size)
         middleware = list(self.middleware)
@@ -333,7 +335,7 @@ class DeepAgentRuntime:
             skills=self._resolve_skills(),
             middleware=middleware,
             interrupt_on=_interrupt_on_with_async_subagents(
-                self.interrupt_on,
+                interrupt_on,
                 has_async_subagents=self._has_async_subagents,
             ),
             memory=self._resolve_memory(),
@@ -825,6 +827,21 @@ def _interrupt_on_tools_from_env(env: Mapping[str, str]) -> dict[str, bool]:
     if raw is None or not raw.strip():
         return {}
     return {name: True for name in (part.strip() for part in raw.split(",")) if name}
+
+
+def _interrupt_on_with_mcp_config(
+    interrupt_on: Mapping[str, bool | InterruptOnConfig] | None,
+    env: Mapping[str, str],
+    tools: Sequence[BaseTool | Callable[..., object]],
+) -> Mapping[str, bool | InterruptOnConfig] | None:
+    if not any(getattr(tool, "name", None) == MCP_CONFIG_UPDATE_TOOL for tool in tools):
+        return interrupt_on
+    if env.get(MCP_CONFIG_AUTO_APPROVE_ENV, "").strip().lower() == "true":
+        return interrupt_on
+    return {
+        **(interrupt_on or {}),
+        MCP_CONFIG_UPDATE_TOOL: {"allowed_decisions": ["approve", "reject"]},
+    }
 
 
 def _interrupt_on_with_async_subagents(

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -387,12 +387,8 @@ async def test_mcp_tool_provider_exposes_only_configured_server_authentication(
 
     loaded = await provider.load()
 
-    assert [tool.name for tool in loaded.tools] == [
-        "get_mcp_server_status",
-        "authenticate_mcp_server",
-        "reload_mcp_configuration",
-    ]
-    status_tool = loaded.tools[0]
+    tools = {tool.name: tool for tool in loaded.tools}
+    status_tool = tools["get_mcp_server_status"]
     assert status_tool.description == (
         "Report configured MCP server availability. Current servers: notion (unauthenticated)."
     )
@@ -405,7 +401,7 @@ async def test_mcp_tool_provider_exposes_only_configured_server_authentication(
     )
     assert loaded.servers[0].status == "unauthenticated"
     assert loaded.servers[0].uses_oauth is True
-    schema = loaded.tools[1].tool_call_schema.model_json_schema()
+    schema = tools["authenticate_mcp_server"].tool_call_schema.model_json_schema()
     assert schema["properties"]["reauthenticate"] == {
         "default": False,
         "description": (

--- a/libs/talon/tests/unit_tests/test_mcp_config.py
+++ b/libs/talon/tests/unit_tests/test_mcp_config.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Self
+
+import pytest
+from deepagents.backends import StateBackend
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage
+
+from deepagents_talon.config import TalonConfig
+from deepagents_talon.interfaces import AgentRequest
+from deepagents_talon.mcp import MCPToolProvider
+from deepagents_talon.mcp_config import MCP_CONFIG_AUTO_APPROVE_ENV, MCPConfigStore
+from deepagents_talon.runtime import DeepAgentRuntime
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from deepagents_talon.interfaces import ToolApprovalDecision, ToolApprovalRequest
+
+
+@pytest.fixture
+def config_tools(tmp_path: Path):
+    path = tmp_path / "private" / ".mcp.json"
+    updates: list[bool] = []
+    store = MCPConfigStore(path, lambda: updates.append(True))
+    return path, *store.tools(), updates
+
+
+def test_view_redacts_literals_without_expansion(config_tools, monkeypatch):
+    path, view, _, _ = config_tools
+    path.parent.mkdir()
+    server = {
+        "transport": "http",
+        "url": "https://user:private@example.test/mcp?token=private",
+        "headers": {"Authorization": "Bearer private", "X-Key": "${CREDENTIAL}"},
+        "env": {"KEY": "${CREDENTIAL:-private}", "OTHER": "prefix-${CREDENTIAL}"},
+        "args": ["--key=private"],
+        "command": "private",
+        "unknown": {"nested": "private"},
+    }
+    path.write_text(json.dumps({"mcpServers": {"example": server}, "metadata": "private"}))
+    monkeypatch.setenv("CREDENTIAL", "expanded-private")
+
+    result = view.invoke({})
+
+    assert "private" not in json.dumps(result)
+    assert result["mcpServers"]["example"]["headers"]["X-Key"] == "${CREDENTIAL}"
+    assert result["mcpServers"]["example"]["transport"] == "http"
+    assert result["mcpServers"]["example"]["command"] == "<redacted>"
+    assert "metadata" not in result
+
+
+def test_update_preserves_secrets_and_unrelated_settings(config_tools):
+    path, view, update, updates = config_tools
+    path.parent.mkdir()
+    original = {
+        "mcpServers": {
+            "example": {"url": "https://example.test/mcp", "headers": {"X-Key": "stored-value"}},
+            "other": {"command": "server", "args": ["stored-value"]},
+        },
+        "metadata": {"keep": True},
+    }
+    path.write_text(json.dumps(original))
+    result = view.invoke({})
+    server = result["mcpServers"]["example"]
+    server["allowedTools"] = ["read_*"]
+
+    assert update.invoke(
+        {"server_name": "example", "server": server, "expected_revision": result["revision"]}
+    ) == {"status": "updated", "available": "next_turn"}
+
+    expected = json.loads(json.dumps(original))
+    expected["mcpServers"]["example"]["allowedTools"] = ["read_*"]
+    assert json.loads(path.read_text()) == expected
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert updates == [True]
+    assert view.invoke({})["revision"] != result["revision"]
+
+
+def test_add_remove_and_stale_revision(config_tools):
+    path, view, update, updates = config_tools
+    revision = view.invoke({})["revision"]
+    arguments = {
+        "server_name": "example",
+        "server": {"command": "server"},
+        "expected_revision": revision,
+    }
+    assert update.invoke(arguments)["status"] == "updated"
+    assert update.invoke(arguments)["status"] == "conflict"
+    assert (
+        update.invoke(
+            {**arguments, "server": None, "expected_revision": view.invoke({})["revision"]}
+        )["status"]
+        == "updated"
+    )
+    assert json.loads(path.read_text()) == {"mcpServers": {}}
+    assert updates == [True, True]
+
+
+def test_external_edit_invalidates_pending_update(config_tools):
+    path, view, update, updates = config_tools
+    revision = view.invoke({})["revision"]
+    path.parent.mkdir()
+    path.write_text('{"mcpServers": {}, "operator": true}')
+    original = path.read_bytes()
+    result = update.invoke(
+        {"server_name": "example", "server": {"command": "server"}, "expected_revision": revision}
+    )
+    assert result["status"] == "conflict"
+    assert path.read_bytes() == original
+    assert updates == []
+
+
+@pytest.mark.parametrize(
+    "server",
+    [
+        {"url": "<redacted>"},
+        {"command": "server", "env": {"PYTHONPATH": "/untrusted"}},
+        {"url": "https://example.test", "auth": "oauth", "headers": {"Authorization": "value"}},
+        {"url": "https://example.test", "allowedTools": []},
+        {"command": "server", "allowedTools": ["*"], "disabledTools": ["*"]},
+        {"url": "https://example.test", "unknown": "value"},
+        {"transport": "invalid"},
+        {"transport": []},
+        {"args": "bad"},
+        {"command": 123},
+        {"command": "${INVALID"},
+        {"url": "https://example.test", "env": []},
+    ],
+)
+def test_invalid_update_leaves_file_unchanged(config_tools, server):
+    path, view, update, updates = config_tools
+    result = update.invoke(
+        {
+            "server_name": "example",
+            "server": server,
+            "expected_revision": view.invoke({})["revision"],
+        }
+    )
+    assert result["status"] == "error"
+    assert not path.exists()
+    assert updates == []
+
+
+@pytest.mark.parametrize("content", ["{private invalid", "[]", '{"mcpServers": []}'])
+def test_malformed_config_errors_are_redacted(config_tools, content):
+    path, view, update, updates = config_tools
+    path.parent.mkdir()
+    path.write_text(content)
+    assert view.invoke({})["status"] == "error"
+    result = update.invoke({"server_name": "example", "server": None, "expected_revision": "x"})
+    assert result["status"] == "error"
+    assert "private" not in json.dumps(result)
+    assert path.read_text() == content
+    assert updates == []
+
+
+def test_symlink_cannot_read_or_update_another_file(config_tools, tmp_path):
+    path, view, update, updates = config_tools
+    revision = view.invoke({})["revision"]
+    target = tmp_path / "target"
+    target.write_text('{"mcpServers": {}}')
+    path.parent.mkdir()
+    path.symlink_to(target)
+    assert view.invoke({})["status"] == "error"
+    assert (
+        update.invoke({"server_name": "example", "server": None, "expected_revision": revision})[
+            "status"
+        ]
+        == "error"
+    )
+    assert target.read_text() == '{"mcpServers": {}}'
+    assert updates == []
+
+
+def test_failed_atomic_replace_preserves_file_and_cleans_temp(config_tools, monkeypatch):
+    path, view, update, updates = config_tools
+    path.parent.mkdir()
+    path.write_text('{"mcpServers": {}}')
+
+    def fail_replace(*_args: object):
+        msg = "private error"
+        raise OSError(msg)
+
+    monkeypatch.setattr(type(path), "replace", fail_replace)
+    result = update.invoke(
+        {
+            "server_name": "example",
+            "server": {"command": "server"},
+            "expected_revision": view.invoke({})["revision"],
+        }
+    )
+    assert result["status"] == "error"
+    assert "private" not in json.dumps(result)
+    assert path.read_text() == '{"mcpServers": {}}'
+    assert not list(path.parent.glob(".mcp-*"))
+    assert updates == []
+
+
+def test_concurrent_updates_do_not_overwrite_each_other(config_tools):
+    path, view, update, updates = config_tools
+    revision = view.invoke({})["revision"]
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(
+            pool.map(
+                update.invoke,
+                [
+                    {
+                        "server_name": name,
+                        "server": {"command": "server"},
+                        "expected_revision": revision,
+                    }
+                    for name in ("one", "two")
+                ],
+            )
+        )
+    assert sorted(result["status"] for result in results) == ["conflict", "updated"]
+    assert len(json.loads(path.read_text())["mcpServers"]) == 1
+    assert updates == [True]
+
+
+async def test_provider_keeps_management_tools_after_refresh(tmp_path):
+    config = TalonConfig(
+        "test", tmp_path, env={"DEEPAGENTS_TALON_MCP_CONFIG": str(tmp_path / "mcp")}
+    )
+    provider = MCPToolProvider(config)
+    tools = {tool.name: tool for tool in (await provider.load()).tools}
+    revision = tools["get_mcp_configuration"].invoke({})["revision"]
+    result = tools["update_mcp_server"].invoke(
+        {
+            "server_name": "absent",
+            "server": None,
+            "expected_revision": revision,
+        }
+    )
+    assert result["status"] == "updated"
+    refreshed = await provider.refresh_if_needed()
+    assert refreshed is not None
+    assert {tool.name for tool in refreshed} == tools.keys()
+    assert await provider.refresh_if_needed() is None
+
+
+class ToolCallingModel(FakeMessagesListChatModel):
+    def bind_tools(self, *_args: object, **_kwargs: object) -> Self:
+        return self
+
+
+@pytest.mark.parametrize("after_reload", [False, True])
+@pytest.mark.parametrize(
+    ("decision", "auto_approve", "trigger", "writes"),
+    [
+        ("approve", None, "channel", True),
+        ("reject", None, "channel", False),
+        (None, None, "channel", False),
+        ("approve", None, "cron", False),
+        (None, "true", "channel", True),
+        (None, "false", "channel", False),
+        (None, "typo", "channel", False),
+    ],
+)
+async def test_runtime_gates_real_config_writes(  # noqa: PLR0913  # Independent approval/reload cases.
+    config_tools, decision, auto_approve, trigger, writes, after_reload
+):
+    path, view, update, _ = config_tools
+    arguments = {
+        "server_name": "example",
+        "server": {"command": "server"},
+        "expected_revision": view.invoke({})["revision"],
+    }
+    model = ToolCallingModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "update_mcp_server", "args": arguments, "id": "call"}],
+            ),
+            AIMessage(content="done"),
+        ]
+    )
+    approvals: list[ToolApprovalRequest] = []
+
+    async def approve(request: ToolApprovalRequest) -> ToolApprovalDecision:
+        assert not path.exists()
+        approvals.append(request)
+        return decision
+
+    async def reload_tools():
+        return [view, update]
+
+    runtime = DeepAgentRuntime(
+        model=model,
+        tools=[] if after_reload else [view, update],
+        reload_tools=reload_tools,
+        backend=StateBackend(),
+        env={} if auto_approve is None else {MCP_CONFIG_AUTO_APPROVE_ENV: auto_approve},
+        interrupt_on={"update_mcp_server": False},
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+    await runtime.start()
+    try:
+        if after_reload:
+            await runtime.reload_mcp_configuration()
+        await runtime.invoke(
+            AgentRequest(
+                conversation_id="chat",
+                text="configure MCP",
+                metadata={"trigger": trigger},
+                approval_handler=approve if decision is not None else None,
+            )
+        )
+    finally:
+        await runtime.stop()
+    assert path.exists() is writes
+    assert bool(approvals) is (decision is not None and trigger != "cron")
+
+
+async def test_pending_approval_rejects_concurrent_edit(config_tools):
+    path, view, update, _ = config_tools
+    arguments = {
+        "server_name": "example",
+        "server": {"command": "server"},
+        "expected_revision": view.invoke({})["revision"],
+    }
+    model = ToolCallingModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "update_mcp_server", "args": arguments, "id": "call"}],
+            ),
+            AIMessage(content="done"),
+        ]
+    )
+    waiting, resume = asyncio.Event(), asyncio.Event()
+
+    async def approve(_request: ToolApprovalRequest) -> ToolApprovalDecision:
+        waiting.set()
+        await resume.wait()
+        return "approve"
+
+    runtime = DeepAgentRuntime(
+        model=model,
+        tools=[view, update],
+        backend=StateBackend(),
+        env={},
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+    await runtime.start()
+    task = asyncio.create_task(
+        runtime.invoke(
+            AgentRequest(
+                conversation_id="chat",
+                text="configure MCP",
+                approval_handler=approve,
+            )
+        )
+    )
+    try:
+        await asyncio.wait_for(waiting.wait(), timeout=5)
+        path.parent.mkdir()
+        path.write_text('{"mcpServers": {}, "operator": true}')
+        resume.set()
+        await task
+        assert json.loads(path.read_text()) == {"mcpServers": {}, "operator": True}
+    finally:
+        resume.set()
+        await task
+        await runtime.stop()

--- a/libs/talon/tests/unit_tests/test_mcp_config.py
+++ b/libs/talon/tests/unit_tests/test_mcp_config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Self
@@ -10,9 +9,7 @@ from deepagents.backends import StateBackend
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage
 
-from deepagents_talon.config import TalonConfig
 from deepagents_talon.interfaces import AgentRequest
-from deepagents_talon.mcp import MCPToolProvider
 from deepagents_talon.mcp_config import MCP_CONFIG_AUTO_APPROVE_ENV, MCPConfigStore
 from deepagents_talon.runtime import DeepAgentRuntime
 
@@ -30,55 +27,39 @@ def config_tools(tmp_path: Path):
     return path, *store.tools(), updates
 
 
-def test_view_redacts_literals_without_expansion(config_tools, monkeypatch):
-    path, view, _, _ = config_tools
-    path.parent.mkdir()
-    server = {
-        "transport": "http",
-        "url": "https://user:private@example.test/mcp?token=private",
-        "headers": {"Authorization": "Bearer private", "X-Key": "${CREDENTIAL}"},
-        "env": {"KEY": "${CREDENTIAL:-private}", "OTHER": "prefix-${CREDENTIAL}"},
-        "args": ["--key=private"],
-        "command": "private",
-        "unknown": {"nested": "private"},
-    }
-    path.write_text(json.dumps({"mcpServers": {"example": server}, "metadata": "private"}))
-    monkeypatch.setenv("CREDENTIAL", "expanded-private")
-
-    result = view.invoke({})
-
-    assert "private" not in json.dumps(result)
-    assert result["mcpServers"]["example"]["headers"]["X-Key"] == "${CREDENTIAL}"
-    assert result["mcpServers"]["example"]["transport"] == "http"
-    assert result["mcpServers"]["example"]["command"] == "<redacted>"
-    assert "metadata" not in result
-
-
-def test_update_preserves_secrets_and_unrelated_settings(config_tools):
+def test_redacted_round_trip_preserves_secrets_and_other_settings(config_tools, monkeypatch):
     path, view, update, updates = config_tools
     path.parent.mkdir()
     original = {
         "mcpServers": {
-            "example": {"url": "https://example.test/mcp", "headers": {"X-Key": "stored-value"}},
-            "other": {"command": "server", "args": ["stored-value"]},
+            "example": {
+                "url": "https://user:private@example.test/mcp?token=private",
+                "headers": {"Authorization": "Bearer private", "X-Key": "${CREDENTIAL}"},
+                "env": {"KEY": "${CREDENTIAL:-private}"},
+                "args": ["private"],
+                "command": "private",
+                "transport": "http",
+            },
+            "other": {"command": "server"},
         },
-        "metadata": {"keep": True},
+        "metadata": "private",
     }
     path.write_text(json.dumps(original))
+    monkeypatch.setenv("CREDENTIAL", "expanded-private")
     result = view.invoke({})
+    assert "private" not in json.dumps(result)
     server = result["mcpServers"]["example"]
+    assert server["headers"]["X-Key"] == "${CREDENTIAL}"
+    assert server["transport"] == "http"
     server["allowedTools"] = ["read_*"]
-
-    assert update.invoke(
+    response = update.invoke(
         {"server_name": "example", "server": server, "expected_revision": result["revision"]}
-    ) == {"status": "updated", "available": "next_turn"}
-
-    expected = json.loads(json.dumps(original))
-    expected["mcpServers"]["example"]["allowedTools"] = ["read_*"]
-    assert json.loads(path.read_text()) == expected
+    )
+    assert response == {"status": "updated", "available": "next_turn"}
+    original["mcpServers"]["example"]["allowedTools"] = ["read_*"]
+    assert json.loads(path.read_text()) == original
     assert path.stat().st_mode & 0o777 == 0o600
     assert updates == [True]
-    assert view.invoke({})["revision"] != result["revision"]
 
 
 def test_add_remove_and_stale_revision(config_tools):
@@ -90,46 +71,30 @@ def test_add_remove_and_stale_revision(config_tools):
         "expected_revision": revision,
     }
     assert update.invoke(arguments)["status"] == "updated"
-    assert update.invoke(arguments)["status"] == "conflict"
-    assert (
-        update.invoke(
-            {**arguments, "server": None, "expected_revision": view.invoke({})["revision"]}
-        )["status"]
-        == "updated"
+    revision = view.invoke({})["revision"]
+    path.write_text('{"mcpServers": {"operator": {"command": "server"}}}')
+    assert update.invoke({**arguments, "expected_revision": revision})["status"] == "conflict"
+    assert "example" not in json.loads(path.read_text())["mcpServers"]
+    result = update.invoke(
+        {
+            "server_name": "operator",
+            "server": None,
+            "expected_revision": view.invoke({})["revision"],
+        }
     )
+    assert result["status"] == "updated"
     assert json.loads(path.read_text()) == {"mcpServers": {}}
     assert updates == [True, True]
-
-
-def test_external_edit_invalidates_pending_update(config_tools):
-    path, view, update, updates = config_tools
-    revision = view.invoke({})["revision"]
-    path.parent.mkdir()
-    path.write_text('{"mcpServers": {}, "operator": true}')
-    original = path.read_bytes()
-    result = update.invoke(
-        {"server_name": "example", "server": {"command": "server"}, "expected_revision": revision}
-    )
-    assert result["status"] == "conflict"
-    assert path.read_bytes() == original
-    assert updates == []
 
 
 @pytest.mark.parametrize(
     "server",
     [
         {"url": "<redacted>"},
-        {"command": "server", "env": {"PYTHONPATH": "/untrusted"}},
         {"url": "https://example.test", "auth": "oauth", "headers": {"Authorization": "value"}},
-        {"url": "https://example.test", "allowedTools": []},
-        {"command": "server", "allowedTools": ["*"], "disabledTools": ["*"]},
         {"url": "https://example.test", "unknown": "value"},
-        {"transport": "invalid"},
         {"transport": []},
-        {"args": "bad"},
-        {"command": 123},
         {"command": "${INVALID"},
-        {"url": "https://example.test", "env": []},
     ],
 )
 def test_invalid_update_leaves_file_unchanged(config_tools, server):
@@ -223,33 +188,11 @@ def test_concurrent_updates_do_not_overwrite_each_other(config_tools):
     assert updates == [True]
 
 
-async def test_provider_keeps_management_tools_after_refresh(tmp_path):
-    config = TalonConfig(
-        "test", tmp_path, env={"DEEPAGENTS_TALON_MCP_CONFIG": str(tmp_path / "mcp")}
-    )
-    provider = MCPToolProvider(config)
-    tools = {tool.name: tool for tool in (await provider.load()).tools}
-    revision = tools["get_mcp_configuration"].invoke({})["revision"]
-    result = tools["update_mcp_server"].invoke(
-        {
-            "server_name": "absent",
-            "server": None,
-            "expected_revision": revision,
-        }
-    )
-    assert result["status"] == "updated"
-    refreshed = await provider.refresh_if_needed()
-    assert refreshed is not None
-    assert {tool.name for tool in refreshed} == tools.keys()
-    assert await provider.refresh_if_needed() is None
-
-
 class ToolCallingModel(FakeMessagesListChatModel):
     def bind_tools(self, *_args: object, **_kwargs: object) -> Self:
         return self
 
 
-@pytest.mark.parametrize("after_reload", [False, True])
 @pytest.mark.parametrize(
     ("decision", "auto_approve", "trigger", "writes"),
     [
@@ -258,12 +201,11 @@ class ToolCallingModel(FakeMessagesListChatModel):
         (None, None, "channel", False),
         ("approve", None, "cron", False),
         (None, "true", "channel", True),
-        (None, "false", "channel", False),
         (None, "typo", "channel", False),
     ],
 )
-async def test_runtime_gates_real_config_writes(  # noqa: PLR0913  # Independent approval/reload cases.
-    config_tools, decision, auto_approve, trigger, writes, after_reload
+async def test_runtime_gates_real_config_writes(
+    config_tools, decision, auto_approve, trigger, writes
 ):
     path, view, update, _ = config_tools
     arguments = {
@@ -292,7 +234,7 @@ async def test_runtime_gates_real_config_writes(  # noqa: PLR0913  # Independent
 
     runtime = DeepAgentRuntime(
         model=model,
-        tools=[] if after_reload else [view, update],
+        tools=[],
         reload_tools=reload_tools,
         backend=StateBackend(),
         env={} if auto_approve is None else {MCP_CONFIG_AUTO_APPROVE_ENV: auto_approve},
@@ -303,8 +245,7 @@ async def test_runtime_gates_real_config_writes(  # noqa: PLR0913  # Independent
     )
     await runtime.start()
     try:
-        if after_reload:
-            await runtime.reload_mcp_configuration()
+        await runtime.reload_mcp_configuration()
         await runtime.invoke(
             AgentRequest(
                 conversation_id="chat",
@@ -317,58 +258,3 @@ async def test_runtime_gates_real_config_writes(  # noqa: PLR0913  # Independent
         await runtime.stop()
     assert path.exists() is writes
     assert bool(approvals) is (decision is not None and trigger != "cron")
-
-
-async def test_pending_approval_rejects_concurrent_edit(config_tools):
-    path, view, update, _ = config_tools
-    arguments = {
-        "server_name": "example",
-        "server": {"command": "server"},
-        "expected_revision": view.invoke({})["revision"],
-    }
-    model = ToolCallingModel(
-        responses=[
-            AIMessage(
-                content="",
-                tool_calls=[{"name": "update_mcp_server", "args": arguments, "id": "call"}],
-            ),
-            AIMessage(content="done"),
-        ]
-    )
-    waiting, resume = asyncio.Event(), asyncio.Event()
-
-    async def approve(_request: ToolApprovalRequest) -> ToolApprovalDecision:
-        waiting.set()
-        await resume.wait()
-        return "approve"
-
-    runtime = DeepAgentRuntime(
-        model=model,
-        tools=[view, update],
-        backend=StateBackend(),
-        env={},
-        include_web_tools=False,
-        skills=(),
-        memory=(),
-    )
-    await runtime.start()
-    task = asyncio.create_task(
-        runtime.invoke(
-            AgentRequest(
-                conversation_id="chat",
-                text="configure MCP",
-                approval_handler=approve,
-            )
-        )
-    )
-    try:
-        await asyncio.wait_for(waiting.wait(), timeout=5)
-        path.parent.mkdir()
-        path.write_text('{"mcpServers": {}, "operator": true}')
-        resume.set()
-        await task
-        assert json.loads(path.read_text()) == {"mcpServers": {}, "operator": True}
-    finally:
-        resume.set()
-        await task
-        await runtime.stop()


### PR DESCRIPTION
Talon can inspect and update its MCP configuration through chat, with redacted reads and human approval required for updates by default.

---

Adds `get_mcp_configuration` and `update_mcp_server`, bound to the operator-selected file outside the workspace. Updates preserve redacted credentials, reject stale revisions, write atomically, and reload before the next turn.

Set `DEEPAGENTS_TALON_MCP_CONFIG_AUTO_APPROVE=true` to disable the default gate. Explicit approval policies still apply. Configuration changes can launch commands or send credentials to new destinations; these tools require Linux/macOS and do not isolate the existing shell backend.

Validation: 161 focused Python tests and 14 bridge tests passed; `make lint` passed (Ruff and ty). No new dependencies or public signature changes.
