### PR TITLE
fix(code): standardize recent-thread environment variable

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -384,9 +384,6 @@ The app no longer honors this value. It detects the old name so users receive a
 migration notice pointing to `DANGEROUSLY_ENABLE_PROJECT_MCP_SERVERS`.
 """
 
-LEGACY_RECENT_THREADS = "DA_CLI_RECENT_THREADS"
-"""Deprecated thread-list limit retained as a compatibility fallback."""
-
 LOG_LEVEL = "DEEPAGENTS_CODE_LOG_LEVEL"
 """Minimum level for `deepagents_code` runtime logging.
 

--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -384,6 +384,9 @@ The app no longer honors this value. It detects the old name so users receive a
 migration notice pointing to `DANGEROUSLY_ENABLE_PROJECT_MCP_SERVERS`.
 """
 
+LEGACY_RECENT_THREADS = "DA_CLI_RECENT_THREADS"
+"""Deprecated thread-list limit retained as a compatibility fallback."""
+
 LOG_LEVEL = "DEEPAGENTS_CODE_LOG_LEVEL"
 """Minimum level for `deepagents_code` runtime logging.
 
@@ -505,6 +508,9 @@ hostile values the dotenv denylist does not yet enumerate. The global
 `~/.deepagents/.env` is unaffected. This is user-controlled process env, not a
 repo file, so a project `.env` cannot disable itself.
 """
+
+RECENT_THREADS = "DEEPAGENTS_CODE_RECENT_THREADS"
+"""Maximum number of recent threads loaded and displayed (default: 20)."""
 
 RECURSION_LIMIT = "DEEPAGENTS_CODE_RECURSION_LIMIT"
 """Override the main agent's LangGraph `recursion_limit` (graph step budget).

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -1585,13 +1585,9 @@ def get_thread_limit() -> int:
     """
     import os
 
-    from deepagents_code._env_vars import LEGACY_RECENT_THREADS, RECENT_THREADS
+    from deepagents_code._env_vars import RECENT_THREADS
 
-    name = RECENT_THREADS
-    raw = os.environ.get(name)
-    if raw is None:
-        name = LEGACY_RECENT_THREADS
-        raw = os.environ.get(name)
+    raw = os.environ.get(RECENT_THREADS)
     if raw is None:
         return _DEFAULT_THREAD_LIMIT
     try:
@@ -1599,7 +1595,7 @@ def get_thread_limit() -> int:
     except ValueError:
         logger.warning(
             "Invalid %s value %r, using default %d",
-            name,
+            RECENT_THREADS,
             raw,
             _DEFAULT_THREAD_LIMIT,
         )

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -1578,24 +1578,28 @@ _DEFAULT_THREAD_LIMIT = 20
 
 
 def get_thread_limit() -> int:
-    """Read the thread listing limit from `DA_CLI_RECENT_THREADS`.
-
-    Falls back to `_DEFAULT_THREAD_LIMIT` when the variable is unset or contains
-    a non-integer value. The result is clamped to a minimum of 1.
+    """Read the thread listing limit from the environment.
 
     Returns:
         Number of threads to display.
     """
     import os
 
-    raw = os.environ.get("DA_CLI_RECENT_THREADS")
+    from deepagents_code._env_vars import LEGACY_RECENT_THREADS, RECENT_THREADS
+
+    name = RECENT_THREADS
+    raw = os.environ.get(name)
+    if raw is None:
+        name = LEGACY_RECENT_THREADS
+        raw = os.environ.get(name)
     if raw is None:
         return _DEFAULT_THREAD_LIMIT
     try:
         return max(1, int(raw))
     except ValueError:
         logger.warning(
-            "Invalid DA_CLI_RECENT_THREADS value %r, using default %d",
+            "Invalid %s value %r, using default %d",
+            name,
             raw,
             _DEFAULT_THREAD_LIMIT,
         )
