### PR TITLE
fix(talon): bound archive scans, query embeddings, and deletion markers

### DIFF
--- a/libs/talon/deepagents_talon/history_prepared_store.py
+++ b/libs/talon/deepagents_talon/history_prepared_store.py
@@ -45,7 +45,15 @@ class PreparedVectorStore(BaseStore):
         }
         for op in operations:
             if isinstance(op, SearchOp) and op.query is not None:
-                cache[True, op.query] = await self.embed.aembed_query(op.query)
+                vector = await self.embed.aembed_query(op.query)
+                cache[True, op.query] = vector
+                # Only some Stores embed a search through aembed_query; SQLite and
+                # PostgreSQL route it through aembed_documents instead. Publishing the
+                # query vector under the document key too keeps query prompts and
+                # provider input types backend-neutral, without a second round trip.
+                # A document in this same batch keeps its own vector: that one is
+                # stored durably, while a query vector is used once and discarded.
+                cache.setdefault((False, op.query), vector)
         token = EMBEDDING_CACHE.set(cache)
         try:
             return await self.store.abatch(operations)

--- a/libs/talon/deepagents_talon/history_vectors.py
+++ b/libs/talon/deepagents_talon/history_vectors.py
@@ -38,6 +38,13 @@ _MAX_SEARCH_PAGES = 32
 _BATCH_SIZE = 4
 _RETRY_SECONDS = 30
 _SEARCH_TIMEOUT_SECONDS = 2
+# One indexing batch embeds up to 500 chunks in sequential provider requests, each
+# already bounded by the adapter's own request timeout, so this only has to catch a
+# Store write that never returns at all.
+_BATCH_TIMEOUT_SECONDS = 300
+# Unacknowledged work is retried from durable state on the next start, so abandoning
+# a wedged batch at shutdown costs a repeat, never data.
+_CLOSE_TIMEOUT_SECONDS = 10
 
 
 @dataclass
@@ -70,8 +77,9 @@ class HistoryVectorIndex:
     ) -> None:
         """Keep indexing separate from checkpoint persistence."""
         self.profile = profile
-        self._slots = asyncio.Semaphore(profile.concurrency if profile else 1)
-        # Indexing can occupy every configured slot, so a search holds its own.
+        # Indexing needs no permit of its own: every non-query caller holds `self.lock`
+        # for the whole batch, so at most one is ever outstanding. Provider concurrency
+        # is bounded by `BoundedEmbeddings.slots` instead.
         self._query_slots = asyncio.Semaphore(1)
         self._pending: set[asyncio.Task[list[Result]]] = set()
         self.search_visibility = search_visibility
@@ -91,13 +99,28 @@ class HistoryVectorIndex:
         self.task = asyncio.create_task(self._run(), name="talon-history-index")
 
     async def close(self) -> None:
-        """Finish the active batch before the caller closes database connections."""
+        """Finish the active batch before the caller closes database connections.
+
+        A Store write that never returns must not hold host shutdown open forever, so
+        the batch is abandoned once the deadline passes and retried on the next start.
+        """
         self.stopping = True
         self.wake.set()
