### PR TITLE
fix(talon): stop HistoryEmbeddings defaulting to Qwen's query prefix

### DIFF
--- a/libs/talon/deepagents_talon/history_embeddings.py
+++ b/libs/talon/deepagents_talon/history_embeddings.py
@@ -46,9 +46,15 @@ class HistoryEmbeddings(Embeddings):
         model: str = MODEL,
         max_input_tokens: int = 8192,
         batch_size: int = 4,
-        query_prompt: str = QUERY_PROMPT,
+        query_prompt: str = "",
     ) -> None:
-        """Defer optional imports and model downloads until embedding is requested."""
+        """Defer optional imports and model downloads until embedding is requested.
+
+        `query_prompt` defaults to none because the caller that owns the profile
+        applies the model's instruction format before delegating here. Defaulting
+        to Qwen's prefix instead would embed it twice whenever a caller forgot to
+        pass an empty string.
+        """
         self.model = model
         self.max_input_tokens = max_input_tokens
         self.batch_size = batch_size

--- a/libs/talon/tests/unit_tests/test_history_vectors.py
+++ b/libs/talon/tests/unit_tests/test_history_vectors.py
@@ -276,6 +276,21 @@ async def test_default_store_adds_qwen_instruction_only_to_queries(tmp_path):
             await asyncio.gather(store._task, return_exceptions=True)
 
 
+def test_local_embeddings_do_not_prefix_queries_on_their_own(monkeypatch):
+    calls = []
+
+    def embed(_self, texts):
+        calls.append(texts)
+        return [[1.0, 0.0] for _ in texts]
+
+    monkeypatch.setattr(HistoryEmbeddings, "embed_documents", embed)
+    assert HistoryEmbeddings().query_prompt == ""
+    assert HistoryEmbeddings().embed_query("automobile") == [1.0, 0.0]
+    assert calls == [["automobile"]]
+    assert HistoryEmbeddings(query_prompt=QUERY_PROMPT).embed_query("automobile") == [1.0, 0.0]
+    assert calls[-1] == [QUERY_PROMPT + "automobile"]
+
+
 @pytest.mark.parametrize("value", ["1", "true", "YES", " on "])
 def test_vector_environment_opt_in(tmp_path, value):
     config = TalonConfig.from_env(


### PR DESCRIPTION
Third follow-up to #6108. Independent of #6132 and #6133 — touches only `history_embeddings.py` — so it can land in any order. Targets `jkennedyvz/talon/vector-history-search`; retarget to `main` once #6108 merges.

`HistoryEmbeddings.__init__` defaults `query_prompt` to Qwen's instruction prefix, but the prefix is applied a layer up in `BoundedEmbeddings.aembed_query`, which owns the profile. So `_adapter` constructs it with `query_prompt=""` specifically to stop the instruction being prepended twice:

```python
embed = HistoryEmbeddings(
    model=profile.model,
    max_input_tokens=profile.max_input_tokens,
    batch_size=profile.batch_size,
    query_prompt="",
)
```

Two layers both know how to apply the prompt, and correctness rests on the caller remembering to opt out. Defaulting to `""` makes double-application impossible rather than merely avoided; the call site keeps its explicit argument, which is now redundant but harmless.

Nothing changes at runtime — every existing construction already passes `""`.

## Validation

`ruff check`, `ruff format`, and the talon unit suite pass locally (226 passed, 3 skipped). `ty check` reports the same 4 pre-existing unresolved-import diagnostics as the rest of this stack — untouched here.

Added a regression test asserting the bare constructor sends query text through unprefixed, and that an explicit prompt still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)