### PR TITLE
feat(code): reuse server across workspace switches

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6068,6 +6068,42 @@ class DeepAgentsApp(App):
             ),
         )
 
+    def _refresh_mcp_client_state(self) -> None:
+        info = self._mcp_server_info or []
+        self._mcp_tool_count = sum(len(server.tools) for server in info)
+        self._mcp_unauthenticated = sum(
+            1 for server in info if server.needs_attention()
+        )
+        self._mcp_errored = sum(1 for server in info if server.status == "error")
+        self._mcp_awaiting_reconnect = sum(
+            1 for server in info if server.status == "awaiting_reconnect"
+        )
+        try:
+            self.query_one("#welcome-banner", WelcomeBanner).set_connected(
+                self._mcp_tool_count,
+                mcp_unauthenticated=self._mcp_unauthenticated,
+                mcp_errored=self._mcp_errored,
+                mcp_awaiting_reconnect=self._mcp_awaiting_reconnect,
+            )
+        except NoMatches:
+            logger.warning("Welcome banner not found during MCP state refresh")
+        except ScreenStackError:
+            logger.debug("Screen stack empty during MCP state refresh", exc_info=True)
+        self._sync_status_connection()
+        if self._active_mcp_viewer is not None:
+            viewer = self._active_mcp_viewer
+
+            async def _refresh_viewer() -> None:
+                await viewer.refresh_server_info(info)
+
+            task = asyncio.create_task(_refresh_viewer())
+            task.add_done_callback(_log_task_exception)
+        if self._active_plugin_manager is not None:
+            self._active_plugin_manager.update_connection_state(
+                info,
+                mcp_connecting=False,
+            )
+
     def on_deep_agents_app_server_ready(self, event: ServerReady) -> None:
         """Handle successful background server startup."""
         # Latch before `_connecting` clears: the `_sync_status_connection` below
@@ -6107,33 +6143,7 @@ class DeepAgentsApp(App):
 
             task = asyncio.create_task(_drop())
             task.add_done_callback(_log_task_exception)
-        self._mcp_tool_count = sum(len(s.tools) for s in (event.mcp_server_info or []))
-        self._mcp_unauthenticated = sum(
-            1 for s in (event.mcp_server_info or []) if s.needs_attention()
-        )
-        self._mcp_errored = sum(
-            1 for s in (event.mcp_server_info or []) if s.status == "error"
-        )
-        self._mcp_awaiting_reconnect = sum(
-            1 for s in (event.mcp_server_info or []) if s.status == "awaiting_reconnect"
-        )
-
-        # Update welcome banner to show ready state
-        try:
-            banner = self.query_one("#welcome-banner", WelcomeBanner)
-            banner.set_connected(
-                self._mcp_tool_count,
-                mcp_unauthenticated=self._mcp_unauthenticated,
-                mcp_errored=self._mcp_errored,
-                mcp_awaiting_reconnect=self._mcp_awaiting_reconnect,
-            )
-        except NoMatches:
-            logger.warning("Welcome banner not found during server ready transition")
-        except ScreenStackError:
-            logger.debug(
-                "Screen stack empty during server ready transition", exc_info=True
-            )
-        self._sync_status_connection()
+        self._refresh_mcp_client_state()
 
         # Refresh the status bar model so a successful retry after a failed
         # startup (e.g. `/model` switching providers after `ModelConfigError`)
@@ -6144,33 +6154,6 @@ class DeepAgentsApp(App):
             logger.warning("Status bar not found during server ready transition")
         else:
             self._sync_status_model()
-
-        if self._active_mcp_viewer is not None:
-            viewer = self._active_mcp_viewer
-
-            async def _refresh_viewer() -> None:
-                # No local `suppress` — the `_log_task_exception` done
-                # callback is the single error sink. Silencing here
-                # would make that callback dead code (its `task.result()`
-                # call could never see a raised exception) and a real
-                # `DuplicateIds` / `AttributeError` would leave the
-                # viewer stuck on the connecting placeholder with no
-                # signal in the logs.
-                await viewer.refresh_server_info(self._mcp_server_info or [])
-
-            task = asyncio.create_task(_refresh_viewer())
-            task.add_done_callback(_log_task_exception)
-
-        # A `/plugins` manager opened mid-startup holds a connecting snapshot
-        # (empty `mcp_server_info`, `mcp_connecting=True`) that would otherwise
-        # suppress the settled connected/`/reload` status until the modal is
-        # reopened. Push both halves: clearing the flag alone would render
-        # every MCP-declaring plugin as disconnected instead.
-        if self._active_plugin_manager is not None:
-            self._active_plugin_manager.update_connection_state(
-                self._mcp_server_info or [],
-                mcp_connecting=False,
-            )
 
         # Session-start sequence: load resumed history, run `--startup-cmd`
         # (if any), then dispatch the initial prompt/skill and drain
