### PR TITLE
fix(sdk): restore trim_tokens_to_summarize default in create_summarization_middleware

### DIFF
--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -1638,7 +1638,7 @@ def create_summarization_middleware(
     backend: BackendProtocol,
     *,
     summary_prompt: str = DEEPAGENTS_DEFAULT_SUMMARY_PROMPT,
-    trim_tokens_to_summarize: int | None = None,
+    trim_tokens_to_summarize: int | None = _DEFAULT_TRIM_TOKEN_LIMIT,
     token_counter: TokenCounter = count_tokens_approximately,
 ) -> _DeepAgentsSummarizationMiddleware:
     """Create a Deep Agents `SummarizationMiddleware` with model-aware defaults.
@@ -1683,6 +1683,13 @@ def create_summarization_middleware(
         backend: Backend instance for persisting conversation history.
         summary_prompt: Prompt template for generating summaries.
         trim_tokens_to_summarize: Max tokens to include when generating summary.
+
+            Defaults to `_DEFAULT_TRIM_TOKEN_LIMIT` (4000), matching
+            [`_DeepAgentsSummarizationMiddleware`][deepagents.middleware.summarization._DeepAgentsSummarizationMiddleware].
+            Without this, the summary-generation call receives the full,
+            untrimmed message history and can overflow the summarization
+            model's own context window. Pass `None` explicitly to opt out
+            of trimming.
         token_counter: Function to count tokens in messages.
 
     Returns:

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_factory.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_factory.py
@@ -6,7 +6,8 @@ from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
-from langchain_core.messages import AIMessage, MessageLikeRepresentation
+from langchain.agents.middleware.summarization import _DEFAULT_TRIM_TOKEN_LIMIT
+from langchain_core.messages import AIMessage, HumanMessage, MessageLikeRepresentation
 
 from deepagents.middleware.summarization import create_summarization_middleware
 from tests.unit_tests.chat_model import GenericFakeChatModel
@@ -86,6 +87,53 @@ def test_factory_summarization_knobs_are_keyword_only() -> None:
     assert params["summary_prompt"].kind is Parameter.KEYWORD_ONLY
     assert params["trim_tokens_to_summarize"].kind is Parameter.KEYWORD_ONLY
     assert params["token_counter"].kind is Parameter.KEYWORD_ONLY
+
+
+def test_factory_defaults_trim_tokens_to_summarize() -> None:
+    """Regression for #5913: factory must not silently disable trimming.
+
+    `create_summarization_middleware` previously defaulted
+    `trim_tokens_to_summarize` to `None`, overriding the middleware's own
+    `_DEFAULT_TRIM_TOKEN_LIMIT` default. That let the full, untrimmed
+    conversation reach the summary-generation model call, which could
+    overflow the summarization model's context window on large histories.
+    """
+    model = _make_model(with_profile_limit=120_000)
+    middleware = create_summarization_middleware(model, cast("Any", MagicMock()))
+
+    assert middleware._lc_helper.trim_tokens_to_summarize == _DEFAULT_TRIM_TOKEN_LIMIT
+    assert middleware._lc_helper.trim_tokens_to_summarize is not None
+
+
+def test_factory_still_allows_explicit_none_opt_out() -> None:
+    """Callers can still explicitly disable trimming via `trim_tokens_to_summarize=None`."""
+    model = _make_model(with_profile_limit=120_000)
+    middleware = create_summarization_middleware(
+        model,
+        cast("Any", MagicMock()),
+        trim_tokens_to_summarize=None,
+    )
+
+    assert middleware._lc_helper.trim_tokens_to_summarize is None
+
+
+def test_default_trim_limit_bounds_messages_sent_to_summary_model() -> None:
+    """Regression for #5913: a large history is trimmed before summarization.
+
+    With the restored default, `_trim_messages_for_summary` must bound the
+    batch of messages handed to the summary-generation call instead of
+    passing the entire, potentially oversized conversation through.
+    """
+    model = _make_model(with_profile_limit=120_000)
+    middleware = create_summarization_middleware(model, cast("Any", MagicMock()))
+
+    # Simulate a conversation large enough that, untrimmed, it would exceed
+    # a small summarization model's own context window.
+    large_messages = [HumanMessage(content=f"Question {i}: " + "x" * 2000) for i in range(500)]
+
+    trimmed = middleware._lc_helper._trim_messages_for_summary(large_messages)
+
+    assert len(trimmed) < len(large_messages)
 
 
 def test_factory_rejects_string_model() -> None:


### PR DESCRIPTION
## Summary

Fixes #5913.

**Root cause:** `create_summarization_middleware` in
`libs/deepagents/deepagents/middleware/summarization.py` declared
`trim_tokens_to_summarize: int | None = None`, which silently overrode
the `_DeepAgentsSummarizationMiddleware.__init__` class default of
`_DEFAULT_TRIM_TOKEN_LIMIT` (4000 tokens). Since `create_deep_agent`
calls the factory without passing this argument, every agent built via
`create_deep_agent` had trimming disabled for the summary-generation
call.

With `trim_tokens_to_summarize=None`,
`SummarizationMiddleware._trim_messages_for_summary` returns the full,
untrimmed conversation history unchanged. That full history is then
sent to the summarization model call
(`_acreate_summary`/`_aoffload_to_backend` in
`_summarize_and_evict_messages`). On large conversations this can
exceed the summarization model's own (often smaller/cheaper) context
window and raise a `context_length_exceeded` error, which is not
caught and propagates up through the agent, crashing it — exactly the
scenario reproduced in the issue.

**Fix:** restore the factory's default to `_DEFAULT_TRIM_TOKEN_LIMIT`
so it matches the middleware class default, while still honoring an
explicit `trim_tokens_to_summarize=None` passed by callers who want to
opt out of trimming.

## Changes

- `libs/deepagents/deepagents/middleware/summarization.py`: default
  `trim_tokens_to_summarize` in `create_summarization_middleware` to
  `_DEFAULT_TRIM_TOKEN_LIMIT` instead of `None`; updated the docstring
  to explain the default and the `None` opt-out.
- `libs/deepagents/tests/unit_tests/middleware/test_summarization_factory.py`:
  added regression tests:
  - `test_factory_defaults_trim_tokens_to_summarize` — factory default
    now matches `_DEFAULT_TRIM_TOKEN_LIMIT`.
  - `test_factory_still_allows_explicit_none_opt_out` — explicit
    `None` still works for callers who want it.
  - `test_default_trim_limit_bounds_messages_sent_to_summary_model` —
    a large message batch is actually trimmed before reaching
    `_trim_messages_for_summary`'s output, verifying the fix has a
    real effect (not just a default-value assertion).

## Test plan

- [x] `uv run --group test pytest tests/unit_tests/middleware/test_summarization_factory.py` — 9 passed (6 existing + 3 new).
- [x] `uv run --group test pytest -n auto tests/unit_tests/` (full unit suite) — same pre-existing failures/errors present both before and after this change (Windows sandbox socket-blocking issue unrelated to this fix, verified by running the identical suite on a clean checkout of the same commit).
- [x] `uv run --all-groups ruff check` / `ruff format --diff` — clean.
- [x] `uv run --all-groups ty check deepagents` — clean (only 2 pre-existing, unrelated `nturl2path` deprecation warnings in `_version.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)