### PR TITLE
fix(talon): backfill missing research subagent defaults

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -381,7 +381,7 @@ optional.
 
 ## Research defaults
 
-Fresh homes receive ordinary `AGENTS.md` files for main, `internal-research`, and
+On startup, homes receive any missing `AGENTS.md` files for main, `internal-research`, and
 `external-research`, with defensive prompts. External research owns `fetch_url` and
 Tavily-backed `web_search`, attached at construction by default. Search is added
 only when `TAVILY_API_KEY` is nonempty in the runtime environment; without it,
@@ -395,7 +395,7 @@ launch-time additions apply only to that task. Main retains filesystem, action t
 approval controls, chooses placement from the workflow, and mediates minimal
 internal-to-external context.
 
-Existing files are unchanged; built-in web access now needs an `external-research` definition.
+Existing files are unchanged; missing research definitions are installed automatically.
 Review the packaged `deepagents_talon/defaults/` files,
 back up affected instructions, and merge the selected changes without replacing custom
 content. Call `reload_subagent_configuration` and inspect `get_agent_tools`; roll back

--- a/libs/talon/deepagents_talon/config.py
+++ b/libs/talon/deepagents_talon/config.py
@@ -114,6 +114,7 @@ class TalonConfig:
             _create_home(self.home)
         self.home.mkdir(mode=0o700, parents=True, exist_ok=True)
         self.home.chmod(0o700)
+        _install_defaults(self.home)
         for child in (
             self.manifest_dir,
             self.agents_dir,

--- a/libs/talon/deepagents_talon/config.py
+++ b/libs/talon/deepagents_talon/config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import re
 import tempfile
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -239,12 +240,16 @@ def _install_defaults(home: Path) -> None:
         contents = source.read_text(encoding="utf-8")
         target = home / source.relative_to(defaults)
         target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        try:
-            fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        except FileExistsError:
-            continue
-        with os.fdopen(fd, "w", encoding="utf-8") as output:
-            output.write(contents)
+        _publish_default(target, contents)
+
+
+def _publish_default(target: Path, contents: str) -> None:
+    with tempfile.TemporaryDirectory(prefix=".talon-", dir=target.parent) as directory:
+        staged = Path(directory) / "AGENTS.md"
+        staged.write_text(contents, encoding="utf-8")
+        staged.chmod(0o600)
+        with suppress(FileExistsError):
+            os.link(staged, target)
 
 
 def _first_present(

--- a/libs/talon/tests/unit_tests/test_research_defaults.py
+++ b/libs/talon/tests/unit_tests/test_research_defaults.py
@@ -56,6 +56,37 @@ def test_existing_home_backfills_missing_research_defaults(tmp_path: Path) -> No
         assert external.stat().st_mode & 0o777 == 0o600
 
 
+@pytest.mark.parametrize("name", ["internal-research", "external-research"])
+def test_interrupted_backfill_recovers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str
+) -> None:
+    config = TalonConfig("existing", tmp_path / "existing")
+    config.home.mkdir()
+    instructions = config.home / "AGENTS.md"
+    instructions.write_text("Custom instructions")
+    target = config.agents_dir / name / "AGENTS.md"
+    write_text = Path.write_text
+
+    def interrupted(path: Path, contents: str, encoding: str | None = None) -> int:
+        if path.parent.parent == target.parent:
+            write_text(path, contents[:10], encoding=encoding)
+            msg = "disk full"
+            raise OSError(msg)
+        return write_text(path, contents, encoding=encoding)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "write_text", interrupted)
+        with pytest.raises(OSError, match="disk full"):
+            config.ensure_home()
+    assert not target.exists()
+    assert not list(target.parent.iterdir())
+    config.ensure_home()
+    defaults = Path(__file__).parents[2] / "deepagents_talon" / "defaults"
+    assert target.read_text() == (defaults / "agents" / name / "AGENTS.md").read_text()
+    assert target.stat().st_mode & 0o777 == 0o600
+    assert instructions.read_text() == "Custom instructions"
+
+
 def test_interrupted_install_does_not_publish_partial_home(tmp_path, monkeypatch):
     config = TalonConfig("fresh", tmp_path / "fresh")
 

--- a/libs/talon/tests/unit_tests/test_research_defaults.py
+++ b/libs/talon/tests/unit_tests/test_research_defaults.py
@@ -19,7 +19,7 @@ _FIXTURES = json.loads(
 )
 
 
-def test_install_only_on_fresh_setup(tmp_path):
+def test_install_defaults_preserves_existing_files(tmp_path: Path) -> None:
     fresh = TalonConfig("fresh", tmp_path / "fresh")
     fresh.ensure_home()
     instructions = fresh.home / "AGENTS.md"
@@ -29,13 +29,31 @@ def test_install_only_on_fresh_setup(tmp_path):
     assert (fresh.agents_dir / "external-research" / "AGENTS.md").is_file()
     instructions.write_text("User instructions")
     fresh.ensure_home()
-    _install_defaults(fresh.home)
     assert instructions.read_text() == "User instructions"
     existing = TalonConfig("existing", tmp_path / "existing")
     existing.home.mkdir()
     existing.ensure_home()
-    assert not (existing.home / "AGENTS.md").exists()
-    assert not list(existing.agents_dir.iterdir())
+    assert (existing.home / "AGENTS.md").is_file()
+    assert (existing.agents_dir / "internal-research" / "AGENTS.md").is_file()
+    assert (existing.agents_dir / "external-research" / "AGENTS.md").is_file()
+
+
+def test_existing_home_backfills_missing_research_defaults(tmp_path: Path) -> None:
+    config = TalonConfig("existing", tmp_path / "existing")
+    internal = config.agents_dir / "internal-research" / "AGENTS.md"
+    internal.parent.mkdir(parents=True)
+    internal.write_text("Custom internal research")
+    instructions = config.home / "AGENTS.md"
+    instructions.write_text("Custom main instructions")
+    external = config.agents_dir / "external-research" / "AGENTS.md"
+    external.parent.mkdir()
+
+    for _ in range(2):
+        config.ensure_home()
+        assert internal.read_text() == "Custom internal research"
+        assert instructions.read_text() == "Custom main instructions"
+        assert external.is_file()
+        assert external.stat().st_mode & 0o777 == 0o600
 
 
 def test_interrupted_install_does_not_publish_partial_home(tmp_path, monkeypatch):


### PR DESCRIPTION
Talon now installs missing built-in research subagent definitions when starting an existing assistant home, while preserving customized files.

---

Previously, defaults were installed only when the assistant home was first created, leaving older homes without `internal-research` and `external-research`. Reuse the exclusive-create installer during home setup so missing directories and prompts are filled in without overwriting existing instructions.

Each default is staged privately and published atomically with a hard link that refuses to overwrite existing files. Interrupted writes leave the destination absent so startup can retry.

Validated with 35 configuration and research-default tests, 17 WhatsApp bridge tests, and package lint/type checks. Regression coverage includes partially populated homes, custom prompts, repeated startup, and recovery after partial writes for both research definitions.