@@ -29012,6 +28995,61 @@ class DeepAgentsApp(App):
             self.on_deep_agents_app_server_ready(event)
             return "continue"
 
+    async def _reuse_server_after_cwd_switch(
+        self, cwd: Path, thread_id: str
+    ) -> Literal["continue", "abort", "restart"]:
+        remote = self._remote_agent()
+        if remote is None or self._sandbox_type is not None:
+            return "restart"
+        from langgraph_sdk.errors import ConflictError
+
+        previous_cwd = Path(self._cwd)
+        previous_server_cwd = (
+            self._server_kwargs.get("cwd") if self._server_kwargs is not None else None
+        )
+        previous_mcp_info = self._mcp_server_info
+        workspace_snapshot = remote._snapshot_workspace()
+        config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
+        try:
+            mcp_info = await remote.aswitch_workspace(config, str(cwd))
+        except ConflictError:
+            return "restart"
+        except Exception as exc:
+            logger.exception("Server could not validate the destination workspace")
+            self.notify(
+                f"Could not switch to the thread cwd ({type(exc).__name__}: {exc}). "
+                "Staying in the current directory.",
+                severity="error",
+                timeout=10,
+                markup=False,
+            )
+            return "abort"
+        try:
+            self._preserve_launch_relative_server_paths(previous_cwd)
+            await self._switch_process_cwd(cwd)
+            if self._server_kwargs is not None:
+                self._server_kwargs["cwd"] = self._cwd
+            self._mcp_server_info = mcp_info
+            self._mcp_optimistic_original_server_info.clear()
+            self._pending_mcp_login_reconnect = False
+            self._pending_mcp_disable_reconnect_servers.clear()
+            self._mcp_viewer_disable_toggled = False
+            self._sync_pending_mcp_reconnect()
+            self._refresh_mcp_client_state()
+        except BaseException:
+            remote._restore_workspace(workspace_snapshot)
+            self._mcp_server_info = previous_mcp_info
+            if self._server_kwargs is not None:
+                self._server_kwargs["cwd"] = previous_server_cwd
+            if not await asyncio.to_thread(
+                self._cwd_paths_equal, self._cwd, previous_cwd
+            ):
+                await self._switch_process_cwd(previous_cwd)
+            self._refresh_mcp_client_state()
+            raise
+        else:
+            return "continue"
+
     @staticmethod
     async def _preview_project_settings_change(cwd: Path) -> bool:
         """Return whether switching cwd would refresh project settings."""
@@ -29217,7 +29255,14 @@ class DeepAgentsApp(App):
             return "abort"
         if choice == "switch":
             if restart_server:
-                outcome = await self._replace_server_after_cwd_switch(target)
+                reuse_outcome = await self._reuse_server_after_cwd_switch(
+                    target, thread_id
+                )
+                outcome = (
+                    await self._replace_server_after_cwd_switch(target)
+                    if reuse_outcome == "restart"
+                    else reuse_outcome
+                )
                 if outcome == "abort":
                     # A failed restart returns "abort" just like a user-declined
                     # abort, so the caller cannot tell them apart.

--- a/libs/code/deepagents_code/client/remote_client.py
+++ b/libs/code/deepagents_code/client/remote_client.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
 
+    from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.offload_middleware import OffloadResult
 
 logger = logging.getLogger(__name__)
@@ -801,24 +802,15 @@ class RemoteAgent:
             raise RuntimeError(msg)
         return await self.abind_workspace(config, self._workspace_cwd)
 
-    async def abind_workspace(
+    async def _request_workspace(
         self, config: Mapping[str, Any], cwd: str
-    ) -> dict[str, Any]:
-        """Create or verify the remote thread's durable workspace binding.
-
-        Returns:
-            The server-validated workspace descriptor.
-
-        Raises:
-            TypeError: If the server returns a malformed descriptor.
-        """
+    ) -> tuple[dict[str, Any], list[MCPServerInfo] | None]:
         thread_id = _require_thread_id(config)
