### PR TITLE
fix(talon): preserve WhatsApp approval loops and handle reactions

### DIFF
--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -43,8 +43,10 @@ from deepagents_talon.channels.base import (
 from deepagents_talon.interfaces import (
     ChannelMedia,
     ChannelMessage,
+    ChannelReaction,
     ChannelStatus,
     MessageHandler,
+    ReactionHandler,
     SendResult,
 )
 from deepagents_talon.observability import log_debug_event
@@ -285,6 +287,7 @@ class WhatsAppChannel:
             token=config.bridge_token,
         )
         self._handler: MessageHandler | None = None
+        self._reaction_handler: ReactionHandler | None = None
         self._process: asyncio.subprocess.Process | None = None
         self._bridge_stdout: asyncio.Task[None] | None = None
         self._bridge_stderr: asyncio.Task[None] | None = None
@@ -301,6 +304,35 @@ class WhatsAppChannel:
             handler: Coroutine callback invoked for accepted inbound messages.
         """
         self._handler = handler
+
+    def set_reaction_handler(self, handler: ReactionHandler) -> None:
+        """Register the host callback for inbound reactions.
+
+        Args:
+            handler: Coroutine callback invoked for accepted inbound reactions.
+        """
+        self._reaction_handler = handler
+
+    async def _dispatch_reaction(self, message: ChannelMessage) -> bool:
+        if message.sender_id not in self.config.exposure.operator_ids:
+            return False
+        if message.metadata.get("from_self") and not message.metadata.get("self_chat"):
+            return False
+        if not message.message_id or not message.text:
+            return False
+        if self._reaction_handler is None:
+            logger.warning("Dropping WhatsApp reaction because no handler is registered")
+            return False
+        await self._reaction_handler(
+            ChannelReaction(
+                conversation_id=message.conversation_id,
+                message_id=message.message_id,
+                sender_id=message.sender_id,
+                emoji=message.text,
+                metadata=message.metadata,
+            )
+        )
+        return True
 
     async def start(self) -> None:
         """Start the bridge subprocess and background polling tasks."""
@@ -545,6 +577,9 @@ class WhatsAppChannel:
                     )
                 accepted = 0
                 for message in messages:
+                    if message.metadata.get("event_type") == "reaction":
+                        accepted += await self._dispatch_reaction(message)
+                        continue
                     if _allows_whatsapp_message(self.config.exposure, message):
                         accepted += 1
                         checked = _enforce_inbound_media_cap(
@@ -803,6 +838,7 @@ def _parse_message(payload: object) -> ChannelMessage:
         message_id=optional_str(values.get("message_id") or values.get("messageId")),
         metadata={
             "provider": "whatsapp",
+            "event_type": values.get("event_type"),
             "message_type": message_type,
             "media_type": media_type,
             "chat_name": values.get("chat_name") or values.get("chatName"),

--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -314,25 +314,58 @@ class WhatsAppChannel:
         self._reaction_handler = handler
 
     async def _dispatch_reaction(self, message: ChannelMessage) -> bool:
-        if message.sender_id not in self.config.exposure.operator_ids:
-            return False
-        if message.metadata.get("from_self") and not message.metadata.get("self_chat"):
-            return False
-        if not message.message_id or not message.text:
-            return False
-        if self._reaction_handler is None:
-            logger.warning("Dropping WhatsApp reaction because no handler is registered")
-            return False
-        await self._reaction_handler(
-            ChannelReaction(
-                conversation_id=message.conversation_id,
-                message_id=message.message_id,
-                sender_id=message.sender_id,
-                emoji=message.text,
-                metadata=message.metadata,
-            )
+        log_debug_event(
+            logger,
+            "whatsapp.inbound.reaction.received",
+            sender_id_present=bool(message.sender_id),
+            operator_match=message.sender_id in self.config.exposure.operator_ids,
+            operator_count=len(self.config.exposure.operator_ids),
+            from_self=bool(message.metadata.get("from_self")),
+            self_chat=bool(message.metadata.get("self_chat")),
+            message_id_present=bool(message.message_id),
+            emoji_present=bool(message.text),
+            handler_registered=self._reaction_handler is not None,
         )
+        reason = self._reaction_rejection_reason(message)
+        if reason or self._reaction_handler is None or not message.message_id:
+            log_debug_event(logger, "whatsapp.inbound.reaction.rejected", reason=reason)
+            if reason == "missing_handler":
+                logger.warning("Dropping WhatsApp reaction because no handler is registered")
+            return False
+        log_debug_event(logger, "whatsapp.inbound.reaction.dispatching")
+        try:
+            await self._reaction_handler(
+                ChannelReaction(
+                    conversation_id=message.conversation_id,
+                    message_id=message.message_id,
+                    sender_id=message.sender_id,
+                    emoji=message.text,
+                    metadata=message.metadata,
+                )
+            )
+        except Exception:
+            log_debug_event(logger, "whatsapp.inbound.reaction.dispatch_failed")
+            raise
+        log_debug_event(logger, "whatsapp.inbound.reaction.dispatched")
         return True
+
+    def _reaction_rejection_reason(self, message: ChannelMessage) -> str | None:
+        from_self = message.metadata.get("from_self") is True
+        self_chat = message.metadata.get("self_chat") is True
+        if from_self and not self_chat:
+            return "self_outside_self_chat"
+        if (
+            not (from_self and self_chat)
+            and message.sender_id not in self.config.exposure.operator_ids
+        ):
+            return "sender_not_operator"
+        if not message.message_id:
+            return "missing_message_id"
+        if not message.text:
+            return "missing_emoji"
+        if self._reaction_handler is None:
+            return "missing_handler"
+        return None
 
     async def start(self) -> None:
         """Start the bridge subprocess and background polling tasks."""

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
@@ -11,6 +11,7 @@ const {
   contactIdentityIds,
   createCompatibleClientClass,
   isSelfChat,
+  messageSenderId,
   normalizeMessage,
   quotedMessageContext,
   reactionEntry,
@@ -126,9 +127,16 @@ client.on("message", (message) => {
 });
 
 client.on("message_reaction", (reaction) => {
-  const entry = reactionEntry(reaction, botId, botIds);
-  if (entry) {
-    queue.push(entry);
+  console.log('[bridge] talon_event {"event":"whatsapp.bridge.reaction.received"}');
+  try {
+    const entry = reactionEntry(reaction, botId, botIds);
+    if (entry) {
+      queue.push(entry);
+      console.log('[bridge] talon_event {"event":"whatsapp.bridge.reaction.queued"}');
+    }
+  } catch (error) {
+    console.log('[bridge] talon_event {"event":"whatsapp.bridge.reaction.parse_failed"}');
+    throw error;
   }
 });
 
@@ -208,7 +216,7 @@ async function enqueueMessage(message, fromSelf) {
       `[bridge] Message media unavailable; type=${message.type || "unknown"} mediaType=${mediaType}`,
     );
   }
-  const senderId = widString(message.author) || (fromSelf && botId ? botId : messageFrom);
+  const senderId = messageSenderId(message, fromSelf, botId, messageFrom);
   const senderName =
     (contact && (contact.pushname || contact.name || contact.shortName)) ||
     data.notifyName ||

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
@@ -13,6 +13,7 @@ const {
   isSelfChat,
   normalizeMessage,
   quotedMessageContext,
+  reactionEntry,
   serializedId,
   widString,
 } = require("./id_compat");
@@ -122,6 +123,13 @@ client.on("message_create", (message) => {
 
 client.on("message", (message) => {
   void enqueueMessage(message, false);
+});
+
+client.on("message_reaction", (reaction) => {
+  const entry = reactionEntry(reaction, botId, botIds);
+  if (entry) {
+    queue.push(entry);
+  }
 });
 
 client.on("media_uploaded", (message) => {

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/id_compat.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/id_compat.js
@@ -47,14 +47,30 @@ function serializedId(value) {
   return typeof value.id === "string" && value.id ? value.id : null;
 }
 
+function messageSenderId(message, fromSelf, botId, messageFrom) {
+  return fromSelf === true && botId ? botId : widString(message.author) || messageFrom;
+}
+
 function reactionEntry(reaction, botId, botIds) {
   const messageId = serializedId(reaction.msgId);
   const chatId = widString(reaction.msgId && reaction.msgId.remote);
   const fromSelf = Boolean(reaction.id && reaction.id.fromMe === true);
   const selfChat = isSelfChat(fromSelf, chatId, botIds);
   const senderId = fromSelf ? botId : widString(reaction.senderId);
-  if (!messageId || !chatId || !senderId || !reaction.reaction ||
-      chatId === "status@broadcast" || (fromSelf && !selfChat)) {
+  const reason = !messageId ? "missing_message_id"
+    : !chatId ? "missing_chat_id"
+    : !senderId ? "missing_sender_id"
+    : !reaction.reaction ? "missing_emoji"
+    : chatId === "status@broadcast" ? "status_broadcast"
+    : fromSelf && !selfChat ? "self_outside_self_chat" : null;
+  console.log(`[bridge] talon_event ${JSON.stringify({
+    event: reason ? "whatsapp.bridge.reaction.rejected" : "whatsapp.bridge.reaction.converted",
+    reason, from_self: fromSelf, self_chat: selfChat,
+    message_id_present: Boolean(messageId), chat_id_present: Boolean(chatId),
+    sender_id_present: Boolean(senderId), emoji_present: Boolean(reaction.reaction),
+    bot_id_present: Boolean(botId), bot_alias_count: botIds.length,
+  })}`);
+  if (reason) {
     return null;
   }
   return {
@@ -288,6 +304,7 @@ module.exports = {
   installMessageKeyCompatibility,
   installPageCompatibility,
   isSelfChat,
+  messageSenderId,
   normalizeId,
   normalizeMessage,
   quotedMessageContext,

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/id_compat.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/id_compat.js
@@ -47,6 +47,23 @@ function serializedId(value) {
   return typeof value.id === "string" && value.id ? value.id : null;
 }
 
+function reactionEntry(reaction, botId, botIds) {
+  const messageId = serializedId(reaction.msgId);
+  const chatId = widString(reaction.msgId && reaction.msgId.remote);
+  const fromSelf = Boolean(reaction.id && reaction.id.fromMe === true);
+  const selfChat = isSelfChat(fromSelf, chatId, botIds);
+  const senderId = fromSelf ? botId : widString(reaction.senderId);
+  if (!messageId || !chatId || !senderId || !reaction.reaction ||
+      chatId === "status@broadcast" || (fromSelf && !selfChat)) {
+    return null;
+  }
+  return {
+    event_type: "reaction", chat_id: chatId, user_id: senderId,
+    message_id: messageId, text: reaction.reaction,
+    from_self: fromSelf, self_chat: selfChat,
+  };
+}
+
 async function quotedMessageContext(message) {
   if (!message.hasQuotedMsg) {
     return { participant: null, messageId: null, status: "not_reply" };
@@ -274,6 +291,7 @@ module.exports = {
   normalizeId,
   normalizeMessage,
   quotedMessageContext,
+  reactionEntry,
   serializedId,
   widString,
 };

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -125,6 +125,7 @@ class _PendingToolApproval:
     provider: str
     channel_conversation_id: str
     agent_conversation_id: str
+    prompt_text: str
     prompt_message_id: str | None
     sender_id: str | None
 
@@ -307,10 +308,8 @@ class TalonHost:
 
             pending = self._pending_tool_approvals.get(agent_conversation_id)
             if pending is not None:
-                authorized = pending.sender_id is None or message.sender_id == pending.sender_id
-                if not authorized or _parse_tool_approval_reply(message.text) is not None:
-                    await self._handle_tool_approval_reply(channel, message, pending)
-                    return
+                await self._handle_tool_approval_reply(channel, message, pending)
+                return
 
             if await self._intercept_authorization_message(
                 channel,
@@ -1032,22 +1031,27 @@ class TalonHost:
             provider=provider,
             channel_conversation_id=reply_conversation_id,
             agent_conversation_id=approval.conversation_id,
+            prompt_text=_format_tool_approval_prompt(approval),
             prompt_message_id=None,
             sender_id=sender_id,
         )
         self._pending_tool_approvals[approval.conversation_id] = pending
         try:
-            result = await send_with_retry(
-                lambda: channel.send_message(
-                    reply_conversation_id,
-                    _format_tool_approval_prompt(approval),
-                )
-            )
-            pending.prompt_message_id = result.message_id
+            await self._send_tool_approval_prompt(channel, pending)
             return await future
         finally:
             if self._pending_tool_approvals.get(approval.conversation_id) is pending:
                 del self._pending_tool_approvals[approval.conversation_id]
+
+    async def _send_tool_approval_prompt(
+        self,
+        channel: ChannelAdapter,
+        pending: _PendingToolApproval,
+    ) -> None:
+        result = await send_with_retry(
+            lambda: channel.send_message(pending.channel_conversation_id, pending.prompt_text)
+        )
+        pending.prompt_message_id = result.message_id
 
     async def _handle_tool_approval_reply(
         self,
@@ -1066,12 +1070,7 @@ class TalonHost:
 
         decision = _parse_tool_approval_reply(message.text)
         if decision is None:
-            await send_with_retry(
-                lambda: channel.send_message(
-                    message.conversation_id,
-                    "Reply `approve` to run the tool call or `deny` to skip it.",
-                )
-            )
+            await self._send_tool_approval_prompt(channel, pending)
             return
 
         if not pending.future.done():

--- a/libs/talon/tests/channels/whatsapp_bridge/id_compat.test.js
+++ b/libs/talon/tests/channels/whatsapp_bridge/id_compat.test.js
@@ -13,10 +13,33 @@ const {
   isSelfChat,
   normalizeId,
   normalizeMessage,
+  reactionEntry,
   quotedMessageContext,
   serializedId,
   widString,
 } = require("../../../deepagents_talon/channels/whatsapp_bridge/id_compat");
+
+test("queues reactions with the target message ID and reacting sender", () => {
+  const reaction = {
+    id: { fromMe: false, remote: "chat@g.us", id: "REACTION" },
+    msgId: { fromMe: true, remote: "chat@g.us", id: "PROMPT" },
+    senderId: { _serialized: "operator@lid" },
+    reaction: "\u{1f44d}",
+  };
+  assert.deepEqual(reactionEntry(reaction, "bot@c.us", ["bot@c.us"]), {
+    event_type: "reaction", chat_id: "chat@g.us", user_id: "operator@lid",
+    message_id: "true_chat@g.us_PROMPT", text: "\u{1f44d}",
+    from_self: false, self_chat: false,
+  });
+  assert.equal(reactionEntry({ ...reaction, reaction: "" }, "bot@c.us", []), null);
+  assert.equal(reactionEntry({ ...reaction, senderId: null }, "bot@c.us", []), null);
+  const own = { ...reaction, id: { ...reaction.id, fromMe: true } };
+  assert.equal(reactionEntry(own, "bot@c.us", ["bot@c.us"]), null);
+  const self = { ...own, msgId: { ...own.msgId, remote: "bot@lid" } };
+  const entry = reactionEntry(self, "bot@c.us", ["bot@c.us", "bot@lid"]);
+  assert.equal(entry.user_id, "bot@c.us");
+  assert.equal(entry.self_chat, true);
+});
 
 test("reads legacy, renamed, and component WhatsApp IDs", () => {
   assert.equal(widString({ _serialized: "123@lid" }), "123@lid");

--- a/libs/talon/tests/channels/whatsapp_bridge/id_compat.test.js
+++ b/libs/talon/tests/channels/whatsapp_bridge/id_compat.test.js
@@ -11,6 +11,7 @@ const {
   createCompatibleClientClass,
   installMessageKeyCompatibility,
   isSelfChat,
+  messageSenderId,
   normalizeId,
   normalizeMessage,
   reactionEntry,
@@ -18,6 +19,27 @@ const {
   serializedId,
   widString,
 } = require("../../../deepagents_talon/channels/whatsapp_bridge/id_compat");
+
+test("self-chat messages and approval reactions use the same paired-account identity", () => {
+  const botId = "phone@c.us";
+  const aliases = [botId, "alias@lid"];
+  for (const author of aliases) {
+    for (const emoji of ["\u{1f44d}", "\u{1f44e}"]) {
+      const message = normalizeMessage({ author: { _serialized: author } });
+      const sender = messageSenderId(message, true, botId, botId);
+      const reaction = reactionEntry({
+        id: { fromMe: true },
+        msgId: { fromMe: true, remote: "alias@lid", id: "PROMPT" },
+        senderId: author,
+        reaction: emoji,
+      }, botId, aliases);
+      assert.equal(sender, reaction.user_id);
+      assert.equal(sender, botId);
+    }
+  }
+  assert.equal(messageSenderId({ author: "other@lid" }, false, botId, "group@g.us"), "other@lid");
+  assert.equal(messageSenderId({}, false, botId, "other@c.us"), "other@c.us");
+});
 
 test("queues reactions with the target message ID and reacting sender", () => {
   const reaction = {
@@ -39,6 +61,33 @@ test("queues reactions with the target message ID and reacting sender", () => {
   const entry = reactionEntry(self, "bot@c.us", ["bot@c.us", "bot@lid"]);
   assert.equal(entry.user_id, "bot@c.us");
   assert.equal(entry.self_chat, true);
+});
+
+test("reaction diagnostics explain filtering without exposing payloads", (t) => {
+  const logs = [];
+  t.mock.method(console, "log", (line) => logs.push(line));
+  const reaction = {
+    id: { fromMe: false },
+    msgId: { fromMe: true, remote: "private-chat", id: "private-message" },
+    senderId: "private-sender", reaction: "private-emoji",
+  };
+  const cases = [
+    [{}, null],
+    [{ msgId: null }, "missing_message_id"],
+    [{ msgId: { _serialized: "private-message" } }, "missing_chat_id"],
+    [{ senderId: null }, "missing_sender_id"],
+    [{ reaction: "" }, "missing_emoji"],
+    [{ msgId: { remote: "status@broadcast", id: "private-message" } }, "status_broadcast"],
+    [{ id: { fromMe: true } }, "self_outside_self_chat"],
+  ];
+  for (const [changes, reason] of cases) {
+    const entry = reactionEntry({ ...reaction, ...changes }, "private-bot", ["private-bot"]);
+    assert.equal(entry === null, reason !== null);
+    const event = JSON.parse(logs.at(-1).split("talon_event ")[1]);
+    assert.equal(event.reason, reason);
+    assert.equal(event.event, reason ? "whatsapp.bridge.reaction.rejected" : "whatsapp.bridge.reaction.converted");
+  }
+  assert.equal(logs.some((line) => line.includes("private-")), false);
 });
 
 test("reads legacy, renamed, and component WhatsApp IDs", () => {

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -968,13 +968,13 @@ async def test_host_keeps_tool_approval_scoped_to_original_sender(tmp_path: Path
     await _wait_for_sent_count(channel, 4)
     await host.stop()
 
-    assert [request.text for request in agent.requests] == ["run", "maybe"]
-    assert agent.recoveries == ["chat"]
+    assert [request.text for request in agent.requests] == ["run"]
+    assert agent.recoveries == []
     assert channel.sent[1] == (
         "chat",
         "Only the operator who started this run can approve or deny it.",
     )
-    assert "Tool approval required." in channel.sent[2][1]
+    assert channel.sent[2] == channel.sent[0]
     assert channel.sent[3] == ("chat", "decision:reject")
 
 

--- a/libs/talon/tests/unit_tests/test_whatsapp_reactions.py
+++ b/libs/talon/tests/unit_tests/test_whatsapp_reactions.py
@@ -1,0 +1,132 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from deepagents_talon.channels.base import ChannelExposure, ExposureMode
+from deepagents_talon.channels.whatsapp import WhatsAppChannel, WhatsAppChannelConfig
+from deepagents_talon.host import TalonHost
+from deepagents_talon.interfaces import ChannelMessage, ChannelReaction, ReactionChannelAdapter
+from tests.channels.test_whatsapp import RecordingTransport
+from tests.test_host import ApprovalAgent, _config
+
+
+@pytest.mark.parametrize(
+    ("sender", "emoji", "self_state", "expected"),
+    [
+        ("operator", "\U0001f44d", (False, False), 1),
+        ("operator", "\U0001f44e", (False, False), 1),
+        ("stranger", "\U0001f44d", (False, False), 0),
+        (None, "\U0001f44d", (False, False), 0),
+        ("operator", "", (False, False), 0),
+        ("operator", "\U0001f44d", (True, False), 0),
+        ("operator", "\U0001f44d", (True, True), 1),
+    ],
+)
+async def test_poll_dispatches_only_authorized_reactions(
+    tmp_path: Path,
+    sender: str | None,
+    emoji: str,
+    self_state: tuple[bool, bool],
+    expected: int,
+) -> None:
+    transport = RecordingTransport(
+        messages=[
+            {
+                "event_type": "reaction",
+                "chat_id": "chat",
+                "user_id": sender,
+                "message_id": "approval-prompt",
+                "text": emoji,
+                "from_self": self_state[0],
+                "self_chat": self_state[1],
+            }
+        ]
+    )
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path,
+            exposure=ChannelExposure(mode=ExposureMode.OPEN, operator_ids=frozenset({"operator"})),
+            poll_interval_seconds=0,
+        ),
+        transport=transport,
+    )
+    assert isinstance(channel, ReactionChannelAdapter)
+    reactions: list[ChannelReaction] = []
+    messages: list[ChannelMessage] = []
+
+    async def receive(reaction: ChannelReaction) -> None:
+        reactions.append(reaction)
+
+    async def receive_message(message: ChannelMessage) -> None:
+        messages.append(message)
+
+    async def get(path: str) -> object:
+        channel._stopped.set()
+        return await RecordingTransport.get(transport, path)
+
+    transport.get = get
+    channel.set_reaction_handler(receive)
+    channel.set_message_handler(receive_message)
+    await channel._poll_messages()
+    assert messages == []
+    assert len(reactions) == expected
+    if expected:
+        assert reactions[0].message_id == "approval-prompt"
+        assert reactions[0].sender_id == "operator"
+        assert reactions[0].emoji == emoji
+
+
+class ApprovalTransport(RecordingTransport):
+    def __init__(self) -> None:
+        super().__init__()
+        self.sent: asyncio.Queue[str] = asyncio.Queue()
+
+    async def post(self, path: str, payload: dict[str, object]) -> object:
+        result = await super().post(path, payload)
+        if path == "/send":
+            self.sent.put_nowait(str(payload["text"]))
+        return result
+
+
+@pytest.mark.parametrize(
+    ("emoji", "decision"), [("\U0001f44d\U0001f3fd", "approve"), ("\U0001f44e", "reject")]
+)
+async def test_whatsapp_reaction_resolves_host_approval(
+    tmp_path: Path,
+    emoji: str,
+    decision: str,
+) -> None:
+    transport = ApprovalTransport()
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path / "whatsapp",
+            exposure=ChannelExposure(operator_ids=frozenset({"operator"})),
+            poll_interval_seconds=0.001,
+        ),
+        transport=transport,
+    )
+    agent = ApprovalAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        await host.receive_message(
+            channel,
+            ChannelMessage(conversation_id="chat", text="run", sender_id="operator"),
+        )
+        prompt = await asyncio.wait_for(transport.sent.get(), timeout=2)
+        assert "Tool approval required." in prompt
+        transport.messages.append(
+            {
+                "event_type": "reaction",
+                "chat_id": "chat",
+                "user_id": "operator",
+                "message_id": "sent",
+                "text": emoji,
+            }
+        )
+        result = await asyncio.wait_for(transport.sent.get(), timeout=2)
+        assert f"decision:{decision}" in result
+        assert len(agent.requests) == 1
+    finally:
+        await host.stop()

--- a/libs/talon/tests/unit_tests/test_whatsapp_reactions.py
+++ b/libs/talon/tests/unit_tests/test_whatsapp_reactions.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -77,31 +79,132 @@ async def test_poll_dispatches_only_authorized_reactions(
         assert reactions[0].emoji == emoji
 
 
+@pytest.mark.parametrize(
+    ("from_self", "self_chat", "expected"),
+    [
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
+        (False, False, False),
+        ("true", True, False),
+        (True, "true", False),
+    ],
+)
+async def test_self_reactions_without_configured_operators(
+    tmp_path: Path, *, from_self: bool | str, self_chat: bool | str, expected: bool
+) -> None:
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(session_dir=tmp_path, exposure=ChannelExposure()),
+        transport=RecordingTransport(),
+    )
+    reactions: list[ChannelReaction] = []
+
+    async def receive(reaction: ChannelReaction) -> None:
+        reactions.append(reaction)
+
+    channel.set_reaction_handler(receive)
+    message = ChannelMessage(
+        conversation_id="chat",
+        sender_id="paired-account",
+        message_id="prompt",
+        text="\U0001f44d",
+        metadata={"from_self": from_self, "self_chat": self_chat},
+    )
+    assert await channel._dispatch_reaction(message) is expected
+    assert len(reactions) == int(expected)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "sender_not_operator",
+        "self_outside_self_chat",
+        "missing_message_id",
+        "missing_emoji",
+        "missing_handler",
+        None,
+        "dispatch_failed",
+    ],
+)
+async def test_reaction_diagnostics_are_private(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, reason: str | None
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="deepagents_talon.channels.whatsapp")
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path,
+            exposure=ChannelExposure(operator_ids=frozenset({"private-sender"})),
+        ),
+        transport=RecordingTransport(),
+    )
+
+    async def receive(_reaction: ChannelReaction) -> None:
+        if reason == "dispatch_failed":
+            msg = "private-exception"
+            raise ValueError(msg)
+
+    if reason != "missing_handler":
+        channel.set_reaction_handler(receive)
+    message = ChannelMessage(
+        conversation_id="private-chat",
+        sender_id="private-stranger" if reason == "sender_not_operator" else "private-sender",
+        message_id=None if reason == "missing_message_id" else "private-message",
+        text="" if reason == "missing_emoji" else "private-emoji",
+        metadata={"from_self": reason == "self_outside_self_chat", "self_chat": False},
+    )
+    if reason == "dispatch_failed":
+        with pytest.raises(ValueError, match="private-exception"):
+            await channel._dispatch_reaction(message)
+    else:
+        assert await channel._dispatch_reaction(message) is (reason is None)
+    events = [
+        json.loads(record.message.split("talon_event ", 1)[1])
+        for record in caplog.records
+        if "talon_event " in record.message
+    ]
+    assert events[0]["event"] == "whatsapp.inbound.reaction.received"
+    if reason is None or reason == "dispatch_failed":
+        outcome = "dispatched" if reason is None else "dispatch_failed"
+        assert events[-1]["event"] == f"whatsapp.inbound.reaction.{outcome}"
+    else:
+        assert events[-1]["reason"] == reason
+        assert events[-1]["event"] == "whatsapp.inbound.reaction.rejected"
+    assert "private-" not in caplog.text
+
+
 class ApprovalTransport(RecordingTransport):
     def __init__(self) -> None:
         super().__init__()
         self.sent: asyncio.Queue[str] = asyncio.Queue()
+        self.send_count = 0
 
     async def post(self, path: str, payload: dict[str, object]) -> object:
         result = await super().post(path, payload)
         if path == "/send":
+            self.send_count += 1
             self.sent.put_nowait(str(payload["text"]))
+            return {"success": True, "message_id": f"sent-{self.send_count}"}
         return result
 
 
 @pytest.mark.parametrize(
     ("emoji", "decision"), [("\U0001f44d\U0001f3fd", "approve"), ("\U0001f44e", "reject")]
 )
+@pytest.mark.parametrize("self_chat", [False, True])
 async def test_whatsapp_reaction_resolves_host_approval(
     tmp_path: Path,
     emoji: str,
     decision: str,
+    *,
+    self_chat: bool,
 ) -> None:
     transport = ApprovalTransport()
     channel = WhatsAppChannel(
         WhatsAppChannelConfig(
             session_dir=tmp_path / "whatsapp",
-            exposure=ChannelExposure(operator_ids=frozenset({"operator"})),
+            exposure=ChannelExposure(
+                operator_ids=frozenset() if self_chat else frozenset({"operator"})
+            ),
             poll_interval_seconds=0.001,
         ),
         transport=transport,
@@ -116,13 +219,30 @@ async def test_whatsapp_reaction_resolves_host_approval(
         )
         prompt = await asyncio.wait_for(transport.sent.get(), timeout=2)
         assert "Tool approval required." in prompt
+        for text in ("how is it going?", "one more thing"):
+            transport.messages.append(
+                {
+                    "chat_id": "chat",
+                    "user_id": "operator",
+                    "message_id": "follow-up",
+                    "text": text,
+                    "from_self": self_chat,
+                    "self_chat": self_chat,
+                }
+            )
+            reminder = await asyncio.wait_for(transport.sent.get(), timeout=2)
+            assert reminder == prompt
+            assert len(agent.requests) == 1
+            assert agent.recoveries == []
         transport.messages.append(
             {
                 "event_type": "reaction",
                 "chat_id": "chat",
                 "user_id": "operator",
-                "message_id": "sent",
+                "message_id": "sent-3",
                 "text": emoji,
+                "from_self": self_chat,
+                "self_chat": self_chat,
             }
         )
         result = await asyncio.wait_for(transport.sent.get(), timeout=2)


### PR DESCRIPTION
WhatsApp users can approve or deny tool calls with reactions, and follow-up messages keep the pending approval active by reposting its prompt.

---

Route WhatsApp reactions through the host approval handler, normalize self-chat sender identity, and retain operator checks. While approval is pending, repost the full prompt for unrecognized replies and track its latest message ID so reactions resolve the existing run.

Adds coverage for reaction authorization, self-chats, private diagnostics, and approval/denial after repeated follow-up messages.

Validation: inspected the branch diff; tests were not run as part of opening this draft.
