### PR TITLE
fix(talon): stop losing MCP refresh tokens on a refresh response

### DIFF
--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -12,7 +12,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from urllib.parse import parse_qs, urljoin, urlparse
 
 import httpx
@@ -48,7 +48,7 @@ from deepagents_talon.authorization import (
     current_authorization_handler,
     current_authorization_invocation,
 )
-from deepagents_talon.mcp_config import warn_agent_workspace_path
+from deepagents_talon.mcp_config import locked_path, warn_agent_workspace_path
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable
@@ -77,6 +77,27 @@ _REDIRECT_STATUS = 300
 _BAD_REQUEST_STATUS = 400
 _SERVER_ERROR_STATUS = 500
 _UNSAFE_ENDPOINT_MESSAGE = "OAuth endpoint is not a safe public HTTPS URL."
+
+
+def _no_authorization_channel_error(server_name: str) -> MCPAuthorizationError:
+    """Return the failure for a run with nowhere to send an authorization prompt.
+
+    The conversation may well be interactive; what is missing is a handler for
+    this run. Scheduled jobs invoke the agent without one, and a background
+    subagent does not inherit it, so name the remedy instead of the channel.
+
+    Args:
+        server_name: Configured MCP server name, for the login command.
+
+    Returns:
+        The error to raise.
+    """
+    msg = (
+        "MCP authorization has no conversation to prompt in: this run was not "
+        "started by a channel message (a scheduled job or a background subagent). "
+        f"Authorize from a chat, or run: deepagents-talon mcp login {server_name}"
+    )
+    return MCPAuthorizationError(msg)
 
 
 class _AuthorizationServerMetadata(BaseModel):
@@ -192,12 +213,18 @@ class FileTokenStorage:
         return float(raw)
 
     async def set_tokens(self, tokens: OAuthToken) -> None:
-        """Persist OAuth tokens and their absolute expiry time."""
+        """Persist OAuth tokens and their absolute expiry time.
+
+        RFC 6749 section 6 lets a refresh response omit `refresh_token`, meaning
+        "keep the one you have", and many servers do. Replacing the whole blob
+        would destroy the long-lived credential on the first such refresh and
+        force a full interactive login, so the stored value is carried forward.
+        """
         values = {
             "tokens": json.loads(tokens.model_dump_json()),
             "expires_at": _token_expiry(tokens),
         }
-        await asyncio.to_thread(self._update_values, values)
+        await asyncio.to_thread(self._update_values, values, keep_refresh_token=True)
         _mark_authorization_complete()
 
     async def set_tokens_and_client_info(
@@ -211,7 +238,7 @@ class FileTokenStorage:
             "expires_at": _token_expiry(tokens),
             "client_info": json.loads(client_info.model_dump_json(exclude_none=True)),
         }
-        await asyncio.to_thread(self._update_values, values)
+        await asyncio.to_thread(self._update_values, values, keep_refresh_token=True)
         _mark_authorization_complete()
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
@@ -238,7 +265,9 @@ class FileTokenStorage:
     def _update(self, key: str, value: object) -> None:
         self._update_values({key: value})
 
-    def _update_values(self, values: dict[str, object]) -> None:
+    def _update_values(
+        self, values: dict[str, object], *, keep_refresh_token: bool = False
+    ) -> None:
         directory = self.path.parent
         directory.mkdir(mode=0o700, parents=True, exist_ok=True)
         for parent in self._directories[:-1]:
@@ -247,23 +276,52 @@ class FileTokenStorage:
             with contextlib.suppress(OSError):
                 parent.chmod(0o700)
         directory.chmod(0o700)
-        data = self._read() or {}
-        data.update(values)
+        # Two concurrent refreshes read-modify-write the same file, so without
+        # the lock one side's tokens and client_info are silently dropped.
+        with locked_path(self.path):
+            data = self._read() or {}
+            if keep_refresh_token:
+                values = _with_stored_refresh_token(values, data)
+            data.update(values)
+            self._write(data, directory)
+
+    def _write(self, data: dict[str, object], directory: Path) -> None:
         descriptor, temporary = tempfile.mkstemp(dir=directory, prefix=".tokens-", text=True)
         try:
             os.fchmod(descriptor, 0o600)
-            with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            stream = os.fdopen(descriptor, "w", encoding="utf-8")
+            # fdopen owns the descriptor from here, and this runs on a worker
+            # thread: closing it twice could close an unrelated reused fd.
+            descriptor = -1
+            with stream as file:
                 json.dump(data, file)
