### PR TITLE
fix(talon): bound archive scans, query embeddings, and deletion markers

### DIFF
--- a/libs/talon/deepagents_talon/history_prepared_store.py
+++ b/libs/talon/deepagents_talon/history_prepared_store.py
@@ -45,7 +45,15 @@ class PreparedVectorStore(BaseStore):
         }
         for op in operations:
             if isinstance(op, SearchOp) and op.query is not None:
-                cache[True, op.query] = await self.embed.aembed_query(op.query)
+                vector = await self.embed.aembed_query(op.query)
+                cache[True, op.query] = vector
+                # Only some Stores embed a search through aembed_query; SQLite and
+                # PostgreSQL route it through aembed_documents instead. Publishing the
+                # query vector under the document key too keeps query prompts and
+                # provider input types backend-neutral, without a second round trip.
+                # A document in this same batch keeps its own vector: that one is
+                # stored durably, while a query vector is used once and discarded.
+                cache.setdefault((False, op.query), vector)
         token = EMBEDDING_CACHE.set(cache)
         try:
             return await self.store.abatch(operations)

--- a/libs/talon/deepagents_talon/store_archive.py
+++ b/libs/talon/deepagents_talon/store_archive.py
@@ -299,7 +299,7 @@ class StoreConversationArchive:
             return None
         return entry
 
