### PR TITLE
fix(talon): harden the MCP OAuth device flow and credential handling

### DIFF
--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -115,12 +115,6 @@ def _authentication_required(exc: BaseException) -> bool:
     )
 
 
-def _device_authorization_completed(exc: BaseException) -> bool:
-    return any(
-        isinstance(leaf, DeviceAuthorizationCompletedError) for leaf in _exception_leaves(exc)
-    )
-
-
 @dataclass(frozen=True, slots=True)
 class MCPToolInfo:
     """Metadata for one MCP tool."""
@@ -512,10 +506,22 @@ async def login_mcp_server(
         pass
     except ExceptionGroup as group:
         # A completed device flow raises from inside the session's task group,
-        # which wraps it; only a group holding some other failure is an error.
-        if not _device_authorization_completed(group):
+        # which wraps it, and can aggregate with a sibling failure from tearing
+        # down the abandoned code flow. The marker is raised only after the
+        # credentials are persisted, so its presence still means the login
+        # succeeded; report the rest rather than discarding or misreading it.
+        leaves = tuple(_exception_leaves(group))
+        remainder = tuple(
+            leaf for leaf in leaves if not isinstance(leaf, DeviceAuthorizationCompletedError)
+        )
+        if len(remainder) == len(leaves):
             print(f"MCP login failed: {format_login_error(group)}", file=sys.stderr)  # noqa: T201
             return 1
+        for leaf in remainder:
+            logger.warning(
+                "MCP login session failed after credentials were saved: %s",
+                format_login_error(leaf),
+            )
     except (
         HTTPError,
         McpError,

--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -170,8 +170,10 @@ class FileTokenStorage:
         These files hold live bearer and refresh tokens in cleartext, so the
         directory is restricted to the owner and a location inside the agent
         workspace is warned about. Against Talon's default shell backend that is
-        hardening, not a boundary: the agent can still read any absolute path it
-        is given.
+        hardening, not a boundary, and it cannot become one here: the agent can
+        read any absolute path it is given, and filesystem deny rules cannot be
+        applied to a backend that executes commands. See
+        `mcp_config.warn_agent_workspace_path`.
 
         Args:
             server_name: Configured MCP server name.

--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -234,13 +234,22 @@ class FileTokenStorage:
         tokens: OAuthToken,
         client_info: OAuthClientInformationFull,
     ) -> None:
-        """Atomically persist OAuth tokens and their client registration."""
+        """Atomically persist OAuth tokens and their client registration.
+
+        This records a *fresh* grant, so unlike `set_tokens` it does not carry a
+        stored `refresh_token` forward. RFC 6749 section 6's "keep the one you
+        have" applies to a refresh response; stitching the previous grant's
+        refresh token onto a new access token would leave a credential the
+        authorization server may already have revoked -- which is exactly what an
+        explicit reauthentication invalidates -- instead of correctly recording
+        that this grant is not refreshable.
+        """
         values = {
             "tokens": json.loads(tokens.model_dump_json()),
             "expires_at": _token_expiry(tokens),
             "client_info": json.loads(client_info.model_dump_json(exclude_none=True)),
         }
-        await asyncio.to_thread(self._update_values, values, keep_refresh_token=True)
+        await asyncio.to_thread(self._update_values, values)
         _mark_authorization_complete()
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:

--- a/libs/talon/deepagents_talon/mcp_config.py
+++ b/libs/talon/deepagents_talon/mcp_config.py
@@ -82,7 +82,7 @@ def warn_agent_workspace_path(path: Path, agent_root: Path | None, *, subject: s
     commands with `virtual_mode=False`, so a path outside the workspace is still
     readable by absolute path; keeping it out of the workspace only removes the
     relative-path route and keeps it out of the model's working tree. Because it
-    buys no present protection, a bad placement is not worth failing a start over
+    buys no protection at all, a bad placement is not worth failing a start over
     -- with no workspace configured the root is the working directory, so Talon
     launched from `$HOME` puts both default paths inside it.
 
@@ -96,8 +96,15 @@ def warn_agent_workspace_path(path: Path, agent_root: Path | None, *, subject: s
     """
     resolved = path.parent.resolve() / path.name
     root = agent_workspace_root() if agent_root is None else agent_root
-    # Round 2: raise here instead, once the runtime deny rules for the token
-    # directory and the configuration path make the placement worth enforcing.
+    # This stays a warning, because no filesystem deny rule can promote it to an
+    # error. FilesystemMiddleware refuses to load permissions at all alongside an
+    # execution-capable backend (deepagents/middleware/filesystem.py:1741-1748,
+    # "Tool-level permissions for the execute tool are not implemented"), and
+    # every _check_fs_permission call site in that file guards a read or write
+    # tool -- none guards execute -- so even routing the paths through a
+    # CompositeBackend would not stop `cat`. Keeping these files away from the
+    # agent needs an OS keyring, or a directory the agent process cannot read at
+    # all: a separate uid, or a sandboxed backend.
     if resolved.is_relative_to(root):
         logger.warning(
             "%s %s is inside the agent workspace %s; move it elsewhere, or point %s "
@@ -119,8 +126,9 @@ class MCPConfigStore:
     `O_NOFOLLOW` open, and the `update_mcp_server` approval interrupt alike. So
     `update_mcp_server` mediates change; it cannot keep a configured secret from
     the model. Only `${ENV_VAR}` references, which are never expanded here, do
-    that. Enforcing placement, denying the path to the agent's filesystem tools,
-    and moving credentials out of a readable file are tracked separately.
+    that, and no filesystem deny rule can change it -- see
+    `warn_agent_workspace_path` for why that approach is closed off. Moving
+    credentials somewhere the agent process cannot read is tracked separately.
 
     Args:
         path: Operator-selected configuration path, ideally outside the agent

--- a/libs/talon/deepagents_talon/mcp_config.py
+++ b/libs/talon/deepagents_talon/mcp_config.py
@@ -52,6 +52,8 @@ _ENUMS = {
     "type": {"stdio", "http", "sse", "streamable_http", "streamable-http"},
     "auth": {"oauth"},
 }
+# Everything else in `_FIELDS` decides where a credential is sent or what runs.
+_TOOL_FILTER_FIELDS = frozenset({"allowedTools", "disabledTools"})
 _LOCK_TIMEOUT_SECONDS = 5.0
 _LOCK_POLL_SECONDS = 0.05
 
@@ -337,13 +339,21 @@ def _reject_unapproved_execution_change(
     replacement: dict[str, object],
     previous: object,
 ) -> None:
-    """Refuse an unapproved change that runs new code with a secret it never saw.
+    """Refuse an unapproved change that redirects a secret the caller never saw.
 
-    `_restore` fills `<redacted>` path-wise, so a caller can keep a stored `env`
-    secret while replacing `command`/`args` -- or flip the derived transport,
-    which turns a URL into a command line. With the approval interrupt disabled
-    that reaches a real credential unreviewed, so refuse the combination and let
-    the caller resend the settings without reusing redacted values.
+    `_restore` fills `<redacted>` path-wise, so a caller can keep a stored
+    credential while changing where it goes: swapping `command`/`args`, flipping
+    the derived transport to turn a URL into a command line, or pointing `url` at
+    another host so the restored `Authorization` header is sent there. With the
+    approval interrupt disabled any of those reaches a real credential
+    unreviewed.
+
+    The check is deliberately not a list of dangerous fields. The first version
+    enumerated `command`, `args` and the transport, and a review caught that it
+    omitted `url` -- the same attack through an unlisted field. Instead every
+    managed setting must be unchanged apart from the tool filters, which cannot
+    redirect anything, so a field added to `_FIELDS` later is covered by default
+    rather than by remembering to add it here.
 
     Args:
         submitted: Settings as supplied, before redacted values were restored.
@@ -351,20 +361,29 @@ def _reject_unapproved_execution_change(
         previous: Stored settings for this server, if any.
 
     Raises:
-        _UnsafeUpdateError: The update reuses a stored secret and changes what runs.
+        _UnsafeUpdateError: The update reuses a stored secret and changes a
+            setting that could send it somewhere else.
     """
     if not _restores_redacted(submitted):
         return
     old = cast("dict[str, object]", previous) if isinstance(previous, dict) else {}
-    changed = any(replacement.get(field) != old.get(field) for field in ("command", "args"))
-    if not changed and _derived_transport(replacement) == _derived_transport(old):
+    if _redirecting_fields(replacement) == _redirecting_fields(old):
         return
     msg = (
-        "Auto-approved MCP updates cannot change command, args, or transport while "
-        "reusing <redacted> values. Resend the settings with literal ${ENV_VAR} "
-        "references instead, or ask the operator to re-enable update approval."
+        "Auto-approved MCP updates that reuse <redacted> values cannot change any "
+        "other setting; only allowedTools and disabledTools may differ. Resend the "
+        "settings with ${ENV_VAR} references instead of redacted values, or ask the "
+        "operator to re-enable update approval."
     )
     raise _UnsafeUpdateError(msg)
+
+
+def _redirecting_fields(server: dict[str, object]) -> dict[str, object]:
+    return {
+        key: value
+        for key, value in server.items()
+        if key in _FIELDS and key not in _TOOL_FILTER_FIELDS
+    }
 
 
 def _restores_redacted(value: object) -> bool:

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, ClassVar, Self
@@ -1308,3 +1309,33 @@ async def test_authenticate_reports_failure_for_a_grouped_session_error(
 
     assert result == {"status": "failed", "server_name": "notion"}
     assert await provider.refresh_if_needed() is None
+
+
+async def test_login_succeeds_and_logs_a_failure_alongside_the_completion_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The marker is only raised after credentials persist, so the login did succeed."""
+    config_path = tmp_path / "custom.mcp.json"
+    _write_config(config_path, {"remote": {"url": "https://example.com/mcp", "auth": "oauth"}})
+
+    async def complete_then_fail(*_args: object) -> None:
+        async with anyio.create_task_group() as group:
+            group.start_soon(_raise_device_completion)
+            group.start_soon(_raise_connection_failure)
+
+    monkeypatch.setattr("deepagents_talon.mcp._open_mcp_session", complete_then_fail)
+    monkeypatch.setattr("deepagents_talon.mcp.FileTokenStorage", EmptyOAuthStorage)
+    monkeypatch.setattr("deepagents_talon.mcp.build_oauth_provider", lambda **_kwargs: object())
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_talon.mcp"):
+        result = await login_mcp_server(_config(tmp_path), "remote", str(config_path))
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert captured.out == "Logged in to MCP server 'remote'.\n"
+    assert captured.err == ""
+    assert "after credentials were saved" in caplog.text
+    assert "connection reset" in caplog.text

--- a/libs/talon/tests/test_mcp_auth.py
+++ b/libs/talon/tests/test_mcp_auth.py
@@ -1129,3 +1129,25 @@ async def test_authorization_without_a_conversation_names_the_remedy() -> None:
     assert "scheduled job or a background subagent" in message
     assert "deepagents-talon mcp login notion" in message
     assert "device-secret" not in message
+
+
+async def test_fresh_grant_without_a_refresh_token_clears_the_stored_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A new grant is not a refresh response: the old refresh token may be revoked."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+    await storage.set_tokens(
+        OAuthToken(access_token="first", refresh_token="from-old-grant")  # noqa: S106
+    )
+    client = OAuthClientInformationFull(
+        redirect_uris=["http://localhost:3000/callback"],
+        client_id="client-id",
+    )
+
+    await storage.set_tokens_and_client_info(OAuthToken(access_token="fresh"), client)  # noqa: S106
+
+    stored = await storage.get_tokens()
+    assert stored is not None
+    assert stored.access_token == "fresh"  # noqa: S105
+    assert stored.refresh_token is None

--- a/libs/talon/tests/unit_tests/test_mcp_config.py
+++ b/libs/talon/tests/unit_tests/test_mcp_config.py
@@ -445,3 +445,74 @@ def test_update_reports_conflict_when_the_lock_is_held(config_tools, monkeypatch
 
     assert result["status"] == "conflict"
     assert updates == []
+
+
+def test_auto_approve_refuses_a_url_swap_that_reuses_a_stored_secret(tmp_path: Path):
+    """The first guard listed command/args/transport and missed this one."""
+    path = tmp_path / "private" / ".mcp.json"
+    path.parent.mkdir()
+    path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "example": {
+                        "url": "https://legit.test/mcp",
+                        "headers": {"Authorization": "Bearer real-secret"},
+                    }
+                }
+            }
+        )
+    )
+    view, update = MCPConfigStore(path, lambda: None, auto_approve=True).tools()
+    stored = view.invoke({})
+
+    result = update.invoke(
+        {
+            "server_name": "example",
+            "server": {
+                "url": "https://attacker.test/",
+                "headers": stored["mcpServers"]["example"]["headers"],
+            },
+            "expected_revision": stored["revision"],
+        }
+    )
+
+    assert result["status"] == "error"
+    saved = json.loads(path.read_text())["mcpServers"]["example"]
+    assert saved["url"] == "https://legit.test/mcp"
+    assert saved["headers"] == {"Authorization": "Bearer real-secret"}
+
+
+def test_auto_approve_allows_a_tool_filter_change_that_reuses_a_stored_secret(tmp_path: Path):
+    """Tool filters cannot redirect a credential, so redacted reuse stays usable."""
+    path = tmp_path / "private" / ".mcp.json"
+    path.parent.mkdir()
+    path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "example": {
+                        "url": "https://legit.test/mcp",
+                        "headers": {"Authorization": "Bearer real-secret"},
+                    }
+                }
+            }
+        )
+    )
+    view, update = MCPConfigStore(path, lambda: None, auto_approve=True).tools()
+    stored = view.invoke({})
+    server = stored["mcpServers"]["example"]
+    server["allowedTools"] = ["read_*"]
+
+    result = update.invoke(
+        {
+            "server_name": "example",
+            "server": server,
+            "expected_revision": stored["revision"],
+        }
+    )
+
+    assert result["status"] == "updated"
+    saved = json.loads(path.read_text())["mcpServers"]["example"]
+    assert saved["allowedTools"] == ["read_*"]
+    assert saved["headers"] == {"Authorization": "Bearer real-secret"}


### PR DESCRIPTION
Fixes three High and nine Medium findings in the MCP OAuth stack, found in a pre-release review of the ~23k lines added to `libs/talon` since `deepagents-talon==0.0.6`.

## High

- **The device-login CLI crashed after succeeding.** `login_mcp_server` caught `DeviceAuthorizationCompletedError`, but it is raised inside `ClientSession`'s anyio task group and arrives wrapped in an `ExceptionGroup` — so `deepagents-talon mcp login <github-server>` persisted credentials and then exited with a traceback and a non-zero status. Now matched on leaves. The same omission made `authenticate_mcp_server` raise into the agent instead of returning `{"status": "failed"}`.
- **Device-flow HTTP clients bypassed the SSRF-safe transport** and honoured ambient `HTTPS_PROXY`/`SSL_CERT_FILE` while carrying the `device_code` and receiving tokens. All four now use the pinned `_oauth_http_client()`. Blocking `getaddrinfo` calls moved off the event loop, which also makes the 10s discovery bound real rather than nominal.
- **Credential-path placement** is now checked and warned about, the intermediate `~/.deepagents` directory no longer lands at the umask, and the docstrings say plainly what is and is not enforced.

## Medium

`set_tokens` no longer destroys the stored refresh token when a response omits one (RFC 6749 §6 permits omission, and this defeated the whole point of persisted refresh); the token writer no longer double-closes a file descriptor from a worker thread, where fd reuse could have closed an unrelated handle; token writes take a shared bounded lock and `fsync`; `flock` acquisition is bounded and returns the existing `conflict` status; auto-approved config updates are refused when they change `command`/`args` or the derived transport while reusing `<redacted>` values; `format_login_error` no longer raises `IndexError` on an exception with an empty message; and config fields outside `_FIELDS` are preserved across updates rather than making a server permanently un-editable.

## What this does *not* do

**MCP credentials are not protected from the agent's shell.** Tokens live in cleartext under `~/.deepagents/mcp-tokens/`, and Talon's default `LocalShellBackend` reaches any absolute path. The placement check *warns*; it cannot enforce, and it cannot be promoted to an error later:

- `deepagents/middleware/filesystem.py:1741-1748` raises `NotImplementedError` when permissions are set on a backend where `supports_execution()` is true (`LocalShellBackend` does) unless every path routes to a non-exec backend.
- Every `_check_fs_permission` call site in that file passes `"read"` or `"write"` — **none passes `"execute"`** — so the `CompositeBackend` escape hatch would still not stop `cat`.

The real fix is architectural (OS keyring, or a directory the agent process cannot read) and is tracked separately. `update_mcp_server` provides change mediation, not confidentiality.

## One finding withdrawn as wrong

An earlier commit in this branch added same-origin binding for OAuth endpoints; a later commit reverts it. The reviewing analysis was mistaken: `_validate_metadata`'s existing issuer check *is* RFC 8414 §3, correctly implemented in both discovery paths, because `issuer` derives from the same URL the SDK builds its candidates from. The binding closed nothing that check doesn't already close, while permanently rejecting conforming split-origin authorization servers — Google is one (`issuer: accounts.google.com`, `token_endpoint: oauth2.googleapis.com`). Both commits are kept so the trace is answerable from `git log`.

## Tests

823 passed / 7 skipped / 86% (baseline 801). Each fix was verified to fail against pre-fix source by reverting it individually against the finished tree.

## Also noted, not fixed here

The device path silently loses split-origin authorization servers: `_issuer_endpoint` enforces same-origin, `_discover_device_metadata` swallows the error and returns `None`, and Talon falls back to auth-code with no diagnostic. Pre-existing; relaxing it is its own security decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
