### PR TITLE
feat(sdk): resume wrapped `read_file` rows with cursors

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -5,11 +5,13 @@ you need different storage strategies for different paths (e.g., state for
 temp files, persistent store for memories).
 """
 
+import asyncio
 from collections import defaultdict
 from collections.abc import Sequence
 from typing import cast
 
 from deepagents.backends.protocol import (
+    READ_CURSOR_UNSUPPORTED_ERROR,
     BackendProtocol,
     DeleteResult,
     EditResult,
@@ -27,6 +29,7 @@ from deepagents.backends.protocol import (
     WriteResult,
     _apply_grep_max_count,
     _method_accepts_max_count,
+    _method_accepts_read_cursor,
     execute_accepts_timeout,
 )
 from deepagents.backends.state import StateBackend
@@ -393,6 +396,8 @@ class CompositeBackend(BackendProtocol):
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
         """Read file content, routing to appropriate backend.
 
@@ -400,22 +405,36 @@ class CompositeBackend(BackendProtocol):
             file_path: Absolute file path.
             offset: Line offset to start reading from (0-indexed).
             limit: Maximum number of lines to read.
+            cursor: Opaque continuation cursor from a previous read. Resumes
+                mid-source-line and takes precedence over `offset`. Only passed
+                to the routed backend when it accepts the keyword; otherwise an
+                unsupported-cursor error is returned.
 
         Returns:
             `ReadResult`
         """
         backend, stripped_key = self._get_backend_and_key(file_path)
-        return backend.read(stripped_key, offset=offset, limit=limit)
+        if cursor is None or _method_accepts_read_cursor(type(backend), "read"):
+            return backend.read(stripped_key, offset=offset, limit=limit, cursor=cursor)
+        return ReadResult(error=READ_CURSOR_UNSUPPORTED_ERROR)
 
     async def aread(
         self,
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
         """Async version of read."""
         backend, stripped_key = self._get_backend_and_key(file_path)
-        return await backend.aread(stripped_key, offset=offset, limit=limit)
+        if cursor is None:
+            return await backend.aread(stripped_key, offset=offset, limit=limit)
+        if _method_accepts_read_cursor(type(backend), "aread"):
+            return await backend.aread(stripped_key, offset=offset, limit=limit, cursor=cursor)
+        if _method_accepts_read_cursor(type(backend), "read"):
+            return await asyncio.to_thread(backend.read, stripped_key, offset, limit, cursor=cursor)
+        return ReadResult(error=READ_CURSOR_UNSUPPORTED_ERROR)
 
     @staticmethod
     def _coerce_grep_result(raw: GrepResult | list[GrepMatch] | str) -> GrepResult:

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -456,13 +456,15 @@ class ContextHubBackend(BackendProtocol):
     def _strip_prefix(path: str) -> str:
         return path.lstrip("/")
 
-    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000, *, cursor: str | None = None) -> ReadResult:
         """Read file content for the requested line range.
 
         Args:
             file_path: Absolute file path.
             offset: 0-indexed starting line.
             limit: Maximum number of lines.
+            cursor: Opaque continuation cursor from a previous read. Resumes
+                mid-source-line and takes precedence over `offset`.
 
         Returns:
             `ReadResult` with raw (unformatted) content.
@@ -478,7 +480,7 @@ class ContextHubBackend(BackendProtocol):
             return ReadResult(error=f"File '{file_path}' not found")
 
         file_data = create_file_data(content)
-        return slice_read_response(file_data, offset, limit)
+        return slice_read_response(file_data, offset, limit, cursor=cursor)
 
     def write(self, file_path: str, content: str) -> WriteResult:
         """Commit `content` to `file_path`."""

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -416,6 +416,8 @@ class FilesystemBackend(BackendProtocol):
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
         """Read file content for the requested line range.
 
@@ -431,6 +433,9 @@ class FilesystemBackend(BackendProtocol):
                 returns empty content with no pagination metadata. Empty and
                 whitespace-only files return the empty-file reminder regardless
                 of `limit`, and binary files return their full payload.
+            cursor: Opaque continuation cursor from a previous read. Resumes
+                mid-source-line and takes precedence over `offset`; binary
+                files ignore it and return their full payload.
 
         Returns:
             `ReadResult` with raw (unformatted) content for the requested window.
@@ -448,6 +453,8 @@ class FilesystemBackend(BackendProtocol):
 
             fd = os.open(resolved_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
             try:
+                stat_result = os.fstat(fd)
+                identity = (stat_result.st_size, stat_result.st_mtime_ns)
                 file_type = _get_backend_read_file_type(file_path)
                 if file_type != "text":
                     if file_type == "video" and os.fstat(fd).st_size > MAX_VIDEO_INPUT_BYTES:
@@ -475,7 +482,7 @@ class FilesystemBackend(BackendProtocol):
                     # exactly like the state and store backends. `edit()`
                     # depends on that last property to detect EOF-newline
                     # mismatches in the model's `old_string`.
-                    return slice_read_response(FileData(content=content, encoding="utf-8"), offset, limit)
+                    return slice_read_response(FileData(content=content, encoding="utf-8"), offset, limit, cursor=cursor, identity=identity)
 
             return ReadResult(file_data=file_data)
         except (OSError, UnicodeDecodeError) as e:

--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import base64
 import logging
-from typing import TYPE_CHECKING
+import zlib
+from typing import TYPE_CHECKING, Final
 
 from deepagents.backends.protocol import (
     ExecuteResponse,
@@ -20,7 +21,33 @@ from deepagents.backends.sandbox import (
     TRUNCATION_MSG,
     BaseSandbox,
 )
-from deepagents.backends.utils import _get_backend_read_file_type, normalize_read_bounds
+from deepagents.backends.utils import (
+    MAX_CURSOR_ROWS,
+    _chunked_rows,
+    _get_backend_read_file_type,
+    make_read_cursor,
+    normalize_read_bounds,
+    parse_read_cursor,
+)
+
+_UTF8_2_BYTE: Final = 0xE0
+_UTF8_3_BYTE: Final = 0xF0
+_ASCII_MAX: Final = 0x80
+
+
+def _utf8_char_len(data: bytes) -> int:
+    """Count characters in a UTF-8-safe byte prefix without decoding tail garbage."""
+    count = 0
+    index = 0
+    while index < len(data):
+        byte = data[index]
+        width = 1 if byte < _ASCII_MAX else 2 if byte < _UTF8_2_BYTE else 3 if byte < _UTF8_3_BYTE else 4
+        if width > 1 and index + width > len(data):
+            break
+        index += width
+        count += 1
+    return count
+
 
 if TYPE_CHECKING:
     from langsmith.sandbox import AsyncSandbox, AsyncSandboxClient, ExecutionResult, Sandbox
@@ -166,11 +193,13 @@ class LangSmithSandbox(BaseSandbox):
         except SandboxClientError as e:
             return WriteResult(error=f"Failed to write file '{file_path}': {e}")
 
-    def read(  # noqa: PLR0911 - early returns for distinct error conditions
+    def read(  # noqa: PLR0911, PLR0912, PLR0915, C901 - early returns for distinct error conditions; the read pipeline's branches stay inline to mirror _READ_COMMAND_TEMPLATE
         self,
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
         r"""Read file content using the LangSmith SDK.
 
@@ -184,16 +213,20 @@ class LangSmithSandbox(BaseSandbox):
             returned base64-encoded, capped at `MAX_BINARY_BYTES`.
         - Text content is normalized for universal newlines (`\r\n` and bare
             `\r` collapse to `\n`), split on `\n`, paginated by `offset` /
-            `limit`, joined back with `\n`, and capped at `MAX_OUTPUT_BYTES`
+            `limit` with `limit` bounding displayed rows of
+            `MAX_LINE_LENGTH` characters, and capped at `MAX_OUTPUT_BYTES`
             with `TRUNCATION_MSG` appended on overflow.
-        - A negative `offset` is clamped to the start of the file, and a
-            non-positive `limit` returns empty content with no pagination
-            metadata.
+        - A page that stops mid-source-line carries a `continuation_cursor`;
+            passing it back resumes at the exact character and takes
+            precedence over `offset`/`limit`. A negative `offset` is clamped
+            to the start of the file, and a non-positive `limit` returns
+            empty content with no pagination metadata.
 
         Args:
             file_path: Absolute path to the file to read.
             offset: Number of leading text lines to skip.
-            limit: Maximum number of text lines to return.
+            limit: Maximum number of displayed rows to return.
+            cursor: Opaque continuation cursor from a previous read.
 
         Returns:
             `ReadResult` with `file_data` on success or `error` on failure.
@@ -251,44 +284,71 @@ class LangSmithSandbox(BaseSandbox):
         # clamp above is ever bypassed or removed. `no_lines_requested` flags
         # the window as never inspected so the middleware can tell it apart
         # from a genuinely empty file.
-        if limit <= 0:
+        if limit <= 0 and cursor is None:
             return ReadResult(file_data=FileData(content="", encoding="utf-8"), no_lines_requested=True)
 
         total_lines = len(lines)
-        if not lines or offset >= total_lines:
-            return ReadResult(error=f"File '{file_path}': Line offset {offset} exceeds file length ({total_lines} lines)")
-
-        page = lines[offset : offset + limit]
-        content = "\n".join(page)
-        returned_lines = len(page)
+        identity = (len(raw), zlib.crc32(raw) & 0xFFFFFFFF)
+        if cursor is not None:
+            parsed = parse_read_cursor(cursor, content=normalized, size=identity[0], mtime_ns=identity[1])
+            if isinstance(parsed, str):
+                return ReadResult(error=f"File '{file_path}': {parsed}")
+            start_index, first_char_offset = parsed
+            page_lines = lines[start_index : start_index + MAX_CURSOR_ROWS]
+            rows, next_cursor = _chunked_rows(page_lines, identity, MAX_CURSOR_ROWS, first_char_offset=first_char_offset)
+        else:
+            if not lines or offset >= total_lines:
+                return ReadResult(error=f"File '{file_path}': Line offset {offset} exceeds file length ({total_lines} lines)")
+            start_index = offset
+            first_char_offset = 0
+            rows, next_cursor = _chunked_rows(lines[offset:], identity, limit)
 
         # Cap rendered text at MAX_OUTPUT_BYTES and append TRUNCATION_MSG, so
         # large pages don't reintroduce the transport-size symptom this
         # override fixes.
-        encoded = content.encode("utf-8")
-        msg_bytes = TRUNCATION_MSG.encode("utf-8")
-        effective_limit = MAX_OUTPUT_BYTES - len(msg_bytes)
-        if len(encoded) > effective_limit:
-            truncated = encoded[:effective_limit].decode("utf-8", errors="ignore")
-            # The byte cap can drop whole lines from the page and cut the final
-            # rendered line mid-way. Advance the resume offset only past lines
-            # that were fully rendered (each is followed by its "\n"), so a
-            # re-read from `next_offset` never silently skips unshown lines; the
-            # partial boundary line is re-read from its start. Fall back to 1
-            # when even the first line overflows the cap, to guarantee forward
-            # progress instead of re-reading the same truncated page.
-            returned_lines = truncated.count("\n") or 1
-            content = truncated + TRUNCATION_MSG
+        encoded_rows = [chunk.encode("utf-8") for _, chunk, _ in rows]
+        effective_limit = MAX_OUTPUT_BYTES - len(TRUNCATION_MSG.encode("utf-8"))
+        current_bytes = 0
+        cut_row: int | None = None
+        for row_pos, piece in enumerate(encoded_rows):
+            separator = 1 if row_pos else 0
+            if current_bytes + separator + len(piece) > effective_limit:
+                cut_row = row_pos
+                break
+            current_bytes += separator + len(piece)
+        if cut_row is not None:
+            remaining = effective_limit - current_bytes - (1 if cut_row else 0)
+            line_index, _chunk_text, chunk_offset = rows[cut_row]
+            partial_text = encoded_rows[cut_row][:remaining].decode("utf-8", errors="ignore") if remaining > 0 else ""
+            shown = _utf8_char_len(partial_text.encode("utf-8"))
+            rows = rows[:cut_row]
+            if shown:
+                rows = [*rows, (line_index, partial_text, chunk_offset)]
+            source_line = lines[start_index + line_index]
+            resume_char = chunk_offset + shown
+            if resume_char < len(source_line):
+                next_cursor = make_read_cursor(identity[0], identity[1], start_index + line_index, resume_char, source_line)
+            elif start_index + line_index + 1 < total_lines:
+                next_cursor = make_read_cursor(identity[0], identity[1], start_index + line_index + 1, 0, lines[start_index + line_index + 1])
+            else:
+                next_cursor = None
+            content = "\n".join(chunk_text for _, chunk_text, _ in rows) + TRUNCATION_MSG
+        else:
+            content = "\n".join(chunk for _, chunk, _ in rows)
+        row_chunk_offsets = [(line_index, chunk_offset) for line_index, _, chunk_offset in rows]
 
-        end_line = offset + returned_lines
-        next_offset = end_line if end_line < total_lines else None
+        end_line = start_index + rows[-1][0] + 1 if rows else start_index + 1
+        next_offset = end_line if next_cursor is None and end_line < total_lines else None
 
         return ReadResult(
             file_data=FileData(content=content, encoding="utf-8"),
             total_lines=total_lines,
-            start_line=offset + 1,
+            start_line=start_index + 1,
             end_line=end_line,
             next_offset=next_offset,
+            continuation_cursor=next_cursor,
+            first_row_char_offset=rows[0][2] if rows else first_char_offset,
+            row_chunk_offsets=row_chunk_offsets,
         )
 
     def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -61,6 +61,9 @@ PERMISSION_DENIED: Final = "permission_denied"
 IS_DIRECTORY: Final = "is_directory"
 INVALID_PATH: Final = "invalid_path"
 
+READ_CURSOR_UNSUPPORTED_ERROR: Final = "This backend does not support cursor-based resume; re-read using `offset` and `limit` instead."
+"""Structured error for cursor reads against backends that predate the `cursor` parameter."""
+
 
 @dataclass
 class FileDownloadResponse:
@@ -222,6 +225,36 @@ class ReadResult:
     next_offset: int | None = None
     """0-indexed offset for the next unread source line."""
 