-    async def _text_entries(
+    async def _text_entries(  # noqa: PLR0913  # Preserve existing arguments when adding partial scans.
         self,
         scope: ArchiveScope,
         *,
@@ -307,6 +307,7 @@ class StoreConversationArchive:
         session_id: str,
         after: int,
         limit: int,
+        partial: bool = False,
     ) -> list[ArchiveEntry]:
         async with self.records.access():
             if session_id:
@@ -327,7 +328,7 @@ class StoreConversationArchive:
                     msg = "Conversation archive contains an invalid ordering link"
                     raise RuntimeError(msg)
             hits: list[ArchiveEntry] = []
-            async for _, record in self._retrieval_chain(cursor, link):
+            async for _, record in self._retrieval_chain(cursor, link, partial=partial):
                 entry = await self.visible(record, scope)
                 if (
                     entry is not None
@@ -339,12 +340,20 @@ class StoreConversationArchive:
                         break
             return hits
 
-    async def _retrieval_chain(self, cursor: int, link: str) -> AsyncIterator[tuple[int, Record]]:
+    async def _retrieval_chain(
+        self, cursor: int, link: str, *, partial: bool = False
+    ) -> AsyncIterator[tuple[int, Record]]:
         scanned = 0
         async for identifier, record in self.records.chain(cursor, link):
             yield identifier, record
             scanned += 1
             if scanned == _MAX_SCAN and number(record, link):
+                # Ranked retrieval already scores a bounded candidate pool, so a
+                # truncated scan only narrows it. A page from entries() or
+                # conversations() claims completeness, so truncating one there
+                # would report "no more results" while records remain.
+                if partial:
+                    return
                 msg = (
                     "Conversation history scan limit exceeded (500 records); "
                     "no partial page returned"
@@ -516,27 +525,40 @@ class StoreConversationArchive:
             return
         root = await self.records.root()
         deletion = number(root, "last") + 1
-        await self.records.commit(
-            [
-                (
-                    str(session["cursor"]),
-                    {**session, "deleting": True, "delete_cursor": session["head"]},
-                ),
-                (
-                    str(deletion),
-                    {"owner": session["cursor"], "previous_deleting": number(root, "deleting")},
-                ),
-                (
-                    "root",
-                    {
-                        **root,
-                        "last": deletion,
-                        "deletions": number(root, "deletions") + 1,
-                        "deleting": deletion,
-                    },
-                ),
-            ]
-        )
+        previous = number(root, "deleting")
+        writes: list[Write] = [
+            (
+                str(session["cursor"]),
+                {
+                    **session,
+                    "deleting": True,
+                    "delete_cursor": session["head"],
+                    "delete_marker": deletion,
+                },
+            ),
+            (
+                str(deletion),
+                # Linked in both directions so a completed marker leaves the chain
+                # without a walk; see `_unlink_deletion`.
+                {
+                    "owner": session["cursor"],
+                    "previous_deleting": previous,
+                    "next_deleting": 0,
+                },
+            ),
+            (
+                "root",
+                {
+                    **root,
+                    "last": deletion,
+                    "deletions": number(root, "deletions") + 1,
+                    "deleting": deletion,
+                },
+            ),
+        ]
+        if previous and (marker := await self.records.get(str(previous))) is not None:
+            writes.append((str(previous), {**marker, "next_deleting": deletion}))
+        await self.records.commit(writes)
 
     async def delete_text(self, session_id: str) -> None:
         """Erase text and dedup records after vector deletion, under the records lock."""
@@ -552,17 +574,50 @@ class StoreConversationArchive:
             writes.extend((str(record[key]), None) for key in ("dedup", "message"))
             await self.records.commit(writes)
         root = await self.records.root()
+        deletions = number(root, "deletions") - 1
+        markers, deleting = await self._unlink_deletion(session, root, drained=deletions <= 0)
         links = {"previous_scope": session["previous_scope"]}
         scoped = await self.records.get(scope_key(cast("ArchiveScope", session["scope"]))) or {}
         others = await self._other_sessions(scoped, number(session, "cursor"))
         await self.records.commit(
             [
+                *markers,
                 (scope_key(cast("ArchiveScope", session["scope"])), scoped if others else None),
                 (str(session["cursor"]), links),
                 ("session:" + digest(session_id), None),
-                ("root", {**root, "deletions": number(root, "deletions") - 1}),
+                ("root", {**root, "deletions": deletions, "deleting": deleting}),
             ]
         )
+
+    async def _unlink_deletion(
+        self, session: Record, root: Record, *, drained: bool
+    ) -> tuple[list[Write], int]:
+        """Remove a completed deletion marker, returning its writes and the new chain head.
+
+        The chain exists so an interrupted deletion can be found again after a restart.
+        Retaining completed markers would instead record every deletion the assistant
+        has ever performed, and the indexing worker re-walks that chain on every poll
+        for as long as any one deletion is still outstanding. Archives written before
+        markers were linked in both directions have no `delete_marker`; their chain is
+        abandoned wholesale once the last outstanding deletion drains.
+        """
+        deleting = 0 if drained else number(root, "deleting")
+        cursor = number(session, "delete_marker")
+        marker = await self.records.get(str(cursor)) if cursor else None
+        if marker is None:
+            return [], deleting
+        previous, following = number(marker, "previous_deleting"), number(marker, "next_deleting")
+        writes: list[Write] = [(str(cursor), None)]
+        if not following and deleting == cursor:
+            deleting = previous
+        neighbors = (
+            (following, "previous_deleting", previous),
+            (previous, "next_deleting", following),
+        )
+        for neighbor, field, value in neighbors:
+            if neighbor and (record := await self.records.get(str(neighbor))) is not None:
+                writes.append((str(neighbor), {**record, field: value}))
+        return writes, deleting
 
     async def _other_sessions(self, scoped: Record, cursor: int) -> bool:
         async for identifier, record in self.records.chain(

--- a/libs/talon/deepagents_talon/store_archive_index.py
+++ b/libs/talon/deepagents_talon/store_archive_index.py
@@ -139,13 +139,19 @@ class StoreVectorArchive:
             return False
 
     async def lexical(self, scope: ArchiveScope, query: str, limit: int) -> list[str]:
-        """Find literal keyword candidates without backend-specific full-text operators."""
+        """Find literal keyword candidates without backend-specific full-text operators.
+
+        Stops at the archive's scan budget rather than raising: these candidates are
+        fused with the semantic ranking, so a short list degrades recall while a
+        raised error would fail a search the semantic leg had already answered.
+        """
         entries = await self.archive._text_entries(  # noqa: SLF001  # Storage adapter shares archive retrieval.
             scope,
             query=query,
             session_id="",
             after=0,
             limit=limit,
+            partial=True,
         )
         return [str(entry["cursor"]) for entry in entries]
 

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -599,6 +599,31 @@ async def test_threaded_store_uses_native_async_embeddings(tmp_path):
     assert set(raw.queries) == {"question"}
 
 
+async def test_query_prompt_reaches_stores_that_embed_searches_as_documents(tmp_path):
+    from langgraph.store.memory import InMemoryStore  # noqa: PLC0415
+
+    from deepagents_talon.history_prepared_store import PreparedVectorStore  # noqa: PLC0415
+
+    class DocumentSearchStore(InMemoryStore):
+        # PostgreSQL and SQLite both embed a search through aembed_documents; only the
+        # SQLite subclass marks those calls as queries, so this stands in for the rest.
+        async def _aembed_search_queries(self, search_ops):
+            queries = list({op.query for op, _ in search_ops.values() if op.query})
+            return dict(zip(queries, await self.embeddings.aembed_documents(queries), strict=True))
+
+    raw = RecordingEmbeddings()
+    profile = configuration(tmp_path, QUERY_PROMPT="Instruct: ").history_embedding_profile
+    embed = BoundedEmbeddings(raw, profile)
+    store = PreparedVectorStore(
+        DocumentSearchStore(index={"dims": 2, "embed": embed, "fields": ["text"]}), embed
+    )
+    await store.aput(("test",), "one", {"text": "document"})
+    assert (await store.asearch(("test",), query="question"))[0].key == "one"
+    assert raw.queries == ["Instruct: question"]
+    # The query must not be re-embedded as an unprefixed document inside the batch.
+    assert raw.documents == ["document"]
+
+
 async def test_vector_plugin_receives_generation_and_deletion_mode(tmp_path, monkeypatch):
     from contextlib import asynccontextmanager  # noqa: PLC0415
 

--- a/libs/talon/tests/unit_tests/test_store_archive.py
+++ b/libs/talon/tests/unit_tests/test_store_archive.py
@@ -57,6 +57,76 @@ async def test_retrieval_budget_bounds_reads_and_releases_lock(options):
     assert (await archive.entries(SCOPE, limit=1))[0]["text"] == "still writable"
 
 
+async def test_hybrid_search_ranks_partial_candidates_beyond_the_scan_budget():
+    metadata = CountingStore()
+    vectors = InMemoryStore(index={"dims": 2, "embed": StaticEmbeddings(), "fields": ["text"]})
+    async with StoreConversationArchive(
+        metadata, namespace=("budget-search",), vector_store=vectors
+    ).open() as archive:
+        # Only the oldest record is a semantic match, and no record matches the query
+        # literally, so the keyword leg walks the whole chain past its scan budget.
+        await archive.append(
+            SCOPE,
+            "session",
+            "time",
+            [
+                HumanMessage("car" if index == 0 else f"note {index}", id=str(index))
+                for index in range(501)
+            ],
+        )
+        async with asyncio.timeout(5):
+            while True:
+                if not await archive.vectors.archive.pending(SCOPE):
+                    break
+                await asyncio.sleep(0)
+        async with archive.vectors.lock:
+            pass
+        page = await archive.search_page(SCOPE, query="automobile")
+        assert page["semantic_status"] == "completed"
+        assert page["results"][0]["text"] == "car"
+        # A page that claims completeness still refuses to truncate silently.
+        with pytest.raises(RuntimeError, match="scan limit exceeded"):
+            await archive.entries(SCOPE, query="automobile")
+
+
+async def test_completed_deletion_markers_leave_the_outstanding_deletion_chain():
+    class ScopedFailure(InMemoryStore):
+        blocked = ()
+
+        async def abatch(self, ops):
+            operations = list(ops)
+            if any(
+                isinstance(op, PutOp) and op.value is None and op.namespace == self.blocked
+                for op in operations
+            ):
+                msg = "vector deletion failed"
+                raise OSError(msg)
+            return await super().abatch(operations)
+
+    metadata = CountingStore()
+    vectors = ScopedFailure(index={"dims": 2, "embed": StaticEmbeddings(), "fields": ["text"]})
+    async with StoreConversationArchive(
+        metadata, namespace=("markers",), vector_store=vectors
+    ).open() as archive:
+        vectors.blocked = archive.vectors.namespace(
+            OTHER["talon_history_channel"], OTHER["talon_history_chat"]
+        )
+        await archive.append(OTHER, "stuck", "time", [HumanMessage("stuck")])
+        with pytest.raises(OSError, match="vector deletion failed"):
+            await archive.delete_session("stuck")
+        for index in range(20):
+            await archive.append(SCOPE, f"session-{index}", "time", [HumanMessage("erase")])
+            await archive.delete_session(f"session-{index}")
+        # One deletion is still outstanding, so every poll re-reads the marker chain.
+        metadata.reads = 0
+        assert await archive.vectors.archive.rows("", indexing=True, limit=4)
+        assert metadata.reads <= 10  # Journal, root, the one live marker and its session.
+        vectors.blocked = ()
+        await archive.delete_session("stuck")
+        root = await archive.records.root()
+        assert (root["deletions"], root["deleting"]) == (0, 0)
+
+
 @asynccontextmanager
 async def stores(backend, tmp_path):
     index = {"dims": 2, "embed": StaticEmbeddings(), "fields": ["text"]}


### PR DESCRIPTION
**Stack 1 of 4 — history/archive.** Reviews cleanest bottom-up: this PR → `history-2-indexing-worker` → `history-3-drivers-adapters` → #6147.

Three High-severity defects in the conversation archive, found reviewing the ~23k lines added to `libs/talon` since `deepagents-talon==0.0.6`. All three are live in released 0.0.7.

- **Hybrid search raised on any long conversation.** `lexical()` was called unwrapped while the *optional* semantic leg beside it was defensively wrapped — backwards. With `_MAX_SCAN = 500` and `_CANDIDATES = 100`, any chat over 500 archived chunks whose query matched fewer than 100 of the newest 500 made `search_conversations` raise. `_retrieval_chain` now takes `partial=`; `entries()` and `conversations()` still raise, since a truncated page there would be a correctness lie.
- **Query embeddings were prefixed only on SQLite.** On Postgres and plugin backends the query was chunked and embedded as a *document* — no instruction prefix, no query input type, plus an extra provider round trip from inside the DB batch. `PreparedVectorStore.abatch` now publishes the vector under both cache keys.
- **The deletion-marker chain grew without bound** and was re-walked on every poll. Markers are now doubly linked and unlinked in O(1) as deletions complete.

Each test was verified to fail against pre-fix source with the exact symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Reviewing this PR alone:** it is one level of a four-PR stack, so an automated reviewer reading it cannot see the levels above. Several findings filed against the mid-stack PRs turned out to be defects that the top of the same chain already fixes; each such thread has a reply naming the fixing PR. Read bottom-up, or read the top PR first if you want the final state.