### PR TITLE
feat(talon): support fresh subagents and per-task tool selection

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -242,15 +242,9 @@ imports into `~/.deepagents/crowbar/`. Pass `--assistant-id <id>` to select a
 different assistant for the import, or `--target-dir <dir>` to write all
 imported files under an explicit directory.
 
-The importer writes Fleet prompts, skills, and subagent prompts. Talon loads local
-subagents from `agents/<name>/AGENTS.md` using dcode's YAML frontmatter format:
+Talon loads local subagents from `agents/<name>/AGENTS.md` using YAML frontmatter:
 `description` is required, `name` defaults to the directory name, and `model` is
-optional. Local subagents use fork mode so they inherit the current conversation and
-runtime policy; Talon also provides the standard `general-purpose` subagent unless the
-assistant defines one. Fleet `tools.json` and `config.json` are ignored and are not
-copied into the Talon agent directory. Talon does not support the old Fleet direct-run
-startup path or its environment variables; import the zip first, then run Talon against
-the materialized local assistant.
+optional.
 
 ## Background Subagents
 
@@ -261,17 +255,11 @@ changes on subsequent turns. Ordinary turns reuse the loaded definitions. Invali
 edits retain the last valid configuration; running subagents keep their original
 configuration.
 
-Set `mode: fresh` and `tools: [exact_tool_name]` in local frontmatter for task-only
-context without inherited tools or middleware. Omitted tools mean no tools;
-unknown names reject activation. Existing approval gates and main-agent filesystem
-access remain intact. Fork remains the default for named agents. Invalid definitions
-reject startup. For `general-purpose`, `task` requires a `tools` list on each launch
-(`[]` means none). Select only what the task needs; supply skill instructions in
-`description` or select `read_file` to load them. General tasks always use fresh context.
-
-`get_agent_tools` shows attachments, selectable general-purpose tools, and inactive
-edits; opaque inventories are unknown. `list_subagents` shows per-task selections.
-MCP edits require successful reload. Cancel running tasks to revoke old capabilities.
+Subagents use fresh task context; fork is unsupported. Attach local tools with
+`tools: [exact_tool_name]` (omitted means none). For `general-purpose`, pass a `tools`
+list to `task` on each launch. Supply skill instructions in `description` or select
+`read_file` to load them. `get_agent_tools` shows available attachments and inactive
+edits; `list_subagents` shows per-task selections.
 
 `task` launches local subagents and `start_async_task` launches remote subagents.
 Both return immediately. The user can continue chatting while the main agent uses

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -264,13 +264,14 @@ configuration.
 Set `mode: fresh` and `tools: [exact_tool_name]` in local frontmatter for task-only
 context without inherited tools or middleware. Omitted tools mean no tools;
 unknown names reject activation. Existing approval gates and main-agent filesystem
-access remain intact. With fresh roles, `general-purpose` must also be fresh;
-the automatic fallback has no tools. Fork remains the default. Invalid definitions
-reject startup.
+access remain intact. Fork remains the default for named agents. Invalid definitions
+reject startup. For `general-purpose`, `task` requires a `tools` list on each launch
+(`[]` means none). Select only what the task needs; supply skill instructions in
+`description` or select `read_file` to load them. General tasks always use fresh context.
 
-`get_agent_tools` shows main/fresh attachments and inactive edits; other inventories
-are unknown. MCP edits require successful reload. Cancel running tasks to revoke
-their old capabilities.
+`get_agent_tools` shows attachments, selectable general-purpose tools, and inactive
+edits; opaque inventories are unknown. `list_subagents` shows per-task selections.
+MCP edits require successful reload. Cancel running tasks to revoke old capabilities.
 
 `task` launches local subagents and `start_async_task` launches remote subagents.
 Both return immediately. The user can continue chatting while the main agent uses

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -256,8 +256,10 @@ edits retain the last valid configuration; running subagents keep their original
 configuration.
 
 Subagents use fresh task context; fork is unsupported. Attach local tools with
-`tools: [exact_tool_name]` (omitted means none). For `general-purpose`, pass a `tools`
-list to `task` on each launch. Supply skill instructions in `description` or select
+`tools: [exact_tool_name]` (omitted means none); named agents use those configured tools.
+`general-purpose` defaults to no tools. Pass a `tools` list to `task` on each launch
+to grant capabilities, including `execute` for shell access. Supply context and skill
+instructions in `description` or select
 `read_file` to load them. `get_agent_tools` shows available attachments and inactive
 edits; `list_subagents` shows per-task selections.
 

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -261,6 +261,17 @@ changes on subsequent turns. Ordinary turns reuse the loaded definitions. Invali
 edits retain the last valid configuration; running subagents keep their original
 configuration.
 
+Set `mode: fresh` and `tools: [exact_tool_name]` in local frontmatter for task-only
+context without inherited tools or middleware. Omitted tools mean no tools;
+unknown names reject activation. Existing approval gates and main-agent filesystem
+access remain intact. With fresh roles, `general-purpose` must also be fresh;
+the automatic fallback has no tools. Fork remains the default. Invalid definitions
+reject startup.
+
+`get_agent_tools` shows main/fresh attachments and inactive edits; other inventories
+are unknown. MCP edits require successful reload. Cancel running tasks to revoke
+their old capabilities.
+
 `task` launches local subagents and `start_async_task` launches remote subagents.
 Both return immediately. The user can continue chatting while the main agent uses
 `list_subagents` to inspect work and `cancel_subagent` to cancel it. When work

--- a/libs/talon/deepagents_talon/background.py
+++ b/libs/talon/deepagents_talon/background.py
@@ -46,6 +46,7 @@ class _Job:
     result: str | None = None
     cancelled: bool = False
     notified: bool = False
+    tools: list[str] | None = None
 
     @property
     def status(self) -> str:
@@ -64,11 +65,17 @@ class BackgroundSubagents(AgentMiddleware):
         self._remote: dict[str, AsyncSubAgent] = {}
 
         @tool
-        async def list_subagents(runtime: ToolRuntime) -> list[dict[str, str | None]]:
+        async def list_subagents(runtime: ToolRuntime) -> list[dict[str, str | list[str] | None]]:
             """Inspect this thread's subagents, including their status and final results."""
             owner = runtime.config.get("configurable", {}).get("thread_id")
             return [
-                {"task_id": key, "name": job.name, "status": job.status, "result": job.result}
+                {
+                    "task_id": key,
+                    "name": job.name,
+                    "status": job.status,
+                    "result": job.result,
+                    "tools": job.tools,
+                }
                 for key, job in self._jobs.items()
                 if job.owner == owner
             ]
@@ -160,6 +167,7 @@ class BackgroundSubagents(AgentMiddleware):
                 )
             task_id = f"subagent-{uuid4().hex}"
             job = _Job(owner, str(request.tool_call["args"].get("subagent_type", "")))
+            job.tools = request.tool_call["args"].get("tools")
             self._jobs[task_id] = job
             job.worker = asyncio.create_task(
                 self._run(job, request, task_id), name=task_id, context=contextvars.Context()

--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -219,12 +219,13 @@ class MCPToolProvider:
             "reload_mcp_configuration",
             description=(
                 "Reload Talon's configured MCP servers before the next agent turn. "
-                "Use after the operator changes the MCP configuration."
+                "Use after the operator changes the MCP configuration. Verify activation "
+                "with get_agent_tools; running tasks retain their original capabilities."
             ),
         )
         def reload_mcp_configuration() -> dict[str, str]:
             self.request_refresh()
-            return {"status": "scheduled", "available": "next_turn"}
+            return {"status": "scheduled", "available": "after_successful_reload"}
 
         return reload_mcp_configuration
 

--- a/libs/talon/deepagents_talon/mcp_config.py
+++ b/libs/talon/deepagents_talon/mcp_config.py
@@ -89,7 +89,8 @@ class MCPConfigStore:
                 expected_revision: Revision returned by get_mcp_configuration.
 
             Changes can execute commands or send credentials to configured URLs.
