### PR TITLE
fix(sandbox): don't let a binary-file match break grep

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -19,6 +19,7 @@ import base64
 import json
 import logging
 import os
+import re
 import shlex
 from abc import ABC, abstractmethod
 from typing import Any, Final, Literal
@@ -994,6 +995,14 @@ def _build_grep_cmd(pattern: str, path: str | None, glob: str | None, max_count:
     return f"{base} || true"
 
 
+#: GNU grep prints `Binary file <path> matches` to **stdout** (not stderr, so the
+#: `2>/dev/null` on the grep command does not suppress it) when a binary file
+#: contains the pattern. The notice has no `-Z` NUL separator, so treating it as a
+#: match line would misreport it as a parse error — spuriously failing the whole
+#: search when a binary file is present. Recognize and skip these lines instead.
+_BINARY_MATCH_NOTICE: Final = re.compile(r"^Binary file .* matches$")
+
+
 def _parse_grep_output(result: ExecuteResponse, path: str | None, max_count: int | None = None) -> GrepResult:
     output = result.output.rstrip("\n")
     if result.exit_code is not None and result.exit_code != 0:
@@ -1004,6 +1013,10 @@ def _parse_grep_output(result: ExecuteResponse, path: str | None, max_count: int
     matches: list[GrepMatch] = []
     parse_error: str | None = None
     for line in output.split("\n"):
+        # A binary file that matches yields a `Binary file <path> matches` notice
+        # rather than a `path\0line:text` record; skip it (see note above).
+        if _BINARY_MATCH_NOTICE.match(line):
+            continue
         # Format is: path\0line_number:text
         try:
             file_path, rest = line.split("\0", 1)

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -515,6 +515,32 @@ def test_grep_preserves_matches_when_later_output_is_malformed() -> None:
     ]
 
 
+def test_grep_ignores_binary_file_match_notice() -> None:
+    """A lone `Binary file <path> matches` notice is skipped, not reported as an error."""
+    sandbox = MockSandbox()
+    # GNU grep writes this to stdout (survives `2>/dev/null`) when a binary file matches.
+    sandbox._next_output = "Binary file /test/app.bin matches"
+
+    result = sandbox.grep("needle", "/test")
+
+    assert result.error is None
+    assert result.matches == []
+
+
+def test_grep_skips_binary_notice_but_keeps_text_matches() -> None:
+    """A binary-file notice interleaved with real matches is skipped, matches preserved."""
+    sandbox = MockSandbox()
+    sandbox._next_output = "/test/file.txt\00012:needle here\nBinary file /test/app.bin matches\n/test/other.txt\0007:needle again"
+
+    result = sandbox.grep("needle", "/test")
+
+    assert result.error is None
+    assert result.matches == [
+        {"path": "/test/file.txt", "line": 12, "text": "needle here"},
+        {"path": "/test/other.txt", "line": 7, "text": "needle again"},
+    ]
+
+
 def test_grep_defaults_path_to_current_directory() -> None:
     """grep() searches the current directory when no path is provided."""
     sandbox = MockSandbox()


### PR DESCRIPTION
Fixes #6124

## Problem

`grep` over any tree that contains a **binary file matching the pattern** fails or drops results.

GNU grep prints `Binary file <path> matches` to **stdout** (not stderr) when a binary file contains the search string. The sandbox grep command only redirects stderr (`... 2>/dev/null || true`), so that notice reaches `_parse_grep_output`. The notice has no `-Z` NUL separator, so the parser treated it as a malformed record:

- If it was the **only** output → the whole search returned a spurious error: `Path '.': Binary file <path> matches`.
- If it was **mixed** with real matches → it was recorded as a parse error (and the notice line churned `parse_error`).

In practice, any repo with a matching compiled artifact, image, or `.pyc` could break a search.

### Reproduction

`_parse_grep_output` receives grep's stdout. A binary match yields a line like:

```
Binary file /app/data.bin matches
```

Before this change, `sandbox.grep("needle", "/test")` with that output returns
`GrepResult(error="Path '.': Binary file /app/data.bin matches")` instead of `matches=[]`.

### Fix

Recognize and skip `Binary file <path> matches` notice lines in `_parse_grep_output`. This fixes both the sync `grep` and async `agrep` paths, which share the parser. Binary files simply no longer appear in (or break) text-search results — matching what a code-search tool should do.

Kept the change at the parser level (rather than adding a `grep -I` flag) so it's portable across grep variants in the various sandbox images and doesn't depend on a flag the remote grep may not support.

### Tests

Added two regression tests in `test_sandbox_backend.py`:

- a lone binary-file notice returns `matches=[]` with no error;
- a notice interleaved with real matches is skipped while the matches are preserved.

`test_sandbox_backend.py` (177) and the middleware grep tests (47) pass; `ruff check`, `ruff format`, and `ty` are clean.

### Context

Found while using the E2B sandbox backend (`langchain-e2b`), whose grep path mirrors this helper — so it benefits from the fix in core too.