### PR TITLE
fix(talon): surface indexing failures and bound the indexing worker

### DIFF
--- a/libs/talon/deepagents_talon/history_vectors.py
+++ b/libs/talon/deepagents_talon/history_vectors.py
@@ -38,6 +38,13 @@ _MAX_SEARCH_PAGES = 32
 _BATCH_SIZE = 4
 _RETRY_SECONDS = 30
 _SEARCH_TIMEOUT_SECONDS = 2
+# One indexing batch embeds up to 500 chunks in sequential provider requests, each
+# already bounded by the adapter's own request timeout, so this only has to catch a
+# Store write that never returns at all.
+_BATCH_TIMEOUT_SECONDS = 300
+# Unacknowledged work is retried from durable state on the next start, so abandoning
+# a wedged batch at shutdown costs a repeat, never data.
+_CLOSE_TIMEOUT_SECONDS = 10
 
 
 @dataclass
@@ -70,8 +77,9 @@ class HistoryVectorIndex:
     ) -> None:
         """Keep indexing separate from checkpoint persistence."""
         self.profile = profile
-        self._slots = asyncio.Semaphore(profile.concurrency if profile else 1)
-        # Indexing can occupy every configured slot, so a search holds its own.
+        # Indexing needs no permit of its own: every non-query caller holds `self.lock`
+        # for the whole batch, so at most one is ever outstanding. Provider concurrency
+        # is bounded by `BoundedEmbeddings.slots` instead.
         self._query_slots = asyncio.Semaphore(1)
         self._pending: set[asyncio.Task[list[Result]]] = set()
         self.search_visibility = search_visibility
@@ -91,13 +99,28 @@ class HistoryVectorIndex:
         self.task = asyncio.create_task(self._run(), name="talon-history-index")
 
     async def close(self) -> None:
-        """Finish the active batch before the caller closes database connections."""
+        """Finish the active batch before the caller closes database connections.
+
+        A Store write that never returns must not hold host shutdown open forever, so
+        the batch is abandoned once the deadline passes and retried on the next start.
+        """
         self.stopping = True
         self.wake.set()
