### PR TITLE
fix(talon): share one optional-driver loader and close provider clients

### DIFF
--- a/libs/talon/deepagents_talon/history_adapters.py
+++ b/libs/talon/deepagents_talon/history_adapters.py
@@ -6,6 +6,7 @@ import asyncio
 import inspect
 import logging
 import math
+import time
 from contextlib import AsyncExitStack, asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import replace
@@ -31,6 +32,10 @@ EMBEDDING_CACHE: ContextVar[dict[tuple[bool, str], list[float]] | None] = Contex
     "talon_history_embeddings", default=None
 )
 _REQUEST_TIMEOUT = 30
+# A Store worker thread must never wait on the event loop indefinitely, so the
+# bridge polls for a loop that has stopped and enforces an overall deadline.
+_BRIDGE_TIMEOUT_SECONDS = 300
+_BRIDGE_POLL_SECONDS = 1
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +171,22 @@ class BoundedEmbeddings(Embeddings):
             operation.close()
             msg = "Use async history embeddings on the event loop"
             raise RuntimeError(msg)
-        return asyncio.run_coroutine_threadsafe(operation, self.loop).result()
+        future = asyncio.run_coroutine_threadsafe(operation, self.loop)
+        deadline = time.monotonic() + _BRIDGE_TIMEOUT_SECONDS
+        while True:
+            try:
+                return future.result(timeout=_BRIDGE_POLL_SECONDS)
+            except TimeoutError:
+                # A loop that has stopped will never run the coroutine, and waiting on
+                # it holds the Store's worker thread open through its own shutdown.
+                if self.loop.is_closed() or not self.loop.is_running():
+                    future.cancel()
+                    msg = "History embeddings stopped; the event loop is no longer running"
+                    raise RuntimeError(msg) from None
+                if time.monotonic() >= deadline:
+                    future.cancel()
+                    msg = "History embedding exceeded its deadline waiting for the event loop"
+                    raise RuntimeError(msg) from None
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Bridge Store worker threads to the owned async client."""

--- a/libs/talon/deepagents_talon/history_adapters.py
+++ b/libs/talon/deepagents_talon/history_adapters.py
@@ -107,7 +107,11 @@ async def _adapter(
         return HistoryVoyageEmbeddings(
             model=profile.model,
             api_key=_key(config, "VOYAGE_API_KEY"),
-            output_dimension=cast("Literal[256, 512, 1024, 2048]", profile.dims),
+            # Omitting the width leaves the model's native output, which is what
+            # SEND_DIMENSIONS=0 asks for when a model cannot resize.
+            output_dimension=cast("Literal[256, 512, 1024, 2048] | None", profile.dims)
+            if profile.send_dimensions
+            else None,
             batch_size=profile.batch_size,
             truncation=False,
             base_url=profile.base_url or "https://api.voyageai.com/v1",

--- a/libs/talon/deepagents_talon/history_adapters.py
+++ b/libs/talon/deepagents_talon/history_adapters.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
+import inspect
 import logging
 import math
 from contextlib import AsyncExitStack, asynccontextmanager
@@ -16,9 +16,10 @@ from langchain_core.embeddings import Embeddings
 from pydantic import SecretStr
 
 from deepagents_talon.config import TalonConfigError
+from deepagents_talon.history_drivers import load_driver
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Coroutine
+    from collections.abc import AsyncIterator, Callable, Coroutine
     from types import ModuleType
 
     from deepagents_talon.config import TalonConfig
@@ -49,17 +50,33 @@ async def open_profile(config: TalonConfig) -> AsyncIterator[EmbeddingProfile | 
         except Exception:  # noqa: BLE001  # Provider validation can include API keys.
             msg = "Could not initialize history embeddings; check the selected adapter and settings"
             raise TalonConfigError(msg) from None
+        # Registered here rather than per adapter: `atlas` and `voyage` previously
+        # had no cleanup at all, and a reindex reopens the archive, so a client that
+        # keeps its pool past close leaks sockets on every cycle.
+        _register_close(stack, embed)
         if profile.client_side:
             embed = BoundedEmbeddings(embed, profile)
         yield replace(profile, embed=embed)
 
 
+async def _close_client(closer: Callable[[], object]) -> None:
+    # A synchronous close tears down sockets, so it runs off the event loop; an
+    # async one only builds its coroutine there and is awaited here.
+    result = await asyncio.to_thread(closer)
+    if inspect.isawaitable(result):
+        await result
+
+
+def _register_close(stack: AsyncExitStack, embed: object) -> None:
+    for name in ("aclose", "close"):
+        closer = getattr(embed, name, None)
+        if callable(closer):
+            stack.push_async_callback(_close_client, closer)
+            return
+
+
 def _driver(module: str, extra: str) -> ModuleType:
-    try:
-        return importlib.import_module(module)
-    except ImportError:
-        msg = f"History embeddings require deepagents-talon[{extra}]: uv sync --extra {extra}"
-        raise ImportError(msg) from None
+    return load_driver(module, extra, "History embeddings require")
 
 
 async def _adapter(
@@ -69,14 +86,12 @@ async def _adapter(
         _driver("sentence_transformers", "history-local")
         from deepagents_talon.history_embeddings import HistoryEmbeddings  # noqa: PLC0415
 
-        embed = HistoryEmbeddings(
+        return HistoryEmbeddings(
             model=profile.model,
             max_input_tokens=profile.max_input_tokens,
             batch_size=profile.batch_size,
             query_prompt="",
         )
-        stack.push_async_callback(embed.aclose)
-        return embed
     if profile.adapter == "atlas":
         driver = _driver("langchain_mongodb.embeddings", "mongodb")
         return driver.AutoEmbeddings(model=profile.model)

--- a/libs/talon/deepagents_talon/history_backends.py
+++ b/libs/talon/deepagents_talon/history_backends.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from functools import partial
 from importlib.metadata import EntryPoint, entry_points
@@ -14,6 +13,7 @@ import aiosqlite
 from langgraph.store.sqlite.aio import AsyncSqliteStore
 
 from deepagents_talon.config import TalonConfigError
+from deepagents_talon.history_drivers import load_driver
 from deepagents_talon.store_archive import StoreConversationArchive
 from deepagents_talon.store_records import finish
 
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
     from deepagents_talon.history_profiles import EmbeddingProfile
 
 _STARTUP_TIMEOUT = 15
+# Atlas index creation legitimately outlasts connection setup, so it is budgeted
+# separately rather than squeezed into the shared startup deadline.
+_AUTO_INDEX_TIMEOUT = 60
 _MAX_HNSW_DIMS = 2000
 type StoreFactory = Callable[[str], AbstractAsyncContextManager[BaseStore]]
 
@@ -144,11 +147,7 @@ async def _sqlite_store(uri: str) -> AsyncIterator[BaseStore]:
 
 
 def _driver(module: str, extra: str) -> ModuleType:
-    try:
-        return importlib.import_module(module)
-    except ImportError:
-        msg = f"History backend requires deepagents-talon[{extra}]: uv sync --extra {extra}"
-        raise ImportError(msg) from None
+    return load_driver(module, extra, "History backend requires")
 
 
 @asynccontextmanager
@@ -198,37 +197,44 @@ async def _mongodb_store(
     pymongo = _driver("pymongo", "mongodb")
     async with AsyncExitStack() as stack:
         try:
-            client = pymongo.MongoClient(
-                uri,
-                connect=False,
-                serverSelectionTimeoutMS=10000,
-                connectTimeoutMS=10000,
-                socketTimeoutMS=10000,
-                readPreference="primary",
-                w="majority",
-            )
-            stack.push_async_callback(asyncio.to_thread, client.close)
-            target = client.get_default_database()[collection]
-            config = (
-                driver.create_vector_index_config(
-                    embed=index["embed"],
-                    dims=-1 if profile and not profile.client_side else index["dims"],
-                    fields=["text"],
-                    relevance_score_fn=None if profile and not profile.client_side else "cosine",
-                    embedding_key="embedding",
+            # `finish()` deliberately runs to completion, so this deadline bounds
+            # connection setup and teardown around the store build rather than
+            # interrupting it; `auto_index_timeout` is what bounds the build itself.
+            async with asyncio.timeout(_STARTUP_TIMEOUT + _AUTO_INDEX_TIMEOUT):
+                client = pymongo.MongoClient(
+                    uri,
+                    connect=False,
+                    serverSelectionTimeoutMS=10000,
+                    connectTimeoutMS=10000,
+                    socketTimeoutMS=10000,
+                    readPreference="primary",
+                    w="majority",
                 )
-                if index is not None
-                else None
-            )
-            store = await finish(
-                asyncio.to_thread(
-                    driver.MongoDBStore,
-                    target,
-                    index_config=config,
-                    auto_index_timeout=60,
-                    query_model=profile.query_model or None if profile else None,
+                stack.push_async_callback(asyncio.to_thread, client.close)
+                target = client.get_default_database()[collection]
+                config = (
+                    driver.create_vector_index_config(
+                        embed=index["embed"],
+                        dims=-1 if profile and not profile.client_side else index["dims"],
+                        fields=["text"],
+                        relevance_score_fn=None
+                        if profile and not profile.client_side
+                        else "cosine",
+                        embedding_key="embedding",
+                    )
+                    if index is not None
+                    else None
                 )
-            )
+                store = await finish(
+                    asyncio.to_thread(
+                        driver.MongoDBStore,
+                        target,
+                        index_config=config,
+                        auto_index_timeout=_AUTO_INDEX_TIMEOUT,
+                        query_model=profile.query_model or None if profile else None,
+                    )
+                )
+                stack.push_async_callback(_stop_dispatcher, store)
         except Exception:  # noqa: BLE001  # Driver startup errors may contain URI credentials.
             msg = "Could not initialize MongoDB history; check the URI, server, and permissions"
             raise TalonConfigError(msg) from None

--- a/libs/talon/deepagents_talon/history_drivers.py
+++ b/libs/talon/deepagents_talon/history_drivers.py
@@ -1,0 +1,36 @@
+"""Load optional providers with install guidance that preserves the real cause."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def load_driver(module: str, extra: str, subject: str) -> ModuleType:
+    """Import an optional provider, naming the extra only when that extra is missing.
+
+    Args:
+        module: Importable module supplied by the extra.
+        extra: Project extra that installs it.
+        subject: Sentence lead-in ending in its verb, e.g. `History backend requires`.
+
+    Raises:
+        ImportError: The extra is absent, or the module itself failed to import. An
+            installed extra that fails for its own reason (a broken native
+            dependency, a missing system library) re-raises unchanged, because
+            telling the user to install what they already have hides the cause.
+    """
+    try:
+        return importlib.import_module(module)
+    except ImportError as error:
+        if (
+            error.name is not None
+            and module != error.name
+            and not module.startswith(error.name + ".")
+        ):
+            raise
+        msg = f"{subject} deepagents-talon[{extra}]: uv sync --extra {extra}"
+        raise ImportError(msg) from error

