### PR TITLE
fix(talon): report Discord gateway failures after startup

### DIFF
--- a/libs/talon/deepagents_talon/channels/discord.py
+++ b/libs/talon/deepagents_talon/channels/discord.py
@@ -166,8 +166,20 @@ class _DiscordInboundReaction:
     emoji: str
 
 
+@dataclass(frozen=True, slots=True)
+class _DiscordConnectionState:
+    """Provider-neutral view of a Gateway connection lifecycle event."""
+
+    connected: bool
+    detail: str
+
+
 InboundMessageCallback = Callable[[_DiscordInboundMessage], Awaitable[None]]
 InboundReactionCallback = Callable[[_DiscordInboundReaction], Awaitable[None]]
+InboundConnectionCallback = Callable[[_DiscordConnectionState], Awaitable[None]]
+
+_CONNECTED_STATE = _DiscordConnectionState(connected=True, detail="connected")
+_RECONNECTING_STATE = _DiscordConnectionState(connected=True, detail="reconnecting")
 
 
 class _DiscordGateway(Protocol):
@@ -186,8 +198,9 @@ class _DiscordGateway(Protocol):
         *,
         handle_message: InboundMessageCallback,
         handle_reaction: InboundReactionCallback,
+        handle_connection: InboundConnectionCallback,
     ) -> None:
-        """Connect to the Gateway and begin dispatching inbound events."""
+        """Connect to the Gateway and begin dispatching inbound and connection events."""
 
     async def stop(self) -> None:
         """Disconnect from the Gateway and release resources."""
@@ -219,6 +232,7 @@ class _DiscordPyGateway:
         self._connect_timeout_seconds = connect_timeout_seconds
         self._client: discord.Client | None = None
         self._task: asyncio.Task[None] | None = None
+        self._watch: asyncio.Task[None] | None = None
 
     @property
     def bot_id(self) -> str | None:
@@ -231,21 +245,17 @@ class _DiscordPyGateway:
         *,
         handle_message: InboundMessageCallback,
         handle_reaction: InboundReactionCallback,
+        handle_connection: InboundConnectionCallback,
     ) -> None:
         intents = discord.Intents.default()
         intents.message_content = True
         client = discord.Client(intents=intents)
-
-        @client.event
-        async def on_message(message: discord.Message) -> None:
-            await handle_message(_convert_message(message, bot_id=self.bot_id))
-
-        @client.event
-        async def on_raw_reaction_add(payload: discord.RawReactionActionEvent) -> None:
-            reaction = _convert_reaction(payload)
-            if reaction is not None:
-                await handle_reaction(reaction)
-
+        self._register_events(
+            client,
+            handle_message=handle_message,
+            handle_reaction=handle_reaction,
+            handle_connection=handle_connection,
+        )
         self._client = client
         task = asyncio.create_task(
             client.start(self._token, reconnect=True),
@@ -260,7 +270,11 @@ class _DiscordPyGateway:
         )
         if ready_task in done:
             if task in pending:
-                # Gateway connected; leave it running for the adapter's lifetime.
+                # Gateway connected; watch the task so a later failure is not silent.
+                self._watch = asyncio.create_task(
+                    self._watch_gateway(task, handle_connection),
+                    name="talon:discord:gateway-watch",
+                )
                 return
             await task
             return
@@ -273,13 +287,91 @@ class _DiscordPyGateway:
         msg = "Timed out connecting to the Discord Gateway"
         raise TimeoutError(msg)
 