+    continuation_cursor: str | None = None
+    """Opaque cursor for resuming mid-source-line on the next `read` call.
+
+    Set when the returned window stopped partway through the last source line
+    (a 5,000-character display row budget or a byte cap cut it short). The
+    cursor encodes the 0-indexed source line and character offset to resume
+    from, plus a content checksum; a read on modified content fails with an
+    invalid-cursor error rather than silently skipping or repeating text.
+    Callers resume by passing the cursor back as `read(..., cursor=...)`.
+    """
+
+    first_row_char_offset: int = 0
+    """Character offset within `start_line`'s source line where content begins.
+
+    Non-zero only for cursor-resumed reads that begin mid-source-line; the
+    middleware uses it to number the first rendered row as a continuation row
+    (e.g. `2.1`) rather than a primary row.
+    """
+
+    row_chunk_offsets: list[tuple[int, int]] | None = None
+    """Per-row `(line_index, char_offset)` pairs, aligned with content rows.
+
+    Set by row-based backends: entry `i` locates the `i`-th `\n`-separated row
+    of `file_data.content` as `line_index` (0-indexed from the window's first
+    source line) plus its char offset within that source line, so the
+    middleware can number continuation rows correctly (e.g. a row at offset
+    5000 of the window's second line renders as `2.1`) without re-deriving
+    chunk boundaries. `None` for legacy line-whole results.
+    """
+
     no_lines_requested: bool = False
     """The read asked for zero lines and the file was never inspected.
 
@@ -255,6 +288,9 @@ class ReadResult:
             raise ValueError(msg)
         if self.next_offset is not None and self.start_line is None:
             msg = "ReadResult.next_offset requires start_line and end_line to be set"
+            raise ValueError(msg)
+        if self.continuation_cursor is not None and (self.error is not None or self.no_lines_requested):
+            msg = "ReadResult.continuation_cursor cannot be combined with error or no_lines_requested"
             raise ValueError(msg)
         if self.total_lines is not None and self.start_line is None:
             msg = "ReadResult.total_lines requires start_line and end_line to be set"
@@ -456,6 +492,8 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
         """Read file content for the requested line range.
 
@@ -474,6 +512,13 @@ class BackendProtocol(abc.ABC):  # noqa: B024
             file_path: Absolute path to the file to read. Must start with `'/'`.
             offset: Line number to start reading from (0-indexed).
             limit: Maximum number of lines to read.
+            cursor: Opaque continuation cursor from a previous
+                `ReadResult.continuation_cursor`. When provided, resumes at the
+                exact mid-line character the previous page stopped at and takes
+                precedence over `offset`; an invalid or stale cursor returns a
+                `ReadResult` with `error` set. Treat `None` exactly as an
+                omitted argument so pre-existing implementations that do not
+                accept `cursor` keep working.
 
         Returns:
             `ReadResult` with raw (unformatted) content for the requested window,
@@ -492,8 +537,14 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
         """Async version of read."""
+        if cursor is not None and _method_accepts_read_cursor(type(self), "read"):
+            return await asyncio.to_thread(self.read, file_path, offset, limit, cursor=cursor)
+        if cursor is not None:
+            return ReadResult(error=READ_CURSOR_UNSUPPORTED_ERROR)
         return await asyncio.to_thread(self.read, file_path, offset, limit)
 
     def grep(
@@ -941,6 +992,23 @@ def _method_accepts_max_count(cls: type[BackendProtocol], method_name: Literal["
         )
         return False
     return "max_count" in sig.parameters or any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in sig.parameters.values())
+
+
+@lru_cache(maxsize=256)
+def _method_accepts_read_cursor(cls: type[BackendProtocol], method_name: Literal["read", "aread"]) -> bool:
+    """Check whether a backend read method accepts the optional `cursor` keyword."""
+    try:
+        sig = inspect.signature(getattr(cls, method_name))
+    except (AttributeError, ValueError, TypeError):
+        logger.warning(
+            "Could not inspect signature of %s.%s; assuming cursor is not supported. "
+            "A supplied cursor will be rejected as unsupported instead of raising.",
+            cls.__qualname__,
+            method_name,
+            exc_info=True,
+        )
+        return False
+    return "cursor" in sig.parameters or any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in sig.parameters.values())
 
 
 @lru_cache(maxsize=128)

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -486,7 +486,7 @@ Mirrors the `MAX_OUTPUT_BYTES` literal in `_READ_COMMAND_TEMPLATE`.
 TRUNCATION_MSG: Final = (
     "\n\n[Output was truncated due to size limits. "
     "This paginated read result exceeded the sandbox stdout limit. "
-    "Continue reading with a larger offset or smaller limit to inspect the rest of the file.]"
+    "Continue reading with the returned continuation cursor or a smaller limit to inspect the rest of the file.]"
 )
 """Sentinel appended to `read()` content when `MAX_OUTPUT_BYTES` is hit."""
 
@@ -653,18 +653,61 @@ files cannot be read.
 """
 
 _READ_COMMAND_TEMPLATE = """python3 -c "
-import codecs, os, stat as _stat, sys, base64, json
+import codecs, os, stat as _stat, sys, base64, json, zlib
 
 MAX_OUTPUT_BYTES = 500 * 1024
 MAX_BINARY_BYTES = 500 * 1024
 MAX_LINE_COUNT_BYTES = 1024 * 1024
+MAX_LINE_LENGTH = 5000
+MAX_CURSOR_ROWS = 100
 TRUNCATION_MSG = '\\n\\n' + (
     '[Output was truncated due to size limits. '
     'This paginated read result exceeded the sandbox stdout limit. '
-    'Continue reading with a larger offset or smaller limit to inspect the rest of the file.]'
+    'Continue reading with the returned continuation cursor or a smaller limit to inspect the rest of the file.]'
 )
 
 path = base64.b64decode('{path_b64}').decode('utf-8')
+
+
+def make_cursor(size, mtime_ns, line_index, char_offset, line_text):
+    identity = format(zlib.crc32((str(size) + ':' + str(mtime_ns)).encode()) & 0xFFFFFFFF, '08x') + format(mtime_ns & 0xFFFFFFFF, '08x')
+    line_hash = format(zlib.crc32(line_text.encode('utf-8')) & 0xFFFFFFFF, '08x')
+    return 'v1:' + str(line_index) + ':' + str(char_offset) + ':' + identity + ':' + line_hash
+
+
+def readline_universal(f, max_bytes):
+    out = bytearray()
+    overflow = False
+    while True:
+        pos = f.tell()
+        chunk = f.read(262144)
+        if not chunk:
+            if not out and not overflow:
+                return None
+            return bytes(out), False, overflow
+        i_n = chunk.find(b'\\n')
+        i_r = chunk.find(b'\\r')
+        ends = [x for x in (i_n, i_r) if x != -1]
+        if not ends:
+            if not overflow:
+                out += chunk
+                if len(out) > max_bytes:
+                    overflow = True
+            continue
+        i = min(ends)
+        if not overflow:
+            out += chunk[:i]
+        if chunk[i:i+1] == b'\\r':
+            if i + 1 < len(chunk):
+                term_len = 2 if chunk[i+1:i+2] == b'\\n' else 1
+            else:
+                nxt = f.read(1)
+                term_len = 2 if nxt == b'\\n' else 1
+            f.seek(pos + i + term_len)
+        else:
+            f.seek(pos + i + 1)
+        return bytes(out), True, overflow
+
 
 try:
     st = os.stat(path)
@@ -689,9 +732,6 @@ try:
     with open(path, 'rb') as f:
         raw_prefix = f.read(8192)
 
-    # The 8192-byte prefix can slice a multi-byte UTF-8 char (CJK is 3 bytes,
-    # emoji is 4); the incremental decoder buffers a trailing partial sequence
-    # instead of raising, so legitimate text isn't misclassified as binary.
     is_binary = False
     try:
         codecs.getincrementaldecoder('utf-8')().decode(raw_prefix, final=False)
@@ -706,113 +746,169 @@ try:
 
     offset = {offset}
     limit = {limit}
+    cursor = base64.b64decode('{cursor_b64}').decode('utf-8') if '{cursor_b64}' else None
 
-    # No lines requested: no line range to report. Reached whenever a caller
-    # asks for zero lines, including a negative limit that _build_read_cmd
-    # floored to 0; without this the empty window would fall through to the
-    # offset-exceeds-length error below. Checked here, after the not-found,
-    # directory, empty-file, and binary branches, so real failures and the
-    # empty-file reminder are still reported first.
-    if limit <= 0:
+    identity = format(zlib.crc32((str(st.st_size) + ':' + str(st.st_mtime_ns)).encode()) & 0xFFFFFFFF, '08x') + format(
+        st.st_mtime_ns & 0xFFFFFFFF, '08x'
+    )
+    c_line, c_char = None, None
+    if cursor is not None:
+        fields = cursor.split(':')
+        valid = (
+            len(fields) == 5
+            and fields[0] == 'v1'
+            and fields[1].isdigit()
+            and fields[2].isdigit()
+            and len(fields[3]) == 16
+            and all(ch in '0123456789abcdef' for ch in fields[3])
+            and len(fields[4]) == 8
+            and all(ch in '0123456789abcdef' for ch in fields[4])
+        )
+        if valid:
+            c_line, c_char = int(fields[1]), int(fields[2])
+            valid = c_line <= 10 ** 9
+        if not valid:
+            print(json.dumps({{'error': 'invalid_cursor: expected a cursor returned by a previous read of this file'}}))
+            sys.exit(0)
+        if fields[3] != identity:
+            print(json.dumps({{'error': 'stale_cursor: the file changed since this cursor was issued; re-read without a cursor'}}))
+            sys.exit(0)
+
+    if limit <= 0 and cursor is None:
         print(json.dumps({{'encoding': 'utf-8', 'content': '', 'no_lines_requested': True}}))
         sys.exit(0)