--- a/libs/talon/deepagents_talon/history_prepared_store.py
+++ b/libs/talon/deepagents_talon/history_prepared_store.py
@@ -9,7 +9,7 @@ from langgraph.store.base import BaseStore, PutOp, SearchOp
 from deepagents_talon.history_adapters import EMBEDDING_CACHE
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
     from langchain_core.embeddings import Embeddings
     from langgraph.store.base import Op, Result
@@ -24,17 +24,27 @@ class PreparedVectorStore(BaseStore):
         self.embed = embed
 
     def batch(self, ops: Iterable[Op]) -> list[Result]:
-        """Delegate synchronous operations to the underlying Store."""
-        return self.store.batch(ops)
+        """Refuse synchronous operations, which would bypass vector preparation.
+
+        Delegating would reach the inner Store with an empty cache, so embedding
+        would run from its worker thread inside the database lock - the exact
+        failure this wrapper exists to prevent.
+
+        Raises:
+            NotImplementedError: Always; use the async Store API.
+        """
+        msg = "History vectors require the async Store API; a synchronous batch cannot prepare them"
+        raise NotImplementedError(msg)
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:
         """Prepare complete document and query vectors before Store I/O."""
         operations = list(ops)
         documents = list(
             dict.fromkeys(
-                str(op.value["text"])
+                text
                 for op in operations
                 if isinstance(op, PutOp) and op.value is not None and op.index is not False
+                for text in _indexed(op)
             )
         )
         cache = {
@@ -59,3 +69,15 @@ class PreparedVectorStore(BaseStore):
             return await self.store.abatch(operations)
         finally:
             EMBEDDING_CACHE.reset(token)
+
+
+def _indexed(op: PutOp) -> Iterator[str]:
+    """Yield the fields this write will embed, without assuming they are named `text`."""
+    # `index=None` defers to the Store's own configuration, which is not visible from
+    # here; `text` is what the archive configures. A structured path is left to the
+    # Store, which then embeds it itself instead of reading a prepared vector.
+    fields = op.index if isinstance(op.index, (list, tuple)) else ("text",)
+    for field in fields:
+        value = op.value.get(field) if op.value is not None else None
+        if value is not None and not any(token in field for token in ".[$"):
+            yield str(value)

--- a/libs/talon/deepagents_talon/history_profiles.py
+++ b/libs/talon/deepagents_talon/history_profiles.py
@@ -256,6 +256,17 @@ def _validate_profile(profile: EmbeddingProfile) -> None:
     if profile.adapter == "atlas" and (profile.query_prompt or profile.base_url):
         msg = "Atlas manages embedding prompts and endpoints server-side"
         raise TalonConfigError(msg)
+    if profile.adapter == "local" and profile.base_url:
+        # `base_url` enters the fingerprint, so accepting one the adapter never reads
+        # would demand a full reindex for a setting that changes nothing.
+        msg = f"{_PREFIX}BASE_URL does not apply to the local adapter, which loads its own model"
+        raise TalonConfigError(msg)
+    if not profile.send_dimensions and profile.adapter in {"local", "atlas"}:
+        msg = (
+            f"{_PREFIX}SEND_DIMENSIONS applies only to the voyage and openai-compatible "
+            "adapters; this one cannot request an output width"
+        )
+        raise TalonConfigError(msg)
     if profile.query_model and profile.adapter != "atlas":
         msg = "A separate history query model is supported only by Atlas"
         raise TalonConfigError(msg)

--- a/libs/talon/deepagents_talon/history_voyage.py
+++ b/libs/talon/deepagents_talon/history_voyage.py
@@ -1,5 +1,7 @@
 """Voyage adapter for inputs already bounded by the history profile."""
 
+import asyncio
+import inspect
 from collections.abc import Generator
 from typing import Self
 
@@ -29,6 +31,17 @@ class HistoryVoyageEmbeddings(VoyageAIEmbeddings):
             max_retries=0,
         )
         return self