-        if self.task is not None:
-            await self.task
-        if self._pending:
-            await asyncio.gather(*self._pending, return_exceptions=True)
+        tasks = [task for task in (self.task, *self._pending) if task is not None]
+        if not tasks:
+            return
+        _, unfinished = await asyncio.wait(tasks, timeout=_CLOSE_TIMEOUT_SECONDS)
+        if unfinished:
+            logger.warning(
+                "History vector indexing did not stop within %ss; abandoning the active batch "
+                "for the next start to retry",
+                _CLOSE_TIMEOUT_SECONDS,
+            )
+            for task in unfinished:
+                task.cancel()
+            await asyncio.gather(*unfinished, return_exceptions=True)
+        if self.task is not None and not self.task.cancelled() and (error := self.task.exception()):
+            raise error
 
     def namespace(self, channel: str, chat: str) -> tuple[str, ...]:
         """Build a collision-resistant namespace without Store-specific escaping.
@@ -109,8 +132,9 @@ class HistoryVectorIndex:
         return ("talon_history", self.identity, _digest(channel), _digest(chat))
 
     async def _batch(self, operations: Sequence[Op], *, query: bool = False) -> list[Result]:
-        slots = self._query_slots if query else self._slots
-        await slots.acquire()
+        slots = self._query_slots if query else None
+        if slots is not None:
+            await slots.acquire()
         task = asyncio.create_task(self._call_store(operations, slots))
         self._pending.add(task)
         task.add_done_callback(self._finished)
@@ -123,11 +147,15 @@ class HistoryVectorIndex:
             return await task
         return await asyncio.shield(task)
 
-    async def _call_store(self, operations: Sequence[Op], slots: asyncio.Semaphore) -> list[Result]:
+    async def _call_store(
+        self, operations: Sequence[Op], slots: asyncio.Semaphore | None
+    ) -> list[Result]:
         try:
-            return await self.store.abatch(operations)
+            async with asyncio.timeout(_BATCH_TIMEOUT_SECONDS):
+                return await self.store.abatch(operations)
         finally:
-            slots.release()
+            if slots is not None:
+                slots.release()
 
     def _finished(self, task: asyncio.Task[list[Result]]) -> None:
         self._pending.discard(task)
@@ -174,7 +202,12 @@ class HistoryVectorIndex:
             except Exception as error:  # noqa: BLE001  # Optional indexing must not stop conversation writes.
                 failures += 1
                 delay = _retry_delay(error, failures)
-                logger.warning("History vector indexing failed; pending work will be retried")
+                # Without the cause a permanently broken backend repeats an identical
+                # line forever; the adapter's dimension and credential errors name the
+                # exact settings that fix them.
+                logger.warning(
+                    "History vector indexing failed; retrying in %.0fs", delay, exc_info=error
+                )
             if failures:
                 await self._backoff(delay)
             else:
@@ -286,10 +319,13 @@ class HistoryVectorIndex:
             items = cast("list[SearchItem]", results[0])
             keys = [item.key for item in items if item.score is not None]
         except TimeoutError:
-            logger.warning("History vector search timed out; using keyword search")
+            logger.warning(
+                "History vector search timed out after %ss; using keyword search",
+                _SEARCH_TIMEOUT_SECONDS,
+            )
             return [], "timeout"
         except Exception:  # noqa: BLE001  # Search remains usable without the optional backend.
-            logger.warning("History vector search unavailable; using keyword search")
+            logger.warning("History vector search unavailable; using keyword search", exc_info=True)
             return [], "error"
         else:
             return keys, "unavailable" if items and not keys else "completed"

--- a/libs/talon/deepagents_talon/store_archive.py
+++ b/libs/talon/deepagents_talon/store_archive.py
@@ -299,7 +299,7 @@ class StoreConversationArchive:
             return None
         return entry
 
-    async def _text_entries(
+    async def _text_entries(  # noqa: PLR0913  # Preserve existing arguments when adding partial scans.
         self,
         scope: ArchiveScope,
         *,
@@ -307,6 +307,7 @@ class StoreConversationArchive:
         session_id: str,
         after: int,
         limit: int,
+        partial: bool = False,
     ) -> list[ArchiveEntry]:
         async with self.records.access():
             if session_id:
@@ -327,7 +328,7 @@ class StoreConversationArchive:
                     msg = "Conversation archive contains an invalid ordering link"
                     raise RuntimeError(msg)
             hits: list[ArchiveEntry] = []
-            async for _, record in self._retrieval_chain(cursor, link):
+            async for _, record in self._retrieval_chain(cursor, link, partial=partial):
                 entry = await self.visible(record, scope)
                 if (
                     entry is not None
@@ -339,12 +340,20 @@ class StoreConversationArchive:
                         break
             return hits
 
-    async def _retrieval_chain(self, cursor: int, link: str) -> AsyncIterator[tuple[int, Record]]:
+    async def _retrieval_chain(
+        self, cursor: int, link: str, *, partial: bool = False
+    ) -> AsyncIterator[tuple[int, Record]]:
         scanned = 0
         async for identifier, record in self.records.chain(cursor, link):
             yield identifier, record
             scanned += 1
             if scanned == _MAX_SCAN and number(record, link):
+                # Ranked retrieval already scores a bounded candidate pool, so a
+                # truncated scan only narrows it. A page from entries() or
+                # conversations() claims completeness, so truncating one there
+                # would report "no more results" while records remain.
+                if partial:
+                    return
                 msg = (
                     "Conversation history scan limit exceeded (500 records); "
                     "no partial page returned"
@@ -516,27 +525,40 @@ class StoreConversationArchive:
             return
         root = await self.records.root()
         deletion = number(root, "last") + 1
-        await self.records.commit(
-            [
-                (
-                    str(session["cursor"]),
-                    {**session, "deleting": True, "delete_cursor": session["head"]},
-                ),
-                (
-                    str(deletion),
-                    {"owner": session["cursor"], "previous_deleting": number(root, "deleting")},
-                ),
-                (
-                    "root",
-                    {
-                        **root,
-                        "last": deletion,
-                        "deletions": number(root, "deletions") + 1,
-                        "deleting": deletion,
-                    },
-                ),
-            ]
-        )
+        previous = number(root, "deleting")
+        writes: list[Write] = [
+            (
+                str(session["cursor"]),
+                {
+                    **session,
+                    "deleting": True,
+                    "delete_cursor": session["head"],
+                    "delete_marker": deletion,
+                },
+            ),
+            (
+                str(deletion),
+                # Linked in both directions so a completed marker leaves the chain
+                # without a walk; see `_unlink_deletion`.
+                {
+                    "owner": session["cursor"],
+                    "previous_deleting": previous,
+                    "next_deleting": 0,
+                },
+            ),
+            (
+                "root",
+                {
+                    **root,
+                    "last": deletion,
+                    "deletions": number(root, "deletions") + 1,
+                    "deleting": deletion,
+                },
+            ),
+        ]
+        if previous and (marker := await self.records.get(str(previous))) is not None:
+            writes.append((str(previous), {**marker, "next_deleting": deletion}))
+        await self.records.commit(writes)
 
     async def delete_text(self, session_id: str) -> None:
         """Erase text and dedup records after vector deletion, under the records lock."""
@@ -552,17 +574,50 @@ class StoreConversationArchive:
             writes.extend((str(record[key]), None) for key in ("dedup", "message"))
             await self.records.commit(writes)
         root = await self.records.root()
+        deletions = number(root, "deletions") - 1
+        markers, deleting = await self._unlink_deletion(session, root, drained=deletions <= 0)
         links = {"previous_scope": session["previous_scope"]}
         scoped = await self.records.get(scope_key(cast("ArchiveScope", session["scope"]))) or {}
         others = await self._other_sessions(scoped, number(session, "cursor"))
         await self.records.commit(
             [
+                *markers,
                 (scope_key(cast("ArchiveScope", session["scope"])), scoped if others else None),
                 (str(session["cursor"]), links),
                 ("session:" + digest(session_id), None),
-                ("root", {**root, "deletions": number(root, "deletions") - 1}),
+                ("root", {**root, "deletions": deletions, "deleting": deleting}),
             ]
         )
+
+    async def _unlink_deletion(
+        self, session: Record, root: Record, *, drained: bool
+    ) -> tuple[list[Write], int]:
+        """Remove a completed deletion marker, returning its writes and the new chain head.
+
+        The chain exists so an interrupted deletion can be found again after a restart.
+        Retaining completed markers would instead record every deletion the assistant
+        has ever performed, and the indexing worker re-walks that chain on every poll
+        for as long as any one deletion is still outstanding. Archives written before
+        markers were linked in both directions have no `delete_marker`; their chain is
+        abandoned wholesale once the last outstanding deletion drains.
+        """
+        deleting = 0 if drained else number(root, "deleting")
+        cursor = number(session, "delete_marker")
+        marker = await self.records.get(str(cursor)) if cursor else None
+        if marker is None:
+            return [], deleting
+        previous, following = number(marker, "previous_deleting"), number(marker, "next_deleting")
+        writes: list[Write] = [(str(cursor), None)]
+        if not following and deleting == cursor:
+            deleting = previous
+        neighbors = (
+            (following, "previous_deleting", previous),
+            (previous, "next_deleting", following),
+        )
+        for neighbor, field, value in neighbors:
+            if neighbor and (record := await self.records.get(str(neighbor))) is not None:
+                writes.append((str(neighbor), {**record, field: value}))
+        return writes, deleting
 
     async def _other_sessions(self, scoped: Record, cursor: int) -> bool:
         async for identifier, record in self.records.chain(

--- a/libs/talon/deepagents_talon/store_archive_index.py
+++ b/libs/talon/deepagents_talon/store_archive_index.py
@@ -139,13 +139,19 @@ class StoreVectorArchive:
             return False
 
     async def lexical(self, scope: ArchiveScope, query: str, limit: int) -> list[str]:
-        """Find literal keyword candidates without backend-specific full-text operators."""
+        """Find literal keyword candidates without backend-specific full-text operators.
+
+        Stops at the archive's scan budget rather than raising: these candidates are
+        fused with the semantic ranking, so a short list degrades recall while a
+        raised error would fail a search the semantic leg had already answered.
+        """
         entries = await self.archive._text_entries(  # noqa: SLF001  # Storage adapter shares archive retrieval.
             scope,
             query=query,
             session_id="",
             after=0,
             limit=limit,
+            partial=True,
         )
         return [str(entry["cursor"]) for entry in entries]
 

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -580,6 +580,31 @@ async def test_threaded_store_uses_native_async_embeddings(tmp_path):
     assert set(raw.queries) == {"question"}
 
 
+async def test_query_prompt_reaches_stores_that_embed_searches_as_documents(tmp_path):
+    from langgraph.store.memory import InMemoryStore  # noqa: PLC0415
+
+    from deepagents_talon.history_prepared_store import PreparedVectorStore  # noqa: PLC0415
+
+    class DocumentSearchStore(InMemoryStore):
+        # PostgreSQL and SQLite both embed a search through aembed_documents; only the
+        # SQLite subclass marks those calls as queries, so this stands in for the rest.
+        async def _aembed_search_queries(self, search_ops):
+            queries = list({op.query for op, _ in search_ops.values() if op.query})
+            return dict(zip(queries, await self.embeddings.aembed_documents(queries), strict=True))
+
+    raw = RecordingEmbeddings()
+    profile = configuration(tmp_path, QUERY_PROMPT="Instruct: ").history_embedding_profile
+    embed = BoundedEmbeddings(raw, profile)
+    store = PreparedVectorStore(
+        DocumentSearchStore(index={"dims": 2, "embed": embed, "fields": ["text"]}), embed
+    )
+    await store.aput(("test",), "one", {"text": "document"})
+    assert (await store.asearch(("test",), query="question"))[0].key == "one"
+    assert raw.queries == ["Instruct: question"]
+    # The query must not be re-embedded as an unprefixed document inside the batch.
+    assert raw.documents == ["document"]
+
+
 async def test_vector_plugin_receives_generation_and_deletion_mode(tmp_path, monkeypatch):
     from contextlib import asynccontextmanager  # noqa: PLC0415
 

--- a/libs/talon/tests/unit_tests/test_history_vectors.py
+++ b/libs/talon/tests/unit_tests/test_history_vectors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from contextlib import asynccontextmanager
 
@@ -18,6 +19,7 @@ from deepagents_talon.history_backends import open_history
 from deepagents_talon.history_embeddings import QUERY_PROMPT, HistoryEmbeddings
 from deepagents_talon.history_profiles import EmbeddingProfile
 from deepagents_talon.sqlite_history import _HistorySqliteStore, sqlite_store
+from deepagents_talon.store_archive import StoreConversationArchive
 from tests.archive_helpers import open_vector_archive
 from tests.store_archive_contract import StaticEmbeddings as Embedding
 
@@ -150,6 +152,80 @@ async def test_failed_indexing_is_retried_after_restart(tmp_path):
         assert (
             ((await archive.search_page(SCOPE, query="automobile"))["results"])[0]["text"] == "car"
         )
+
+
+async def test_indexing_failure_logs_the_underlying_cause(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr("deepagents_talon.history_vectors._RETRY_SECONDS", 0.01)
+    monkeypatch.setattr("deepagents_talon.history_vectors.secrets.randbelow", lambda _bound: 0)
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.history_vectors")
+    failing = FailingEmbedding()
+    async with (
+        vector_store("memory", None, failing) as store,
+        open_vector_archive(str(tmp_path / "archive.sqlite"), store=store) as archive,
+    ):
+        await append(archive, "car")
+        await asyncio.wait_for(failing.failed.wait(), 2)
+        async with asyncio.timeout(3):
+            while True:
+                if any("indexing failed" in item.message for item in caplog.records):
+                    break
+                await asyncio.sleep(0.01)
+    # A permanently broken backend otherwise repeats one identical line forever.
+    record = next(item for item in caplog.records if "indexing failed" in item.message)
+    assert "embedding unavailable" in str(record.exc_info[1])
+
+
+async def test_close_abandons_a_wedged_indexing_batch(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr("deepagents_talon.history_vectors._CLOSE_TIMEOUT_SECONDS", 0.2)
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.history_vectors")
+    started = asyncio.Event()
+
+    class WedgedStore(InMemoryStore):
+        async def abatch(self, ops):
+            operations = list(ops)
+            if any(isinstance(op, PutOp) and op.value is not None for op in operations):
+                started.set()
+                await asyncio.Event().wait()
+            return await super().abatch(operations)
+
+    store = WedgedStore(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    # A Store write that never returns must not hold host shutdown open forever.
+    async with asyncio.timeout(5):
+        async with open_vector_archive(str(tmp_path / "archive.sqlite"), store=store) as archive:
+            await append(archive, "car")
+            await asyncio.wait_for(started.wait(), 2)
+    assert any("abandoning the active batch" in item.message for item in caplog.records)
+
+
+async def test_indexing_batches_never_overlap_so_they_need_no_permit():
+    active, peak = 0, 0
+
+    class CountingBatch(InMemoryStore):
+        async def abatch(self, ops):
+            nonlocal active, peak
+            operations = list(ops)
+            indexing = any(isinstance(op, PutOp) for op in operations)
+            active += indexing
+            peak = max(peak, active)
+            try:
+                await asyncio.sleep(0)
+                return await super().abatch(operations)
+            finally:
+                active -= indexing
+
+    store = CountingBatch(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    # Concurrency above one must not produce overlapping Store batches: the worker
+    # holds its lock across each one, which is why it carries no permit of its own.
+    profile = EmbeddingProfile(
+        adapter="openai-compatible", model="test", dims=2, max_input_tokens=512, concurrency=8
+    )
+    async with StoreConversationArchive(
+        InMemoryStore(), namespace=("serial",), vector_store=store, embedding_profile=profile
+    ).open() as archive:
+        for index in range(12):
+            await append(archive, f"car {index}", session=f"session-{index}")
+        await settled(archive)
+    assert peak == 1
 
 
 async def test_existing_vectors_survive_restart_and_do_not_reembed(tmp_path):
@@ -481,7 +557,8 @@ async def test_search_tool_pages_preserve_status_and_report_expired_cursors(tmp_
         assert expired["results"] == []
 
 
-async def test_search_backend_failure_reports_error(tmp_path):
+async def test_search_backend_failure_reports_error(tmp_path, caplog):
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.history_vectors")
     async with (
         vector_store("sqlite", tmp_path / "vectors.sqlite", FailingEmbedding()) as store,
         open_vector_archive(str(tmp_path / "archive.sqlite"), store=store) as archive,
@@ -490,6 +567,9 @@ async def test_search_backend_failure_reports_error(tmp_path):
         page = await archive.search_page(SCOPE, query="automobile")
         assert page["semantic_status"] == "error"
         assert page["results"] == []
+    # An operator needs the cause; the fallback alone cannot be diagnosed.
+    record = next(item for item in caplog.records if "search unavailable" in item.message)
+    assert "embedding unavailable" in str(record.exc_info[1])
 
 
 async def test_search_reports_store_without_semantic_support(tmp_path):

--- a/libs/talon/tests/unit_tests/test_store_archive.py
+++ b/libs/talon/tests/unit_tests/test_store_archive.py
@@ -57,6 +57,76 @@ async def test_retrieval_budget_bounds_reads_and_releases_lock(options):
     assert (await archive.entries(SCOPE, limit=1))[0]["text"] == "still writable"
 
 
+async def test_hybrid_search_ranks_partial_candidates_beyond_the_scan_budget():
+    metadata = CountingStore()
+    vectors = InMemoryStore(index={"dims": 2, "embed": StaticEmbeddings(), "fields": ["text"]})
+    async with StoreConversationArchive(
+        metadata, namespace=("budget-search",), vector_store=vectors
+    ).open() as archive:
+        # Only the oldest record is a semantic match, and no record matches the query
+        # literally, so the keyword leg walks the whole chain past its scan budget.
+        await archive.append(
+            SCOPE,
+            "session",
+            "time",
+            [
+                HumanMessage("car" if index == 0 else f"note {index}", id=str(index))
+                for index in range(501)
+            ],
+        )
+        async with asyncio.timeout(5):
+            while True:
+                if not await archive.vectors.archive.pending(SCOPE):
+                    break
+                await asyncio.sleep(0)
+        async with archive.vectors.lock:
+            pass
+        page = await archive.search_page(SCOPE, query="automobile")
+        assert page["semantic_status"] == "completed"
+        assert page["results"][0]["text"] == "car"
+        # A page that claims completeness still refuses to truncate silently.
+        with pytest.raises(RuntimeError, match="scan limit exceeded"):
+            await archive.entries(SCOPE, query="automobile")
+
+
+async def test_completed_deletion_markers_leave_the_outstanding_deletion_chain():
+    class ScopedFailure(InMemoryStore):
+        blocked = ()
+
+        async def abatch(self, ops):
+            operations = list(ops)
+            if any(
+                isinstance(op, PutOp) and op.value is None and op.namespace == self.blocked
+                for op in operations
+            ):
+                msg = "vector deletion failed"
+                raise OSError(msg)
+            return await super().abatch(operations)
+
+    metadata = CountingStore()
+    vectors = ScopedFailure(index={"dims": 2, "embed": StaticEmbeddings(), "fields": ["text"]})
+    async with StoreConversationArchive(
+        metadata, namespace=("markers",), vector_store=vectors
+    ).open() as archive:
+        vectors.blocked = archive.vectors.namespace(
+            OTHER["talon_history_channel"], OTHER["talon_history_chat"]
+        )
+        await archive.append(OTHER, "stuck", "time", [HumanMessage("stuck")])
+        with pytest.raises(OSError, match="vector deletion failed"):
+            await archive.delete_session("stuck")
+        for index in range(20):
+            await archive.append(SCOPE, f"session-{index}", "time", [HumanMessage("erase")])
+            await archive.delete_session(f"session-{index}")
+        # One deletion is still outstanding, so every poll re-reads the marker chain.
+        metadata.reads = 0
+        assert await archive.vectors.archive.rows("", indexing=True, limit=4)
+        assert metadata.reads <= 10  # Journal, root, the one live marker and its session.
+        vectors.blocked = ()
+        await archive.delete_session("stuck")
+        root = await archive.records.root()
+        assert (root["deletions"], root["deleting"]) == (0, 0)
+
+
 @asynccontextmanager
 async def stores(backend, tmp_path):
     index = {"dims": 2, "embed": StaticEmbeddings(), "fields": ["text"]}


### PR DESCRIPTION
**Stack 1 of 4 — history/archive.** Reviews cleanest bottom-up: this PR → `history-2-indexing-worker` → `history-3-drivers-adapters` → #6147.

Three High-severity defects in the conversation archive, found reviewing the ~23k lines added to `libs/talon` since `deepagents-talon==0.0.6`. All three are live in released 0.0.7.

- **Hybrid search raised on any long conversation.** `lexical()` was called unwrapped while the *optional* semantic leg beside it was defensively wrapped — backwards. With `_MAX_SCAN = 500` and `_CANDIDATES = 100`, any chat over 500 archived chunks whose query matched fewer than 100 of the newest 500 made `search_conversations` raise. `_retrieval_chain` now takes `partial=`; `entries()` and `conversations()` still raise, since a truncated page there would be a correctness lie.
- **Query embeddings were prefixed only on SQLite.** On Postgres and plugin backends the query was chunked and embedded as a *document* — no instruction prefix, no query input type, plus an extra provider round trip from inside the DB batch. `PreparedVectorStore.abatch` now publishes the vector under both cache keys.
- **The deletion-marker chain grew without bound** and was re-walked on every poll. Markers are now doubly linked and unlinked in O(1) as deletions complete.

Each test was verified to fail against pre-fix source with the exact symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