+    if cursor is not None:
+        limit = min(MAX_CURSOR_ROWS, (MAX_OUTPUT_BYTES - len(TRUNCATION_MSG.encode('utf-8'))) // (2 * MAX_LINE_LENGTH + 1))
 
+    target_line = c_line if cursor is not None else offset
+    f = open(path, 'rb')
     line_count = 0
-    returned_lines = 0
-    truncated = False
-    parts = []
-    current_bytes = 0
+    while line_count < target_line:
+        if readline_universal(f, MAX_LINE_COUNT_BYTES) is None:
+            break
+        line_count += 1
+    res = readline_universal(f, MAX_LINE_COUNT_BYTES)
+    if res is None:
+        f.close()
+        print(json.dumps({{'error': 'Line offset ' + str(target_line) + ' exceeds file length (' + str(line_count) + ' lines)'}}))
+        sys.exit(0)
+    line_bytes, terminated, overflow = res
+    if overflow:
+        f.close()
+        print(json.dumps({{'error': 'resume line exceeds the maximum supported size of ' + str(MAX_LINE_COUNT_BYTES) + ' bytes'}}))
+        sys.exit(0)
+    line_text = line_bytes.decode('utf-8')
+    if cursor is not None:
+        if c_char > len(line_text):
+            f.close()
+            print(json.dumps({{'error': 'stale_cursor: the file changed since this cursor was issued; re-read without a cursor'}}))
+            sys.exit(0)
+        if format(zlib.crc32(line_text.encode('utf-8')) & 0xFFFFFFFF, '08x') != fields[4]:
+            f.close()
+            print(json.dumps({{'error': 'stale_cursor: the file changed since this cursor was issued; re-read without a cursor'}}))
+            sys.exit(0)
+
     msg_bytes = len(TRUNCATION_MSG.encode('utf-8'))
     effective_limit = MAX_OUTPUT_BYTES - msg_bytes
+    row_budget = limit
 
-    at_eof = False
-    with open(path, 'r', encoding='utf-8', newline=None) as f:
-        while line_count < offset:
-            raw_line = f.readline()
-            if raw_line == '':
-                at_eof = True
+    parts = []
+    row_offsets = []
+    current_bytes = 0
+    next_cursor = None
+    budget_exhausted = False
+    truncated = False
+    index = target_line
+    end_index = target_line
+    pos = c_char if cursor is not None else 0
+    line = line_text
+    hit_eof = False
+    while True:
+        cut = False
+        while True:
+            if len(parts) >= row_budget:
+                cut = True
+                budget_exhausted = True
+                if pos < len(line):
+                    next_cursor = make_cursor(st.st_size, st.st_mtime_ns, index, pos, line)
                 break
-            line_count += 1
-
-        while not at_eof and returned_lines < limit and not truncated:
-            raw_line = f.readline()
-            if raw_line == '':
-                at_eof = True
-                break
-            line_count += 1
-            line = raw_line.rstrip('\\n').rstrip('\\r')
-            piece = line if returned_lines == 0 else '\\n' + line
-            piece_bytes = len(piece.encode('utf-8'))
+            chunk = line[pos:pos + MAX_LINE_LENGTH]
+            prefix = '' if not parts else '\\n'
+            piece_bytes = len(prefix.encode('utf-8')) + len(chunk.encode('utf-8'))
             if current_bytes + piece_bytes > effective_limit:
                 truncated = True
-                remaining_bytes = effective_limit - current_bytes
+                remaining_bytes = effective_limit - current_bytes - len(prefix.encode('utf-8'))
+                shown = 0
                 if remaining_bytes > 0:
-                    prefix = piece.encode('utf-8')[:remaining_bytes].decode('utf-8', errors='ignore')
-                    if prefix:
-                        parts.append(prefix)
-                        current_bytes += len(prefix.encode('utf-8'))
+                    partial = chunk.encode('utf-8')[:remaining_bytes].decode('utf-8', errors='ignore')
+                    if partial:
+                        parts.append(prefix + partial)
+                        row_offsets.append((index - target_line, pos))
+                        current_bytes += len(prefix.encode('utf-8')) + len(partial.encode('utf-8'))
+                        shown = len(partial)
+                next_cursor = make_cursor(st.st_size, st.st_mtime_ns, index, pos + shown, line)
+                cut = True
                 break
-
-            parts.append(piece)
+            parts.append(prefix + chunk)
+            row_offsets.append((index - target_line, pos))
             current_bytes += piece_bytes
-            returned_lines += 1
+            pos += len(chunk)
+            if pos >= len(line):
+                break
+        end_index = index
+        if cut:
+            break
+        index += 1
+        if len(parts) >= row_budget or f.tell() == st.st_size:
+            if f.tell() == st.st_size:
+                hit_eof = True
+            break
+        res = readline_universal(f, MAX_LINE_COUNT_BYTES)
+        if res is None:
+            hit_eof = True
+            break
+        line_bytes, terminated, overflow = res
+        if overflow:
+            next_cursor = make_cursor(st.st_size, st.st_mtime_ns, index, 0, '')
+            break
+        line = line_bytes.decode('utf-8')
+        pos = 0
+    f.close()
 
-        # The page can fill (returned_lines == limit) exactly at EOF without the
-        # loop readline ever returning an empty string. Detect that via position:
-        # after reading whole lines from a UTF-8 handle the decoder state is clean
-        # at a line boundary, so tell() is the raw byte offset and equals st_size
-        # at EOF. Worst case if this ever misjudges is a surfaced offset-exceeds-
-        # length error on the next re-read (large files only, where total_lines
-        # stays None) -- never a silent skip, since a false at_eof of True cannot
-        # arise (a clean or packed tell() past EOF cannot equal st_size).
-        if not at_eof:
-            at_eof = f.tell() == st.st_size
-
-    if returned_lines == 0 and not truncated:
-        print(json.dumps({{'error': 'Line offset ' + str(offset) + ' exceeds file length (' + str(line_count) + ' lines)'}}))
-        sys.exit(0)
-
-    # When the page already reached EOF, reuse its scan's count for free.
-    # Otherwise re-scan for the total only when the file is small enough that
-    # the extra pass stays bounded; surrogateescape keeps an invalid byte after
-    # the requested page from invalidating content that was decoded successfully.
-    if at_eof:
+    total_lines = None
+    if st.st_size <= MAX_LINE_COUNT_BYTES:
+        pf = open(path, 'rb')
+        line_count = 0
+        while readline_universal(pf, MAX_LINE_COUNT_BYTES) is not None:
+            line_count += 1
+        pf.close()
         total_lines = line_count
-    elif st.st_size <= MAX_LINE_COUNT_BYTES:
-        with open(path, 'r', encoding='utf-8', errors='surrogateescape', newline=None) as f:
-            total_lines = sum(1 for _ in f)
-    else:
-        total_lines = None
+    elif hit_eof:
+        total_lines = index
 
     text = ''.join(parts)
     if truncated:
         text += TRUNCATION_MSG
 
-    # A byte cap can cut the final rendered line mid-way; that partial line is
-    # deliberately not counted toward returned_lines (see the truncation
-    # branch), so next_offset resumes at its start and the whole boundary line
-    # is re-read. If even the first requested line overflows the cap no full
-    # line was returned: advance by one so the read still makes progress instead
-    # of looping on the same page (that line's tail is unreadable via line
-    # offsets).
-    if truncated and returned_lines == 0:
-        returned_lines = 1
-
-    end_line = offset + returned_lines
-    if total_lines is not None:
-        next_offset = end_line if end_line < total_lines else None
+    if next_cursor is None and not budget_exhausted and not truncated:
+        if total_lines is not None:
+            next_offset = end_index + 1 if end_index + 1 < total_lines else None
+        elif hit_eof:
+            next_offset = None
+        else:
+            next_offset = end_index + 1
     else:
-        # total_lines is None only via the large-file branch above, which is
-        # reached only when the page stopped short of EOF, so lines always
-        # remain here.
-        next_offset = end_line
+        next_offset = None
     print(json.dumps({{
         'encoding': 'utf-8',
         'content': text,
         'total_lines': total_lines,
-        'start_line': offset + 1,
-        'end_line': end_line,
+        'start_line': target_line + 1,
+        'end_line': end_index + 1,
         'next_offset': next_offset,
+        'continuation_cursor': next_cursor,
+        'first_row_char_offset': c_char if cursor is not None else 0,
+        'row_chunk_offsets': row_offsets,
     }}))
 except FileNotFoundError:
     print(json.dumps({{'error': 'file_not_found'}}))
@@ -823,25 +919,36 @@ except PermissionError:
 
 Runs on the sandbox via `execute()`. Only the requested page is returned,
 avoiding full-file transfer for paginated text reads. The path is
-base64-encoded; `file_type`, `offset`, and `limit` are interpolated directly.
-`offset` and `limit` are model-supplied tool arguments, so interpolation is
-only safe because `_build_read_cmd` coerces both to `int` via
+base64-encoded; `file_type`, `offset`, `limit`, and `cursor` are interpolated
+directly. `offset` and `limit` are model-supplied tool arguments, so
+interpolation is only safe because `_build_read_cmd` coerces both to `int` via
 `normalize_read_bounds` first — that coercion is what bounds them to integer
-literals, and must not be removed.
+literals, and must not be removed. `cursor` is base64-encoded like the path,
+and the script revalidates its shape before use.
+
+`limit` bounds displayed rows of `MAX_LINE_LENGTH` characters, so a long
+source line consumes several rows of the page. A page that stops with content
+undisplayed carries `continuation_cursor` (a `v1:<line>:<char>:<identity>:
+<line-hash>` resume point pinned to the file's size, mtime, and line content);
+passing it back resumes at the exact character without repeating or skipping
+text, bounded by `MAX_CURSOR_ROWS` rows per resume.
 
 Output: single-line JSON. On success (text): `{{"encoding", "content",
-"total_lines", "start_line", "end_line", "next_offset"}}`, where `start_line`
-and `end_line` are 1-indexed and `next_offset` is the 0-indexed offset of the
-next unread line (`null` once the file is fully read). `total_lines` is `null`
-when the file is large enough that a full re-scan to count its lines would be
-unbounded. On success
+"total_lines", "start_line", "end_line", "next_offset",
+"continuation_cursor", "first_row_char_offset"}}`, where `start_line` and
+`end_line` are 1-indexed, `next_offset` is the 0-indexed offset of the next
+unread line (`null` once the file is fully read or when a continuation cursor
+takes over), `continuation_cursor` is `null` unless undisplayed content
+remains, and `first_row_char_offset` is the mid-line character offset a cursor
+resume started at. On success
 (binary): `{{"encoding": "base64", "content": ...}}` without pagination keys.
 An empty file short-circuits to `{{"encoding": "utf-8", "content": <empty-file
 reminder>}}`, and a non-positive `limit` to `{{"encoding": "utf-8", "content":
 "", "no_lines_requested": true}}`, both also without pagination keys. The
 empty-file check runs first, so an empty file yields the reminder even when
 `limit` is non-positive. On failure:
-`{{"error": ...}}`.
+`{{"error": ...}}`, including `invalid_cursor`/`stale_cursor` for cursors
+that fail shape or identity validation.
 """
 
 
@@ -890,7 +997,7 @@ def _parse_ls_output(output: str, path: str) -> LsResult:
     return LsResult(entries=file_infos)
 
 
-def _build_read_cmd(file_path: str, offset: int, limit: int) -> str:
+def _build_read_cmd(file_path: str, offset: int, limit: int, cursor: str | None = None) -> str:
     file_type = _get_backend_read_file_type(file_path)
     path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
     # The `offset` clamp is load-bearing: the script has no negative-offset
@@ -905,6 +1012,7 @@ def _build_read_cmd(file_path: str, offset: int, limit: int) -> str:
         file_type=file_type,
         offset=offset,
         limit=limit,
+        cursor_b64=base64.b64encode(cursor.encode("utf-8")).decode("ascii") if cursor is not None else "",
     )
 
 
@@ -933,6 +1041,9 @@ def _parse_read_output(output: str, file_path: str) -> ReadResult:
             start_line=data.get("start_line"),
             end_line=data.get("end_line"),
             next_offset=data.get("next_offset"),
+            continuation_cursor=data.get("continuation_cursor"),
+            first_row_char_offset=int(data.get("first_row_char_offset") or 0),
+            row_chunk_offsets=data.get("row_chunk_offsets"),
             no_lines_requested=bool(data.get("no_lines_requested")),
         )
     except (KeyError, TypeError, ValueError) as exc:
@@ -1527,19 +1638,22 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
-        """Read file content with server-side line-based pagination.
+        """Read file content with server-side row-based pagination.
 
         Runs a Python script on the sandbox via `execute()` that reads the
         file, detects encoding, and applies offset/limit pagination for text
-        files. Only the requested page is returned over the wire, and text
-        output is capped to about 500 KiB to avoid backend stdout/log transport
-        failures. When that cap is exceeded, the returned content is truncated
-        with guidance to continue pagination using a different `offset` or
-        smaller `limit`.
+        files, with `limit` bounding displayed rows of 5,000 characters. Only
+        the requested page is returned over the wire, and text output is
+        capped to about 500 KiB to avoid backend stdout/log transport
+        failures. A page that stops with content undisplayed carries a
+        `continuation_cursor`; passing it back resumes at the exact character
+        without skipping or repeating text.
 
         Binary files (non-UTF-8) are returned base64-encoded without
-        pagination.
+        pagination; a `cursor` is ignored for them.
 
         Args:
             file_path: Absolute path to the file to read.
@@ -1547,16 +1661,18 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
 
                 Only applied to text files, and clamped to the start of the file
                 when negative.
-            limit: Maximum number of lines to return.
+            limit: Maximum number of displayed rows to return.
 
                 Only applied to text files with content: a non-positive value
                 returns empty content with no pagination metadata. Empty files
                 return the empty-file reminder regardless of `limit`.
+            cursor: Opaque continuation cursor from a previous read. Resumes
+                mid-source-line and takes precedence over `offset` and `limit`.
 
         Returns:
             `ReadResult` with `file_data` on success or `error` on failure.
         """
-        result = self.execute(_build_read_cmd(file_path, offset, limit))
+        result = self.execute(_build_read_cmd(file_path, offset, limit, cursor))
         return _parse_read_output(result.output, file_path)
 
     async def aread(
@@ -1564,9 +1680,11 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
         """Async version of `read`, delegating to `aexecute`."""
-        result = await self.aexecute(_build_read_cmd(file_path, offset, limit))
+        result = await self.aexecute(_build_read_cmd(file_path, offset, limit, cursor))
         return _parse_read_output(result.output, file_path)
 
     def _write_preflight(self, file_path: str) -> WriteResult | None:

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -177,6 +177,8 @@ class StateBackend(BackendProtocol):
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
         """Read file content for the requested line range.
 
@@ -184,6 +186,8 @@ class StateBackend(BackendProtocol):
             file_path: Absolute file path.
             offset: Line offset to start reading from (0-indexed).
             limit: Maximum number of lines to read.
+            cursor: Opaque continuation cursor from a previous read. Resumes
+                mid-source-line and takes precedence over `offset`.
 
         Returns:
             `ReadResult` with raw (unformatted) content for the requested window.
@@ -201,7 +205,7 @@ class StateBackend(BackendProtocol):
             # the stored file; timestamps and encoding are carried through.
             return ReadResult(file_data=_copy_file_data_with_content(file_data, file_data_to_string(file_data)))
 
-        return slice_read_response(file_data, offset, limit)
+        return slice_read_response(file_data, offset, limit, cursor=cursor)
 
     def write(
         self,

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -368,6 +368,8 @@ class StoreBackend(BackendProtocol):
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
         """Read file content for the requested line range.
 
@@ -375,6 +377,8 @@ class StoreBackend(BackendProtocol):
             file_path: Absolute file path.
             offset: Line offset to start reading from (0-indexed).
             limit: Maximum number of lines to read.
+            cursor: Opaque continuation cursor from a previous read. Resumes
+                mid-source-line and takes precedence over `offset`.
 
         Returns:
             `ReadResult` with raw (unformatted) content for the requested window.
@@ -396,13 +400,15 @@ class StoreBackend(BackendProtocol):
         if _get_backend_read_file_type(file_path) != "text":
             return ReadResult(file_data=file_data)
 
-        return slice_read_response(file_data, offset, limit)
+        return slice_read_response(file_data, offset, limit, cursor=cursor)
 
     async def aread(
         self,
         file_path: str,
         offset: int = 0,
         limit: int = 2000,
+        *,
+        cursor: str | None = None,
     ) -> ReadResult:
         """Async version of read using native store async methods.
 
@@ -423,7 +429,7 @@ class StoreBackend(BackendProtocol):
         if _get_backend_read_file_type(file_path) != "text":
             return ReadResult(file_data=file_data)
 
-        return slice_read_response(file_data, offset, limit)
+        return slice_read_response(file_data, offset, limit, cursor=cursor)
 
     def write(
         self,

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -9,6 +9,7 @@ import functools
 import logging
 import os
 import re
+import zlib
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import PurePosixPath
@@ -86,8 +87,161 @@ Derived from Google's multimodal API supported formats:
 """
 
 MAX_LINE_LENGTH = 5000
+"""Width of one displayed text row; longer source lines split into continuation rows.
+
+`read_file` applies this as the page budget: `limit` counts displayed rows of
+this width, not raw source lines, and a page that stops mid-source-line emits a
+continuation cursor so nothing is skipped.
+"""
+
+MAX_CURSOR_ROWS: Final = 100
+"""Maximum displayed rows a cursor-resume read may return.
+
+Bounds a resume on a pathologically long source line; the resume result then
+carries its own cursor pointing at the following row.
+"""
+
 TOOL_RESULT_TOKEN_LIMIT = 20000  # Same threshold as eviction
 TRUNCATION_GUIDANCE = "... [results truncated, try being more specific with your parameters]"
+
+_CURSOR_VERSION: Final = "v1"
+_CURSOR_MAX_LINE_INDEX: Final = 1_000_000_000
+"""Upper bound on the line index a cursor may address (files past 1e9 lines are unsupported)."""
+
+_CURSOR_MAX_LENGTH: Final = 128
+"""Maximum accepted cursor length; a `v1` cursor never exceeds it."""
+
+_CURSOR_FIELD_COUNT: Final = 5
+_IDENTITY_HEX_LENGTH: Final = 16
+_LINE_HASH_HEX_LENGTH: Final = 8
+
+_INVALID_CURSOR_ERROR: Final = "Invalid cursor: expected a cursor returned by a previous read of this file"
+_STALE_CURSOR_ERROR: Final = "Stale cursor: the file changed since this cursor was issued; re-read without a cursor"
+
+
+def make_file_identity_tag(size: int, mtime_ns: int) -> str:
+    """Hash bounded file identity metadata into a hex tag for cursor pinning."""
+    return format(zlib.crc32(f"{size}:{mtime_ns}".encode()) & 0xFFFFFFFF, "08x") + format(mtime_ns & 0xFFFFFFFF, "08x")
+
+
+def make_read_cursor(size: int, mtime_ns: int, line_index: int, char_offset: int, line_text: str) -> str:
+    """Build an opaque cursor pinning a mid-line resume point to the file.
+
+    The cursor binds the position to the file's identity (size and mtime
+    nanoseconds, hashed) and to the target line's current content, so a resume
+    fails rather than landing at a wrong position when the file changed.
+
+    Args:
+        size: File size in bytes.
+        mtime_ns: File modification time in nanoseconds.
+        line_index: 0-indexed source line to resume on.
+        char_offset: 0-indexed character within that line to resume at.
+        line_text: Current content of the resume line.
+
+    Returns:
+        A versioned cursor string encoding the position and pin hashes.
+    """
+    line_hash = format(zlib.crc32(line_text.encode("utf-8")) & 0xFFFFFFFF, "08x")
+    return f"{_CURSOR_VERSION}:{line_index}:{char_offset}:{make_file_identity_tag(size, mtime_ns)}:{line_hash}"
+
+
+def _parse_cursor_fields(cursor: str) -> tuple[int, int, str, str] | None:
+    """Split a cursor into `(line_index, char_offset, identity, line_hash)`, or `None` if malformed."""
+    if not isinstance(cursor, str) or len(cursor) > _CURSOR_MAX_LENGTH:
+        return None
+    parts = cursor.split(":")
+    if len(parts) != _CURSOR_FIELD_COUNT or parts[0] != _CURSOR_VERSION:
+        return None
+    line_text, char_text, identity, line_hash = parts[1], parts[2], parts[3], parts[4]
+    if not (
+        line_text.isdigit()
+        and char_text.isdigit()
+        and len(identity) == _IDENTITY_HEX_LENGTH
+        and re.fullmatch(r"[0-9a-f]{16}", identity)
+        and len(line_hash) == _LINE_HASH_HEX_LENGTH
+        and re.fullmatch(r"[0-9a-f]{8}", line_hash)
+    ):
+        return None
+    line_index = int(line_text)
+    char_offset = int(char_text)
+    if line_index > _CURSOR_MAX_LINE_INDEX:
+        return None
+    return (line_index, char_offset, identity, line_hash)
+
+
+def parse_read_cursor(cursor: str, *, content: str, size: int, mtime_ns: int) -> tuple[int, int] | str:
+    """Validate a cursor against the file it resumes from.
+
+    Parsing is strictly bounded: exact field shape, digit-only bounded
+    integers, and pin hashes so a cursor from modified content or a different
+    file fails instead of resuming at a wrong position.
+
+    Args:
+        cursor: Opaque cursor previously returned in `ReadResult.continuation_cursor`.
+        content: Full LF-normalized file content the cursor is applied to.
+        size: Current file size in bytes.
+        mtime_ns: Current file modification time in nanoseconds.
+
+    Returns:
+        `(line_index, char_offset)` on success, or an error message string.
+    """
+    fields = _parse_cursor_fields(cursor)
+    if fields is None:
+        return _INVALID_CURSOR_ERROR
+    line_index, char_offset, identity, line_hash = fields
+    if identity != make_file_identity_tag(size, mtime_ns):
+        return _STALE_CURSOR_ERROR
+    lines = content.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    if line_index >= len(lines) or char_offset > len(lines[line_index]):
+        return _STALE_CURSOR_ERROR
+    if format(zlib.crc32(lines[line_index].encode("utf-8")) & 0xFFFFFFFF, "08x") != line_hash:
+        return _STALE_CURSOR_ERROR
+    return (line_index, char_offset)
+
+
+def _chunked_rows(
+    lines: list[str],
+    identity: tuple[int, int],
+    line_budget: int,
+    *,
+    first_char_offset: int = 0,
+) -> tuple[list[tuple[int, str, int]], str | None]:
+    """Pack source lines into displayed rows of at most `MAX_LINE_LENGTH` chars.
+
+    Args:
+        lines: Source lines to render, each assumed newline-free.
+        identity: `(size, mtime_ns)` of the file, used to pin resume cursors.
+        line_budget: Maximum number of displayed rows to return. Must be `>= 1`.
+        first_char_offset: Character offset into `lines[0]` to start at, used by
+            cursor resumes that begin mid-line.
+
+    Returns:
+        Tuple of `(rows, cursor)`. Each row is `(index_into_lines, text,
+        char_offset)`. `cursor` resumes at the first undisplayed character
+        when the budget cut a line short mid-way; `None` otherwise, including
+        when whole lines beyond the budget went undisplayed (a cursorless
+        re-read from `next_offset` covers those).
+    """
+    size, mtime_ns = identity
+    rows: list[tuple[int, str, int]] = []
+    for line_index, line in enumerate(lines):
+        offset = first_char_offset if line_index == 0 else 0
+        if offset >= len(line) and line:
+            continue
+        while True:
+            if len(rows) >= line_budget:
+                return rows, make_read_cursor(size, mtime_ns, line_index, offset, line)
+            chunk = line[offset : offset + MAX_LINE_LENGTH]
+            rows.append((line_index, chunk, offset))
+            offset += len(chunk)
+            if offset >= len(line):
+                break
+        if len(rows) >= line_budget:
+            break
+    return rows, None
+
 
 # Re-export protocol types for backwards compatibility
 FileInfo = _FileInfo
@@ -209,8 +363,10 @@ def sanitize_tool_call_id(tool_call_id: str) -> str:
 def format_content_with_line_numbers(
     content: str | list[str],
     start_line: int = 1,
+    *,
+    row_chunk_offsets: list[tuple[int, int]] | None = None,
 ) -> str:
-    """Format file content with line numbers.
+    r"""Format file content with line numbers.
 
     Chunks lines longer than `MAX_LINE_LENGTH` with continuation markers
     (e.g., `5.1`, `5.2`). Line markers are separated from source content
@@ -219,6 +375,12 @@ def format_content_with_line_numbers(
     Args:
         content: File content as string or list of lines
         start_line: Starting line number
+        row_chunk_offsets: When set, `content` is already chunked into
+            displayed rows (one per `\n`-separated entry) and entry `i` holds
+            that row's char offset within its source line. Rows are numbered
+            from those offsets (e.g. a row at offset 5000 of line 5 renders as
+            `5.1`), and no re-chunking occurs. Backends set this via
+            `ReadResult.row_chunk_offsets` for row-paginated results.
 
     Returns:
         Formatted content with line numbers and continuation markers
@@ -229,6 +391,17 @@ def format_content_with_line_numbers(
             lines = lines[:-1]
     else:
         lines = content
+
+    if row_chunk_offsets is not None:
+        prealigned: list[tuple[str, str]] = []
+        marker_width = 0
+        for line, (line_index, chunk_offset) in zip(lines, [tuple(pair) for pair in row_chunk_offsets], strict=True):
+            line_num = line_index + start_line
+            chunk_idx = chunk_offset // MAX_LINE_LENGTH
+            marker = str(line_num) if chunk_idx == 0 else f"{line_num}.{chunk_idx}"
+            prealigned.append((marker, line))
+            marker_width = max(marker_width, len(marker))
+        return "\n".join(f"{marker:>{marker_width}}  {line}" for marker, line in prealigned)
 
     rows: list[tuple[str, str]] = []
     marker_width = 0
@@ -448,17 +621,35 @@ def slice_read_response(
     file_data: FileData,
     offset: int,
     limit: int,
+    *,
+    cursor: str | None = None,
+    identity: tuple[int, int] | None = None,
 ) -> ReadResult:
-    """Slice file data to the requested line range without formatting.
+    """Slice file data to the requested window without formatting.
 
     The returned `ReadResult` carries the raw (unformatted) window in
     `file_data`; line-number formatting is applied downstream by the
     middleware layer.
 
+    For cursorless reads, `limit` bounds displayed rows: source lines longer
+    than `MAX_LINE_LENGTH` are emitted as successive 5,000-character chunks,
+    each chunk consuming one row of the budget. A page that stops mid-line
+    sets `continuation_cursor` so the next read can resume at the exact
+    character without skipping or repeating text; lines beyond the budget
+    stay reachable cursorless via `next_offset`. Cursor resumes ignore
+    `offset`/`limit` and return the tail of the cursor's source line plus
+    following lines, up to `MAX_CURSOR_ROWS` rows.
+
     Args:
         file_data: `FileData` dict.
         offset: Line offset (0-indexed).
-        limit: Maximum number of lines.
+        limit: Maximum number of displayed rows.
+        cursor: Opaque continuation cursor from a previous
+            `ReadResult.continuation_cursor`. Takes precedence over `offset`
+            and `limit` when provided.
+        identity: `(size, mtime_ns)` of the underlying file, used to pin
+            emitted cursors and validate supplied ones. When omitted, a
+            pseudo-identity derived from the content pins cursors instead.
 
     Both bounds are clamped through `normalize_read_bounds` before slicing, so
     a negative `offset` reads from the first line and a negative `limit` is
@@ -466,13 +657,14 @@ def slice_read_response(
 
     Returns:
         `ReadResult` with the sliced raw content and pagination metadata
-            (`total_lines`, `start_line`, `end_line`, `next_offset`). The
-            pagination fields are left unset for empty or whitespace-only
-            content, and when the clamped `limit` is `0`; the zero-`limit`
-            result additionally sets `no_lines_requested` so the middleware
-            can tell the never-inspected window apart from a genuinely empty
-            file. `error` is set instead when the offset exceeds the file
-            length.
+            (`total_lines`, `start_line`, `end_line`, `next_offset`,
+            `continuation_cursor`). The pagination fields are left unset for
+            empty or whitespace-only content, and when the clamped `limit` is
+            `0`; the zero-`limit` result additionally sets
+            `no_lines_requested` so the middleware can tell the
+            never-inspected window apart from a genuinely empty file. `error`
+            is set instead when the offset exceeds the file length or the
+            cursor is invalid or stale.
     """
     content = file_data_to_string(file_data)
     offset, limit = normalize_read_bounds(offset, limit)
@@ -487,35 +679,100 @@ def slice_read_response(
     # middleware can tell it apart from a genuinely empty file, which arrives
     # via the blank-content branch above (its `ReadResult` is otherwise
     # identical: empty content, no pagination metadata).
-    if limit == 0:
+    if limit == 0 and cursor is None:
         return ReadResult(file_data=_copy_file_data_with_content(file_data, ""), no_lines_requested=True)
 
-    # `splitlines(keepends=True)` retains each line's terminator, including
-    # the absence of one on the final line. Joining with `""` therefore
-    # round-trips the trailing-newline state of the file faithfully —
-    # required so `edit()` can report EOF-newline mismatches accurately. It
-    # also splits on CR / CRLF, so line indexing matches the LF-normalized
-    # form without first rewriting the whole (potentially huge) string.
-    lines = content.splitlines(keepends=True)
-    start_idx = offset
-    end_idx = min(start_idx + limit, len(lines))
+    normalized = content.replace("\r\n", "\n").replace("\r", "\n")
+    lines = normalized.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
     total_lines = len(lines)
 
-    if start_idx >= total_lines:
+    if cursor is not None:
+        return _resume_read_response(file_data, normalized, lines, total_lines, cursor, identity or _content_identity(normalized))
+
+    if offset >= total_lines:
         return ReadResult(error=f"Line offset {offset} exceeds file length ({total_lines} lines)")
 
-    # Normalize line endings to LF, but only across the requested window.
-    # State/Store backends may carry CRLF or CR content as written;
-    # downstream tooling (edit match, grep, format) assumes LF.
-    sliced = "".join(lines[start_idx:end_idx]).replace("\r\n", "\n").replace("\r", "\n")
-    next_offset = end_idx if end_idx < total_lines else None
-    return ReadResult(
+    rows, next_cursor = _chunked_rows(lines[offset:], identity or _content_identity(normalized), max(limit, 1))
+    last_line_index, last_chunk, last_chunk_offset = rows[-1]
+    end_idx = offset + last_line_index
+    next_offset = end_idx + 1 if next_cursor is None and end_idx + 1 < total_lines else None
+    sliced = "\n".join(chunk for _, chunk, _ in rows)
+    if (
+        next_cursor is None
+        and last_chunk_offset + len(last_chunk) == len(lines[last_line_index])
+        and (end_idx + 1 < total_lines or normalized.endswith("\n"))
+    ):
+        sliced += "\n"
+    result = ReadResult(
         file_data=_copy_file_data_with_content(file_data, sliced),
         total_lines=total_lines,
-        start_line=start_idx + 1,
-        end_line=end_idx,
+        start_line=offset + 1,
+        end_line=end_idx + 1,
         next_offset=next_offset,
+        continuation_cursor=next_cursor,
+        row_chunk_offsets=[(line_index, chunk_offset) for line_index, _, chunk_offset in rows],
     )
+    result.first_row_char_offset = rows[0][2] if rows else 0
+    return result
+
+
+def _content_identity(content: str) -> tuple[int, int]:
+    """Derive a stable pseudo-identity for content without filesystem metadata."""
+    encoded = content.encode("utf-8")
+    return len(encoded), zlib.crc32(encoded) & 0xFFFFFFFF
+
+
+def _resume_read_response(
+    file_data: FileData,
+    normalized: str,
+    lines: list[str],
+    total_lines: int,
+    cursor: str,
+    identity: tuple[int, int],
+) -> ReadResult:
+    r"""Resume a read from a continuation cursor's mid-line position.
+
+    Args:
+        file_data: `FileData` dict the cursor is applied to.
+        normalized: Full LF-normalized file content.
+        lines: `normalized` split on `"\n"` with a trailing empty entry dropped.
+        total_lines: Length of `lines`.
+        cursor: Cursor string to validate and resume from.
+        identity: `(size, mtime_ns)` of the underlying file, for cursor pins.
+
+    Returns:
+        `ReadResult` for the resumed window, or an error result for a
+            malformed, stale, or out-of-range cursor.
+    """
+    parsed = parse_read_cursor(cursor, content=normalized, size=identity[0], mtime_ns=identity[1])
+    if isinstance(parsed, str):
+        return ReadResult(error=parsed)
+    line_index, char_offset = parsed
+    page_lines = lines[line_index : line_index + MAX_CURSOR_ROWS]
+    rows, next_cursor = _chunked_rows(page_lines, identity, MAX_CURSOR_ROWS, first_char_offset=char_offset)
+    last_line_index = line_index + rows[-1][0]
+    next_offset = last_line_index + 1 if next_cursor is None and last_line_index + 1 < total_lines else None
+    sliced = "\n".join(chunk for _, chunk, _ in rows)
+    _, last_chunk, last_offset = rows[-1]
+    if (
+        next_cursor is None
+        and last_offset + len(last_chunk) == len(lines[last_line_index])
+        and (last_line_index + 1 < total_lines or normalized.endswith("\n"))
+    ):
+        sliced += "\n"
+    result = ReadResult(
+        file_data=_copy_file_data_with_content(file_data, sliced),
+        total_lines=total_lines,
+        start_line=line_index + 1,
+        end_line=last_line_index + 1,
+        next_offset=next_offset,
+        continuation_cursor=next_cursor,
+        row_chunk_offsets=[(line_index, chunk_offset) for line_index, _, chunk_offset in rows],
+    )
+    result.first_row_char_offset = rows[0][2]
+    return result
 
 
 def perform_string_replacement(

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -40,6 +40,7 @@ from pydantic import BaseModel, Field
 from deepagents.backends import CompositeBackend, FilesystemBackend, LocalShellBackend, StateBackend
 from deepagents.backends.composite import _route_for_path
 from deepagents.backends.protocol import (
+    READ_CURSOR_UNSUPPORTED_ERROR,
     BackendProtocol,
     DeleteResult,
     EditResult,
@@ -58,6 +59,7 @@ from deepagents.backends.protocol import (
     WriteResult,
     _apply_grep_max_count,
     _method_accepts_max_count,
+    _method_accepts_read_cursor,
     _supports_delete,
     execute_accepts_timeout,
 )
@@ -805,7 +807,8 @@ def _remaining_lines_notice(read_result: ReadResult) -> str:
 
     Args:
         read_result: Backend read result carrying the pagination metadata
-            (`start_line`, `end_line`, `next_offset`, `total_lines`).
+            (`start_line`, `end_line`, `next_offset`, `total_lines`,
+            `continuation_cursor`).
 
     Returns:
         A model-facing notice describing the window that was read and where to
@@ -815,12 +818,21 @@ def _remaining_lines_notice(read_result: ReadResult) -> str:
     start_line = read_result.start_line
     end_line = read_result.end_line
     next_offset = read_result.next_offset
-    if start_line is None or end_line is None or next_offset is None:
+    cursor = read_result.continuation_cursor
+    if start_line is None or end_line is None or (next_offset is None and cursor is None):
         return ""
 
     total_lines = read_result.total_lines
     read_count = end_line - start_line + 1
     read_unit = "line" if read_count == 1 else "lines"
+    total_part = f" of {total_lines} total" if total_lines is not None else ""
+    if cursor is not None:
+        return (
+            f"\n\n[Read {read_count} {read_unit} (lines {start_line}-{end_line}{total_part}); "
+            f"the page ended before the next undisplayed row. Resume exactly where it stopped with "
+            f"cursor={cursor!r} (takes precedence over offset/limit). Do not reuse offset alone, or "
+            f"the remainder of line {end_line} may be skipped.]"
+        )
     if total_lines is None:
         return f"\n\n[Read {read_count} {read_unit} (lines {start_line}-{end_line}). More lines remain from offset {next_offset}.]"
     if end_line >= total_lines:
@@ -932,38 +944,26 @@ def _truncate_paginated_read(
     read_result: ReadResult,
     token_limit: int | None,
 ) -> str:
-    """Truncate a paginated read without skipping undisplayed source lines.
+    """Truncate a paginated read that overflows the tool-result char budget.
 
-    The backend computes the pagination notice from the full window it
-    returned, but the char budget may drop trailing rows from what the model
-    actually sees. Appending the backend's notice verbatim would then advertise
-    a `next_offset` past those dropped lines, so a re-read would silently skip
-    them. This recomputes the notice from the last *complete* rendered row that
-    still fits, and falls back to the size warning alone (no stale offset) when
-    not even one full source line fits.
+    Backends bound the page to `limit` displayed rows, so this is a last-resort
+    safety cut rather than normal pagination. Because a hard char cut can split
+    a source line mid-row and the backend's notice would then overstate what
+    was shown, the notice is dropped on this path; the model is pointed at
+    reformatting instead.
 
     Args:
         content: Line-numbered content produced by
             `format_content_with_line_numbers` (a marker followed by two spaces
             and the source content).
         file_path: Path used to format the truncation message.
-        read_result: Backend read result carrying the window metadata; the
-            adjusted `next_offset` is derived from its 1-indexed line range.
+        read_result: Backend read result carrying the window metadata.
         token_limit: Char budget is `NUM_CHARS_PER_TOKEN * token_limit`; when
             falsy, content is returned with its notice untouched.
 
     Returns:
-        The (possibly truncated) content with a notice that never overstates
-            which source lines were shown.
-
-    Examples:
-        If the backend returns source lines 11-20 with `next_offset=20`, but
-        the budget fits only through line 14, the returned notice reports lines
-        11-14 and tells the caller to resume from offset 14 rather than 20.
-
-        A long source line may be rendered as rows `14` and `14.1`. If the
-        budget fits row `14` but not `14.1`, neither row is retained: the notice
-        reports line 13 as the last displayed line and resumes from offset 13.
+        The (possibly truncated) content; the pagination notice is appended
+            only when the content fits the budget.
     """
     notice = _remaining_lines_notice(read_result)
     if not token_limit or len(content) + len(notice) < NUM_CHARS_PER_TOKEN * token_limit:
@@ -971,79 +971,31 @@ def _truncate_paginated_read(
 
     truncation_msg = READ_FILE_TRUNCATION_MSG.format(file_path=file_path)
     threshold = NUM_CHARS_PER_TOKEN * token_limit
-    if read_result.start_line is not None and read_result.end_line is not None:
-        # Build the safe places where the content can be truncated. A long source
-        # line may span rendered rows numbered `12`, `12.1`, and so on, so cutting
-        # at every newline could keep only part of that source line. `position`
-        # tracks each rendered row's end in `content`; comparing the integer part
-        # of adjacent row markers records a boundary only after the final row for
-        # a source line. The loop below uses these boundaries to find the latest
-        # complete source line that fits alongside the truncation message and the
-        # pagination notice.
-        rows = content.split("\n")
-        position = 0
-        boundaries: list[tuple[int, int]] = []
-        for index, row in enumerate(rows):
-            position += len(row)
-            marker = row.lstrip().partition("  ")[0].partition(".")[0]
-            source_line = int(marker)
-            # Rows numbered past the window's last source line are not file
-            # content: a byte-capped backend page appends its own truncation
-            # banner (preceded by a blank line), which `format_content_with_line_numbers`
-            # then numbers as `end_line + 1`, `end_line + 2`, .... Stop before
-            # them so a banner row is never chosen as a boundary — resuming from
-            # its inflated number would overshoot `total_lines` and skip real
-            # lines. Rows are numbered monotonically, so the first out-of-range
-            # row means the rest are banner too.
-            if source_line > read_result.end_line:
-                break
-            next_source_line = None
-            if index + 1 < len(rows):
-                next_marker = rows[index + 1].lstrip().partition("  ")[0].partition(".")[0]
-                next_source_line = int(next_marker)
-            if next_source_line != source_line:
-                boundaries.append((position, source_line))
-            position += 1
-
-        # Only advertise source lines whose complete rendered rows fit. If the
-        # byte cut landed partway through a row, resuming after that row would
-        # silently skip its undisplayed tail. `next_offset` is the 0-indexed line
-        # after the last one shown, which for a 1-indexed `end_line` is exactly
-        # `end_line` (no reliance on how the request `offset` maps to `start_line`).
-        for boundary, end_line in reversed(boundaries):
-            adjusted_result = ReadResult(
-                total_lines=read_result.total_lines,
-                start_line=read_result.start_line,
-                end_line=end_line,
-                next_offset=end_line,
-            )
-            adjusted_notice = _remaining_lines_notice(adjusted_result)
-            if boundary + len(truncation_msg) + len(adjusted_notice) <= threshold:
-                return content[:boundary] + truncation_msg + adjusted_notice
-
     # No complete source line fits. Keep the size warning but omit the
     # backend's stale pagination offset.
     max_content_length = max(0, threshold - len(truncation_msg))
     return content[:max_content_length] + truncation_msg
 
 
-def _pad_blank_rows(content: str, start_line: int, end_line: int) -> str | list[str]:
+def _pad_blank_rows(content: str, read_result: ReadResult) -> str | list[str]:
     r"""Restore blank source rows a page loses to `split("\n")`.
 
     Backends that join a page's lines with `"\n"` as a separator leave a blank
     final row indistinguishable from a trailing terminator, which
-    `format_content_with_line_numbers` drops. Pads to the window the backend
-    reported and never truncates, since a backend may append a truncation
-    banner numbered past `end_line`.
+    `format_content_with_line_numbers` drops. Row-paginated results skip
+    padding entirely: `row_chunk_offsets` already aligns each `\n`-separated
+    entry with its displayed row.
 
     Args:
         content: Serialized content for the read window.
-        start_line: First source line in the window.
-        end_line: Last source line in the window.
+        read_result: Backend read result carrying the window metadata.
 
     Returns:
         A list of rows when padding was needed, `content` unchanged otherwise.
     """
+    start_line, end_line = read_result.start_line, read_result.end_line
+    if start_line is None or end_line is None or read_result.row_chunk_offsets is not None:
+        return content
     rows = content.split("\n")
     if rows and rows[-1] == "":
         rows.pop()
@@ -1155,12 +1107,22 @@ class ReadFileSchema(BaseModel):
 
     offset: int = Field(
         default=DEFAULT_READ_OFFSET,
-        description="Line number to start reading from (0-indexed). Use for pagination of large files.",
+        description="Line number to start reading from (0-indexed). Use for pagination of large files. Ignored when `cursor` is provided.",
     )
 
     limit: int = Field(
         default=DEFAULT_READ_LIMIT,
-        description="Maximum number of lines to read. Use for pagination of large files.",
+        description="Maximum number of displayed rows to read. Use for pagination of large files. Ignored when `cursor` is provided.",
+    )
+
+    cursor: str | None = Field(
+        default=None,
+        description=(
+            "Opaque continuation cursor copied verbatim from a previous read's "
+            "'Resume exactly where it stopped with cursor=' notice. Takes precedence over "
+            "`offset`/`limit` and resumes at the exact character where the previous page "
+            "stopped. Never construct a cursor by hand; an invalid or stale cursor returns an error."
+        ),
     )
 
 
@@ -1273,8 +1235,9 @@ _READ_FILE_TOOL_DESCRIPTION_TEMPLATE = """Reads a file from the filesystem. Assu
 
 Usage:
 - {first_line}. Use `offset`/`limit` to page through large files instead of reading them whole.
+- `limit` counts displayed rows: lines over 5,000 characters are split into continuation rows (e.g. 5.1, 5.2), and each continuation row consumes one row of the budget.
+- When a page ends before the next row is displayed, the result ends with a `cursor='...'` notice. Pass that cursor back verbatim (as `cursor`) to resume at the exact character; it takes precedence over `offset`/`limit`. Resuming with `offset` alone would skip the undisplayed remainder of the last line.
 - Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.
-- Lines over 5,000 characters are split with continuation markers (e.g. 5.1, 5.2); `limit` counts source lines, so continuation rows do not consume the budget.
 - Speculatively batch multiple `read_file` calls in one response when several files may be useful.
 - An empty file returns a system-reminder warning in place of contents.
 - Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.
@@ -1882,7 +1845,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=LsSchema,
         )
 
-    def _create_read_file_tool(self) -> BaseTool:  # noqa: C901
+    def _create_read_file_tool(self) -> BaseTool:  # noqa: C901, PLR0915  # tool body wires per-call validation, cursor dispatch, and result shaping
         """Create the read_file tool."""
         video_enabled = video_dependencies_available()
         default_description = READ_FILE_VIDEO_TOOL_DESCRIPTION if video_enabled else READ_FILE_TOOL_DESCRIPTION
@@ -1978,21 +1941,20 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="success",
                 )
 
-            rows: str | list[str] = content
-            if read_result.start_line is not None and read_result.end_line is not None:
-                rows = _pad_blank_rows(content, read_result.start_line, read_result.end_line)
-            content = format_content_with_line_numbers(
-                rows,
-                # `max(offset, 0)` so the fallback gutter stays 1-indexed: a
-                # backend that returns numberable text without `start_line`
-                # would otherwise render a zero or negative line marker, which
-                # the row-marker parsers downstream assume never happens.
-                start_line=read_result.start_line or max(offset, 0) + 1,
-            )
-            # `limit` already bounded raw source lines at the backend; do not
-            # re-truncate by row count here, or wrapped continuation rows would
-            # push real source lines off the end of the page (#2453).
-            # The clamp notice is appended after truncation so it cannot be cut.
+            rows: str | list[str] = _pad_blank_rows(content, read_result)
+            if read_result.row_chunk_offsets is not None and len(read_result.row_chunk_offsets) == len(
+                rows if isinstance(rows, list) else rows.split("\n")
+            ):
+                content = format_content_with_line_numbers(
+                    rows,
+                    start_line=read_result.start_line or max(offset, 0) + 1,
+                    row_chunk_offsets=read_result.row_chunk_offsets,
+                )
+            else:
+                content = format_content_with_line_numbers(
+                    rows,
+                    start_line=read_result.start_line or max(offset, 0) + 1,
+                )
             return ToolMessage(
                 content=_truncate_paginated_read(content, validated_path, read_result, token_limit) + _clamped_offset_notice(offset),
                 name="read_file",
@@ -2005,6 +1967,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             runtime: ToolRuntime[None, FilesystemState],
             offset: int = DEFAULT_READ_OFFSET,
             limit: int = DEFAULT_READ_LIMIT,
+            cursor: str | None = None,
         ) -> ToolMessage | Command:
             """Synchronous wrapper for read_file tool."""
             resolved_backend = self.backend
@@ -2024,7 +1987,12 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
-            read_result = resolved_backend.read(validated_path, offset=offset, limit=limit)
+            if cursor is not None and not _method_accepts_read_cursor(type(resolved_backend), "read"):
+                read_result = ReadResult(error=READ_CURSOR_UNSUPPORTED_ERROR)
+            elif cursor is not None:
+                read_result = resolved_backend.read(validated_path, offset=offset, limit=limit, cursor=cursor)
+            else:
+                read_result = resolved_backend.read(validated_path, offset=offset, limit=limit)
             return _handle_read_result(read_result, validated_path, runtime.tool_call_id, offset, limit)
 
         async def async_read_file(
@@ -2032,6 +2000,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             runtime: ToolRuntime[None, FilesystemState],
             offset: int = DEFAULT_READ_OFFSET,
             limit: int = DEFAULT_READ_LIMIT,
+            cursor: str | None = None,
         ) -> ToolMessage | Command:
             """Asynchronous wrapper for read_file tool."""
             resolved_backend = self.backend
@@ -2051,7 +2020,12 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
-            read_result = await resolved_backend.aread(validated_path, offset=offset, limit=limit)
+            if cursor is not None and not _method_accepts_read_cursor(type(resolved_backend), "aread"):
+                read_result = ReadResult(error=READ_CURSOR_UNSUPPORTED_ERROR)
+            elif cursor is not None:
+                read_result = await resolved_backend.aread(validated_path, offset=offset, limit=limit, cursor=cursor)
+            else:
+                read_result = await resolved_backend.aread(validated_path, offset=offset, limit=limit)
             return _handle_read_result(read_result, validated_path, runtime.tool_call_id, offset, limit)
 
         return StructuredTool.from_function(

--- a/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
@@ -437,54 +437,121 @@ def test_read_pagination_metadata_final_window_has_no_next_offset() -> None:
     assert result.next_offset is None
 
 
-def test_read_truncation_next_offset_reflects_rendered_lines() -> None:
-    """A byte-capped page must not advance `next_offset` past lines it dropped.
+def test_read_truncation_emits_continuation_cursor_for_dropped_rows() -> None:
+    """A byte-capped page resumes dropped rows via cursor, never `next_offset`.
 
     Regression: `end_line`/`next_offset` were derived from the full page before
     the `MAX_OUTPUT_BYTES` cap trimmed trailing lines, so a re-read from
-    `next_offset` silently skipped the dropped lines.
+    `next_offset` silently skipped the dropped lines. Now the page carries a
+    continuation cursor instead, and resuming with it continues exactly where
+    the rendered rows stopped.
     """
     sb, mock_sdk = _make_sandbox()
     line = "x" * 100_000
     # Eight ~100 KB lines: a single 8-line page far exceeds the 500 KB cap, so
-    # the byte cap drops the tail. `next_offset` must point at the first line
-    # not fully rendered, well short of the 8-line window's end.
+    # the byte cap drops the tail.
     mock_sdk.read.return_value = ("\n".join([line] * 8)).encode("utf-8")
 
-    result = sb.read("/app/big.txt", offset=0, limit=8)
+    result = sb.read("/app/big.txt", offset=0, limit=120)
 
     assert result.error is None
     assert result.file_data is not None
     assert result.file_data["content"].endswith(TRUNCATION_MSG)
     assert result.total_lines == 8
     assert result.start_line == 1
-    assert result.next_offset is not None
-    # Resume offset is the count of fully rendered lines, not the full window.
-    assert result.end_line == result.next_offset
-    assert 0 < result.next_offset < 8
+    assert result.next_offset is None
+    assert result.continuation_cursor is not None
+    assert 1 <= result.end_line < 8
+
+    # Following the cursor chain to the end reconstructs every character
+    # exactly (no skip, no repeat) and terminates.
+    parts = [result.file_data["content"].removesuffix(TRUNCATION_MSG)]
+    cursor = result.continuation_cursor
+    for _ in range(40):
+        assert cursor is not None
+        page = sb.read("/app/big.txt", cursor=cursor)
+        assert page.error is None
+        assert page.file_data is not None
+        parts.append(page.file_data["content"].removesuffix(TRUNCATION_MSG))
+        cursor = page.continuation_cursor
+        if cursor is None:
+            break
+    assert cursor is None
+    recovered = "".join(parts).replace("\n", "")
+    assert recovered == "x" * 800_000
+    rows = [row for part in parts for row in part.split("\n")]
+    assert all(set(row) == {"x"} and len(row) <= 5000 for row in rows)
 
 
-def test_read_oversized_first_line_advances_next_offset() -> None:
-    """A first line larger than the byte cap still advances `next_offset` by one.
+def test_read_byte_cap_cut_at_multibyte_boundary_resumes_exactly() -> None:
+    """A byte cap that lands inside a multi-byte char still resumes exactly.
 
-    When even the first rendered line overflows `MAX_OUTPUT_BYTES`, the retained
-    prefix contains no line terminator, so the `or 1` fallback must advance the
-    resume offset past that line — otherwise a re-read loops on the same page.
+    The cut row's cursor must derive its char offset from the UTF-8-safe
+    decoded prefix, so no character is repeated or skipped across the chain.
+    """
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.read.return_value = ("é" * 400_000).encode("utf-8")
+
+    result = sb.read("/app/mb.txt", offset=0, limit=200)
+
+    assert result.error is None
+    assert result.file_data is not None
+    body = result.file_data["content"].removesuffix(TRUNCATION_MSG)
+    assert body.endswith("é")
+    assert result.continuation_cursor is not None
+    cut_char = int(result.continuation_cursor.split(":")[2])
+    assert body.replace("\n", "") == ("é" * 400_000)[:cut_char]
+
+    total = body
+    cursor = result.continuation_cursor
+    for _ in range(10):
+        assert cursor is not None
+        page = sb.read("/app/mb.txt", cursor=cursor)
+        assert page.error is None
+        assert page.file_data is not None
+        total += page.file_data["content"].removesuffix(TRUNCATION_MSG)
+        cursor = page.continuation_cursor
+        if cursor is None:
+            break
+    assert cursor is None
+    assert total.replace("\n", "") == "é" * 400_000
+
+
+def test_read_oversized_first_line_resumes_via_cursor() -> None:
+    """A first line larger than the byte cap resumes mid-line via cursor.
+
+    The old `or 1` fallback advanced `next_offset` past the unreadable line,
+    silently skipping its tail. Now the result carries a cursor that resumes at
+    the line's start, so no text is skipped and the read cannot loop.
     """
     sb, mock_sdk = _make_sandbox()
     big_line = "y" * 600_000
     mock_sdk.read.return_value = (big_line + "\nsmall1\nsmall2").encode("utf-8")
 
-    result = sb.read("/app/huge_line.txt", offset=0, limit=5)
+    result = sb.read("/app/huge_line.txt", offset=0, limit=200)
 
     assert result.error is None
     assert result.file_data is not None
     assert result.file_data["content"].endswith(TRUNCATION_MSG)
     assert result.total_lines == 3
     assert result.start_line == 1
-    # The oversized line cannot be paginated within, so resume just past it.
-    assert result.end_line == 1
-    assert result.next_offset == 1
+    assert result.next_offset is None
+    assert result.continuation_cursor is not None
+
+    # Following the cursor chain eventually surfaces the later lines whole.
+    cursor = result.continuation_cursor
+    seen = ""
+    for _ in range(10):
+        assert cursor is not None
+        page = sb.read("/app/huge_line.txt", cursor=cursor)
+        assert page.error is None
+        assert page.file_data is not None
+        seen = page.file_data["content"]
+        cursor = page.continuation_cursor
+        if cursor is None:
+            break
+    assert cursor is None
+    assert "small1" in seen and "small2" in seen
 
 
 def test_read_binary_at_exact_max_size_succeeds() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -31,6 +31,7 @@ from deepagents.backends.sandbox import (
     _GREP_PATH_GLOB_TEMPLATE,
     _READ_COMMAND_TEMPLATE,
     _WRITE_CHECK_TEMPLATE,
+    TRUNCATION_MSG,
     BaseSandbox,
     _build_grep_cmd,
     _build_read_cmd,
@@ -1108,6 +1109,7 @@ def test_read_command_template_format() -> None:
         file_type="text",
         offset=0,
         limit=2000,
+        cursor_b64="",
     )
 
     assert "python3 -c" in cmd
@@ -1399,13 +1401,14 @@ def _run_read_cmd(cmd: str) -> dict:
     return json.loads(proc.stdout.strip())
 
 
-def _run_read_script(target: Path, *, file_type: str = "text", offset: int = 0, limit: int = 2000) -> dict:
+def _run_read_script(target: Path, *, file_type: str = "text", offset: int = 0, limit: int = 2000, cursor: str | None = None) -> dict:
     return _run_read_cmd(
         _READ_COMMAND_TEMPLATE.format(
             path_b64=base64.b64encode(str(target).encode("utf-8")).decode("ascii"),
             file_type=file_type,
             offset=offset,
             limit=limit,
+            cursor_b64=base64.b64encode(cursor.encode("utf-8")).decode("ascii") if cursor is not None else "",
         )
     )
 
@@ -1581,31 +1584,81 @@ def test_read_script_bounds_total_count_and_does_not_decode_unrequested_bytes(tm
     assert result["start_line"] == 1
     assert result["end_line"] == 1
     assert result["next_offset"] == 1
+    assert result["continuation_cursor"] is None
 
 
-def test_read_script_truncation_next_offset_reflects_rendered_lines(tmp_path: Path) -> None:
-    """A byte-capped page must not advance `next_offset` past lines it dropped.
+def test_read_script_truncation_emits_continuation_cursor(tmp_path: Path) -> None:
+    """A byte-capped page resumes dropped rows via cursor, never `next_offset`.
 
     Regression: counting a partially rendered boundary line toward the resume
     offset made a re-read from `next_offset` skip that line's remaining bytes.
+    Now the page carries a continuation cursor, and resuming with it continues
+    exactly where the rendered rows stopped.
     """
     line = "x" * 100_000
     target = tmp_path / "big.txt"
     target.write_text("\n".join([line] * 8))
 
-    result = _run_read_script(target, offset=0, limit=8)
+    result = _run_read_script(target, offset=0, limit=120)
 
     assert result["total_lines"] == 8
     assert result["start_line"] == 1
-    assert "truncated" in result["content"].lower()
-    assert result["next_offset"] is not None
-    # Resume at the count of fully rendered lines, short of the 8-line window.
-    assert result["end_line"] == result["next_offset"]
-    assert 0 < result["next_offset"] < 8
+    assert result["next_offset"] is None
+    assert result["continuation_cursor"] is not None
+    assert 1 <= result["end_line"] < 8
+
+    # Following the cursor chain to the end reconstructs every character
+    # exactly (no skip, no repeat) and terminates.
+    parts = [result["content"].removesuffix(TRUNCATION_MSG)]
+    cursor = result["continuation_cursor"]
+    for _ in range(20):
+        assert cursor is not None
+        page = _run_read_script(target, cursor=cursor)
+        assert "error" not in page
+        parts.append(page["content"].removesuffix(TRUNCATION_MSG))
+        cursor = page["continuation_cursor"]
+        if cursor is None:
+            break
+    assert cursor is None
+    recovered = "".join(parts).replace("\n", "")
+    assert recovered == "x" * 800_000
+    rows = [row for part in parts for row in part.split("\n")]
+    assert all(set(row) == {"x"} and len(row) <= 5000 for row in rows)
 
 
-def test_read_script_single_oversized_line_advances_to_avoid_loop(tmp_path: Path) -> None:
-    """A lone line larger than the byte cap still advances `next_offset` (no re-read loop)."""
+def test_read_script_byte_cap_cut_at_multibyte_boundary_resumes_exactly(tmp_path: Path) -> None:
+    """A byte cap that lands inside a multi-byte char still resumes exactly."""
+    target = tmp_path / "mb.txt"
+    target.write_text("é" * 400_000)
+
+    result = _run_read_script(target, offset=0, limit=200)
+
+    assert result["continuation_cursor"] is not None
+    body = result["content"].removesuffix(TRUNCATION_MSG)
+    assert body.endswith("é")
+    cut_char = int(result["continuation_cursor"].split(":")[2])
+    assert body.replace("\n", "") == ("é" * 400_000)[:cut_char]
+
+    total = body
+    cursor = result["continuation_cursor"]
+    for _ in range(10):
+        assert cursor is not None
+        page = _run_read_script(target, cursor=cursor)
+        assert "error" not in page
+        total += page["content"].removesuffix(TRUNCATION_MSG)
+        cursor = page["continuation_cursor"]
+        if cursor is None:
+            break
+    assert cursor is None
+    assert total.replace("\n", "") == "é" * 400_000
+
+
+def test_read_script_single_oversized_line_resumes_via_cursor(tmp_path: Path) -> None:
+    """A lone line larger than the byte cap resumes mid-line via cursor.
+
+    The old fallback advanced `next_offset` past the unreadable line, silently
+    skipping its tail; the cursor instead resumes at the exact character.
+    """
     target = tmp_path / "huge_line.txt"
     target.write_text("small0\n" + ("y" * 600_000) + "\nsmall2")
 
@@ -1613,9 +1666,86 @@ def test_read_script_single_oversized_line_advances_to_avoid_loop(tmp_path: Path
 
     assert result["total_lines"] == 3
     assert result["start_line"] == 2
-    # The oversized line cannot be paginated within, so resume past it.
     assert result["end_line"] == 2
-    assert result["next_offset"] == 2
+    assert result["next_offset"] is None
+    assert result["continuation_cursor"] is not None
+
+    # Following the cursor chain eventually surfaces the trailing line whole.
+    cursor = result["continuation_cursor"]
+    seen = ""
+    for _ in range(10):
+        assert cursor is not None
+        page = _run_read_script(target, cursor=cursor)
+        assert "error" not in page
+        seen = page["content"]
+        cursor = page["continuation_cursor"]
+        if cursor is None:
+            break
+    assert cursor is None
+    assert "small2" in seen
+
+
+def test_read_script_limit_bounds_displayed_rows_and_emits_cursor(tmp_path: Path) -> None:
+    """`limit` bounds 5,000-char rows; a mid-line page carries a resume cursor."""
+    target = tmp_path / "wrapped.txt"
+    target.write_text("alpha\n" + ("x" * 12000) + "\nomega\nlast")
+
+    result = _run_read_script(target, offset=0, limit=2)
+
+    assert result["content"] == "alpha\n" + "x" * 5000
+    assert result["start_line"] == 1
+    assert result["end_line"] == 2
+    assert result["next_offset"] is None
+    assert result["continuation_cursor"].startswith("v1:1:5000:")
+    assert result["row_chunk_offsets"] == [[0, 0], [1, 0]]
+
+
+def test_read_script_cursor_resume_through_tail_and_next_lines(tmp_path: Path) -> None:
+    """A cursor resume continues at the exact character without repeat/skip."""
+    target = tmp_path / "wrapped.txt"
+    target.write_text("alpha\n" + ("x" * 12000) + "\nomega\nlast")
+
+    first = _run_read_script(target, offset=0, limit=2)
+    resumed = _run_read_script(target, cursor=first["continuation_cursor"])
+
+    assert "error" not in resumed
+    assert resumed["content"].split("\n") == ["x" * 5000, "x" * 2000, "omega", "last"]
+    assert resumed["start_line"] == 2
+    assert resumed["end_line"] == 4
+    assert resumed["continuation_cursor"] is None
+    assert resumed["next_offset"] is None
+    assert resumed["first_row_char_offset"] == 5000
+
+
+def test_read_script_malformed_cursor_returns_structured_error(tmp_path: Path) -> None:
+    target = tmp_path / "notes.txt"
+    target.write_text("one\ntwo")
+
+    result = _run_read_script(target, cursor="not-a-cursor")
+
+    assert result["error"].startswith("invalid_cursor")
+
+
+def test_read_script_stale_cursor_after_file_change(tmp_path: Path) -> None:
+    target = tmp_path / "wrapped.txt"
+    target.write_text("alpha\n" + ("x" * 12000) + "\nomega")
+
+    first = _run_read_script(target, offset=0, limit=2)
+    target.write_text("rewritten\nfile")
+
+    result = _run_read_script(target, cursor=first["continuation_cursor"])
+
+    assert result["error"].startswith("stale_cursor")
+
+
+def test_read_script_binary_ignores_cursor(tmp_path: Path) -> None:
+    """Binary reads stay unpaginated and never cursor-checked."""
+    target = tmp_path / "bin.png"
+    target.write_bytes(bytes(range(256)) * 4)
+
+    result = _run_read_script(target, file_type="video", cursor="junk")
+
+    assert result["encoding"] == "base64"
 
 
 # -- script-level permission/error tests --------------------------------------

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -679,6 +679,89 @@ class TestSliceReadResponse:
         assert self._content(result) == "   \n\t\n"
 
 
+class TestReadContinuationCursor:
+    """Row-budget slicing and cursor resume for long-line pagination (#809/#3641)."""
+
+    LONG_FILE = "alpha\n" + "x" * 12000 + "\nomega\nlast"
+
+    @staticmethod
+    def _file(content: str) -> FileData:
+        return FileData(content=content, encoding="utf-8")
+
+    def test_initial_page_ends_mid_line_with_cursor(self) -> None:
+        """`limit` bounds displayed rows: a long line emits one 5,000-char row per budget slot."""
+        result = slice_read_response(self._file(self.LONG_FILE), offset=0, limit=2)
+        assert result.error is None
+        assert result.file_data is not None
+        assert result.file_data["content"] == "alpha\n" + "x" * 5000
+        assert result.start_line == 1
+        assert result.end_line == 2
+        assert result.next_offset is None
+        assert result.continuation_cursor is not None
+        assert result.continuation_cursor.startswith("v1:1:5000:")
+
+    def test_cursor_resumes_through_tail_and_next_lines(self) -> None:
+        """A cursor resume returns the exact remainder without repeat or skip."""
+        first = slice_read_response(self._file(self.LONG_FILE), offset=0, limit=2)
+        assert first.continuation_cursor is not None
+
+        resumed = slice_read_response(self._file(self.LONG_FILE), offset=0, limit=100, cursor=first.continuation_cursor)
+        assert resumed.error is None
+        assert resumed.file_data is not None
+        rows = resumed.file_data["content"].split("\n")
+        assert rows == ["x" * 5000, "x" * 2000, "omega", "last"]
+        assert resumed.start_line == 2
+        assert resumed.end_line == 4
+        assert resumed.first_row_char_offset == 5000
+        assert resumed.continuation_cursor is None
+        assert resumed.next_offset is None
+        # Row alignment metadata renders the tail as continuation rows of line 2.
+        assert resumed.row_chunk_offsets == [(0, 5000), (0, 10000), (1, 0), (2, 0)]
+
+    def test_stale_cursor_after_file_change_returns_error(self) -> None:
+        first = slice_read_response(self._file(self.LONG_FILE), offset=0, limit=2)
+        assert first.continuation_cursor is not None
+
+        stale = slice_read_response(self._file("rewritten\ncontent"), offset=0, limit=10, cursor=first.continuation_cursor)
+        assert stale.error is not None
+        assert "Stale cursor" in stale.error
+        assert stale.file_data is None
+
+    @pytest.mark.parametrize("cursor", ["", "garbage", "v1:0:0", "v1:0:0:zzzzzzzz", "v2:0:0:89e479c2", "v1:9999999999:0:89e479c2", "x" * 100])
+    def test_malformed_cursor_returns_error(self, cursor: str) -> None:
+        result = slice_read_response(self._file(self.LONG_FILE), offset=0, limit=10, cursor=cursor)
+        assert result.error is not None
+        assert "Invalid cursor" in result.error or "Stale cursor" in result.error
+
+    def test_cursor_line_past_eof_is_stale(self) -> None:
+        first = slice_read_response(self._file(self.LONG_FILE), offset=0, limit=2)
+        assert first.continuation_cursor is not None
+        parts = first.continuation_cursor.split(":")
+        forged = ":".join(["v1", "9999", "0", parts[3], parts[4]])
+        result = slice_read_response(self._file(self.LONG_FILE), offset=0, limit=10, cursor=forged)
+        assert result.error is not None
+        assert "Stale cursor" in result.error
+
+    def test_cursor_ignores_offset_and_limit(self) -> None:
+        """A supplied cursor wins over degenerate `offset`/`limit` arguments."""
+        first = slice_read_response(self._file(self.LONG_FILE), offset=0, limit=2)
+        assert first.continuation_cursor is not None
+        resumed = slice_read_response(self._file(self.LONG_FILE), offset=-5, limit=0, cursor=first.continuation_cursor)
+        assert resumed.error is None
+        assert resumed.file_data is not None
+        assert resumed.file_data["content"].split("\n")[0] == "x" * 5000
+
+    def test_normal_line_pagination_unchanged(self) -> None:
+        """Whole-line windows keep offset/next_offset semantics with no cursor."""
+        fd = self._file("\n".join(f"line{i}" for i in range(10)))
+        page = slice_read_response(fd, offset=2, limit=3)
+        assert page.file_data is not None
+        assert page.file_data["content"] == "line2\nline3\nline4\n"
+        assert page.next_offset == 5
+        assert page.continuation_cursor is None
+        assert page.row_chunk_offsets == [(0, 0), (1, 0), (2, 0)]
+
+
 class TestGrepMaxCount:
     """`max_count` total-cap semantics for `grep_matches_from_files`.
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -20,22 +20,34 @@
   },
   {
     "function": {
-      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Lines over 5,000 characters are split with continuation markers (e.g. 5.1, 5.2); `limit` counts source lines, so continuation rows do not consume the budget.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
+      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- `limit` counts displayed rows: lines over 5,000 characters are split into continuation rows (e.g. 5.1, 5.2), and each continuation row consumes one row of the budget.\n- When a page ends before the next row is displayed, the result ends with a `cursor='...'` notice. Pass that cursor back verbatim (as `cursor`) to resume at the exact character; it takes precedence over `offset`/`limit`. Resuming with `offset` alone would skip the undisplayed remainder of the last line.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
       "name": "read_file",
       "parameters": {
         "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque continuation cursor copied verbatim from a previous read's 'Resume exactly where it stopped with cursor=' notice. Takes precedence over `offset`/`limit` and resumes at the exact character where the previous page stopped. Never construct a cursor by hand; an invalid or stale cursor returns an error."
+          },
           "file_path": {
             "description": "Absolute path to the file to read. Must be absolute, not relative.",
             "type": "string"
           },
           "limit": {
             "default": 100,
-            "description": "Maximum number of lines to read. Use for pagination of large files.",
+            "description": "Maximum number of displayed rows to read. Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           },
           "offset": {
             "default": 0,
-            "description": "Line number to start reading from (0-indexed). Use for pagination of large files.",
+            "description": "Line number to start reading from (0-indexed). Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -20,22 +20,34 @@
   },
   {
     "function": {
-      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Lines over 5,000 characters are split with continuation markers (e.g. 5.1, 5.2); `limit` counts source lines, so continuation rows do not consume the budget.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
+      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- `limit` counts displayed rows: lines over 5,000 characters are split into continuation rows (e.g. 5.1, 5.2), and each continuation row consumes one row of the budget.\n- When a page ends before the next row is displayed, the result ends with a `cursor='...'` notice. Pass that cursor back verbatim (as `cursor`) to resume at the exact character; it takes precedence over `offset`/`limit`. Resuming with `offset` alone would skip the undisplayed remainder of the last line.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
       "name": "read_file",
       "parameters": {
         "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque continuation cursor copied verbatim from a previous read's 'Resume exactly where it stopped with cursor=' notice. Takes precedence over `offset`/`limit` and resumes at the exact character where the previous page stopped. Never construct a cursor by hand; an invalid or stale cursor returns an error."
+          },
           "file_path": {
             "description": "Absolute path to the file to read. Must be absolute, not relative.",
             "type": "string"
           },
           "limit": {
             "default": 100,
-            "description": "Maximum number of lines to read. Use for pagination of large files.",
+            "description": "Maximum number of displayed rows to read. Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           },
           "offset": {
             "default": 0,
-            "description": "Line number to start reading from (0-indexed). Use for pagination of large files.",
+            "description": "Line number to start reading from (0-indexed). Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_media_extra_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_media_extra_tools.json
@@ -20,10 +20,22 @@
   },
   {
     "function": {
-      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- For text files, by default it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Lines over 5,000 characters are split with continuation markers (e.g. 5.1, 5.2); `limit` counts source lines, so continuation rows do not consume the budget.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- For videos, `offset`/`limit` are interpreted as seconds (default window 100 s; sampled at a fixed rate). Use smaller windows when you need more temporal detail.\n- Always read a file before editing it.",
+      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- For text files, by default it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- `limit` counts displayed rows: lines over 5,000 characters are split into continuation rows (e.g. 5.1, 5.2), and each continuation row consumes one row of the budget.\n- When a page ends before the next row is displayed, the result ends with a `cursor='...'` notice. Pass that cursor back verbatim (as `cursor`) to resume at the exact character; it takes precedence over `offset`/`limit`. Resuming with `offset` alone would skip the undisplayed remainder of the last line.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- For videos, `offset`/`limit` are interpreted as seconds (default window 100 s; sampled at a fixed rate). Use smaller windows when you need more temporal detail.\n- Always read a file before editing it.",
       "name": "read_file",
       "parameters": {
         "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque continuation cursor copied verbatim from a previous read's 'Resume exactly where it stopped with cursor=' notice. Takes precedence over `offset`/`limit` and resumes at the exact character where the previous page stopped. Never construct a cursor by hand; an invalid or stale cursor returns an error."
+          },
           "file_path": {
             "description": "Absolute path to the file to read. Must be absolute, not relative.",
             "type": "string"

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -20,22 +20,34 @@
   },
   {
     "function": {
-      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Lines over 5,000 characters are split with continuation markers (e.g. 5.1, 5.2); `limit` counts source lines, so continuation rows do not consume the budget.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
+      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- `limit` counts displayed rows: lines over 5,000 characters are split into continuation rows (e.g. 5.1, 5.2), and each continuation row consumes one row of the budget.\n- When a page ends before the next row is displayed, the result ends with a `cursor='...'` notice. Pass that cursor back verbatim (as `cursor`) to resume at the exact character; it takes precedence over `offset`/`limit`. Resuming with `offset` alone would skip the undisplayed remainder of the last line.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
       "name": "read_file",
       "parameters": {
         "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque continuation cursor copied verbatim from a previous read's 'Resume exactly where it stopped with cursor=' notice. Takes precedence over `offset`/`limit` and resumes at the exact character where the previous page stopped. Never construct a cursor by hand; an invalid or stale cursor returns an error."
+          },
           "file_path": {
             "description": "Absolute path to the file to read. Must be absolute, not relative.",
             "type": "string"
           },
           "limit": {
             "default": 100,
-            "description": "Maximum number of lines to read. Use for pagination of large files.",
+            "description": "Maximum number of displayed rows to read. Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           },
           "offset": {
             "default": 0,
-            "description": "Line number to start reading from (0-indexed). Use for pagination of large files.",
+            "description": "Line number to start reading from (0-indexed). Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
@@ -20,22 +20,34 @@
   },
   {
     "function": {
-      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Lines over 5,000 characters are split with continuation markers (e.g. 5.1, 5.2); `limit` counts source lines, so continuation rows do not consume the budget.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
+      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- `limit` counts displayed rows: lines over 5,000 characters are split into continuation rows (e.g. 5.1, 5.2), and each continuation row consumes one row of the budget.\n- When a page ends before the next row is displayed, the result ends with a `cursor='...'` notice. Pass that cursor back verbatim (as `cursor`) to resume at the exact character; it takes precedence over `offset`/`limit`. Resuming with `offset` alone would skip the undisplayed remainder of the last line.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
       "name": "read_file",
       "parameters": {
         "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque continuation cursor copied verbatim from a previous read's 'Resume exactly where it stopped with cursor=' notice. Takes precedence over `offset`/`limit` and resumes at the exact character where the previous page stopped. Never construct a cursor by hand; an invalid or stale cursor returns an error."
+          },
           "file_path": {
             "description": "Absolute path to the file to read. Must be absolute, not relative.",
             "type": "string"
           },
           "limit": {
             "default": 100,
-            "description": "Maximum number of lines to read. Use for pagination of large files.",
+            "description": "Maximum number of displayed rows to read. Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           },
           "offset": {
             "default": 0,
-            "description": "Line number to start reading from (0-indexed). Use for pagination of large files.",
+            "description": "Line number to start reading from (0-indexed). Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -20,22 +20,34 @@
   },
   {
     "function": {
-      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Lines over 5,000 characters are split with continuation markers (e.g. 5.1, 5.2); `limit` counts source lines, so continuation rows do not consume the budget.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
+      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- `limit` counts displayed rows: lines over 5,000 characters are split into continuation rows (e.g. 5.1, 5.2), and each continuation row consumes one row of the budget.\n- When a page ends before the next row is displayed, the result ends with a `cursor='...'` notice. Pass that cursor back verbatim (as `cursor`) to resume at the exact character; it takes precedence over `offset`/`limit`. Resuming with `offset` alone would skip the undisplayed remainder of the last line.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
       "name": "read_file",
       "parameters": {
         "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque continuation cursor copied verbatim from a previous read's 'Resume exactly where it stopped with cursor=' notice. Takes precedence over `offset`/`limit` and resumes at the exact character where the previous page stopped. Never construct a cursor by hand; an invalid or stale cursor returns an error."
+          },
           "file_path": {
             "description": "Absolute path to the file to read. Must be absolute, not relative.",
             "type": "string"
           },
           "limit": {
             "default": 100,
-            "description": "Maximum number of lines to read. Use for pagination of large files.",
+            "description": "Maximum number of displayed rows to read. Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           },
           "offset": {
             "default": 0,
-            "description": "Line number to start reading from (0-indexed). Use for pagination of large files.",
+            "description": "Line number to start reading from (0-indexed). Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -20,22 +20,34 @@
   },
   {
     "function": {
-      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Lines over 5,000 characters are split with continuation markers (e.g. 5.1, 5.2); `limit` counts source lines, so continuation rows do not consume the budget.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
+      "description": "Reads a file from the filesystem. Assume any path the user provides is valid; reading a missing file returns an error.\n\nUsage:\n- By default, it reads up to 100 lines starting from the beginning of the file. Use `offset`/`limit` to page through large files instead of reading them whole.\n- `limit` counts displayed rows: lines over 5,000 characters are split into continuation rows (e.g. 5.1, 5.2), and each continuation row consumes one row of the budget.\n- When a page ends before the next row is displayed, the result ends with a `cursor='...'` notice. Pass that cursor back verbatim (as `cursor`) to resume at the exact character; it takes precedence over `offset`/`limit`. Resuming with `offset` alone would skip the undisplayed remainder of the last line.\n- Results are returned with line numbers starting at `offset` + 1 (1 by default), then two spaces, then the source line. Never include these line-number prefixes when editing.\n- Speculatively batch multiple `read_file` calls in one response when several files may be useful.\n- An empty file returns a system-reminder warning in place of contents.\n- Large tool results may be offloaded to a file; the tool message gives the path. Read that path here, paging with `offset`/`limit`.\n- Images (`.png`, `.jpg`, etc.), audio, video, and PDFs return multimodal content blocks (https://docs.langchain.com/oss/python/langchain/messages#multimodal).\n- For images and PDFs, pagination via `offset`/`limit` is text-only - supply `file_path` only\n- Always read a file before editing it.",
       "name": "read_file",
       "parameters": {
         "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque continuation cursor copied verbatim from a previous read's 'Resume exactly where it stopped with cursor=' notice. Takes precedence over `offset`/`limit` and resumes at the exact character where the previous page stopped. Never construct a cursor by hand; an invalid or stale cursor returns an error."
+          },
           "file_path": {
             "description": "Absolute path to the file to read. Must be absolute, not relative.",
             "type": "string"
           },
           "limit": {
             "default": 100,
-            "description": "Maximum number of lines to read. Use for pagination of large files.",
+            "description": "Maximum number of displayed rows to read. Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           },
           "offset": {
             "default": 0,
-            "description": "Line number to start reading from (0-indexed). Use for pagination of large files.",
+            "description": "Line number to start reading from (0-indexed). Use for pagination of large files. Ignored when `cursor` is provided.",
             "type": "integer"
           }
         },

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -35,7 +35,7 @@ from deepagents.backends import CompositeBackend, FilesystemBackend, LocalShellB
 from deepagents.backends.protocol import BackendProtocol, ExecuteResponse, SandboxBackendProtocol
 from deepagents.backends.state import StateBackend
 from deepagents.backends.store import StoreBackend
-from deepagents.backends.utils import TOOL_RESULT_TOKEN_LIMIT, create_file_data
+from deepagents.backends.utils import TOOL_RESULT_TOKEN_LIMIT, _content_identity, create_file_data, make_file_identity_tag, slice_read_response
 from deepagents.graph import create_deep_agent
 from deepagents.middleware.filesystem import NUM_CHARS_PER_TOKEN, FilesystemMiddleware, FilesystemPermission
 from deepagents.middleware.rubric import RUBRIC_GRADER_MESSAGE_SOURCE, RubricMiddleware
@@ -493,9 +493,13 @@ class TestDeepAgentEndToEnd:
             assert len(result["messages"]) > 0
 
     def test_deep_agent_truncate_lines(self, tmp_path: Path, backend: BackendProtocol) -> None:
-        """`limit` bounds source lines; wrapped continuations don't displace later lines."""
-        # 18k chars wraps into 4 rows (2, 2.1, 2.2, 2.3) but still counts as one
-        # source line against `limit`.
+        """`limit` bounds displayed rows; continuation rows consume the budget.
+
+        #809: a long line's continuation rows count against `limit`, so a
+        `limit=3` page covers line 1 plus the first two 5,000-char chunks of
+        the 18k-char line 2 — nothing is cut silently, and the notice carries
+        a cursor to resume mid-line.
+        """
         very_long_line = "x" * 18000
         lines = [
             "short line 0",
@@ -509,7 +513,6 @@ class TestDeepAgentEndToEnd:
         file_path = "/my_file"
         starter_files = prepopulate_file(backend, file_path, content)
 
-        # `limit=3` source lines → lines 1, 2 (all 4 wrapped chunks), 3.
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -545,18 +548,16 @@ class TestDeepAgentEndToEnd:
 
         assert "short line 0" in file_content
         assert "xxx" in file_content
-        # All four wrapped chunks of source line 2 render in order.
-        for marker in ("  2  ", "2.1  ", "2.2  ", "2.3  "):
-            assert marker in file_content, f"missing continuation marker {marker!r}"
-        # Source line 3 is the third source line and must be included.
-        assert "short line 2" in file_content
-        # Source lines 4 and 5 fall outside `limit=3`.
-        assert "short line 3" not in file_content
-        assert "short line 4" not in file_content
-        # The partial window surfaces the resume offset end-to-end for every
+        # The budget fits the first two wrapped chunks of source line 2; the
+        # rest of the line is reachable through the cursor, not this page.
+        assert "2.1  " in file_content
+        assert "2.2  " not in file_content
+        assert "short line 2" not in file_content
+        assert "cursor='v1:1:10000:" in file_content
+        # The partial window surfaces the resume cursor end-to-end for every
         # backend (StateBackend included, which has no standalone read test).
-        assert "lines 1-3 of 5 total" in file_content
-        assert "2 lines remaining from offset 3.]" in file_content
+        assert "lines 1-2 of 5 total" in file_content
+        assert "takes precedence over offset/limit" in file_content
 
     def test_deep_agent_read_empty_file(self, tmp_path: Path, backend: BackendProtocol) -> None:
         """Test reading an empty file through the agent."""
@@ -1221,18 +1222,19 @@ class TestDeepAgentEndToEnd:
         assert len(tool_messages) > 0
         file_content = tool_messages[0].content
 
-        # `limit=1` (one source line) renders the wrapped chunks; size cap
-        # still trims when the formatted result exceeds the byte budget.
-        assert "1.1" in file_content
-        assert "Output was truncated due to size limits" in file_content
+        # `limit=1` shows the first 5,000-char row of the line; the size cap
+        # trims nothing further, and the notice carries a resume cursor.
+        assert "1.1" not in file_content
+        assert "cursor='v1:0:5000:" in file_content
         assert len(file_content) <= 80000
 
     def test_deep_agent_read_file_pagination_does_not_skip_wrapped_lines(self, tmp_path: Path, backend: BackendProtocol) -> None:
-        """Wrapped long lines must not displace later source lines across pagination.
+        """Cursor resume must not skip or repeat wrapped-line text across pages.
 
         Regression for #2453: previously `limit` re-truncated formatted output
         after wrapping, so a 15k-char line on page 1 pushed `important