+
+    async def aclose(self) -> None:
+        """Release both SDK connection pools; a reindex reopens the archive."""
+        for client in (self._client, self._aclient):
+            for name in ("aclose", "close"):
+                closer = getattr(client, name, None)
+                if callable(closer):
+                    result = await asyncio.to_thread(closer)
+                    if inspect.isawaitable(result):
+                        await result
+                    break
 
     def _build_batches(self, texts: list[str]) -> Generator[tuple[list[str], int], None, None]:
         # Upstream's batching downloads tokenizers synchronously, even for async calls.

--- a/libs/talon/tests/unit_tests/test_history_backends.py
+++ b/libs/talon/tests/unit_tests/test_history_backends.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import threading
 import traceback
 from collections import defaultdict
@@ -13,7 +14,7 @@ import pytest
 from langchain_core.messages import HumanMessage
 from langgraph.store.memory import InMemoryStore
 
-from deepagents_talon import history_adapters, history_backends
+from deepagents_talon import history_adapters, history_backends, history_drivers
 from deepagents_talon.archive import ArchiveScope
 from deepagents_talon.config import TalonConfig, TalonConfigError
 from deepagents_talon.history_backends import open_history
@@ -23,6 +24,10 @@ if TYPE_CHECKING:
 
 URI_KEY = "DEEPAGENTS_TALON_HISTORY_URI"
 SCOPE = ArchiveScope(talon_history_channel="test", talon_history_chat="one")
