### PR TITLE
feat(talon): add /help command

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -152,6 +152,12 @@ LANGSMITH_PROJECT=deepagents-talon
 
 When enabled, Talon wraps each agent run in a LangSmith tracing context with assistant id, conversation id, trigger metadata, and source message metadata.
 
+## Chat commands
+
+Send `/help` for a brief guide to Talon, its built-in commands (`/new`, `/stop`,
+and `/mcp-reload`), and using MCP configuration and OAuth through chat. Help does
+not interrupt current work or consume a pending approval or sign-in response.
+
 ## MCP Tools
 
 Talon loads MCP servers from `~/.deepagents/.mcp.json`. Set `DEEPAGENTS_TALON_MCP_CONFIG` to use a different path. For user-level MCP servers, edit the standard file:

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -70,6 +70,21 @@ logger = logging.getLogger(__name__)
 _STOP_COMMAND = "/stop"
 _NEW_COMMAND = "/new"
 _MCP_RELOAD_COMMAND = "/mcp-reload"
+_HELP_COMMAND = "/help"
+_HELP_MESSAGE = (
+    "Talon is your personal agent in chat. Send a message to ask for help or get work done; "
+    "ask for reminders or recurring tasks to schedule them. "
+    "Each conversation keeps its context.\n\n"
+    "/help — Show this guide.\n"
+    "/new — Stop current work and start a fresh conversation.\n"
+    "/stop — Stop current work.\n"
+    "/mcp-reload — Reload MCP configuration after manual edits.\n\n"
+    "MCP: Ask to view, add, update, or remove a server (Linux/macOS), "
+    "then approve the change when prompted. Updated tools are available next turn.\n"
+    "OAuth: Ask to authenticate a configured MCP server. Open the sign-in link, "
+    "follow the prompts, and paste the full callback URL into the same chat when asked. "
+    "Send /stop to cancel."
+)
 _NEW_CONVERSATION_MESSAGE = "Started a fresh conversation."
 _MCP_RELOAD_SUCCESS_MESSAGE = "Reloaded MCP configuration."
 _MCP_RELOAD_FAILURE_MESSAGE = "Could not reload MCP configuration. Check Talon logs."
@@ -285,6 +300,12 @@ class TalonHost:
         )
         async with self._locks[conversation_root]:
             agent_conversation_id = self._agent_conversation_id(conversation_root)
