### PR TITLE
fix(sdk): refresh memory on each invocation

### DIFF
--- a/libs/deepagents/deepagents/middleware/memory.py
+++ b/libs/deepagents/deepagents/middleware/memory.py
@@ -280,7 +280,6 @@ class MemoryMiddleware(AgentMiddleware[MemoryState, ContextT, ResponseT]):
         """Load memory content before agent execution (synchronous).
 
         Loads memory from all configured sources and stores in state.
-        Only loads if not already present in state.
 
         Args:
             state: Current agent state.
@@ -290,10 +289,6 @@ class MemoryMiddleware(AgentMiddleware[MemoryState, ContextT, ResponseT]):
         Returns:
             State update with memory_contents populated.
         """
-        # Skip if already loaded
-        if "memory_contents" in state:
-            return None
-
         backend = self._backend
         contents: dict[str, str] = {}
 
@@ -314,7 +309,6 @@ class MemoryMiddleware(AgentMiddleware[MemoryState, ContextT, ResponseT]):
         """Load memory content before agent execution.
 
         Loads memory from all configured sources and stores in state.
-        Only loads if not already present in state.
 
         Args:
             state: Current agent state.
@@ -324,10 +318,6 @@ class MemoryMiddleware(AgentMiddleware[MemoryState, ContextT, ResponseT]):
         Returns:
             State update with memory_contents populated.
         """
-        # Skip if already loaded
-        if "memory_contents" in state:
-            return None
-
         backend = self._backend
         contents: dict[str, str] = {}
 

--- a/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware.py
@@ -334,23 +334,28 @@ def test_load_memory_handles_missing_file(tmp_path: Path) -> None:
     assert user_path in result["memory_contents"]
 
 
-def test_before_agent_skips_if_already_loaded(tmp_path: Path) -> None:
-    """Test that before_agent doesn't reload if already in state."""
-    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+def test_checkpointed_thread_reloads_memory_each_turn(tmp_path: Path) -> None:
+    """A persisted thread sees memory file changes on its next turn."""
+    memory_path = tmp_path / "memory" / "AGENTS.md"
+    memory_path.parent.mkdir()
+    memory_path.write_text("alpha memory\n", encoding="utf-8")
 
-    user_path = str(tmp_path / "user" / "AGENTS.md")
-    user_content = make_memory_content("User Preferences", "- Some content")
-    backend.upload_files([(user_path, user_content.encode("utf-8"))])
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="first"), AIMessage(content="second")]))
+    agent = create_deep_agent(
+        model=model,
+        backend=FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True),
+        memory=["/memory/AGENTS.md"],
+        checkpointer=InMemorySaver(),
+    )
+    config: RunnableConfig = {"configurable": {"thread_id": "memory-reload"}}
 
-    sources: list[str] = [user_path]
-    middleware = MemoryMiddleware(backend=backend, sources=sources)
+    agent.invoke({"messages": [HumanMessage(content="first")]}, config)
+    memory_path.write_text("beta memory\n", encoding="utf-8")
+    agent.invoke({"messages": [HumanMessage(content="second")]}, config)
 
-    # Pre-populate state
-    state = {"memory_contents": {user_path: "Already loaded content"}}
-    result = middleware.before_agent(state, None, {})  # type: ignore[arg-type]
-
-    # Should return None (no update needed)
-    assert result is None
+    second_system = next(message for message in model.call_history[1]["messages"] if isinstance(message, SystemMessage))
+    assert "beta memory" in second_system.text
+    assert "alpha memory" not in second_system.text
 
 
 def test_load_memory_with_empty_sources(tmp_path: Path) -> None:
@@ -578,7 +583,7 @@ def test_agent_with_memory_middleware_empty_sources(tmp_path: Path) -> None:
 
 
 async def test_agent_with_memory_middleware_async(tmp_path: Path) -> None:
-    """Test that memory middleware works with async agent invocation."""
+    """Async persisted threads reload memory on each invocation."""
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
     memory_path = str(tmp_path / "user" / "AGENTS.md")
@@ -587,33 +592,24 @@ async def test_agent_with_memory_middleware_async(tmp_path: Path) -> None:
     responses = backend.upload_files([(memory_path, memory_content.encode("utf-8"))])
     assert responses[0].error is None
 
