### PR TITLE
fix(acp): reject unadvertised session modes

### DIFF
--- a/libs/acp/deepagents_acp/server.py
+++ b/libs/acp/deepagents_acp/server.py
@@ -436,6 +436,9 @@ class AgentServerACP(ACPAgent):
         """Switch the session to a different mode, resetting the agent."""
         if self._modes is not None and session_id in self._session_mode_states:
             state = self._session_mode_states[session_id]
+            if not any(mode.id == mode_id for mode in state.available_modes):
+                msg = f"Invalid mode: {mode_id}"
+                raise RequestError(-32602, msg)
             self._session_modes[session_id] = mode_id
             self._session_mode_states[session_id] = SessionModeState(
                 available_modes=state.available_modes,

--- a/libs/acp/tests/test_agent.py
+++ b/libs/acp/tests/test_agent.py
@@ -1311,6 +1311,39 @@ async def test_set_session_mode_resets_agent_with_new_mode() -> None:
     assert len(created_agents) == 2
 
 
+async def test_set_session_mode_rejects_unavailable_mode() -> None:
+    created_modes: list[str] = []
+
+    def agent_factory(context: AgentSessionContext) -> CompiledStateGraph:
+        created_modes.append(context.mode)
+        model = GenericFakeChatModel(
+            messages=iter([AIMessage(content="OK")]), stream_delimiter=None
+        )
+        return create_deep_agent(model=model, checkpointer=MemorySaver())
+
+    modes = SessionModeState(
+        current_mode_id="mode_a",
+        available_modes=[SessionMode(id="mode_a", name="Mode A")],
+    )
+    agent_server = AgentServerACP(agent=agent_factory, modes=modes)
+    agent_server.on_connect(FakeACPClient())  # type: ignore[arg-type]
+    session = await agent_server.new_session(cwd="/tmp", mcp_servers=[])
+    session_id = session.session_id
+    await agent_server.prompt(
+        [TextContentBlock(type="text", text="Test in mode A")], session_id=session_id
+    )
+
+    assert created_modes == ["mode_a"]
+
+    with pytest.raises(RequestError) as exc_info:
+        await agent_server.set_session_mode(mode_id="unavailable", session_id=session_id)
+
+    assert exc_info.value.code == -32602
+    assert agent_server._session_modes[session_id] == "mode_a"
+    assert agent_server._session_mode_states[session_id].current_mode_id == "mode_a"
+    assert created_modes == ["mode_a"]
+
+
 async def test_reset_agent_with_compiled_state_graph() -> None:
     """Test that _reset_agent works correctly when agent_factory is a CompiledStateGraph."""
     model = GenericFakeChatModel(messages=iter([AIMessage(content="Hello")]), stream_delimiter=None)


### PR DESCRIPTION
Fixes #6138

Reject ACP session mode changes when the requested mode was not advertised by the server.

---

`session/set_mode` previously accepted arbitrary mode IDs, updated session state, and reset the agent with the invalid value. This was inconsistent with `set_config_option("mode", ...)` and could place the session in an unsupported state.

Validate `mode_id` against the session's advertised `available_modes` before mutating state or resetting the agent. Add regression coverage to verify invalid values return JSON-RPC error `-32602`, preserve the existing mode state, and do not recreate the agent.

Validated with the focused session-mode tests and ACP formatting, lint, and type checks.