+
+            if command == _HELP_COMMAND:
+                await send_with_retry(
+                    lambda: channel.send_message(channel_conversation_id, _HELP_MESSAGE)
+                )
+                return
 
             if command == _NEW_COMMAND:
                 await self._start_new_conversation(

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -294,18 +294,18 @@ class TalonHost:
         provider = await _channel_provider(channel)
         command = _command_name(message.text)
         channel_conversation_id = message.conversation_id
+        if command == _HELP_COMMAND:
+            await send_with_retry(
+                lambda: channel.send_message(channel_conversation_id, _HELP_MESSAGE)
+            )
+            return
+
         conversation_root = self._conversation_root(
             provider or type(channel).__name__,
             channel_conversation_id,
         )
         async with self._locks[conversation_root]:
             agent_conversation_id = self._agent_conversation_id(conversation_root)
-
-            if command == _HELP_COMMAND:
-                await send_with_retry(
-                    lambda: channel.send_message(channel_conversation_id, _HELP_MESSAGE)
-                )
-                return
 
             if command == _NEW_COMMAND:
                 await self._start_new_conversation(

--- a/libs/talon/tests/unit_tests/test_help.py
+++ b/libs/talon/tests/unit_tests/test_help.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
 
 from deepagents_talon.host import TalonHost
-from deepagents_talon.interfaces import ChannelMessage
+from deepagents_talon.interfaces import ChannelMessage, SendResult
 from tests.conftest import RecordingChannel
 from tests.test_host import (
     ApprovalAgent,
@@ -18,6 +19,51 @@ from tests.test_host import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+class StalledHelpChannel(RecordingChannel):
+    def __init__(self) -> None:
+        super().__init__()
+        self.help_started = asyncio.Event()
+        self.release_help = asyncio.Event()
+
+    async def send_message(self, conversation_id: str, text: str) -> SendResult:
+        if "/help" in text:
+            self.help_started.set()
+            await self.release_help.wait()
+        return await super().send_message(conversation_id, text)
+
+
+@pytest.mark.parametrize("stop", [False, True])
+async def test_stalled_help_allows_conversation_progress(tmp_path: Path, *, stop: bool) -> None:
+    channel = StalledHelpChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    help_task = None
+    try:
+        await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+        await _wait_for_request(agent, "block")
+        help_task = asyncio.create_task(
+            host.receive_message(channel, ChannelMessage(conversation_id="chat", text="/help"))
+        )
+        async with asyncio.timeout(1):
+            await channel.help_started.wait()
+            if stop:
+                await host.receive_message(
+                    channel, ChannelMessage(conversation_id="chat", text="/stop")
+                )
+            else:
+                agent.released.set()
+            await _wait_for_sent_count(channel, 1)
+        expected = "Stopped current run." if stop else "reply:block"
+        assert channel.sent == [("chat", expected)]
+        assert not help_task.done()
+    finally:
+        channel.release_help.set()
+        if help_task is not None:
+            await help_task
+        await host.stop()
 
 
 @pytest.mark.parametrize("command", ["/help", " /HELP ", "/help@TestBot"])

--- a/libs/talon/tests/unit_tests/test_help.py
+++ b/libs/talon/tests/unit_tests/test_help.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deepagents_talon.host import TalonHost
+from deepagents_talon.interfaces import ChannelMessage
+from tests.conftest import RecordingChannel
+from tests.test_host import (
+    ApprovalAgent,
+    AuthorizationAgent,
+    BlockingAgent,
+    _config,
+    _wait_for_request,
+    _wait_for_sent_count,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize("command", ["/help", " /HELP ", "/help@TestBot"])
+async def test_help_replies_without_invoking_agent(tmp_path: Path, command: str) -> None:
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        await host.receive_message(channel, ChannelMessage(conversation_id="chat", text=command))
+        assert agent.requests == []
+        assert len(channel.sent) == 1
+        conversation_id, text = channel.sent[0]
+        assert conversation_id == "chat"
+        for topic in ("/help", "/new", "/stop", "/mcp-reload", "MCP", "OAuth", "callback URL"):
+            assert topic in text
+    finally:
+        await host.stop()
+
+
+async def test_help_preserves_active_work(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+        await _wait_for_request(agent, "block")
+        await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="/help"))
+        agent.released.set()
+        await _wait_for_sent_count(channel, 2)
+        assert channel.sent[-1] == ("chat", "reply:block")
+        assert [request.text for request in agent.requests] == ["block"]
+        assert agent.recoveries == []
+    finally:
+        await host.stop()
+
+
+@pytest.mark.parametrize("authorization", [False, True])
+async def test_help_preserves_pending_reply(tmp_path: Path, *, authorization: bool) -> None:
+    channel = RecordingChannel(provider="telegram")
+    agent = AuthorizationAgent() if authorization else ApprovalAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        for text in ("start", "/help"):
+            await host.receive_message(
+                channel,
+                ChannelMessage(conversation_id="chat", text=text, sender_id="operator"),
+            )
+            await _wait_for_sent_count(channel, 1 if text == "start" else 2)
+        reply = "http://localhost:3000/callback?code=test&state=test" if authorization else "yes"
+        await host.receive_message(
+            channel,
+            ChannelMessage(conversation_id="chat", text=reply, sender_id="operator"),
+        )
+        expected = "authorization:completed" if authorization else "decision:approve"
+        await _wait_for_sent_count(channel, 4 if authorization else 3)
+        assert channel.sent[-1] == ("chat", expected)
+        assert [request.text for request in agent.requests] == ["start"]
+    finally:
+        await host.stop()


### PR DESCRIPTION
Talon now supports `/help` with a brief introduction, built-in commands, and instructions for managing MCP servers and signing in with OAuth through chat.

---

Handle help directly in the host so users can discover commands without invoking the model or interrupting active work, pending tool approvals, or OAuth sign-in. Reuse existing command normalization, including Telegram bot suffixes.

Validation: 45 existing host tests and 6 new help cases passed, along with 17 WhatsApp bridge tests. Package lint, formatting, and type checks passed.