-            Successful changes become available on the next agent turn.
+            Saved changes activate only after a successful reload before the next turn.
+            Use get_agent_tools to verify activation. Running tasks retain old capabilities.
             """
             return self._update(server_name, server, expected_revision)
 
@@ -144,7 +145,7 @@ class MCPConfigStore:
                 "message": "Cannot update MCP configuration; check settings.",
             }
         self._on_update()
-        return {"status": "updated", "available": "next_turn"}
+        return {"status": "updated", "available": "after_successful_reload"}
 
     @contextmanager
     def _locked(self) -> Iterator[None]:

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -56,7 +56,7 @@ from deepagents_talon.observability import (
     log_event,
     stable_log_ref,
 )
-from deepagents_talon.subagents import Attachment, LocalSubAgent, prepare_subagents
+from deepagents_talon.subagents import Attachment, LocalSubAgent, TaskTools, prepare_subagents
 
 if TYPE_CHECKING:
     from deepagents.backends.protocol import BackendProtocol
@@ -361,9 +361,12 @@ class DeepAgentRuntime:
                 local["model"] = _resolve_model_from_env(
                     cast("str", local["model"]), self.env, context_size=context_size
                 )
+        general = next((spec for spec in resolved if spec["name"] == "general-purpose"), None)
         resolved, attachments = prepare_subagents(resolved, tools, model, interrupt_on)
         tools.append(self._attachment_tool(attachments))
         middleware = list(self.middleware)
+        task_tools = TaskTools(model, interrupt_on, cast("SubAgent | None", general))
+        middleware.append(task_tools)
         middleware.append(self.background.configured(resolved))
         interrupt_on = _interrupt_on_with_async_subagents(
             interrupt_on, has_async_subagents=_has_async_subagents(resolved)
@@ -383,6 +386,11 @@ class DeepAgentRuntime:
             checkpointer=self.checkpointer,
         )
         node = getattr(getattr(graph, "nodes", {}).get("tools"), "bound", None)
+        if isinstance(node, ToolNode) and "task" in node.tools_by_name:
+            selectable = task_tools.bind(node.tools_by_name)
+            for attachment in attachments:
+                if attachment["name"] == "general-purpose":
+                    attachment.update(mode="per_task", tools=None, selectable_tools=selectable)
         attachments.insert(
             0,
             {

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -356,7 +356,11 @@ class DeepAgentRuntime:
         context_size = _context_size_from_env(self.env)
         model = _resolve_model_from_env(self.model, self.env, context_size=context_size)
         for spec in resolved:
-            if spec.get("fresh") and isinstance(spec.get("model"), str):
+            if (
+                "runnable" not in spec
+                and "graph_id" not in spec
+                and isinstance(spec.get("model"), str)
+            ):
                 local = cast("LocalSubAgent", spec)
                 local["model"] = _resolve_model_from_env(
                     cast("str", local["model"]), self.env, context_size=context_size
@@ -548,7 +552,7 @@ class DeepAgentRuntime:
         def get_agent_tools() -> dict[str, object]:
             """Inspect active tool attachments without credentials or prompt contents.
 
-            Null tools mean an opaque legacy/remote agent has not been inspected.
+            Null tools mean an opaque compiled/remote agent has not been inspected.
             Saved edits require reload. Running turns and tasks retain old capabilities;
             use list_subagents and cancel_subagent before claiming revocation is complete.
             """
@@ -1281,7 +1285,6 @@ def _subagent_from_frontmatter(
         "name": name,
         "description": description,
         "system_prompt": prompt.strip(),
-        "mode": "fork",
     }
     if model:
         subagent["model"] = model
@@ -1290,23 +1293,18 @@ def _subagent_from_frontmatter(
 
 
 def _local_subagent_options(spec: LocalSubAgent, frontmatter: dict[str, object]) -> None:
-    mode = frontmatter.get("mode", "fork")
-    if mode not in ("fork", "fresh"):
-        msg = "Local subagent mode must be fork or fresh"
+    if frontmatter.get("mode", "fresh") != "fresh":
+        msg = "Talon subagents use fresh context; remove the mode setting"
         raise ValueError(msg)
-    if mode == "fresh":
-        spec["mode"] = "isolated"
-        spec["fresh"] = True
-    if "tools" in frontmatter or mode == "fresh":
-        names = frontmatter.get("tools", [])
-        if (
-            not isinstance(names, list)
-            or any(not isinstance(name, str) or not name.strip() for name in names)
-            or len(names) != len(set(names))
-        ):
-            msg = "Local subagent tools must be unique, nonempty exact names"
-            raise ValueError(msg)
-        spec["tool_names"] = cast("list[str]", names)
+    names = frontmatter.get("tools", [])
+    if (
+        not isinstance(names, list)
+        or any(not isinstance(name, str) or not name.strip() for name in names)
+        or len(names) != len(set(names))
+    ):
+        msg = "Local subagent tools must be unique, nonempty exact names"
+        raise ValueError(msg)
+    spec["tool_names"] = cast("list[str]", names)
 
 
 def _normalize_subagent_metadata(

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, TypeGuard, cast
 import yaml
 from deepagents import create_deep_agent
 from deepagents.backends import LocalShellBackend
+from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from deepagents.middleware.summarization import (
     SummarizationToolMiddleware,
@@ -366,7 +367,8 @@ class DeepAgentRuntime:
                     cast("str", local["model"]), self.env, context_size=context_size
                 )
         general = next((spec for spec in resolved if spec["name"] == "general-purpose"), None)
-        resolved, attachments = prepare_subagents(resolved, tools, model, interrupt_on)
+        attachments_tools = [*FilesystemMiddleware(backend=self.backend).tools, *tools]
+        resolved, attachments = prepare_subagents(resolved, attachments_tools, model, interrupt_on)
         tools.append(self._attachment_tool(attachments))
         middleware = list(self.middleware)
         task_tools = TaskTools(model, interrupt_on, cast("SubAgent | None", general))

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -29,6 +29,7 @@ from langchain.chat_models import init_chat_model
 from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.prebuilt import ToolNode
 from langgraph.types import Command
 
 from deepagents_code.tools import fetch_url, web_search
@@ -55,6 +56,7 @@ from deepagents_talon.observability import (
     log_event,
     stable_log_ref,
 )
+from deepagents_talon.subagents import Attachment, LocalSubAgent, prepare_subagents
 
 if TYPE_CHECKING:
     from deepagents.backends.protocol import BackendProtocol
@@ -323,6 +325,8 @@ class DeepAgentRuntime:
         self.max_retries = max_retries
         self.max_continuations = max_continuations
         self._graph: object | None = None
+        self._attachments: list[Attachment] = []
+        self._mcp_reload_failed = False
         self._invocation_graph: contextvars.ContextVar[object | None] = contextvars.ContextVar(
             "talon_invocation_graph",
             default=None,
@@ -335,7 +339,7 @@ class DeepAgentRuntime:
 
     async def start(self) -> None:
         """Construct the Deep Agents graph."""
-        self._resolved_subagents = self._resolve_subagents()
+        self._resolved_subagents = self._resolve_subagents(strict=True)
         self._graph = self._create_graph()
 
     def _create_graph(
@@ -344,11 +348,21 @@ class DeepAgentRuntime:
         *,
         subagents: list[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
     ) -> object:
-        resolved = self._resolved_subagents if subagents is None else subagents
+        resolved = [
+            spec.copy() for spec in (self._resolved_subagents if subagents is None else subagents)
+        ]
         tools = self._build_tools(runtime_tools)
         interrupt_on = _interrupt_on_with_mcp_config(self.interrupt_on, self.env, tools)
         context_size = _context_size_from_env(self.env)
         model = _resolve_model_from_env(self.model, self.env, context_size=context_size)
+        for spec in resolved:
+            if spec.get("fresh") and isinstance(spec.get("model"), str):
+                local = cast("LocalSubAgent", spec)
+                local["model"] = _resolve_model_from_env(
+                    cast("str", local["model"]), self.env, context_size=context_size
+                )
+        resolved, attachments = prepare_subagents(resolved, tools, model, interrupt_on)
+        tools.append(self._attachment_tool(attachments))
         middleware = list(self.middleware)
         middleware.append(self.background.configured(resolved))
         interrupt_on = _interrupt_on_with_async_subagents(
@@ -356,7 +370,7 @@ class DeepAgentRuntime:
         )
         if context_size is not None and not _has_summarization_tool_middleware(middleware):
             middleware.append(create_summarization_tool_middleware(model, self.backend))
-        return create_deep_agent(
+        graph = create_deep_agent(
             model=model,
             tools=tools,
             system_prompt=self._resolve_system_prompt(),
@@ -368,6 +382,17 @@ class DeepAgentRuntime:
             memory=self._resolve_memory(),
             checkpointer=self.checkpointer,
         )
+        node = getattr(getattr(graph, "nodes", {}).get("tools"), "bound", None)
+        attachments.insert(
+            0,
+            {
+                "name": "main",
+                "mode": "conversation",
+                "tools": sorted(node.tools_by_name) if isinstance(node, ToolNode) else None,
+            },
+        )
+        self._attachments = attachments
+        return graph
 
     async def stop(self) -> None:
         """Release runtime resources."""
@@ -472,9 +497,13 @@ class DeepAgentRuntime:
         if self.refresh_tools is None:
             return
         async with self._tools_lock:
-            refreshed = await self.refresh_tools()
-            if refreshed is not None:
-                self._replace_runtime_tools(refreshed)
+            try:
+                refreshed = await self.refresh_tools()
+                if refreshed is not None:
+                    self._replace_runtime_tools(refreshed)
+            except Exception:  # noqa: BLE001  # keep the previous graph usable after an invalid edit
+                self._mcp_reload_failed = True
+                logger.warning("MCP reload failed; saved changes are inactive")
 
     async def reload_mcp_configuration(self) -> None:
         """Reload MCP tools without restarting the Talon runtime."""
@@ -482,7 +511,11 @@ class DeepAgentRuntime:
             msg = "MCP configuration reload is unavailable"
             raise RuntimeError(msg)
         async with self._tools_lock:
-            self._replace_runtime_tools(await self.reload_tools())
+            try:
+                self._replace_runtime_tools(await self.reload_tools())
+            except Exception:
+                self._mcp_reload_failed = True
+                raise
 
     def _replace_runtime_tools(
         self,
@@ -492,16 +525,38 @@ class DeepAgentRuntime:
         graph = self._create_graph(replacement)
         self.tools = replacement
         self._graph = graph
+        self._mcp_reload_failed = False
 
     async def reload_subagent_configuration(self) -> None:
         """Activate validated definitions for subsequent turns, preserving active graphs."""
         async with self._tools_lock:
             replacement = self._resolve_subagents(strict=True)
-            if replacement == self._resolved_subagents:
-                return
             graph = self._create_graph(subagents=replacement)
             self._resolved_subagents = replacement
             self._graph = graph
+
+    def _attachment_tool(self, attachments: list[Attachment]) -> BaseTool:
+        @tool
+        def get_agent_tools() -> dict[str, object]:
+            """Inspect active tool attachments without credentials or prompt contents.
+
+            Null tools mean an opaque legacy/remote agent has not been inspected.
+            Saved edits require reload. Running turns and tasks retain old capabilities;
+            use list_subagents and cancel_subagent before claiming revocation is complete.
+            """
+            try:
+                changed = self._resolve_subagents(strict=True) != self._resolved_subagents
+            except Exception:  # noqa: BLE001  # never return configuration contents
+                changed = True
+            return {
+                "agents": attachments,
+                "latest_agents": self._attachments,
+                "saved_changes_inactive": changed or self._mcp_reload_failed,
+                "current_turn_uses_previous_graph": attachments is not self._attachments,
+                "running_tasks": "Running turns and tasks retain their original capabilities.",
+            }
+
+        return get_agent_tools
 
     def _subagent_reload_tool(self) -> BaseTool:
         @tool(
@@ -519,7 +574,7 @@ class DeepAgentRuntime:
             except Exception:  # noqa: BLE001  # report reload failure without leaking config values
                 return {
                     "status": "failed",
-                    "message": "Invalid configuration; previous agents retained",
+                    "message": "Saved changes are inactive; previous agents retained",
                 }
             return {"status": "reloaded", "available": "next_turn"}
 
@@ -1222,7 +1277,28 @@ def _subagent_from_frontmatter(
     }
     if model:
         subagent["model"] = model
+    _local_subagent_options(cast("LocalSubAgent", subagent), cast("dict[str, object]", frontmatter))
     return subagent
+
+
+def _local_subagent_options(spec: LocalSubAgent, frontmatter: dict[str, object]) -> None:
+    mode = frontmatter.get("mode", "fork")
+    if mode not in ("fork", "fresh"):
+        msg = "Local subagent mode must be fork or fresh"
+        raise ValueError(msg)
+    if mode == "fresh":
+        spec["mode"] = "isolated"
+        spec["fresh"] = True
+    if "tools" in frontmatter or mode == "fresh":
+        names = frontmatter.get("tools", [])
+        if (
+            not isinstance(names, list)
+            or any(not isinstance(name, str) or not name.strip() for name in names)
+            or len(names) != len(set(names))
+        ):
+            msg = "Local subagent tools must be unique, nonempty exact names"
+            raise ValueError(msg)
+        spec["tool_names"] = cast("list[str]", names)
 
 
 def _normalize_subagent_metadata(

--- a/libs/talon/deepagents_talon/subagents.py
+++ b/libs/talon/deepagents_talon/subagents.py
@@ -86,10 +86,10 @@ class TaskTools(AgentMiddleware):
             "task",
             description=original.description
             + (
-                " For general-purpose, tools is required: choose only the exact tool names needed "
-                "from get_agent_tools (empty list means none). Supply the task and relevant skill "
-                "instructions in description, or select read_file to read the skill. No parent "
-                "history or skills are inherited. Named agents use their configured tools."
+                " For general-purpose, tools defaults to none: choose exact tool names "
+                "from get_agent_tools, including execute for shell access. Supply task context "
+                "and skill instructions in description, or select read_file to read the skill. "
+                "No parent history or skills are inherited. Named agents use configured tools."
             ),
         )
         async def task(
@@ -108,11 +108,8 @@ class TaskTools(AgentMiddleware):
                         "runtime": runtime,
                     }
                 )
-            if (
-                tools is None
-                or len(tools) != len(set(tools))
-                or any(name not in available for name in tools)
-            ):
+            tools = tools or []
+            if len(tools) != len(set(tools)) or any(name not in available for name in tools):
                 return "Specify tools as a list of unique names from get_agent_tools."
             spec: LocalSubAgent = {
                 "name": "general-purpose",

--- a/libs/talon/deepagents_talon/subagents.py
+++ b/libs/talon/deepagents_talon/subagents.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
 class LocalSubAgent(SubAgent):
     """Local frontmatter additions resolved before SDK graph construction."""
 
-    fresh: NotRequired[bool]
     tool_names: NotRequired[list[str]]
 
 
@@ -156,7 +155,7 @@ class TaskTools(AgentMiddleware):
     ) -> ToolMessage | Command:
         """Select the wrapper before background dispatch snapshots the tool."""
         if request.tool_call["name"] == "task" and self._task:
-            if _IN_SUBAGENT.get() or request.runtime.state.get("_deepagents_forked_context"):
+            if _IN_SUBAGENT.get():
                 return ToolMessage(
                     "Delegate from the main agent.", tool_call_id=request.tool_call["id"]
                 )
@@ -206,15 +205,17 @@ def prepare_subagents(
         SDK definitions and a safe inventory; opaque agents have unknown tools.
 
     Raises:
-        ValueError: An attachment is unavailable or the fallback is privileged.
+        ValueError: An attachment is unavailable or fork mode is requested.
     """
     available = _tool_map(tools)
     candidates = list(specs)