+    def _register_events(
+        self,
+        client: discord.Client,
+        *,
+        handle_message: InboundMessageCallback,
+        handle_reaction: InboundReactionCallback,
+        handle_connection: InboundConnectionCallback,
+    ) -> None:
+        """Register the Gateway event handlers `DiscordChannel` depends on.
+
+        `discord.py` keys handlers off the callback name, so each function must keep
+        the name of the event it serves.
+
+        Args:
+            client: Client whose Gateway events are being subscribed to.
+            handle_message: Callback invoked for each inbound message.
+            handle_reaction: Callback invoked for each inbound reaction.
+            handle_connection: Callback invoked when the connection state changes.
+        """
+
+        @client.event
+        async def on_message(message: discord.Message) -> None:
+            await handle_message(_convert_message(message, bot_id=self.bot_id))
+
+        @client.event
+        async def on_raw_reaction_add(payload: discord.RawReactionActionEvent) -> None:
+            reaction = _convert_reaction(payload)
+            if reaction is not None:
+                await handle_reaction(reaction)
+
+        @client.event
+        async def on_ready() -> None:
+            await handle_connection(_CONNECTED_STATE)
+
+        @client.event
+        async def on_resumed() -> None:
+            await handle_connection(_CONNECTED_STATE)
+
+        @client.event
+        async def on_disconnect() -> None:
+            # `discord.py` reconnects on its own for every disconnect that reaches
+            # here, so this is a detail-only transition; `connected` stays true
+            # until the gateway task itself terminates.
+            await handle_connection(_RECONNECTING_STATE)
+
+    async def _watch_gateway(
+        self,
+        task: asyncio.Task[None],
+        handle_connection: InboundConnectionCallback,
+    ) -> None:
+        """Report the gateway task's terminal outcome instead of discarding it.
+
+        Awaiting the task retrieves its exception, so an unrecoverable Gateway
+        failure -- a revoked token closing with 4004, or 4014 once privileged
+        intents are withdrawn -- is logged and reflected in the channel status
+        rather than silently ending inbound delivery.
+
+        Args:
+            task: The running `client.start` task.
+            handle_connection: Callback invoked with the terminal state.
+        """
+        try:
+            await task
+        except asyncio.CancelledError:
+            raise
+        # A narrower catch would restore the silent-death bug this watcher exists
+        # to fix: any type that escaped here would end inbound delivery unreported.
+        except Exception as error:
+            logger.exception("Discord Gateway connection ended unexpectedly")
+            detail = f"gateway stopped: {type(error).__name__}"
+        else:
+            detail = "gateway stopped"
+        await handle_connection(_DiscordConnectionState(connected=False, detail=detail))
+
     async def stop(self) -> None:
         if self._client is not None:
             await self._client.close()
+        if self._watch is not None:
+            self._watch.cancel()
+            await asyncio.gather(self._watch, return_exceptions=True)
         if self._task is not None:
             await asyncio.gather(self._task, return_exceptions=True)
         self._client = None
         self._task = None
+        self._watch = None
 
     async def send_message(self, channel_id: str, text: str) -> str:
         channel = await self._resolve_channel(channel_id)
@@ -350,6 +442,7 @@ class DiscordChannel:
         self._reaction_handler: ReactionHandler | None = None
         self._exposure = config.exposure
         self._status = ChannelStatus(provider="discord", connected=False, detail="disconnected")
