### PR TITLE
fix(talon): harden the MCP OAuth device flow and credential paths

### DIFF
--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -43,10 +43,10 @@ from deepagents_talon.mcp_auth import (
     format_login_error,
     prepare_oauth_login,
 )
-from deepagents_talon.mcp_config import MCPConfigStore
+from deepagents_talon.mcp_config import MCPConfigStore, agent_workspace_root
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Mapping, Sequence
+    from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
 
     from langchain_core.tools import BaseTool
     from langchain_mcp_adapters.client import Connection
@@ -84,12 +84,37 @@ class _MCPLoginRequiredError(MCPConfigError):
     """An MCP server requires OAuth login before loading tools."""
 
 
+def _exception_leaves(exc: BaseException) -> Iterator[BaseException]:
+    """Yield `exc`, or every leaf of it when it is a possibly nested group.
+
+    Anyio task groups wrap even a single exception, so any failure raised inside
+    an MCP `ClientSession` reaches callers as a group and must be matched on its
+    leaves rather than on the group type.
+
+    Args:
+        exc: Exception to flatten.
+
+    Yields:
+        Each non-group exception, in the order the group holds them.
+    """
+    if isinstance(exc, BaseExceptionGroup):
+        for nested in exc.exceptions:
+            yield from _exception_leaves(nested)
+    else:
+        yield exc
+
+
 def _authentication_required(exc: BaseException) -> bool:
