### PR TITLE
fix(talon): make remote embedding settings explicit and search non-blocking

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -120,10 +120,11 @@ Embedding settings use the `DEEPAGENTS_TALON_HISTORY_EMBED_` prefix:
 | `DIMS` | Output width; required for remote client adapters |
 | `MAX_INPUT_TOKENS` | Model context budget; required remotely, local defaults to 8192 |
 | `BATCH_SIZE` | Local defaults to 4 (maximum 4); remote defaults to 32 (maximum 96) |
-| `CONCURRENCY` | Local uses 1; remote defaults to 4 (maximum 16) |
+| `CONCURRENCY` | Indexing requests in flight; local uses 1, remote defaults to 4 (maximum 16) |
 | `BYTES_PER_TOKEN` | UTF-8 bytes budgeted per token, 1-4; defaults to the worst case of 1 |
 | `QUERY_PROMPT` | Optional query instruction; Qwen3-Embedding models default to Qwen's prefix |
-| `BASE_URL` | Optional HTTPS endpoint without credentials, query parameters, or fragments |
+| `SEND_DIMENSIONS` | Send the OpenAI `dimensions` parameter; set `0` for models that reject it |
+| `BASE_URL` | Optional HTTPS endpoint, routable host, without credentials, query, or fragments |
 | `API_KEY` | Optional environment override for the adapter's standard API key |
 | `QUERY_MODEL` | Optional compatible query-time model, supported only by Atlas |
 
@@ -144,6 +145,15 @@ with a length-weighted mean, which is logged once per run because pooled documen
 are compared against unpooled queries. Transcript pagination stays unchanged.
 Oversized queries fall back to keyword search. Atlas requires a budget
 large enough for a complete archive chunk because embedding happens server-side.
+A search holds a slot of its own at both the store and the provider, so it never
+queues behind indexing and may add one request above `CONCURRENCY`.
+
+`BASE_URL` must name a routable host: address literals in loopback, private,
+link-local, or reserved ranges are refused, as is `localhost`, because the
+configured endpoint receives the provider API key. A public name that resolves
+to a private address still connects, which needs resolution-time control the
+embedding clients do not expose.
+
 Remote indexing uses bounded batches and concurrency; errors retain pending work
 for retry. Selecting a remote adapter sends archived text and queries to that
 provider and may incur charges.

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -150,7 +150,9 @@ queues behind indexing and may add one request above `CONCURRENCY`.
 
 `BASE_URL` must name a routable host: address literals in loopback, private,
 link-local, or reserved ranges are refused, as is `localhost`, because the
-configured endpoint receives the provider API key. A public name that resolves
+configured endpoint receives the provider API key. Abbreviated IPv4 spellings
+that the C resolver still accepts, such as `127.1` and `2130706433`, are
+refused as the addresses they reach. A public name that resolves
 to a private address still connects, which needs resolution-time control the
 embedding clients do not expose.
 

--- a/libs/talon/deepagents_talon/history_adapters.py
+++ b/libs/talon/deepagents_talon/history_adapters.py
@@ -10,6 +10,7 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import replace
 from typing import TYPE_CHECKING, Literal, cast
+from urllib.parse import urlsplit
 
 from langchain_core.embeddings import Embeddings
 from pydantic import SecretStr
