### PR TITLE
fix(talon): stop one conversation from stalling or outliving the rest

### DIFF
--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -13,7 +13,8 @@ import os
 import signal
 import tempfile
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -133,6 +134,12 @@ class _Turn:
 
 
 @dataclass(slots=True)
+class _ConversationLock:
+    lock: asyncio.Lock
+    holders: int = 0
+
+
+@dataclass(slots=True)
 class _BackgroundRetry:
     attempts: int
     deadline: float
@@ -207,7 +214,7 @@ class TalonHost:
         self.channels = tuple(channels)
         self.scheduler = scheduler
         self.voice_transcriber = voice_transcriber
-        self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+        self._locks: dict[str, _ConversationLock] = {}
         self._cron_controls: dict[str, _CronControl] = {}
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._conversation_tasks: defaultdict[str, set[asyncio.Task[None]]] = defaultdict(set)
@@ -225,6 +232,51 @@ class TalonHost:
         self._background_retries: dict[str, _BackgroundRetry] = {}
         self._stopped = asyncio.Event()
         self._running = False
+
+    @asynccontextmanager
+    async def _conversation_lock(self, conversation_root: str) -> AsyncIterator[None]:
+        """Serialize one conversation's work and forget it once nothing is left.
+
+        Args:
+            conversation_root: Conversation whose turns must not overlap.
+        """
+        control = self._locks.setdefault(conversation_root, _ConversationLock(asyncio.Lock()))
+        control.holders += 1
+        try:
+            async with control.lock:
+                yield
+        finally:
+            control.holders -= 1
+            # Nothing holds or awaits this lock, so replacing it cannot split
+            # mutual exclusion between an old object and a new one.
+            if control.holders == 0 and self._locks.get(conversation_root) is control:
+                del self._locks[conversation_root]
+                for conversation_id in {
+                    conversation_root,
+                    self._agent_conversation_id(conversation_root),
+                }:
+                    self._forget_idle_conversation(conversation_id)
+
+    def _forget_idle_conversation(self, conversation_id: str) -> None:
+        """Drop turn state for a conversation with nothing left in flight.
+
+        Args:
+            conversation_id: Agent conversation whose turn state may be dropped.
+        """
+        task = self._tasks.get(conversation_id)
+        if (
+            (task is not None and not task.done())
+            or conversation_id in self._conversation_tasks
+            or conversation_id in self._blocked
+            or conversation_id in self._background_routes
+            or conversation_id in self._pending_tool_approvals
+            or conversation_id in self._pending_authorizations
+            or conversation_id in self._authorization_flows
+            or conversation_id in self._terminal_authorizations
+        ):
+            return
+        self._tasks.pop(conversation_id, None)
+        self._generations.pop(conversation_id, None)
 
     @property
     def running(self) -> bool:
@@ -354,7 +406,7 @@ class TalonHost:
             provider or type(channel).__name__,
             channel_conversation_id,
         )