-        graph = self._get_graph()
         payload: dict[str, Any] = {"cwd": cwd}
         if self._workspace_config is not None:
             payload["workspace_config"] = self._workspace_config
             payload["config_fingerprint"] = self._workspace_config_fingerprint
-        response = await graph.client.http.post(
+        response = await self._get_graph().client.http.post(
             f"/dcode/threads/{thread_id}/workspace",
             json=payload,
         )
@@ -827,9 +819,74 @@ class RemoteAgent:
         ):
             msg = "Workspace server returned an invalid binding response."
             raise TypeError(msg)
-        workspace = cast("dict[str, Any]", response["workspace"])
+        raw_mcp = response.get("mcp_server_info")
+        if raw_mcp is None:
+            mcp_server_info = None
+        elif isinstance(raw_mcp, list) and all(
+            isinstance(item, dict) for item in raw_mcp
+        ):
+            from deepagents_code.mcp_tools import MCPServerInfo, MCPToolInfo
+
+            try:
+                mcp_server_info = [
+                    MCPServerInfo(
+                        name=item["name"],
+                        transport=item["transport"],
+                        tools=tuple(
+                            MCPToolInfo(**tool) for tool in item.get("tools", [])
+                        ),
+                        status=item.get("status", "ok"),
+                        error=item.get("error"),
+                        pending_reconnect=item.get("pending_reconnect", False),
+                        uses_oauth=item.get("uses_oauth", False),
+                    )
+                    for item in raw_mcp
+                ]
+            except (KeyError, TypeError, ValueError) as exc:
+                msg = "Workspace server returned invalid MCP metadata."
+                raise TypeError(msg) from exc
+        else:
+            msg = "Workspace server returned invalid MCP metadata."
+            raise TypeError(msg)
+        return cast("dict[str, Any]", response["workspace"]), mcp_server_info
+
+    async def abind_workspace(
+        self, config: Mapping[str, Any], cwd: str
+    ) -> dict[str, Any]:
+        """Create or verify the remote thread's durable workspace binding.
+
+        Returns:
+            The server-validated workspace descriptor.
+        """
+        thread_id = _require_thread_id(config)
+        workspace, _ = await self._request_workspace(config, cwd)
         self._workspaces[thread_id] = workspace
         return workspace
+
+    def _snapshot_workspace(self) -> tuple[str | None, dict[str, dict[str, Any]]]:
+        return self._workspace_cwd, dict(self._workspaces)
+
+    def _restore_workspace(
+        self, snapshot: tuple[str | None, dict[str, dict[str, Any]]]
+    ) -> None:
+        self._workspace_cwd, workspaces = snapshot
+        self._workspaces.clear()
+        self._workspaces.update(workspaces)
+
+    async def aswitch_workspace(
+        self, config: Mapping[str, Any], cwd: str
+    ) -> list[MCPServerInfo] | None:
+        """Bind one thread to a workspace and make it the default for new threads.
+
+        Returns:
+            MCP metadata for the server runtime selected by the binding.
+        """
+        thread_id = _require_thread_id(config)
+        workspace, mcp_server_info = await self._request_workspace(config, cwd)
+        self._workspace_cwd = cwd
+        self._workspaces.clear()
+        self._workspaces[thread_id] = workspace
+        return mcp_server_info
 
     def set_workspace(
         self,

--- a/libs/code/deepagents_code/offload_api.py
+++ b/libs/code/deepagents_code/offload_api.py
@@ -8,6 +8,7 @@ import threading
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
+from dataclasses import asdict
 from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any, Literal, cast
 from weakref import WeakValueDictionary
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
 
     from deepagents_code._server_config import ServerConfig
     from deepagents_code.cost_tracking import PreparedOperationCost
+    from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.offload_middleware import (
         OffloadExecution,
         OffloadResponse,
@@ -199,11 +201,17 @@ def _runtime_unavailable_detail(consequence: str) -> str:
     )
 
 
+def _mcp_server_info_payload(
+    server_info: list[MCPServerInfo] | None,
+) -> list[dict[str, Any]] | None:
+    return None if server_info is None else [asdict(server) for server in server_info]
+
+
 async def workspace(request: Request) -> JSONResponse:
     """Create or verify the durable workspace assigned to a thread.
 
     Returns:
-        A validated workspace descriptor or an error response.
+        A validated workspace descriptor and its MCP metadata, or an error.
     """
     thread_id = request.path_params["thread_id"]
     body = await request.json()
@@ -276,7 +284,7 @@ async def workspace(request: Request) -> JSONResponse:
     # `ValueError` to 422, but a `ValueError` out of the runtime build is server
     # misconfiguration, not a malformed request.
     try:
-        await get_server_runtime(binding)
+        runtime = await get_server_runtime(binding)
     except WorkspaceConflictError as exc:
         return JSONResponse({"detail": str(exc)}, status_code=409)
     except SystemExit:
@@ -304,7 +312,12 @@ async def workspace(request: Request) -> JSONResponse:
             {"detail": "Workspace was bound but thread metadata could not be updated."},
             status_code=503,
         )