-        instruction` off the page, and page 2 resumed past it.
+        instruction` off the page, and page 2 resumed past it. Page 1 now ends
+        mid-line-2 with a cursor, and page 2 resumes at the exact character.
         """
         long_line = "x" * 15000
         content = f"line1\n{long_line}\nimportant instruction\nline4"
@@ -1258,7 +1260,7 @@ class TestDeepAgentEndToEnd:
                         tool_calls=[
                             {
                                 "name": "read_file",
-                                "args": {"file_path": file_path, "offset": 3, "limit": 3},
+                                "args": {"file_path": file_path, "cursor": "v1:1:15000:PLACEHOLDER"},
                                 "id": "call_2",
                                 "type": "tool_call",
                             }
@@ -1278,19 +1280,25 @@ class TestDeepAgentEndToEnd:
 
         tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
         assert len(tool_messages) == 2
-        combined = tool_messages[0].content + tool_messages[1].content
-        assert "important instruction" in combined
-        assert "line4" in combined
-        # The primary row and both continuation chunks of the wrapped line 2
-        # must render in order, before `important instruction`, with nothing
-        # dropped at the page boundary.
-        for marker in ("  2  ", "2.1  ", "2.2  "):
-            assert marker in combined, f"missing continuation marker {marker!r}"
-        idx_first = combined.index("  2  ")
-        idx_cont1 = combined.index("2.1  ")
-        idx_cont2 = combined.index("2.2  ")
-        idx_next = combined.index("important instruction")
-        assert idx_first < idx_cont1 < idx_cont2 < idx_next
+        page1, page2 = tool_messages[0].content, tool_messages[1].content
+        # Page 1: line 1 + the first two chunks of line 2 (budget = 3 rows).
+        assert "2.1  " in page1 and "2.2  " not in page1
+        cursor = page1.split("cursor='", 1)[1].split("'", 1)[0]
+        assert cursor.startswith("v1:1:10000:")
+        # The model's second call used a placeholder cursor, which must fail
+        # as a structured error rather than resume at a wrong position.
+        assert "Invalid cursor" in page2 or "Stale cursor" in page2
+        # Re-issuing with the real cursor resumes at the exact character. The
+        # backend pinned the cursor to its file identity, so rebuild the pin
+        # against this in-memory copy before validating the resume position.
+        fields = cursor.split(":")
+        identity = _content_identity(create_file_data(content)["content"])
+        pinned = ":".join(["v1", fields[1], fields[2], make_file_identity_tag(*identity), fields[4]])
+        resumed = slice_read_response(create_file_data(content), 0, 100, cursor=pinned)
+        assert resumed.error is None and resumed.file_data is not None
+        resumed_rows = resumed.file_data["content"].split("\n")
+        assert resumed_rows == ["x" * 5000, "important instruction", "line4"]
+        assert resumed.continuation_cursor is None
 
     def test_read_large_single_line_file_returns_reasonable_size(self) -> None:
         """Test that read_file doesn't return excessive chars for a single-line file.

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1504,7 +1504,12 @@ class TestFilesystemMiddleware:
         file_data = create_file_data(content)
         sliced = slice_read_response(file_data, offset=0, limit=100)
         assert sliced.file_data is not None
