### PR TITLE
fix(sdk): suggest populating path in `glob` tool result where appropriate

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -891,6 +891,11 @@ GLOB_UNREADABLE_NOTE = (
     "Narrowing the search will NOT reveal the missing files -- they are inaccessible. Continue "
     "with what is listed, or report the access problem rather than retrying."
 )
+GLOB_PATHLESS_DENIED_HINT = (
+    ". A glob without 'path' is authorized against the backend's default root, not the "
+    "directories named in 'pattern'. Retry with an explicit 'path' inside an allowed "
+    "directory and a 'pattern' relative to it."
+)
 
 
 def _glob_timeout_message() -> str:
@@ -2368,7 +2373,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
             if _check_fs_permission(self._permissions, "read", permission_path) == "deny":
                 return ToolMessage(
-                    content=f"Error: permission denied for read on {permission_path}",
+                    content=f"Error: permission denied for read on {permission_path}{GLOB_PATHLESS_DENIED_HINT if path is None else ''}",
                     name="glob",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
@@ -2468,7 +2473,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
             if _check_fs_permission(self._permissions, "read", permission_path) == "deny":
                 return ToolMessage(
-                    content=f"Error: permission denied for read on {permission_path}",
+                    content=f"Error: permission denied for read on {permission_path}{GLOB_PATHLESS_DENIED_HINT if path is None else ''}",
                     name="glob",
                     tool_call_id=runtime.tool_call_id,
                     status="error",

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -119,6 +119,12 @@ async def _ainvoke_with_permissions(tool, args, rules, tool_call_id="test", back
     return str(result)
 
 
+_PATHLESS_GLOB_RULES = [
+    FilesystemPermission(operations=["read"], paths=["/workspace", "/workspace/**"], mode="allow"),
+    FilesystemPermission(operations=["read"], paths=["/", "/*", "/**"], mode="deny"),
+]
+
+
 class TestRecursiveDeletePermissions:
     """All-or-nothing write-permission enforcement for recursive delete.
 
@@ -1292,6 +1298,34 @@ class TestGlobToolPermissions:
         result = _invoke_with_permissions(glob_tool, {"pattern": "*.txt", "path": "/workspace"}, rules)
         assert "permission denied" not in result
 
+    def test_glob_pathless_denial_points_at_the_path_argument(self):
+        """A pathless glob is authorized on `/`, so the denial must name the remedy."""
+        backend = _make_backend({"/workspace/a.txt": "x"})
+        middleware = FilesystemMiddleware(backend=backend)
+        glob_tool = next(t for t in middleware.tools if t.name == "glob")
+        result = _invoke_with_permissions(glob_tool, {"pattern": "/workspace/*.txt"}, _PATHLESS_GLOB_RULES)
+        assert "permission denied for read on /" in result
+        assert filesystem_module.GLOB_PATHLESS_DENIED_HINT.strip() in result
+
+    def test_glob_denial_with_explicit_path_omits_pathless_hint(self):
+        """Passing `path` is not the remedy when that path is itself denied."""
+        backend = _make_backend({"/secrets/key.txt": "top secret"})
+        middleware = FilesystemMiddleware(backend=backend)
+        glob_tool = next(t for t in middleware.tools if t.name == "glob")
+        rules = [FilesystemPermission(operations=["read"], paths=["/secrets/**", "/secrets"], mode="deny")]
+        result = _invoke_with_permissions(glob_tool, {"pattern": "*.txt", "path": "/secrets"}, rules)
+        assert "permission denied for read on /secrets" in result
+        assert filesystem_module.GLOB_PATHLESS_DENIED_HINT.strip() not in result
+
+    def test_glob_remedy_named_in_pathless_denial_succeeds(self):
+        """The retry the hint asks for must actually be allowed."""
+        backend = _make_backend({"/workspace/a.txt": "x"})
+        middleware = FilesystemMiddleware(backend=backend)
+        glob_tool = next(t for t in middleware.tools if t.name == "glob")
+        result = _invoke_with_permissions(glob_tool, {"pattern": "*.txt", "path": "/workspace"}, _PATHLESS_GLOB_RULES)
+        assert "permission denied" not in result
+        assert "/workspace/a.txt" in result
+
     def test_glob_filters_denied_results(self):
         backend = _make_backend(
             {
@@ -1323,6 +1357,14 @@ class TestGlobToolPermissions:
         result = await _ainvoke_with_permissions(glob_tool, {"pattern": "*.txt", "path": "/secrets"}, rules)
         assert "permission denied" in result
         assert "read" in result
+
+    async def test_glob_pathless_denial_points_at_the_path_argument_async(self):
+        backend = _make_backend({"/workspace/a.txt": "x"})
+        middleware = FilesystemMiddleware(backend=backend)
+        glob_tool = next(t for t in middleware.tools if t.name == "glob")
+        result = await _ainvoke_with_permissions(glob_tool, {"pattern": "/workspace/*.txt"}, _PATHLESS_GLOB_RULES)
+        assert "permission denied for read on /" in result
+        assert filesystem_module.GLOB_PATHLESS_DENIED_HINT.strip() in result
 
     async def test_glob_filters_denied_results_async(self):
         backend = _make_backend(


### PR DESCRIPTION
Resolves https://github.com/langchain-ai/deepagents/issues/4882

```python
permissions = [
    FilesystemPermission(operations=["read"], paths=["/workspace", "/workspace/**"], mode="allow"),
    FilesystemPermission(operations=["read"], paths=["/", "/*", "/**"], mode="deny"),
]

# Glob tool call:
{"pattern": "/workspace/*.txt"}
```
Before:
```python
ToolMessage(
    content="Error: permission denied for read on /",
    name="glob",
    tool_call_id="glob-1",
    status="error",
)
```
After:
```python
ToolMessage(
    content=(
        "Error: permission denied for read on /. A glob without 'path' is authorized "
        "against the backend's default root, not the directories named in 'pattern'. "
        "Retry with an explicit 'path' inside an allowed directory and a 'pattern' "
        "relative to it."
    ),
    name="glob",
    tool_call_id="glob-1",
    status="error",
)
```

<!-- release-please override: parser-safe message used by release-please for changelog generation; the rest of the body is unaffected -->
BEGIN_COMMIT_OVERRIDE
fix(sdk): suggest populating path in `glob` tool result where appropriate (#6199)

Resolves https://github.com/langchain-ai/deepagents/issues/4882

END_COMMIT_OVERRIDE