+_BROKEN_DRIVERS = [
+    ("mongodb", "langgraph.store.mongodb"),
+    ("postgresql", "langgraph.store.postgres.aio"),
+]
 
 
 @pytest.mark.parametrize("scheme", ["mongodb", "mongodb+srv", "postgres", "postgresql", "mysql"])
@@ -167,15 +172,11 @@ class FakeDatabase:
         return self.uri, name
 
 
-def fake_backend(monkeypatch, *, failing=False, started=None, release=None):
-    store = InMemoryStore()
-    mongo_data = defaultdict(InMemoryStore)
+async def _setup_generation(*_args: object):
+    return None
 
-    async def setup_generation(*_args: object):
-        return None
 
-    state = SimpleNamespace(closed=False, dispatcher=None)
-
+def fake_client(state):
     class Client:
         def __init__(self, uri, **_kwargs: object) -> None:
             self.uri = uri
@@ -186,6 +187,32 @@ def fake_backend(monkeypatch, *, failing=False, started=None, release=None):
         def close(self):
             state.closed = True
 
+    return Client
+
+
+def fake_driver(state, store, mongo_store, failing):
+    def driver(module, _extra):
+        if module == "pymongo":
+            return SimpleNamespace(MongoClient=fake_client(state))
+        if module == "langgraph.store.mongodb" and not failing:
+            # Real MongoDBStore inherits AsyncBatchedBaseStore's dispatcher task; a
+            # store whose construction fails never starts one.
+            state.dispatcher = asyncio.create_task(asyncio.Event().wait())
+        return SimpleNamespace(
+            AsyncPostgresStore=postgres_driver(store, state, failing),
+            MongoDBStore=mongo_store,
+            create_vector_index_config=lambda **kwargs: kwargs,
+            setup_generation=_setup_generation,
+        )
+
+    return driver
+
+
+def fake_backend(monkeypatch, *, failing=False, started=None, release=None):
+    store = InMemoryStore()
+    mongo_data = defaultdict(InMemoryStore)
+    state = SimpleNamespace(closed=False, dispatcher=None)
+
     def mongo_store(target, *, index_config=None, **_kwargs: object):
         uri, collection = target
         if started is not None:
