### PR TITLE
fix(talon): correct history embedding token budget and prompt defaults

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -121,16 +121,28 @@ Embedding settings use the `DEEPAGENTS_TALON_HISTORY_EMBED_` prefix:
 | `MAX_INPUT_TOKENS` | Model context budget; required remotely, local defaults to 8192 |
 | `BATCH_SIZE` | Local defaults to 4 (maximum 4); remote defaults to 32 (maximum 96) |
 | `CONCURRENCY` | Local uses 1; remote defaults to 4 (maximum 16) |
-| `QUERY_PROMPT` | Optional query instruction; only local Qwen has a default prefix |
+| `BYTES_PER_TOKEN` | UTF-8 bytes budgeted per token, 1-4; defaults to the worst case of 1 |
+| `QUERY_PROMPT` | Optional query instruction; Qwen3-Embedding models default to Qwen's prefix |
 | `BASE_URL` | Optional HTTPS endpoint without credentials, query parameters, or fragments |
 | `API_KEY` | Optional environment override for the adapter's standard API key |
 | `QUERY_MODEL` | Optional compatible query-time model, supported only by Atlas |
 
-Queries retain each provider's query/document semantics on all three databases.
+Queries retain each provider's query/document semantics on all three databases,
+and the instruction prefix follows the model rather than the adapter, so a
+Qwen3-Embedding model reached through OpenRouter is prompted like a local one.
+
 Inputs use UTF-8 byte counts as a conservative token bound, reserving 128 tokens
-for provider instructions. Oversized documents are split without losing text and
-their vectors are combined with a length-weighted mean; transcript pagination stays
-unchanged. Oversized queries fall back to keyword search. Atlas requires a budget
+for provider instructions. `BYTES_PER_TOKEN` converts the token limit into that
+byte measure and defaults to 1, which assumes every byte can become its own token.
+Natural non-ASCII text is far cheaper than that -- a CJK character is roughly three
+bytes but about one token -- so the default splits transcripts a model could embed
+whole. Raising it trades safety margin for fewer splits; the value is part of the
+embedding fingerprint, so a change rebuilds the index.
+
+Oversized documents are split without losing text and their vectors are combined
+with a length-weighted mean, which is logged once per run because pooled documents
+are compared against unpooled queries. Transcript pagination stays unchanged.
+Oversized queries fall back to keyword search. Atlas requires a budget
 large enough for a complete archive chunk because embedding happens server-side.
 Remote indexing uses bounded batches and concurrency; errors retain pending work
 for retry. Selecting a remote adapter sends archived text and queries to that

--- a/libs/talon/deepagents_talon/history_adapters.py
+++ b/libs/talon/deepagents_talon/history_adapters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import logging
 import math
 from contextlib import AsyncExitStack, asynccontextmanager
 from contextvars import ContextVar
@@ -22,11 +23,14 @@ if TYPE_CHECKING:
     from deepagents_talon.config import TalonConfig
     from deepagents_talon.history_profiles import EmbeddingProfile
 
+_PREFIX = "DEEPAGENTS_TALON_HISTORY_EMBED_"
 QUERY_EMBEDDING: ContextVar[bool] = ContextVar("talon_history_query", default=False)
 EMBEDDING_CACHE: ContextVar[dict[tuple[bool, str], list[float]] | None] = ContextVar(
     "talon_history_embeddings", default=None
 )
 _REQUEST_TIMEOUT = 30
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -136,6 +140,7 @@ class BoundedEmbeddings(Embeddings):
         self.profile = profile
         self.loop = asyncio.get_running_loop()
         self.slots = asyncio.Semaphore(profile.concurrency)
+        self.reported_pooling = False
 
     def _bridge[T](self, operation: Coroutine[object, object, T]) -> T:
         # MongoDBStore invokes sync embeddings from its worker thread.
@@ -162,7 +167,7 @@ class BoundedEmbeddings(Embeddings):
         if (cached := (EMBEDDING_CACHE.get() or {}).get((True, text))) is not None:
             return cached
         query = self.profile.query_prompt + text