+                file.flush()
+                os.fsync(file.fileno())
             Path(temporary).replace(self.path)
         except BaseException:
-            with contextlib.suppress(OSError):
-                os.close(descriptor)
+            if descriptor != -1:
+                with contextlib.suppress(OSError):
+                    os.close(descriptor)
             Path(temporary).unlink(missing_ok=True)
             raise
 
 
 def _token_expiry(tokens: OAuthToken) -> float | None:
     return time.time() + tokens.expires_in if tokens.expires_in is not None else None
+
+
+def _with_stored_refresh_token(
+    values: dict[str, object], data: dict[str, object]
+) -> dict[str, object]:
+    incoming = values.get("tokens")
+    stored = data.get("tokens")
+    if not isinstance(incoming, dict) or not isinstance(stored, dict):
+        return values
+    current = cast("dict[str, object]", incoming)
+    previous = cast("dict[str, object]", stored)
+    if current.get("refresh_token") is not None or previous.get("refresh_token") is None:
+        return values
+    return {**values, "tokens": {**current, "refresh_token": previous["refresh_token"]}}
 
 
 def _mark_authorization_complete() -> None:
@@ -490,8 +548,7 @@ async def _present_device_code(
     invocation_id = current_authorization_invocation()
     attempt = current_authorization_attempt()
     if handler is None or invocation_id is None or attempt is None:
-        msg = "MCP authorization requires an interactive Talon channel"
-        raise MCPAuthorizationError(msg)
+        raise _no_authorization_channel_error(server_name)
     binding = AuthorizationBinding(
         server_name=server_name,
         invocation_id=invocation_id,
@@ -736,6 +793,10 @@ class _PersistedExpiryOAuthProvider(OAuthClientProvider):
         if _normalized_url(str(metadata.issuer)) != _normalized_url(issuer):
             msg = "OAuth metadata issuer does not match the authorization server."
             raise MCPAuthorizationError(msg)
+        # The metadata document is not necessarily served by the issuer -- the
+        # SDK also probes the resource server's origin -- so a resource server
+        # can name a legitimate issuer and still point token_endpoint at a host
+        # that would receive the authorization code and PKCE verifier.
         for endpoint in (
             metadata.issuer,
             metadata.authorization_endpoint,
@@ -744,6 +805,9 @@ class _PersistedExpiryOAuthProvider(OAuthClientProvider):
         ):
             if endpoint is not None:
                 await _validate_oauth_url(str(endpoint))
+                if _origin(str(endpoint)) != _origin(issuer):
+                    msg = "OAuth endpoint does not match the authorization server."
+                    raise MCPAuthorizationError(msg)
 
     async def _perform_authorization(self) -> httpx.Request:
         await self._validate_metadata()
@@ -882,8 +946,7 @@ def _channel_handlers(
         invocation_id = current_authorization_invocation()
         attempt = current_authorization_attempt()
         if handler is None or invocation_id is None or attempt is None:
-            msg = "MCP authorization requires an interactive Talon channel"
-            raise MCPAuthorizationError(msg)
+            raise _no_authorization_channel_error(server_name)
         binding = AuthorizationBinding(
             server_name=server_name,
             invocation_id=invocation_id,
@@ -996,9 +1059,21 @@ async def _preseed_slack_client_info(storage: FileTokenStorage) -> None:
 
 
 def format_login_error(exc: BaseException) -> str:
-    """Return a credential-safe OAuth failure message."""
+    """Return a credential-safe OAuth failure message.
+
+    Args:
+        exc: Failure to describe.
+
+    Returns:
+        The first line of the message for exception types whose text is known
+        not to embed credentials, and the type name otherwise -- including when
+        the message is empty, as `str(OSError())` is. Both call sites are
+        themselves error handlers, so this must not raise.
+    """
     if isinstance(exc, (OSError, ValidationError, TypeError, ValueError)):
-        return str(exc).splitlines()[0]
+        first = str(exc).splitlines()
+        if first and first[0]:
+            return first[0]
     return type(exc).__name__
 
 

--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -790,13 +790,15 @@ class _PersistedExpiryOAuthProvider(OAuthClientProvider):
         issuer = self.context.auth_server_url or self.context.get_authorization_base_url(
             self.context.server_url
         )
+        # RFC 8414 section 3: the issuer must match the URL the document was
+        # discovered from, which this is -- `issuer` derives from the same value
+        # the SDK builds its discovery candidates from, in both paths. Endpoints
+        # are deliberately not pinned to the issuer's origin: split-origin
+        # authorization servers conform (Google issues from accounts.google.com
+        # with its token endpoint on oauth2.googleapis.com).
         if _normalized_url(str(metadata.issuer)) != _normalized_url(issuer):
             msg = "OAuth metadata issuer does not match the authorization server."
             raise MCPAuthorizationError(msg)
-        # The metadata document is not necessarily served by the issuer -- the
-        # SDK also probes the resource server's origin -- so a resource server
-        # can name a legitimate issuer and still point token_endpoint at a host
-        # that would receive the authorization code and PKCE verifier.
         for endpoint in (
             metadata.issuer,
             metadata.authorization_endpoint,
@@ -805,9 +807,6 @@ class _PersistedExpiryOAuthProvider(OAuthClientProvider):
         ):
             if endpoint is not None:
                 await _validate_oauth_url(str(endpoint))
-                if _origin(str(endpoint)) != _origin(issuer):
-                    msg = "OAuth endpoint does not match the authorization server."
-                    raise MCPAuthorizationError(msg)
 
     async def _perform_authorization(self) -> httpx.Request:
         await self._validate_metadata()

--- a/libs/talon/tests/test_mcp_auth.py
+++ b/libs/talon/tests/test_mcp_auth.py
@@ -4,8 +4,10 @@ import asyncio
 import ipaddress
 import json
 import logging
+import os
 import socket
 import stat
+import tempfile
 import threading
 import time
 from typing import TYPE_CHECKING
@@ -26,12 +28,14 @@ from deepagents_talon.mcp_auth import (
     _discover_device_metadata,
     _issuer_endpoint,
     _OAuthSafeTransport,
+    _present_device_code,
     build_oauth_provider,
     extract_oauth_callback_url,
+    format_login_error,
     prepare_device_client,
     prepare_oauth_login,
 )
-from deepagents_talon.mcp_config import WORKSPACE_ENV
+from deepagents_talon.mcp_config import WORKSPACE_ENV, locked_path
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -981,3 +985,202 @@ async def test_token_storage_tightens_intermediate_directories(
     assert stat.S_IMODE(state.stat().st_mode) == 0o700
     assert stat.S_IMODE(storage.path.parent.stat().st_mode) == 0o700
     assert stat.S_IMODE(storage.path.stat().st_mode) == 0o600
+
+
+async def test_refresh_without_a_refresh_token_keeps_the_stored_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RFC 6749 section 6 lets a refresh response omit refresh_token."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+    await storage.set_tokens(
+        OAuthToken(access_token="first", refresh_token="long-lived")  # noqa: S106
+    )
+
+    await storage.set_tokens(OAuthToken(access_token="second"))  # noqa: S106
+
+    stored = await storage.get_tokens()
+    assert stored is not None
+    assert stored.access_token == "second"  # noqa: S105
+    assert stored.refresh_token == "long-lived"  # noqa: S105
+
+
+async def test_refresh_with_a_new_refresh_token_replaces_the_stored_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+    await storage.set_tokens(
+        OAuthToken(access_token="first", refresh_token="rotated-away")  # noqa: S106
+    )
+
+    await storage.set_tokens(
+        OAuthToken(access_token="second", refresh_token="rotated-in")  # noqa: S106
+    )
+
+    stored = await storage.get_tokens()
+    assert stored is not None
+    assert stored.refresh_token == "rotated-in"  # noqa: S105
+
+
+async def test_failed_token_write_closes_its_descriptor_exactly_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second close on a worker thread can land on an unrelated reused fd."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+    descriptors: list[int] = []
+    mkstemp = tempfile.mkstemp
+
+    def record_mkstemp(**kwargs: object) -> tuple[int, str]:
+        descriptor, name = mkstemp(**kwargs)
+        descriptors.append(descriptor)
+        return descriptor, name
+
+    closed: list[int] = []
+    real_close = os.close
+
+    def record_close(descriptor: int) -> None:
+        closed.append(descriptor)
+        real_close(descriptor)
+
+    def explode(*_args: object, **_kwargs: object) -> None:
+        msg = "disk full"
+        raise OSError(msg)
+
+    monkeypatch.setattr("deepagents_talon.mcp_auth.tempfile.mkstemp", record_mkstemp)
+    monkeypatch.setattr("deepagents_talon.mcp_auth.os.close", record_close)
+    monkeypatch.setattr("deepagents_talon.mcp_auth.json.dump", explode)
+
+    with pytest.raises(OSError, match="disk full"):
+        await storage.set_tokens(OAuthToken(access_token="secret"))  # noqa: S106
+
+    assert descriptors
+    # The stream owns the descriptor once fdopen succeeds and closes it on exit.
+    assert [descriptor for descriptor in closed if descriptor in descriptors] == []
+    assert list(storage.path.parent.glob(".tokens-*")) == []
+
+
+async def test_token_write_is_flushed_and_locked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Concurrent refreshes must not interleave a read-modify-write."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("deepagents_talon.mcp_config._LOCK_TIMEOUT_SECONDS", 0.1)
+    synced: list[int] = []
+    real_fsync = os.fsync
+
+    def record_fsync(descriptor: int) -> None:
+        synced.append(descriptor)
+        real_fsync(descriptor)
+
+    monkeypatch.setattr("deepagents_talon.mcp_auth.os.fsync", record_fsync)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+    await storage.set_tokens(OAuthToken(access_token="first"))  # noqa: S106
+    assert synced
+
+    holding = threading.Event()
+    release = threading.Event()
+
+    def hold_the_lock() -> None:
+        with locked_path(storage.path):
+            holding.set()
+            release.wait(5.0)
+
+    holder = threading.Thread(target=hold_the_lock)
+    holder.start()
+    try:
+        assert holding.wait(5.0)
+        with pytest.raises(TimeoutError):
+            await storage.set_tokens(OAuthToken(access_token="second"))  # noqa: S106
+    finally:
+        release.set()
+        holder.join(5.0)
+
+    stored = await storage.get_tokens()
+    assert stored is not None
+    assert stored.access_token == "first"  # noqa: S105
+
+
+async def test_metadata_endpoints_must_share_the_issuer_origin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    oauth_network: Callable[[Callable[[httpx.Request], httpx.Response]], httpx.MockTransport],
+) -> None:
+    """A resource server can serve issuer-claiming metadata pointing elsewhere."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/mcp":
+            return httpx.Response(
+                401,
+                headers={
+                    "WWW-Authenticate": 'Bearer resource_metadata="https://example.com/resource"'
+                },
+            )
+        if request.url.path == "/resource":
+            return httpx.Response(
+                200,
+                json={
+                    "resource": "https://example.com/mcp",
+                    "authorization_servers": ["https://auth.example/tenant"],
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "issuer": "https://auth.example/tenant",
+                "authorization_endpoint": "https://auth.example/authorize",
+                "token_endpoint": "https://collector.example/token",
+                "registration_endpoint": "https://auth.example/register",
+            },
+        )
+
+    transport = oauth_network(handle)
+    storage = FileTokenStorage("remote", server_url="https://example.com/mcp")
+    await storage.set_tokens(
+        OAuthToken(access_token="expired", refresh_token="refresh")  # noqa: S106
+    )
+    provider = build_oauth_provider(
+        server_name="remote",
+        server_url="https://example.com/mcp",
+        storage=storage,
+        interactive=True,
+    )
+
+    async with httpx.AsyncClient(transport=transport, auth=provider) as client:
+        with pytest.raises(MCPAuthorizationError, match="does not match"):
+            await client.get("https://example.com/mcp")
+
+    assert not any(request.url.host == "collector.example" for request in requests)
+
+
+def test_format_login_error_survives_an_empty_message() -> None:
+    """Both call sites are error handlers; str(OSError()) is empty."""
+    assert format_login_error(OSError()) == "OSError"
+    assert format_login_error(ValueError("first line\nsecond")) == "first line"
+
+
+async def test_authorization_without_a_conversation_names_the_remedy() -> None:
+    """Scheduled jobs and background subagents run without an authorization handler."""
+    device = _DeviceCodeResponse(
+        device_code=SecretStr("device-secret"),
+        user_code=SecretStr("ABCD-1234"),
+        verification_uri="https://auth.example/activate",
+        expires_in=120,
+    )
+
+    with pytest.raises(MCPAuthorizationError) as caught:
+        await _present_device_code(
+            "notion",
+            device,
+            deadline=0.0,
+            interactive=False,
+        )
+
+    message = str(caught.value)
+    assert "scheduled job or a background subagent" in message
+    assert "deepagents-talon mcp login notion" in message
+    assert "device-secret" not in message

--- a/libs/talon/tests/test_mcp_auth.py
+++ b/libs/talon/tests/test_mcp_auth.py
@@ -1102,61 +1102,6 @@ async def test_token_write_is_flushed_and_locked(
     assert stored.access_token == "first"  # noqa: S105
 
 
-async def test_metadata_endpoints_must_share_the_issuer_origin(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    oauth_network: Callable[[Callable[[httpx.Request], httpx.Response]], httpx.MockTransport],
-) -> None:
-    """A resource server can serve issuer-claiming metadata pointing elsewhere."""
-    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
-    requests: list[httpx.Request] = []
-
-    def handle(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
-        if request.url.path == "/mcp":
-            return httpx.Response(
-                401,
-                headers={
-                    "WWW-Authenticate": 'Bearer resource_metadata="https://example.com/resource"'
-                },
-            )
-        if request.url.path == "/resource":
-            return httpx.Response(
-                200,
-                json={
-                    "resource": "https://example.com/mcp",
-                    "authorization_servers": ["https://auth.example/tenant"],
-                },
-            )
-        return httpx.Response(
-            200,
-            json={
-                "issuer": "https://auth.example/tenant",
-                "authorization_endpoint": "https://auth.example/authorize",
-                "token_endpoint": "https://collector.example/token",
-                "registration_endpoint": "https://auth.example/register",
-            },
-        )
-
-    transport = oauth_network(handle)
-    storage = FileTokenStorage("remote", server_url="https://example.com/mcp")
-    await storage.set_tokens(
-        OAuthToken(access_token="expired", refresh_token="refresh")  # noqa: S106
-    )
-    provider = build_oauth_provider(
-        server_name="remote",
-        server_url="https://example.com/mcp",
-        storage=storage,
-        interactive=True,
-    )
-
-    async with httpx.AsyncClient(transport=transport, auth=provider) as client:
-        with pytest.raises(MCPAuthorizationError, match="does not match"):
-            await client.get("https://example.com/mcp")
-
-    assert not any(request.url.host == "collector.example" for request in requests)
-
-
 def test_format_login_error_survives_an_empty_message() -> None:
     """Both call sites are error handlers; str(OSError()) is empty."""
     assert format_login_error(OSError()) == "OSError"


### PR DESCRIPTION
**Stack 3 of 4 — MCP OAuth.** Based on `linted/talon/mcp-2-config-store` (#6160). Review #6159 and #6160 first.

Token storage durability, plus a finding that was investigated and withdrawn.

- **`set_tokens` destroyed the stored refresh token when a response omitted one.** RFC 6749 §6 permits a refresh response to omit `refresh_token`, meaning "keep the one you have", and many servers do — so the long-lived credential was destroyed on the first such refresh, forcing a full interactive re-login and defeating the point of the persisted-refresh work in #6100 and #6090. Now merged inside the same locked read-modify-write that already preserved `client_info`.
- **A double `close()` on a file descriptor.** If the write raised, `os.fdopen`'s context manager had already closed the descriptor and the error path closed it again — with the `EBADF` hidden by `suppress(OSError)`. Because this runs under `asyncio.to_thread`, another thread could `open()` and receive that fd number in between, so the second close could silently close an unrelated file, socket or DB handle. Ownership now transfers explicitly.
- **Token writes were unsynced and unlocked**, so two concurrent refreshes silently dropped one side's tokens *and* `client_info`, and an unsynced rename could leave a partial credential file that the reader then rejected outright. Now uses the same `flock` + `fsync` discipline as the config store, extracted to one shared helper.

**Two commits, one of which reverts the other — deliberately kept.** A review finding claimed `_validate_metadata` failed to bind OAuth endpoints to the issuer origin. It was implemented, then investigated and reverted: the existing issuer check *is* RFC 8414 §3, correctly implemented in both discovery paths, because `issuer` derives from the same URL the SDK builds its candidates from. The binding closed nothing that check doesn't already close, while permanently rejecting conforming split-origin authorization servers — Google is one (`issuer: accounts.google.com`, `token_endpoint: oauth2.googleapis.com`, verified against the live discovery document). Both commits stay so the trace is answerable from `git log` rather than looking like churn.

Also noted, not fixed: the device path silently loses split-origin authorization servers — `_issuer_endpoint` enforces same-origin, the error is swallowed, and Talon falls back to auth-code with no diagnostic. Pre-existing; relaxing it is its own security decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Reviewing this PR alone:** it is one level of a four-PR stack, so an automated reviewer reading it cannot see the levels above. Several findings filed against the mid-stack PRs turned out to be defects that the top of the same chain already fixes; each such thread has a reply naming the fixing PR. Read bottom-up, or read the top PR first if you want the final state.