### PR TITLE
fix(talon): share one optional-driver loader and close provider clients

### DIFF
--- a/libs/talon/deepagents_talon/archive.py
+++ b/libs/talon/deepagents_talon/archive.py
@@ -60,7 +60,7 @@ class SearchPage(TypedDict):
     pagination_status: Literal["ok", "expired"]
 
 
-def _search_page(
+def build_search_page(
     hits: list[ArchiveEntry],
     limit: int,
     status: SemanticStatus,
@@ -68,22 +68,38 @@ def _search_page(
     pending: bool = False,
     expired: bool = False,
 ) -> SearchPage:
+    """Build one page of results with its retrieval coverage, for any archive backend.
+
+    Args:
+        hits: Ranked entries, one more than `limit` when a further page exists.
+        limit: Maximum entries to return.
+        status: Whether semantic retrieval ran, degraded, or was not requested.
+        pending: Whether source records are still awaiting indexing.
+        expired: Whether the caller's continuation token no longer resolves.
+    """
     results = hits[:limit]
     has_more = len(hits) > limit
     return SearchPage(
         results=results,
         semantic_status=status,
         indexing_pending=pending,
-        indexing_status=_indexing_status(status, pending=pending, visibility="unknown"),
+        indexing_status=indexing_status(status, pending=pending, visibility="unknown"),
         has_more=has_more,
         next_after=str(results[-1]["cursor"]) if has_more else None,
         pagination_status="expired" if expired else "ok",
     )
 
 
-def _indexing_status(
+def indexing_status(
     status: SemanticStatus, *, pending: bool, visibility: SearchVisibility
 ) -> IndexingStatus:
+    """Report whether the index behind a search is known to be current.
+
+    Args:
+        status: Whether semantic retrieval ran, degraded, or was not requested.
+        pending: Whether source records are still awaiting indexing.
+        visibility: Whether acknowledged writes are immediately searchable.
+    """
     if status in {"disabled", "not_requested"}:
         return "not_requested"
     if pending:

--- a/libs/talon/deepagents_talon/history_adapters.py
+++ b/libs/talon/deepagents_talon/history_adapters.py
@@ -6,6 +6,7 @@ import asyncio
 import inspect
 import logging
 import math
+import time
 from contextlib import AsyncExitStack, asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import replace
@@ -31,6 +32,10 @@ EMBEDDING_CACHE: ContextVar[dict[tuple[bool, str], list[float]] | None] = Contex
     "talon_history_embeddings", default=None
 )
 _REQUEST_TIMEOUT = 30
+# A Store worker thread must never wait on the event loop indefinitely, so the
+# bridge polls for a loop that has stopped and enforces an overall deadline.
+_BRIDGE_TIMEOUT_SECONDS = 300
+_BRIDGE_POLL_SECONDS = 1
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +171,22 @@ class BoundedEmbeddings(Embeddings):
             operation.close()
             msg = "Use async history embeddings on the event loop"
             raise RuntimeError(msg)
-        return asyncio.run_coroutine_threadsafe(operation, self.loop).result()
+        future = asyncio.run_coroutine_threadsafe(operation, self.loop)
+        deadline = time.monotonic() + _BRIDGE_TIMEOUT_SECONDS
+        while True:
+            try:
+                return future.result(timeout=_BRIDGE_POLL_SECONDS)
+            except TimeoutError:
+                # A loop that has stopped will never run the coroutine, and waiting on
+                # it holds the Store's worker thread open through its own shutdown.
+                if self.loop.is_closed() or not self.loop.is_running():
+                    future.cancel()
+                    msg = "History embeddings stopped; the event loop is no longer running"
+                    raise RuntimeError(msg) from None
+                if time.monotonic() >= deadline:
+                    future.cancel()
+                    msg = "History embedding exceeded its deadline waiting for the event loop"
+                    raise RuntimeError(msg) from None
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Bridge Store worker threads to the owned async client."""

--- a/libs/talon/deepagents_talon/history_adapters.py
+++ b/libs/talon/deepagents_talon/history_adapters.py
@@ -107,7 +107,11 @@ async def _adapter(
         return HistoryVoyageEmbeddings(
             model=profile.model,
             api_key=_key(config, "VOYAGE_API_KEY"),
-            output_dimension=cast("Literal[256, 512, 1024, 2048]", profile.dims),
+            # Omitting the width leaves the model's native output, which is what
+            # SEND_DIMENSIONS=0 asks for when a model cannot resize.
+            output_dimension=cast("Literal[256, 512, 1024, 2048] | None", profile.dims)
+            if profile.send_dimensions
+            else None,
             batch_size=profile.batch_size,
             truncation=False,
             base_url=profile.base_url or "https://api.voyageai.com/v1",

--- a/libs/talon/deepagents_talon/history_adapters.py
+++ b/libs/talon/deepagents_talon/history_adapters.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
+import inspect
 import logging
 import math
 from contextlib import AsyncExitStack, asynccontextmanager
@@ -16,9 +16,10 @@ from langchain_core.embeddings import Embeddings
 from pydantic import SecretStr
 
 from deepagents_talon.config import TalonConfigError
+from deepagents_talon.history_drivers import load_driver
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Coroutine
+    from collections.abc import AsyncIterator, Callable, Coroutine
     from types import ModuleType
 
     from deepagents_talon.config import TalonConfig
@@ -49,17 +50,33 @@ async def open_profile(config: TalonConfig) -> AsyncIterator[EmbeddingProfile | 
         except Exception:  # noqa: BLE001  # Provider validation can include API keys.
             msg = "Could not initialize history embeddings; check the selected adapter and settings"
             raise TalonConfigError(msg) from None
+        # Registered here rather than per adapter: `atlas` and `voyage` previously
+        # had no cleanup at all, and a reindex reopens the archive, so a client that
+        # keeps its pool past close leaks sockets on every cycle.
+        _register_close(stack, embed)
         if profile.client_side:
             embed = BoundedEmbeddings(embed, profile)
         yield replace(profile, embed=embed)
 
 
+async def _close_client(closer: Callable[[], object]) -> None:
+    # A synchronous close tears down sockets, so it runs off the event loop; an
+    # async one only builds its coroutine there and is awaited here.
+    result = await asyncio.to_thread(closer)
+    if inspect.isawaitable(result):
+        await result
+
+
+def _register_close(stack: AsyncExitStack, embed: object) -> None:
+    for name in ("aclose", "close"):
+        closer = getattr(embed, name, None)
+        if callable(closer):
+            stack.push_async_callback(_close_client, closer)
+            return
+
+
 def _driver(module: str, extra: str) -> ModuleType:
-    try:
-        return importlib.import_module(module)
-    except ImportError:
-        msg = f"History embeddings require deepagents-talon[{extra}]: uv sync --extra {extra}"
-        raise ImportError(msg) from None
+    return load_driver(module, extra, "History embeddings require")
 
 
 async def _adapter(
@@ -69,14 +86,12 @@ async def _adapter(
         _driver("sentence_transformers", "history-local")
         from deepagents_talon.history_embeddings import HistoryEmbeddings  # noqa: PLC0415
 
-        embed = HistoryEmbeddings(
+        return HistoryEmbeddings(
             model=profile.model,
             max_input_tokens=profile.max_input_tokens,
             batch_size=profile.batch_size,
             query_prompt="",
         )
-        stack.push_async_callback(embed.aclose)
-        return embed
     if profile.adapter == "atlas":
         driver = _driver("langchain_mongodb.embeddings", "mongodb")
         return driver.AutoEmbeddings(model=profile.model)

--- a/libs/talon/deepagents_talon/history_backends.py
+++ b/libs/talon/deepagents_talon/history_backends.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from functools import partial
 from importlib.metadata import EntryPoint, entry_points
@@ -14,6 +13,7 @@ import aiosqlite
 from langgraph.store.sqlite.aio import AsyncSqliteStore
 
 from deepagents_talon.config import TalonConfigError
+from deepagents_talon.history_drivers import load_driver
 from deepagents_talon.store_archive import StoreConversationArchive
 from deepagents_talon.store_records import finish
 
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
     from deepagents_talon.history_profiles import EmbeddingProfile
 
 _STARTUP_TIMEOUT = 15
+# Atlas index creation legitimately outlasts connection setup, so it is budgeted
+# separately rather than squeezed into the shared startup deadline.
+_AUTO_INDEX_TIMEOUT = 60
 _MAX_HNSW_DIMS = 2000
 type StoreFactory = Callable[[str], AbstractAsyncContextManager[BaseStore]]
 
@@ -144,11 +147,7 @@ async def _sqlite_store(uri: str) -> AsyncIterator[BaseStore]:
 
 
 def _driver(module: str, extra: str) -> ModuleType:
-    try:
-        return importlib.import_module(module)
-    except ImportError:
-        msg = f"History backend requires deepagents-talon[{extra}]: uv sync --extra {extra}"
-        raise ImportError(msg) from None
+    return load_driver(module, extra, "History backend requires")
 
 
 @asynccontextmanager
@@ -198,37 +197,44 @@ async def _mongodb_store(
     pymongo = _driver("pymongo", "mongodb")
     async with AsyncExitStack() as stack:
         try:
-            client = pymongo.MongoClient(
-                uri,
-                connect=False,
-                serverSelectionTimeoutMS=10000,
-                connectTimeoutMS=10000,
-                socketTimeoutMS=10000,
-                readPreference="primary",
-                w="majority",
-            )
-            stack.push_async_callback(asyncio.to_thread, client.close)
-            target = client.get_default_database()[collection]
-            config = (
-                driver.create_vector_index_config(
-                    embed=index["embed"],
-                    dims=-1 if profile and not profile.client_side else index["dims"],
-                    fields=["text"],
-                    relevance_score_fn=None if profile and not profile.client_side else "cosine",
-                    embedding_key="embedding",
+            # `finish()` deliberately runs to completion, so this deadline bounds
+            # connection setup and teardown around the store build rather than
+            # interrupting it; `auto_index_timeout` is what bounds the build itself.
+            async with asyncio.timeout(_STARTUP_TIMEOUT + _AUTO_INDEX_TIMEOUT):
+                client = pymongo.MongoClient(
+                    uri,
+                    connect=False,
+                    serverSelectionTimeoutMS=10000,
+                    connectTimeoutMS=10000,
+                    socketTimeoutMS=10000,
+                    readPreference="primary",
+                    w="majority",
                 )
-                if index is not None
-                else None
-            )
-            store = await finish(
-                asyncio.to_thread(
-                    driver.MongoDBStore,
-                    target,
-                    index_config=config,
-                    auto_index_timeout=60,
-                    query_model=profile.query_model or None if profile else None,
+                stack.push_async_callback(asyncio.to_thread, client.close)
+                target = client.get_default_database()[collection]
+                config = (
+                    driver.create_vector_index_config(
+                        embed=index["embed"],
+                        dims=-1 if profile and not profile.client_side else index["dims"],
+                        fields=["text"],
+                        relevance_score_fn=None
+                        if profile and not profile.client_side
+                        else "cosine",
+                        embedding_key="embedding",
+                    )
+                    if index is not None
+                    else None
                 )
-            )
+                store = await finish(
+                    asyncio.to_thread(
+                        driver.MongoDBStore,
+                        target,
+                        index_config=config,
+                        auto_index_timeout=_AUTO_INDEX_TIMEOUT,
+                        query_model=profile.query_model or None if profile else None,
+                    )
+                )
+                stack.push_async_callback(_stop_dispatcher, store)
         except Exception:  # noqa: BLE001  # Driver startup errors may contain URI credentials.
             msg = "Could not initialize MongoDB history; check the URI, server, and permissions"
             raise TalonConfigError(msg) from None

--- a/libs/talon/deepagents_talon/history_drivers.py
+++ b/libs/talon/deepagents_talon/history_drivers.py
@@ -1,0 +1,36 @@
+"""Load optional providers with install guidance that preserves the real cause."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def load_driver(module: str, extra: str, subject: str) -> ModuleType:
+    """Import an optional provider, naming the extra only when that extra is missing.
+
+    Args:
+        module: Importable module supplied by the extra.
+        extra: Project extra that installs it.
+        subject: Sentence lead-in ending in its verb, e.g. `History backend requires`.
+
+    Raises:
+        ImportError: The extra is absent, or the module itself failed to import. An
+            installed extra that fails for its own reason (a broken native
+            dependency, a missing system library) re-raises unchanged, because
+            telling the user to install what they already have hides the cause.
+    """
+    try:
+        return importlib.import_module(module)
+    except ImportError as error:
+        if (
+            error.name is not None
+            and module != error.name
+            and not module.startswith(error.name + ".")
+        ):
+            raise
+        msg = f"{subject} deepagents-talon[{extra}]: uv sync --extra {extra}"
+        raise ImportError(msg) from error

--- a/libs/talon/deepagents_talon/history_postgres.py
+++ b/libs/talon/deepagents_talon/history_postgres.py
@@ -1,4 +1,12 @@
-"""Isolate pgvector dimensions and migrations by embedding generation."""
+"""Isolate pgvector dimensions and migrations by embedding generation.
+
+This module drives internals of `langgraph-checkpoint-postgres` that are not public
+API: `store.VECTOR_MIGRATIONS`, each migration's `condition` and `_replace`, and the
+`dict_row` cursor factory behind the cast in `_vector_table`. A rename inside 3.x
+would not fail loudly - it would leave the migration rewrite below a silent no-op -
+so the `postgres` extra pins that dependency to a single minor version. Widening the
+pin means re-checking those four couplings first.
+"""
 
 from __future__ import annotations
 
@@ -45,6 +53,7 @@ async def _vector_table(store: AsyncPostgresStore, schema: sql.Identifier, dims:
         "WHERE e.extname='vector'"
     )
     row = await cursor.fetchone()
+    await cursor.close()
     if row is None:
         msg = "PostgreSQL vector extension is unavailable"
         raise RuntimeError(msg)

--- a/libs/talon/deepagents_talon/history_prepared_store.py
+++ b/libs/talon/deepagents_talon/history_prepared_store.py
@@ -9,7 +9,7 @@ from langgraph.store.base import BaseStore, PutOp, SearchOp
 from deepagents_talon.history_adapters import EMBEDDING_CACHE
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
     from langchain_core.embeddings import Embeddings
     from langgraph.store.base import Op, Result
@@ -24,17 +24,27 @@ class PreparedVectorStore(BaseStore):
         self.embed = embed
 
     def batch(self, ops: Iterable[Op]) -> list[Result]:
-        """Delegate synchronous operations to the underlying Store."""
-        return self.store.batch(ops)
+        """Refuse synchronous operations, which would bypass vector preparation.
+
+        Delegating would reach the inner Store with an empty cache, so embedding
+        would run from its worker thread inside the database lock - the exact
+        failure this wrapper exists to prevent.
+
+        Raises:
+            NotImplementedError: Always; use the async Store API.
+        """
+        msg = "History vectors require the async Store API; a synchronous batch cannot prepare them"
+        raise NotImplementedError(msg)
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:
         """Prepare complete document and query vectors before Store I/O."""
         operations = list(ops)
         documents = list(
             dict.fromkeys(
-                str(op.value["text"])
+                text
                 for op in operations
                 if isinstance(op, PutOp) and op.value is not None and op.index is not False
+                for text in _indexed(op)
             )
         )
         cache = {
@@ -59,3 +69,15 @@ class PreparedVectorStore(BaseStore):
             return await self.store.abatch(operations)
         finally:
             EMBEDDING_CACHE.reset(token)
+
+
+def _indexed(op: PutOp) -> Iterator[str]:
+    """Yield the fields this write will embed, without assuming they are named `text`."""
+    # `index=None` defers to the Store's own configuration, which is not visible from
+    # here; `text` is what the archive configures. A structured path is left to the
+    # Store, which then embeds it itself instead of reading a prepared vector.
+    fields = op.index if isinstance(op.index, (list, tuple)) else ("text",)
+    for field in fields:
+        value = op.value.get(field) if op.value is not None else None
+        if value is not None and not any(token in field for token in ".[$"):
+            yield str(value)

--- a/libs/talon/deepagents_talon/history_profiles.py
+++ b/libs/talon/deepagents_talon/history_profiles.py
@@ -256,6 +256,17 @@ def _validate_profile(profile: EmbeddingProfile) -> None:
     if profile.adapter == "atlas" and (profile.query_prompt or profile.base_url):
         msg = "Atlas manages embedding prompts and endpoints server-side"
         raise TalonConfigError(msg)
+    if profile.adapter == "local" and profile.base_url:
+        # `base_url` enters the fingerprint, so accepting one the adapter never reads
+        # would demand a full reindex for a setting that changes nothing.
+        msg = f"{_PREFIX}BASE_URL does not apply to the local adapter, which loads its own model"
+        raise TalonConfigError(msg)
+    if not profile.send_dimensions and profile.adapter in {"local", "atlas"}:
+        msg = (
+            f"{_PREFIX}SEND_DIMENSIONS applies only to the voyage and openai-compatible "
+            "adapters; this one cannot request an output width"
+        )
+        raise TalonConfigError(msg)
     if profile.query_model and profile.adapter != "atlas":
         msg = "A separate history query model is supported only by Atlas"
         raise TalonConfigError(msg)

--- a/libs/talon/deepagents_talon/history_vector_backends.py
+++ b/libs/talon/deepagents_talon/history_vector_backends.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from contextlib import asynccontextmanager
 from importlib.metadata import entry_points
@@ -13,9 +14,8 @@ from langgraph.store.base import PutOp
 
 from deepagents_talon.config import TalonConfigError
 from deepagents_talon.history_vectors import HistoryVectorIndex
-from deepagents_talon.store_archive import number
 from deepagents_talon.store_archive_index import StoreVectorArchive
-from deepagents_talon.store_records import finish
+from deepagents_talon.store_records import finish, number
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable
@@ -26,6 +26,10 @@ if TYPE_CHECKING:
     from deepagents_talon.config import TalonConfig
     from deepagents_talon.history_profiles import EmbeddingProfile
     from deepagents_talon.store_archive import StoreConversationArchive
+
+logger = logging.getLogger(__name__)
+_ERASE_BATCH = 96
+_PROGRESS_SECONDS = 5
 
 
 async def prepare_generation(config: TalonConfig, archive: StoreConversationArchive) -> str | None:
@@ -74,29 +78,43 @@ async def prepare_generation(config: TalonConfig, archive: StoreConversationArch
 
 async def _erase_vectors(archive: StoreConversationArchive, store: BaseStore) -> None:
     records = archive.records
-    root = await records.root()
+    # Reads run under `access()`, which replays an interrupted journal first; the
+    # caller already recovers, but this function must not depend on that.
+    async with records.access():
+        root = await records.root()
     index = HistoryVectorIndex(StoreVectorArchive(archive), store, indexing=False)
     index.identity = str(root["identity"])
     cursor, last = number(root, "reindex_cursor"), number(root, "last")
+    start, reported = cursor, asyncio.get_running_loop().time()
     while cursor < last:
-        stop = min(cursor + 96, last)
+        stop = min(cursor + _ERASE_BATCH, last)
         operations: list[PutOp] = []
-        for identifier in range(cursor + 1, stop + 1):
-            record = await records.get(str(identifier))
-            if record is not None and record.get("kind") == "chunk":
-                owner = await records.get(str(number(record, "owner")))
-                if owner is not None:
-                    scope = cast("dict[str, str]", owner["scope"])
-                    namespace = index.namespace(
-                        scope["talon_history_channel"], scope["talon_history_chat"]
-                    )
-                    operations.append(PutOp(namespace, str(identifier), None))
+        async with records.access():
+            for identifier in range(cursor + 1, stop + 1):
+                record = await records.get(str(identifier))
+                if record is not None and record.get("kind") == "chunk":
+                    owner = await records.get(str(number(record, "owner")))
+                    if owner is not None:
+                        scope = cast("dict[str, str]", owner["scope"])
+                        namespace = index.namespace(
+                            scope["talon_history_channel"], scope["talon_history_chat"]
+                        )
+                        operations.append(PutOp(namespace, str(identifier), None))
         if operations:
             await finish(store.abatch(operations))
         cursor = stop
         async with records.access():
             root = await records.root()
             await records.commit([("root", {**root, "reindex_cursor": cursor})])
+        # This runs before the host serves anything and is O(archive), so a large
+        # rebuild otherwise looks like a hang. Progress is durable in
+        # `reindex_cursor`, so an interrupted rebuild resumes where it stopped.
+        now = asyncio.get_running_loop().time()
+        if now - reported >= _PROGRESS_SECONDS:
+            reported = now
+            logger.info(
+                "Rebuilding history vectors: erased %d of %d records", cursor - start, last - start
+            )
 
 
 @asynccontextmanager

--- a/libs/talon/deepagents_talon/history_vectors.py
+++ b/libs/talon/deepagents_talon/history_vectors.py
@@ -38,6 +38,13 @@ _MAX_SEARCH_PAGES = 32
 _BATCH_SIZE = 4
 _RETRY_SECONDS = 30
 _SEARCH_TIMEOUT_SECONDS = 2
+# One indexing batch embeds up to 500 chunks in sequential provider requests, each
+# already bounded by the adapter's own request timeout, so this only has to catch a
+# Store write that never returns at all.
+_BATCH_TIMEOUT_SECONDS = 300
+# Unacknowledged work is retried from durable state on the next start, so abandoning
+# a wedged batch at shutdown costs a repeat, never data.
+_CLOSE_TIMEOUT_SECONDS = 10
 
 
 @dataclass
@@ -70,8 +77,9 @@ class HistoryVectorIndex:
     ) -> None:
         """Keep indexing separate from checkpoint persistence."""
         self.profile = profile
-        self._slots = asyncio.Semaphore(profile.concurrency if profile else 1)
-        # Indexing can occupy every configured slot, so a search holds its own.
+        # Indexing needs no permit of its own: every non-query caller holds `self.lock`
+        # for the whole batch, so at most one is ever outstanding. Provider concurrency
+        # is bounded by `BoundedEmbeddings.slots` instead.
         self._query_slots = asyncio.Semaphore(1)
         self._pending: set[asyncio.Task[list[Result]]] = set()
         self.search_visibility = search_visibility
@@ -91,13 +99,28 @@ class HistoryVectorIndex:
         self.task = asyncio.create_task(self._run(), name="talon-history-index")
 
     async def close(self) -> None:
-        """Finish the active batch before the caller closes database connections."""
+        """Finish the active batch before the caller closes database connections.
+
+        A Store write that never returns must not hold host shutdown open forever, so
+        the batch is abandoned once the deadline passes and retried on the next start.
+        """
         self.stopping = True
         self.wake.set()
-        if self.task is not None:
-            await self.task
-        if self._pending:
-            await asyncio.gather(*self._pending, return_exceptions=True)
+        tasks = [task for task in (self.task, *self._pending) if task is not None]
+        if not tasks:
+            return
+        _, unfinished = await asyncio.wait(tasks, timeout=_CLOSE_TIMEOUT_SECONDS)
+        if unfinished:
+            logger.warning(
+                "History vector indexing did not stop within %ss; abandoning the active batch "
+                "for the next start to retry",
+                _CLOSE_TIMEOUT_SECONDS,
+            )
+            for task in unfinished:
+                task.cancel()
+            await asyncio.gather(*unfinished, return_exceptions=True)
+        if self.task is not None and not self.task.cancelled() and (error := self.task.exception()):
+            raise error
 
     def namespace(self, channel: str, chat: str) -> tuple[str, ...]:
         """Build a collision-resistant namespace without Store-specific escaping.
@@ -109,8 +132,9 @@ class HistoryVectorIndex:
         return ("talon_history", self.identity, _digest(channel), _digest(chat))
 
     async def _batch(self, operations: Sequence[Op], *, query: bool = False) -> list[Result]:
-        slots = self._query_slots if query else self._slots
-        await slots.acquire()
+        slots = self._query_slots if query else None
+        if slots is not None:
+            await slots.acquire()
         task = asyncio.create_task(self._call_store(operations, slots))
         self._pending.add(task)
         task.add_done_callback(self._finished)
@@ -123,11 +147,15 @@ class HistoryVectorIndex:
             return await task
         return await asyncio.shield(task)
 
-    async def _call_store(self, operations: Sequence[Op], slots: asyncio.Semaphore) -> list[Result]:
+    async def _call_store(
+        self, operations: Sequence[Op], slots: asyncio.Semaphore | None
+    ) -> list[Result]:
         try:
-            return await self.store.abatch(operations)
+            async with asyncio.timeout(_BATCH_TIMEOUT_SECONDS):
+                return await self.store.abatch(operations)
         finally:
-            slots.release()
+            if slots is not None:
+                slots.release()
 
     def _finished(self, task: asyncio.Task[list[Result]]) -> None:
         self._pending.discard(task)
@@ -174,7 +202,12 @@ class HistoryVectorIndex:
             except Exception as error:  # noqa: BLE001  # Optional indexing must not stop conversation writes.
                 failures += 1
                 delay = _retry_delay(error, failures)
-                logger.warning("History vector indexing failed; pending work will be retried")
+                # Without the cause a permanently broken backend repeats an identical
+                # line forever; the adapter's dimension and credential errors name the
+                # exact settings that fix them.
+                logger.warning(
+                    "History vector indexing failed; retrying in %.0fs", delay, exc_info=error
+                )
             if failures:
                 await self._backoff(delay)
             else:
@@ -286,10 +319,13 @@ class HistoryVectorIndex:
             items = cast("list[SearchItem]", results[0])
             keys = [item.key for item in items if item.score is not None]
         except TimeoutError:
-            logger.warning("History vector search timed out; using keyword search")
+            logger.warning(
+                "History vector search timed out after %ss; using keyword search",
+                _SEARCH_TIMEOUT_SECONDS,
+            )
             return [], "timeout"
         except Exception:  # noqa: BLE001  # Search remains usable without the optional backend.
-            logger.warning("History vector search unavailable; using keyword search")
+            logger.warning("History vector search unavailable; using keyword search", exc_info=True)
             return [], "error"
         else:
             return keys, "unavailable" if items and not keys else "completed"

--- a/libs/talon/deepagents_talon/history_vectors.py
+++ b/libs/talon/deepagents_talon/history_vectors.py
@@ -20,8 +20,8 @@ from deepagents_talon.archive import (
     SearchPage,
     SearchVisibility,
     SemanticStatus,
-    _indexing_status,
-    _search_page,
+    build_search_page,
+    indexing_status,
 )
 
 if TYPE_CHECKING:
@@ -106,10 +106,24 @@ class HistoryVectorIndex:
         """
         self.stopping = True
         self.wake.set()
-        tasks = [task for task in (self.task, *self._pending) if task is not None]
-        if not tasks:
-            return
-        _, unfinished = await asyncio.wait(tasks, timeout=_CLOSE_TIMEOUT_SECONDS)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _CLOSE_TIMEOUT_SECONDS
+        # `_pending` is not stable here. `stopping` is only checked at the top of the
+        # worker's loop, so a worker already inside an iteration still registers its
+        # Store task afterwards - and `_batch` shields that task, so cancelling the
+        # worker does not stop it. A single snapshot would let `close()` return while
+        # a write is in flight, and the caller then tears the Store down underneath it.
+        while True:
+            tasks = [
+                task for task in (self.task, *self._pending) if task is not None and not task.done()
+            ]
+            remaining = deadline - loop.time()
+            if not tasks or remaining <= 0:
+                break
+            await asyncio.wait(tasks, timeout=remaining)
+        unfinished = [
+            task for task in (self.task, *self._pending) if task is not None and not task.done()
+        ]
         if unfinished:
             logger.warning(
                 "History vector indexing did not stop within %ss; abandoning the active batch "
@@ -256,7 +270,7 @@ class HistoryVectorIndex:
         if after and (
             snapshot is None or snapshot.query != cache_key or cursor not in snapshot.keys
         ):
-            return _search_page(
+            return build_search_page(
                 [],
                 limit,
                 "not_requested",
@@ -277,13 +291,13 @@ class HistoryVectorIndex:
         if len(self._pages) > _MAX_SEARCH_PAGES:
             self._pages.popitem(last=False)
         hits = await self.archive.ranked(scope, snapshot.keys, int(cursor or 0), limit + 1)
-        page = _search_page(
+        page = build_search_page(
             hits,
             limit,
             snapshot.status,
             pending=pending or snapshot.pending,
         )
-        page["indexing_status"] = _indexing_status(
+        page["indexing_status"] = indexing_status(
             snapshot.status, pending=page["indexing_pending"], visibility=self.search_visibility
         )
         if page["next_after"] is not None:

--- a/libs/talon/deepagents_talon/history_voyage.py
+++ b/libs/talon/deepagents_talon/history_voyage.py
@@ -1,5 +1,7 @@
 """Voyage adapter for inputs already bounded by the history profile."""
 
+import asyncio
+import inspect
 from collections.abc import Generator
 from typing import Self
 
@@ -29,6 +31,17 @@ class HistoryVoyageEmbeddings(VoyageAIEmbeddings):
             max_retries=0,
         )
         return self
+
+    async def aclose(self) -> None:
+        """Release both SDK connection pools; a reindex reopens the archive."""
+        for client in (self._client, self._aclient):
+            for name in ("aclose", "close"):
+                closer = getattr(client, name, None)
+                if callable(closer):
+                    result = await asyncio.to_thread(closer)
+                    if inspect.isawaitable(result):
+                        await result
+                    break
 
     def _build_batches(self, texts: list[str]) -> Generator[tuple[list[str], int], None, None]:
         # Upstream's batching downloads tokenizers synchronously, even for async calls.

--- a/libs/talon/deepagents_talon/store_archive.py
+++ b/libs/talon/deepagents_talon/store_archive.py
@@ -17,8 +17,17 @@ from uuid import uuid4
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
-from deepagents_talon.archive import CHUNK_SIZE, _search_page
-from deepagents_talon.store_records import Record, StoreRecords, Write, digest
+from deepagents_talon.archive import CHUNK_SIZE, build_search_page
+from deepagents_talon.history_vectors import HistoryVectorIndex
+from deepagents_talon.store_archive_index import StoreVectorArchive
+from deepagents_talon.store_records import (
+    Record,
+    StoreRecords,
+    Write,
+    digest,
+    number,
+    scope_key,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator, Sequence
@@ -38,16 +47,6 @@ if TYPE_CHECKING:
 _MAX_PAGE_SIZE = 20
 _MAX_SCAN = 500
 _MAX_SEARCH_PAGES = 32
-
-
-def number(record: Record, key: str) -> int:
-    """Read a numeric ordering field from a versioned archive record."""
-    return cast("int", record.get(key, 0))
-
-
-def scope_key(scope: ArchiveScope) -> str:
-    """Encode a trusted chat scope as a backend-independent lookup key."""
-    return "scope:" + digest(scope["talon_history_channel"], scope["talon_history_chat"])
 
 
 def _bounds(after: int, limit: int) -> None:
@@ -120,9 +119,6 @@ class StoreConversationArchive:
         self._setup_lock = asyncio.Lock()
         self.vectors = None
         if vector_store is not None:
-            from deepagents_talon.history_vectors import HistoryVectorIndex  # noqa: PLC0415
-            from deepagents_talon.store_archive_index import StoreVectorArchive  # noqa: PLC0415
-
             self.vectors = HistoryVectorIndex(
                 StoreVectorArchive(self),
                 vector_store,
@@ -299,7 +295,7 @@ class StoreConversationArchive:
             return None
         return entry
 
-    async def _text_entries(  # noqa: PLR0913  # Preserve existing arguments when adding partial scans.
+    async def text_entries(  # noqa: PLR0913  # Preserve existing arguments when adding partial scans.
         self,
         scope: ArchiveScope,
         *,
@@ -309,6 +305,20 @@ class StoreConversationArchive:
         limit: int,
         partial: bool = False,
     ) -> list[ArchiveEntry]:
+        """Read scoped transcripts by ordering link, for this archive's own adapters.
+
+        Args:
+            scope: Trusted channel and chat identity.
+            query: Literal words to match against complete message revisions.
+            session_id: Read this session chronologically when supplied.
+            after: Previous result cursor.
+            limit: Maximum entries to return.
+            partial: Stop at the scan budget instead of raising; only for ranked
+                candidate generation, never for a page that claims completeness.
+
+        Raises:
+            RuntimeError: The scan budget is exhausted and `partial` is not set.
+        """
         async with self.records.access():
             if session_id:
                 session = await self.session(session_id)
@@ -385,7 +395,7 @@ class StoreConversationArchive:
         """
         _bounds(after, limit)
         await self.setup()
-        return await self._text_entries(
+        return await self.text_entries(
             scope, query=query, session_id=session_id, after=after, limit=limit
         )
 
@@ -413,12 +423,12 @@ class StoreConversationArchive:
         continuation = self._pages.get(after) if after else None
         status = "disabled" if query.strip() else "not_requested"
         if after and (continuation is None or continuation[:3] != context):
-            return _search_page([], limit, status, expired=True)
+            return build_search_page([], limit, status, expired=True)
         cursor = continuation[3] if continuation else 0
-        hits = await self._text_entries(
+        hits = await self.text_entries(
             scope, query=query, session_id="", after=cursor, limit=limit + 1
         )
-        page = _search_page(hits, limit, status, expired=bool(after and not hits))
+        page = build_search_page(hits, limit, status, expired=bool(after and not hits))
         if page["has_more"]:
             token = uuid4().hex
             self._pages[token] = (*context, page["results"][-1]["cursor"])

--- a/libs/talon/deepagents_talon/store_archive_index.py
+++ b/libs/talon/deepagents_talon/store_archive_index.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from deepagents_talon.store_archive import number, scope_key
+from deepagents_talon.history_index import VectorArchive
+from deepagents_talon.store_records import number, scope_key
 
 if TYPE_CHECKING:
     from deepagents_talon.archive import ArchiveEntry, ArchiveScope
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from deepagents_talon.store_records import Record
 
 
-class StoreVectorArchive:
+class StoreVectorArchive(VectorArchive):
     """Reconcile immutable archive entries instead of maintaining a SQL queue."""
 
     def __init__(self, archive: StoreConversationArchive) -> None:
@@ -145,7 +146,7 @@ class StoreVectorArchive:
         fused with the semantic ranking, so a short list degrades recall while a
         raised error would fail a search the semantic leg had already answered.
         """
-        entries = await self.archive._text_entries(  # noqa: SLF001  # Storage adapter shares archive retrieval.
+        entries = await self.archive.text_entries(
             scope,
             query=query,
             session_id="",

--- a/libs/talon/deepagents_talon/store_records.py
+++ b/libs/talon/deepagents_talon/store_records.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
     from langgraph.store.base import BaseStore
 
+    from deepagents_talon.archive import ArchiveScope
+
 Record = dict[str, object]
 Write = tuple[str, Record | None]
 _MAX_WRITES = 12
@@ -22,6 +24,16 @@ _MAX_WRITES = 12
 def digest(*values: str) -> str:
     """Hash identifiers without relying on backend namespace escaping."""
     return hashlib.sha256(json.dumps(values, ensure_ascii=True).encode()).hexdigest()
+
+
+def number(record: Record, key: str) -> int:
+    """Read a numeric ordering field from a versioned archive record."""
+    return cast("int", record.get(key, 0))
+
+
+def scope_key(scope: ArchiveScope) -> str:
+    """Encode a trusted chat scope as a backend-independent lookup key."""
+    return "scope:" + digest(scope["talon_history_channel"], scope["talon_history_chat"])
 
 
 async def finish[T](operation: Coroutine[object, object, T]) -> T:

--- a/libs/talon/pyproject.toml
+++ b/libs/talon/pyproject.toml
@@ -41,7 +41,11 @@ mongodb = [
     "langgraph-store-mongodb>=0.4.0,<0.5.0",
 ]
 postgres = [
-    "langgraph-checkpoint-postgres>=3.1.2,<4.0.0",
+    # Pinned to one minor rather than the usual <4.0.0: history_postgres.py drives
+    # `store.VECTOR_MIGRATIONS`, `migration.condition`, `migration._replace` and the
+    # `dict_row` cursor factory, none of which are public API. A rename inside 3.x
+    # would not fail loudly - it would leave the migration rewrite a silent no-op.
+    "langgraph-checkpoint-postgres>=3.1.2,<3.2.0",
     "psycopg[binary]>=3.3.5,<4.0.0",
 ]
 media = [

--- a/libs/talon/tests/unit_tests/test_history_backends.py
+++ b/libs/talon/tests/unit_tests/test_history_backends.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import threading
 import traceback
 from collections import defaultdict
@@ -13,7 +14,7 @@ import pytest
 from langchain_core.messages import HumanMessage
 from langgraph.store.memory import InMemoryStore
 
-from deepagents_talon import history_adapters, history_backends
+from deepagents_talon import history_adapters, history_backends, history_drivers
 from deepagents_talon.archive import ArchiveScope
 from deepagents_talon.config import TalonConfig, TalonConfigError
 from deepagents_talon.history_backends import open_history
@@ -23,6 +24,10 @@ if TYPE_CHECKING:
 
 URI_KEY = "DEEPAGENTS_TALON_HISTORY_URI"
 SCOPE = ArchiveScope(talon_history_channel="test", talon_history_chat="one")
+_BROKEN_DRIVERS = [
+    ("mongodb", "langgraph.store.mongodb"),
+    ("postgresql", "langgraph.store.postgres.aio"),
+]
 
 
 @pytest.mark.parametrize("scheme", ["mongodb", "mongodb+srv", "postgres", "postgresql", "mysql"])
@@ -167,15 +172,11 @@ class FakeDatabase:
         return self.uri, name
 
 
-def fake_backend(monkeypatch, *, failing=False, started=None, release=None):
-    store = InMemoryStore()
-    mongo_data = defaultdict(InMemoryStore)
+async def _setup_generation(*_args: object):
+    return None
 
-    async def setup_generation(*_args: object):
-        return None
 
-    state = SimpleNamespace(closed=False, dispatcher=None)
-
+def fake_client(state):
     class Client:
         def __init__(self, uri, **_kwargs: object) -> None:
             self.uri = uri
@@ -186,6 +187,32 @@ def fake_backend(monkeypatch, *, failing=False, started=None, release=None):
         def close(self):
             state.closed = True
 
+    return Client
+
+
+def fake_driver(state, store, mongo_store, failing):
+    def driver(module, _extra):
+        if module == "pymongo":
+            return SimpleNamespace(MongoClient=fake_client(state))
+        if module == "langgraph.store.mongodb" and not failing:
+            # Real MongoDBStore inherits AsyncBatchedBaseStore's dispatcher task; a
+            # store whose construction fails never starts one.
+            state.dispatcher = asyncio.create_task(asyncio.Event().wait())
+        return SimpleNamespace(
+            AsyncPostgresStore=postgres_driver(store, state, failing),
+            MongoDBStore=mongo_store,
+            create_vector_index_config=lambda **kwargs: kwargs,
+            setup_generation=_setup_generation,
+        )
+
+    return driver
+
+
+def fake_backend(monkeypatch, *, failing=False, started=None, release=None):
+    store = InMemoryStore()
+    mongo_data = defaultdict(InMemoryStore)
+    state = SimpleNamespace(closed=False, dispatcher=None)
+
     def mongo_store(target, *, index_config=None, **_kwargs: object):
         uri, collection = target
         if started is not None:
@@ -193,22 +220,20 @@ def fake_backend(monkeypatch, *, failing=False, started=None, release=None):
             release.wait(timeout=5)
         if failing:
             raise RuntimeError(uri)
-        backend = InMemoryStore(index=index_config)
+
+        class Dispatching(InMemoryStore):
+            # InMemoryStore is slotted; the dispatcher task needs a __dict__.
+            pass
+
+        backend = Dispatching(index=index_config)
         backend._data = mongo_data[collection]._data
         backend._vectors = mongo_data[collection]._vectors
+        backend._task = state.dispatcher
         return backend
 
-    def driver(module, _extra):
-        if module == "pymongo":
-            return SimpleNamespace(MongoClient=Client)
-        return SimpleNamespace(
-            AsyncPostgresStore=postgres_driver(store, state, failing),
-            MongoDBStore=mongo_store,
-            create_vector_index_config=lambda **kwargs: kwargs,
-            setup_generation=setup_generation,
-        )
-
-    monkeypatch.setattr(history_backends, "_driver", driver)
+    monkeypatch.setattr(
+        history_backends, "_driver", fake_driver(state, store, mongo_store, failing)
+    )
     return state
 
 
@@ -284,11 +309,32 @@ async def test_missing_backend_extra_has_install_guidance(tmp_path, monkeypatch,
         msg = "missing optional driver"
         raise ModuleNotFoundError(msg)
 
-    monkeypatch.setattr(history_backends.importlib, "import_module", missing)
+    monkeypatch.setattr(history_drivers.importlib, "import_module", missing)
     config = TalonConfig.from_env({URI_KEY: f"{scheme}://localhost/talon"}, base_home=tmp_path)
     with pytest.raises(ImportError, match=f"uv sync --extra {extra}"):
         async with open_history(config):
             pytest.fail("missing backend must not fall back to SQLite")
+
+
+@pytest.mark.parametrize(("scheme", "module"), _BROKEN_DRIVERS)
+async def test_installed_backend_reports_its_own_import_failure(
+    tmp_path, monkeypatch, scheme, module
+):
+    real = importlib.import_module
+
+    def broken(name):
+        if name == module:
+            msg = "libpq.so.5: cannot open shared object file"
+            raise ImportError(msg, name="psycopg_binary")
+        return real(name)
+
+    monkeypatch.setattr(history_drivers.importlib, "import_module", broken)
+    config = TalonConfig.from_env({URI_KEY: f"{scheme}://localhost/talon"}, base_home=tmp_path)
+    with pytest.raises(ImportError, match="libpq") as error:
+        async with open_history(config):
+            pytest.fail("a driver that is installed but broken must not be reported as missing")
+    # Telling the user to install what they already have hides the real cause.
+    assert "uv sync" not in str(error.value)
 
 
 @pytest.mark.parametrize("scheme", ["mongodb", "postgresql"])

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
+import time
 from dataclasses import replace
 from types import SimpleNamespace
 
@@ -578,6 +580,61 @@ async def test_threaded_store_uses_native_async_embeddings(tmp_path):
     assert result[0].key == "one"
     assert raw.documents == ["document"]
     assert set(raw.queries) == {"question"}
+
+
+async def test_sync_store_api_is_refused_rather_than_embedding_in_the_lock(tmp_path):
+    from langgraph.store.memory import InMemoryStore  # noqa: PLC0415
+
+    from deepagents_talon.history_prepared_store import PreparedVectorStore  # noqa: PLC0415
+
+    raw = RecordingEmbeddings()
+    embed = BoundedEmbeddings(raw, configuration(tmp_path).history_embedding_profile)
+    store = PreparedVectorStore(
+        InMemoryStore(index={"dims": 2, "embed": embed, "fields": ["text"]}), embed
+    )
+    # Delegating would embed from the Store's worker thread inside the database lock.
+    with pytest.raises(NotImplementedError, match="async Store API"):
+        store.put(("test",), "one", {"text": "document"})
+    assert raw.documents == []
+
+
+async def test_prepared_store_indexes_configured_fields_without_assuming_text(tmp_path):
+    from langgraph.store.memory import InMemoryStore  # noqa: PLC0415
+
+    from deepagents_talon.history_prepared_store import PreparedVectorStore  # noqa: PLC0415
+
+    raw = RecordingEmbeddings()
+    embed = BoundedEmbeddings(raw, configuration(tmp_path).history_embedding_profile)
+    store = PreparedVectorStore(
+        InMemoryStore(index={"dims": 2, "embed": embed, "fields": ["body"]}), embed
+    )
+    await store.aput(("test",), "one", {"body": "document"}, index=["body"])
+    assert raw.documents == ["document"]
+
+
+async def test_bridge_gives_up_when_the_loop_cannot_run_the_coroutine(tmp_path, monkeypatch):
+    # raising=False so an unbounded bridge fails on the hang itself, not the constant.
+    monkeypatch.setattr(history_adapters, "_BRIDGE_TIMEOUT_SECONDS", 0.1, raising=False)
+    monkeypatch.setattr(history_adapters, "_BRIDGE_POLL_SECONDS", 0.02, raising=False)
+    profile = configuration(tmp_path).history_embedding_profile
+    embed = BoundedEmbeddings(RecordingEmbeddings(), profile)
+    outcome = []
+
+    def call():
+        try:
+            embed.embed_documents(["text"])
+        except RuntimeError as error:
+            outcome.append(error)
+
+    worker = threading.Thread(target=call, daemon=True)
+    worker.start()
+    # Never awaiting keeps the loop from serving the worker's coroutine at all, which
+    # is the state a stopping loop leaves it in. Without a bound the worker would wait
+    # here forever, holding the Store's own shutdown open.
+    time.sleep(0.5)  # noqa: ASYNC251  # Stalling the loop is what this test reproduces.
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    assert "deadline" in str(outcome[0])
 
 
 async def test_adapter_client_is_closed_when_the_archive_closes(tmp_path, monkeypatch):

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 import threading
 import time
 from dataclasses import replace
@@ -81,6 +82,58 @@ def test_remote_adapters_name_the_settings_they_require(tmp_path, missing):
     del env[PREFIX + missing]
     with pytest.raises(TalonConfigError, match=f"{missing} is required"):
         TalonConfig.from_env(env, base_home=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        {"ADAPTER": "local", "MODEL": "BAAI/bge-m3", "BASE_URL": "https://api.example.org/v1"},
+        {"ADAPTER": "local", "MODEL": "BAAI/bge-m3", "SEND_DIMENSIONS": "0"},
+        {"ADAPTER": "atlas", "MODEL": "voyage-3-large", "MAX_INPUT_TOKENS": "16256"},
+    ],
+)
+def test_settings_an_adapter_cannot_honour_are_refused(tmp_path, settings):
+    # Silently ignoring these is worse than refusing: BASE_URL enters the fingerprint
+    # and forces a reindex, and SEND_DIMENSIONS is advertised as the fix for a
+    # dimension mismatch it cannot repair on these adapters.
+    if settings["ADAPTER"] == "atlas":
+        settings = {**settings, "DIMS": "1024", "SEND_DIMENSIONS": "0"}
+    with pytest.raises(TalonConfigError, match=r"BASE_URL|SEND_DIMENSIONS"):
+        configuration(tmp_path, **settings)
+
+
+@pytest.mark.parametrize(("flag", "expected"), [("1", 1024), ("0", None)])
+async def test_voyage_honours_send_dimensions(tmp_path, monkeypatch, flag, expected):
+    captured = {}
+
+    class FakeVoyage(Embeddings):
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def embed_documents(self, texts):
+            return [[1.0, 0.0] for _ in texts]
+
+        def embed_query(self, _text):
+            return [1.0, 0.0]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "deepagents_talon.history_voyage",
+        SimpleNamespace(HistoryVoyageEmbeddings=FakeVoyage),
+    )
+    monkeypatch.setattr(history_adapters, "_driver", lambda *_args: SimpleNamespace())
+    config = configuration(
+        tmp_path,
+        ADAPTER="voyage",
+        MODEL="voyage-3-large",
+        DIMS="1024",
+        BASE_URL="",
+        SEND_DIMENSIONS=flag,
+        API_KEY="test-key",
+    )
+    async with open_profile(config) as profile:
+        assert profile is not None
+    assert captured["output_dimension"] == expected
 
 
 def test_public_endpoints_remain_configurable(tmp_path):

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -580,6 +580,23 @@ async def test_threaded_store_uses_native_async_embeddings(tmp_path):
     assert set(raw.queries) == {"question"}
 
 
+async def test_adapter_client_is_closed_when_the_archive_closes(tmp_path, monkeypatch):
+    closed = []
+
+    class ClosingEmbeddings(RecordingEmbeddings):
+        async def aclose(self):
+            closed.append(True)
+
+    raw = ClosingEmbeddings()
+    fake_adapter(monkeypatch, raw)
+    config = configuration(tmp_path)
+    async with open_history(config) as archive:
+        await archive.append(SCOPE, "session", "time", [HumanMessage("car")])
+        await settled(archive)
+    # A reindex reopens the archive, so an unclosed pool leaks sockets per cycle.
+    assert closed == [True]
+
+
 async def test_query_prompt_reaches_stores_that_embed_searches_as_documents(tmp_path):
     from langgraph.store.memory import InMemoryStore  # noqa: PLC0415
 

--- a/libs/talon/tests/unit_tests/test_history_vectors.py
+++ b/libs/talon/tests/unit_tests/test_history_vectors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from contextlib import asynccontextmanager
 
@@ -18,6 +19,7 @@ from deepagents_talon.history_backends import open_history
 from deepagents_talon.history_embeddings import QUERY_PROMPT, HistoryEmbeddings
 from deepagents_talon.history_profiles import EmbeddingProfile
 from deepagents_talon.sqlite_history import _HistorySqliteStore, sqlite_store
+from deepagents_talon.store_archive import StoreConversationArchive
 from tests.archive_helpers import open_vector_archive
 from tests.store_archive_contract import StaticEmbeddings as Embedding
 
@@ -150,6 +152,80 @@ async def test_failed_indexing_is_retried_after_restart(tmp_path):
         assert (
             ((await archive.search_page(SCOPE, query="automobile"))["results"])[0]["text"] == "car"
         )
+
+
+async def test_indexing_failure_logs_the_underlying_cause(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr("deepagents_talon.history_vectors._RETRY_SECONDS", 0.01)
+    monkeypatch.setattr("deepagents_talon.history_vectors.secrets.randbelow", lambda _bound: 0)
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.history_vectors")
+    failing = FailingEmbedding()
+    async with (
+        vector_store("memory", None, failing) as store,
+        open_vector_archive(str(tmp_path / "archive.sqlite"), store=store) as archive,
+    ):
+        await append(archive, "car")
+        await asyncio.wait_for(failing.failed.wait(), 2)
+        async with asyncio.timeout(3):
+            while True:
+                if any("indexing failed" in item.message for item in caplog.records):
+                    break
+                await asyncio.sleep(0.01)
+    # A permanently broken backend otherwise repeats one identical line forever.
+    record = next(item for item in caplog.records if "indexing failed" in item.message)
+    assert "embedding unavailable" in str(record.exc_info[1])
+
+
+async def test_close_abandons_a_wedged_indexing_batch(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr("deepagents_talon.history_vectors._CLOSE_TIMEOUT_SECONDS", 0.2)
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.history_vectors")
+    started = asyncio.Event()
+
+    class WedgedStore(InMemoryStore):
+        async def abatch(self, ops):
+            operations = list(ops)
+            if any(isinstance(op, PutOp) and op.value is not None for op in operations):
+                started.set()
+                await asyncio.Event().wait()
+            return await super().abatch(operations)
+
+    store = WedgedStore(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    # A Store write that never returns must not hold host shutdown open forever.
+    async with asyncio.timeout(5):
+        async with open_vector_archive(str(tmp_path / "archive.sqlite"), store=store) as archive:
+            await append(archive, "car")
+            await asyncio.wait_for(started.wait(), 2)
+    assert any("abandoning the active batch" in item.message for item in caplog.records)
+
+
+async def test_indexing_batches_never_overlap_so_they_need_no_permit():
+    active, peak = 0, 0
+
+    class CountingBatch(InMemoryStore):
+        async def abatch(self, ops):
+            nonlocal active, peak
+            operations = list(ops)
+            indexing = any(isinstance(op, PutOp) for op in operations)
+            active += indexing
+            peak = max(peak, active)
+            try:
+                await asyncio.sleep(0)
+                return await super().abatch(operations)
+            finally:
+                active -= indexing
+
+    store = CountingBatch(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    # Concurrency above one must not produce overlapping Store batches: the worker
+    # holds its lock across each one, which is why it carries no permit of its own.
+    profile = EmbeddingProfile(
+        adapter="openai-compatible", model="test", dims=2, max_input_tokens=512, concurrency=8
+    )
+    async with StoreConversationArchive(
+        InMemoryStore(), namespace=("serial",), vector_store=store, embedding_profile=profile
+    ).open() as archive:
+        for index in range(12):
+            await append(archive, f"car {index}", session=f"session-{index}")
+        await settled(archive)
+    assert peak == 1
 
 
 async def test_existing_vectors_survive_restart_and_do_not_reembed(tmp_path):
@@ -481,7 +557,8 @@ async def test_search_tool_pages_preserve_status_and_report_expired_cursors(tmp_
         assert expired["results"] == []
 
 
-async def test_search_backend_failure_reports_error(tmp_path):
+async def test_search_backend_failure_reports_error(tmp_path, caplog):
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.history_vectors")
     async with (
         vector_store("sqlite", tmp_path / "vectors.sqlite", FailingEmbedding()) as store,
         open_vector_archive(str(tmp_path / "archive.sqlite"), store=store) as archive,
@@ -490,6 +567,9 @@ async def test_search_backend_failure_reports_error(tmp_path):
         page = await archive.search_page(SCOPE, query="automobile")
         assert page["semantic_status"] == "error"
         assert page["results"] == []
+    # An operator needs the cause; the fallback alone cannot be diagnosed.
+    record = next(item for item in caplog.records if "search unavailable" in item.message)
+    assert "embedding unavailable" in str(record.exc_info[1])
 
 
 async def test_search_reports_store_without_semantic_support(tmp_path):

--- a/libs/talon/tests/unit_tests/test_history_vectors.py
+++ b/libs/talon/tests/unit_tests/test_history_vectors.py
@@ -197,6 +197,46 @@ async def test_close_abandons_a_wedged_indexing_batch(tmp_path, monkeypatch, cap
     assert any("abandoning the active batch" in item.message for item in caplog.records)
 
 
+async def test_close_waits_for_a_batch_registered_after_it_started(monkeypatch):
+    monkeypatch.setattr("deepagents_talon.history_vectors._CLOSE_TIMEOUT_SECONDS", 0.3)
+    state = {"started": False, "cancelled": False}
+
+    class WedgedStore(InMemoryStore):
+        async def abatch(self, ops):
+            operations = list(ops)
+            if any(isinstance(op, PutOp) and op.value is not None for op in operations):
+                state["started"] = True
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    state["cancelled"] = True
+                    raise
+            return await super().abatch(operations)
+
+    store = WedgedStore(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    archive = StoreConversationArchive(InMemoryStore(), namespace=("late",), vector_store=store)
+    await archive.setup()
+    closing = None
+    try:
+        async with archive.vectors.lock:
+            for _ in range(3):
+                # The worker parks acquiring this lock, already past its `stopping` check.
+                await asyncio.sleep(0)
+            await append(archive, "car")
+            closing = asyncio.create_task(archive.aclose())
+            for _ in range(3):
+                await asyncio.sleep(0)
+        # Releasing lets the worker register a Store task after close() began, so a
+        # single snapshot of `_pending` no longer describes what is in flight.
+        await asyncio.wait_for(closing, 5)
+    finally:
+        if closing is not None and not closing.done():
+            closing.cancel()
+    assert state["started"]
+    # close() must not return while a shielded write is still touching the Store.
+    assert state["cancelled"]
+
+
 async def test_indexing_batches_never_overlap_so_they_need_no_permit():
     active, peak = 0, 0
 
@@ -226,6 +266,43 @@ async def test_indexing_batches_never_overlap_so_they_need_no_permit():
             await append(archive, f"car {index}", session=f"session-{index}")
         await settled(archive)
     assert peak == 1
+
+
+def test_worker_protocol_is_declared_and_no_longer_needs_deferred_imports():
+    from deepagents_talon import store_archive as module  # noqa: PLC0415
+    from deepagents_talon.history_index import VectorArchive  # noqa: PLC0415
+    from deepagents_talon.store_archive_index import StoreVectorArchive  # noqa: PLC0415
+
+    # Declared rather than merely structural, so a drifting signature fails the type
+    # check instead of silently diverging from the worker's expectations.
+    assert VectorArchive in StoreVectorArchive.__mro__
+    # The store_archive <-> store_archive_index cycle that forced function-level
+    # imports is gone, so the workers resolve at module scope.
+    assert module.HistoryVectorIndex is not None
+    assert module.StoreVectorArchive is not None
+
+
+async def test_vector_erase_recovers_an_interrupted_journal_before_reading():
+    from deepagents_talon.history_vector_backends import _erase_vectors  # noqa: PLC0415
+
+    metadata = InMemoryStore()
+    vectors = InMemoryStore(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    async with StoreConversationArchive(
+        metadata, namespace=("erase",), vector_store=vectors
+    ).open() as archive:
+        for index in range(3):
+            await append(archive, f"car {index}", session=f"session-{index}")
+        await settled(archive)
+        namespace = archive.vectors.namespace("whatsapp", "one")
+        assert len(await vectors.asearch(namespace)) == 3
+        records = archive.records
+        root = await records.get("root")
+    # An interrupted commit leaves its writes in the journal and the live root behind.
+    await metadata.aput(records.namespace, "root", {**root, "last": 1}, index=False)
+    await metadata.aput(records.namespace, "journal", {"writes": [["root", root]]}, index=False)
+    # Reading the stale root would leave the newest vectors behind after a rebuild.
+    await _erase_vectors(archive, vectors)
+    assert await vectors.asearch(namespace) == []
 
 
 async def test_existing_vectors_survive_restart_and_do_not_reembed(tmp_path):

--- a/libs/talon/uv.lock
+++ b/libs/talon/uv.lock
@@ -1073,7 +1073,7 @@ requires-dist = [
     { name = "langchain-mcp-adapters", specifier = ">=0.3.2,<1.0.0" },
     { name = "langchain-openai", marker = "extra == 'history-openai'", specifier = ">=1.1.14,<2.0.0" },
     { name = "langchain-voyageai", marker = "extra == 'history-voyage'", specifier = ">=0.4.1,<0.5.0" },
-    { name = "langgraph-checkpoint-postgres", marker = "extra == 'postgres'", specifier = ">=3.1.2,<4.0.0" },
+    { name = "langgraph-checkpoint-postgres", marker = "extra == 'postgres'", specifier = ">=3.1.2,<3.2.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.1,<4.0.0" },
     { name = "langgraph-store-mongodb", marker = "extra == 'mongodb'", specifier = ">=0.4.0,<0.5.0" },
     { name = "librosa", marker = "extra == 'media'", specifier = ">=0.11.0,<1.0.0" },


### PR DESCRIPTION
**Stack 3 of 4 — history/archive.** Based on `linted/talon/history-2-indexing-worker` (#6154). Review #6153 and #6154 first.

Optional-dependency loading, provider client lifetimes, and embedding settings that were silently ignored.

- **One optional-driver loader replaces two duplicates.** `_driver` existed byte-identically in `history_adapters.py` and `history_backends.py`, differing only in a message prefix, and both did `raise ImportError(msg) from None` — so an extra that *is* installed but fails for another reason (broken `torch`, missing libpq) told the user to install what they already had, with no traceback. The shared loader in `history_drivers.py` checks `ImportError.name` and re-raises anything that isn't the extra itself, chaining the cause either way.
- **MongoDB startup was unbounded and its dispatcher never stopped**, unlike its two sibling backends. The startup budget is now explicit — see the comment on why `asyncio.timeout` alone cannot bound it, since `finish()` runs to completion by design.
- **Voyage and Atlas embedding clients were never closed**, leaking connection pools on every archive reopen. Cleanup registration moved into `open_profile` so it covers whichever adapter resolves.
- **`PreparedVectorStore.batch()` silently skipped the preparation the class exists for**, reaching the inner store with an empty cache; it now refuses. Field extraction no longer hardcodes `text`.
- **`_bridge` waited on a cross-thread future with no timeout**, so a worker thread could block forever against a stopping loop.
- **`SEND_DIMENSIONS` and `BASE_URL` were honoured by one adapter each and silently ignored elsewhere** — including by the adapter the `SEND_DIMENSIONS` error message tells you to use it with. Now honoured or refused at config time.

Verified by inspection only: Voyage client release and `output_dimension` handling — `voyageai` and `langchain-mongodb` aren't installed in CI, so the tests cover the registration path via fakes, not real SDK pool release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