-    # Create fake model
-    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="Async invocation successful.")]))
+    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="First invocation."), AIMessage(content="Second invocation.")]))
 
-    # Create middleware
     sources: list[str] = [memory_path]
     middleware = MemoryMiddleware(backend=backend, sources=sources)
+    agent = create_agent(model=fake_model, middleware=[middleware], checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "async-memory-reload"}}
 
-    # Create agent
-    agent = create_agent(model=fake_model, middleware=[middleware])
-
-    # Invoke asynchronously
-    result = await agent.ainvoke({"messages": [HumanMessage(content="Hello")]})
+    result = await agent.ainvoke({"messages": [HumanMessage(content="Hello")]}, config)
+    updated_content = make_memory_content("Async Test", "- Updated async memory")
+    backend.upload_files([(memory_path, updated_content.encode("utf-8"))])
+    await agent.ainvoke({"messages": [HumanMessage(content="Hello again")]}, config)
 
     assert "messages" in result
     assert len(result["messages"]) > 0
-
-    # Verify memory_contents is NOT in final state (it's private)
     assert "memory_contents" not in result
-
-    # Verify memory was injected in system prompt with new format
-    first_call = fake_model.call_history[0]
-    system_message = first_call["messages"][0]
-    content = system_message.text
-
-    assert "<agent_memory>" in content
-    assert memory_path in content
-    assert "Test async loading" in content
+    second_system = fake_model.call_history[1]["messages"][0].text
+    assert "Updated async memory" in second_system
+    assert "Test async loading" not in second_system
 
 
 def test_memory_middleware_with_state_backend() -> None:

--- a/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware_async.py
@@ -122,8 +122,8 @@ async def test_load_memory_handles_missing_file_async(tmp_path: Path) -> None:
     assert user_path in result["memory_contents"]
 
 
-async def test_before_agent_skips_if_already_loaded_async(tmp_path: Path) -> None:
-    """Test that abefore_agent doesn't reload if already in state."""
+async def test_before_agent_reloads_existing_state_async(tmp_path: Path) -> None:
+    """Memory sources replace stale state on async invocations."""
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
     user_path = str(tmp_path / "user" / "AGENTS.md")
@@ -133,12 +133,10 @@ async def test_before_agent_skips_if_already_loaded_async(tmp_path: Path) -> Non
     sources: list[str] = [user_path]
     middleware = MemoryMiddleware(backend=backend, sources=sources)
 
-    # Pre-populate state
     state = {"memory_contents": {user_path: "Already loaded content"}}
     result = await middleware.abefore_agent(state, None, {})  # type: ignore[arg-type]
 
-    # Should return None (no update needed)
-    assert result is None
+    assert result == {"memory_contents": {user_path: user_content}}
 
 
 async def test_load_memory_with_empty_sources_async(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/deepagents/issues/6122

An agent on a checkpointed thread now sees its own memory writes on the next turn.

---

On a thread with a checkpointer, writing or editing a memory file had no effect on the following turn: the agent was still prompted with the text loaded on the first turn, so it behaved as though the edit never happened. Only a fresh thread picked it up.

`memory_contents` is persisted in checkpointed state, and `MemoryMiddleware` returned early whenever that key was present, so it never reread the source. Each turn now reloads the configured memory sources and replaces the persisted contents. The field stays private in final agent state.

Regression tests cover a checkpointed thread and the async path. Both fail on `main` and pass here.

```bash
cd libs/deepagents
uv run --group test pytest -q --disable-socket --allow-unix-socket \
  tests/unit_tests/middleware/test_memory_middleware.py::test_checkpointed_thread_reloads_memory_each_turn \
  tests/unit_tests/middleware/test_memory_middleware_async.py::test_before_agent_reloads_existing_state_async
```

<details>
<summary>Raw logs</summary>

```text
# main, regression tests only
E       AssertionError: assert 'beta memory' in '<agent_memory>\n/memory/AGENTS.md\n\nalpha memory\n\n</agent_memory>...'
2 failed in 0.65s

# this branch
2 passed in 7.47s
```

</details>

## Social handles (optional)
