### PR TITLE
fix(sdk): move agent lookups inside try in async subagent tools

### DIFF
--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -442,10 +442,10 @@ def _build_check_tool(  # noqa: C901  # complexity from necessary error handling
         if isinstance(task, str):
             return task
 
-        client = clients.get_async(task["agent_name"])
         try:
+            client = clients.get_async(task["agent_name"])
             run = await client.runs.get(thread_id=task["thread_id"], run_id=task["run_id"])
-        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        except Exception as e:  # noqa: BLE001  # get_async() may raise KeyError; SDK raises untyped errors
             return f"Failed to get run status: {e}"
 
         thread_values: dict[str, Any] = {}
@@ -493,8 +493,8 @@ def _build_update_tool(
         tracked = _resolve_tracked_task(task_id, runtime)
         if isinstance(tracked, str):
             return tracked
-        spec = agent_map[tracked["agent_name"]]
         try:
+            spec = agent_map[tracked["agent_name"]]
             client = clients.get_sync(tracked["agent_name"])
             run = client.runs.create(
                 thread_id=tracked["thread_id"],
@@ -502,7 +502,7 @@ def _build_update_tool(
                 input={"messages": [{"role": "user", "content": message}]},
                 multitask_strategy="interrupt",
             )
-        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        except Exception as e:  # noqa: BLE001  # a stale agent_name raises KeyError; SDK raises untyped errors
             logger.warning("Failed to update async subagent '%s': %s", tracked["agent_name"], e)
             return f"Failed to update async subagent: {e}"
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -532,8 +532,8 @@ def _build_update_tool(
         tracked = _resolve_tracked_task(task_id, runtime)
         if isinstance(tracked, str):
             return tracked
-        spec = agent_map[tracked["agent_name"]]
         try:
+            spec = agent_map[tracked["agent_name"]]
             client = clients.get_async(tracked["agent_name"])
             run = await client.runs.create(
                 thread_id=tracked["thread_id"],
@@ -541,7 +541,7 @@ def _build_update_tool(
                 input={"messages": [{"role": "user", "content": message}]},
                 multitask_strategy="interrupt",
             )
-        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        except Exception as e:  # noqa: BLE001  # a stale agent_name raises KeyError; SDK raises untyped errors
             logger.warning("Failed to update async subagent '%s': %s", tracked["agent_name"], e)
             return f"Failed to update async subagent: {e}"
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -622,10 +622,10 @@ def _build_cancel_tool(
         if isinstance(tracked, str):
             return tracked
 
-        client = clients.get_async(tracked["agent_name"])
         try:
+            client = clients.get_async(tracked["agent_name"])
             await client.runs.cancel(thread_id=tracked["thread_id"], run_id=tracked["run_id"])
-        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        except Exception as e:  # noqa: BLE001  # get_async() may raise KeyError; SDK raises untyped errors
             return f"Failed to cancel run: {e}"
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         updated = AsyncTask(

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -788,6 +788,55 @@ class TestUnknownTaskId:
         assert "No tracked task found" in result
 
 
+_STALE_AGENT_CASES = [
+    ("check_async_task", {}, "Failed to get run status"),
+    ("cancel_async_task", {}, "Failed to cancel run"),
+    ("update_async_task", {"message": "hello"}, "Failed to update async subagent"),
+]
+
+
+class TestStaleAgentName:
+    """A tracked task may name an agent that is no longer configured.
+
+    Both `agent_map[name]` and the `self._agents[name]` inside
+    `_ClientCache.get_sync`/`get_async` read the same dict, so a name absent
+    from `async_subagents` raises `KeyError` either way. The lookup therefore
+    has to sit inside the tool's `try`, or it escapes as an unhandled exception
+    instead of the tool's own error string. Both entry points are pinned
+    because `StructuredTool` exposes `func` and `coroutine` as one tool and
+    they must agree.
+
+    `start_async_task` is not covered here: `_validate_agent_type` rejects an
+    unknown name before the lookup, so its `agent_map` access is unreachable.
+    """
+
+    @pytest.mark.parametrize(("tool_name", "extra", "expected"), _STALE_AGENT_CASES)
+    def test_sync_returns_error_string(self, tool_name: str, extra: dict[str, Any], expected: str) -> None:
+        tools = _build_async_subagent_tools([_make_spec("worker")])
+        tool = _get_tool(tools, tool_name)
+        result = tool.func(
+            task_id="thread_abc",
+            **extra,
+            runtime=_make_runtime_with_task(agent_name="researcher"),
+        )
+        assert isinstance(result, str)
+        assert expected in result
+        assert "researcher" in result
+
+    @pytest.mark.parametrize(("tool_name", "extra", "expected"), _STALE_AGENT_CASES)
+    async def test_async_returns_error_string(self, tool_name: str, extra: dict[str, Any], expected: str) -> None:
+        tools = _build_async_subagent_tools([_make_spec("worker")])
+        tool = _get_tool(tools, tool_name)
+        result = await tool.coroutine(
+            task_id="thread_abc",
+            **extra,
+            runtime=_make_runtime_with_task(agent_name="researcher"),
+        )
+        assert isinstance(result, str)
+        assert expected in result
+        assert "researcher" in result
+
+
 class TestLaunchErrorHandling:
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_launch_sdk_error_returns_error_string(self, mock_get_client: MagicMock) -> None:


### PR DESCRIPTION
Fixes #5640

---

#3967 moved `clients.get_sync()` inside the existing `try` in `check_async_task` and `cancel_async_task` so a failing agent lookup returns the tool's own error string. The async twins were left fetching the client before the `try`, with their pre-#3967 `except` comments still in place, and `update_async_task`/`aupdate_async_task` carry the same escape one line earlier at `spec = agent_map[...]`. Since `agent_map` and `_ClientCache._agents` are the same object, all four read one dict: a checkpointed task naming a subagent that has since been renamed or removed raises `KeyError` there, unhandled, aborting tool execution. `_tasks_reducer` is `merged.update(update)`, so the stale task never clears and `list_async_tasks` keeps offering the model the `task_id` that crashes it.

This moves the lookup inside the existing `try` at all four sites and updates the `except` comments to match. `start_async_task`/`astart_async_task` are deliberately untouched: `_validate_agent_type` rejects an unknown name before their `agent_map` access, so it is unreachable — the difference is that `subagent_type` is model input and gets validated, while `tracked["agent_name"]` comes from the checkpoint and does not. Nothing on the success path changes, and no error text or signature changes.

The new parametrized test covers `check`/`cancel`/`update` × sync/async. Four of those six fail on `main` and the two sync cases pass, pinning what #3967 established; these are the first tests in the file to touch the async entry points at all.

I am opening this without being assigned, so `require_issue_link` will close it — that is expected. It is here so the change is reviewable rather than described: the issue has had no maintainer activity in 21 days, and `async_subagents.py` was touched once in that window (#5377) without these four sites being noticed. Happy to have it reopened via assignment, or closed for good if the direction is wrong.

## Release note

`check_async_task`, `cancel_async_task` and `update_async_task` now return an error string instead of raising when a tracked task names an async subagent that is no longer configured, on the async path as well as the sync one.

---

*This contribution was prepared with AI assistance.*