-        if self.task is not None:
-            await self.task
-        if self._pending:
-            await asyncio.gather(*self._pending, return_exceptions=True)
+        tasks = [task for task in (self.task, *self._pending) if task is not None]
+        if not tasks:
+            return
+        _, unfinished = await asyncio.wait(tasks, timeout=_CLOSE_TIMEOUT_SECONDS)
+        if unfinished:
+            logger.warning(
+                "History vector indexing did not stop within %ss; abandoning the active batch "
+                "for the next start to retry",
+                _CLOSE_TIMEOUT_SECONDS,
+            )
+            for task in unfinished:
+                task.cancel()
+            await asyncio.gather(*unfinished, return_exceptions=True)
+        if self.task is not None and not self.task.cancelled() and (error := self.task.exception()):
+            raise error
 
     def namespace(self, channel: str, chat: str) -> tuple[str, ...]:
         """Build a collision-resistant namespace without Store-specific escaping.
@@ -109,8 +132,9 @@ class HistoryVectorIndex:
         return ("talon_history", self.identity, _digest(channel), _digest(chat))
 
     async def _batch(self, operations: Sequence[Op], *, query: bool = False) -> list[Result]:
-        slots = self._query_slots if query else self._slots
-        await slots.acquire()
+        slots = self._query_slots if query else None
+        if slots is not None:
+            await slots.acquire()
         task = asyncio.create_task(self._call_store(operations, slots))
         self._pending.add(task)
         task.add_done_callback(self._finished)
@@ -123,11 +147,15 @@ class HistoryVectorIndex:
             return await task
         return await asyncio.shield(task)
 
-    async def _call_store(self, operations: Sequence[Op], slots: asyncio.Semaphore) -> list[Result]:
+    async def _call_store(
+        self, operations: Sequence[Op], slots: asyncio.Semaphore | None
+    ) -> list[Result]:
         try:
-            return await self.store.abatch(operations)
+            async with asyncio.timeout(_BATCH_TIMEOUT_SECONDS):
+                return await self.store.abatch(operations)
         finally:
-            slots.release()
+            if slots is not None:
+                slots.release()
 
     def _finished(self, task: asyncio.Task[list[Result]]) -> None:
         self._pending.discard(task)
@@ -174,7 +202,12 @@ class HistoryVectorIndex:
             except Exception as error:  # noqa: BLE001  # Optional indexing must not stop conversation writes.
                 failures += 1
                 delay = _retry_delay(error, failures)
-                logger.warning("History vector indexing failed; pending work will be retried")
+                # Without the cause a permanently broken backend repeats an identical
+                # line forever; the adapter's dimension and credential errors name the
+                # exact settings that fix them.
+                logger.warning(
+                    "History vector indexing failed; retrying in %.0fs", delay, exc_info=error
+                )
             if failures:
                 await self._backoff(delay)
             else:
@@ -286,10 +319,13 @@ class HistoryVectorIndex:
             items = cast("list[SearchItem]", results[0])
             keys = [item.key for item in items if item.score is not None]
         except TimeoutError:
-            logger.warning("History vector search timed out; using keyword search")
+            logger.warning(
+                "History vector search timed out after %ss; using keyword search",
+                _SEARCH_TIMEOUT_SECONDS,
+            )
             return [], "timeout"
         except Exception:  # noqa: BLE001  # Search remains usable without the optional backend.
-            logger.warning("History vector search unavailable; using keyword search")
+            logger.warning("History vector search unavailable; using keyword search", exc_info=True)
             return [], "error"
         else:
             return keys, "unavailable" if items and not keys else "completed"

--- a/libs/talon/tests/unit_tests/test_history_vectors.py
+++ b/libs/talon/tests/unit_tests/test_history_vectors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from contextlib import asynccontextmanager
 
@@ -18,6 +19,7 @@ from deepagents_talon.history_backends import open_history
 from deepagents_talon.history_embeddings import QUERY_PROMPT, HistoryEmbeddings
 from deepagents_talon.history_profiles import EmbeddingProfile
 from deepagents_talon.sqlite_history import _HistorySqliteStore, sqlite_store
+from deepagents_talon.store_archive import StoreConversationArchive
 from tests.archive_helpers import open_vector_archive
 from tests.store_archive_contract import StaticEmbeddings as Embedding
 
@@ -150,6 +152,80 @@ async def test_failed_indexing_is_retried_after_restart(tmp_path):
         assert (
             ((await archive.search_page(SCOPE, query="automobile"))["results"])[0]["text"] == "car"
         )
+
+
+async def test_indexing_failure_logs_the_underlying_cause(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr("deepagents_talon.history_vectors._RETRY_SECONDS", 0.01)
+    monkeypatch.setattr("deepagents_talon.history_vectors.secrets.randbelow", lambda _bound: 0)
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.history_vectors")
+    failing = FailingEmbedding()
+    async with (
+        vector_store("memory", None, failing) as store,
+        open_vector_archive(str(tmp_path / "archive.sqlite"), store=store) as archive,
+    ):
+        await append(archive, "car")
+        await asyncio.wait_for(failing.failed.wait(), 2)
+        async with asyncio.timeout(3):
+            while True:
+                if any("indexing failed" in item.message for item in caplog.records):
+                    break
+                await asyncio.sleep(0.01)
+    # A permanently broken backend otherwise repeats one identical line forever.
+    record = next(item for item in caplog.records if "indexing failed" in item.message)
+    assert "embedding unavailable" in str(record.exc_info[1])
+
+
+async def test_close_abandons_a_wedged_indexing_batch(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr("deepagents_talon.history_vectors._CLOSE_TIMEOUT_SECONDS", 0.2)
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.history_vectors")
+    started = asyncio.Event()
+
+    class WedgedStore(InMemoryStore):
+        async def abatch(self, ops):
+            operations = list(ops)
+            if any(isinstance(op, PutOp) and op.value is not None for op in operations):
+                started.set()
+                await asyncio.Event().wait()
+            return await super().abatch(operations)
+
+    store = WedgedStore(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    # A Store write that never returns must not hold host shutdown open forever.
+    async with asyncio.timeout(5):
+        async with open_vector_archive(str(tmp_path / "archive.sqlite"), store=store) as archive:
+            await append(archive, "car")
+            await asyncio.wait_for(started.wait(), 2)
+    assert any("abandoning the active batch" in item.message for item in caplog.records)
+
+
+async def test_indexing_batches_never_overlap_so_they_need_no_permit():
+    active, peak = 0, 0
+
+    class CountingBatch(InMemoryStore):
+        async def abatch(self, ops):
+            nonlocal active, peak
+            operations = list(ops)
+            indexing = any(isinstance(op, PutOp) for op in operations)
+            active += indexing
+            peak = max(peak, active)
+            try:
+                await asyncio.sleep(0)
+                return await super().abatch(operations)
+            finally:
+                active -= indexing
+
+    store = CountingBatch(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    # Concurrency above one must not produce overlapping Store batches: the worker
+    # holds its lock across each one, which is why it carries no permit of its own.
+    profile = EmbeddingProfile(
+        adapter="openai-compatible", model="test", dims=2, max_input_tokens=512, concurrency=8
+    )
+    async with StoreConversationArchive(
+        InMemoryStore(), namespace=("serial",), vector_store=store, embedding_profile=profile
+    ).open() as archive:
+        for index in range(12):
+            await append(archive, f"car {index}", session=f"session-{index}")
+        await settled(archive)
+    assert peak == 1
 
 
 async def test_existing_vectors_survive_restart_and_do_not_reembed(tmp_path):
@@ -481,7 +557,8 @@ async def test_search_tool_pages_preserve_status_and_report_expired_cursors(tmp_
         assert expired["results"] == []
 
 
-async def test_search_backend_failure_reports_error(tmp_path):
+async def test_search_backend_failure_reports_error(tmp_path, caplog):
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.history_vectors")
     async with (
         vector_store("sqlite", tmp_path / "vectors.sqlite", FailingEmbedding()) as store,
         open_vector_archive(str(tmp_path / "archive.sqlite"), store=store) as archive,
@@ -490,6 +567,9 @@ async def test_search_backend_failure_reports_error(tmp_path):
         page = await archive.search_page(SCOPE, query="automobile")
         assert page["semantic_status"] == "error"
         assert page["results"] == []
+    # An operator needs the cause; the fallback alone cannot be diagnosed.
+    record = next(item for item in caplog.records if "search unavailable" in item.message)
+    assert "embedding unavailable" in str(record.exc_info[1])
 
 
 async def test_search_reports_store_without_semantic_support(tmp_path):


### PR DESCRIPTION
**Stack 2 of 4 — history/archive.** Based on `linted/talon/history-1-archive-scans` (#PREV). Review that one first.

Makes the vector-indexing worker diagnosable and bounded.

- **All indexing and search failures were swallowed with no exception detail.** The handlers bound `error` and used it only for the retry delay, so a permanently broken backend emitted an identical one-line warning every 30–300s forever — discarding a dimension-mismatch message that names the exact env vars that fix it.
- **`close()` could block forever.** The Store batch had no timeout at any level, so a wedged write hung `aclose()` and therefore host shutdown. Now bounded, with the batch cancelled after a shutdown deadline.
- **The `_slots` semaphore was dead.** Every non-query caller already held `self.lock` for the batch's duration, so `CONCURRENCY > 1` had no effect here — it read as if the worker honoured the setting for Store writes when it did not.

Note: the `close()` bound introduced a regression — a single `_pending` snapshot could miss a batch registered after it was taken — which is fixed in #6147 at the top of this stack. Flagged so a reviewer of this PR alone knows the sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
