### PR TITLE
docs(talon): document missing environment defaults

### DIFF
--- a/examples/talon/.env.example
+++ b/examples/talon/.env.example
@@ -5,15 +5,44 @@ DEEPAGENTS_TALON_CONTEXT_SIZE=75000
 DEEPAGENTS_TALON_RECURSION_LIMIT=500
 OPENAI_API_KEY=
 
+# Optional runtime settings. Commented values are runtime defaults unless noted.
+# Talon-prefixed identity/model overrides fall back to the AGENT_* values above.
+# DEEPAGENTS_TALON_ASSISTANT_ID=${AGENT_ASSISTANT_ID}
+# DEEPAGENTS_TALON_MODEL=${AGENT_MODEL}
+# DEEPAGENTS_TALON_HOME=${HOME}/.deepagents
+# Workspace defaults to the current directory; Docker sets it to /workspace.
+# DEEPAGENTS_TALON_WORKSPACE=.
+# Additional skills directories and memory overrides use OS path separators or ;.
+# Empty values preserve the built-in skills and assistant memory discovery.
+# DEEPAGENTS_TALON_SKILLS_DIRS=
+# DEEPAGENTS_TALON_MEMORY_PATHS=
+# Optional comma-separated tool names that always require channel approval.
+# DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS=
+
+# MCP configuration updates require approval unless explicitly opted out.
+# DEEPAGENTS_TALON_MCP_CONFIG=${HOME}/.deepagents/.mcp.json
+# DEEPAGENTS_TALON_MCP_CONFIG_AUTO_APPROVE=false
+
+# Startup cleanup of completed cron jobs and downloaded inbound media.
+# DEEPAGENTS_TALON_CRON_RETENTION_DAYS=30
+# DEEPAGENTS_TALON_INBOUND_MEDIA_RETENTION_HOURS=24
+# Media limit is in bytes (1 GiB); WhatsApp is additionally capped at 64 MiB.
+# DEEPAGENTS_TALON_MAX_MEDIA_BYTES=1073741824
+# Unset/empty outbound media directory falls back to the workspace/current directory.
+# DEEPAGENTS_TALON_OUTBOUND_MEDIA_DIR=
+
 # Optional LangSmith tracing. Traces are emitted only when both are set.
 LANGSMITH_TRACING=false
 LANGSMITH_API_KEY=
 LANGSMITH_PROJECT=deepagents-talon
+# Include raw channel identifiers in approval logs (disabled by default).
+# DEEPAGENTS_TALON_APPROVAL_LOG_RAW_IDS=false
 
 # Voice transcription.
 # Uses local NVIDIA Parakeet through Transformers. First use downloads the model.
 DEEPAGENTS_TALON_VOICE_TRANSCRIPTION_ENABLED=true
 DEEPAGENTS_TALON_VOICE_TRANSCRIPTION_DEVICE=cpu
+# DEEPAGENTS_TALON_VOICE_TRANSCRIPTION_MODEL=nvidia/parakeet-tdt-0.6b-v3
 
 # --- WhatsApp channel ---
 # Uncomment to enable the WhatsApp channel adapter.
@@ -25,6 +54,22 @@ DEEPAGENTS_TALON_VOICE_TRANSCRIPTION_DEVICE=cpu
 # DEEPAGENTS_TALON_WHATSAPP_BRIDGE_HOST=127.0.0.1
 # DEEPAGENTS_TALON_WHATSAPP_BRIDGE_PORT=3000
 # DEEPAGENTS_TALON_WHATSAPP_START_BRIDGE=true
