### PR TITLE
hotfix(code): honor effective reasoning effort in cache warnings

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12040,9 +12040,11 @@ class DeepAgentsApp(App):
                 age_seconds = max(elapsed or 0.0, 0.0)
                 if (
                     model_spec != last_spec
-                    # Only cache-participating params are compared. Astra's
-                    # request-level `/effort` value participates because OpenAI
-                    # may rewrite its model-side instruction prefix.
+                    # Only cache-participating params are compared. OpenAI and
+                    # Anthropic reasoning-effort settings participate because
+                    # both providers render effort into the prefix: OpenAI may
+                    # rewrite model-side instructions, Anthropic always renders
+                    # the thinking config into the prompt.
                     or cache_identity_params(current_params, model_spec=model_spec)
                     != cache_identity_params(last_params, model_spec=last_spec)
                     # `None` means no endpoint was ever recorded -- e.g. a

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -11909,6 +11909,7 @@ class DeepAgentsApp(App):
                 parse_cache_timestamp,
                 resolve_prompt_cache_policy,
             )
+            from deepagents_code.config import _compose_openai_reasoning_effort
             from deepagents_code.model_config import (
                 ModelConfig,
                 is_warning_suppressed,
@@ -11939,6 +11940,14 @@ class DeepAgentsApp(App):
                 fallback_base_url = config.get_base_url(provider)
                 if isinstance(fallback_base_url, str):
                     current_params["base_url"] = fallback_base_url
+            # Match model construction before projecting the cache identity.
+            overrides = self._model_params_override or {}
+            current_params = _compose_openai_reasoning_effort(
+                provider,
+                current_params,
+                overrides.get("reasoning_effort"),
+                overrides.get("reasoning"),
+            )
             # Endpoint changes have their own normalized identity. Keeping
             # `base_url` out of this mapping avoids treating the same endpoint
             # as two independent identity changes.

--- a/libs/code/deepagents_code/cold_cache.py
+++ b/libs/code/deepagents_code/cold_cache.py
@@ -76,20 +76,42 @@ CACHE_IDENTITY_PARAM_KEYS = frozenset(
 )
 """Invocation params that select or invalidate a provider cache entry.
 
-The identity check compares only these, plus `reasoning_effort` for GPT-6 Astra.
-Comparing whole `model_params` maps instead would report a model change for every
-unrelated knob -- `temperature` or `max_tokens`, for example -- and the modal
-would then assert that "the previous cached prefix cannot be reused" when
-nothing about the prefix moved. Astra is the exception because changing its
-request-level reasoning effort can rewrite model-side instructions and reduce
-prefix reuse. A modal that fires on a false premise trains users into the
-permanent suppression.
+The identity check compares only these, plus the provider's reasoning-effort
+settings where a change is documented to move the cached prefix (see
+`_EFFORT_CACHE_IDENTITY_PROVIDERS`). Comparing whole `model_params` maps
+instead would report a model change for every unrelated knob -- `temperature`
+or `max_tokens`, for example -- and the modal would then assert that "the
+previous cached prefix cannot be reused" when nothing about the prefix moved.
+A modal that fires on a false premise trains users into the permanent
+suppression.
 
 `cache_control` is deliberately absent: `AnthropicPromptCachingMiddleware`
 overwrites `model_settings["cache_control"]` with its own TTL on every
 Anthropic request (see `_ANTHROPIC_MIDDLEWARE_TTL_SECONDS`), so a
 user-supplied value never reaches the wire. Comparing it would report an
 identity change for a setting the effective requests never differed on.
+"""
+
+_EFFORT_CACHE_IDENTITY_PROVIDERS = frozenset({"openai", "openai_codex", "anthropic"})
+"""Providers whose reasoning-effort settings participate in cache identity.
+
+OpenAI documents `reasoning.effort` as a setting that "can change model-side
+reasoning instructions" for its models generally -- the GPT-6 Astra
+`configuration_update` escape hatch exists precisely because the top-level
+knob rewrites the hidden prefix -- and pre-GPT-5.6 minimum cacheable lengths
+vary with request settings including reasoning effort:
+https://developers.openai.com/api/docs/guides/prompt-caching
+
+Anthropic is stricter: the thinking/effort configuration is rendered into the
+prompt, so changing it always invalidates message blocks:
+https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+
+Other providers (`google_genai`, `fireworks`, `xai`, ...) document no link
+between effort and cache identity, so their effort settings stay out of the
+projection: including them would fire the modal on a false premise.
+`openai_codex` resolves no cache policy today (`resolve_prompt_cache_policy`
+gates on the `openai` provider), so its entries matter only for checkpointed
+storage until that changes.
 """
 
 _OPENAI_MODEL_VERSION = re.compile(r"^gpt-(?P<major>\d+)(?:\.(?P<minor>\d+))?")
@@ -899,6 +921,50 @@ def resolve_prompt_cache_policy(
     return None
 
 
+_EFFORT_IDENTITY_KEY = "reasoning_effort"
+"""Checkpoint key the effective effort value is projected under.
+
+Canonical rather than request-shaped: the identity question is whether the
+effort value changed, not which request shape carried it. Storing the native
+shape would report an identity change for a flat-to-nested representation
+swap that leaves the prefix untouched.
+"""
+
+
+def _effort_identity_entries(
+    model_params: Mapping[str, Any], provider: str
+) -> dict[str, Any]:
+    """Project the provider's effective reasoning effort from `model_params`.
+
+    Uses the same path resolution and precedence as `/effort`
+    (`reasoning_effort._effort_paths`), so native request shapes -- OpenAI's
+    nested `reasoning: {"effort": ...}`, Anthropic's `output_config.effort`
+    -- participate alongside the canonical flat `reasoning_effort`. Sibling
+    keys in nested containers (`reasoning.summary`, say) stay out: they are
+    not documented to move the prefix, and including them would fire the
+    modal on a false premise.
+
+    Args:
+        model_params: Full invocation params.
+        provider: Lowercase provider name from the model spec.
+
+    Returns:
+        `{_EFFORT_IDENTITY_KEY: value}` when an effort setting is present and
+            non-`None`, or `{}` when the provider has none configured.
+    """
+    from deepagents_code.reasoning_effort import _effort_paths
+
+    for path in _effort_paths(provider):
+        if len(path) == 1:
+            if path[0] in model_params and model_params[path[0]] is not None:
+                return {_EFFORT_IDENTITY_KEY: model_params[path[0]]}
+        else:
+            nested = model_params.get(path[0])
+            if isinstance(nested, dict) and nested.get(path[1]) is not None:
+                return {_EFFORT_IDENTITY_KEY: nested[path[1]]}
+    return {}
+
+
 def cache_identity_params(
     model_params: Mapping[str, Any] | None,
     *,
@@ -917,16 +983,11 @@ def cache_identity_params(
         return {}
     keys = CACHE_IDENTITY_PARAM_KEYS
     if model_spec:
-        provider, separator, model_name = model_spec.partition(":")
-        effective_model = (
-            _effective_model_name(provider, model_name) if separator else None
-        )
-        if (
-            provider.strip().lower() == "openai"
-            and effective_model
-            and effective_model.lower().startswith("gpt-6-astra")
-        ):
-            keys |= {"reasoning_effort"}
+        provider = model_spec.partition(":")[0].strip().lower()
+        if provider in _EFFORT_CACHE_IDENTITY_PROVIDERS:
+            result = {key: value for key, value in model_params.items() if key in keys}
+            result.update(_effort_identity_entries(model_params, provider))
+            return result
     return {key: value for key, value in model_params.items() if key in keys}
 
 

--- a/libs/code/deepagents_code/configurable_model.py
+++ b/libs/code/deepagents_code/configurable_model.py
@@ -724,6 +724,7 @@ def _effective_cache_params(
     if not model_spec or ":" not in model_spec:
         overrides = dict(runtime_overrides) if runtime_overrides else None
         return cache_identity_params(overrides, model_spec=model_spec) or None
+    from deepagents_code.config import _compose_openai_reasoning_effort
     from deepagents_code.model_config import ModelConfig
 
     _, _, model_name = model_spec.partition(":")
@@ -748,6 +749,11 @@ def _effective_cache_params(
     if not isinstance(kwargs, dict):
         overrides = dict(runtime_overrides) if runtime_overrides else None
         return cache_identity_params(overrides, model_spec=model_spec) or None
+    # Match constructor precedence when config uses native nested reasoning.
+    overrides = runtime_overrides or {}
+    kwargs = _compose_openai_reasoning_effort(
+        provider, kwargs, overrides.get("reasoning_effort"), overrides.get("reasoning")
+    )
     # `base_url` is tracked separately as the endpoint identity; keeping it out
     # of the params avoids a double-counted identity change.
     result = cache_identity_params(

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -28618,8 +28618,9 @@ class TestColdCacheWarningFlow:
             ("google_genai:gemini-3", None),
         ],
     )
+    @pytest.mark.parametrize("nested_config", [False, True])
     async def test_reasoning_effort_cache_identity(
-        self, model_spec: str, expected_reason: str | None
+        self, model_spec: str, expected_reason: str | None, nested_config: bool
     ) -> None:
         """An `/effort` change warns only where effort moves the prefix.
 
@@ -28628,6 +28629,8 @@ class TestColdCacheWarningFlow:
         the prompt, so an effort change invalidates the cached prefix for
         both. Google documents no such link, so no warning may fire there.
         """
+        from deepagents_code.model_config import ModelConfig
+
         app = DeepAgentsApp()
         app._model_override = model_spec
         app._model_params_override = {"reasoning_effort": "high"}
@@ -28636,8 +28639,18 @@ class TestColdCacheWarningFlow:
         app._last_model_request_at = datetime.now(UTC).isoformat()
         app._context_tokens = 50_000
         app._cold_cache_warning_threshold_usd = 0.10
-        config = MagicMock()
-        config.get_effective_kwargs.return_value = {"reasoning_effort": "high"}
+        provider, _, model_name = model_spec.partition(":")
+        config = ModelConfig(
+            providers={
+                provider: {
+                    "params": {
+                        model_name: {"reasoning": {"effort": "medium"}}
+                        if nested_config
+                        else {}
+                    }
+                }
+            }
+        )
 
         def estimate(usage: dict[str, Any], _model: str, _provider: str) -> float:
             details = usage.get("input_token_details", {})
@@ -28656,6 +28669,12 @@ class TestColdCacheWarningFlow:
         ):
             warning = await app._cold_cache_warning_for(
                 QueuedMessage("continue", "normal")
+            )
+
+            app._last_cache_model_params = {"reasoning_effort": "high"}
+            assert (
+                await app._cold_cache_warning_for(QueuedMessage("continue", "normal"))
+                is None
             )
 
         assert getattr(warning, "reason", None) == expected_reason

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -28613,12 +28613,21 @@ class TestColdCacheWarningFlow:
         ("model_spec", "expected_reason"),
         [
             ("openai:gpt-6-astra", "identity_changed"),
-            ("openai:gpt-5.6", None),
+            ("openai:gpt-5.6", "identity_changed"),
+            ("anthropic:claude-opus-5", "identity_changed"),
+            ("google_genai:gemini-3", None),
         ],
     )
     async def test_reasoning_effort_cache_identity(
         self, model_spec: str, expected_reason: str | None
     ) -> None:
+        """An `/effort` change warns only where effort moves the prefix.
+
+        OpenAI documents that changing `reasoning.effort` can rewrite
+        model-side instructions, and Anthropic renders thinking config into
+        the prompt, so an effort change invalidates the cached prefix for
+        both. Google documents no such link, so no warning may fire there.
+        """
         app = DeepAgentsApp()
         app._model_override = model_spec
         app._model_params_override = {"reasoning_effort": "high"}

--- a/libs/code/tests/unit_tests/test_cold_cache.py
+++ b/libs/code/tests/unit_tests/test_cold_cache.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -13,6 +13,7 @@ from deepagents_code.cold_cache import (
     CacheConfidence,
     CacheWriteBucket,
     PromptCachePolicy,
+    cache_identity_params,
     endpoint_cache_identity,
     estimate_rewarm_cost,
     load_trusted_cache_endpoints,
@@ -104,6 +105,88 @@ def test_gpt_5_6_and_newer_ignore_legacy_retention() -> None:
         assert resolve_prompt_cache_policy(
             model_spec, {"prompt_cache_retention": "24h"}
         ) == _policy("OpenAI", 1800, "may_be_cold", 1024, "generic_write")
+
+
+@pytest.mark.parametrize(
+    ("model_spec", "params", "expected"),
+    [
+        # OpenAI: effort participates for every model, flat or nested.
+        (
+            "openai:gpt-6-astra",
+            {"reasoning_effort": "high"},
+            {"reasoning_effort": "high"},
+        ),
+        ("openai:gpt-5.6", {"reasoning_effort": "high"}, {"reasoning_effort": "high"}),
+        (
+            "openai_codex:gpt-5.6-codex",
+            {"reasoning_effort": "high"},
+            {"reasoning_effort": "high"},
+        ),
+        # Anthropic: both the flat and the native `output_config` shape.
+        ("anthropic:claude-opus-5", {"effort": "high"}, {"reasoning_effort": "high"}),
+        (
+            "anthropic:claude-opus-5",
+            {"output_config": {"effort": "high"}},
+            {"reasoning_effort": "high"},
+        ),
+        # Providers with no documented effort-to-cache link stay inert.
+        ("google_genai:gemini-3", {"reasoning_effort": "high"}, {}),
+        (
+            "fireworks:accounts/fireworks/models/glm-5p2",
+            {"reasoning_effort": "high"},
+            {},
+        ),
+        ("xai:grok-5", {"reasoning_effort": "high"}, {}),
+        # Unknown provider and unprefixed spec cannot resolve one either.
+        ("unknown:model", {"reasoning_effort": "high"}, {}),
+        ("gpt-5.6", {"reasoning_effort": "high"}, {}),
+        (None, {"reasoning_effort": "high"}, {}),
+        # Unrelated knobs never participate, on any provider.
+        (
+            "openai:gpt-5.6",
+            {"temperature": 0.7, "max_tokens": 4096},
+            {},
+        ),
+    ],
+)
+def test_cache_identity_params_scope_effort_to_documented_providers(
+    model_spec: str | None, params: dict[str, Any], expected: dict[str, Any]
+) -> None:
+    """Effort joins the identity only where a change moves the cached prefix.
+
+    OpenAI's caching guide lists `reasoning.effort` as a setting that can
+    change model-side reasoning instructions; Anthropic renders thinking
+    config into the prompt. Other providers document no such link, so
+    including their effort settings would fire the modal on a false premise.
+    """
+    assert cache_identity_params(params, model_spec=model_spec) == expected
+
+
+def test_cache_identity_params_includes_nested_openai_reasoning() -> None:
+    """The composed `reasoning` mapping participates, not just its `effort`.
+
+    `/effort` composes a session override into the native `reasoning` block
+    when config carries one, so the flat `reasoning_effort` key alone would
+    miss effort changes for those users. The projection is canonical -- both
+    shapes map to the same identity -- so neither a flat-to-nested
+    representation swap nor a `reasoning.summary` change reads as a cache
+    identity change, while a real effort change still does.
+    """
+    assert cache_identity_params(
+        {"reasoning": {"effort": "high", "summary": "auto"}},
+        model_spec="openai:gpt-5.6",
+    ) == {"reasoning_effort": "high"}
+    assert cache_identity_params(
+        {"reasoning_effort": "high"}, model_spec="openai:gpt-5.6"
+    ) == {"reasoning_effort": "high"}
+    assert cache_identity_params(
+        {"reasoning": {"effort": "high", "summary": "detailed"}},
+        model_spec="openai:gpt-5.6",
+    ) == {"reasoning_effort": "high"}
+    assert cache_identity_params(
+        {"reasoning": {"effort": "low", "summary": "auto"}},
+        model_spec="openai:gpt-5.6",
+    ) == {"reasoning_effort": "low"}
 
 
 def test_trusted_endpoints_enable_policies_on_alternate_hosts() -> None:

--- a/libs/code/tests/unit_tests/test_configurable_model.py
+++ b/libs/code/tests/unit_tests/test_configurable_model.py
@@ -332,6 +332,38 @@ def test_checkpoint_records_reasoning_effort_for_cache_identity(
     assert update["_model_params"] == {"reasoning_effort": "high"}
 
 
+@pytest.mark.parametrize("effort", ["high", "low"])
+def test_checkpoint_composes_configured_reasoning_effort(effort: str) -> None:
+    """Runtime effort overrides nested config in the saved cache identity."""
+    from deepagents_code.model_config import ModelConfig
+
+    config = ModelConfig(
+        providers={
+            "openai": {
+                "params": {
+                    "gpt-5.6": {"reasoning": {"effort": "medium", "summary": "auto"}}
+                }
+            }
+        }
+    )
+    request = _make_request(
+        _make_model("gpt-5.6"),
+        context=CLIContext(model_params={"reasoning_effort": effort}),
+    )
+    with patch("deepagents_code.model_config.ModelConfig.load", return_value=config):
+        result = ConfigurableModelMiddleware().wrap_model_call(
+            request, lambda _r: _make_response()
+        )
+
+    update = _checkpoint_update(result)
+    assert update["_last_cache_params"] == {"reasoning_effort": effort}
+    assert update["_model_params"] == {"reasoning_effort": effort}
+    assert config.get_kwargs("openai", model_name="gpt-5.6")["reasoning"] == {
+        "effort": "medium",
+        "summary": "auto",
+    }
+
+
 def test_checkpoint_records_nested_openai_reasoning_effort() -> None:
     """The nested `reasoning: {"effort": ...}` shape must not slip through.
 

--- a/libs/code/tests/unit_tests/test_configurable_model.py
+++ b/libs/code/tests/unit_tests/test_configurable_model.py
@@ -296,9 +296,30 @@ def test_checkpoint_records_effective_cache_params() -> None:
     assert update["_model_params"] is None
 
 
-def test_checkpoint_records_astra_reasoning_effort_for_cache_identity() -> None:
+@pytest.mark.parametrize(
+    ("ls_provider", "model_name", "expected"),
+    [
+        ("openai", "gpt-6-astra", {"reasoning_effort": "high"}),
+        ("openai", "gpt-5.6", {"reasoning_effort": "high"}),
+        ("anthropic", "claude-opus-5", {"reasoning_effort": "high"}),
+        ("google_genai", "gemini-3", None),
+    ],
+)
+def test_checkpoint_records_reasoning_effort_for_cache_identity(
+    ls_provider: str, model_name: str, expected: dict[str, Any] | None
+) -> None:
+    """Effort reaches `_last_cache_params` only where it moves the prefix.
+
+    OpenAI and Anthropic render reasoning effort into the prompt prefix (the
+    GPT-6 Astra `configuration_update` escape hatch exists because the
+    top-level knob rewrites it; Anthropic always renders thinking config), so
+    an effort change there can invalidate the cache. Google documents no such
+    link, so its effort settings must stay out of the identity projection.
+    """
+    model = _make_model(model_name)
+    model._get_ls_params.return_value = {"ls_provider": ls_provider}
     request = _make_request(
-        _make_model("gpt-6-astra"),
+        model,
         context=CLIContext(model_params={"reasoning_effort": "high"}),
     )
 
@@ -307,8 +328,36 @@ def test_checkpoint_records_astra_reasoning_effort_for_cache_identity() -> None:
     )
 
     update = _checkpoint_update(result)
-    assert update["_last_cache_params"] == {"reasoning_effort": "high"}
+    assert update["_last_cache_params"] == expected
     assert update["_model_params"] == {"reasoning_effort": "high"}
+
+
+def test_checkpoint_records_nested_openai_reasoning_effort() -> None:
+    """The nested `reasoning: {"effort": ...}` shape must not slip through.
+
+    `/effort` composes session overrides into the native `reasoning` mapping
+    for OpenAI when config carries one (`_compose_openai_reasoning_effort`), so
+    the flat `reasoning_effort` key alone would miss effort changes for users
+    with a configured `reasoning` block. The checkpoint stores the canonical
+    effort value, not the container: `reasoning.summary` is not documented to
+    move the prefix, so only the effort value participates.
+    """
+    request = _make_request(
+        _make_model("gpt-5.6"),
+        context=CLIContext(
+            model_params={"reasoning": {"effort": "high", "summary": "auto"}}
+        ),
+    )
+
+    result = ConfigurableModelMiddleware().wrap_model_call(
+        request, lambda _r: _make_response()
+    )
+
+    update = _checkpoint_update(result)
+    assert update["_last_cache_params"] == {"reasoning_effort": "high"}
+    assert update["_model_params"] == {
+        "reasoning": {"effort": "high", "summary": "auto"}
+    }
 
 
 def test_checkpoint_cache_params_exclude_unrelated_config() -> None:
@@ -344,9 +393,14 @@ def test_checkpoint_cache_params_exclude_unrelated_config() -> None:
         )
 
     update = _checkpoint_update(result)
-    # Only the identity key survives; `base_url` is tracked separately as the
-    # endpoint identity, and the runtime override is not a cache-identity key.
-    assert update["_last_cache_params"] == {"prompt_cache_retention": "24h"}
+    # Only the identity keys survive: `base_url` is tracked separately as the
+    # endpoint identity, `temperature` and friends are unrelated knobs, and
+    # the runtime effort override is projected too because OpenAI effort
+    # participates in cache identity.
+    assert update["_last_cache_params"] == {
+        "prompt_cache_retention": "24h",
+        "reasoning_effort": "high",
+    }
     # Resume semantics are untouched: exactly the runtime overrides.
     assert update["_model_params"] == {"reasoning_effort": "high"}
 
@@ -1084,7 +1138,9 @@ class TestModelParams:
         assert _checkpoint_update(result) == {
             "_model_spec": "openai:claude-opus-4-5",
             "_model_params": {"reasoning_effort": "high"},
-            "_last_cache_params": None,
+            # `_make_model` reports the OpenAI provider regardless of the model
+            # name, so the effort override participates in cache identity here.
+            "_last_cache_params": {"reasoning_effort": "high"},
         }
 
 


### PR DESCRIPTION
Changing `/effort` now triggers cold-cache warnings for OpenAI and Anthropic models, with runtime overrides correctly taking precedence over configured nested reasoning settings.

---

Follow-up to #6196: the merged snapshot omitted the provider-wide effort identity change. This includes that change and fixes cache comparisons and checkpoints to use the same reasoning-override composition as model construction. For example, `/effort high` over configured `reasoning.effort = "medium"` now records and compares `high`.

Effort is stored canonically so equivalent flat and nested settings do not cause a warning. Tests cover provider selection, nested configuration, override precedence, and unchanged-effort reuse.