@@ -193,22 +220,20 @@ def fake_backend(monkeypatch, *, failing=False, started=None, release=None):
             release.wait(timeout=5)
         if failing:
             raise RuntimeError(uri)
-        backend = InMemoryStore(index=index_config)
+
+        class Dispatching(InMemoryStore):
+            # InMemoryStore is slotted; the dispatcher task needs a __dict__.
+            pass
+
+        backend = Dispatching(index=index_config)
         backend._data = mongo_data[collection]._data
         backend._vectors = mongo_data[collection]._vectors
+        backend._task = state.dispatcher
         return backend
 
-    def driver(module, _extra):
-        if module == "pymongo":
-            return SimpleNamespace(MongoClient=Client)
-        return SimpleNamespace(
-            AsyncPostgresStore=postgres_driver(store, state, failing),
-            MongoDBStore=mongo_store,
-            create_vector_index_config=lambda **kwargs: kwargs,
-            setup_generation=setup_generation,
-        )
-
-    monkeypatch.setattr(history_backends, "_driver", driver)
+    monkeypatch.setattr(
+        history_backends, "_driver", fake_driver(state, store, mongo_store, failing)
+    )
     return state
 
 
@@ -284,11 +309,32 @@ async def test_missing_backend_extra_has_install_guidance(tmp_path, monkeypatch,
         msg = "missing optional driver"
         raise ModuleNotFoundError(msg)
 
-    monkeypatch.setattr(history_backends.importlib, "import_module", missing)
+    monkeypatch.setattr(history_drivers.importlib, "import_module", missing)
     config = TalonConfig.from_env({URI_KEY: f"{scheme}://localhost/talon"}, base_home=tmp_path)
     with pytest.raises(ImportError, match=f"uv sync --extra {extra}"):
         async with open_history(config):
             pytest.fail("missing backend must not fall back to SQLite")
+
+
+@pytest.mark.parametrize(("scheme", "module"), _BROKEN_DRIVERS)
+async def test_installed_backend_reports_its_own_import_failure(
+    tmp_path, monkeypatch, scheme, module
+):
+    real = importlib.import_module
+
+    def broken(name):
+        if name == module:
+            msg = "libpq.so.5: cannot open shared object file"
+            raise ImportError(msg, name="psycopg_binary")
+        return real(name)
+
+    monkeypatch.setattr(history_drivers.importlib, "import_module", broken)
+    config = TalonConfig.from_env({URI_KEY: f"{scheme}://localhost/talon"}, base_home=tmp_path)
+    with pytest.raises(ImportError, match="libpq") as error:
+        async with open_history(config):
+            pytest.fail("a driver that is installed but broken must not be reported as missing")
+    # Telling the user to install what they already have hides the real cause.
+    assert "uv sync" not in str(error.value)
 
 
 @pytest.mark.parametrize("scheme", ["mongodb", "postgresql"])

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -599,6 +599,23 @@ async def test_threaded_store_uses_native_async_embeddings(tmp_path):
     assert set(raw.queries) == {"question"}
 
 
+async def test_adapter_client_is_closed_when_the_archive_closes(tmp_path, monkeypatch):
+    closed = []
+
+    class ClosingEmbeddings(RecordingEmbeddings):
+        async def aclose(self):
+            closed.append(True)
+
+    raw = ClosingEmbeddings()
+    fake_adapter(monkeypatch, raw)
+    config = configuration(tmp_path)
+    async with open_history(config) as archive:
+        await archive.append(SCOPE, "session", "time", [HumanMessage("car")])
+        await settled(archive)
+    # A reindex reopens the archive, so an unclosed pool leaks sockets per cycle.
+    assert closed == [True]
+
+
 async def test_query_prompt_reaches_stores_that_embed_searches_as_documents(tmp_path):
     from langgraph.store.memory import InMemoryStore  # noqa: PLC0415
 

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
+import time
 from dataclasses import replace
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -597,6 +599,61 @@ async def test_threaded_store_uses_native_async_embeddings(tmp_path):
     assert result[0].key == "one"
     assert raw.documents == ["document"]
     assert set(raw.queries) == {"question"}
+
+
+async def test_sync_store_api_is_refused_rather_than_embedding_in_the_lock(tmp_path):
+    from langgraph.store.memory import InMemoryStore  # noqa: PLC0415
+
+    from deepagents_talon.history_prepared_store import PreparedVectorStore  # noqa: PLC0415
+
+    raw = RecordingEmbeddings()
+    embed = BoundedEmbeddings(raw, configuration(tmp_path).history_embedding_profile)
+    store = PreparedVectorStore(
+        InMemoryStore(index={"dims": 2, "embed": embed, "fields": ["text"]}), embed
+    )
+    # Delegating would embed from the Store's worker thread inside the database lock.
+    with pytest.raises(NotImplementedError, match="async Store API"):
+        store.put(("test",), "one", {"text": "document"})
+    assert raw.documents == []
+
+
+async def test_prepared_store_indexes_configured_fields_without_assuming_text(tmp_path):
+    from langgraph.store.memory import InMemoryStore  # noqa: PLC0415
+
+    from deepagents_talon.history_prepared_store import PreparedVectorStore  # noqa: PLC0415
+
+    raw = RecordingEmbeddings()
+    embed = BoundedEmbeddings(raw, configuration(tmp_path).history_embedding_profile)
+    store = PreparedVectorStore(
+        InMemoryStore(index={"dims": 2, "embed": embed, "fields": ["body"]}), embed
+    )
+    await store.aput(("test",), "one", {"body": "document"}, index=["body"])
+    assert raw.documents == ["document"]
+
+
+async def test_bridge_gives_up_when_the_loop_cannot_run_the_coroutine(tmp_path, monkeypatch):
+    # raising=False so an unbounded bridge fails on the hang itself, not the constant.
+    monkeypatch.setattr(history_adapters, "_BRIDGE_TIMEOUT_SECONDS", 0.1, raising=False)
+    monkeypatch.setattr(history_adapters, "_BRIDGE_POLL_SECONDS", 0.02, raising=False)
+    profile = configuration(tmp_path).history_embedding_profile
+    embed = BoundedEmbeddings(RecordingEmbeddings(), profile)
+    outcome = []
+
+    def call():
+        try:
+            embed.embed_documents(["text"])
+        except RuntimeError as error:
+            outcome.append(error)
+
+    worker = threading.Thread(target=call, daemon=True)
+    worker.start()
+    # Never awaiting keeps the loop from serving the worker's coroutine at all, which
+    # is the state a stopping loop leaves it in. Without a bound the worker would wait
+    # here forever, holding the Store's own shutdown open.
+    time.sleep(0.5)  # noqa: ASYNC251  # Stalling the loop is what this test reproduces.
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    assert "deadline" in str(outcome[0])
 
 
 async def test_adapter_client_is_closed_when_the_archive_closes(tmp_path, monkeypatch):

--- a/libs/talon/tests/unit_tests/test_history_profiles.py
+++ b/libs/talon/tests/unit_tests/test_history_profiles.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 import threading
 import time
 from dataclasses import replace
@@ -86,6 +87,58 @@ def test_remote_adapters_name_the_settings_they_require(tmp_path, missing):
     del env[PREFIX + missing]
     with pytest.raises(TalonConfigError, match=f"{missing} is required"):
         TalonConfig.from_env(env, base_home=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        {"ADAPTER": "local", "MODEL": "BAAI/bge-m3", "BASE_URL": "https://api.example.org/v1"},
+        {"ADAPTER": "local", "MODEL": "BAAI/bge-m3", "SEND_DIMENSIONS": "0"},
+        {"ADAPTER": "atlas", "MODEL": "voyage-3-large", "MAX_INPUT_TOKENS": "16256"},
+    ],
+)
+def test_settings_an_adapter_cannot_honour_are_refused(tmp_path, settings):
+    # Silently ignoring these is worse than refusing: BASE_URL enters the fingerprint
+    # and forces a reindex, and SEND_DIMENSIONS is advertised as the fix for a
+    # dimension mismatch it cannot repair on these adapters.
+    if settings["ADAPTER"] == "atlas":
+        settings = {**settings, "DIMS": "1024", "SEND_DIMENSIONS": "0"}
+    with pytest.raises(TalonConfigError, match=r"BASE_URL|SEND_DIMENSIONS"):
+        configuration(tmp_path, **settings)
+
+
+@pytest.mark.parametrize(("flag", "expected"), [("1", 1024), ("0", None)])
+async def test_voyage_honours_send_dimensions(tmp_path, monkeypatch, flag, expected):
+    captured = {}
+
+    class FakeVoyage(Embeddings):
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def embed_documents(self, texts):
+            return [[1.0, 0.0] for _ in texts]
+
+        def embed_query(self, _text):
+            return [1.0, 0.0]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "deepagents_talon.history_voyage",
+        SimpleNamespace(HistoryVoyageEmbeddings=FakeVoyage),
+    )
+    monkeypatch.setattr(history_adapters, "_driver", lambda *_args: SimpleNamespace())
+    config = configuration(
+        tmp_path,
+        ADAPTER="voyage",
+        MODEL="voyage-3-large",
+        DIMS="1024",
+        BASE_URL="",
+        SEND_DIMENSIONS=flag,
+        API_KEY="test-key",
+    )
+    async with open_profile(config) as profile:
+        assert profile is not None
+    assert captured["output_dimension"] == expected
 
 
 def test_public_endpoints_remain_configurable(tmp_path):