-        if len(query.encode()) > self.profile.max_input_tokens - 128:
+        if len(query.encode()) > self.profile.input_budget:
             msg = "History embedding query exceeds the configured input budget"
             raise ValueError(msg)
         async with self.slots, asyncio.timeout(_REQUEST_TIMEOUT):
@@ -177,7 +182,8 @@ class BoundedEmbeddings(Embeddings):
         cache = EMBEDDING_CACHE.get() or {}
         if all((False, text) in cache for text in texts):
             return [cache[False, text] for text in texts]
-        chunks = [_chunks(text, self.profile.max_input_tokens - 128) for text in texts]
+        chunks = [_chunks(text, self.profile.input_budget) for text in texts]
+        self._report_pooling(chunks)
         flattened = [chunk for document in chunks for chunk in document]
         vectors = await self._documents(flattened)
         output: list[list[float]] = []
@@ -187,6 +193,25 @@ class BoundedEmbeddings(Embeddings):
             output.append(_pool(group, [len(chunk.encode()) for chunk in document]))
             cursor += len(document)
         return output
+
+    def _report_pooling(self, chunks: list[list[str]]) -> None:
+        """Announce, once, that documents no longer fit one request and are averaged.
+
+        Pooled documents are compared against unpooled queries, so retrieval quality
+        degrades quietly. Raising the token budget or the byte/token ratio removes it.
+        """
+        widest = max((len(document) for document in chunks), default=1)
+        if widest > 1 and not self.reported_pooling:
+            self.reported_pooling = True
+            logger.warning(
+                "History documents exceed the %d-byte embedding budget and are averaged "
+                "across up to %d requests; raise %sMAX_INPUT_TOKENS or %sBYTES_PER_TOKEN "
+                "to embed them whole",
+                self.profile.input_budget,
+                widest,
+                _PREFIX,
+                _PREFIX,
+            )
 
     async def _documents(self, texts: list[str]) -> list[list[float]]:
         size = self.profile.batch_size

--- a/libs/talon/deepagents_talon/history_profiles.py
+++ b/libs/talon/deepagents_talon/history_profiles.py
@@ -75,9 +75,10 @@ class EmbeddingProfile:
             self.model,
             self.dims,
             self.max_input_tokens,
-            self.bytes_per_token,
             self.base_url,
-            "utf8-weighted-mean-v1",
+            # Splitting and pooling run only where Talon computes vectors, so their
+            # settings cannot change what a server-side adapter already stored.
+            [self.bytes_per_token, "utf8-weighted-mean-v1"] if self.client_side else [],
         )
         return hashlib.sha256(json.dumps(identity).encode()).hexdigest()
 

--- a/libs/talon/deepagents_talon/history_profiles.py
+++ b/libs/talon/deepagents_talon/history_profiles.py
@@ -23,6 +23,8 @@ _PREFIX = "DEEPAGENTS_TALON_HISTORY_EMBED_"
 _MAX_MODEL_LENGTH = 256
 _SERVER_INPUT_BOUND = CHUNK_SIZE * 4 + 128
 _ADAPTERS = {"local", "voyage", "openai-compatible", "atlas"}
+_INSTRUCTION_FAMILY = "qwen3-embedding"
+_RESERVED_TOKENS = 128
 
 
 @dataclass(frozen=True)
@@ -39,6 +41,7 @@ class EmbeddingProfile:
     max_input_tokens: int = 8192
     batch_size: int = 4
     concurrency: int = 1
+    bytes_per_token: int = 1
     query_prompt: str = LOCAL_PROMPT
     base_url: str = ""
     query_model: str = ""
@@ -50,16 +53,30 @@ class EmbeddingProfile:
         return self.adapter != "atlas"
 
     @property
+    def input_budget(self) -> int:
+        """Bound one provider request in UTF-8 bytes, reserving room for instructions.
+
+        `bytes_per_token` converts the provider's token limit into the byte measure
+        used for splitting. It defaults to the worst case of one token per byte, so
+        raising it trades a safety margin for fewer splits on non-ASCII transcripts.
+        """
+        return (self.max_input_tokens - _RESERVED_TOKENS) * self.bytes_per_token
+
+    @property
     def fingerprint(self) -> str:
