### PR TITLE
fix(talon): make background subagents and host start/stop recoverable

### DIFF
--- a/libs/talon/deepagents_talon/background.py
+++ b/libs/talon/deepagents_talon/background.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import logging
 from contextlib import aclosing
 from copy import copy
 from dataclasses import dataclass, replace
@@ -27,9 +28,19 @@ if TYPE_CHECKING:
     from langchain_core.runnables import RunnableConfig
     from langgraph_sdk.schema import StreamPart
 
+logger = logging.getLogger(__name__)
+
 _IN_SUBAGENT: contextvars.ContextVar[bool] = contextvars.ContextVar("talon_subagent", default=False)
 _MAX_TASKS = 128
 _MAX_RUNNING = 4
+_MAX_DELIVERIES = 3
+_TASK_TIMEOUT_SECONDS = 3600
+_FAILED_RESULT = "Subagent failed before returning a result."
+_TIMED_OUT_RESULT = "Subagent ran out of time before returning a result."
+_UNDELIVERED_RESULT = (
+    f"The conversation failed to process this result {_MAX_DELIVERIES} times, "
+    "so it was dropped and never reached the user."
+)
 _INSTRUCTIONS = (
     "The task and start_async_task tools launch background subagents and return a task ID. "
     "Keep talking to the user while they work. Use list_subagents to inspect progress and "
@@ -46,6 +57,7 @@ class _Job:
     result: str | None = None
     cancelled: bool = False
     notified: bool = False
+    deliveries: int = 0
     tools: list[str] | None = None
 
     @property
@@ -170,7 +182,7 @@ class BackgroundSubagents(AgentMiddleware):
             job.tools = request.tool_call["args"].get("tools")
             self._jobs[task_id] = job
             job.worker = asyncio.create_task(
-                self._run(job, request, task_id), name=task_id, context=contextvars.Context()
+                self._run(job, request, task_id), name=task_id, context=contextvars.copy_context()
             )
         return ToolMessage(
             f"Started background subagent. task_id: {task_id}", tool_call_id=request.tool_call["id"]
@@ -181,8 +193,9 @@ class BackgroundSubagents(AgentMiddleware):
         config: RunnableConfig = {"configurable": {"thread_id": task_id}, "recursion_limit": 500}
         runtime = replace(request.runtime, config=config, state=dict(request.runtime.state))
         call = {**request.tool_call, "args": {**request.tool_call["args"], "runtime": runtime}}
+        timeout = asyncio.timeout(_TASK_TIMEOUT_SECONDS)
         try:
-            async with asyncio.timeout(3600):
+            async with timeout:
                 if request.tool_call["name"] == "start_async_task":
                     job.result = await self._run_remote(request)
                     return
@@ -203,8 +216,10 @@ class BackgroundSubagents(AgentMiddleware):
             job.result = job.result[:64_000]
         except asyncio.CancelledError:
             job.cancelled = True
-        except Exception:  # noqa: BLE001  # report failures without exposing tool arguments or credentials
-            job.result = "Subagent failed before returning a result."
+        except Exception:
+            logger.exception("Background subagent %s failed", task_id)
+            # This result reaches the model and the user: no arguments, no credentials.
+            job.result = _TIMED_OUT_RESULT if timeout.expired() else _FAILED_RESULT
 
     async def _run_remote(self, request: ToolCallRequest) -> str:
         spec = self._remote[request.tool_call["args"]["subagent_type"]]
@@ -249,6 +264,29 @@ class BackgroundSubagents(AgentMiddleware):
             and not job.cancelled
             and not job.notified
         }
+
+    def record_delivery_failure(self, results: dict[str, str]) -> list[str]:
+        """Count one failed delivery and drop results the main agent cannot process.
+
+        Args:
+            results: Result IDs handed to a main-agent turn that then failed.
+
+        Returns:
+            Result IDs dropped after too many failed delivery attempts.
+        """
+        dropped = []
+        for key in results:
+            job = self._jobs.get(key)
+            if job is None or job.notified:
+                continue
+            job.deliveries += 1
+            if job.deliveries < _MAX_DELIVERIES:
+                continue
+            job.notified = True
+            job.result = f"{_UNDELIVERED_RESULT}\n{job.result}"
+            dropped.append(key)
+            logger.warning("Dropped undelivered background subagent result %s", key)
+        return dropped
 
     def acknowledge(self, results: dict[str, str]) -> None:
         """Mark results processed only after the main agent completes a turn.

--- a/libs/talon/deepagents_talon/background.py
+++ b/libs/talon/deepagents_talon/background.py
@@ -18,6 +18,8 @@ from langchain_core.tools import tool
 from langgraph.types import Command
 from langgraph_sdk import get_client
 
+from deepagents_talon.authorization import set_authorization_handler
+
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable, Sequence
 
@@ -190,6 +192,12 @@ class BackgroundSubagents(AgentMiddleware):
 
     async def _run(self, job: _Job, request: ToolCallRequest, task_id: str) -> None:
         _IN_SUBAGENT.set(True)
+        # The copied context carries the host's history scope and cron origin, which the
+        # tools a subagent may hold require. It must not carry the authorization handler:
+        # a flow started once the originating turn has ended would outlive the host's
+        # `_clear_authorization`, stranding a pending prompt in the conversation. Enabling
+        # background authorization needs host-side cleanup first.
+        set_authorization_handler(None)
         config: RunnableConfig = {"configurable": {"thread_id": task_id}, "recursion_limit": 500}
         runtime = replace(request.runtime, config=config, state=dict(request.runtime.state))
         call = {**request.tool_call, "args": {**request.tool_call["args"], "runtime": runtime}}

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -101,6 +101,9 @@ _CANCEL_TIMEOUT_MESSAGE = (
     "Could not stop the current run within 30 seconds. Your new message was not started. "
     "Restart Talon to recover."
 )
+_AGENT_FAILURE_MESSAGE = "Something went wrong while working on that. Check Talon logs."
+_BACKGROUND_RETRY_BASE_SECONDS = 2.0
+_BACKGROUND_RETRY_MAX_SECONDS = 60.0
 _EMOJI_VARIATION_SELECTOR = "\ufe0f"
 _EMOJI_SKIN_TONES = frozenset(
     {
@@ -127,6 +130,12 @@ class _Turn:
     provider: str | None
     generation: int
     recovery_degraded: bool
+
+
+@dataclass(slots=True)
+class _BackgroundRetry:
+    attempts: int
+    deadline: float
 
 
 @dataclass(slots=True)
@@ -213,6 +222,7 @@ class TalonHost:
         self._background_routes: dict[
             str, tuple[ChannelAdapter, ChannelMessage, str, str | None]
         ] = {}
+        self._background_retries: dict[str, _BackgroundRetry] = {}
         self._stopped = asyncio.Event()
         self._running = False
 
@@ -222,25 +232,31 @@ class TalonHost:
         return self._running
 
     async def start(self) -> None:
-        """Start the agent runtime, scheduler, and channels."""
+        """Start the agent runtime, scheduler, and channels.
+
+        Raises:
+            Exception: Whatever a managed component raised while starting. The
+                components already started are stopped in reverse order first,
+                so a partial start never leaves connections or subprocesses open.
+        """
         if self._running:
             return
 
         self.config.ensure_home()
         await self.agent.start()
-
-        for channel in self.channels:
-            channel.set_message_handler(
-                lambda message, current=channel: self.receive_message(current, message),
-            )
-            if isinstance(channel, ReactionChannelAdapter):
-                channel.set_reaction_handler(
-                    lambda reaction, current=channel: self.receive_reaction(current, reaction),
-                )
-            await channel.start()
-
-        if self.scheduler is not None:
-            await self.scheduler.start()
+        started: list[ChannelAdapter] = []
+        scheduler: CronScheduler | None = None
+        try:
+            for channel in self.channels:
+                self._bind_channel(channel)
+                await channel.start()
+                started.append(channel)
+            if self.scheduler is not None:
+                await self.scheduler.start()
+                scheduler = self.scheduler
+        except BaseException:
+            await self._unwind_start(started, scheduler)
+            raise
 
         self._stopped.clear()
         self._running = True
@@ -249,7 +265,11 @@ class TalonHost:
         logger.info("Talon host started for assistant %s", self.config.assistant_id)
 
     async def stop(self) -> None:
-        """Stop managed components and cancel in-flight agent work."""
+        """Stop managed components and cancel in-flight agent work.
+
+        Every component is stopped even when an earlier one fails, so shutdown
+        always completes and always releases the host.
+        """
         if not self._running:
             self._stopped.set()
             return
@@ -257,19 +277,48 @@ class TalonHost:
         self._running = False
         if self._background_loop is not None:
             self._background_loop.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._background_loop
+            await asyncio.gather(self._background_loop, return_exceptions=True)
         await self._cancel_all()
 
         for channel in reversed(self.channels):
-            await channel.stop()
+            await self._stop_component(channel.stop, "channel")
 
         if self.scheduler is not None:
-            await self.scheduler.stop()
+            await self._stop_component(self.scheduler.stop, "scheduler")
 
-        await self.agent.stop()
+        await self._stop_component(self.agent.stop, "agent runtime")
         self._stopped.set()
         logger.info("Talon host stopped for assistant %s", self.config.assistant_id)
+
+    def _bind_channel(self, channel: ChannelAdapter) -> None:
+        channel.set_message_handler(
+            lambda message, current=channel: self.receive_message(current, message),
+        )
+        if isinstance(channel, ReactionChannelAdapter):
+            channel.set_reaction_handler(
+                lambda reaction, current=channel: self.receive_reaction(current, reaction),
+            )
+
+    async def _unwind_start(
+        self,
+        channels: list[ChannelAdapter],
+        scheduler: CronScheduler | None,
+    ) -> None:
+        if scheduler is not None:
+            await self._stop_component(scheduler.stop, "scheduler")
+        for channel in reversed(channels):
+            await self._stop_component(channel.stop, "channel")
+        await self._stop_component(self.agent.stop, "agent runtime")
+
+    async def _stop_component(
+        self,
+        stop: Callable[[], Awaitable[None]],
+        component: str,
+    ) -> None:
+        try:
+            await stop()
+        except Exception:
+            logger.exception("Failed to stop Talon %s", component)
 
     async def run_until_stopped(self) -> None:
         """Start the host and keep it alive until shutdown is requested."""
@@ -472,7 +521,10 @@ class TalonHost:
     async def _process_background_results(self) -> None:
         while self._running:
             await asyncio.sleep(1)
-            await self._dispatch_background_results()
+            try:
+                await self._dispatch_background_results()
+            except Exception:
+                logger.exception("Failed to deliver background subagent results")
 
     async def _dispatch_background_results(self) -> None:
         if not isinstance(self.agent, BackgroundRuntime):
@@ -484,10 +536,14 @@ class TalonHost:
                     continue
                 if owner not in self.agent.background.owners():
                     self._background_routes.pop(owner, None)
+                    self._background_retries.pop(owner, None)
                     continue
                 if owner in self._blocked or self._agent_conversation_id(root) != owner:
                     continue
-                if self.agent.background.results(owner):
+                if not self.agent.background.results(owner):
+                    self._background_retries.pop(owner, None)
+                    continue
+                if self._claim_background_turn(owner):
                     await self._replace_agent_turn(
                         channel,
                         ChannelMessage(
@@ -499,6 +555,25 @@ class TalonHost:
                         owner,
                         provider,
                     )
+
+    def _claim_background_turn(self, owner: str) -> bool:
+        """Take a delivery slot for one conversation, spacing out repeat attempts.
+
+        Args:
+            owner: Conversation whose pending results need a main-agent turn.
+
+        Returns:
+            Whether a turn may start now. A conversation that keeps failing to
+            consume its results waits longer before each further attempt.
+        """
+        now = asyncio.get_running_loop().time()
+        retry = self._background_retries.get(owner)
+        if retry is not None and now < retry.deadline:
+            return False
+        attempts = 0 if retry is None else retry.attempts + 1
+        delay = min(_BACKGROUND_RETRY_BASE_SECONDS * 2**attempts, _BACKGROUND_RETRY_MAX_SECONDS)
+        self._background_retries[owner] = _BackgroundRetry(attempts, now + delay)
+        return True
 
     async def _run_agent_turn(
         self,
@@ -553,6 +628,8 @@ class TalonHost:
                 ),
             )
             suppress_result = agent_conversation_id in self._terminal_authorizations
+        except Exception:  # noqa: BLE001  # _invoke_agent logged the traceback for operators
+            result = AgentResult(text=_AGENT_FAILURE_MESSAGE)
         finally:
             typing_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -432,16 +432,23 @@ class DeepAgentRuntime:
         return graph
 
     async def stop(self) -> None:
-        """Release runtime resources."""
-        if not await self.background.cancel():
-            msg = "Background subagents did not stop; runtime resources remain open"
-            raise RuntimeError(msg)
-        self._graph = None
-        cleanup = getattr(self.checkpointer, "close", None)
-        if callable(cleanup):
-            result = cleanup()
-            if isinstance(result, Awaitable):
-                await result
+        """Release runtime resources.
+
+        Raises:
+            RuntimeError: If a background worker outlived its cancellation wait.
+                Graph and checkpointer teardown still runs before the raise.
+        """
+        try:
+            if not await self.background.cancel():
+                msg = "Background subagents did not stop; runtime resources remain open"
+                raise RuntimeError(msg)
+        finally:
+            self._graph = None
+            cleanup = getattr(self.checkpointer, "close", None)
+            if callable(cleanup):
+                result = cleanup()
+                if isinstance(result, Awaitable):
+                    await result
 
     async def recover_interrupted(self, conversation_id: str) -> None:
         """Append an interruption marker after the latest committed checkpoint."""
@@ -496,6 +503,8 @@ class DeepAgentRuntime:
         except BaseException as error:
             if activity is not None:
                 activity.run_failed(error)
+            if not isinstance(error, asyncio.CancelledError):
+                self.background.record_delivery_failure(pending)
             raise
         finally:
             reset_authorization_handler(authorization_token)

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import TYPE_CHECKING, cast
 
+from deepagents_talon.background import BackgroundSubagents
 from deepagents_talon.config import TalonConfig
 from deepagents_talon.cron import CronJobStore, CronOrigin, CronSchedule
 from deepagents_talon.host import TalonHost
@@ -66,6 +68,32 @@ class BlockingAgent:
         if request.text == "block":
             await self.released.wait()
         return AgentResult(text=f"reply:{request.text}")
+
+
+class ExplodingAgent(BlockingAgent):
+    async def invoke(self, request: AgentRequest) -> AgentResult:
+        self.requests.append(request)
+        message = "sensitive upstream detail"
+        raise RuntimeError(message)
+
+
+class FailingStopAgent(BlockingAgent):
+    async def stop(self) -> None:
+        self.stopped = True
+        message = "agent stop failed"
+        raise RuntimeError(message)
+
+
+class BackgroundAgent(BlockingAgent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.background = BackgroundSubagents()
+
+
+class FailingStartChannel(RecordingChannel):
+    async def start(self) -> None:
+        message = "channel start failed"
+        raise RuntimeError(message)
 
 
 class FailingRecoveryAgent(BlockingAgent):
@@ -1412,3 +1440,118 @@ def _talon_events(caplog, event: str) -> list[dict[str, object]]:
         for payload in [json.loads(message.removeprefix("talon_event "))]
         if payload.get("event") == event
     ]
+
+
+async def test_failed_turn_replies_without_leaking_the_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    channel = RecordingChannel()
+    agent = ExplodingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    try:
+        with caplog.at_level(logging.ERROR, logger="deepagents_talon.host"):
+            await host.receive_message(channel, ChannelMessage("chat", "hello"))
+            await asyncio.wait_for(host._tasks["chat"], 2)
+
+        assert [conversation for conversation, _ in channel.sent] == ["chat"]
+        assert channel.sent[0][1]
+        assert "sensitive upstream detail" not in channel.sent[0][1]
+        assert "sensitive upstream detail" in caplog.text
+    finally:
+        await host.stop()
+
+
+async def test_start_unwinds_started_components_when_a_channel_fails(tmp_path: Path) -> None:
+    first = RecordingChannel()
+    second = FailingStartChannel(provider="broken")
+    agent = BlockingAgent()
+    scheduler = RecordingScheduler()
+    host = TalonHost(
+        config=_config(tmp_path),
+        agent=agent,
+        channels=[first, second],
+        scheduler=scheduler,
+    )
+
+    with pytest.raises(RuntimeError, match="channel start failed"):
+        await host.start()
+
+    assert first.started is True
+    assert first.stopped is True
+    assert second.stopped is False
+    assert agent.stopped is True
+    assert scheduler.started is False
+    assert host.running is False
+
+
+async def test_stop_completes_when_a_component_fails_to_stop(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    scheduler = RecordingScheduler()
+    agent = FailingStopAgent()
+    host = TalonHost(
+        config=_config(tmp_path),
+        agent=agent,
+        channels=[channel],
+        scheduler=scheduler,
+    )
+    await host.start()
+
+    await host.stop()
+
+    assert channel.stopped is True
+    assert scheduler.stopped is True
+    assert host._stopped.is_set()
+
+
+async def test_stop_completes_when_the_background_loop_already_died(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = BackgroundAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    assert host._background_loop is not None
+    host._background_loop.cancel()
+    await asyncio.sleep(0)
+
+    async def died() -> None:
+        message = "dispatcher died"
+        raise RuntimeError(message)
+
+    host._background_loop = asyncio.create_task(died())
+    await asyncio.sleep(0)
+
+    await host.stop()
+
+    assert channel.stopped is True
+    assert agent.stopped is True
+    assert host._stopped.is_set()
+
+
+async def test_background_delivery_survives_a_failing_tick(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    channel = RecordingChannel()
+    host = TalonHost(config=_config(tmp_path), agent=BackgroundAgent(), channels=[channel])
+    ticks = 0
+
+    async def dispatch() -> None:
+        nonlocal ticks
+        ticks += 1
+        if ticks == 1:
+            message = "dispatch exploded"
+            raise RuntimeError(message)
+        host._running = False
+
+    monkeypatch.setattr(host, "_dispatch_background_results", dispatch)
+    with caplog.at_level(logging.ERROR, logger="deepagents_talon.host"):
+        await host.start()
+        assert host._background_loop is not None
+        await asyncio.wait_for(host._background_loop, 5)
+
+    assert ticks == 2
+    assert "dispatch exploded" in caplog.text
+    await host.stop()

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -10,6 +10,7 @@ import pytest
 from deepagents.backends import LocalShellBackend
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.messages import AIMessage, RemoveMessage, ToolMessage
+from langgraph.checkpoint.memory import InMemorySaver
 
 from deepagents_talon.authorization import AuthorizationEvent, current_authorization_handler
 from deepagents_talon.cron import CronJobStore
@@ -1350,3 +1351,36 @@ async def test_runtime_registers_clock_tool_without_web_or_cron_tools(monkeypatc
     await runtime.start()
 
     assert [_tool_name(tool) for tool in captured["tools"]] == ["current_time", "get_agent_tools"]
+
+
+async def test_stop_releases_the_checkpointer_when_workers_refuse_to_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    closed: list[str] = []
+
+    class Checkpointer(InMemorySaver):
+        def close(self) -> None:
+            closed.append("closed")
+
+    monkeypatch.setattr(
+        "deepagents_talon.runtime.create_deep_agent", lambda **_kwargs: RecordingGraph()
+    )
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        checkpointer=Checkpointer(),
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+    await runtime.start()
+
+    async def refuse(_owner: str | None = None) -> bool:
+        return False
+
+    monkeypatch.setattr(runtime.background, "cancel", refuse)
+
+    with pytest.raises(RuntimeError, match="Background subagents did not stop"):
+        await runtime.stop()
+
+    assert closed == ["closed"]
+    assert runtime._graph is None

--- a/libs/talon/tests/unit_tests/test_background.py
+++ b/libs/talon/tests/unit_tests/test_background.py
@@ -13,10 +13,17 @@ from langchain_core.messages import AIMessage
 from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import tool
 
+from deepagents_talon.archive import ArchiveScope
+from deepagents_talon.authorization import (
+    current_authorization_handler,
+    reset_authorization_handler,
+    set_authorization_handler,
+)
 from deepagents_talon.background import _IN_SUBAGENT, BackgroundSubagents
+from deepagents_talon.cron import CronOrigin
 from deepagents_talon.host import TalonHost
 from deepagents_talon.interfaces import AgentRequest, ChannelMessage
-from deepagents_talon.runtime import DeepAgentRuntime
+from deepagents_talon.runtime import _CRON_ORIGIN, _HISTORY_SCOPE, DeepAgentRuntime
 from tests.conftest import RecordingChannel
 from tests.test_host import _config
 
@@ -439,3 +446,29 @@ async def test_repeatedly_failing_turns_drop_the_unprocessed_result(monkeypatch)
         assert "research result" in job.result
     finally:
         await runtime.stop()
+
+
+async def test_background_worker_keeps_scoped_state_but_not_the_authorization_handler():
+    async def authorize(_event):
+        return None
+
+    @tool
+    async def task() -> str:
+        """Report the scoped state this worker inherited."""
+        return f"{_HISTORY_SCOPE.get()}|{_CRON_ORIGIN.get()}|{current_authorization_handler()}"
+
+    scope = ArchiveScope(talon_history_channel="whatsapp", talon_history_chat="chat")
+    origin = CronOrigin("chat")
+    background = BackgroundSubagents()
+    _HISTORY_SCOPE.set(scope)
+    _CRON_ORIGIN.set(origin)
+    token = set_authorization_handler(authorize)
+    try:
+        await background.awrap_tool_call(_request("one", task), _unused_handler)
+        await asyncio.gather(*(job.worker for job in background._jobs.values()))
+        assert current_authorization_handler() is authorize
+    finally:
+        reset_authorization_handler(token)
+
+    (job,) = background._jobs.values()
+    assert job.result == f"{scope}|{origin}|None"

--- a/libs/talon/tests/unit_tests/test_background.py
+++ b/libs/talon/tests/unit_tests/test_background.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -11,7 +13,7 @@ from langchain_core.messages import AIMessage
 from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import tool
 
-from deepagents_talon.background import BackgroundSubagents
+from deepagents_talon.background import _IN_SUBAGENT, BackgroundSubagents
 from deepagents_talon.host import TalonHost
 from deepagents_talon.interfaces import AgentRequest, ChannelMessage
 from deepagents_talon.runtime import DeepAgentRuntime
@@ -349,4 +351,91 @@ async def test_interrupted_main_keeps_worker_and_retries_unprocessed_result(monk
         assert not runtime.background.results("chat")
     finally:
         release.set()
+        await runtime.stop()
+
+
+async def test_background_worker_inherits_caller_context_and_isolates_its_own():
+    marker = contextvars.ContextVar("marker", default="unset")
+
+    @tool
+    async def task() -> str:
+        """Report the context the worker runs in."""
+        return f"{marker.get()}/{_IN_SUBAGENT.get()}"
+
+    background = BackgroundSubagents()
+    marker.set("main conversation")
+    await background.awrap_tool_call(_request("one", task), _unused_handler)
+    await asyncio.gather(*(job.worker for job in background._jobs.values()))
+
+    assert [job.result for job in background._jobs.values()] == ["main conversation/True"]
+    assert _IN_SUBAGENT.get() is False
+
+
+async def test_background_failure_is_logged_and_reported_without_arguments(caplog):
+    @tool
+    async def task(credential: str) -> str:
+        """Fail while holding a credential."""
+        assert credential
+        msg = "upstream rejected the request"
+        raise RuntimeError(msg)
+
+    background = BackgroundSubagents()
+    with caplog.at_level(logging.ERROR, logger="deepagents_talon.background"):
+        await background.awrap_tool_call(
+            _request("one", task, credential="sk-not-a-real-key"), _unused_handler
+        )
+        await asyncio.gather(*(job.worker for job in background._jobs.values()))
+
+    (job,) = background._jobs.values()
+    assert job.result == "Subagent failed before returning a result."
+    assert "RuntimeError: upstream rejected the request" in caplog.text
+    assert "sk-not-a-real-key" not in caplog.text
+
+
+async def test_background_timeout_is_reported_separately_from_failure(monkeypatch):
+    monkeypatch.setattr("deepagents_talon.background._TASK_TIMEOUT_SECONDS", 0.01)
+
+    @tool
+    async def task() -> str:
+        """Never return."""
+        await asyncio.Event().wait()
+        return "done"
+
+    background = BackgroundSubagents()
+    await background.awrap_tool_call(_request("one", task), _unused_handler)
+    await asyncio.gather(*(job.worker for job in background._jobs.values()))
+
+    (job,) = background._jobs.values()
+    assert job.result == "Subagent ran out of time before returning a result."
+    assert not job.cancelled
+
+
+async def test_repeatedly_failing_turns_drop_the_unprocessed_result(monkeypatch):
+    async def child(_state):
+        return {"messages": [AIMessage(content="research result")]}
+
+    runtime = _runtime(monkeypatch, child, [_delegate(), AIMessage(content="Started")])
+    await runtime.start()
+    try:
+        assert (await runtime.invoke(AgentRequest("chat", "delegate"))).text == "Started"
+        await asyncio.gather(*(job.worker for job in runtime.background._jobs.values()))
+        assert runtime.background.results("chat")
+
+        async def fail(_request, _activity):
+            msg = "model failed"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(runtime, "_invoke_until_text", fail)
+        failures = 0
+        while runtime.background.results("chat") and failures < 8:
+            with pytest.raises(RuntimeError):
+                await runtime.invoke(AgentRequest("chat", "process results"))
+            failures += 1
+
+        assert failures == 3
+        assert "chat" not in runtime.background.owners()
+        (job,) = runtime.background._jobs.values()
+        assert "never reached the user" in job.result
+        assert "research result" in job.result
+    finally:
         await runtime.stop()

--- a/libs/talon/tests/unit_tests/test_background_runtime.py
+++ b/libs/talon/tests/unit_tests/test_background_runtime.py
@@ -7,9 +7,11 @@ from langchain.agents import create_agent
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage
 from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
 
 from deepagents_talon.interfaces import AgentRequest
 from deepagents_talon.runtime import DeepAgentRuntime
+from tests.archive_helpers import make_runtime, make_saver
 
 
 class ToolModel(FakeMessagesListChatModel):
@@ -101,3 +103,77 @@ async def test_real_graph_launch_and_child_approval(tmp_path, monkeypatch, name)
         assert "approval" in next(iter(results.values()))
     finally:
         await runtime.stop()
+
+
+async def test_background_subagent_keeps_the_hosts_history_scope(tmp_path, monkeypatch):
+    path = tmp_path / "agents" / "researcher" / "AGENTS.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "---\ndescription: Research\nmodel: test:child\n"
+        "tools: [search_conversations]\n---\nSearch this chat's history."
+    )
+    parent = ToolModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "task",
+                        "id": "launch",
+                        "args": {"subagent_type": "researcher", "description": "recall"},
+                    }
+                ],
+            ),
+            AIMessage(content="Started background work"),
+        ]
+    )
+    child = ToolModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "search_conversations", "id": "recall", "args": {"query": "orchard"}}
+                ],
+            ),
+            AIMessage(content="Reviewed the history"),
+        ]
+    )
+    monkeypatch.setattr(
+        "deepagents_talon.runtime._resolve_model_from_env",
+        lambda model, *_args, **_kwargs: child if model == "test:child" else parent,
+    )
+    monkeypatch.setattr(
+        "deepagents.graph.resolve_model", lambda model: child if model == "test:child" else model
+    )
+    monkeypatch.setattr(
+        "deepagents_talon.subagents.create_agent",
+        lambda **kwargs: create_agent(**{**kwargs, "model": child}),
+    )
+
+    async with make_saver(str(tmp_path / "history.sqlite"), InMemorySaver) as saver:
+        scopes = []
+        search_page = saver.archive.search_page
+
+        async def record(scope, **kwargs: object):
+            scopes.append(scope)
+            return await search_page(scope, **kwargs)
+
+        monkeypatch.setattr(saver.archive, "search_page", record)
+        runtime = make_runtime(saver, tmp_path)
+        await runtime.start()
+        try:
+            result = await runtime.invoke(
+                AgentRequest(
+                    "chat",
+                    "recall the orchard",
+                    metadata={"history_channel": "whatsapp", "history_chat": "chat"},
+                )
+            )
+            assert result.text == "Started background work"
+            await asyncio.gather(*(job.worker for job in runtime.background._jobs.values()))
+            results = [job.result for job in runtime.background._jobs.values()]
+        finally:
+            await runtime.stop()
+
+    assert results == ["Reviewed the history"]
+    assert scopes == [{"talon_history_channel": "whatsapp", "talon_history_chat": "chat"}]


### PR DESCRIPTION
**Stack 1 of 4 — background subagents & host lifecycle.** Reviews cleanest bottom-up: this PR → `lifecycle-2-subagent-orchestration` → `lifecycle-3-host-state` → #6148.

Six High-severity defects in the newest and least-exercised subsystem in the package. All are live in released 0.0.7.

- **A failing turn re-ran forever, at 1 Hz, burning tokens.** `acknowledge()` ran only on the success path, so a turn that failed while consuming a background result left the result pending and the dispatcher started a fresh turn a second later — indefinitely. Delivery attempts are now bounded with backoff, and `CancelledError` is deliberately excluded so interrupt-driven retries stay unbounded as an existing test intends.
- **The dispatcher died silently, then broke `stop()`.** No `try/except` in the loop body, and `stop()` re-raised the stored exception before tearing anything down.
- **Background workers ran in an empty `contextvars.Context()`**, so `_HISTORY_SCOPE`, `_CRON_ORIGIN` and `_AUTHORIZATION_HANDLER` all reverted to `None` and any context-scoped tool raised — surfacing only as "Subagent failed before returning a result." Now `copy_context()`, with the authorization handler deliberately withheld: a flow started after the turn ends would outlive `_clear_authorization`.
- **Every background failure was swallowed with no logging** — the module never imported `logging` at all.
- **An agent turn that raised sent the user nothing.**
- **`start()` and `stop()` leaked components on partial failure.** A channel raising during `start()` left `_running` false, so `stop()` returned early and tore down nothing — orphaning the WhatsApp Node subprocess and leaking checkpointer connections.

Every test verified to fail against pre-fix source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Reviewing this PR alone:** it is one level of a four-PR stack, so an automated reviewer reading it cannot see the levels above. Several findings filed against the mid-stack PRs turned out to be defects that the top of the same chain already fixes; each such thread has a reply naming the fixing PR. Read bottom-up, or read the top PR first if you want the final state.