-        result = format_content_with_line_numbers(sliced.file_data["content"], start_line=1)
+        assert sliced.row_chunk_offsets is not None
+        result = format_content_with_line_numbers(
+            sliced.file_data["content"],
+            start_line=1,
+            row_chunk_offsets=sliced.row_chunk_offsets,
+        )
         lines = result.split("\n")
         assert len(lines) == 5  # 1 first + 3 continuation (2, 2.1, 2.2) + 1 third
         assert lines[0] == "  1  first line"
@@ -1523,7 +1528,12 @@ class TestFilesystemMiddleware:
         file_data = create_file_data(content)
         sliced = slice_read_response(file_data, offset=2, limit=10)
         assert sliced.file_data is not None
-        result = format_content_with_line_numbers(sliced.file_data["content"], start_line=3)
+        assert sliced.row_chunk_offsets is not None
+        result = format_content_with_line_numbers(
+            sliced.file_data["content"],
+            start_line=3,
+            row_chunk_offsets=sliced.row_chunk_offsets,
+        )
         lines = result.split("\n")
         assert len(lines) == 4  # 3 continuation (3, 3.1, 3.2) + 1 line4
         assert lines[0].startswith("  3  ")
@@ -1549,6 +1559,63 @@ class TestFilesystemMiddleware:
 
         assert isinstance(result, ToolMessage)
         assert result.content == ("1  one\n2  two\n\n[Read 2 lines (lines 1-2 of 5 total). 3 lines remaining from offset 2.]")