-        """Identify the vector space and preprocessing without including credentials."""
+        """Identify stored document vectors, excluding credentials and query-time settings.
+
+        `query_prompt` and `query_model` are deliberately absent: both apply only when
+        embedding a query, so changing either cannot invalidate a stored vector and must
+        not force callers to rebuild the index.
+        """
         identity = (
             self.adapter,
             self.model,
             self.dims,
             self.max_input_tokens,
-            self.query_prompt,
+            self.bytes_per_token,
             self.base_url,
-            self.query_model,
             "utf8-weighted-mean-v1",
         )
         return hashlib.sha256(json.dumps(identity).encode()).hexdigest()
@@ -91,14 +108,26 @@ def parse_profile(env: Mapping[str, str]) -> EmbeddingProfile:
         max_input_tokens=_number(env, "MAX_INPUT_TOKENS", 8192 if local else None, 131072),
         batch_size=_number(env, "BATCH_SIZE", 4 if local else 32, 4 if local else 96),
         concurrency=_number(env, "CONCURRENCY", 1 if local else 4, 1 if local else 16),
-        query_prompt=env.get(
-            _PREFIX + "QUERY_PROMPT", LOCAL_PROMPT if local and model == LOCAL_MODEL else ""
-        ),
+        bytes_per_token=_number(env, "BYTES_PER_TOKEN", 1, 4),
+        query_prompt=env.get(_PREFIX + "QUERY_PROMPT", _default_prompt(adapter, model)),
         base_url=_endpoint(env, adapter),
         query_model=env.get(_PREFIX + "QUERY_MODEL", ""),
     )
     _validate_profile(profile)
     return profile
+
+
+def _default_prompt(adapter: str, model: str) -> str:
+    """Apply the instruction format a model was trained with, however it is reached.
+
+    Qwen3-Embedding expects an instruction prefix on queries and none on documents, and
+    that convention belongs to the model rather than to the adapter serving it, so the
+    same model reached through a hosted OpenAI-compatible endpoint needs it too. Atlas
+    embeds server-side and never sees a client prompt.
+    """
+    if adapter == "atlas":
+        return ""
+    return LOCAL_PROMPT if _INSTRUCTION_FAMILY in model.lower() else ""
 
 
 def _number(env: Mapping[str, str], name: str, default: int | None, maximum: int) -> int:
@@ -136,7 +165,7 @@ def _endpoint(env: Mapping[str, str], adapter: str) -> str:
 
 
 def _validate_profile(profile: EmbeddingProfile) -> None:
-    if len(profile.query_prompt.encode()) + 132 >= profile.max_input_tokens:
+    if len(profile.query_prompt.encode()) + 4 >= profile.input_budget:
         msg = "History embedding token budget must leave room for query text"
         raise TalonConfigError(msg)
     if profile.adapter in {"voyage", "atlas"} and profile.dims not in {256, 512, 1024, 2048}:

