### PR TITLE
fix(talon): bound the vector rebuild, break the import cycle, pin postgres

### DIFF
--- a/libs/talon/deepagents_talon/archive.py
+++ b/libs/talon/deepagents_talon/archive.py
@@ -60,7 +60,7 @@ class SearchPage(TypedDict):
     pagination_status: Literal["ok", "expired"]
 
 
-def _search_page(
+def build_search_page(
     hits: list[ArchiveEntry],
     limit: int,
     status: SemanticStatus,
@@ -68,22 +68,38 @@ def _search_page(
     pending: bool = False,
     expired: bool = False,
 ) -> SearchPage:
+    """Build one page of results with its retrieval coverage, for any archive backend.
+
+    Args:
+        hits: Ranked entries, one more than `limit` when a further page exists.
+        limit: Maximum entries to return.
+        status: Whether semantic retrieval ran, degraded, or was not requested.
+        pending: Whether source records are still awaiting indexing.
+        expired: Whether the caller's continuation token no longer resolves.
+    """
     results = hits[:limit]
     has_more = len(hits) > limit
     return SearchPage(
         results=results,
         semantic_status=status,
         indexing_pending=pending,
-        indexing_status=_indexing_status(status, pending=pending, visibility="unknown"),
+        indexing_status=indexing_status(status, pending=pending, visibility="unknown"),
         has_more=has_more,
         next_after=str(results[-1]["cursor"]) if has_more else None,
         pagination_status="expired" if expired else "ok",
     )
 
 
-def _indexing_status(
+def indexing_status(
     status: SemanticStatus, *, pending: bool, visibility: SearchVisibility
 ) -> IndexingStatus:
+    """Report whether the index behind a search is known to be current.
+
+    Args:
+        status: Whether semantic retrieval ran, degraded, or was not requested.
+        pending: Whether source records are still awaiting indexing.
+        visibility: Whether acknowledged writes are immediately searchable.
+    """
     if status in {"disabled", "not_requested"}:
         return "not_requested"
     if pending:

--- a/libs/talon/deepagents_talon/history_postgres.py
+++ b/libs/talon/deepagents_talon/history_postgres.py
@@ -1,4 +1,12 @@
-"""Isolate pgvector dimensions and migrations by embedding generation."""
+"""Isolate pgvector dimensions and migrations by embedding generation.
+
+This module drives internals of `langgraph-checkpoint-postgres` that are not public
+API: `store.VECTOR_MIGRATIONS`, each migration's `condition` and `_replace`, and the
+`dict_row` cursor factory behind the cast in `_vector_table`. A rename inside 3.x
+would not fail loudly - it would leave the migration rewrite below a silent no-op -
+so the `postgres` extra pins that dependency to a single minor version. Widening the
+pin means re-checking those four couplings first.
+"""
 
 from __future__ import annotations
 
@@ -45,6 +53,7 @@ async def _vector_table(store: AsyncPostgresStore, schema: sql.Identifier, dims:
         "WHERE e.extname='vector'"
     )
     row = await cursor.fetchone()
+    await cursor.close()
     if row is None:
         msg = "PostgreSQL vector extension is unavailable"
         raise RuntimeError(msg)

--- a/libs/talon/deepagents_talon/history_vector_backends.py
+++ b/libs/talon/deepagents_talon/history_vector_backends.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from contextlib import asynccontextmanager
 from importlib.metadata import entry_points
@@ -26,6 +27,10 @@ if TYPE_CHECKING:
     from deepagents_talon.config import TalonConfig
     from deepagents_talon.history_profiles import EmbeddingProfile
     from deepagents_talon.store_archive import StoreConversationArchive
+
+logger = logging.getLogger(__name__)
+_ERASE_BATCH = 96
+_PROGRESS_SECONDS = 5
 
 
 async def prepare_generation(config: TalonConfig, archive: StoreConversationArchive) -> str | None:
@@ -74,29 +79,43 @@ async def prepare_generation(config: TalonConfig, archive: StoreConversationArch
 
 async def _erase_vectors(archive: StoreConversationArchive, store: BaseStore) -> None:
     records = archive.records
-    root = await records.root()
+    # Reads run under `access()`, which replays an interrupted journal first; the
+    # caller already recovers, but this function must not depend on that.
+    async with records.access():
+        root = await records.root()
     index = HistoryVectorIndex(StoreVectorArchive(archive), store, indexing=False)
     index.identity = str(root["identity"])
     cursor, last = number(root, "reindex_cursor"), number(root, "last")
+    start, reported = cursor, asyncio.get_running_loop().time()
     while cursor < last:
-        stop = min(cursor + 96, last)
+        stop = min(cursor + _ERASE_BATCH, last)
         operations: list[PutOp] = []
-        for identifier in range(cursor + 1, stop + 1):
-            record = await records.get(str(identifier))
-            if record is not None and record.get("kind") == "chunk":
-                owner = await records.get(str(number(record, "owner")))
-                if owner is not None:
-                    scope = cast("dict[str, str]", owner["scope"])
-                    namespace = index.namespace(
-                        scope["talon_history_channel"], scope["talon_history_chat"]
-                    )
-                    operations.append(PutOp(namespace, str(identifier), None))
+        async with records.access():
+            for identifier in range(cursor + 1, stop + 1):
+                record = await records.get(str(identifier))
+                if record is not None and record.get("kind") == "chunk":
+                    owner = await records.get(str(number(record, "owner")))
+                    if owner is not None:
+                        scope = cast("dict[str, str]", owner["scope"])
+                        namespace = index.namespace(
+                            scope["talon_history_channel"], scope["talon_history_chat"]
+                        )
+                        operations.append(PutOp(namespace, str(identifier), None))
         if operations:
             await finish(store.abatch(operations))
         cursor = stop
         async with records.access():
             root = await records.root()
             await records.commit([("root", {**root, "reindex_cursor": cursor})])
+        # This runs before the host serves anything and is O(archive), so a large
+        # rebuild otherwise looks like a hang. Progress is durable in
+        # `reindex_cursor`, so an interrupted rebuild resumes where it stopped.
+        now = asyncio.get_running_loop().time()
+        if now - reported >= _PROGRESS_SECONDS:
+            reported = now
+            logger.info(
+                "Rebuilding history vectors: erased %d of %d records", cursor - start, last - start
+            )
 
 
 @asynccontextmanager

--- a/libs/talon/deepagents_talon/history_vector_backends.py
+++ b/libs/talon/deepagents_talon/history_vector_backends.py
@@ -14,9 +14,8 @@ from langgraph.store.base import PutOp
 
 from deepagents_talon.config import TalonConfigError
 from deepagents_talon.history_vectors import HistoryVectorIndex
-from deepagents_talon.store_archive import number
 from deepagents_talon.store_archive_index import StoreVectorArchive
-from deepagents_talon.store_records import finish
+from deepagents_talon.store_records import finish, number
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable

--- a/libs/talon/deepagents_talon/history_vectors.py
+++ b/libs/talon/deepagents_talon/history_vectors.py
@@ -45,6 +45,10 @@ _BATCH_TIMEOUT_SECONDS = 300
 # Unacknowledged work is retried from durable state on the next start, so abandoning
 # a wedged batch at shutdown costs a repeat, never data.
 _CLOSE_TIMEOUT_SECONDS = 10
+# Cancellation normally lands on the next loop iteration; this only has to outlast
+# that, and bounds a Store that never honours it. Together these are the whole of
+# `close()`'s wait: no await in it is unbounded.
+_CANCEL_GRACE_SECONDS = 1
 
 
 @dataclass
@@ -101,8 +105,15 @@ class HistoryVectorIndex:
     async def close(self) -> None:
         """Finish the active batch before the caller closes database connections.
 
-        A Store write that never returns must not hold host shutdown open forever, so
-        the batch is abandoned once the deadline passes and retried on the next start.
+        Returns within `_CLOSE_TIMEOUT_SECONDS + _CANCEL_GRACE_SECONDS`, having asked
+        every in-flight operation to stop. It cannot promise they have: `_batch` shields
+        the Store task so a cancelled caller cannot leave a partial batch, and a Store
+        that runs blocking work in a thread cannot be interrupted from this loop at all.
+        A batch still running when this returns is abandoned, not awaited - the caller
+        may then close connections underneath it, and the Store may log errors as that
+        happens. That is the deliberate trade: unacknowledged work is retried on the
+        next start, so an abandoned batch costs a repeat, while a wedged `close()`
+        costs the host its shutdown.
         """
         self.stopping = True
         self.wake.set()
@@ -132,7 +143,21 @@ class HistoryVectorIndex:
             )
             for task in unfinished:
                 task.cancel()
-            await asyncio.gather(*unfinished, return_exceptions=True)
+            # Cancellation needs its own grace rather than the remainder of the
+            # deadline above, which the drain loop has usually just exhausted: it
+            # normally lands on the next loop iteration, and waiting ~0s for it would
+            # abandon batches that were about to stop. Bounded, because a Store that
+            # ignores or defers cancellation would otherwise block here forever -
+            # the same wedged shutdown this deadline exists to prevent.
+            _, running = await asyncio.wait(unfinished, timeout=_CANCEL_GRACE_SECONDS)
+            if running:
+                logger.error(
+                    "History vector indexing ignored cancellation; abandoning %d in-flight "
+                    "Store operation(s) and continuing shutdown. Unacknowledged work is "
+                    "retried on the next start, and the Store may report errors as its "
+                    "connection closes underneath them.",
+                    len(running),
+                )
         if self.task is not None and not self.task.cancelled() and (error := self.task.exception()):
             raise error
 

--- a/libs/talon/deepagents_talon/history_vectors.py
+++ b/libs/talon/deepagents_talon/history_vectors.py
@@ -106,10 +106,24 @@ class HistoryVectorIndex:
         """
         self.stopping = True
         self.wake.set()
-        tasks = [task for task in (self.task, *self._pending) if task is not None]
-        if not tasks:
-            return
-        _, unfinished = await asyncio.wait(tasks, timeout=_CLOSE_TIMEOUT_SECONDS)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _CLOSE_TIMEOUT_SECONDS
+        # `_pending` is not stable here. `stopping` is only checked at the top of the
+        # worker's loop, so a worker already inside an iteration still registers its
+        # Store task afterwards - and `_batch` shields that task, so cancelling the
+        # worker does not stop it. A single snapshot would let `close()` return while
+        # a write is in flight, and the caller then tears the Store down underneath it.
+        while True:
+            tasks = [
+                task for task in (self.task, *self._pending) if task is not None and not task.done()
+            ]
+            remaining = deadline - loop.time()
+            if not tasks or remaining <= 0:
+                break
+            await asyncio.wait(tasks, timeout=remaining)
+        unfinished = [
+            task for task in (self.task, *self._pending) if task is not None and not task.done()
+        ]
         if unfinished:
             logger.warning(
                 "History vector indexing did not stop within %ss; abandoning the active batch "

--- a/libs/talon/deepagents_talon/history_vectors.py
+++ b/libs/talon/deepagents_talon/history_vectors.py
@@ -20,8 +20,8 @@ from deepagents_talon.archive import (
     SearchPage,
     SearchVisibility,
     SemanticStatus,
-    _indexing_status,
-    _search_page,
+    build_search_page,
+    indexing_status,
 )
 
 if TYPE_CHECKING:
@@ -256,7 +256,7 @@ class HistoryVectorIndex:
         if after and (
             snapshot is None or snapshot.query != cache_key or cursor not in snapshot.keys
         ):
-            return _search_page(
+            return build_search_page(
                 [],
                 limit,
                 "not_requested",
@@ -277,13 +277,13 @@ class HistoryVectorIndex:
         if len(self._pages) > _MAX_SEARCH_PAGES:
             self._pages.popitem(last=False)
         hits = await self.archive.ranked(scope, snapshot.keys, int(cursor or 0), limit + 1)
-        page = _search_page(
+        page = build_search_page(
             hits,
             limit,
             snapshot.status,
             pending=pending or snapshot.pending,
         )
-        page["indexing_status"] = _indexing_status(
+        page["indexing_status"] = indexing_status(
             snapshot.status, pending=page["indexing_pending"], visibility=self.search_visibility
         )
         if page["next_after"] is not None:

--- a/libs/talon/deepagents_talon/store_archive.py
+++ b/libs/talon/deepagents_talon/store_archive.py
@@ -17,8 +17,17 @@ from uuid import uuid4
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
-from deepagents_talon.archive import CHUNK_SIZE, _search_page
-from deepagents_talon.store_records import Record, StoreRecords, Write, digest
+from deepagents_talon.archive import CHUNK_SIZE, build_search_page
+from deepagents_talon.history_vectors import HistoryVectorIndex
+from deepagents_talon.store_archive_index import StoreVectorArchive
+from deepagents_talon.store_records import (
+    Record,
+    StoreRecords,
+    Write,
+    digest,
+    number,
+    scope_key,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator, Sequence
@@ -38,16 +47,6 @@ if TYPE_CHECKING:
 _MAX_PAGE_SIZE = 20
 _MAX_SCAN = 500
 _MAX_SEARCH_PAGES = 32
-
-
-def number(record: Record, key: str) -> int:
-    """Read a numeric ordering field from a versioned archive record."""
-    return cast("int", record.get(key, 0))
-
-
-def scope_key(scope: ArchiveScope) -> str:
-    """Encode a trusted chat scope as a backend-independent lookup key."""
-    return "scope:" + digest(scope["talon_history_channel"], scope["talon_history_chat"])
 
 
 def _bounds(after: int, limit: int) -> None:
@@ -120,9 +119,6 @@ class StoreConversationArchive:
         self._setup_lock = asyncio.Lock()
         self.vectors = None
         if vector_store is not None:
-            from deepagents_talon.history_vectors import HistoryVectorIndex  # noqa: PLC0415
-            from deepagents_talon.store_archive_index import StoreVectorArchive  # noqa: PLC0415
-
             self.vectors = HistoryVectorIndex(
                 StoreVectorArchive(self),
                 vector_store,
@@ -299,7 +295,7 @@ class StoreConversationArchive:
             return None
         return entry
 
-    async def _text_entries(  # noqa: PLR0913  # Preserve existing arguments when adding partial scans.
+    async def text_entries(  # noqa: PLR0913  # Preserve existing arguments when adding partial scans.
         self,
         scope: ArchiveScope,
         *,
@@ -309,6 +305,20 @@ class StoreConversationArchive:
         limit: int,
         partial: bool = False,
     ) -> list[ArchiveEntry]:
+        """Read scoped transcripts by ordering link, for this archive's own adapters.
+
+        Args:
+            scope: Trusted channel and chat identity.
+            query: Literal words to match against complete message revisions.
+            session_id: Read this session chronologically when supplied.
+            after: Previous result cursor.
+            limit: Maximum entries to return.
+            partial: Stop at the scan budget instead of raising; only for ranked
+                candidate generation, never for a page that claims completeness.
+
+        Raises:
+            RuntimeError: The scan budget is exhausted and `partial` is not set.
+        """
         async with self.records.access():
             if session_id:
                 session = await self.session(session_id)
@@ -385,7 +395,7 @@ class StoreConversationArchive:
         """
         _bounds(after, limit)
         await self.setup()
-        return await self._text_entries(
+        return await self.text_entries(
             scope, query=query, session_id=session_id, after=after, limit=limit
         )
 
@@ -413,12 +423,12 @@ class StoreConversationArchive:
         continuation = self._pages.get(after) if after else None
         status = "disabled" if query.strip() else "not_requested"
         if after and (continuation is None or continuation[:3] != context):
-            return _search_page([], limit, status, expired=True)
+            return build_search_page([], limit, status, expired=True)
         cursor = continuation[3] if continuation else 0
-        hits = await self._text_entries(
+        hits = await self.text_entries(
             scope, query=query, session_id="", after=cursor, limit=limit + 1
         )
-        page = _search_page(hits, limit, status, expired=bool(after and not hits))
+        page = build_search_page(hits, limit, status, expired=bool(after and not hits))
         if page["has_more"]:
             token = uuid4().hex
             self._pages[token] = (*context, page["results"][-1]["cursor"])

--- a/libs/talon/deepagents_talon/store_archive_index.py
+++ b/libs/talon/deepagents_talon/store_archive_index.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from deepagents_talon.store_archive import number, scope_key
+from deepagents_talon.history_index import VectorArchive
+from deepagents_talon.store_records import number, scope_key
 
 if TYPE_CHECKING:
     from deepagents_talon.archive import ArchiveEntry, ArchiveScope
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from deepagents_talon.store_records import Record
 
 
-class StoreVectorArchive:
+class StoreVectorArchive(VectorArchive):
     """Reconcile immutable archive entries instead of maintaining a SQL queue."""
 
     def __init__(self, archive: StoreConversationArchive) -> None:
@@ -145,7 +146,7 @@ class StoreVectorArchive:
         fused with the semantic ranking, so a short list degrades recall while a
         raised error would fail a search the semantic leg had already answered.
         """
-        entries = await self.archive._text_entries(  # noqa: SLF001  # Storage adapter shares archive retrieval.
+        entries = await self.archive.text_entries(
             scope,
             query=query,
             session_id="",

--- a/libs/talon/deepagents_talon/store_records.py
+++ b/libs/talon/deepagents_talon/store_records.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
     from langgraph.store.base import BaseStore
 
+    from deepagents_talon.archive import ArchiveScope
+
 Record = dict[str, object]
 Write = tuple[str, Record | None]
 _MAX_WRITES = 12
@@ -22,6 +24,16 @@ _MAX_WRITES = 12
 def digest(*values: str) -> str:
     """Hash identifiers without relying on backend namespace escaping."""
     return hashlib.sha256(json.dumps(values, ensure_ascii=True).encode()).hexdigest()
+
+
+def number(record: Record, key: str) -> int:
+    """Read a numeric ordering field from a versioned archive record."""
+    return cast("int", record.get(key, 0))
+
+
+def scope_key(scope: ArchiveScope) -> str:
+    """Encode a trusted chat scope as a backend-independent lookup key."""
+    return "scope:" + digest(scope["talon_history_channel"], scope["talon_history_chat"])
 
 
 async def finish[T](operation: Coroutine[object, object, T]) -> T:

--- a/libs/talon/pyproject.toml
+++ b/libs/talon/pyproject.toml
@@ -41,7 +41,11 @@ mongodb = [
     "langgraph-store-mongodb>=0.4.0,<0.5.0",
 ]
 postgres = [
-    "langgraph-checkpoint-postgres>=3.1.2,<4.0.0",
+    # Pinned to one minor rather than the usual <4.0.0: history_postgres.py drives
+    # `store.VECTOR_MIGRATIONS`, `migration.condition`, `migration._replace` and the
+    # `dict_row` cursor factory, none of which are public API. A rename inside 3.x
+    # would not fail loudly - it would leave the migration rewrite a silent no-op.
+    "langgraph-checkpoint-postgres>=3.1.2,<3.2.0",
     "psycopg[binary]>=3.3.5,<4.0.0",
 ]
 media = [

--- a/libs/talon/tests/unit_tests/test_history_vectors.py
+++ b/libs/talon/tests/unit_tests/test_history_vectors.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 import aiosqlite
 import pytest
@@ -235,6 +235,51 @@ async def test_close_waits_for_a_batch_registered_after_it_started(monkeypatch):
     assert state["started"]
     # close() must not return while a shielded write is still touching the Store.
     assert state["cancelled"]
+
+
+async def test_close_returns_when_the_store_ignores_cancellation(monkeypatch, caplog):
+    monkeypatch.setattr("deepagents_talon.history_vectors._CLOSE_TIMEOUT_SECONDS", 0.1)
+    # raising=False so an unbounded post-cancel wait fails on the hang, not the constant.
+    monkeypatch.setattr(
+        "deepagents_talon.history_vectors._CANCEL_GRACE_SECONDS", 0.1, raising=False
+    )
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.history_vectors")
+    started, finished = asyncio.Event(), asyncio.Event()
+
+    class UncancellableStore(InMemoryStore):
+        async def abatch(self, ops):
+            operations = list(ops)
+            if not any(isinstance(op, PutOp) and op.value is not None for op in operations):
+                return await super().abatch(operations)
+            started.set()
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + 2
+            while loop.time() < deadline:
+                # Stands in for a Store whose blocking work runs in a thread, which
+                # cannot be interrupted from the event loop at all.
+                with suppress(asyncio.CancelledError):
+                    await asyncio.sleep(0.02)
+            finished.set()
+            return []
+
+    store = UncancellableStore(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    archive = StoreConversationArchive(
+        InMemoryStore(), namespace=("uncancellable",), vector_store=store
+    )
+    loop = asyncio.get_running_loop()
+    async with asyncio.timeout(8):
+        await archive.setup()
+        await append(archive, "car")
+        await asyncio.wait_for(started.wait(), 2)
+        elapsed = loop.time()
+        await archive.aclose()
+        elapsed = loop.time() - elapsed
+        # Bounded well inside the store's own 2s, so shutdown did not wait on it.
+        assert elapsed < 1
+        assert not finished.is_set()
+        assert any("ignored cancellation" in item.message for item in caplog.records)
+        # Let the abandoned batch drain so it is not still pending at teardown.
+        await asyncio.wait_for(finished.wait(), 5)
 
 
 async def test_indexing_batches_never_overlap_so_they_need_no_permit():

--- a/libs/talon/tests/unit_tests/test_history_vectors.py
+++ b/libs/talon/tests/unit_tests/test_history_vectors.py
@@ -228,6 +228,20 @@ async def test_indexing_batches_never_overlap_so_they_need_no_permit():
     assert peak == 1
 
 
+def test_worker_protocol_is_declared_and_no_longer_needs_deferred_imports():
+    from deepagents_talon import store_archive as module  # noqa: PLC0415
+    from deepagents_talon.history_index import VectorArchive  # noqa: PLC0415
+    from deepagents_talon.store_archive_index import StoreVectorArchive  # noqa: PLC0415
+
+    # Declared rather than merely structural, so a drifting signature fails the type
+    # check instead of silently diverging from the worker's expectations.
+    assert VectorArchive in StoreVectorArchive.__mro__
+    # The store_archive <-> store_archive_index cycle that forced function-level
+    # imports is gone, so the workers resolve at module scope.
+    assert module.HistoryVectorIndex is not None
+    assert module.StoreVectorArchive is not None
+
+
 async def test_vector_erase_recovers_an_interrupted_journal_before_reading():
     from deepagents_talon.history_vector_backends import _erase_vectors  # noqa: PLC0415
 

--- a/libs/talon/tests/unit_tests/test_history_vectors.py
+++ b/libs/talon/tests/unit_tests/test_history_vectors.py
@@ -197,6 +197,46 @@ async def test_close_abandons_a_wedged_indexing_batch(tmp_path, monkeypatch, cap
     assert any("abandoning the active batch" in item.message for item in caplog.records)
 
 
+async def test_close_waits_for_a_batch_registered_after_it_started(monkeypatch):
+    monkeypatch.setattr("deepagents_talon.history_vectors._CLOSE_TIMEOUT_SECONDS", 0.3)
+    state = {"started": False, "cancelled": False}
+
+    class WedgedStore(InMemoryStore):
+        async def abatch(self, ops):
+            operations = list(ops)
+            if any(isinstance(op, PutOp) and op.value is not None for op in operations):
+                state["started"] = True
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    state["cancelled"] = True
+                    raise
+            return await super().abatch(operations)
+
+    store = WedgedStore(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    archive = StoreConversationArchive(InMemoryStore(), namespace=("late",), vector_store=store)
+    await archive.setup()
+    closing = None
+    try:
+        async with archive.vectors.lock:
+            for _ in range(3):
+                # The worker parks acquiring this lock, already past its `stopping` check.
+                await asyncio.sleep(0)
+            await append(archive, "car")
+            closing = asyncio.create_task(archive.aclose())
+            for _ in range(3):
+                await asyncio.sleep(0)
+        # Releasing lets the worker register a Store task after close() began, so a
+        # single snapshot of `_pending` no longer describes what is in flight.
+        await asyncio.wait_for(closing, 5)
+    finally:
+        if closing is not None and not closing.done():
+            closing.cancel()
+    assert state["started"]
+    # close() must not return while a shielded write is still touching the Store.
+    assert state["cancelled"]
+
+
 async def test_indexing_batches_never_overlap_so_they_need_no_permit():
     active, peak = 0, 0
 

--- a/libs/talon/tests/unit_tests/test_history_vectors.py
+++ b/libs/talon/tests/unit_tests/test_history_vectors.py
@@ -228,6 +228,29 @@ async def test_indexing_batches_never_overlap_so_they_need_no_permit():
     assert peak == 1
 
 
+async def test_vector_erase_recovers_an_interrupted_journal_before_reading():
+    from deepagents_talon.history_vector_backends import _erase_vectors  # noqa: PLC0415
+
+    metadata = InMemoryStore()
+    vectors = InMemoryStore(index={"dims": 2, "embed": Embedding(), "fields": ["text"]})
+    async with StoreConversationArchive(
+        metadata, namespace=("erase",), vector_store=vectors
+    ).open() as archive:
+        for index in range(3):
+            await append(archive, f"car {index}", session=f"session-{index}")
+        await settled(archive)
+        namespace = archive.vectors.namespace("whatsapp", "one")
+        assert len(await vectors.asearch(namespace)) == 3
+        records = archive.records
+        root = await records.get("root")
+    # An interrupted commit leaves its writes in the journal and the live root behind.
+    await metadata.aput(records.namespace, "root", {**root, "last": 1}, index=False)
+    await metadata.aput(records.namespace, "journal", {"writes": [["root", root]]}, index=False)
+    # Reading the stale root would leave the newest vectors behind after a rebuild.
+    await _erase_vectors(archive, vectors)
+    assert await vectors.asearch(namespace) == []
+
+
 async def test_existing_vectors_survive_restart_and_do_not_reembed(tmp_path):
     path = str(tmp_path / "archive.sqlite")
     async with (

--- a/libs/talon/uv.lock
+++ b/libs/talon/uv.lock
@@ -1073,7 +1073,7 @@ requires-dist = [
     { name = "langchain-mcp-adapters", specifier = ">=0.3.2,<1.0.0" },
     { name = "langchain-openai", marker = "extra == 'history-openai'", specifier = ">=1.6.0,<2.0.0" },
     { name = "langchain-voyageai", marker = "extra == 'history-voyage'", specifier = ">=0.4.1,<0.5.0" },
-    { name = "langgraph-checkpoint-postgres", marker = "extra == 'postgres'", specifier = ">=3.1.2,<4.0.0" },
+    { name = "langgraph-checkpoint-postgres", marker = "extra == 'postgres'", specifier = ">=3.1.2,<3.2.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.1,<4.0.0" },
     { name = "langgraph-store-mongodb", marker = "extra == 'mongodb'", specifier = ">=0.4.0,<0.5.0" },
     { name = "librosa", marker = "extra == 'media'", specifier = ">=0.11.0,<1.0.0" },


### PR DESCRIPTION
**Stack 4 of 4 — history/archive.** Based on `linted/talon/history-3-drivers-adapters`. Review levels 1–3 first.

The rebuild path, the import cycle, the dependency pin, and a regression fix.

- **`_erase_vectors` did unbounded startup work and read outside the records lock.** It scans cursor-by-cursor with a second `records.get` per chunk, inside `prepare_generation`, which `open_history` awaits before the host serves anything — so a large archive meant O(n) round trips on startup with no progress reporting. Reads now happen under `records.access()`, which is what performs journal recovery.
- **The archive import cycle is broken** and the private cross-module seams retired: `number`/`scope_key` moved into `store_records`, workers import at module scope, `_search_page`/`_indexing_status`/`_text_entries` are public, and `StoreVectorArchive` now declares the `VectorArchive` protocol it implements — which nothing previously enforced, so it could drift from its single implementation undetected.
- **`langgraph-checkpoint-postgres` is pinned to `<3.2.0`.** `history_postgres.py` drives four non-public APIs (`store.VECTOR_MIGRATIONS`, `migration.condition`, `migration._replace`, and the `dict_row` cursor factory), and a rename inside 3.x would not fail loudly — it would leave the migration rewrite a silent no-op. A capability check was considered and rejected: `psycopg` isn't installed in CI, the module can't be imported by any test, and shipping an unverifiable guard to the one module no test can reach is worse than pinning.
- **`close()` could return with a write still in flight** — a regression introduced by the bound added in level 2. A single `_pending` snapshot could miss a batch registered after it was taken, and because `_batch` shields Store tasks, cancelling the worker didn't stop it. Now drains against a monotonic deadline.

The pre-level-2 `close()` read `_pending` *after* awaiting the worker, which was correct by accident. Replacing it with an upfront snapshot traded "hangs forever" for "returns too early" — the worse half of that trade in a shutdown path.

Verified by inspection only: the two `history_postgres.py` edits, including the cursor close. No test exercises that module, before or after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
