### PR TITLE
fix(sdk): derive offload filenames from a hashed tool_call_id to avoid OS path-length limits

### DIFF
--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -6,6 +6,7 @@ enable composition without fragile string parsing.
 """
 
 import functools
+import hashlib
 import logging
 import os
 import re
@@ -204,6 +205,56 @@ def sanitize_tool_call_id(tool_call_id: str) -> str:
     Replaces dangerous characters (., /, \) with underscores.
     """
     return tool_call_id.replace(".", "_").replace("/", "_").replace("\\", "_")
+
+
+_BOUNDED_ID_PREFIX_LENGTH = 40
+_BOUNDED_ID_HASH_LENGTH = 16
+# Comfortably under the ~255-byte path-component limit of common filesystems,
+# even once combined with a directory prefix (e.g. `/large_tool_results/`).
+# Ordinary provider ids (OpenAI, Anthropic, short synthetic test ids, ...) sit
+# far below this, so `bound_tool_call_id_for_filename` is a no-op for them --
+# only ids that could actually overflow a filename get rewritten.
+_MAX_SAFE_SANITIZED_ID_LENGTH = 200
+
+
+def bound_tool_call_id_for_filename(tool_call_id: str) -> str:
+    """Derive a filename-safe stem from a `tool_call_id`, bounding its length.
+
+    Provider tool_call_ids are not bounded in length: LiteLLM's Gemini
+    provider, for example, embeds a ~1-1.5KB "thought signature" inside the
+    id (`call_<uuid>__thought__<base64>`), which the id must carry verbatim
+    since Vertex validates it on replay. Building a filename directly from
+    `sanitize_tool_call_id(tool_call_id)` embeds that raw length in the
+    filename, which can exceed the ~255-byte path-component limit of common
+    filesystems and cause the write to silently fail.
+
+    For ids short enough to be filename-safe as-is, this returns
+    `sanitize_tool_call_id(tool_call_id)` unchanged, preserving today's
+    filenames (and the associated `read_file` guidance the model sees) for
+    the common case. Only ids whose sanitized form exceeds
+    `_MAX_SAFE_SANITIZED_ID_LENGTH` are rewritten to a bounded
+    `{prefix}-{hash}` form.
+
+    Naive truncation (e.g. `tool_call_id[:40]`) is not a safe fix on its own:
+    two different long ids that happen to share the same first 40 characters
+    (as Gemini ids do -- they share the same `call_<uuid>__thought__` prefix
+    shape) would collide on the same filename. Appending a hash of the full,
+    untruncated id makes the result collision-resistant regardless of shared
+    prefixes, while staying short enough to fit within filesystem limits and
+    to be reliably copied by a model into a follow-up `read_file` call.
+
+    Args:
+        tool_call_id: The raw tool_call_id (unsanitized, of any length).
+
+    Returns:
+        A filename-safe string: the sanitized id unchanged when short enough,
+            otherwise `{sanitized_prefix}-{hash}`.
+    """
+    sanitized = sanitize_tool_call_id(tool_call_id)
+    if len(sanitized) <= _MAX_SAFE_SANITIZED_ID_LENGTH:
+        return sanitized
+    digest = hashlib.sha256(tool_call_id.encode("utf-8")).hexdigest()[:_BOUNDED_ID_HASH_LENGTH]
+    return f"{sanitized[:_BOUNDED_ID_PREFIX_LENGTH]}-{digest}"
 
 
 def format_content_with_line_numbers(

--- a/libs/deepagents/deepagents/middleware/_message_eviction.py
+++ b/libs/deepagents/deepagents/middleware/_message_eviction.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, cast
 
 from langchain_core.messages import BaseMessage, ToolMessage
 
-from deepagents.backends.utils import format_content_with_line_numbers, sanitize_tool_call_id
+from deepagents.backends.utils import bound_tool_call_id_for_filename, format_content_with_line_numbers
 
 if TYPE_CHECKING:
     from langchain_core.messages.content import ContentBlock
@@ -129,8 +129,8 @@ def _offload_tool_message_content(
     by tool_call_id. Returns `None` if the backend write fails — caller should
     keep the original message in that case.
     """
-    sanitized_id = sanitize_tool_call_id(message.tool_call_id) if message.tool_call_id else "unknown"
-    file_path = f"{large_tool_results_prefix}/{sanitized_id}"
+    bounded_id = bound_tool_call_id_for_filename(message.tool_call_id) if message.tool_call_id else "unknown"
+    file_path = f"{large_tool_results_prefix}/{bounded_id}"
     result = backend.write(file_path, content_str)
     if result is None or result.error:
         return None
@@ -149,8 +149,8 @@ async def _aoffload_tool_message_content(
     large_tool_results_prefix: str,
 ) -> ToolMessage | None:
     """Async variant of `_offload_tool_message_content` using `backend.awrite`."""
-    sanitized_id = sanitize_tool_call_id(message.tool_call_id) if message.tool_call_id else "unknown"
-    file_path = f"{large_tool_results_prefix}/{sanitized_id}"
+    bounded_id = bound_tool_call_id_for_filename(message.tool_call_id) if message.tool_call_id else "unknown"
+    file_path = f"{large_tool_results_prefix}/{bounded_id}"
     result = await backend.awrite(file_path, content_str)
     if result is None or result.error:
         return None

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -71,6 +71,7 @@ from deepagents.backends.utils import (
     _get_file_type,
     _glob_anchor,
     _paths_overlap,
+    bound_tool_call_id_for_filename,
     check_empty_content,
     format_content_with_line_numbers,
     format_grep_matches,
@@ -2827,7 +2828,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         """
         if not self._tool_token_limit_before_evict or not tool_call_id:
             return None
-        capture_path = f"{self._large_tool_results_prefix}/{sanitize_tool_call_id(tool_call_id)}"
+        capture_path = f"{self._large_tool_results_prefix}/{bound_tool_call_id_for_filename(tool_call_id)}"
         if isinstance(resolved_backend, CompositeBackend):
             default = resolved_backend.default
             if not isinstance(default, BaseSandbox):

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -20,7 +20,7 @@ from langgraph.types import Command
 from pydantic import ValidationError
 
 import deepagents.middleware.filesystem as filesystem_middleware
-from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
+from deepagents.backends import CompositeBackend, FilesystemBackend, StateBackend, StoreBackend
 from deepagents.backends.protocol import (
     BackendProtocol,
     ExecuteResponse,
@@ -32,6 +32,7 @@ from deepagents.backends.protocol import (
 from deepagents.backends.utils import (
     TOOL_RESULT_TOKEN_LIMIT,
     TRUNCATION_GUIDANCE,
+    bound_tool_call_id_for_filename,
     create_file_data,
     format_content_with_line_numbers,
     sanitize_tool_call_id,
@@ -40,9 +41,11 @@ from deepagents.backends.utils import (
     update_file_data,
 )
 from deepagents.middleware._message_eviction import (
+    _aoffload_tool_message_content,
     _build_evicted_content,
     _create_content_preview,
     _extract_text_from_message,
+    _offload_tool_message_content,
 )
 from deepagents.middleware.filesystem import (
     EMPTY_CONTENT_WARNING,
@@ -2077,6 +2080,36 @@ class TestFilesystemMiddleware:
         assert sanitize_tool_call_id("call/123") == "call_123"
         assert sanitize_tool_call_id("test.id") == "test_id"
 
+    def test_bound_tool_call_id_for_filename_short_id_unchanged(self):
+        """Short ids (the common case) pass through exactly like `sanitize_tool_call_id`."""
+        assert bound_tool_call_id_for_filename("call_123") == "call_123"
+        assert bound_tool_call_id_for_filename("call/123") == "call_123"
+        assert bound_tool_call_id_for_filename("test.id") == "test_id"
+
+    def test_bound_tool_call_id_for_filename_bounds_long_id(self):
+        """A LiteLLM-Gemini-shaped id (~1.5KB thought signature) is bounded, not embedded verbatim.
+
+        Regression test for https://github.com/langchain-ai/deepagents/issues/5560:
+        embedding the raw id in a filename can exceed the ~255-byte OS path-component
+        limit, silently failing the offload write.
+        """
+        gemini_id = "call_2945190__thought__" + "A" * 1400
+        bounded = bound_tool_call_id_for_filename(gemini_id)
+        assert len(bounded) < 255
+        assert bounded.startswith("call_2945190__thought__")
+
+    def test_bound_tool_call_id_for_filename_avoids_prefix_collision(self):
+        """Two long ids sharing a common prefix must not collide on the same filename.
+
+        Naive truncation (e.g. `id[:40]`) would map both of these to the same
+        stem since they share their first 40+ characters; the hash suffix
+        must disambiguate them.
+        """
+        prefix = "call_shared_prefix__thought__"
+        id_a = prefix + "A" * 1400
+        id_b = prefix + "B" * 1400
+        assert bound_tool_call_id_for_filename(id_a) != bound_tool_call_id_for_filename(id_b)
+
     def test_intercept_sanitizes_tool_call_id(self):
         """Test that tool_call_id with dangerous characters is sanitized in file path."""
         backend, mem_store = _make_backend()
@@ -3382,6 +3415,88 @@ class TestBuildEvictedContent:
         assert result[0] == {"type": "text", "text": "replacement"}
         assert result[1] == img1
         assert result[2] == img2
+
+
+class TestOffloadToolMessageContentLongToolCallId:
+    """Regression tests for https://github.com/langchain-ai/deepagents/issues/5560.
+
+    LiteLLM's Gemini provider embeds a ~1-1.5KB "thought signature" inside the
+    tool_call_id (`call_<uuid>__thought__<base64>`). Before the fix, building
+    the offload filename directly from that id could exceed the OS
+    path-component length limit, silently failing the `backend.write` and
+    causing `_offload_tool_message_content` to return `None` -- the caller
+    then kept the original oversized message and the eviction never happened.
+    """
+
+    @staticmethod
+    def _gemini_style_tool_call_id() -> str:
+        # Mirrors the shape LiteLLM emits for Gemini tool calls: a normal
+        # prefix followed by ~1.4KB of embedded thought-signature bytes.
+        return "call_2945190__thought__" + "A" * 1400
+
+    def test_long_tool_call_id_offloads_successfully(self, tmp_path):
+        """A tool_call_id long enough to previously exceed OS filename limits still offloads."""
+        backend = FilesystemBackend(root_dir=str(tmp_path))
+        gemini_id = self._gemini_style_tool_call_id()
+        original_content = "result line\n" * 30000
+
+        message = ToolMessage(content=original_content, tool_call_id=gemini_id)
+        result = _offload_tool_message_content(message, original_content, backend, "/large_tool_results")
+
+        assert result is not None, "offload must not silently fail for a long tool_call_id"
+        assert isinstance(result, ToolMessage)
+        # The replacement is a small preview/notice, not the original bulk content.
+        assert len(str(result.content)) < len(original_content)
+        assert "Tool result too large" in str(result.content)
+
+        # A file was actually written to the backend under the offload prefix,
+        # at the bounded path (not the raw, over-length id).
+        expected_path = f"/large_tool_results/{bound_tool_call_id_for_filename(gemini_id)}"
+        read_result = backend.read(expected_path, limit=30000)
+        assert read_result.error is None
+        assert read_result.file_data is not None
+        assert read_result.file_data["content"] == original_content
+
+    def test_long_tool_call_id_offload_path_is_bounded(self, tmp_path):
+        """The offload path embedded in the notice never depends on the raw id length."""
+        backend = FilesystemBackend(root_dir=str(tmp_path))
+        gemini_id = self._gemini_style_tool_call_id()
+        original_content = "result line\n" * 30000
+
+        message = ToolMessage(content=original_content, tool_call_id=gemini_id)
+        result = _offload_tool_message_content(message, original_content, backend, "/large_tool_results")
+
+        assert result is not None
+        # Extract the file_path line from the notice and confirm its filename
+        # component is well within filesystem limits.
+        content_str = str(result.content)
+        assert "/large_tool_results/" in content_str
+        file_path_segment = content_str.split("/large_tool_results/", maxsplit=1)[1].split(maxsplit=1)[0]
+        assert len(file_path_segment) < 255
+
+    @pytest.mark.asyncio
+    async def test_long_tool_call_id_offloads_successfully_async(self, tmp_path):
+        """Async variant: `_aoffload_tool_message_content` also bounds the filename."""
+        backend = FilesystemBackend(root_dir=str(tmp_path))
+        gemini_id = self._gemini_style_tool_call_id()
+        original_content = "result line\n" * 30000
+
+        message = ToolMessage(content=original_content, tool_call_id=gemini_id)
+        result = await _aoffload_tool_message_content(message, original_content, backend, "/large_tool_results")
+
+        assert result is not None, "async offload must not silently fail for a long tool_call_id"
+        assert len(str(result.content)) < len(original_content)
+
+    def test_short_tool_call_id_filename_unchanged(self, tmp_path):
+        """Short ids keep today's exact filename (no hash suffix) for backward compatibility."""
+        backend = FilesystemBackend(root_dir=str(tmp_path))
+        original_content = "result line\n" * 30000
+        message = ToolMessage(content=original_content, tool_call_id="call_123")
+
+        result = _offload_tool_message_content(message, original_content, backend, "/large_tool_results")
+
+        assert result is not None
+        assert "/large_tool_results/call_123" in str(result.content)
 
 
 class TestPatchToolCallsMiddleware:


### PR DESCRIPTION
## Root cause

`FilesystemMiddleware`'s large-result eviction offloads oversized tool results to a file whose path is derived directly from the tool call's `tool_call_id`: `f"{prefix}/{sanitize_tool_call_id(tool_call_id)}"`.

`sanitize_tool_call_id` only replaces path-separator characters — it never bounds length. LiteLLM's Gemini provider embeds a ~1-1.5KB "thought signature" inside the id (`call_<uuid>__thought__<base64>`), which must survive verbatim since Vertex validates it on replay. With such an id, the derived filename exceeds the ~255-byte path-component limit of common filesystems, `backend.write` fails, `_offload_tool_message_content` returns `None`, and the caller keeps the **original oversized message** — the eviction the size threshold promised silently never happens, with nothing logged.

## Fix

Added `bound_tool_call_id_for_filename` in `deepagents/backends/utils.py`, next to the existing `sanitize_tool_call_id`:

- Ids short enough to be filename-safe as-is pass through **unchanged** — this keeps today's filenames (and the `read_file` guidance shown to the model) identical for the common case, and keeps existing tests that assert exact short paths passing.
- Ids whose sanitized form would exceed a safe length (200 chars, comfortably under the ~255-byte OS limit even combined with a directory prefix) are rewritten to `{sanitized_prefix}-{sha256_hexdigest[:16]}`.

A hash suffix is used rather than naive truncation (e.g. `id[:40]`) because two different long ids can share a long common prefix — Gemini ids do, via the shared `call_<uuid>__thought__` shape — so truncation alone risks collisions. Appending a hash of the *full, untruncated* id makes the result collision-resistant regardless of shared prefixes.

Wired into both call sites that build an offload path from a `tool_call_id`:
- `_offload_tool_message_content` / `_aoffload_tool_message_content` in `deepagents/middleware/_message_eviction.py`
- `FilesystemMiddleware._resolve_capture`'s capture-at-source path in `deepagents/middleware/filesystem.py`

I checked whether the "silent" failure is a separate bug (e.g. a broad `except` swallowing something unexpected). It isn't: `FilesystemBackend.write` catches `OSError`/`RuntimeError` and returns a `WriteResult(error=...)`; `_offload_tool_message_content` deliberately treats any write error as "keep the original message" per its docstring. That's reasonable fallback behavior once the filename itself is bounded, so I left it as-is and focused the fix on the filename derivation.

## Tests

Added to `libs/deepagents/tests/unit_tests/test_middleware.py`, next to the existing `sanitize_tool_call_id` tests:

- `test_bound_tool_call_id_for_filename_short_id_unchanged` — short ids match `sanitize_tool_call_id` exactly.
- `test_bound_tool_call_id_for_filename_bounds_long_id` — a LiteLLM-Gemini-shaped id (~1.4KB) is bounded to well under 255 chars.
- `test_bound_tool_call_id_for_filename_avoids_prefix_collision` — two long ids sharing a common prefix map to different filenames.
- `TestOffloadToolMessageContentLongToolCallId` — regression tests reproducing the issue's exact repro against a real `FilesystemBackend`: offload now succeeds (sync and async) for the Gemini-shaped id, the file is actually written and readable back with its full content, the embedded `file_path` in the notice stays under 255 chars, and short ids keep their existing (unhashed) filename.

## Verification

- Reproduced the issue exactly as described (`_offload_tool_message_content` returning `None` for the Gemini-shaped id against a real `FilesystemBackend` in a tempdir) before the fix, and confirmed it now returns a properly evicted `ToolMessage` after the fix.
- `ruff check` / `ruff format --diff` / `ty check` all clean on the changed files.
- Ran the package's unit test suite (`pytest tests/unit_tests/`). All new tests pass. Pre-existing failures/errors observed in this local Windows environment are a `ProactorEventLoop`/`pytest-socket` teardown interaction affecting async tests broadly — I reproduced the identical failure set on unmodified `upstream/main` before making any changes, confirming it's environmental and unrelated to this change.

Fixes #5560

🤖 Generated with [Claude Code](https://claude.com/claude-code)