-    return JSONResponse({"workspace": binding.to_payload()})
+    return JSONResponse(
+        {
+            "workspace": binding.to_payload(),
+            "mcp_server_info": _mcp_server_info_payload(runtime.mcp_server_info),
+        }
+    )
 
 
 def _extensions(request: Request) -> JSONResponse:

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
 
     from deepagents_code.config import CredentialsSnapshot
     from deepagents_code.extensions.registry import ExtensionRegistry
+    from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.offload_middleware import OffloadOperation
     from deepagents_code.workspace import WorkspaceBinding
 
@@ -268,13 +269,7 @@ def _mcp_tool_is_explicitly_read_only(tool: Any) -> bool:  # noqa: ANN401
 
 
 class ServerRuntime(NamedTuple):
-    """The one-per-process result of building this server's agent.
-
-    A named tuple rather than a bare tuple so the three slots are addressed by
-    name: `agent` is structurally opaque to the type checker (the SDK exposes no
-    usable compiled-graph type here), so a positional transposition would hand
-    LangGraph the backend as its compiled graph with no complaint.
-    """
+    """The one-per-process result with named slots to prevent transposition."""
 
     agent: Any
     """Compiled LangGraph agent graph served as `agent`."""
@@ -284,6 +279,9 @@ class ServerRuntime(NamedTuple):
 
     offload: OffloadOperation
     """Server-owned thread offload operation bound to `backend`."""