### PR DESCRIPTION
**Stack 3 of 4 — history/archive.** Based on `linted/talon/history-2-indexing-worker` (#6154). Review #6153 and #6154 first.

Optional-dependency loading, provider client lifetimes, and embedding settings that were silently ignored.

- **One optional-driver loader replaces two duplicates.** `_driver` existed byte-identically in `history_adapters.py` and `history_backends.py`, differing only in a message prefix, and both did `raise ImportError(msg) from None` — so an extra that *is* installed but fails for another reason (broken `torch`, missing libpq) told the user to install what they already had, with no traceback. The shared loader in `history_drivers.py` checks `ImportError.name` and re-raises anything that isn't the extra itself, chaining the cause either way.
- **MongoDB startup was unbounded and its dispatcher never stopped**, unlike its two sibling backends. The startup budget is now explicit — see the comment on why `asyncio.timeout` alone cannot bound it, since `finish()` runs to completion by design.
- **Voyage and Atlas embedding clients were never closed**, leaking connection pools on every archive reopen. Cleanup registration moved into `open_profile` so it covers whichever adapter resolves.
- **`PreparedVectorStore.batch()` silently skipped the preparation the class exists for**, reaching the inner store with an empty cache; it now refuses. Field extraction no longer hardcodes `text`.
- **`_bridge` waited on a cross-thread future with no timeout**, so a worker thread could block forever against a stopping loop.
- **`SEND_DIMENSIONS` and `BASE_URL` were honoured by one adapter each and silently ignored elsewhere** — including by the adapter the `SEND_DIMENSIONS` error message tells you to use it with. Now honoured or refused at config time.

Verified by inspection only: Voyage client release and `output_dimension` handling — `voyageai` and `langchain-mongodb` aren't installed in CI, so the tests cover the registration path via fakes, not real SDK pool release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Reviewing this PR alone:** it is one level of a four-PR stack, so an automated reviewer reading it cannot see the levels above. Several findings filed against the mid-stack PRs turned out to be defects that the top of the same chain already fixes; each such thread has a reply naming the fixing PR. Read bottom-up, or read the top PR first if you want the final state.