+
+    def test_read_file_mid_line_page_offers_cursor_and_resume(self):
+        """A page cut mid-line advertises a cursor; passing it back resumes exactly."""
+        long_line = "x" * 12000
+        files = {"/big.txt": FileData(content=f"alpha\n{long_line}\nomega", encoding="utf-8")}
+        backend, _ = _make_backend(files)
+        middleware = FilesystemMiddleware(backend=backend)
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        first = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/big.txt", "offset": 0, "limit": 2})
+        assert isinstance(first, ToolMessage)
+        assert "cursor='v1:1:5000:" in first.content
+        assert "takes precedence over offset/limit" in first.content
+        cursor = first.content.split("cursor='", 1)[1].split("'", 1)[0]
+
+        resumed = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/big.txt", "cursor": cursor})
+        assert isinstance(resumed, ToolMessage)
+        rows = resumed.content.split("\n")
+        assert rows[0].startswith("2.1  ")
+        assert rows[0].count("x") == 5000
+        assert rows[1].startswith("2.2  ")
+        assert rows[1].count("x") == 2000
+        assert rows[2].endswith("  omega")
+
+    def test_read_file_invalid_cursor_returns_structured_error(self):
+        files = {"/notes.txt": FileData(content="one\ntwo", encoding="utf-8")}
+        backend, _ = _make_backend(files)
+        middleware = FilesystemMiddleware(backend=backend)
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "cursor": "not-a-cursor"})
+
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert "Invalid cursor" in result.content
+
+    def test_read_file_cursor_not_forwarded_to_legacy_backend(self):
+        """Custom backends without a `cursor` parameter reject cursor reads cleanly."""
+        files = {"/notes.txt": FileData(content="one\ntwo", encoding="utf-8")}
+        backend, _ = _make_backend(files)
+        FilesystemMiddleware(backend=backend)
+
+        class LegacyBackend:
+            def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+                return backend.read(file_path, offset=offset, limit=limit)
+
+        legacy_middleware = FilesystemMiddleware(backend=LegacyBackend())
+        legacy_tool = next(tool for tool in legacy_middleware.tools if tool.name == "read_file")
+
+        plain = legacy_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 1})
+        assert isinstance(plain, ToolMessage)
+        assert plain.status != "error"
+
+        with_cursor = legacy_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "cursor": "v1:0:0:00000000"})
+        assert isinstance(with_cursor, ToolMessage)
+        assert with_cursor.status == "error"
+        assert "does not support cursor" in with_cursor.content
 
     def test_read_file_full_window_omits_remaining_lines_notice(self):
         files = {
@@ -1754,7 +1821,10 @@ class TestFilesystemMiddleware:
         numbered_lines = [line for line in result.content.splitlines() if line.lstrip().partition("  ")[0].isdigit()]
         last_displayed_line = int(numbered_lines[-1].lstrip().partition("  ")[0])
         assert last_displayed_line < 100
-        assert f"remaining from offset {last_displayed_line}.]" in result.content
+        # The char budget cut is a last-resort safety valve: the stale backend
+        # notice is dropped rather than advertising offsets past cut rows.
+        assert "Output was truncated due to size limits" in result.content
+        assert "remaining from offset" not in result.content
 
     def test_read_file_truncation_adds_notice_when_backend_reached_eof(self):
         backend, _ = _make_backend()
@@ -1778,16 +1848,17 @@ class TestFilesystemMiddleware:
         numbered_lines = [line for line in result.content.splitlines() if line.lstrip().partition("  ")[0].isdigit()]
         last_displayed_line = int(numbered_lines[-1].lstrip().partition("  ")[0])
         assert last_displayed_line < 100
-        assert numbered_lines[-1].endswith("x" * 80)
-        assert f"remaining from offset {last_displayed_line}.]" in result.content
+        # The backend reached EOF but the display cut rows; the size warning
+        # stands alone rather than claiming the file was fully read.
+        assert "Output was truncated due to size limits" in result.content
 
     def test_read_file_truncation_never_splits_a_wrapped_source_line(self):
-        """When the budget cuts inside a wrapped line's rows, resume before that line.
+        """The safety truncation cuts chars but never teaches a stale offset.
 
         Source line 3 is 15000 chars, so it renders as rows `3`, `3.1`, `3.2`.
-        The char budget fits lines 1-2 but not the full wrapped line, so the
-        notice must report line 2 and resume from offset 2 — never advertise an
-        offset that lands inside the undisplayed tail of line 3.
+        The char budget cannot fit the window, so the result carries the size
+        warning alone: the backend's `next_offset` would overstate what was
+        shown and silently skip the wrapped line's tail.
         """
         backend, _ = _make_backend()
         read_result = ReadResult(
@@ -1808,11 +1879,7 @@ class TestFilesystemMiddleware:
 
         assert isinstance(result, ToolMessage)
         assert "Output was truncated due to size limits" in result.content
-        # Line 2 is the last complete source line that fits; the wrapped line 3
-        # is dropped whole and the resume offset points at it, not inside it.
-        assert "[Read 2 lines (lines 1-2 of 10 total). 8 lines remaining from offset 2.]" in result.content
-        # No partial rendering of the wrapped line leaked through.
-        assert "c" * 5000 not in result.content
+        assert "remaining from offset" not in result.content
 
     def test_intercept_short_toolmessage(self):
         """Test that small ToolMessages pass through unchanged."""


### PR DESCRIPTION
`read_file` now bounds displayed rows without skipping text between pages.

---

- `limit` counts rendered 5,000-character rows, including continuation rows.
- Mid-line pages return an opaque cursor; passing it back resumes at the exact character.
- Cursorless `offset` pagination keeps its existing source-line semantics.
- Invalid or stale cursors fail cleanly instead of reading from the wrong position.
- First-party filesystem, state, store, composite, sandbox, and LangSmith backends share the contract.

```mermaid
flowchart LR
    A[read_file offset=0 limit=2] --> B[rows 1 and 2]
    B --> C[cursor]
    C --> D[read_file cursor=...]
    D --> E[rows 2.1 and 2.2, then later lines]
```

Made by [Open SWE](https://openswe.vercel.app/agents/44d850f8-ddfd-5de5-a701-82689f06d0f5)