+
+    mcp_server_info: list[MCPServerInfo] | None = None
+    """Workspace-scoped MCP metadata for the interactive client."""
 
 
 async def _make_graphs(
@@ -558,6 +556,7 @@ async def _make_graphs_in_environment(
             agent=agent,
             backend=composite_backend,
             offload=offload,
+            mcp_server_info=mcp_server_info,
         )
 
     from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -25609,6 +25609,54 @@ class TestResumeThreadCwdSwitch:
         assert screen._project_settings_change_detected is True
         retarget.assert_awaited_once_with(reload_manager=reload_manager)
 
+    async def test_offer_switch_reuses_hostable_server(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from deepagents_code.client.remote_client import RemoteAgent
+        from deepagents_code.config import credentials
+
+        current = tmp_path / "current"
+        target = tmp_path / "target"
+        current.mkdir()
+        target.mkdir()
+        monkeypatch.chdir(current)
+        agent = RemoteAgent("http://test:0")
+        switch_workspace = AsyncMock(return_value=[])
+        monkeypatch.setattr(agent, "aswitch_workspace", switch_workspace)
+        app = DeepAgentsApp(thread_id="thread-1", cwd=current)
+        app._agent = agent
+        app._server_kwargs = {"cwd": str(current)}
+        app._push_screen_wait = AsyncMock(return_value="switch")  # ty: ignore[invalid-assignment]
+        monkeypatch.setattr(
+            app, "_preview_project_settings_change", AsyncMock(return_value=False)
+        )
+        monkeypatch.setattr(
+            credentials, "reload_from_environment", lambda **_kwargs: []
+        )
+        replace_server = AsyncMock()
+        monkeypatch.setattr(app, "_replace_server_after_cwd_switch", replace_server)
+        retarget = AsyncMock()
+        monkeypatch.setattr(app, "_retarget_hooks_after_cwd_switch", retarget)
+
+        with (
+            patch("deepagents_code.sessions.get_thread_cwd", return_value=str(target)),
+            patch("deepagents_code.model_config.clear_caches"),
+        ):
+            outcome = await app._offer_thread_cwd_switch(
+                "thread-1", restart_server=True
+            )
+
+        assert outcome == "continue"
+        assert Path.cwd() == target
+        assert app._server_kwargs["cwd"] == str(target)
+        switch_workspace.assert_awaited_once_with(
+            {"configurable": {"thread_id": "thread-1"}}, str(target)
+        )
+        replace_server.assert_not_awaited()
+        retarget.assert_awaited_once_with(reload_manager=False)
+
     async def test_offer_switch_preserves_launch_relative_server_paths(
         self,
         tmp_path: Path,

--- a/libs/code/tests/unit_tests/test_remote_client.py
+++ b/libs/code/tests/unit_tests/test_remote_client.py
@@ -880,6 +880,66 @@ class TestRemoteAgentWorkspace:
             json={"cwd": "/workspace/project"},
         )
 
+    async def test_switch_preserves_destination_binding_and_returns_metadata(
+        self,
+    ) -> None:
+        agent = RemoteAgent("http://localhost:1234")
+        agent.set_workspace("/workspace/old")
+        agent._workspaces["old"] = {"workspace_id": "old"}
+        post = AsyncMock(
+            return_value={
+                "workspace": {"workspace_id": "new"},
+                "mcp_server_info": [
+                    {
+                        "name": "docs",
+                        "transport": "http",
+                        "tools": [{"name": "search", "description": "Search docs"}],
+                        "status": "ok",
+                        "error": None,
+                        "pending_reconnect": False,
+                        "uses_oauth": False,
+                    }
+                ],
+            }
+        )
+        graph = SimpleNamespace(client=SimpleNamespace(http=SimpleNamespace(post=post)))
+
+        with patch.object(agent, "_get_graph", return_value=graph):
+            info = await agent.aswitch_workspace(
+                {"configurable": {"thread_id": "destination"}}, "/workspace/new"
+            )
+            binding = await agent._workspace_for_thread(
+                {"configurable": {"thread_id": "destination"}}
+            )
+
+        assert agent._workspace_cwd == "/workspace/new"
+        assert binding == {"workspace_id": "new"}
+        assert post.await_count == 1
+        assert info is not None
+        assert info[0].name == "docs"
+        assert info[0].tools[0].name == "search"
+
+    async def test_switch_failure_preserves_workspace_state(self) -> None:
+        agent = RemoteAgent("http://localhost:1234")
+        agent.set_workspace("/workspace/old")
+        agent._workspaces["old"] = {"workspace_id": "old"}
+        graph = SimpleNamespace(
+            client=SimpleNamespace(
+                http=SimpleNamespace(post=AsyncMock(side_effect=RuntimeError("no")))
+            )
+        )
+
+        with (
+            patch.object(agent, "_get_graph", return_value=graph),
+            pytest.raises(RuntimeError, match="no"),
+        ):
+            await agent.aswitch_workspace(
+                {"configurable": {"thread_id": "destination"}}, "/workspace/new"
+            )
+
+        assert agent._workspace_cwd == "/workspace/old"
+        assert agent._workspaces == {"old": {"workspace_id": "old"}}
+
     def test_policy_and_fingerprint_must_be_configured_together(self) -> None:
         agent = RemoteAgent("http://localhost:1234")
 


### PR DESCRIPTION
- Reuse the active server when an in-session resume targets a workspace that server can host.
- Ask the server to validate and bind the destination before changing local cwd state.
- Fall back to server replacement on workspace conflicts and for sandboxed sessions.
- Refresh workspace MCP metadata, tool inputs, hooks, settings, and UI state without restarting.
- Preserve the accepted thread binding and roll back client state if the local switch fails.

### User behavior

Before, every same-agent resume into another directory replaced the server. After, compatible local workspaces switch immediately while keeping the existing server. Restarts remain necessary when the server reports a workspace conflict or when a process-wide sandbox is active. Cached bindings for other threads are cleared; the destination thread's validated binding is retained.

Made by [Open SWE](https://openswe.vercel.app/agents/8a93fe0b-74ea-5501-9647-52f488eb8421)