-    if any(spec.get("fresh") is True for spec in candidates):
-        _add_fresh_fallback(candidates)
+    _add_general_subagent(candidates)
     prepared: list[SubAgent | CompiledSubAgent | AsyncSubAgent] = []
     inventory: list[Attachment] = []
     for original in candidates:
+        if original.get("mode") == "fork":
+            msg = "Talon subagents use fresh context; fork mode is unsupported"
+            raise ValueError(msg)
         spec = cast("LocalSubAgent", original.copy())
         if "tool_names" in spec:
             names = spec.pop("tool_names")
@@ -222,19 +223,29 @@ def prepare_subagents(
                 msg = "Subagent attachment is unavailable; previous configuration retained"
                 raise ValueError(msg)
             spec["tools"] = [available[name] for name in names]
-        fresh = spec.pop("fresh", False)
+        opaque = "graph_id" in spec or "runnable" in spec
         inventory.append(
             {
                 "name": spec["name"],
-                "mode": "fresh"
-                if fresh
-                else str(spec.get("mode", "remote" if "graph_id" in spec else "isolated")),
-                "tools": sorted(_tool_map(spec.get("tools", []))) if fresh else None,
+                "mode": "remote" if "graph_id" in spec else "fresh",
+                "tools": None if opaque else sorted(_tool_map(spec.get("tools", []))),
             }
         )
-        prepared.append(_compile_fresh(spec, model, interrupt_on) if fresh else spec)
-    if not any(spec["name"] == "general-purpose" for spec in candidates):
-        inventory.append({"name": "general-purpose", "mode": "isolated", "tools": None})
+        if "runnable" in original:
+            compiled = cast("CompiledSubAgent", original.copy())
+            compiled.pop("mode", None)
+            compiled["runnable"] = RunnableLambda(_task_only) | compiled["runnable"]
+            prepared.append(compiled)
+        elif spec["name"] == "general-purpose":
+            prepared.append(
+                {
+                    "name": spec["name"],
+                    "description": spec["description"],
+                    "runnable": RunnableLambda(_task_only),
+                }
+            )
+        else:
+            prepared.append(original if opaque else _compile_fresh(spec, model, interrupt_on))
     return prepared, inventory
 
 
@@ -249,18 +260,14 @@ def _tool_map(tools: Sequence[BaseTool | Callable[..., object]]) -> dict[str, Ba
     return result
 
 
-def _add_fresh_fallback(specs: list[SubAgent | CompiledSubAgent | AsyncSubAgent]) -> None:
+def _add_general_subagent(specs: list[SubAgent | CompiledSubAgent | AsyncSubAgent]) -> None:
     existing = next((spec for spec in specs if spec["name"] == "general-purpose"), None)
     if existing is not None:
-        if existing.get("fresh") is not True:
-            msg = "Fresh subagents require a fresh general-purpose fallback"
-            raise ValueError(msg)
         return
     fallback: LocalSubAgent = {
         "name": "general-purpose",
         "description": "Complete a task with tools explicitly selected by the main agent.",
         "system_prompt": "Answer only the delegated question using the supplied information.",
-        "fresh": True,
         "tool_names": [],
     }
     specs.append(fallback)

--- a/libs/talon/deepagents_talon/subagents.py
+++ b/libs/talon/deepagents_talon/subagents.py
@@ -205,7 +205,7 @@ def prepare_subagents(
         SDK definitions and a safe inventory; opaque agents have unknown tools.
 
     Raises:
-        ValueError: An attachment is unavailable or fork mode is requested.
+        ValueError: An attachment is unavailable or a configuration is unsupported.
     """
     available = _tool_map(tools)
     candidates = list(specs)
@@ -213,6 +213,11 @@ def prepare_subagents(
     prepared: list[SubAgent | CompiledSubAgent | AsyncSubAgent] = []
     inventory: list[Attachment] = []
     for original in candidates:
+        if original["name"] == "general-purpose" and (
+            "runnable" in original or "graph_id" in original
+        ):
+            msg = "Compiled and remote subagents must use a name other than 'general-purpose'"
+            raise ValueError(msg)
         if original.get("mode") == "fork":
             msg = "Talon subagents use fresh context; fork mode is unsupported"
             raise ValueError(msg)

--- a/libs/talon/deepagents_talon/subagents.py
+++ b/libs/talon/deepagents_talon/subagents.py
@@ -6,16 +6,23 @@ from typing import TYPE_CHECKING, NotRequired, TypedDict, cast
 
 from deepagents.middleware.subagents import SubAgent
 from langchain.agents import create_agent
-from langchain.agents.middleware import HumanInTheLoopMiddleware
+from langchain.agents.middleware import AgentMiddleware, HumanInTheLoopMiddleware
+from langchain.tools import ToolRuntime  # noqa: TC002  # tool schemas inspect injected annotations
+from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import BaseTool, tool
+from langgraph.types import Command  # noqa: TC002  # tool schemas resolve return annotations
+
+from deepagents_talon.background import _IN_SUBAGENT
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Awaitable, Callable, Mapping, Sequence
 
     from deepagents.middleware.async_subagents import AsyncSubAgent
     from deepagents.middleware.subagents import CompiledSubAgent
     from langchain.agents.middleware import InterruptOnConfig
+    from langchain.agents.middleware.types import ModelRequest, ModelResponse
+    from langchain.tools.tool_node import ToolCallRequest
     from langchain_core.language_models import BaseChatModel
 
 
@@ -32,6 +39,129 @@ class Attachment(TypedDict):
     name: str
     mode: str
     tools: list[str] | None
+    selectable_tools: NotRequired[list[str]]
+
+
+_DELEGATION_TOOLS = frozenset(
+    {
+        "task",
+        "start_async_task",
+        "update_async_task",
+        "cancel_async_task",
+        "check_async_task",
+        "list_async_tasks",
+        "list_subagents",
+        "cancel_subagent",
+    }
+)
+
+
+class TaskTools(AgentMiddleware):
+    """Let the main agent select general-purpose capabilities for each task."""
+
+    def __init__(
+        self,
+        model: str | BaseChatModel,
+        interrupt_on: Mapping[str, bool | InterruptOnConfig] | None,
+        general: SubAgent | None = None,
+    ) -> None:
+        """Retain this graph's model and operator approval policy."""
+        self._model = model
+        self._interrupt_on = dict(interrupt_on or {})
+        self._general = general or {}
+        self._task: BaseTool | None = None
+
+    def bind(self, catalog: Mapping[str, BaseTool]) -> list[str]:
+        """Bind the compiled graph's tools and return selectable names.
+
+        Args:
+            catalog: Actual tools exposed by the parent graph.
+
+        Returns:
+            Names available for explicit attachment, excluding delegation.
+        """
+        available = {name: item for name, item in catalog.items() if name not in _DELEGATION_TOOLS}
+        original = catalog["task"]
+
+        @tool(
+            "task",
+            description=original.description
+            + (
+                " For general-purpose, tools is required: choose only the exact tool names needed "
+                "from get_agent_tools (empty list means none). Supply the task and relevant skill "
+                "instructions in description, or select read_file to read the skill. No parent "
+                "history or skills are inherited. Named agents use their configured tools."
+            ),
+        )
+        async def task(
+            description: str,
+            subagent_type: str,
+            runtime: ToolRuntime,
+            tools: list[str] | None = None,
+        ) -> str | Command:
+            if subagent_type != "general-purpose":
+                if tools is not None:
+                    return "Named subagent tools are fixed by configuration."
+                return await original.ainvoke(
+                    {
+                        "description": description,
+                        "subagent_type": subagent_type,
+                        "runtime": runtime,
+                    }
+                )
+            if (
+                tools is None
+                or len(tools) != len(set(tools))
+                or any(name not in available for name in tools)
+            ):
+                return "Specify tools as a list of unique names from get_agent_tools."
+            spec: LocalSubAgent = {
+                "name": "general-purpose",
+                "description": "Complete the delegated task.",
+                "system_prompt": "Complete only the delegated task using the selected tools.",
+                "tools": [available[name] for name in tools],
+            }
+            if "model" in self._general:
+                spec["model"] = self._general["model"]
+            if "system_prompt" in self._general:
+                spec["system_prompt"] = self._general["system_prompt"]
+            agent = _compile_fresh(spec, self._model, self._interrupt_on)["runnable"]
+            result = await agent.ainvoke({"messages": [HumanMessage(description)]})
+            if result.get("__interrupt__"):
+                return "Subagent needs tool approval; the protected action has not run."
+            return str(result["messages"][-1].content)
+
+        self._task = task
+        return sorted(available)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        """Expose the extended task schema to the main agent."""
+        return await handler(
+            request.override(
+                tools=[
+                    self._task if getattr(item, "name", None) == "task" and self._task else item
+                    for item in request.tools
+                ]
+            )
+        )
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        """Select the wrapper before background dispatch snapshots the tool."""
+        if request.tool_call["name"] == "task" and self._task:
+            if _IN_SUBAGENT.get() or request.runtime.state.get("_deepagents_forked_context"):
+                return ToolMessage(
+                    "Delegate from the main agent.", tool_call_id=request.tool_call["id"]
+                )
+            request = request.override(tool=self._task)
+        return await handler(request)
 
 
 def _task_only(state: dict[str, object]) -> dict[str, object]:
@@ -128,7 +258,7 @@ def _add_fresh_fallback(specs: list[SubAgent | CompiledSubAgent | AsyncSubAgent]
         return
     fallback: LocalSubAgent = {
         "name": "general-purpose",
-        "description": "Answer a delegated question without tools or private context.",
+        "description": "Complete a task with tools explicitly selected by the main agent.",
         "system_prompt": "Answer only the delegated question using the supplied information.",
         "fresh": True,
         "tool_names": [],

--- a/libs/talon/deepagents_talon/subagents.py
+++ b/libs/talon/deepagents_talon/subagents.py
@@ -1,0 +1,136 @@
+"""Explicit local tool attachments and task-only research graphs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NotRequired, TypedDict, cast
+
+from deepagents.middleware.subagents import SubAgent
+from langchain.agents import create_agent
+from langchain.agents.middleware import HumanInTheLoopMiddleware
+from langchain_core.runnables import RunnableLambda
+from langchain_core.tools import BaseTool, tool
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+    from deepagents.middleware.async_subagents import AsyncSubAgent
+    from deepagents.middleware.subagents import CompiledSubAgent
+    from langchain.agents.middleware import InterruptOnConfig
+    from langchain_core.language_models import BaseChatModel
+
+
+class LocalSubAgent(SubAgent):
+    """Local frontmatter additions resolved before SDK graph construction."""
+
+    fresh: NotRequired[bool]
+    tool_names: NotRequired[list[str]]
+
+
+class Attachment(TypedDict):
+    """Credential-free capability inventory for one graph."""
+
+    name: str
+    mode: str
+    tools: list[str] | None
+
+
+def _task_only(state: dict[str, object]) -> dict[str, object]:
+    return {"messages": state["messages"]}
+
+
+def _compile_fresh(
+    spec: LocalSubAgent,
+    model: str | BaseChatModel,
+    interrupt_on: Mapping[str, bool | InterruptOnConfig] | None,
+) -> CompiledSubAgent:
+    approvals = {key: value for key, value in (interrupt_on or {}).items() if value}
+    graph = create_agent(
+        model=spec.get("model", model),
+        tools=spec.get("tools", []),
+        system_prompt=spec.get("system_prompt", ""),
+        middleware=[HumanInTheLoopMiddleware(interrupt_on=approvals)] if approvals else [],
+        checkpointer=False,
+    )
+    return {
+        "name": spec["name"],
+        "description": spec["description"],
+        "runnable": RunnableLambda(_task_only) | graph,
+    }
+
+
+def prepare_subagents(
+    specs: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent],
+    tools: Sequence[BaseTool | Callable[..., object]],
+    model: str | BaseChatModel,
+    interrupt_on: Mapping[str, bool | InterruptOnConfig] | None,
+) -> tuple[list[SubAgent | CompiledSubAgent | AsyncSubAgent], list[Attachment]]:
+    """Resolve exact attachments, compiling fresh roles without inherited middleware.
+
+    Args:
+        specs: Loaded local, compiled, or remote definitions.
+        tools: Currently available tools, including loaded MCP tools.
+        model: Default model for fresh agents.
+        interrupt_on: Operator approval policy retained by fresh agents.
+
+    Returns:
+        SDK definitions and a safe inventory; opaque agents have unknown tools.
+
+    Raises:
+        ValueError: An attachment is unavailable or the fallback is privileged.
+    """
+    available = _tool_map(tools)
+    candidates = list(specs)
+    if any(spec.get("fresh") is True for spec in candidates):
+        _add_fresh_fallback(candidates)
+    prepared: list[SubAgent | CompiledSubAgent | AsyncSubAgent] = []
+    inventory: list[Attachment] = []
+    for original in candidates:
+        spec = cast("LocalSubAgent", original.copy())
+        if "tool_names" in spec:
+            names = spec.pop("tool_names")
+            if any(name not in available for name in names):
+                msg = "Subagent attachment is unavailable; previous configuration retained"
+                raise ValueError(msg)
+            spec["tools"] = [available[name] for name in names]
+        fresh = spec.pop("fresh", False)
+        inventory.append(
+            {
+                "name": spec["name"],
+                "mode": "fresh"
+                if fresh
+                else str(spec.get("mode", "remote" if "graph_id" in spec else "isolated")),
+                "tools": sorted(_tool_map(spec.get("tools", []))) if fresh else None,
+            }
+        )
+        prepared.append(_compile_fresh(spec, model, interrupt_on) if fresh else spec)
+    if not any(spec["name"] == "general-purpose" for spec in candidates):
+        inventory.append({"name": "general-purpose", "mode": "isolated", "tools": None})
+    return prepared, inventory
+
+
+def _tool_map(tools: Sequence[BaseTool | Callable[..., object]]) -> dict[str, BaseTool]:
+    result: dict[str, BaseTool] = {}
+    for item in tools:
+        resolved = item if isinstance(item, BaseTool) else tool(item)
+        if resolved.name in result:
+            msg = "Ambiguous tool names in subagent attachments"
+            raise ValueError(msg)
+        result[resolved.name] = resolved
+    return result
+
+
+def _add_fresh_fallback(specs: list[SubAgent | CompiledSubAgent | AsyncSubAgent]) -> None:
+    existing = next((spec for spec in specs if spec["name"] == "general-purpose"), None)
+    if existing is not None:
+        if existing.get("fresh") is not True:
+            msg = "Fresh subagents require a fresh general-purpose fallback"
+            raise ValueError(msg)
+        return
+    fallback: LocalSubAgent = {
+        "name": "general-purpose",
+        "description": "Answer a delegated question without tools or private context.",
+        "system_prompt": "Answer only the delegated question using the supplied information.",
+        "fresh": True,
+        "tool_names": [],
+    }
+    specs.append(fallback)

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -428,7 +428,7 @@ async def test_mcp_reload_tool_schedules_refresh_without_configuration(
     result = reload_tool.invoke({})
 
     assert reload_tool.name == "reload_mcp_configuration"
-    assert result == {"status": "scheduled", "available": "next_turn"}
+    assert result == {"status": "scheduled", "available": "after_successful_reload"}
 
     async def load() -> SimpleNamespace:
         return SimpleNamespace(tools=(DummyTool("refreshed"),))

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -284,10 +284,7 @@ async def test_runtime_wires_backend_checkpointer_tools_skills_and_memory(
     } <= tool_names
 
 
-async def test_runtime_wires_subagents(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, Any] = {}
+async def test_runtime_resolves_supplied_subagents() -> None:
     subagents = [
         {
             "name": "researcher",
@@ -295,12 +292,6 @@ async def test_runtime_wires_subagents(
             "system_prompt": "Research carefully.",
         },
     ]
-
-    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
-        captured.update(kwargs)
-        return RecordingGraph()
-
-    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
 
     runtime = DeepAgentRuntime(
         model="test:model",
@@ -310,9 +301,9 @@ async def test_runtime_wires_subagents(
         memory=(),
     )
 
-    await runtime.start()
+    resolved = runtime._resolve_subagents(strict=True)
 
-    assert captured["subagents"] == subagents
+    assert resolved == subagents
 
 
 async def test_runtime_requires_approval_for_async_subagent_tools(
@@ -342,7 +333,7 @@ async def test_runtime_requires_approval_for_async_subagent_tools(
 
     await runtime.start()
 
-    assert captured["subagents"] == [async_subagent]
+    assert captured["subagents"][0] == async_subagent
     assert captured["interrupt_on"] == {
         "custom_tool": True,
         "start_async_task": False,
@@ -353,9 +344,7 @@ async def test_runtime_requires_approval_for_async_subagent_tools(
 
 async def test_runtime_merges_local_and_async_subagents(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, Any] = {}
     assistant_dir = tmp_path / "agent-home" / "agent"
     researcher_dir = tmp_path / "agent-home" / "agents" / "researcher"
     researcher_dir.mkdir(parents=True)
@@ -368,12 +357,6 @@ async def test_runtime_merges_local_and_async_subagents(
         "graph_id": "review",
     }
 
-    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
-        captured.update(kwargs)
-        return RecordingGraph()
-
-    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
-
     runtime = DeepAgentRuntime(
         model="test:model",
         assistant_dir=assistant_dir,
@@ -384,14 +367,14 @@ async def test_runtime_merges_local_and_async_subagents(
         env={},
     )
 
-    await runtime.start()
+    resolved = runtime._resolve_subagents(strict=True)
 
-    assert captured["subagents"] == [
+    assert resolved == [
         {
             "name": "researcher",
             "description": "Research tasks",
             "system_prompt": "Research carefully.",
-            "mode": "fork",
+            "tool_names": [],
         },
         async_subagent,
     ]
@@ -399,9 +382,7 @@ async def test_runtime_merges_local_and_async_subagents(
 
 async def test_runtime_loads_local_subagents_from_user_agents_dir(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, Any] = {}
     assistant_dir = tmp_path / "agent-home" / "agent"
     researcher_dir = tmp_path / "agent-home" / "agents" / "researcher"
     reviewer_dir = tmp_path / "agent-home" / "agents" / "reviewer"
@@ -415,12 +396,6 @@ async def test_runtime_loads_local_subagents_from_user_agents_dir(
         "---\ndescription: Review changes\n---\nReview carefully.", encoding="utf-8"
     )
 
-    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
-        captured.update(kwargs)
-        return RecordingGraph()
-
-    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
-
     runtime = DeepAgentRuntime(
         model="test:model",
         assistant_dir=assistant_dir,
@@ -430,30 +405,28 @@ async def test_runtime_loads_local_subagents_from_user_agents_dir(
         env={},
     )
 
-    await runtime.start()
+    resolved = runtime._resolve_subagents(strict=True)
 
-    assert captured["subagents"] == [
+    assert resolved == [
         {
             "name": "researcher",
             "description": "Research tasks",
             "system_prompt": "Research carefully.",
             "model": "openai:model",
-            "mode": "fork",
+            "tool_names": [],
         },
         {
             "name": "reviewer",
             "description": "Review changes",
             "system_prompt": "Review carefully.",
-            "mode": "fork",
+            "tool_names": [],
         },
     ]
 
 
 async def test_runtime_loads_subagents_from_explicit_target_dir(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, Any] = {}
     assistant_dir = tmp_path / "imported-agent"
     researcher_dir = assistant_dir / "agents" / "researcher"
     researcher_dir.mkdir(parents=True)
@@ -461,12 +434,6 @@ async def test_runtime_loads_subagents_from_explicit_target_dir(
         "---\ndescription: Research tasks\n---\nResearch carefully.", encoding="utf-8"
     )
 
-    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
-        captured.update(kwargs)
-        return RecordingGraph()
-
-    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
-
     runtime = DeepAgentRuntime(
         model="test:model",
         assistant_dir=assistant_dir,
@@ -476,23 +443,21 @@ async def test_runtime_loads_subagents_from_explicit_target_dir(
         env={},
     )
 
-    await runtime.start()
+    resolved = runtime._resolve_subagents(strict=True)
 
-    assert captured["subagents"] == [
+    assert resolved == [
         {
             "name": "researcher",
             "description": "Research tasks",
             "system_prompt": "Research carefully.",
-            "mode": "fork",
+            "tool_names": [],
         },
     ]
 
 
 async def test_runtime_uses_user_defined_general_purpose_subagent(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, Any] = {}
     assistant_dir = tmp_path / "agent-home" / "agent"
     general_dir = tmp_path / "agent-home" / "agents" / "general-purpose"
     general_dir.mkdir(parents=True)
@@ -501,12 +466,6 @@ async def test_runtime_uses_user_defined_general_purpose_subagent(
         encoding="utf-8",
     )
 
-    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
-        captured.update(kwargs)
-        return RecordingGraph()
-
-    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
-
     runtime = DeepAgentRuntime(
         model="test:model",
         assistant_dir=assistant_dir,
@@ -515,14 +474,14 @@ async def test_runtime_uses_user_defined_general_purpose_subagent(
         memory=(),
     )
 
-    await runtime.start()
+    resolved = runtime._resolve_subagents(strict=True)
 
-    assert captured["subagents"] == [
+    assert resolved == [
         {
             "name": "general-purpose",
             "description": "Custom general agent",
             "system_prompt": "Use custom instructions.",
-            "mode": "fork",
+            "tool_names": [],
         }
     ]
 

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -189,8 +189,8 @@ async def test_runtime_refreshes_tools_between_turns_and_binds_authorization_han
     )
 
     assert created == [
-        ["current_time", "custom_tool"],
-        ["current_time", "refreshed_tool"],
+        ["current_time", "custom_tool", "get_agent_tools"],
+        ["current_time", "refreshed_tool", "get_agent_tools"],
     ]
     assert current_authorization_handler() is None
 
@@ -527,7 +527,7 @@ async def test_runtime_uses_user_defined_general_purpose_subagent(
     ]
 
 
-async def test_runtime_skips_invalid_local_subagent_definitions(
+async def test_runtime_rejects_invalid_local_subagent_definitions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -555,9 +555,10 @@ async def test_runtime_skips_invalid_local_subagent_definitions(
         memory=(),
     )
 
-    await runtime.start()
+    with pytest.raises(ValueError, match="Invalid or duplicate local subagent"):
+        await runtime.start()
 
-    assert captured["subagents"] is None
+    assert not captured
     assert "invalid name, description, or model" in caplog.text
 
 
@@ -1390,4 +1391,4 @@ async def test_runtime_registers_clock_tool_without_web_or_cron_tools(monkeypatc
 
     await runtime.start()
 
-    assert [_tool_name(tool) for tool in captured["tools"]] == ["current_time"]
+    assert [_tool_name(tool) for tool in captured["tools"]] == ["current_time", "get_agent_tools"]

--- a/libs/talon/tests/unit_tests/test_background_runtime.py
+++ b/libs/talon/tests/unit_tests/test_background_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import nullcontext
 
 import pytest
 from langchain_core._api import LangChainBetaWarning
@@ -17,10 +18,14 @@ class ToolModel(FakeMessagesListChatModel):
         return self
 
 
-async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch):
+@pytest.mark.parametrize("mode", ["fork", "fresh"])
+async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch, mode):
     path = tmp_path / "agents" / "researcher" / "AGENTS.md"
     path.parent.mkdir(parents=True)
-    path.write_text("---\ndescription: Research\nmodel: test:child\n---\nResearch carefully.")
+    path.write_text(
+        f"---\ndescription: Research\nmodel: test:child\nmode: {mode}\n"
+        "tools: [sensitive_effect]\n---\nResearch carefully."
+    )
     effects = []
 
     @tool
@@ -77,7 +82,11 @@ async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch):
         approvals.extend(item["name"] for item in request.action_requests)
         return "approve"
 
-    with pytest.warns(LangChainBetaWarning, match="forked subagents"):
+    with (
+        pytest.warns(LangChainBetaWarning, match="forked subagents")
+        if mode == "fork"
+        else nullcontext()
+    ):
         await runtime.start()
     try:
         result = await runtime.invoke(AgentRequest("chat", "delegate", approval_handler=approve))

--- a/libs/talon/tests/unit_tests/test_background_runtime.py
+++ b/libs/talon/tests/unit_tests/test_background_runtime.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import nullcontext
 
 import pytest
 from langchain.agents import create_agent
-from langchain_core._api import LangChainBetaWarning
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage
 from langchain_core.tools import tool
@@ -19,15 +17,12 @@ class ToolModel(FakeMessagesListChatModel):
         return self
 
 
-@pytest.mark.parametrize(
-    ("mode", "name"),
-    [("fork", "researcher"), ("fresh", "researcher"), ("fresh", "general-purpose")],
-)
-async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch, mode, name):
+@pytest.mark.parametrize("name", ["researcher", "general-purpose"])
+async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch, name):
     path = tmp_path / "agents" / "researcher" / "AGENTS.md"
     path.parent.mkdir(parents=True)
     path.write_text(
-        f"---\ndescription: Research\nmodel: test:child\nmode: {mode}\n"
+        "---\ndescription: Research\nmodel: test:child\n"
         "tools: [sensitive_effect]\n---\nResearch carefully."
     )
     effects = []
@@ -93,12 +88,7 @@ async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch, mode,
         approvals.extend(item["name"] for item in request.action_requests)
         return "approve"
 
-    with (
-        pytest.warns(LangChainBetaWarning, match="forked subagents")
-        if mode == "fork"
-        else nullcontext()
-    ):
-        await runtime.start()
+    await runtime.start()
     try:
         result = await runtime.invoke(AgentRequest("chat", "delegate", approval_handler=approve))
         assert result.text == "Started background work"

--- a/libs/talon/tests/unit_tests/test_background_runtime.py
+++ b/libs/talon/tests/unit_tests/test_background_runtime.py
@@ -4,6 +4,7 @@ import asyncio
 from contextlib import nullcontext
 
 import pytest
+from langchain.agents import create_agent
 from langchain_core._api import LangChainBetaWarning
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage
@@ -18,8 +19,11 @@ class ToolModel(FakeMessagesListChatModel):
         return self
 
 
-@pytest.mark.parametrize("mode", ["fork", "fresh"])
-async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch, mode):
+@pytest.mark.parametrize(
+    ("mode", "name"),
+    [("fork", "researcher"), ("fresh", "researcher"), ("fresh", "general-purpose")],
+)
+async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch, mode, name):
     path = tmp_path / "agents" / "researcher" / "AGENTS.md"
     path.parent.mkdir(parents=True)
     path.write_text(
@@ -43,8 +47,11 @@ async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch, mode)
                         "name": "task",
                         "id": "launch",
                         "args": {
-                            "subagent_type": "researcher",
+                            "subagent_type": name,
                             "description": "work",
+                            **(
+                                {"tools": ["sensitive_effect"]} if name == "general-purpose" else {}
+                            ),
                         },
                     }
                 ],
@@ -66,6 +73,10 @@ async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch, mode)
     )
     monkeypatch.setattr(
         "deepagents.graph.resolve_model", lambda model: child if model == "test:child" else model
+    )
+    monkeypatch.setattr(
+        "deepagents_talon.subagents.create_agent",
+        lambda **kwargs: create_agent(**{**kwargs, "model": child}),
     )
     runtime = DeepAgentRuntime(
         model="test:parent",

--- a/libs/talon/tests/unit_tests/test_mcp_config.py
+++ b/libs/talon/tests/unit_tests/test_mcp_config.py
@@ -55,7 +55,7 @@ def test_redacted_round_trip_preserves_secrets_and_other_settings(config_tools, 
     response = update.invoke(
         {"server_name": "example", "server": server, "expected_revision": result["revision"]}
     )
-    assert response == {"status": "updated", "available": "next_turn"}
+    assert response == {"status": "updated", "available": "after_successful_reload"}
     original["mcpServers"]["example"]["allowedTools"] = ["read_*"]
     assert json.loads(path.read_text()) == original
     assert path.stat().st_mode & 0o777 == 0o600

--- a/libs/talon/tests/unit_tests/test_research_subagents.py
+++ b/libs/talon/tests/unit_tests/test_research_subagents.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import shlex
 
 import pytest
 from langchain.agents import create_agent
@@ -82,7 +83,7 @@ async def test_research_boundaries(tmp_path, monkeypatch, background, name, atta
     skill = tmp_path / "skill.md"
     skill.write_text("Use lookup for research.")
     selected = ["lookup", "read_file"] if name == "general-purpose" and attached else ["lookup"]
-    launch = {"tools": selected if attached else []} if name == "general-purpose" else {}
+    launch = {"tools": selected} if name == "general-purpose" and attached else {}
     effects = []
 
     @tool
@@ -158,6 +159,41 @@ async def test_research_boundaries(tmp_path, monkeypatch, background, name, atta
         await runtime.stop()
 
 
+@pytest.mark.parametrize("name", ["researcher", "general-purpose"])
+async def test_explicit_shell_access(tmp_path, monkeypatch, name):
+    _write_agent(tmp_path, "[execute]")
+    output = tmp_path / "child-output"
+    launch = {"tools": ["execute"]} if name == "general-purpose" else {}
+    parent = ToolModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    _call("task", subagent_type=name, description="Create the file", **launch)
+                ],
+            ),
+            AIMessage(content="Done"),
+        ]
+    )
+    child = ToolModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[_call("execute", command=f"printf done > {shlex.quote(str(output))}")],
+            ),
+            AIMessage(content="Created"),
+        ]
+    )
+    runtime = _runtime(tmp_path, monkeypatch, parent, child)
+    await runtime.start()
+    try:
+        await runtime.invoke(AgentRequest("chat", "Create the file"))
+        await asyncio.gather(*(job.worker for job in runtime.background._jobs.values()))
+        assert output.read_text() == "done"
+    finally:
+        await runtime.stop()
+
+
 def _inventory(runtime):
     return runtime._graph.nodes["tools"].bound.tools_by_name["get_agent_tools"].invoke({})
 
@@ -188,7 +224,10 @@ async def test_fork_is_rejected(tmp_path, source):
         await runtime.start()
 
 
-@pytest.mark.parametrize("selection", [{}, {"tools": ["missing"]}, {"tools": ["task"]}])
+@pytest.mark.parametrize(
+    "selection",
+    [{"tools": ["missing"]}, {"tools": ["task"]}, {"tools": ["read_file", "read_file"]}],
+)
 async def test_general_requires_valid_selection(tmp_path, monkeypatch, selection):
     parent = ToolModel(
         responses=[

--- a/libs/talon/tests/unit_tests/test_research_subagents.py
+++ b/libs/talon/tests/unit_tests/test_research_subagents.py
@@ -63,7 +63,13 @@ def _runtime(root, monkeypatch, parent, child, **kwargs: object):
 
 @pytest.mark.parametrize("background", [False, True])
 @pytest.mark.parametrize(
-    ("name", "attached"), [("researcher", True), ("researcher", False), ("general-purpose", False)]
+    ("name", "attached"),
+    [
+        ("researcher", True),
+        ("researcher", False),
+        ("general-purpose", False),
+        ("general-purpose", True),
+    ],
 )
 async def test_research_boundaries(tmp_path, monkeypatch, background, name, attached):
     _write_agent(tmp_path, "[lookup]" if attached else "[]")
@@ -71,6 +77,10 @@ async def test_research_boundaries(tmp_path, monkeypatch, background, name, atta
     memory = tmp_path / "memory.md"
     memory.write_text(private)
     output = tmp_path / "output.txt"
+    skill = tmp_path / "skill.md"
+    skill.write_text("Use lookup for research.")
+    selected = ["lookup", "read_file"] if name == "general-purpose" and attached else ["lookup"]
+    launch = {"tools": selected if attached else []} if name == "general-purpose" else {}
     effects = []
 
     @tool
@@ -83,16 +93,16 @@ async def test_research_boundaries(tmp_path, monkeypatch, background, name, atta
         _call(name)
         for name in (
             "execute",
-            "read_file",
             "search_conversations",
             "reload_subagent_configuration",
             "task",
             "start_async_task",
         )
     ]
+    skill_calls = [_call("read_file", file_path=str(skill))] if "read_file" in selected else []
     child = ToolModel(
         responses=[
-            AIMessage(content="", tool_calls=[_call("lookup"), *forbidden]),
+            AIMessage(content="", tool_calls=[_call("lookup"), *skill_calls, *forbidden]),
             AIMessage(content="Research complete"),
         ]
         if attached
@@ -102,7 +112,9 @@ async def test_research_boundaries(tmp_path, monkeypatch, background, name, atta
         responses=[
             AIMessage(
                 content="",
-                tool_calls=[_call("task", subagent_type=name, description="Find evidence")],
+                tool_calls=[
+                    _call("task", subagent_type=name, description="Find evidence", **launch)
+                ],
             ),
             AIMessage(
                 content="",
@@ -121,19 +133,24 @@ async def test_research_boundaries(tmp_path, monkeypatch, background, name, atta
         assert output.read_text() == "main works"
         assert memory.read_text() == private
         assert effects == (["lookup"] if attached else [])
-        assert child._tools == ([["lookup"], ["lookup"]] if attached else [])
+        assert child._tools == ([selected, selected] if attached else [])
         assert child._seen[0][-1].content == "Find evidence"
         assert private not in str(child._seen)
         assert "Parent history" not in str(child._seen[0])
+        if name == "general-purpose" and attached:
+            assert "Use lookup for research." in str(child._seen)
         messages = child._seen[-1]
         denied = [message for message in messages if getattr(message, "status", None) == "error"]
         assert {message.name for message in denied} == (
             {call["name"] for call in forbidden} if attached else set()
         )
         inventory = runtime._graph.nodes["tools"].bound.tools_by_name["get_agent_tools"].invoke({})
-        assert next(item for item in inventory["agents"] if item["name"] == name)["tools"] == (
-            ["lookup"] if attached else []
-        )
+        agent = next(item for item in inventory["agents"] if item["name"] == name)
+        if name == "general-purpose":
+            assert "read_file" in agent["selectable_tools"]
+            assert "task" not in agent["selectable_tools"]
+        else:
+            assert agent["tools"] == (["lookup"] if attached else [])
         assert private not in json.dumps(inventory)
     finally:
         await runtime.stop()
@@ -141,6 +158,31 @@ async def test_research_boundaries(tmp_path, monkeypatch, background, name, atta
 
 def _inventory(runtime):
     return runtime._graph.nodes["tools"].bound.tools_by_name["get_agent_tools"].invoke({})
+
+
+@pytest.mark.parametrize("selection", [{}, {"tools": ["missing"]}, {"tools": ["task"]}])
+async def test_general_requires_valid_selection(tmp_path, monkeypatch, selection):
+    parent = ToolModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    _call("task", subagent_type="general-purpose", description="Work", **selection)
+                ],
+            ),
+            AIMessage(content="Done"),
+        ]
+    )
+    child = ToolModel(responses=[AIMessage(content="Must not run")])
+    runtime = _runtime(tmp_path, monkeypatch, parent, child)
+    await runtime.start()
+    try:
+        await runtime.invoke(AgentRequest("chat", "Work"))
+        await asyncio.gather(*(job.worker for job in runtime.background._jobs.values()))
+        assert not child._seen
+        assert "Specify tools" in next(iter(runtime.background.results("chat").values()))
+    finally:
+        await runtime.stop()
 
 
 async def test_attachment_reload_and_invalid_edits_retain_effective_graph(tmp_path, monkeypatch):

--- a/libs/talon/tests/unit_tests/test_research_subagents.py
+++ b/libs/talon/tests/unit_tests/test_research_subagents.py
@@ -8,6 +8,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import tool
 from pydantic import PrivateAttr
 
@@ -32,11 +33,11 @@ def _call(name, **args: object):
     return {"name": name, "id": name, "args": args}
 
 
-def _write_agent(root, tools="[]", *, mode="fresh", name="researcher"):
+def _write_agent(root, tools="[]", *, name="researcher"):
     path = root / "agents" / name / "AGENTS.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        f"---\ndescription: Research\nmodel: test:child\nmode: {mode}\ntools: {tools}\n"
+        f"---\ndescription: Research\nmodel: test:child\ntools: {tools}\n"
         "---\nAnswer the delegated question."
     )
     return path
@@ -158,6 +159,23 @@ async def test_research_boundaries(tmp_path, monkeypatch, background, name, atta
 
 def _inventory(runtime):
     return runtime._graph.nodes["tools"].bound.tools_by_name["get_agent_tools"].invoke({})
+
+
+@pytest.mark.parametrize("source", ["local", "supplied", "compiled"])
+async def test_fork_is_rejected(tmp_path, source):
+    spec = {"name": "researcher", "description": "Research", "mode": "fork"}
+    if source == "local":
+        path = _write_agent(tmp_path)
+        path.write_text(
+            path.read_text().replace("description: Research", "mode: fork\ndescription: Research")
+        )
+    elif source == "compiled":
+        spec["runnable"] = RunnableLambda(lambda state: state)
+    runtime = DeepAgentRuntime(
+        model="test:model", assistant_dir=tmp_path, subagents=[] if source == "local" else [spec]
+    )
+    with pytest.raises(ValueError, match="fresh context"):
+        await runtime.start()
 
 
 @pytest.mark.parametrize("selection", [{}, {"tools": ["missing"]}, {"tools": ["task"]}])

--- a/libs/talon/tests/unit_tests/test_research_subagents.py
+++ b/libs/talon/tests/unit_tests/test_research_subagents.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from langchain.agents import create_agent
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.tools import tool
+from pydantic import PrivateAttr
+
+from deepagents_talon.interfaces import AgentRequest
+from deepagents_talon.runtime import DeepAgentRuntime
+
+
+class ToolModel(FakeMessagesListChatModel):
+    _seen: list = PrivateAttr(default_factory=list)
+    _tools: list = PrivateAttr(default_factory=list)
+
+    def bind_tools(self, tools, **_kwargs: object):
+        self._tools.append([item.name for item in tools])
+        return self
+
+    def _generate(self, messages, *args: object, **kwargs: object):
+        self._seen.append(messages)
+        return super()._generate(messages, *args, **kwargs)
+
+
+def _call(name, **args: object):
+    return {"name": name, "id": name, "args": args}
+
+
+def _write_agent(root, tools="[]", *, mode="fresh", name="researcher"):
+    path = root / "agents" / name / "AGENTS.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\ndescription: Research\nmodel: test:child\nmode: {mode}\ntools: {tools}\n"
+        "---\nAnswer the delegated question."
+    )
+    return path
+
+
+def _runtime(root, monkeypatch, parent, child, **kwargs: object):
+    monkeypatch.setattr(
+        "deepagents_talon.runtime._resolve_model_from_env", lambda *_a, **_k: parent
+    )
+
+    def compile_child(**options: object):
+        options["model"] = child
+        return create_agent(**options)
+
+    monkeypatch.setattr("deepagents_talon.subagents.create_agent", compile_child)
+    return DeepAgentRuntime(
+        model="test:parent",
+        assistant_dir=root,
+        include_web_tools=False,
+        skills=(),
+        **{"memory": (), **kwargs},
+    )
+
+
+@pytest.mark.parametrize("background", [False, True])
+@pytest.mark.parametrize(
+    ("name", "attached"), [("researcher", True), ("researcher", False), ("general-purpose", False)]
+)
+async def test_research_boundaries(tmp_path, monkeypatch, background, name, attached):
+    _write_agent(tmp_path, "[lookup]" if attached else "[]")
+    private = "PRIVATE-PARENT-MARKER"
+    memory = tmp_path / "memory.md"
+    memory.write_text(private)
+    output = tmp_path / "output.txt"
+    effects = []
+
+    @tool
+    def lookup() -> str:
+        """Return research evidence."""
+        effects.append("lookup")
+        return "Source: fixture; evidence found"
+
+    forbidden = [
+        _call(name)
+        for name in (
+            "execute",
+            "read_file",
+            "search_conversations",
+            "reload_subagent_configuration",
+            "task",
+            "start_async_task",
+        )
+    ]
+    child = ToolModel(
+        responses=[
+            AIMessage(content="", tool_calls=[_call("lookup"), *forbidden]),
+            AIMessage(content="Research complete"),
+        ]
+        if attached
+        else [AIMessage(content="No tools")]
+    )
+    parent = ToolModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[_call("task", subagent_type=name, description="Find evidence")],
+            ),
+            AIMessage(
+                content="",
+                tool_calls=[_call("write_file", file_path=str(output), content="main works")],
+            ),
+            AIMessage(content="Done"),
+        ]
+    )
+    runtime = _runtime(tmp_path, monkeypatch, parent, child, tools=[lookup], memory=[str(memory)])
+    if not background:
+        monkeypatch.setattr(runtime.background, "configured", lambda _: AgentMiddleware())
+    await runtime.start()
+    try:
+        await runtime.invoke(AgentRequest("chat", f"Parent history contains {private}"))
+        await asyncio.gather(*(job.worker for job in runtime.background._jobs.values()))
+        assert output.read_text() == "main works"
+        assert memory.read_text() == private
+        assert effects == (["lookup"] if attached else [])
+        assert child._tools == ([["lookup"], ["lookup"]] if attached else [])
+        assert child._seen[0][-1].content == "Find evidence"
+        assert private not in str(child._seen)
+        assert "Parent history" not in str(child._seen[0])
+        messages = child._seen[-1]
+        denied = [message for message in messages if getattr(message, "status", None) == "error"]
+        assert {message.name for message in denied} == (
+            {call["name"] for call in forbidden} if attached else set()
+        )
+        inventory = runtime._graph.nodes["tools"].bound.tools_by_name["get_agent_tools"].invoke({})
+        assert next(item for item in inventory["agents"] if item["name"] == name)["tools"] == (
+            ["lookup"] if attached else []
+        )
+        assert private not in json.dumps(inventory)
+    finally:
+        await runtime.stop()
+
+
+def _inventory(runtime):
+    return runtime._graph.nodes["tools"].bound.tools_by_name["get_agent_tools"].invoke({})
+
+
+async def test_attachment_reload_and_invalid_edits_retain_effective_graph(tmp_path, monkeypatch):
+    _write_agent(tmp_path, "[first]")
+
+    @tool
+    def first() -> str:
+        """First source."""
+        return "first"
+
+    @tool
+    def second() -> str:
+        """Second source."""
+        return "second"
+
+    model = ToolModel(responses=[AIMessage(content="Done")])
+    runtime = _runtime(tmp_path, monkeypatch, model, model, tools=[first, second])
+    await runtime.start()
+    try:
+        old_view = runtime._graph.nodes["tools"].bound.tools_by_name["get_agent_tools"]
+        _write_agent(tmp_path, "[second]")
+        assert _inventory(runtime)["saved_changes_inactive"]
+        assert runtime._attachments[1]["tools"] == ["first"]
+        await runtime.reload_subagent_configuration()
+        assert not _inventory(runtime)["saved_changes_inactive"]
+        assert runtime._attachments[1]["tools"] == ["second"]
+        previous = old_view.invoke({})
+        assert previous["current_turn_uses_previous_graph"]
+        assert previous["agents"][1]["tools"] == ["first"]
+        assert previous["latest_agents"][1]["tools"] == ["second"]
+        active = runtime._graph
+        for tools in ("null", "lookup", "[lookup, lookup]", "[1]", "[missing]"):
+            _write_agent(tmp_path, tools)
+            result = await runtime._subagent_reload_tool().ainvoke({})
+            assert result["status"] == "failed"
+            assert "inactive" in result["message"]
+            assert runtime._graph is active
+            assert _inventory(runtime)["saved_changes_inactive"]
+            assert runtime._attachments[1]["tools"] == ["second"]
+    finally:
+        await runtime.stop()

--- a/libs/talon/tests/unit_tests/test_research_subagents.py
+++ b/libs/talon/tests/unit_tests/test_research_subagents.py
@@ -14,6 +14,7 @@ from pydantic import PrivateAttr
 
 from deepagents_talon.interfaces import AgentRequest
 from deepagents_talon.runtime import DeepAgentRuntime
+from deepagents_talon.subagents import prepare_subagents
 
 
 class ToolModel(FakeMessagesListChatModel):
@@ -159,6 +160,15 @@ async def test_research_boundaries(tmp_path, monkeypatch, background, name, atta
 
 def _inventory(runtime):
     return runtime._graph.nodes["tools"].bound.tools_by_name["get_agent_tools"].invoke({})
+
+
+@pytest.mark.parametrize(
+    "definition", [{"runnable": RunnableLambda(lambda state: state)}, {"graph_id": "remote"}]
+)
+def test_opaque_general_purpose_is_rejected(definition):
+    spec = {"name": "general-purpose", "description": "Custom agent", **definition}
+    with pytest.raises(ValueError, match="must use a name other than 'general-purpose'"):
+        prepare_subagents([spec], [], "test:model", None)
 
 
 @pytest.mark.parametrize("source", ["local", "supplied", "compiled"])

--- a/libs/talon/tests/unit_tests/test_subagent_reload.py
+++ b/libs/talon/tests/unit_tests/test_subagent_reload.py
@@ -11,6 +11,11 @@ from deepagents_talon.interfaces import AgentRequest
 from deepagents_talon.runtime import DeepAgentRuntime
 
 
+@pytest.fixture(autouse=True)
+def stub_child_compilation(monkeypatch):
+    monkeypatch.setattr("deepagents_talon.subagents._compile_fresh", lambda spec, *_args: spec)
+
+
 def _write_agent(path, prompt):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"---\ndescription: Research tasks\n---\n{prompt}")
@@ -21,6 +26,7 @@ def _graph_factory(entered=None, release=None):
         names = ",".join(
             agent.get("system_prompt", agent.get("graph_id", ""))
             for agent in kwargs["subagents"] or []
+            if agent["name"] != "general-purpose"
         )
 
         async def reply(state):


### PR DESCRIPTION
Talon subagents use fresh context: named agents run with configured tools, while `general-purpose` defaults to no tools and accepts tools and context per launch.

---

The main agent can edit and reload named definitions, then invoke them with their configured tools. Dynamic `general-purpose` launches select tools explicitly, including `execute` for shell access, and receive context through `description`. Approval gates remain intact; invalid reloads retain the active configuration.

Compiled and remote agents must use a name other than `general-purpose`, which is reserved for dynamic launches.

Validation: 23 focused subagent/reload tests, Ruff, and type checks passed.

Fixes https://linear.app/langchain/issue/JKB-83
