### PR TITLE
fix(code): parse extra skill dirs with platform separator

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -289,7 +289,7 @@ EXTERNAL_EVENT_SOCKET_PATH = "DEEPAGENTS_CODE_EXTERNAL_EVENT_SOCKET_PATH"
 """Override the default Unix-socket path for the external event listener."""
 
 EXTRA_SKILLS_DIRS = "DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS"
-"""Colon-separated paths added to the skill containment allowlist."""
+"""Paths added to the skill containment allowlist, split with `os.pathsep`."""
 
 GOAL_AUTO_ACCEPT_CRITERIA = "DEEPAGENTS_CODE_GOAL_AUTO_ACCEPT_CRITERIA"
 """Apply generated goal criteria automatically in Auto mode.

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3306,12 +3306,12 @@ def _parse_extra_skills_dirs(
     in user-specified locations without being rejected by the path
     containment check.
 
-    The env var (`DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS`, colon-separated) takes
-    precedence: when set, `config.toml` values are ignored.
+    The env var (`DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS`, separated by
+    `os.pathsep`) takes precedence: when set, `config.toml` values are ignored.
 
     Args:
-        env_raw: Value of `DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS` (colon-separated), or
-            `None` if unset.
+        env_raw: Value of `DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS` (separated by
+            `os.pathsep`), or `None` if unset.
         config_toml_dirs: List of path strings from
             `[skills].extra_allowed_dirs` in `~/.deepagents/config.toml`.
 
@@ -3322,7 +3322,7 @@ def _parse_extra_skills_dirs(
     if env_raw:
         dirs = [
             _resolve_extra_skills_path(p.strip())
-            for p in env_raw.split(":")
+            for p in env_raw.split(os.pathsep)
             if p.strip()
         ]
         return dirs or None

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -163,7 +163,7 @@ class OptionKind(Enum):
     `option_accepts_toml` is the public seam over that same coercion.
     `LOG_LEVEL_DELEGATE`, `SHELL_LIST_DELEGATE`, `EXTENSION_TRUST_DELEGATE`,
     `SKILLS_DIRS_DELEGATE`, `PTC_DELEGATE`, and `STARTUP_MODE_DELEGATE` defer to
-    bespoke parsers (their semantics — dynamic debug fallback, colon-split Path
+    bespoke parsers (their semantics — dynamic debug fallback, pathsep-split Path
     resolution, comma + `recommended`/`all` sentinels, and the PTC/startup-mode
     allowlists — do not compress into a generic coercion). `THEME_DELEGATE` is
     coerced by the providers themselves (`ranked_theme_toml_value` and
@@ -2470,7 +2470,7 @@ _STATIC_OPTIONS: tuple[ConfigOption[object], ...] = (
         group="Tools",
         summary=(
             "Extra directories added to the skill symlink containment "
-            "allowlist (env is colon-separated)."
+            "allowlist (env uses the platform path separator)."
         ),
         kind=OptionKind.SKILLS_DIRS_DELEGATE,
         env_var=_env_vars.EXTRA_SKILLS_DIRS,

--- a/libs/code/tests/unit_tests/test_extra_skills_dirs.py
+++ b/libs/code/tests/unit_tests/test_extra_skills_dirs.py
@@ -1,0 +1,34 @@
+"""Tests for parsing extra skill directories from environment variables."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from deepagents_code import config
+
+
+@pytest.mark.parametrize(
+    ("pathsep", "raw", "expected"),
+    [
+        (";", r"C:\Users\me\skills", [r"C:\Users\me\skills"]),
+        (
+            ";",
+            r"C:\Users\me\skills;D:\team\skills",
+            [r"C:\Users\me\skills", r"D:\team\skills"],
+        ),
+        (":", "/opt/a:/opt/b", ["/opt/a", "/opt/b"]),
+    ],
+)
+def test_parse_extra_skills_dirs_uses_platform_path_separator(
+    monkeypatch: pytest.MonkeyPatch,
+    pathsep: str,
+    raw: str,
+    expected: list[str],
+) -> None:
+    """Environment values retain complete paths for the configured platform."""
+    monkeypatch.setattr(config.os, "pathsep", pathsep)
+    monkeypatch.setattr(config, "_resolve_extra_skills_path", Path)
+
+    assert config._parse_extra_skills_dirs(raw) == [Path(path) for path in expected]


### PR DESCRIPTION
Fixes #6074

Windows users can now configure extra skill directories with drive-letter paths.

---

`DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS` is PATH-shaped, so parsing it with `os.pathsep` preserves Windows drive-letter paths while keeping POSIX behavior unchanged. The update also aligns the affected configuration descriptions and adds platform-independent regression coverage for Windows and POSIX separators.