-    if isinstance(exc, (_MCPLoginRequiredError, MCPAuthorizationError)):
-        return True
-    if isinstance(exc, ExceptionGroup):
-        return any(_authentication_required(nested) for nested in exc.exceptions)
-    return False
+    return any(
+        isinstance(leaf, (_MCPLoginRequiredError, MCPAuthorizationError))
+        for leaf in _exception_leaves(exc)
+    )
+
+
+def _device_authorization_completed(exc: BaseException) -> bool:
+    return any(
+        isinstance(leaf, DeviceAuthorizationCompletedError) for leaf in _exception_leaves(exc)
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,7 +189,11 @@ class MCPToolProvider:
         self._refresh_revision = 0
         self._applied_revision = 0
         self._lock = asyncio.Lock()
-        self._config_store = MCPConfigStore(mcp_config_path(config), self.request_refresh)
+        self._config_store = MCPConfigStore(
+            mcp_config_path(config),
+            self.request_refresh,
+            agent_root=agent_workspace_root(config.env),
+        )
 
     async def load(self) -> MCPTools:
         """Load tools and include the narrow proactive authorization capability."""
@@ -313,6 +342,7 @@ class MCPToolProvider:
                 self._refresh_revision += 1
             raise
         except (
+            ExceptionGroup,
             HTTPError,
             McpError,
             OAuthFlowError,
@@ -475,6 +505,12 @@ async def login_mcp_server(
         await _open_mcp_session(client, server_name)
     except DeviceAuthorizationCompletedError:
         pass
+    except ExceptionGroup as group:
+        # A completed device flow raises from inside the session's task group,
+        # which wraps it; only a group holding some other failure is an error.
+        if not _device_authorization_completed(group):
+            print(f"MCP login failed: {format_login_error(group)}", file=sys.stderr)  # noqa: T201
+            return 1
     except (
         HTTPError,
         McpError,
@@ -622,9 +658,10 @@ async def _finish_authorization(
 
 
 def _authorization_failure_reason(exc: Exception) -> AuthorizationFailureReason:
-    if isinstance(exc, TimeoutError):
+    leaves = tuple(_exception_leaves(exc))
+    if any(isinstance(leaf, TimeoutError) for leaf in leaves):
         return "expired"
-    if isinstance(exc, MCPAuthorizationError):
+    if any(isinstance(leaf, MCPAuthorizationError) for leaf in leaves):
         return "invalid_callback"
     return "error"
 

--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -48,6 +48,7 @@ from deepagents_talon.authorization import (
     current_authorization_handler,
     current_authorization_invocation,
 )
+from deepagents_talon.mcp_config import warn_agent_workspace_path
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable
@@ -75,6 +76,7 @@ _MIN_RESPONSE_STATUS = 200
 _REDIRECT_STATUS = 300
 _BAD_REQUEST_STATUS = 400
 _SERVER_ERROR_STATUS = 500
+_UNSAFE_ENDPOINT_MESSAGE = "OAuth endpoint is not a safe public HTTPS URL."
 
 
 class _AuthorizationServerMetadata(BaseModel):
@@ -140,17 +142,33 @@ class FileTokenStorage:
         *,
         server_url: str,
         force_authorization: bool = False,
+        agent_root: Path | None = None,
     ) -> None:
         """Bind storage to a server name and URL.
+
+        These files hold live bearer and refresh tokens in cleartext, so the
+        directory is restricted to the owner and a location inside the agent
+        workspace is warned about. Against Talon's default shell backend that is
+        hardening, not a boundary: the agent can still read any absolute path it
+        is given.
 
         Args:
             server_name: Configured MCP server name.
             server_url: Remote MCP endpoint used to isolate credentials.
             force_authorization: Whether the first token read should require a
                 fresh OAuth flow without deleting the stored credential.
+            agent_root: Agent workspace root. Defaults to the process workspace.
         """
         digest = hashlib.sha256(server_url.encode()).hexdigest()[:12]
-        self.path = Path.home() / _TOKEN_DIR / f"{server_name}-{digest}.json"
+        directories: list[Path] = []
+        current = Path.home()
+        for part in _TOKEN_DIR.parts:
+            current = current / part
+            directories.append(current)
+        self._directories = tuple(directories)
+        path = current / f"{server_name}-{digest}.json"
+        warn_agent_workspace_path(path, agent_root, subject="MCP credential storage")
+        self.path = path
         self._force_authorization = force_authorization
 
     async def get_tokens(self) -> OAuthToken | None:
@@ -223,6 +241,11 @@ class FileTokenStorage:
     def _update_values(self, values: dict[str, object]) -> None:
         directory = self.path.parent
         directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        for parent in self._directories[:-1]:
+            # mkdir(mode=...) applies the mode to the leaf only, so an
+            # intermediate it created keeps the process umask.
+            with contextlib.suppress(OSError):
+                parent.chmod(0o700)
         directory.chmod(0o700)
         data = self._read() or {}
         data.update(values)
@@ -282,8 +305,8 @@ async def _authorize_discovered_device(
     if client_info is None:
         return False
     authorization = _DeviceAuthorization(
-        device_endpoint=_issuer_endpoint(metadata.device_authorization_endpoint, metadata),
-        token_endpoint=_issuer_endpoint(metadata.token_endpoint, metadata),
+        device_endpoint=await _issuer_endpoint(metadata.device_authorization_endpoint, metadata),
+        token_endpoint=await _issuer_endpoint(metadata.token_endpoint, metadata),
         resource=context.get_resource_url(),
         client_info=client_info,
     )
@@ -296,19 +319,25 @@ async def _discover_device_metadata(
     auth_server_url: str,
 ) -> _AuthorizationServerMetadata | None:
     try:
-        issuer = _safe_https_url(auth_server_url)
+        # Every await inside the timeout must yield, so name resolution runs on a
+        # worker thread; a blocking getaddrinfo here cannot be interrupted.
         async with asyncio.timeout(_DISCOVERY_TIMEOUT_SECONDS):
-            async with httpx.AsyncClient(
-                timeout=_HTTP_TIMEOUT_SECONDS,
-                follow_redirects=False,
-            ) as client:
+            issuer = await asyncio.to_thread(_safe_https_url, auth_server_url)
+            async with _oauth_http_client() as client:
                 for candidate in build_oauth_authorization_server_metadata_discovery_urls(
                     issuer, issuer
                 ):
                     metadata = await _read_device_metadata(client, issuer, candidate)
                     if metadata is not None:
                         return metadata
-    except (httpx.HTTPError, MCPAuthorizationError, OSError, ValidationError, ValueError):
+    except (
+        httpx.HTTPError,
+        MCPAuthorizationError,
+        OSError,
+        SSRFBlockedError,
+        ValidationError,
+        ValueError,
+    ):
         return None
     return None
 
@@ -320,7 +349,7 @@ async def _read_device_metadata(
 ) -> _AuthorizationServerMetadata | None:
     if _origin(candidate) != _origin(issuer):
         return None
-    body = await _get_json(client, _safe_https_url(candidate))
+    body = await _get_json(client, await asyncio.to_thread(_safe_https_url, candidate))
     if body is None:
         return None
     try:
@@ -333,8 +362,8 @@ async def _read_device_metadata(
         metadata.grant_types_supported or ()
     ):
         return None
-    _issuer_endpoint(metadata.device_authorization_endpoint, metadata)
-    _issuer_endpoint(metadata.token_endpoint, metadata)
+    await _issuer_endpoint(metadata.device_authorization_endpoint, metadata)
+    await _issuer_endpoint(metadata.token_endpoint, metadata)
     return metadata
 
 
@@ -344,22 +373,22 @@ async def _register_device_client(
     registration_endpoint = metadata.registration_endpoint or AnyHttpUrl(
         urljoin(str(metadata.issuer), "/register")
     )
-    endpoint = _issuer_endpoint(registration_endpoint, metadata)
-    async with httpx.AsyncClient(
-        timeout=_HTTP_TIMEOUT_SECONDS,
-        follow_redirects=False,
-    ) as client:
-        body = await _post_json(
-            client,
-            endpoint,
-            json_data={
-                "client_name": "Deep Agents Talon",
-                "grant_types": [_DEVICE_GRANT_TYPE],
-                "redirect_uris": [_REDIRECT_URI],
-                "response_types": ["code"],
-                "token_endpoint_auth_method": "none",
-            },
-        )
+    endpoint = await _issuer_endpoint(registration_endpoint, metadata)
+    try:
+        async with _oauth_http_client() as client:
+            body = await _post_json(
+                client,
+                endpoint,
+                json_data={
+                    "client_name": "Deep Agents Talon",
+                    "grant_types": [_DEVICE_GRANT_TYPE],
+                    "redirect_uris": [_REDIRECT_URI],
+                    "response_types": ["code"],
+                    "token_endpoint_auth_method": "none",
+                },
+            )
+    except SSRFBlockedError:
+        return None
     if body is None:
         return None
     try:
@@ -395,25 +424,27 @@ async def _run_device_flow(
     *,
     interactive: bool,
 ) -> OAuthToken:
-    async with httpx.AsyncClient(
-        timeout=_HTTP_TIMEOUT_SECONDS,
-        follow_redirects=False,
-    ) as client:
-        device = await _request_device_code(client, authorization)
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + device.expires_in
-        await _present_device_code(
-            server_name,
-            device,
-            deadline=deadline,
-            interactive=interactive,
-        )
-        return await _poll_for_device_token(
-            client,
-            authorization,
-            device,
-            deadline=deadline,
-        )
+    # The device code and the issued tokens travel on this client, so it must be
+    # the pinned, proxy-ignoring one rather than an ambient-environment client.
+    try:
+        async with _oauth_http_client() as client:
+            device = await _request_device_code(client, authorization)
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + device.expires_in
+            await _present_device_code(
+                server_name,
+                device,
+                deadline=deadline,
+                interactive=interactive,
+            )
+            return await _poll_for_device_token(
+                client,
+                authorization,
+                device,
+                deadline=deadline,
+            )
+    except SSRFBlockedError:
+        raise MCPAuthorizationError(_UNSAFE_ENDPOINT_MESSAGE) from None
 
 
 async def _request_device_code(
@@ -433,7 +464,7 @@ async def _request_device_code(
         raise MCPAuthorizationError(msg)
     try:
         device = _DeviceCodeResponse.model_validate(body)
-        device.verification_uri = _safe_https_url(device.verification_uri)
+        device.verification_uri = await asyncio.to_thread(_safe_https_url, device.verification_uri)
     except (ValidationError, ValueError) as exc:
         msg = "Authorization server returned an invalid device code response."
         raise MCPAuthorizationError(msg) from exc
@@ -591,14 +622,14 @@ def _safe_https_url(url: str) -> str:
     return validate_safe_url(url, allow_http=False)
 
 
-def _issuer_endpoint(
+async def _issuer_endpoint(
     endpoint: AnyHttpUrl | None,
     metadata: _AuthorizationServerMetadata,
 ) -> str:
     if endpoint is None:
         msg = "OAuth endpoint is missing."
         raise MCPAuthorizationError(msg)
-    validated = _safe_https_url(str(endpoint))
+    validated = await asyncio.to_thread(_safe_https_url, str(endpoint))
     if _origin(validated) != _origin(str(metadata.issuer)):
         msg = "OAuth endpoint does not match the authorization server."
         raise MCPAuthorizationError(msg)
@@ -646,7 +677,7 @@ def _reject_oauth_redirect(response: httpx.Response) -> None:
 
 
 async def _validate_oauth_url(url: str) -> None:
-    msg = "OAuth endpoint is not a safe public HTTPS URL."
+    msg = _UNSAFE_ENDPOINT_MESSAGE
     try:
         parsed = urlparse(url)
         await asyncio.to_thread(_safe_https_url, url)
@@ -693,8 +724,7 @@ class _PersistedExpiryOAuthProvider(OAuthClientProvider):
                 _reject_oauth_redirect(response)
                 return response
         except SSRFBlockedError:
-            msg = "OAuth endpoint is not a safe public HTTPS URL."
-            raise MCPAuthorizationError(msg) from None
+            raise MCPAuthorizationError(_UNSAFE_ENDPOINT_MESSAGE) from None
 
     async def _validate_metadata(self) -> None:
         metadata = self.context.oauth_metadata
@@ -747,12 +777,15 @@ class _PersistedExpiryOAuthProvider(OAuthClientProvider):
         raise MCPAuthorizationError(msg)
 
     async def _discover_refresh_resource(self) -> None:
-        async with (
-            httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS, follow_redirects=False) as client,
-            client.stream("GET", self.context.server_url) as response,
-        ):
-            _reject_oauth_redirect(response)
-            challenge = extract_resource_metadata_from_www_auth(response)
+        try:
+            async with (
+                _oauth_http_client() as client,
+                client.stream("GET", self.context.server_url) as response,
+            ):
+                _reject_oauth_redirect(response)
+                challenge = extract_resource_metadata_from_www_auth(response)
+        except SSRFBlockedError:
+            raise MCPAuthorizationError(_UNSAFE_ENDPOINT_MESSAGE) from None
         for url in build_protected_resource_metadata_discovery_urls(
             challenge, self.context.server_url
         ):

--- a/libs/talon/deepagents_talon/mcp_config.py
+++ b/libs/talon/deepagents_talon/mcp_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import logging
 import os
 import re
 import secrets
@@ -17,12 +18,17 @@ from typing import TYPE_CHECKING, cast
 from langchain_core.tools import tool
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable, Iterator, Mapping
 
     from langchain_core.tools import BaseTool
 
+logger = logging.getLogger(__name__)
+
 MCP_CONFIG_AUTO_APPROVE_ENV = "DEEPAGENTS_TALON_MCP_CONFIG_AUTO_APPROVE"
 MCP_CONFIG_UPDATE_TOOL = "update_mcp_server"
+# Duplicated from runtime._WORKSPACE_ENV: importing it would pull the runtime, and the
+# public alias lives in channels, whose package imports every channel driver eagerly.
+WORKSPACE_ENV = "DEEPAGENTS_TALON_WORKSPACE"
 _REDACTED = "<redacted>"
 _REFERENCE = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*\}")
 _NAME = re.compile(r"[A-Za-z0-9_-]+")
@@ -47,17 +53,84 @@ _ENUMS = {
 }
 
 
+def agent_workspace_root(env: Mapping[str, str] | None = None) -> Path:
+    """Return the directory the agent's shell backend reaches with relative paths.
+
+    Args:
+        env: Runtime environment to read. Falls back to the process environment,
+            which is what the default backend itself reads.
+
+    Returns:
+        The configured workspace root, or the current working directory, where
+        `LocalShellBackend(root_dir=None)` runs agent commands.
+    """
+    configured = (env or {}).get(WORKSPACE_ENV) or os.environ.get(WORKSPACE_ENV)
+    return Path(configured).expanduser().resolve() if configured else Path.cwd().resolve()
+
+
+def warn_agent_workspace_path(path: Path, agent_root: Path | None, *, subject: str) -> Path:
+    """Return `path` resolved, warning when it sits inside the agent workspace.
+
+    This reports placement, not secrecy. Talon's default backend runs real shell
+    commands with `virtual_mode=False`, so a path outside the workspace is still
+    readable by absolute path; keeping it out of the workspace only removes the
+    relative-path route and keeps it out of the model's working tree. Because it
+    buys no present protection, a bad placement is not worth failing a start over
+    -- with no workspace configured the root is the working directory, so Talon
+    launched from `$HOME` puts both default paths inside it.
+
+    Args:
+        path: Operator-selected path to check.
+        agent_root: Workspace root. Falls back to `agent_workspace_root()`.
+        subject: Name of the file, used in the warning.
+
+    Returns:
+        The resolved path, with the final component left unresolved.
+    """
+    resolved = path.parent.resolve() / path.name
+    root = agent_workspace_root() if agent_root is None else agent_root
+    # Round 2: raise here instead, once the runtime deny rules for the token
+    # directory and the configuration path make the placement worth enforcing.
+    if resolved.is_relative_to(root):
+        logger.warning(
+            "%s %s is inside the agent workspace %s; move it elsewhere, or point %s "
+            "at a directory that does not contain it",
+            subject,
+            resolved,
+            root,
+            WORKSPACE_ENV,
+        )
+    return resolved
+
+
 class MCPConfigStore:
     """Manage one fixed file without exposing stored credentials to tools.
 
+    Nothing here is a confidentiality boundary. Placement is checked and warned
+    about, not enforced, and against Talon's default shell backend `cat` and
+    `echo >` on the absolute path bypass redaction, the revision CAS, the
+    `O_NOFOLLOW` open, and the `update_mcp_server` approval interrupt alike. So
+    `update_mcp_server` mediates change; it cannot keep a configured secret from
+    the model. Only `${ENV_VAR}` references, which are never expanded here, do
+    that. Enforcing placement, denying the path to the agent's filesystem tools,
+    and moving credentials out of a readable file are tracked separately.
+
     Args:
-        path: Operator-selected configuration path, outside the agent workspace.
+        path: Operator-selected configuration path, ideally outside the agent
+            workspace; a path inside it is warned about, not rejected.
         on_update: Schedule a reload after a successful write.
+        agent_root: Agent workspace root. Defaults to the process workspace.
     """
 
-    def __init__(self, path: Path, on_update: Callable[[], None]) -> None:
+    def __init__(
+        self,
+        path: Path,
+        on_update: Callable[[], None],
+        *,
+        agent_root: Path | None = None,
+    ) -> None:
         """Capture the operator path and a process-local revision key."""
-        self._path = path.parent.resolve() / path.name
+        self._path = warn_agent_workspace_path(path, agent_root, subject="MCP configuration")
         self._on_update = on_update
         self._revision_key = secrets.token_bytes(32)
 
@@ -70,7 +143,9 @@ class MCPConfigStore:
 
             Stored strings are <redacted>, except transport/auth enums and exact
             ${ENV_VAR} references. Values are never expanded. Use this revision
-            with update_mcp_server; do not use filesystem tools for MCP settings.
+            with update_mcp_server. This tool and update_mcp_server are the
+            supported way to read and change MCP settings; do not read or edit
+            the configuration file with filesystem or shell tools.
             """
             return self._view()
 

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, ClassVar, Self
 
+import anyio
 import pytest
 from langchain_mcp_adapters.interceptors import MCPToolCallRequest
 from mcp.client.auth import OAuthFlowError
@@ -41,6 +42,7 @@ from deepagents_talon.mcp import (
     mcp_config_path,
 )
 from deepagents_talon.mcp_auth import (
+    DeviceAuthorizationCompletedError,
     FileTokenStorage,
     MCPAuthorizationError,
     _DeviceCodeResponse,
@@ -1222,3 +1224,87 @@ async def test_invalid_server_does_not_block_valid_server(
     assert [tool.name for tool in result.tools] == ["valid_read"]
     assert result.servers[0].status == "error"
     assert result.servers[1].status == "ok"
+
+
+async def _raise_device_completion() -> None:
+    raise DeviceAuthorizationCompletedError
+
+
+async def _raise_oauth_failure() -> None:
+    msg = "secret token exchange response"
+    raise OAuthFlowError(msg)
+
+
+async def _raise_connection_failure() -> None:
+    msg = "connection reset"
+    raise ConnectionError(msg)
+
+
+async def test_login_succeeds_when_the_device_flow_completes_inside_a_task_group(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A completed device login exits 0: the session task group wraps the marker."""
+    config_path = tmp_path / "custom.mcp.json"
+    _write_config(config_path, {"remote": {"url": "https://example.com/mcp", "auth": "oauth"}})
+
+    async def complete_device_login(*_args: object) -> None:
+        async with anyio.create_task_group() as group:
+            group.start_soon(_raise_device_completion)
+
+    monkeypatch.setattr("deepagents_talon.mcp._open_mcp_session", complete_device_login)
+    monkeypatch.setattr("deepagents_talon.mcp.FileTokenStorage", EmptyOAuthStorage)
+    monkeypatch.setattr("deepagents_talon.mcp.build_oauth_provider", lambda **_kwargs: object())
+
+    result = await login_mcp_server(_config(tmp_path), "remote", str(config_path))
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert captured.err == ""
+    assert captured.out == "Logged in to MCP server 'remote'.\n"
+
+
+async def test_login_reports_a_grouped_failure_without_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "custom.mcp.json"
+    _write_config(config_path, {"remote": {"url": "https://example.com/mcp"}})
+
+    async def fail_inside_task_group(*_args: object) -> None:
+        async with anyio.create_task_group() as group:
+            group.start_soon(_raise_oauth_failure)
+
+    monkeypatch.setattr("deepagents_talon.mcp._open_mcp_session", fail_inside_task_group)
+    monkeypatch.setattr("deepagents_talon.mcp.FileTokenStorage", EmptyOAuthStorage)
+    monkeypatch.setattr("deepagents_talon.mcp.build_oauth_provider", lambda **_kwargs: object())
+
+    result = await login_mcp_server(_config(tmp_path), "remote", str(config_path))
+
+    error = capsys.readouterr().err
+    assert result == 1
+    assert error.startswith("MCP login failed: ")
+    assert "secret token exchange response" not in error
+
+
+async def test_authenticate_reports_failure_for_a_grouped_session_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A network failure with no binding must not raise the group into the agent."""
+    config_path = tmp_path / "oauth.mcp.json"
+    _write_config(config_path, {"notion": {"url": "https://mcp.example", "auth": "oauth"}})
+    provider = MCPToolProvider(_config(tmp_path, {"DEEPAGENTS_TALON_MCP_CONFIG": str(config_path)}))
+    provider._oauth_servers = frozenset({"notion"})
+    monkeypatch.setattr(
+        "deepagents_talon.mcp.FileTokenStorage.get_tokens",
+        lambda _self: _stored_tokens(),
+    )
+
+    async def fail_inside_task_group(_client: object, _server_name: str) -> None:
+        async with anyio.create_task_group() as group:
+            group.start_soon(_raise_connection_failure)
+
+    monkeypatch.setattr("deepagents_talon.mcp._open_mcp_session", fail_inside_task_group)
+
+    result = await provider._authenticate("notion", "tool-call")
+
+    assert result == {"status": "failed", "server_name": "notion"}
+    assert await provider.refresh_if_needed() is None

--- a/libs/talon/tests/test_mcp_auth.py
+++ b/libs/talon/tests/test_mcp_auth.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import json
+import logging
 import socket
 import stat
+import threading
+import time
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
@@ -17,13 +21,17 @@ from deepagents_talon.mcp_auth import (
     FileTokenStorage,
     MCPAuthorizationError,
     _AuthorizationServerMetadata,
+    _authorize_discovered_device,
     _DeviceCodeResponse,
+    _discover_device_metadata,
     _issuer_endpoint,
+    _OAuthSafeTransport,
     build_oauth_provider,
     extract_oauth_callback_url,
     prepare_device_client,
     prepare_oauth_login,
 )
+from deepagents_talon.mcp_config import WORKSPACE_ENV
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -411,6 +419,7 @@ async def test_provider_switches_to_discovered_device_flow(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    oauth_network: Callable[[Callable[[httpx.Request], httpx.Response]], httpx.MockTransport],
 ) -> None:
     monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
     grant = "urn:ietf:params:oauth:grant-type:device_code"
@@ -462,16 +471,7 @@ async def test_provider_switches_to_discovered_device_flow(
             400 if body.get("error") == "authorization_pending" else 200, json=body
         )
 
-    transport = httpx.MockTransport(handle)
-    async_client = httpx.AsyncClient
-    monkeypatch.setattr(
-        "deepagents_talon.mcp_auth.httpx.AsyncClient",
-        lambda **kwargs: async_client(transport=transport, **kwargs),
-    )
-    monkeypatch.setattr(
-        "deepagents_talon.mcp_auth.validate_safe_url",
-        lambda url, **_kwargs: url,
-    )
+    oauth_network(handle)
     sleeps: list[float] = []
 
     async def sleep(delay: float) -> None:
@@ -559,12 +559,9 @@ async def test_provider_keeps_authorization_code_when_device_grant_is_absent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    oauth_network: Callable[[Callable[[httpx.Request], httpx.Response]], httpx.MockTransport],
 ) -> None:
     monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
-    monkeypatch.setattr(
-        "deepagents_talon.mcp_auth.validate_safe_url",
-        lambda url, **_kwargs: url,
-    )
 
     def handle(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -576,12 +573,7 @@ async def test_provider_keeps_authorization_code_when_device_grant_is_absent(
             },
         )
 
-    transport = httpx.MockTransport(handle)
-    async_client = httpx.AsyncClient
-    monkeypatch.setattr(
-        "deepagents_talon.mcp_auth.httpx.AsyncClient",
-        lambda **kwargs: async_client(transport=transport, **kwargs),
-    )
+    oauth_network(handle)
     storage = FileTokenStorage("remote", server_url="https://mcp.example/mcp")
     provider = build_oauth_provider(
         server_name="remote",
@@ -614,7 +606,7 @@ def test_device_response_credentials_are_redacted() -> None:
     assert "user-secret" not in repr(response)
 
 
-def test_device_endpoint_must_match_authorization_server(
+async def test_device_endpoint_must_match_authorization_server(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -629,7 +621,7 @@ def test_device_endpoint_must_match_authorization_server(
     )
 
     with pytest.raises(MCPAuthorizationError, match="does not match"):
-        _issuer_endpoint(metadata.token_endpoint, metadata)
+        await _issuer_endpoint(metadata.token_endpoint, metadata)
 
 
 def _oauth_metadata(**overrides: object) -> dict[str, object]:
@@ -815,3 +807,177 @@ async def test_oauth_blocks_private_dns_before_connecting(
     with pytest.raises(MCPAuthorizationError, match="safe public HTTPS"):
         await client.get("https://example.com/mcp")
     assert [request.url.path for request in requests] == ["/mcp"]
+
+
+async def test_device_flow_uses_only_pinned_clients_that_ignore_ambient_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    oauth_network: Callable[[Callable[[httpx.Request], httpx.Response]], httpx.MockTransport],
+) -> None:
+    """Discovery, registration, the device code and polling all carry credentials."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.invalid:3128")
+    monkeypatch.setenv("ALL_PROXY", "http://proxy.invalid:3128")
+    monkeypatch.setenv("SSL_CERT_FILE", str(tmp_path / "attacker-ca.pem"))
+    grant = "urn:ietf:params:oauth:grant-type:device_code"
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": "https://auth.example",
+                    "token_endpoint": "https://auth.example/token",
+                    "registration_endpoint": "https://auth.example/register",
+                    "grant_types_supported": [grant],
+                    "device_authorization_endpoint": "https://auth.example/device",
+                },
+            )
+        if request.url.path == "/register":
+            return httpx.Response(
+                201,
+                json={
+                    "client_id": "dynamic-client",
+                    "redirect_uris": ["http://localhost:3000/callback"],
+                    "grant_types": [grant],
+                    "token_endpoint_auth_method": "none",
+                },
+            )
+        if request.url.path == "/device":
+            return httpx.Response(
+                200,
+                json={
+                    "device_code": "device-secret",
+                    "user_code": "ABCD-1234",
+                    "verification_uri": "https://auth.example/activate",
+                    "expires_in": 120,
+                    "interval": 1,
+                },
+            )
+        return httpx.Response(200, json={"access_token": "access-secret", "token_type": "bearer"})
+
+    oauth_network(handle)
+    clients: list[dict[str, object]] = []
+    async_client = httpx.AsyncClient
+
+    def record(**kwargs: object) -> httpx.AsyncClient:
+        clients.append(kwargs)
+        return async_client(**kwargs)
+
+    monkeypatch.setattr("deepagents_talon.mcp_auth.httpx.AsyncClient", record)
+
+    async def sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("deepagents_talon.mcp_auth.asyncio.sleep", sleep)
+    storage = FileTokenStorage("remote", server_url="https://mcp.example/mcp")
+    provider = build_oauth_provider(
+        server_name="remote",
+        server_url="https://mcp.example/mcp",
+        storage=storage,
+        interactive=True,
+    )
+    provider.context.auth_server_url = "https://auth.example"
+    provider.context.client_info = OAuthClientInformationFull(
+        client_id="authorization-code-client",
+        redirect_uris=["http://localhost:3000/callback"],
+        grant_types=["authorization_code"],
+        token_endpoint_auth_method="none",  # noqa: S106
+    )
+
+    authorized = await _authorize_discovered_device(
+        "remote", storage, provider.context, interactive=True
+    )
+
+    assert authorized is True
+    tokens = await storage.get_tokens()
+    assert tokens is not None
+    assert tokens.access_token == "access-secret"  # noqa: S105
+    assert len(clients) == 3
+    assert all(isinstance(kwargs["transport"], _OAuthSafeTransport) for kwargs in clients)
+    assert all(kwargs["trust_env"] is False for kwargs in clients)
+    assert "device-secret" not in capsys.readouterr().out
+
+
+async def test_device_metadata_discovery_bounds_slow_name_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 10s discovery bound is unenforceable while getaddrinfo blocks the loop."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth._DISCOVERY_TIMEOUT_SECONDS", 0.05)
+    released = threading.Event()
+
+    def slow_resolve(url: str, **_kwargs: object) -> str:
+        released.wait(5.0)
+        return url
+
+    monkeypatch.setattr("deepagents_talon.mcp_auth.validate_safe_url", slow_resolve)
+    ticks = 0
+
+    async def tick() -> None:
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.005)
+            ticks += 1
+
+    ticker = asyncio.create_task(tick())
+    started = time.monotonic()
+    try:
+        assert await _discover_device_metadata("https://auth.example") is None
+    finally:
+        released.set()
+        ticker.cancel()
+    assert time.monotonic() - started < 1.0
+    assert ticks > 0
+
+
+def test_token_storage_warns_about_the_agent_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Placement is reported, not enforced, until the deny rules make it real."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path / "home")
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_talon.mcp_config"):
+        storage = FileTokenStorage(
+            "remote",
+            server_url="https://example.com/mcp",
+            agent_root=tmp_path,
+        )
+
+    assert storage.path.parent == tmp_path / "home" / ".deepagents" / "mcp-tokens"
+    assert "MCP credential storage" in caplog.text
+    assert str(tmp_path) in caplog.text
+    assert WORKSPACE_ENV in caplog.text
+
+
+async def test_token_storage_works_when_talon_runs_from_the_home_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression guard: the default paths sit under CWD when launched from $HOME."""
+    monkeypatch.delenv(WORKSPACE_ENV, raising=False)
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+
+    await storage.set_tokens(OAuthToken(access_token="secret"))  # noqa: S106
+
+    stored = await storage.get_tokens()
+    assert stored is not None
+    assert stored.access_token == "secret"  # noqa: S105
+
+
+async def test_token_storage_tightens_intermediate_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """mkdir(mode=...) sets the mode on the leaf only, leaving ~/.deepagents open."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    state = tmp_path / ".deepagents"
+    state.mkdir()
+    state.chmod(0o755)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+
+    await storage.set_tokens(OAuthToken(access_token="secret"))  # noqa: S106
+
+    assert stat.S_IMODE(state.stat().st_mode) == 0o700
+    assert stat.S_IMODE(storage.path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(storage.path.stat().st_mode) == 0o600

--- a/libs/talon/tests/unit_tests/test_mcp_config.py
+++ b/libs/talon/tests/unit_tests/test_mcp_config.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import logging
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import TYPE_CHECKING, Self
 
 import pytest
@@ -10,12 +12,15 @@ from langchain_core.language_models.fake_chat_models import FakeMessagesListChat
 from langchain_core.messages import AIMessage
 
 from deepagents_talon.interfaces import AgentRequest
-from deepagents_talon.mcp_config import MCP_CONFIG_AUTO_APPROVE_ENV, MCPConfigStore
+from deepagents_talon.mcp_config import (
+    MCP_CONFIG_AUTO_APPROVE_ENV,
+    WORKSPACE_ENV,
+    MCPConfigStore,
+    agent_workspace_root,
+)
 from deepagents_talon.runtime import DeepAgentRuntime
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from deepagents_talon.interfaces import ToolApprovalDecision, ToolApprovalRequest
 
 
@@ -258,3 +263,40 @@ async def test_runtime_gates_real_config_writes(
         await runtime.stop()
     assert path.exists() is writes
     assert bool(approvals) is (decision is not None and trigger != "cron")
+
+
+def test_config_store_warns_about_a_path_inside_the_agent_workspace(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The docstring invariant is reported; Round 2 turns it into an error."""
+    workspace = tmp_path / "workspace"
+    path = workspace / "nested" / ".mcp.json"
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_talon.mcp_config"):
+        store = MCPConfigStore(path, lambda: None, agent_root=workspace)
+
+    assert store._path == path
+    assert "MCP configuration" in caplog.text
+    assert str(workspace) in caplog.text
+    assert WORKSPACE_ENV in caplog.text
+
+
+def test_config_store_works_when_talon_runs_from_the_home_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression guard: the default config path sits under CWD when launched from $HOME."""
+    monkeypatch.delenv(WORKSPACE_ENV, raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    view, _update = MCPConfigStore(tmp_path / ".deepagents" / ".mcp.json", lambda: None).tools()
+
+    assert view.invoke({})["mcpServers"] == {}
+
+
+def test_agent_workspace_root_prefers_the_configured_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(WORKSPACE_ENV, raising=False)
+
+    assert agent_workspace_root({WORKSPACE_ENV: str(tmp_path)}) == tmp_path.resolve()
+    assert agent_workspace_root({}) == Path.cwd().resolve()


### PR DESCRIPTION
**Stack 1 of 4 — MCP OAuth.** Reviews cleanest bottom-up: this PR → `mcp-2-config-store` → `mcp-3-token-storage` → #6149.

Three High-severity defects in the MCP OAuth stack, all live in released 0.0.7.

- **The device-login CLI crashed after succeeding.** `login_mcp_server` caught `DeviceAuthorizationCompletedError`, but it is raised inside `ClientSession`'s anyio task group and arrives wrapped in an `ExceptionGroup` — so `deepagents-talon mcp login <github-server>` persisted credentials and then exited with a traceback and non-zero status. Now matched on leaves. The same omission made `authenticate_mcp_server` raise into the agent instead of returning `{"status": "failed"}`.
- **Device-flow HTTP clients bypassed the SSRF-safe transport** and honoured ambient `HTTPS_PROXY`/`SSL_CERT_FILE` while carrying the `device_code` and receiving tokens. All four now use the pinned client. Blocking `getaddrinfo` moved off the event loop, which also makes the 10s discovery bound real rather than nominal.
- **Credential-path placement** is checked and warned about, and the intermediate `~/.deepagents` directory no longer lands at the umask.

**What this does not do, and cannot.** MCP credentials are **not** protected from the agent's shell — tokens are cleartext under `~/.deepagents/mcp-tokens/` and the default `LocalShellBackend` reaches any absolute path. The placement check warns; it cannot enforce, and it cannot be promoted to an error later:

- `deepagents/middleware/filesystem.py:1741-1748` raises `NotImplementedError` when permissions are set on a backend where `supports_execution()` is true, unless every path routes to a non-exec backend.
- Every `_check_fs_permission` call site in that file passes `"read"` or `"write"` — **none passes `"execute"`** — so even the `CompositeBackend` escape hatch would not stop `cat`.

The real fix is architectural (OS keyring, or a directory the agent process cannot read) and is tracked separately. `update_mcp_server` provides change mediation, not confidentiality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Reviewing this PR alone:** it is one level of a four-PR stack, so an automated reviewer reading it cannot see the levels above. Several findings filed against the mid-stack PRs turned out to be defects that the top of the same chain already fixes; each such thread has a reply naming the fixing PR. Read bottom-up, or read the top PR first if you want the final state.