-        async with self._locks[conversation_root]:
+        async with self._conversation_lock(conversation_root):
             agent_conversation_id = self._agent_conversation_id(conversation_root)
 
             if await self._handle_conversation_command(
@@ -530,7 +582,12 @@ class TalonHost:
         if not isinstance(self.agent, BackgroundRuntime):
             return
         for owner, (channel, message, root, provider) in list(self._background_routes.items()):
-            async with self._locks[root]:
+            control = self._locks.get(root)
+            if control is not None and control.lock.locked():
+                # A turn or a command owns this conversation, and cancelling one can
+                # take 30 seconds. Leave it and retry on the next tick.
+                continue
+            async with self._conversation_lock(root):
                 active = self._tasks.get(owner)
                 if active is not None and not active.done():
                     continue
@@ -635,7 +692,7 @@ class TalonHost:
             with contextlib.suppress(asyncio.CancelledError):
                 await typing_task
             self._clear_authorization(agent_conversation_id)
-        async with self._locks[turn.conversation_root]:
+        async with self._conversation_lock(turn.conversation_root):
             if (
                 self._agent_conversation_id(turn.conversation_root) == agent_conversation_id
                 and self._generations[agent_conversation_id] == turn.generation
@@ -743,13 +800,16 @@ class TalonHost:
             await send_with_retry(lambda: channel.send_message(chat, _CANCEL_TIMEOUT_MESSAGE))
             return
         try:
-            await self.agent.clear_history(channel_key, chat)
+            # Persist the counter first: a failure here clears nothing, so the retry the
+            # user is told to send still has an archive to clear. The reverse order can
+            # erase history while leaving the conversation on its old thread id.
             next_resets = {
                 **self._conversation_resets,
                 conversation_root: self._conversation_resets.get(conversation_root, 0) + 1,
             }
             _save_conversation_resets(self.config.conversation_state_path, next_resets)
             self._conversation_resets = next_resets
+            await self.agent.clear_history(channel_key, chat)
         except Exception:  # noqa: BLE001  # Report failure without disclosing stored history.
             logger.warning("Conversation history reset failed", exc_info=True)
             message = "Could not finish clearing history. Please try /reset-all-history again."
@@ -1331,6 +1391,7 @@ class TalonHost:
             tasks.discard(task)
             if not tasks:
                 del self._conversation_tasks[conversation_id]
+        self._forget_idle_conversation(conversation_id)
         if task.cancelled():
             return
         exc = task.exception()

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -938,10 +938,27 @@ class TalonHost:
         channel_key: str,
         conversation_id: str,
     ) -> str:
-        if len(self.channels) <= 1 and not (
-            isinstance(self.agent, ConversationHistoryRuntime) and self.agent.history_enabled
-        ):
-            return conversation_id
+        """Key a conversation by its channel, always.
+
+        This value is the LangGraph thread id and the key of the persisted reset
+        counters. It used to be the bare conversation id for a host with one
+        channel and no history, so adding a second channel or enabling history
+        re-keyed every existing conversation. Keying unconditionally costs that
+        migration once instead of on each such change.
+
+        Upgrading a host that had one channel and no history therefore abandons
+        its checkpoints and its reset counters: those rows stay in the stores
+        under the old bare key, unreachable, and every conversation starts
+        empty with its `/new` count back at zero. This is deliberate; there is
+        no migration, and the simplification is not accidental.
+
+        Args:
+            channel_key: Trusted channel provider identifier.
+            conversation_id: Channel-specific conversation identifier.
+
+        Returns:
+            Conversation root shared by every turn of one chat on one channel.
+        """
         return _conversation_key(channel_key, conversation_id)
 
     async def _cancel_all(self) -> None:

--- a/libs/talon/tests/integration_tests/test_core_flows.py
+++ b/libs/talon/tests/integration_tests/test_core_flows.py
@@ -86,7 +86,11 @@ class SchedulingAgent(ScriptedAgent):
             job = self.store.create_job(
                 prompt="scheduled prompt",
                 schedule=CronSchedule.parse("in 1m"),
-                origin=CronOrigin(conversation_id=request.conversation_id),
+                origin=CronOrigin(
+                    conversation_id=str(
+                        request.metadata.get("origin_conversation_id", request.conversation_id)
+                    )
+                ),
                 name="integration",
                 now=self.now,
             )

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -84,6 +84,37 @@ class FailingStopAgent(BlockingAgent):
         raise RuntimeError(message)
 
 
+class StubBackground:
+    def __init__(self) -> None:
+        self.pending: set[str] = set()
+
+    def owners(self) -> set[str]:
+        return set(self.pending)
+
+    def results(self, owner: str) -> dict[str, str]:
+        return {f"{owner}-task": "result"} if owner in self.pending else {}
+
+    async def cancel(self, owner: str | None = None) -> bool:
+        self.pending.discard(owner) if owner else self.pending.clear()
+        return True
+
+
+class ArchiveAgent(BlockingAgent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.history_enabled = True
+        self.cleared: list[tuple[str, str]] = []
+
+    async def clear_history(self, channel: str, chat: str) -> None:
+        self.cleared.append((channel, chat))
+
+
+class RoutedAgent(BlockingAgent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.background = StubBackground()
+
+
 class BackgroundAgent(BlockingAgent):
     def __init__(self) -> None:
         super().__init__()
@@ -1555,3 +1586,83 @@ async def test_background_delivery_survives_a_failing_tick(
     assert ticks == 2
     assert "dispatch exploded" in caplog.text
     await host.stop()
+
+
+async def test_one_locked_conversation_does_not_stall_delivery_for_others(
+    tmp_path: Path,
+) -> None:
+    channel = RecordingChannel()
+    agent = RoutedAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        for owner in ("stuck", "waiting"):
+            agent.background.pending.add(owner)
+            host._background_routes[owner] = (
+                channel,
+                ChannelMessage(owner, "research"),
+                owner,
+                "test",
+            )
+        held = asyncio.Event()
+        release = asyncio.Event()
+
+        async def hold() -> None:
+            async with host._conversation_lock("stuck"):
+                held.set()
+                await release.wait()
+
+        holder = asyncio.create_task(hold())
+        await asyncio.wait_for(held.wait(), 2)
+
+        await asyncio.wait_for(host._dispatch_background_results(), 2)
+
+        assert "waiting" in host._tasks
+        assert "stuck" not in host._tasks
+    finally:
+        release.set()
+        await asyncio.gather(holder, return_exceptions=True)
+        await host.stop()
+
+
+async def test_finished_conversations_do_not_accumulate_state(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        for index in range(3):
+            await host.receive_message(channel, ChannelMessage(f"chat{index}", "hello"))
+            await asyncio.wait_for(host._tasks[f"chat{index}"], 2)
+        await asyncio.sleep(0)
+
+        assert len(channel.sent) == 3
+        assert host._locks == {}
+        assert host._tasks == {}
+        assert dict(host._generations) == {}
+    finally:
+        await host.stop()
+
+
+async def test_history_reset_keeps_the_archive_when_the_counter_cannot_persist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = RecordingChannel()
+    agent = ArchiveAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+
+    def refuse(*_args: object, **_kwargs: object) -> None:
+        message = "disk full"
+        raise OSError(message)
+
+    monkeypatch.setattr("deepagents_talon.host._save_conversation_resets", refuse)
+    await host.start()
+    try:
+        await host.receive_message(channel, ChannelMessage("chat", "/reset-all-history"))
+
+        assert agent.cleared == []
+        assert "try /reset-all-history again" in channel.sent[-1][1]
+        assert host._agent_conversation_id("chat") == "chat"
+    finally:
+        await host.stop()

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -461,7 +461,7 @@ async def test_follow_up_preserves_pending_device_authorization(tmp_path: Path) 
         ChannelMessage(conversation_id="chat", text="login", sender_id="operator"),
     )
     await _wait_for_sent_count(channel, 1)
-    active = host._tasks["chat"]
+    active = host._tasks["telegram:chat"]
     await host.receive_message(
         channel,
         ChannelMessage(conversation_id="chat", text="cancel it", sender_id="attacker"),
@@ -475,7 +475,7 @@ async def test_follow_up_preserves_pending_device_authorization(tmp_path: Path) 
         ChannelMessage(conversation_id="chat", text="any update?", sender_id="operator"),
     )
 
-    assert host._tasks["chat"] is active
+    assert host._tasks["telegram:chat"] is active
     assert not active.done()
     assert [request.text for request in agent.requests] == ["login"]
     assert channel.sent[-1] == (
@@ -561,7 +561,7 @@ async def test_host_interrupts_active_turn_and_continues_same_conversation(tmp_p
     await host.stop()
 
     assert [request.text for request in agent.requests] == ["block", "second"]
-    assert agent.recoveries == ["chat"]
+    assert agent.recoveries == ["test:chat"]
     assert channel.sent == [("chat", "reply:second")]
 
 
@@ -613,7 +613,7 @@ async def test_stop_keeps_ack_when_recovery_fails(tmp_path: Path, caplog) -> Non
     await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="/stop"))
     await host.stop()
 
-    assert agent.recoveries == ["chat"]
+    assert agent.recoveries == ["test:chat"]
     assert channel.sent == [("chat", "Stopped current run.")]
     assert "Failed to recover interrupted conversation" in caplog.text
 
@@ -632,8 +632,8 @@ async def test_new_command_starts_fresh_conversation_thread(tmp_path: Path) -> N
     await host.stop()
 
     assert [request.text for request in agent.requests] == ["first", "second"]
-    assert agent.requests[0].conversation_id == "chat"
-    assert agent.requests[1].conversation_id.startswith("chat:talon-reset:")
+    assert agent.requests[0].conversation_id == "test:chat"
+    assert agent.requests[1].conversation_id.startswith("test:chat:talon-reset:")
     assert channel.sent == [
         ("chat", "seen:0"),
         ("chat", "Started a fresh conversation."),
@@ -668,7 +668,7 @@ async def test_new_command_remains_active_after_restart(tmp_path: Path) -> None:
     await _wait_for_sent_count(restarted_channel, 1)
     await restarted_host.stop()
 
-    assert restarted_agent.requests[0].conversation_id.startswith("chat:talon-reset:")
+    assert restarted_agent.requests[0].conversation_id.startswith("test:chat:talon-reset:")
     assert restarted_channel.sent == [("chat", "seen:0")]
 
 
@@ -684,7 +684,7 @@ async def test_new_command_accepts_telegram_bot_command_suffix(tmp_path: Path) -
     await host.stop()
 
     assert [request.text for request in agent.requests] == ["hello"]
-    assert agent.requests[0].conversation_id.startswith("chat:talon-reset:")
+    assert agent.requests[0].conversation_id.startswith("test:chat:talon-reset:")
     assert channel.sent == [
         ("chat", "Started a fresh conversation."),
         ("chat", "seen:0"),
@@ -705,7 +705,7 @@ async def test_new_command_cancels_in_flight_conversation(tmp_path: Path) -> Non
     await host.stop()
 
     assert [request.text for request in agent.requests] == ["block", "second"]
-    assert agent.requests[1].conversation_id.startswith("chat:talon-reset:")
+    assert agent.requests[1].conversation_id.startswith("test:chat:talon-reset:")
     assert channel.sent == [
         ("chat", "Started a fresh conversation."),
         ("chat", "reply:second"),
@@ -780,8 +780,8 @@ async def test_new_recovers_old_thread_before_reset(tmp_path: Path) -> None:
     await _wait_for_request(agent, "second")
     await host.stop()
 
-    assert agent.recoveries == ["chat"]
-    assert agent.requests[1].conversation_id.startswith("chat:talon-reset:")
+    assert agent.recoveries == ["test:chat"]
+    assert agent.requests[1].conversation_id.startswith("test:chat:talon-reset:")
 
 
 async def test_recovery_failure_starts_replacement_with_metadata(tmp_path: Path) -> None:
@@ -820,7 +820,7 @@ async def test_cancellation_timeout_blocks_until_host_restart(
     await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="fourth"))
     assert [request.text for request in agent.requests] == ["block"]
     assert len(channel.sent) == 3
-    assert "chat" in host._blocked
+    assert "test:chat" in host._blocked
     await host.stop()
 
 
@@ -1403,9 +1403,9 @@ async def test_scheduled_job_runs_while_interactive_turn_remains_active(tmp_path
     assert text == "reply:scheduled prompt"
     assert [request.text for request in agent.requests] == ["block", "scheduled prompt"]
     assert agent.recoveries == []
-    assert agent.requests[0].conversation_id == "chat"
+    assert agent.requests[0].conversation_id == "test:chat"
     assert agent.requests[1].conversation_id == f"{job.id}:talon-cron"
-    assert not host._tasks["chat"].done()
+    assert not host._tasks["test:chat"].done()
     agent.released.set()
     await host.stop()
 
@@ -1485,7 +1485,7 @@ async def test_failed_turn_replies_without_leaking_the_error(
     try:
         with caplog.at_level(logging.ERROR, logger="deepagents_talon.host"):
             await host.receive_message(channel, ChannelMessage("chat", "hello"))
-            await asyncio.wait_for(host._tasks["chat"], 2)
+            await asyncio.wait_for(host._tasks["test:chat"], 2)
 
         assert [conversation for conversation, _ in channel.sent] == ["chat"]
         assert channel.sent[0][1]
@@ -1633,7 +1633,7 @@ async def test_finished_conversations_do_not_accumulate_state(tmp_path: Path) ->
     try:
         for index in range(3):
             await host.receive_message(channel, ChannelMessage(f"chat{index}", "hello"))
-            await asyncio.wait_for(host._tasks[f"chat{index}"], 2)
+            await asyncio.wait_for(host._tasks[f"test:chat{index}"], 2)
         await asyncio.sleep(0)
 
         assert len(channel.sent) == 3
@@ -1663,6 +1663,44 @@ async def test_history_reset_keeps_the_archive_when_the_counter_cannot_persist(
 
         assert agent.cleared == []
         assert "try /reset-all-history again" in channel.sent[-1][1]
-        assert host._agent_conversation_id("chat") == "chat"
+        assert host._agent_conversation_id("test:chat") == "test:chat"
+    finally:
+        await host.stop()
+
+
+async def test_conversation_root_is_channel_keyed_whatever_the_host_looks_like(
+    tmp_path: Path,
+) -> None:
+    channel = RecordingChannel()
+    lone = TalonHost(config=_config(tmp_path), agent=BlockingAgent(), channels=[channel])
+    archiving = TalonHost(
+        config=_config(tmp_path),
+        agent=ArchiveAgent(),
+        channels=[channel, RecordingChannel(provider="telegram")],
+    )
+
+    # One channel with no history used to key by the bare conversation id, so
+    # adding a channel or enabling history re-keyed every thread underneath.
+    assert lone._conversation_root("test", "chat") == "test:chat"
+    assert archiving._conversation_root("test", "chat") == "test:chat"
+
+
+async def test_channel_keyed_threads_still_reply_to_the_channel_conversation(
+    tmp_path: Path,
+) -> None:
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    try:
+        await host.receive_message(channel, ChannelMessage("chat", "hello"))
+        await asyncio.wait_for(host._tasks["test:chat"], 2)
+
+        assert agent.requests[0].conversation_id == "test:chat"
+        # The channel's own id has to travel separately now that it is not the
+        # thread id: cron origins and replies address the conversation, not the thread.
+        assert agent.requests[0].metadata["origin_conversation_id"] == "chat"
+        assert channel.sent == [("chat", "reply:hello")]
     finally:
         await host.stop()

--- a/libs/talon/tests/test_observability.py
+++ b/libs/talon/tests/test_observability.py
@@ -120,7 +120,8 @@ async def test_host_wraps_agent_run_in_langsmith_context(tmp_path, monkeypatch) 
             "metadata": {
                 "assistant_id": "assistant",
                 "channel": "test",
-                "conversation_id": "chat",
+                "conversation_id": "test:chat",
+                "origin_conversation_id": "chat",
                 "sender_id": "sender",
                 "message_id": None,
             },

--- a/libs/talon/tests/unit_tests/test_background.py
+++ b/libs/talon/tests/unit_tests/test_background.py
@@ -86,26 +86,26 @@ async def test_chat_continues_then_main_processes_background_result(tmp_path, mo
     try:
         await host.receive_message(channel, ChannelMessage("chat", "research"))
         await asyncio.wait_for(entered.wait(), 2)
-        await asyncio.wait_for(host._tasks["chat"], 2)
+        await asyncio.wait_for(host._tasks["test:chat"], 2)
         await host.receive_message(channel, ChannelMessage("chat", "hello"))
-        await asyncio.wait_for(host._tasks["chat"], 2)
-        assert runtime.background.owners() == {"chat"}
-        assert not runtime.background.results("chat")
+        await asyncio.wait_for(host._tasks["test:chat"], 2)
+        assert runtime.background.owners() == {"test:chat"}
+        assert not runtime.background.results("test:chat")
         release.set()
         await asyncio.gather(*(job.worker for job in runtime.background._jobs.values()))
         await host._dispatch_background_results()
-        await asyncio.wait_for(host._tasks["chat"], 2)
+        await asyncio.wait_for(host._tasks["test:chat"], 2)
         assert channel.sent == [
             ("chat", "Working on it"),
             ("chat", "Still here"),
             ("chat", "Processed research"),
         ]
-        state = await runtime._graph.aget_state({"configurable": {"thread_id": "chat"}})
+        state = await runtime._graph.aget_state({"configurable": {"thread_id": "test:chat"}})
         assert any(
             "raw research result" in str(message.content) for message in state.values["messages"]
         )
-        assert child_threads[0] != "chat"
-        assert not runtime.background.results("chat")
+        assert child_threads[0] != "test:chat"
+        assert not runtime.background.results("test:chat")
     finally:
         release.set()
         await host.stop()
@@ -138,14 +138,14 @@ async def test_commands_cancel_only_this_threads_children_when_main_idle(
         for owner in ("one", "two"):
             await host.receive_message(channel, ChannelMessage(owner, "research"))
             await asyncio.wait_for(entered.get(), 2)
-            await asyncio.wait_for(host._tasks[owner], 2)
+            await asyncio.wait_for(host._tasks[f"test:{owner}"], 2)
         assert channel.sent == [("one", "Started"), ("two", "Started")]
         await host.receive_message(channel, ChannelMessage("one", command))
         assert len(cancelled) == 1
-        assert runtime.background.owners() == {"two"}
-        assert not runtime.background.results("one")
+        assert runtime.background.owners() == {"test:two"}
+        assert not runtime.background.results("test:one")
         if command == "/new":
-            assert host._agent_conversation_id("one") != "one"
+            assert host._agent_conversation_id("test:one") != "test:one"
     finally:
         await host.stop()
     assert len(cancelled) == 2


### PR DESCRIPTION
**Stack 3 of 4 — background subagents & host lifecycle.** Based on `linted/talon/lifecycle-2-subagent-orchestration` (#6157). Review #6156 and #6157 first.

Per-conversation state and thread keying.

- **One stuck conversation stalled every other.** The background dispatcher iterated routes sequentially holding each conversation's lock, and `receive_message` holds that same lock across a cancel that can take 30s — parking the single dispatcher for the whole window. It now skips a contended route and retries next tick.
- **Per-conversation state grew without bound.** Locks, tasks, generations and block flags were keyed by conversation and never pruned. Now refcounted and dropped only when nothing holds or awaits them — and turn state only for an id with no running task, no pending approval or authorization, no background route and no interrupt block. `_generations` is treated carefully on purpose: pruning a live counter would make a superseded turn's generation match a fresh one and answer when it should stay quiet.
- **`_reset_all_history` could clear the archive but not persist its counter**, leaving the user told to retry against an archive that was already gone. The counter is now written first, so a failed write clears nothing.
- **Thread ids are now always `provider:conversation`**, removing a latent re-keying hazard where enabling history or adding a channel would silently change every thread id.

**On that last one — no user-facing change for the CLI.** `_run_host` always constructs `ConversationSaver` when a model is configured, so `history_enabled` was already true and the keying was already channel-scoped. It affects only embedders constructing `TalonHost` with their own non-archiving checkpointer on a single channel. An earlier draft of this note claimed existing conversations restart empty and that users could return to a pre-`/new` thread; both were wrong, and the second was a false privacy claim — nothing discarded with `/new` resurfaces.

`_conversation_resets` is deliberately left unpruned: its counters map a conversation to its current thread id, so dropping one would silently resurrect an older conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Reviewing this PR alone:** it is one level of a four-PR stack, so an automated reviewer reading it cannot see the levels above. Several findings filed against the mid-stack PRs turned out to be defects that the top of the same chain already fixes; each such thread has a reply naming the fixing PR. Read bottom-up, or read the top PR first if you want the final state.