--- a/libs/talon/deepagents_talon/history_vectors.py
+++ b/libs/talon/deepagents_talon/history_vectors.py
@@ -252,7 +252,7 @@ class HistoryVectorIndex:
             if (
                 self.profile
                 and not self.profile.client_side
-                and len(query.encode()) > self.profile.max_input_tokens - 128
+                and len(query.encode()) > self.profile.input_budget
             ):
                 return [], "error"
             # asyncio.Lock is fair: a waiting query runs before the next indexing

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -100,6 +100,16 @@ def test_instruction_prompt_follows_the_model_not_the_adapter(tmp_path, adapter,
     assert profile.query_prompt.startswith("Instruct:") is prompted
 
 
+def test_client_preprocessing_does_not_gate_server_side_indexes(tmp_path):
+    served = configuration(
+        tmp_path, ADAPTER="atlas", MODEL="voyage-3-large", DIMS="1024", MAX_INPUT_TOKENS="16256"
+    ).history_embedding_profile
+    assert served.client_side is False
+    assert served.fingerprint == replace(served, bytes_per_token=3).fingerprint
+    computed = configuration(tmp_path).history_embedding_profile
+    assert computed.fingerprint != replace(computed, bytes_per_token=3).fingerprint
+
+
 def test_byte_ratio_widens_the_budget_without_changing_the_token_limit(tmp_path):
     narrow = configuration(tmp_path).history_embedding_profile
     wide = configuration(tmp_path, BYTES_PER_TOKEN="3").history_embedding_profile  # noqa: S106

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -60,17 +60,73 @@ def test_invalid_profile_fails_during_configuration(tmp_path, settings):
 def test_fingerprint_covers_vector_space_but_not_keys_or_throughput(tmp_path):
     config = configuration(tmp_path, API_KEY="test-key")
     profile = config.history_embedding_profile
-    assert profile.fingerprint == replace(profile, batch_size=8, concurrency=2).fingerprint
+    for unchanged in (
+        {"batch_size": 8, "concurrency": 2},
+        {"query_prompt": "query: "},
+        {"query_model": "other"},
+    ):
+        assert profile.fingerprint == replace(profile, **unchanged).fingerprint
     for change in (
         {"dims": 3},
         {"model": "other"},
-        {"query_prompt": "query: "},
         {"max_input_tokens": 1024},
+        {"bytes_per_token": 2},
         {"base_url": "https://other.example/v1"},
     ):
         assert profile.fingerprint != replace(profile, **change).fingerprint
     assert "test-key" not in repr(profile)
     assert "test-key" not in repr(config)
+
+
+@pytest.mark.parametrize(
+    ("adapter", "model", "prompted"),
+    [
+        ("local", "Qwen/Qwen3-Embedding-0.6B", True),
+        ("local", "Qwen/Qwen3-Embedding-8B", True),
+        ("local", "BAAI/bge-m3", False),
+        ("openai-compatible", "qwen/qwen3-embedding-8b", True),
+        ("openai-compatible", "openai/text-embedding-3-small", False),
+        ("voyage", "voyage-3-large", False),
+    ],
+)
+def test_instruction_prompt_follows_the_model_not_the_adapter(tmp_path, adapter, model, prompted):
+    settings = {"ADAPTER": adapter, "MODEL": model}
+    if adapter != "openai-compatible":
+        settings["BASE_URL"] = ""
+    if adapter == "voyage":
+        settings["DIMS"] = "1024"
+    profile = configuration(tmp_path, **settings).history_embedding_profile
+    assert bool(profile.query_prompt) is prompted
+    assert profile.query_prompt.startswith("Instruct:") is prompted
+
+
+def test_byte_ratio_widens_the_budget_without_changing_the_token_limit(tmp_path):
+    narrow = configuration(tmp_path).history_embedding_profile
+    wide = configuration(tmp_path, BYTES_PER_TOKEN="3").history_embedding_profile  # noqa: S106
+    assert narrow.input_budget == 384
+    assert wide.input_budget == 384 * 3
+    assert wide.max_input_tokens == narrow.max_input_tokens
+
+
+async def test_pooling_is_reported_once_with_actionable_settings(tmp_path, caplog):
+    profile = configuration(tmp_path).history_embedding_profile
+    bounded = BoundedEmbeddings(RecordingEmbeddings(), profile)
+    with caplog.at_level("WARNING"):
+        await bounded.aembed_documents(["a" * 4000])
+        await bounded.aembed_documents(["b" * 4000])
+    warnings = [record for record in caplog.records if "averaged" in record.getMessage()]
+    assert len(warnings) == 1
+    assert "BYTES_PER_TOKEN" in warnings[0].getMessage()
+
+
+async def test_short_documents_are_embedded_whole_without_warning(tmp_path, caplog):
+    profile = configuration(tmp_path, BYTES_PER_TOKEN="4").history_embedding_profile  # noqa: S106
+    raw = RecordingEmbeddings()
+    bounded = BoundedEmbeddings(raw, profile)
+    with caplog.at_level("WARNING"):
+        await bounded.aembed_documents(["\u65e5\u672c\u8a9e" * 100])
+    assert len(raw.documents) == 1
+    assert caplog.records == []
 
 
 async def test_openrouter_sends_text_and_dimensions_without_loading_local_models(
@@ -213,6 +269,11 @@ async def test_model_change_requires_explicit_rebuild_and_preserves_transcripts(
         await archive.append(SCOPE, "session", "time", [HumanMessage("retained")])
         await settled(archive)
         namespace = archive.vectors.namespace("whatsapp", "one")
+    tuned = configuration(tmp_path, QUERY_PROMPT="Represent this query: ")
+    async with open_history(tuned) as archive:
+        await settled(archive)
+        assert [entry["text"] for entry in await archive.entries(SCOPE)] == ["retained"]
+    assert raw.documents == ["retained"]
     changed = configuration(tmp_path, MODEL="other", DIMS="3")
     with pytest.raises(TalonConfigError, match="HISTORY_REINDEX"):
         async with open_history(changed):


### PR DESCRIPTION
Follow-up to #6108, addressing review feedback that was resolved there on the understanding it would land separately. Targets `jkennedyvz/talon/vector-history-search` so the diff stays reviewable; retarget to `main` once #6108 merges.

## Token budget measured in bytes

`_chunks` compared UTF-8 byte counts against `max_input_tokens`, i.e. it assumed one token per byte. That is the correct worst case for byte-fallback BPE, but natural non-ASCII text is far cheaper — a CJK character is ~3 bytes and ~1 token — so the default budget split transcripts the model could embed whole:

| Text | Bytes | Local default (8192) |
| --- | --- | --- |
| 4000 ASCII chars | 4000 | 1 chunk |
| 4000 CJK chars | 12000 | 2 chunks, pooled |
| 4000 emoji | 16000 | 2 chunks, pooled |

The conversion is now an explicit `DEEPAGENTS_TALON_HISTORY_EMBED_BYTES_PER_TOKEN` (1-4), **still defaulting to 1**, so no existing configuration changes behaviour. Operators who know their tokenizer can raise it and stop splitting. `EmbeddingProfile.input_budget` now gives the query guard and the document splitter a single definition instead of two copies of `max_input_tokens - 128`.

A tokenizer-derived bound would be more precise, but it needs a per-provider tokenizer we do not have remotely; making the estimate explicit and tunable is deliberately the smaller step.

## Pooling was silent

Splitting a document mean-pools its sub-vectors, which are then compared against unpooled query vectors. That is a real retrieval-quality cost with no signal, so it now warns once per run and names the two settings that remove it.

## Instruction prefix followed the adapter, not the model

The Qwen prefix defaulted only when `model == LOCAL_MODEL` exactly. Qwen3-Embedding-4B and -8B use the identical convention and got `""`, as did `qwen/qwen3-embedding-8b` reached through OpenRouter — which is a configuration we intend to run. The default now keys on the model family across adapters. Atlas still rejects client prompts outright.

## Fingerprint forced needless rebuilds

`query_prompt` and `query_model` were part of the fingerprint, so tuning an instruction tripped the mismatch check and demanded `DEEPAGENTS_TALON_HISTORY_REINDEX=1`. Both apply only when embedding a query and cannot invalidate a stored document vector. They are gone from the fingerprint; `bytes_per_token` is now in it, since it does change stored vectors.

## Validation

`ruff check`, `ruff format`, and the full talon unit suite pass locally (234 passed, 3 skipped). `ty check` reports the same 4 pre-existing unresolved-import diagnostics as `main` for this stack (`voyageai`, `langchain_voyageai`, `psycopg`, `langgraph.store.postgres.aio`) — untouched here, they need the optional extras in the lint environment.

New tests cover the family-aware prompt across six adapter/model combinations, the byte-ratio budget, single-shot pooling warnings, and that a `QUERY_PROMPT` change no longer forces a rebuild while a model change still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)