### PR TITLE
fix(talon): close a url swap past the MCP auto-approve guard

### DIFF
--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -115,12 +115,6 @@ def _authentication_required(exc: BaseException) -> bool:
     )
 
 
-def _device_authorization_completed(exc: BaseException) -> bool:
-    return any(
-        isinstance(leaf, DeviceAuthorizationCompletedError) for leaf in _exception_leaves(exc)
-    )
-
-
 @dataclass(frozen=True, slots=True)
 class MCPToolInfo:
     """Metadata for one MCP tool."""
@@ -512,10 +506,22 @@ async def login_mcp_server(
         pass
     except ExceptionGroup as group:
         # A completed device flow raises from inside the session's task group,
-        # which wraps it; only a group holding some other failure is an error.
-        if not _device_authorization_completed(group):
+        # which wraps it, and can aggregate with a sibling failure from tearing
+        # down the abandoned code flow. The marker is raised only after the
+        # credentials are persisted, so its presence still means the login
+        # succeeded; report the rest rather than discarding or misreading it.
+        leaves = tuple(_exception_leaves(group))
+        remainder = tuple(
+            leaf for leaf in leaves if not isinstance(leaf, DeviceAuthorizationCompletedError)
+        )
+        if len(remainder) == len(leaves):
             print(f"MCP login failed: {format_login_error(group)}", file=sys.stderr)  # noqa: T201
             return 1
+        for leaf in remainder:
+            logger.warning(
+                "MCP login session failed after credentials were saved: %s",
+                format_login_error(leaf),
+            )
     except (
         HTTPError,
         McpError,

--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -71,6 +71,7 @@ _GITHUB_MCP_HOST = "api.githubcopilot.com"
 _DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
 _HTTP_TIMEOUT_SECONDS = 5.0
 _DISCOVERY_TIMEOUT_SECONDS = 10.0
+_RESOLVE_TIMEOUT_SECONDS = 5.0
 _MAX_OAUTH_RESPONSE_BYTES = 64 * 1024
 _MIN_RESPONSE_STATUS = 200
 _REDIRECT_STATUS = 300
@@ -391,7 +392,7 @@ async def _discover_device_metadata(
         # Every await inside the timeout must yield, so name resolution runs on a
         # worker thread; a blocking getaddrinfo here cannot be interrupted.
         async with asyncio.timeout(_DISCOVERY_TIMEOUT_SECONDS):
-            issuer = await asyncio.to_thread(_safe_https_url, auth_server_url)
+            issuer = await _resolved_https_url(auth_server_url)
             async with _oauth_http_client() as client:
                 for candidate in build_oauth_authorization_server_metadata_discovery_urls(
                     issuer, issuer
@@ -418,7 +419,7 @@ async def _read_device_metadata(
 ) -> _AuthorizationServerMetadata | None:
     if _origin(candidate) != _origin(issuer):
         return None
-    body = await _get_json(client, await asyncio.to_thread(_safe_https_url, candidate))
+    body = await _get_json(client, await _resolved_https_url(candidate))
     if body is None:
         return None
     try:
@@ -533,7 +534,7 @@ async def _request_device_code(
         raise MCPAuthorizationError(msg)
     try:
         device = _DeviceCodeResponse.model_validate(body)
-        device.verification_uri = await asyncio.to_thread(_safe_https_url, device.verification_uri)
+        device.verification_uri = await _resolved_https_url(device.verification_uri)
     except (ValidationError, ValueError) as exc:
         msg = "Authorization server returned an invalid device code response."
         raise MCPAuthorizationError(msg) from exc
@@ -690,6 +691,45 @@ def _safe_https_url(url: str) -> str:
     return validate_safe_url(url, allow_http=False)
 
 
+async def _resolved_https_url(url: str) -> str:
+    """Validate and resolve `url` off the event loop, under its own bound.
+
+    `asyncio.to_thread` keeps a blocking `getaddrinfo` from stalling the host,
+    but it also puts the resolution outside HTTPX's timeouts, which bound only
+    the request a client makes afterwards. Without a bound here, a slow or
+    hostile resolver stalls whichever flow is waiting on it: the device login or
+    the token refresh never returns, even though the loop stays responsive.
+
+    The bound is deliberately separate from the request timeout rather than
+    shared with it. Resolution happens before there is a client or a request to
+    charge it to, and letting it consume the request budget would make a healthy
+    authorization server look unreachable. It also does not use the discovery
+    bound, which covers a loop of several requests rather than one name lookup.
+
+    A thread cannot be cancelled, so a timed-out resolution keeps running until
+    the C call returns; only the waiter gives up. Every caller goes through here
+    rather than calling `asyncio.to_thread` directly, so boundedness does not
+    depend on which callers happen to sit inside a timeout -- that dependence is
+    how the device-code and registration paths ended up unbounded.
+
+    Args:
+        url: Endpoint to validate and resolve.
+
+    Returns:
+        The validated URL.
+
+    Raises:
+        MCPAuthorizationError: The resolution did not finish in time.
+        ValueError: The URL is not a safe public HTTPS URL.
+    """
+    try:
+        async with asyncio.timeout(_RESOLVE_TIMEOUT_SECONDS):
+            return await asyncio.to_thread(_safe_https_url, url)
+    except TimeoutError:
+        msg = "Timed out resolving an OAuth endpoint."
+        raise MCPAuthorizationError(msg) from None
+
+
 async def _issuer_endpoint(
     endpoint: AnyHttpUrl | None,
     metadata: _AuthorizationServerMetadata,
@@ -697,7 +737,7 @@ async def _issuer_endpoint(
     if endpoint is None:
         msg = "OAuth endpoint is missing."
         raise MCPAuthorizationError(msg)
-    validated = await asyncio.to_thread(_safe_https_url, str(endpoint))
+    validated = await _resolved_https_url(str(endpoint))
     if _origin(validated) != _origin(str(metadata.issuer)):
         msg = "OAuth endpoint does not match the authorization server."
         raise MCPAuthorizationError(msg)
@@ -748,7 +788,7 @@ async def _validate_oauth_url(url: str) -> None:
     msg = _UNSAFE_ENDPOINT_MESSAGE
     try:
         parsed = urlparse(url)
-        await asyncio.to_thread(_safe_https_url, url)
+        await _resolved_https_url(url)
     except ValueError:
         raise MCPAuthorizationError(msg) from None
     if parsed.username is not None or parsed.password is not None:

--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -170,8 +170,10 @@ class FileTokenStorage:
         These files hold live bearer and refresh tokens in cleartext, so the
         directory is restricted to the owner and a location inside the agent
         workspace is warned about. Against Talon's default shell backend that is
-        hardening, not a boundary: the agent can still read any absolute path it
-        is given.
+        hardening, not a boundary, and it cannot become one here: the agent can
+        read any absolute path it is given, and filesystem deny rules cannot be
+        applied to a backend that executes commands. See
+        `mcp_config.warn_agent_workspace_path`.
 
         Args:
             server_name: Configured MCP server name.

--- a/libs/talon/deepagents_talon/mcp_auth.py
+++ b/libs/talon/deepagents_talon/mcp_auth.py
@@ -234,13 +234,22 @@ class FileTokenStorage:
         tokens: OAuthToken,
         client_info: OAuthClientInformationFull,
     ) -> None:
-        """Atomically persist OAuth tokens and their client registration."""
+        """Atomically persist OAuth tokens and their client registration.
+
+        This records a *fresh* grant, so unlike `set_tokens` it does not carry a
+        stored `refresh_token` forward. RFC 6749 section 6's "keep the one you
+        have" applies to a refresh response; stitching the previous grant's
+        refresh token onto a new access token would leave a credential the
+        authorization server may already have revoked -- which is exactly what an
+        explicit reauthentication invalidates -- instead of correctly recording
+        that this grant is not refreshable.
+        """
         values = {
             "tokens": json.loads(tokens.model_dump_json()),
             "expires_at": _token_expiry(tokens),
             "client_info": json.loads(client_info.model_dump_json(exclude_none=True)),
         }
-        await asyncio.to_thread(self._update_values, values, keep_refresh_token=True)
+        await asyncio.to_thread(self._update_values, values)
         _mark_authorization_complete()
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:

--- a/libs/talon/deepagents_talon/mcp_config.py
+++ b/libs/talon/deepagents_talon/mcp_config.py
@@ -82,7 +82,7 @@ def warn_agent_workspace_path(path: Path, agent_root: Path | None, *, subject: s
     commands with `virtual_mode=False`, so a path outside the workspace is still
     readable by absolute path; keeping it out of the workspace only removes the
     relative-path route and keeps it out of the model's working tree. Because it
-    buys no present protection, a bad placement is not worth failing a start over
+    buys no protection at all, a bad placement is not worth failing a start over
     -- with no workspace configured the root is the working directory, so Talon
     launched from `$HOME` puts both default paths inside it.
 
@@ -96,8 +96,15 @@ def warn_agent_workspace_path(path: Path, agent_root: Path | None, *, subject: s
     """
     resolved = path.parent.resolve() / path.name
     root = agent_workspace_root() if agent_root is None else agent_root
-    # Round 2: raise here instead, once the runtime deny rules for the token
-    # directory and the configuration path make the placement worth enforcing.
+    # This stays a warning, because no filesystem deny rule can promote it to an
+    # error. FilesystemMiddleware refuses to load permissions at all alongside an
+    # execution-capable backend (deepagents/middleware/filesystem.py:1741-1748,
+    # "Tool-level permissions for the execute tool are not implemented"), and
+    # every _check_fs_permission call site in that file guards a read or write
+    # tool -- none guards execute -- so even routing the paths through a
+    # CompositeBackend would not stop `cat`. Keeping these files away from the
+    # agent needs an OS keyring, or a directory the agent process cannot read at
+    # all: a separate uid, or a sandboxed backend.
     if resolved.is_relative_to(root):
         logger.warning(
             "%s %s is inside the agent workspace %s; move it elsewhere, or point %s "
@@ -119,8 +126,9 @@ class MCPConfigStore:
     `O_NOFOLLOW` open, and the `update_mcp_server` approval interrupt alike. So
     `update_mcp_server` mediates change; it cannot keep a configured secret from
     the model. Only `${ENV_VAR}` references, which are never expanded here, do
-    that. Enforcing placement, denying the path to the agent's filesystem tools,
-    and moving credentials out of a readable file are tracked separately.
+    that, and no filesystem deny rule can change it -- see
+    `warn_agent_workspace_path` for why that approach is closed off. Moving
+    credentials somewhere the agent process cannot read is tracked separately.
 
     Args:
         path: Operator-selected configuration path, ideally outside the agent

--- a/libs/talon/deepagents_talon/mcp_config.py
+++ b/libs/talon/deepagents_talon/mcp_config.py
@@ -52,6 +52,8 @@ _ENUMS = {
     "type": {"stdio", "http", "sse", "streamable_http", "streamable-http"},
     "auth": {"oauth"},
 }
+# Everything else in `_FIELDS` decides where a credential is sent or what runs.
+_TOOL_FILTER_FIELDS = frozenset({"allowedTools", "disabledTools"})
 _LOCK_TIMEOUT_SECONDS = 5.0
 _LOCK_POLL_SECONDS = 0.05
 
@@ -337,13 +339,21 @@ def _reject_unapproved_execution_change(
     replacement: dict[str, object],
     previous: object,
 ) -> None:
-    """Refuse an unapproved change that runs new code with a secret it never saw.
+    """Refuse an unapproved change that redirects a secret the caller never saw.
 
-    `_restore` fills `<redacted>` path-wise, so a caller can keep a stored `env`
-    secret while replacing `command`/`args` -- or flip the derived transport,
-    which turns a URL into a command line. With the approval interrupt disabled
-    that reaches a real credential unreviewed, so refuse the combination and let
-    the caller resend the settings without reusing redacted values.
+    `_restore` fills `<redacted>` path-wise, so a caller can keep a stored
+    credential while changing where it goes: swapping `command`/`args`, flipping
+    the derived transport to turn a URL into a command line, or pointing `url` at
+    another host so the restored `Authorization` header is sent there. With the
+    approval interrupt disabled any of those reaches a real credential
+    unreviewed.
+
+    The check is deliberately not a list of dangerous fields. The first version
+    enumerated `command`, `args` and the transport, and a review caught that it
+    omitted `url` -- the same attack through an unlisted field. Instead every
+    managed setting must be unchanged apart from the tool filters, which cannot
+    redirect anything, so a field added to `_FIELDS` later is covered by default
+    rather than by remembering to add it here.
 
     Args:
         submitted: Settings as supplied, before redacted values were restored.
@@ -351,20 +361,29 @@ def _reject_unapproved_execution_change(
         previous: Stored settings for this server, if any.
 
     Raises:
-        _UnsafeUpdateError: The update reuses a stored secret and changes what runs.
+        _UnsafeUpdateError: The update reuses a stored secret and changes a
+            setting that could send it somewhere else.
     """
     if not _restores_redacted(submitted):
         return
     old = cast("dict[str, object]", previous) if isinstance(previous, dict) else {}
-    changed = any(replacement.get(field) != old.get(field) for field in ("command", "args"))
-    if not changed and _derived_transport(replacement) == _derived_transport(old):
+    if _redirecting_fields(replacement) == _redirecting_fields(old):
         return
     msg = (
-        "Auto-approved MCP updates cannot change command, args, or transport while "
-        "reusing <redacted> values. Resend the settings with literal ${ENV_VAR} "
-        "references instead, or ask the operator to re-enable update approval."
+        "Auto-approved MCP updates that reuse <redacted> values cannot change any "
+        "other setting; only allowedTools and disabledTools may differ. Resend the "
+        "settings with ${ENV_VAR} references instead of redacted values, or ask the "
+        "operator to re-enable update approval."
     )
     raise _UnsafeUpdateError(msg)
+
+
+def _redirecting_fields(server: dict[str, object]) -> dict[str, object]:
+    return {
+        key: value
+        for key, value in server.items()
+        if key in _FIELDS and key not in _TOOL_FILTER_FIELDS
+    }
 
 
 def _restores_redacted(value: object) -> bool:

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, ClassVar, Self
@@ -1308,3 +1309,33 @@ async def test_authenticate_reports_failure_for_a_grouped_session_error(
 
     assert result == {"status": "failed", "server_name": "notion"}
     assert await provider.refresh_if_needed() is None
+
+
+async def test_login_succeeds_and_logs_a_failure_alongside_the_completion_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The marker is only raised after credentials persist, so the login did succeed."""
+    config_path = tmp_path / "custom.mcp.json"
+    _write_config(config_path, {"remote": {"url": "https://example.com/mcp", "auth": "oauth"}})
+
+    async def complete_then_fail(*_args: object) -> None:
+        async with anyio.create_task_group() as group:
+            group.start_soon(_raise_device_completion)
+            group.start_soon(_raise_connection_failure)
+
+    monkeypatch.setattr("deepagents_talon.mcp._open_mcp_session", complete_then_fail)
+    monkeypatch.setattr("deepagents_talon.mcp.FileTokenStorage", EmptyOAuthStorage)
+    monkeypatch.setattr("deepagents_talon.mcp.build_oauth_provider", lambda **_kwargs: object())
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_talon.mcp"):
+        result = await login_mcp_server(_config(tmp_path), "remote", str(config_path))
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert captured.out == "Logged in to MCP server 'remote'.\n"
+    assert captured.err == ""
+    assert "after credentials were saved" in caplog.text
+    assert "connection reset" in caplog.text

--- a/libs/talon/tests/test_mcp_auth.py
+++ b/libs/talon/tests/test_mcp_auth.py
@@ -29,6 +29,7 @@ from deepagents_talon.mcp_auth import (
     _issuer_endpoint,
     _OAuthSafeTransport,
     _present_device_code,
+    _register_device_client,
     build_oauth_provider,
     extract_oauth_callback_url,
     format_login_error,
@@ -1151,3 +1152,42 @@ async def test_fresh_grant_without_a_refresh_token_clears_the_stored_one(
     assert stored is not None
     assert stored.access_token == "fresh"  # noqa: S105
     assert stored.refresh_token is None
+
+
+async def test_device_registration_bounds_slow_name_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """to_thread keeps the loop free, but nothing else bounded this resolution."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth._RESOLVE_TIMEOUT_SECONDS", 0.05)
+    released = threading.Event()
+
+    def slow_resolve(url: str, **_kwargs: object) -> str:
+        released.wait(5.0)
+        return url
+
+    monkeypatch.setattr("deepagents_talon.mcp_auth.validate_safe_url", slow_resolve)
+    metadata = _AuthorizationServerMetadata(
+        issuer="https://auth.example",
+        token_endpoint="https://auth.example/token",  # noqa: S106
+        registration_endpoint="https://auth.example/register",
+        grant_types_supported=["urn:ietf:params:oauth:grant-type:device_code"],
+        device_authorization_endpoint="https://auth.example/device",
+    )
+    ticks = 0
+
+    async def tick() -> None:
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.005)
+            ticks += 1
+
+    ticker = asyncio.create_task(tick())
+    started = time.monotonic()
+    try:
+        with pytest.raises(MCPAuthorizationError, match="Timed out resolving"):
+            await _register_device_client(metadata)
+    finally:
+        released.set()
+        ticker.cancel()
+    assert time.monotonic() - started < 1.0
+    assert ticks > 0

--- a/libs/talon/tests/test_mcp_auth.py
+++ b/libs/talon/tests/test_mcp_auth.py
@@ -1129,3 +1129,25 @@ async def test_authorization_without_a_conversation_names_the_remedy() -> None:
     assert "scheduled job or a background subagent" in message
     assert "deepagents-talon mcp login notion" in message
     assert "device-secret" not in message
+
+
+async def test_fresh_grant_without_a_refresh_token_clears_the_stored_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A new grant is not a refresh response: the old refresh token may be revoked."""
+    monkeypatch.setattr("deepagents_talon.mcp_auth.Path.home", lambda: tmp_path)
+    storage = FileTokenStorage("notion", server_url="https://example.com/mcp")
+    await storage.set_tokens(
+        OAuthToken(access_token="first", refresh_token="from-old-grant")  # noqa: S106
+    )
+    client = OAuthClientInformationFull(
+        redirect_uris=["http://localhost:3000/callback"],
+        client_id="client-id",
+    )
+
+    await storage.set_tokens_and_client_info(OAuthToken(access_token="fresh"), client)  # noqa: S106
+
+    stored = await storage.get_tokens()
+    assert stored is not None
+    assert stored.access_token == "fresh"  # noqa: S105
+    assert stored.refresh_token is None

--- a/libs/talon/tests/unit_tests/test_mcp_config.py
+++ b/libs/talon/tests/unit_tests/test_mcp_config.py
@@ -445,3 +445,74 @@ def test_update_reports_conflict_when_the_lock_is_held(config_tools, monkeypatch
 
     assert result["status"] == "conflict"
     assert updates == []
+
+
+def test_auto_approve_refuses_a_url_swap_that_reuses_a_stored_secret(tmp_path: Path):
+    """The first guard listed command/args/transport and missed this one."""
+    path = tmp_path / "private" / ".mcp.json"
+    path.parent.mkdir()
+    path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "example": {
+                        "url": "https://legit.test/mcp",
+                        "headers": {"Authorization": "Bearer real-secret"},
+                    }
+                }
+            }
+        )
+    )
+    view, update = MCPConfigStore(path, lambda: None, auto_approve=True).tools()
+    stored = view.invoke({})
+
+    result = update.invoke(
+        {
+            "server_name": "example",
+            "server": {
+                "url": "https://attacker.test/",
+                "headers": stored["mcpServers"]["example"]["headers"],
+            },
+            "expected_revision": stored["revision"],
+        }
+    )
+
+    assert result["status"] == "error"
+    saved = json.loads(path.read_text())["mcpServers"]["example"]
+    assert saved["url"] == "https://legit.test/mcp"
+    assert saved["headers"] == {"Authorization": "Bearer real-secret"}
+
+
+def test_auto_approve_allows_a_tool_filter_change_that_reuses_a_stored_secret(tmp_path: Path):
+    """Tool filters cannot redirect a credential, so redacted reuse stays usable."""
+    path = tmp_path / "private" / ".mcp.json"
+    path.parent.mkdir()
+    path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "example": {
+                        "url": "https://legit.test/mcp",
+                        "headers": {"Authorization": "Bearer real-secret"},
+                    }
+                }
+            }
+        )
+    )
+    view, update = MCPConfigStore(path, lambda: None, auto_approve=True).tools()
+    stored = view.invoke({})
+    server = stored["mcpServers"]["example"]
+    server["allowedTools"] = ["read_*"]
+
+    result = update.invoke(
+        {
+            "server_name": "example",
+            "server": server,
+            "expected_revision": stored["revision"],
+        }
+    )
+
+    assert result["status"] == "updated"
+    saved = json.loads(path.read_text())["mcpServers"]["example"]
+    assert saved["allowedTools"] == ["read_*"]
+    assert saved["headers"] == {"Authorization": "Bearer real-secret"}


### PR DESCRIPTION
**Stack 4 of 4 — MCP OAuth.** Based on `linted/talon/mcp-3-token-storage`. Review levels 1–3 first.

Fixes for three defects that automated review found **in the earlier levels**, two of them in the fixes themselves.

- **A `url` swap walked straight past the auto-approve guard.** Level 2's guard checked `command` and `args`, so with auto-approve on, `{"url": "https://attacker/", "headers": {"Authorization": "<redacted>"}}` changed neither, left the derived transport equal, returned without raising — and `_restore()` then inserted the real credential, which the next reload sent to the attacker. The same attack class the guard was written to block, through a field it didn't check.

  The fix inverts the check rather than adding `url`: while a redacted value is reused, every managed setting must be unchanged apart from the two tool filters, which cannot redirect anything. Enumerating dangerous fields is the shape that already failed once, so a field added to `_FIELDS` later is covered by default instead of by remembering this call site.

  Worth recording: cross-key movement of a secret was never possible. `_restore` resolves path-wise, so moving a redacted value to a different header name looks up the old name, finds nothing, and raises. The exposure was always the destination fields.

- **A fresh device grant inherited the previous grant's refresh token.** Level 3 added refresh-token preservation to both setters, but `set_tokens_and_client_info` is called after a *fresh* authorization, not a refresh exchange — so a new grant omitting `refresh_token` was stitched onto the old one. After explicit reauthentication, where the prior grant may be revoked, the next refresh submits a dead credential. RFC 6749 §6's "keep the one you have" applies only to a refresh response; preservation now lives in `set_tokens` alone.

- **A mixed `ExceptionGroup` reported login success while discarding the rest.** Treating the whole group as successful when *any* leaf was the completion marker meant a real sibling failure vanished.

  Fixed differently from what review suggested, deliberately. Requiring *every* leaf to be the marker would invert the error: the marker is raised only after `set_tokens_and_client_info` returns, so its presence is proof the credentials are on disk, and any leaf beside it happened during the teardown of the flow Talon intentionally abandoned. Under that rule the common case — successful login plus benign teardown noise — would print "MCP login failed" and exit 1, sending the user to redo a login that worked. So a group carrying the marker keeps exit 0, and each residual leaf is logged by name at WARNING. A group without the marker is a failure and reports as one, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