@@ -108,18 +109,15 @@ async def _openai(
     driver = _driver("langchain_openai", "history-openai")
     import httpx  # noqa: PLC0415  # Optional provider transport.
 
-    key = (
-        "OPENROUTER_API_KEY"
-        if profile.base_url == "https://openrouter.ai/api/v1"
-        else "OPENAI_API_KEY"
-    )
+    host = urlsplit(profile.base_url).hostname or ""
+    key = "OPENROUTER_API_KEY" if host.lower() == "openrouter.ai" else "OPENAI_API_KEY"
     sync = stack.enter_context(httpx.Client(timeout=_REQUEST_TIMEOUT, follow_redirects=False))
     asynchronous = await stack.enter_async_context(
         httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, follow_redirects=False)
     )
     return driver.OpenAIEmbeddings(
         model=profile.model,
-        dimensions=profile.dims,
+        dimensions=profile.dims if profile.send_dimensions else None,
         base_url=profile.base_url,
         api_key=_key(config, key),
         max_retries=0,
@@ -140,6 +138,7 @@ class BoundedEmbeddings(Embeddings):
         self.profile = profile
         self.loop = asyncio.get_running_loop()
         self.slots = asyncio.Semaphore(profile.concurrency)
+        self.query_slot = asyncio.Semaphore(1)
         self.reported_pooling = False
 
     def _bridge[T](self, operation: Coroutine[object, object, T]) -> T:
@@ -170,7 +169,7 @@ class BoundedEmbeddings(Embeddings):
         if len(query.encode()) > self.profile.input_budget:
             msg = "History embedding query exceeds the configured input budget"
             raise ValueError(msg)
-        async with self.slots, asyncio.timeout(_REQUEST_TIMEOUT):
+        async with self.query_slot, asyncio.timeout(_REQUEST_TIMEOUT):
             vector = await self.embed.aembed_query(query)
         self._validate([vector], 1)
         return vector
@@ -216,7 +215,7 @@ class BoundedEmbeddings(Embeddings):
     async def _documents(self, texts: list[str]) -> list[list[float]]:
         size = self.profile.batch_size
         output: list[list[float]] = []
-        concurrency = max(1, self.profile.concurrency - 1)
+        concurrency = self.profile.concurrency
         for start in range(0, len(texts), size * concurrency):
             async with asyncio.TaskGroup() as group:
                 tasks = [
@@ -233,11 +232,18 @@ class BoundedEmbeddings(Embeddings):
         return vectors
 
     def _validate(self, vectors: list[list[float]], count: int) -> None:
-        if len(vectors) != count or any(
-            len(vector) != self.profile.dims or not all(math.isfinite(value) for value in vector)
-            for vector in vectors
+        if len(vectors) != count or not all(
+            all(math.isfinite(value) for value in vector) for vector in vectors
         ):
-            msg = "History embedding response has invalid dimensions, values, or count"
+            msg = "History embedding response has an invalid count or values"
+            raise ValueError(msg)
+        widths = {len(vector) for vector in vectors}
+        if widths - {self.profile.dims}:
+            msg = (
+                f"History embedding provider returned {sorted(widths)}-dimensional vectors "
+                f"but {_PREFIX}DIMS is {self.profile.dims}; set DIMS to the model's native "
+                f"width, or {_PREFIX}SEND_DIMENSIONS=0 if the model cannot resize output"
+            )
             raise ValueError(msg)
 
 

--- a/libs/talon/deepagents_talon/history_profiles.py
+++ b/libs/talon/deepagents_talon/history_profiles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import ipaddress
 import json
+import socket
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
@@ -199,9 +200,8 @@ def _routable(hostname: str) -> bool:
     """
     if hostname.lower() in {"localhost", "localhost."}:
         return False
-    try:
-        address = ipaddress.ip_address(hostname.strip("[]"))
-    except ValueError:
+    address = _address(hostname)
+    if address is None:
         return True
     return not (
         address.is_private
@@ -211,6 +211,24 @@ def _routable(hostname: str) -> bool:
         or address.is_multicast
         or address.is_unspecified
     )
+
+
+def _address(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Resolve an address literal, including the abbreviated IPv4 forms.
+
+    `ipaddress` accepts only dotted quads, but the C resolver behind every HTTP
+    client also accepts `127.1`, `2130706433`, `0177.0.0.1`, and `0x7f000001`, all
+    of which reach the loopback interface. Treating those as hostnames would let
+    them past the routability check.
+    """
+    try:
+        return ipaddress.ip_address(hostname.strip("[]"))
+    except ValueError:
+        pass
+    try:
+        return ipaddress.ip_address(socket.inet_aton(hostname))
+    except (OSError, ValueError):
+        return None
 
 
 def _validate_profile(profile: EmbeddingProfile) -> None:

--- a/libs/talon/deepagents_talon/history_profiles.py
+++ b/libs/talon/deepagents_talon/history_profiles.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -42,6 +43,7 @@ class EmbeddingProfile:
     batch_size: int = 4
     concurrency: int = 1
     bytes_per_token: int = 1
+    send_dimensions: bool = True
     query_prompt: str = LOCAL_PROMPT
     base_url: str = ""
     query_model: str = ""
@@ -110,6 +112,7 @@ def parse_profile(env: Mapping[str, str]) -> EmbeddingProfile:
         batch_size=_number(env, "BATCH_SIZE", 4 if local else 32, 4 if local else 96),
         concurrency=_number(env, "CONCURRENCY", 1 if local else 4, 1 if local else 16),
         bytes_per_token=_number(env, "BYTES_PER_TOKEN", 1, 4),
+        send_dimensions=_flag(env, "SEND_DIMENSIONS", default=True),
         query_prompt=env.get(_PREFIX + "QUERY_PROMPT", _default_prompt(adapter, model)),
         base_url=_endpoint(env, adapter),
         query_model=env.get(_PREFIX + "QUERY_MODEL", ""),
@@ -131,13 +134,29 @@ def _default_prompt(adapter: str, model: str) -> str:
     return LOCAL_PROMPT if _INSTRUCTION_FAMILY in model.lower() else ""
 
 
+def _flag(env: Mapping[str, str], name: str, *, default: bool) -> bool:
+    value = env.get(_PREFIX + name, "1" if default else "0").strip().lower()
+    if value in {"1", "true", "yes"}:
+        return True
+    if value in {"0", "false", "no"}:
+        return False
+    msg = f"{_PREFIX}{name} must be a boolean"
+    raise TalonConfigError(msg)
+
+
 def _number(env: Mapping[str, str], name: str, default: int | None, maximum: int) -> int:
+    raw = env.get(_PREFIX + name)
+    if raw is None:
+        if default is None:
+            msg = f"{_PREFIX}{name} is required for this adapter"
+            raise TalonConfigError(msg)
+        return default
     try:
-        value = int(env.get(_PREFIX + name, str(default)))
-        if 1 <= value <= maximum:
-            return value
+        value = int(raw)
     except ValueError:
-        pass
+        value = 0
+    if 1 <= value <= maximum:
+        return value
     msg = f"{_PREFIX}{name} must be an integer between 1 and {maximum}"
     raise TalonConfigError(msg)
 
@@ -158,11 +177,40 @@ def _endpoint(env: Mapping[str, str], adapter: str) -> str:
             and not any(char.isspace() for char in url)
         ):
             _ = parsed.port
-            return url.rstrip("/")
+            if _routable(parsed.hostname):
+                return url.rstrip("/")
     except ValueError:
         pass
-    msg = f"{_PREFIX}BASE_URL must be an HTTPS URL without credentials, query, or fragment"
+    msg = (
+        f"{_PREFIX}BASE_URL must be an HTTPS URL without credentials, query, or fragment, "
+        "naming a routable host"
+    )
     raise TalonConfigError(msg)
+
+
+def _routable(hostname: str) -> bool:
+    """Reject endpoints that address this host or its private network.
+
+    The configured endpoint receives the provider API key, so a misconfigured
+    base URL should not deliver it to a metadata service or an internal listener.
+    Only address literals and `localhost` are checked: a public name that resolves
+    to a private address still connects, which needs resolution-time control the
+    embedding clients do not expose.
+    """
+    if hostname.lower() in {"localhost", "localhost."}:
+        return False
+    try:
+        address = ipaddress.ip_address(hostname.strip("[]"))
+    except ValueError:
+        return True
+    return not (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_reserved
+        or address.is_multicast
+        or address.is_unspecified
+    )
 
 
 def _validate_profile(profile: EmbeddingProfile) -> None:

--- a/libs/talon/deepagents_talon/history_vectors.py
+++ b/libs/talon/deepagents_talon/history_vectors.py
@@ -71,6 +71,8 @@ class HistoryVectorIndex:
         """Keep indexing separate from checkpoint persistence."""
         self.profile = profile
         self._slots = asyncio.Semaphore(profile.concurrency if profile else 1)
+        # Indexing can occupy every configured slot, so a search holds its own.
+        self._query_slots = asyncio.Semaphore(1)
         self._pending: set[asyncio.Task[list[Result]]] = set()
         self.search_visibility = search_visibility
         self.indexing = indexing
@@ -106,18 +108,19 @@ class HistoryVectorIndex:
         """
         return ("talon_history", self.identity, _digest(channel), _digest(chat))
 
-    async def _batch(self, operations: Sequence[Op]) -> list[Result]:
-        await self._slots.acquire()
-        task = asyncio.create_task(self._call_store(operations))
+    async def _batch(self, operations: Sequence[Op], *, query: bool = False) -> list[Result]:
+        slots = self._query_slots if query else self._slots
+        await slots.acquire()
+        task = asyncio.create_task(self._call_store(operations, slots))
         self._pending.add(task)
         task.add_done_callback(self._finished)
         return await asyncio.shield(task)
 
-    async def _call_store(self, operations: Sequence[Op]) -> list[Result]:
+    async def _call_store(self, operations: Sequence[Op], slots: asyncio.Semaphore) -> list[Result]:
         try:
             return await self.store.abatch(operations)
         finally:
-            self._slots.release()
+            slots.release()
 
     def _finished(self, task: asyncio.Task[list[Result]]) -> None:
         self._pending.discard(task)
@@ -255,9 +258,11 @@ class HistoryVectorIndex:
                 and len(query.encode()) > self.profile.input_budget
             ):
                 return [], "error"
-            # asyncio.Lock is fair: a waiting query runs before the next indexing
-            # batch. The deadline covers both waiting and query execution.
-            guard = nullcontext() if self.profile and self.profile.concurrency > 1 else self.lock
+            # Remote adapters hold a dedicated query slot, so a search never waits on
+            # indexing whatever the configured concurrency. Local inference is
+            # single-flight, so the fair lock orders a waiting query ahead of the
+            # next indexing batch. The deadline covers waiting and execution alike.
+            guard = nullcontext() if self.profile and self.profile.adapter != "local" else self.lock
             async with asyncio.timeout(_SEARCH_TIMEOUT_SECONDS), guard:
                 results = await self._batch(
                     [
@@ -268,7 +273,8 @@ class HistoryVectorIndex:
                             query=query,
                             limit=_CANDIDATES,
                         )
-                    ]
+                    ],
+                    query=True,
                 )
             items = cast("list[SearchItem]", results[0])
             keys = [item.key for item in items if item.score is not None]

--- a/libs/talon/deepagents_talon/history_vectors.py
+++ b/libs/talon/deepagents_talon/history_vectors.py
@@ -114,6 +114,13 @@ class HistoryVectorIndex:
         task = asyncio.create_task(self._call_store(operations, slots))
         self._pending.add(task)
         task.add_done_callback(self._finished)
+        if query:
+            # Indexing writes are shielded so a cancelled caller cannot leave a
+            # partial batch, but a search that timed out has no result worth
+            # keeping. Awaiting it directly cancels the request and frees the
+            # single query permit, instead of holding it until the provider's own
+            # timeout and stalling every later search behind it.
+            return await task
         return await asyncio.shield(task)
 
     async def _call_store(self, operations: Sequence[Op], slots: asyncio.Semaphore) -> list[Result]:

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -47,6 +47,12 @@ def configuration(tmp_path, **settings: str):
         {"BASE_URL": "https://key:password@example.org"},
         {"BASE_URL": "https://example.org?key=secret"},
         {"BASE_URL": "https://example.org:invalid"},
+        {"BASE_URL": "https://127.0.0.1/v1"},
+        {"BASE_URL": "https://localhost/v1"},
+        {"BASE_URL": "https://10.1.2.3/v1"},
+        {"BASE_URL": "https://169.254.169.254/v1"},
+        {"BASE_URL": "https://[::1]/v1"},
+        {"SEND_DIMENSIONS": "maybe"},
         {"ADAPTER": "atlas", "DIMS": "1024", "MAX_INPUT_TOKENS": "512"},
     ],
 )
@@ -55,6 +61,26 @@ def test_invalid_profile_fails_during_configuration(tmp_path, settings):
         configuration(tmp_path, **settings)
     assert "password" not in str(error.value)
     assert "key=secret" not in str(error.value)
+
+
+@pytest.mark.parametrize("missing", ["DIMS", "MAX_INPUT_TOKENS"])
+def test_remote_adapters_name_the_settings_they_require(tmp_path, missing):
+    env = {
+        "DEEPAGENTS_TALON_HISTORY_VECTOR_SEARCH": "1",
+        PREFIX + "ADAPTER": "openai-compatible",
+        PREFIX + "MODEL": "test-model",
+        PREFIX + "DIMS": "2",
+        PREFIX + "MAX_INPUT_TOKENS": "512",
+    }
+    del env[PREFIX + missing]
+    with pytest.raises(TalonConfigError, match=f"{missing} is required"):
+        TalonConfig.from_env(env, base_home=tmp_path)
+
+
+def test_public_endpoints_remain_configurable(tmp_path):
+    for url in ("https://openrouter.ai/api/v1", "https://8.8.8.8/v1", "https://api.example.org/v1"):
+        profile = configuration(tmp_path, BASE_URL=url).history_embedding_profile
+        assert profile.base_url == url
 
 
 def test_fingerprint_covers_vector_space_but_not_keys_or_throughput(tmp_path):
@@ -176,6 +202,16 @@ async def test_openrouter_sends_text_and_dimensions_without_loading_local_models
         assert await profile.embed.aembed_query("question") == [1, 0]
     assert [body["input"] for body in requests] == [["document"], ["question"]]
     assert all(body["dimensions"] == 2 for body in requests)
+    requests.clear()
+    unsized = configuration(
+        tmp_path,
+        BASE_URL="https://openrouter.ai/api/v1",
+        API_KEY="test",
+        SEND_DIMENSIONS="0",
+    )
+    async with open_profile(unsized) as profile:
+        await profile.embed.aembed_documents(["document"])
+    assert all("dimensions" not in body for body in requests)
 
 
 async def test_voyage_preserves_document_and_query_input_types(tmp_path, monkeypatch):
@@ -197,6 +233,35 @@ async def test_voyage_preserves_document_and_query_input_types(tmp_path, monkeyp
     assert [options["input_type"] for _, options in calls] == ["document", "query"]
     assert all(options["truncation"] is False for _, options in calls)
     assert [texts for texts, _ in calls] == [["document"], ["question"]]
+
+
+async def test_dimension_mismatch_names_the_settings_that_resolve_it(tmp_path):
+    profile = configuration(tmp_path).history_embedding_profile
+    bounded = BoundedEmbeddings(RecordingEmbeddings(dims=4), profile)
+    with pytest.raises(BaseExceptionGroup) as error:
+        await bounded.aembed_documents(["document"])
+    message = str(error.value.exceptions[0])
+    assert "SEND_DIMENSIONS" in message
+    assert "DIMS is 2" in message
+
+
+async def test_search_does_not_queue_behind_indexing_at_minimum_concurrency(tmp_path, monkeypatch):
+    raw = RecordingEmbeddings()
+    fake_adapter(monkeypatch, raw)
+    config = configuration(tmp_path, CONCURRENCY="1")
+    async with open_history(config) as archive:
+        await archive.append(SCOPE, "first", "time", [HumanMessage("car")])
+        await settled(archive)
+        raw.started.clear()
+        raw.block = True
+        await archive.append(SCOPE, "second", "time", [HumanMessage("indexing")])
+        try:
+            await asyncio.wait_for(raw.started.wait(), 1)
+            page = await asyncio.wait_for(archive.search_page(SCOPE, query="automobile"), 5)
+            assert page["semantic_status"] == "completed"
+            assert raw.queries == ["automobile"]
+        finally:
+            raw.release.set()
 
 
 class RecordingEmbeddings(Embeddings):

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -10,7 +10,7 @@ import pytest
 from langchain_core.embeddings import Embeddings
 from langchain_core.messages import HumanMessage
 
-from deepagents_talon import history_adapters
+from deepagents_talon import history_adapters, history_vectors
 from deepagents_talon.config import TalonConfig, TalonConfigError
 from deepagents_talon.history_adapters import BoundedEmbeddings, open_profile
 from deepagents_talon.history_backends import open_history
@@ -52,6 +52,10 @@ def configuration(tmp_path, **settings: str):
         {"BASE_URL": "https://10.1.2.3/v1"},
         {"BASE_URL": "https://169.254.169.254/v1"},
         {"BASE_URL": "https://[::1]/v1"},
+        {"BASE_URL": "https://127.1/v1"},
+        {"BASE_URL": "https://2130706433/v1"},
+        {"BASE_URL": "https://0177.0.0.1/v1"},
+        {"BASE_URL": "https://0x7f000001/v1"},
         {"SEND_DIMENSIONS": "maybe"},
         {"ADAPTER": "atlas", "DIMS": "1024", "MAX_INPUT_TOKENS": "512"},
     ],
@@ -245,6 +249,23 @@ async def test_dimension_mismatch_names_the_settings_that_resolve_it(tmp_path):
     assert "DIMS is 2" in message
 
 
+async def test_timed_out_search_frees_its_slot_for_the_next_search(tmp_path, monkeypatch):
+    monkeypatch.setattr(history_vectors, "_SEARCH_TIMEOUT_SECONDS", 0.1)
+    raw = RecordingEmbeddings()
+    fake_adapter(monkeypatch, raw)
+    config = configuration(tmp_path, CONCURRENCY="1")
+    async with open_history(config) as archive:
+        await archive.append(SCOPE, "first", "time", [HumanMessage("car")])
+        await settled(archive)
+        raw.stall_queries = True
+        assert (await archive.search_page(SCOPE, query="automobile"))["semantic_status"] == (
+            "timeout"
+        )
+        raw.stall_queries = False
+        page = await asyncio.wait_for(archive.search_page(SCOPE, query="automobile"), 5)
+        assert page["semantic_status"] == "completed"
+
+
 async def test_search_does_not_queue_behind_indexing_at_minimum_concurrency(tmp_path, monkeypatch):
     raw = RecordingEmbeddings()
     fake_adapter(monkeypatch, raw)
@@ -270,6 +291,7 @@ class RecordingEmbeddings(Embeddings):
         self.documents = []
         self.queries = []
         self.block = False
+        self.stall_queries = False
         self.started = asyncio.Event()
         self.release = asyncio.Event()
 
@@ -289,6 +311,8 @@ class RecordingEmbeddings(Embeddings):
 
     async def aembed_query(self, text):
         self.queries.append(text)
+        if self.stall_queries:
+            await asyncio.sleep(1)
         return [1.0, *([0.0] * (self.dims - 1))]
 
 


### PR DESCRIPTION
Second follow-up to #6108, stacked on #6132 (both touch `history_profiles.py` and `history_adapters.py`). Review after that one; retarget both to `main` once the stack lands.

## `dimensions` sent to providers that reject it

`OpenAIEmbeddings(dimensions=profile.dims)` went out unconditionally, but `dimensions` is an OpenAI extension most models behind an OpenAI-compatible API do not implement — including much of the OpenRouter catalog we intend to use. `SEND_DIMENSIONS=0` now omits it.

`_validate` also folded three unrelated conditions into "invalid dimensions, values, or count". Width mismatch is now separate and names the way out:

```
History embedding provider returned [4]-dimensional vectors but
DEEPAGENTS_TALON_HISTORY_EMBED_DIMS is 2; set DIMS to the model's native width,
or DEEPAGENTS_TALON_HISTORY_EMBED_SEND_DIMENSIONS=0 if the model cannot resize output
```

## Required settings reported as malformed

`DIMS` and `MAX_INPUT_TOKENS` are mandatory for remote adapters, expressed as `default=None` reaching `int("None")`. The resulting "must be an integer between 1 and 8192" describes a value the operator never set. It now says the setting is required.

## Search queued behind indexing

With `CONCURRENCY=1` a search timed out into keyword results while an indexing batch was in flight. Three separate points shared one budget:

- `HistoryVectorIndex._slots`, sized at `concurrency`, taken by every store batch including the search
- `BoundedEmbeddings.slots`, likewise, with `_documents` reserving a slot via `concurrency - 1` — which is `max(1, 0) = 1` at the minimum, reserving nothing
- the archive lock in `_semantic`, taken whenever `concurrency == 1`

Both semaphore layers now reserve a dedicated query slot, so a search may add one request above `CONCURRENCY` and never waits on indexing. The archive lock now orders queries only for single-flight local inference, which is the case it was written for. Regression test drives a blocked indexing batch at `CONCURRENCY=1` and asserts the search still completes semantically.

## `BASE_URL` accepted internal addresses

The endpoint receives the provider API key, and validation required HTTPS and rejected credentials, query, and fragment — but `https://169.254.169.254/v1`, `https://10.0.0.1/v1`, and `https://localhost/v1` all passed. Loopback, private, link-local, reserved, multicast, and unspecified address literals are now refused, as is `localhost`.

This does not stop a public name resolving to a private address; that needs resolution-time control the embedding clients do not expose. The docstring and README say so rather than implying more coverage than exists.

Also minor: the OpenRouter key is chosen by hostname rather than exact base-URL equality, so a trailing path or explicit port no longer silently falls back to expecting `OPENAI_API_KEY`.

## Validation

`ruff check`, `ruff format`, and the talon unit suite pass locally (245 passed, 3 skipped). `ty check` reports the same 4 pre-existing unresolved-import diagnostics carried by this stack — untouched here.

New tests cover five rejected endpoint forms plus three that must keep working, both required-setting messages, `SEND_DIMENSIONS=0` omitting the parameter from the wire, the mismatch message, and search under a blocked indexing batch at minimum concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)