@@ -1624,8 +1628,8 @@ async def list_threads_command(
             When `None`, threads for all agents are shown.
         limit: Maximum number of threads to display.
 
-            When `None`, reads from `DA_CLI_RECENT_THREADS` or falls back to
-            the default.
+            When `None`, reads from `DEEPAGENTS_CODE_RECENT_THREADS` or falls
+            back to the default.
         sort_by: Sort field — `"updated"` or `"created"`.
 
             When `None`, reads the merged managed and user config
@@ -1771,9 +1775,11 @@ async def list_threads_command(
     console.print()
     console.print(table)
     if len(threads) >= limit:
+        from deepagents_code._env_vars import RECENT_THREADS
+
         console.print(
             f"[dim]Showing last {limit} threads. "
-            "Override with -n/--limit or DA_CLI_RECENT_THREADS.[/dim]"
+            f"Override with -n/--limit or {RECENT_THREADS}.[/dim]"
         )
     console.print()
 

--- a/libs/code/deepagents_code/tui/widgets/thread_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/thread_selector.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from deepagents_code.sessions import ThreadInfo
 
 from deepagents_code import theme
+from deepagents_code._env_vars import RECENT_THREADS
 from deepagents_code.config import (
     build_langsmith_thread_url,
     get_glyphs,
@@ -1061,8 +1062,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         limit = self._effective_thread_limit()
         if len(self._threads) >= limit:
             lines += (
-                f"\nShowing last {limit} threads. "
-                "Set DA_CLI_RECENT_THREADS to override."
+                f"\nShowing last {limit} threads. Set {RECENT_THREADS} to override."
             )
         return lines
 

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -1184,19 +1184,6 @@ class TestMessageCountFromCheckpointBlob:
 class TestGetThreadLimit:
     """Tests for get_thread_limit() env var parsing."""
 
-    def test_canonical_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The Deep Agents Code-prefixed variable controls the limit."""
-        monkeypatch.setenv("DEEPAGENTS_CODE_RECENT_THREADS", "50")
-        assert sessions.get_thread_limit() == 50
-
-    @pytest.mark.parametrize(("value", "expected"), [("0", 1), ("-5", 1), ("bad", 20)])
-    def test_value_validation(
-        self, monkeypatch: pytest.MonkeyPatch, value: str, expected: int
-    ) -> None:
-        """Values are clamped to one or defaulted when invalid."""
-        monkeypatch.setenv("DEEPAGENTS_CODE_RECENT_THREADS", value)
-        assert sessions.get_thread_limit() == expected
-
 
 class TestListThreadsSortAndBranch:
     """Tests for sort_by and branch params on list_threads."""

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -1189,20 +1189,6 @@ class TestGetThreadLimit:
         monkeypatch.setenv("DEEPAGENTS_CODE_RECENT_THREADS", "50")
         assert sessions.get_thread_limit() == 50
 
-    def test_canonical_value_takes_precedence(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The canonical variable wins over the legacy compatibility alias."""
-        monkeypatch.setenv("DEEPAGENTS_CODE_RECENT_THREADS", "30")
-        monkeypatch.setenv("DA_CLI_RECENT_THREADS", "40")
-        assert sessions.get_thread_limit() == 30
-
-    def test_legacy_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The old variable remains supported when the canonical one is unset."""
-        monkeypatch.delenv("DEEPAGENTS_CODE_RECENT_THREADS", raising=False)
-        monkeypatch.setenv("DA_CLI_RECENT_THREADS", "25")
-        assert sessions.get_thread_limit() == 25
-
     @pytest.mark.parametrize(("value", "expected"), [("0", 1), ("-5", 1), ("bad", 20)])
     def test_value_validation(
         self, monkeypatch: pytest.MonkeyPatch, value: str, expected: int

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -1184,6 +1184,33 @@ class TestMessageCountFromCheckpointBlob:
 class TestGetThreadLimit:
     """Tests for get_thread_limit() env var parsing."""
 
+    def test_canonical_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The Deep Agents Code-prefixed variable controls the limit."""
+        monkeypatch.setenv("DEEPAGENTS_CODE_RECENT_THREADS", "50")
+        assert sessions.get_thread_limit() == 50
+
+    def test_canonical_value_takes_precedence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The canonical variable wins over the legacy compatibility alias."""
+        monkeypatch.setenv("DEEPAGENTS_CODE_RECENT_THREADS", "30")
+        monkeypatch.setenv("DA_CLI_RECENT_THREADS", "40")
+        assert sessions.get_thread_limit() == 30
+
+    def test_legacy_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The old variable remains supported when the canonical one is unset."""
+        monkeypatch.delenv("DEEPAGENTS_CODE_RECENT_THREADS", raising=False)
+        monkeypatch.setenv("DA_CLI_RECENT_THREADS", "25")
+        assert sessions.get_thread_limit() == 25
+
+    @pytest.mark.parametrize(("value", "expected"), [("0", 1), ("-5", 1), ("bad", 20)])
+    def test_value_validation(
+        self, monkeypatch: pytest.MonkeyPatch, value: str, expected: int
+    ) -> None:
+        """Values are clamped to one or defaulted when invalid."""
+        monkeypatch.setenv("DEEPAGENTS_CODE_RECENT_THREADS", value)
+        assert sessions.get_thread_limit() == expected
+
 
 class TestListThreadsSortAndBranch:
     """Tests for sort_by and branch params on list_threads."""


### PR DESCRIPTION
Deep Agents Code now uses the convention-aligned `DEEPAGENTS_CODE_RECENT_THREADS` name for recent-thread limits.

---

- Replace the `DA_CLI_RECENT_THREADS` outlier.
- Update user-facing thread-list and selector hints.
- Companion docs: https://github.com/langchain-ai/docs/pull/5959

Made by [Open SWE](https://openswe.vercel.app/agents/e2adcf18-ca8c-519a-b236-82f6e4299f96) · openai:gpt-5.6-sol (high)