+        self._stopping = False
 
     def set_message_handler(self, handler: MessageHandler) -> None:
         """Register the host callback for inbound messages.
@@ -378,9 +471,11 @@ class DiscordChannel:
         if self.config.inbound_media_dir is not None:
             self.config.inbound_media_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
             self.config.inbound_media_dir.chmod(0o700)
+        self._stopping = False
         await self._gateway.start(
             handle_message=self._process_message,
             handle_reaction=self._process_reaction,
+            handle_connection=self._process_connection,
         )
         self._status = ChannelStatus(provider="discord", connected=True, detail="connected")
         log_debug_event(logger, "discord.channel.started", connected=True)
@@ -388,6 +483,7 @@ class DiscordChannel:
     async def stop(self) -> None:
         """Disconnect from the Discord Gateway and release resources."""
         log_debug_event(logger, "discord.channel.stopping")
+        self._stopping = True
         await self._gateway.stop()
         self._status = ChannelStatus(provider="discord", connected=False, detail="disconnected")
         log_debug_event(logger, "discord.channel.stopped")
@@ -545,6 +641,25 @@ class DiscordChannel:
         log_debug_event(logger, "discord.inbound.reaction.dispatching")
         await self._reaction_handler(reaction)
         log_debug_event(logger, "discord.inbound.reaction.dispatched")
+
+    async def _process_connection(self, state: _DiscordConnectionState) -> None:
+        if self._stopping:
+            # `discord.py` dispatches `on_disconnect` as its own task while the
+            # client closes, so a late event must not overwrite the final status.
+            return
+        previous = self._status
+        self._status = ChannelStatus(
+            provider="discord",
+            connected=state.connected,
+            detail=state.detail,
+        )
+        if self._status != previous:
+            log_debug_event(
+                logger,
+                "discord.connection.changed",
+                connected=state.connected,
+                detail=state.detail,
+            )
 
     async def _prepare_inbound_media(
         self,

--- a/libs/talon/tests/channels/test_discord.py
+++ b/libs/talon/tests/channels/test_discord.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 
 import pytest
@@ -10,9 +11,11 @@ from deepagents_talon.channels.base import ChannelExposure, ExposureMode
 from deepagents_talon.channels.discord import (
     DiscordChannel,
     DiscordChannelConfig,
+    InboundConnectionCallback,
     InboundMessageCallback,
     InboundReactionCallback,
     _DiscordAttachment,
+    _DiscordConnectionState,
     _DiscordInboundMessage,
     _DiscordInboundReaction,
     _DiscordPyGateway,
@@ -35,11 +38,13 @@ class RecordingGateway:
         self.bot_id = "bot-1"
         self._handle_message: InboundMessageCallback | None = None
         self._handle_reaction: InboundReactionCallback | None = None
+        self._handle_connection: InboundConnectionCallback | None = None
 
-    async def start(self, *, handle_message, handle_reaction):
+    async def start(self, *, handle_message, handle_reaction, handle_connection):
         self.started = True
         self._handle_message = handle_message
         self._handle_reaction = handle_reaction
+        self._handle_connection = handle_connection
 
     async def stop(self):
         self.stopped = True
@@ -65,6 +70,10 @@ class RecordingGateway:
     async def deliver_reaction(self, inbound):
         assert self._handle_reaction is not None
         await self._handle_reaction(inbound)
+
+    async def deliver_connection(self, state):
+        assert self._handle_connection is not None
+        await self._handle_connection(state)
 
 
 class FailingTypingGateway(RecordingGateway):
@@ -111,43 +120,141 @@ def _stub_failing_download(monkeypatch):
     monkeypatch.setattr(discord_module, "_download_attachment_file", fake_download)
 
 
-async def test_gateway_enables_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
-    reconnect_values: list[bool] = []
+class _GatewayFailureError(Exception):
+    """Stand-in for an unrecoverable `discord.py` Gateway error such as a 4004 close."""
 
-    class FakeClient:
-        user = None
 
-        def __init__(self, *, intents: object) -> None:
-            del intents
-            self.closed = asyncio.Event()
+class FakeClient:
+    """Stand-in for `discord.Client` that records handlers and never opens a socket."""
 
-        def event(self, callback):
-            return callback
+    def __init__(self, *, intents: object) -> None:
+        del intents
+        self.user = None
+        self.closed = asyncio.Event()
+        self.handlers = {}
+        self.reconnect_values = []
+        self.start_error: BaseException | None = None
 
-        async def start(self, token: str, *, reconnect: bool) -> None:
-            del token
-            reconnect_values.append(reconnect)
-            await self.closed.wait()
+    def event(self, callback):
+        self.handlers[callback.__name__] = callback
+        return callback
 
-        async def wait_until_ready(self) -> None:
-            return None
+    async def start(self, token: str, *, reconnect: bool) -> None:
+        del token
+        self.reconnect_values.append(reconnect)
+        await self.closed.wait()
+        if self.start_error is not None:
+            raise self.start_error
 
-        async def close(self) -> None:
-            self.closed.set()
+    async def wait_until_ready(self) -> None:
+        return None
 
-    monkeypatch.setattr(discord_module.discord, "Client", FakeClient)
+    async def close(self) -> None:
+        self.closed.set()
+
+    async def fire(self, event: str, *args: object) -> None:
+        await self.handlers[event](*args)
+
+    def fail(self, error: BaseException) -> None:
+        """End the gateway task with `error`, as an unrecoverable close would."""
+        self.start_error = error
+        self.closed.set()
+
+
+def _install_fake_client(monkeypatch: pytest.MonkeyPatch) -> list[FakeClient]:
+    created: list[FakeClient] = []
+
+    def factory(*, intents: object) -> FakeClient:
+        client = FakeClient(intents=intents)
+        created.append(client)
+        return client
+
+    monkeypatch.setattr(discord_module.discord, "Client", factory)
+    return created
+
+
+def _connection_recorder():
+    """Record connection states, signalling an event as each one arrives."""
+    states = []
+    arrived = asyncio.Event()
+
+    async def record(state):
+        states.append(state)
+        arrived.set()
+
+    return states, arrived, record
+
+
+async def _start_fake_gateway(handle_connection) -> _DiscordPyGateway:
     gateway = _DiscordPyGateway(
         token="test-token",  # noqa: S106  # inert test token
         connect_timeout_seconds=1,
     )
-
     await gateway.start(
         handle_message=lambda _: asyncio.sleep(0),
         handle_reaction=lambda _: asyncio.sleep(0),
+        handle_connection=handle_connection,
     )
+    return gateway
+
+
+async def test_gateway_enables_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    created = _install_fake_client(monkeypatch)
+
+    gateway = await _start_fake_gateway(lambda _: asyncio.sleep(0))
     await gateway.stop()
 
-    assert reconnect_values == [True]
+    assert created[0].reconnect_values == [True]
+
+
+async def test_gateway_reports_connection_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    created = _install_fake_client(monkeypatch)
+    states, _arrived, record_state = _connection_recorder()
+
+    gateway = await _start_fake_gateway(record_state)
+    client = created[0]
+    await client.fire("on_ready")
+    await client.fire("on_disconnect")
+    await client.fire("on_resumed")
+    await gateway.stop()
+
+    assert states == [
+        _DiscordConnectionState(connected=True, detail="connected"),
+        _DiscordConnectionState(connected=True, detail="reconnecting"),
+        _DiscordConnectionState(connected=True, detail="connected"),
+    ]
+
+
+async def test_gateway_reports_terminal_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    created = _install_fake_client(monkeypatch)
+    states, arrived, record_state = _connection_recorder()
+
+    gateway = await _start_fake_gateway(record_state)
+    with caplog.at_level(logging.ERROR, logger="deepagents_talon.channels.discord"):
+        created[0].fail(_GatewayFailureError("gateway closed with 4004"))
+        await asyncio.wait_for(arrived.wait(), timeout=1)
+    await gateway.stop()
+
+    assert states == [
+        _DiscordConnectionState(connected=False, detail="gateway stopped: _GatewayFailureError"),
+    ]
+    assert "Discord Gateway connection ended unexpectedly" in caplog.text
+
+
+async def test_gateway_watcher_is_quiet_on_a_clean_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = _install_fake_client(monkeypatch)
+    states, _arrived, record_state = _connection_recorder()
+
+    gateway = await _start_fake_gateway(record_state)
+    assert created[0].reconnect_values == [True]
+    await gateway.stop()
+
+    assert states == []
 
 
 def _collector():
@@ -226,6 +333,51 @@ async def test_start_and_stop_toggle_status(tmp_path):
 
     assert gateway.stopped
     assert (await channel.status()).connected is False
+
+
+async def test_terminal_gateway_failure_marks_the_channel_disconnected(tmp_path):
+    gateway = RecordingGateway()
+    channel = DiscordChannel(_make_config(tmp_path), gateway=gateway)
+    await channel.start()
+
+    await gateway.deliver_connection(
+        _DiscordConnectionState(connected=False, detail="gateway stopped: ConnectionClosed"),
+    )
+
+    status = await channel.status()
+    assert status.connected is False
+    assert status.detail == "gateway stopped: ConnectionClosed"
+
+
+async def test_transient_disconnect_keeps_the_channel_connected(tmp_path):
+    gateway = RecordingGateway()
+    channel = DiscordChannel(_make_config(tmp_path), gateway=gateway)
+    await channel.start()
+
+    await gateway.deliver_connection(
+        _DiscordConnectionState(connected=True, detail="reconnecting"),
+    )
+
+    status = await channel.status()
+    assert status.connected is True
+    assert status.detail == "reconnecting"
+
+    await gateway.deliver_connection(_DiscordConnectionState(connected=True, detail="connected"))
+
+    assert (await channel.status()).detail == "connected"
+
+
+async def test_connection_events_after_stop_are_ignored(tmp_path):
+    gateway = RecordingGateway()
+    channel = DiscordChannel(_make_config(tmp_path), gateway=gateway)
+    await channel.start()
+    await channel.stop()
+
+    await gateway.deliver_connection(_DiscordConnectionState(connected=True, detail="connected"))
+
+    status = await channel.status()
+    assert status.connected is False
+    assert status.detail == "disconnected"
 
 
 # --- outbound text/media tests ----------------------------------------------


### PR DESCRIPTION
The Discord channel now reports a Gateway connection that dies after startup, instead of logging nothing and continuing to claim it is connected.

---

`_DiscordPyGateway.start` raced the gateway task against `wait_until_ready` and then returned, leaving the task unobserved for the adapter's lifetime. No handler covered `on_ready`, `on_disconnect`, or `on_resumed`, and `DiscordChannel` wrote its `ChannelStatus` only at start and stop. When `discord.py` gave up — a revoked token closing with 4004, or 4014 once privileged intents are withdrawn — the exception was discarded by the `return_exceptions=True` gather in `stop`, inbound delivery ended silently, and `status` still reported the channel as connected.

A watcher task now awaits the gateway task. Awaiting retrieves the exception rather than dropping it, logs the failure, and reports a disconnected state carrying the exception type. A watcher coroutine is used instead of a done callback because the status callback is a coroutine. The reported detail deliberately excludes the exception message, so nothing from a `ConnectionClosed` or `LoginFailure` string reaches a field that is surfaced in logs.

Transient drops stay connected. `reconnect=True` already recovers those inside `discord.py`, so `on_disconnect` only moves the status detail to `reconnecting`, and `on_ready` or `on_resumed` clears it. Restarting is left out because the failures that terminate the task are auth and config problems a retry cannot resolve, and one channel taking down the host would strand the others. A teardown guard keeps the `on_disconnect` that `discord.py` dispatches during `close` from racing the final status.

Event registration moves into a helper so `start` stays focused on the connect handshake, which is otherwise unchanged.

Tests cover the connection events, the terminal-failure report and its log, the disconnected status that follows, a transient drop keeping the channel connected, and connection events arriving after `stop` being ignored.