+# Session/media paths below assume the default home and AGENT_ASSISTANT_ID above.
+# DEEPAGENTS_TALON_WHATSAPP_SESSION_DIR=${HOME}/.deepagents/${AGENT_ASSISTANT_ID}/channels/whatsapp
+# DEEPAGENTS_TALON_WHATSAPP_MEDIA_DIR=${HOME}/.deepagents/${AGENT_ASSISTANT_ID}/media/inbound/whatsapp
+# DEEPAGENTS_TALON_WHATSAPP_BOT_HEADER="deepagents bot"
+# DEEPAGENTS_TALON_WHATSAPP_POLL_SECONDS=1.0
+# DEEPAGENTS_TALON_WHATSAPP_HEALTH_SECONDS=5.0
+# DEEPAGENTS_TALON_WHATSAPP_REQUEST_TIMEOUT_SECONDS=10.0
+# Optional bridge command override; unset/empty uses START_BRIDGE above.
+# DEEPAGENTS_TALON_WHATSAPP_BRIDGE_COMMAND=
+# Unset/empty bridge token generates a random token at startup.
+# DEEPAGENTS_TALON_WHATSAPP_BRIDGE_TOKEN=
+# Leave these unset for the bridge's browser and web-version defaults.
+# DEEPAGENTS_TALON_WHATSAPP_CHROME_PATH=
+# DEEPAGENTS_TALON_WHATSAPP_WEB_VERSION_CACHE_URL=
+# Open exposure requires an explicit acknowledgement; unset by default.
+# DEEPAGENTS_TALON_WHATSAPP_OPEN_ACK=
 
 # --- Telegram channel ---
 # Uncomment to enable the Telegram channel adapter.
@@ -35,4 +80,25 @@ DEEPAGENTS_TALON_VOICE_TRANSCRIPTION_DEVICE=cpu
 # DEEPAGENTS_TALON_TELEGRAM_ALLOWLIST_CHATS=
 # DEEPAGENTS_TALON_TELEGRAM_ALLOWLIST_USERS=
 # DEEPAGENTS_TALON_TELEGRAM_MENTION_PATTERNS=
+# DEEPAGENTS_TALON_TELEGRAM_SESSION_DIR=${HOME}/.deepagents/${AGENT_ASSISTANT_ID}/channels/telegram
+# DEEPAGENTS_TALON_TELEGRAM_MEDIA_DIR=${HOME}/.deepagents/${AGENT_ASSISTANT_ID}/media/inbound/telegram
+# DEEPAGENTS_TALON_TELEGRAM_API_BASE=https://api.telegram.org
+# DEEPAGENTS_TALON_TELEGRAM_POLL_TIMEOUT_SECONDS=30.0
+# DEEPAGENTS_TALON_TELEGRAM_POLL_INTERVAL_SECONDS=1.0
+# DEEPAGENTS_TALON_TELEGRAM_REQUEST_TIMEOUT_SECONDS=35.0
+# DEEPAGENTS_TALON_TELEGRAM_OPEN_ACK=
+
+# --- Discord channel ---
+# Set ENABLED=true and provide a bot token and operator ID to enable Discord.
+# DEEPAGENTS_TALON_DISCORD_ENABLED=false
+# DEEPAGENTS_TALON_DISCORD_BOT_TOKEN=
+# DEEPAGENTS_TALON_DISCORD_EXPOSURE=self
+# DEEPAGENTS_TALON_DISCORD_OPERATOR_ID=
+# DEEPAGENTS_TALON_DISCORD_ALLOWLIST_CHATS=
+# DEEPAGENTS_TALON_DISCORD_ALLOWLIST_USERS=
+# DEEPAGENTS_TALON_DISCORD_MENTION_PATTERNS=
+# DEEPAGENTS_TALON_DISCORD_MEDIA_DIR=${HOME}/.deepagents/${AGENT_ASSISTANT_ID}/media/inbound/discord
+# DEEPAGENTS_TALON_DISCORD_REQUEST_TIMEOUT_SECONDS=35.0
+# DEEPAGENTS_TALON_DISCORD_OPEN_ACK=
+
 DEEPAGENTS_TALON_AGENT_ACTIVITY_LOGGING=true


### PR DESCRIPTION
The Talon environment example was missing runtime, approval, MCP, retention, media, and channel settings. Add 43 commented entries using source-verified defaults, with notes for computed paths and empty placeholders for credentials and unset options. Existing active settings are unchanged.

Validation: checked all literal Talon environment-variable names against the template, confirmed no duplicate settings or active-value changes, and ran `git diff --check`. No runtime code changes.
