### PR TITLE
feat(code): load scoped project instructions

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -18,6 +18,7 @@ from deepagents.middleware import (
     GRADER_SYSTEM_PROMPT,
     FilesystemMiddleware,
     MemoryMiddleware,
+    ProjectInstructionsMiddleware,
     SkillsMiddleware,  # noqa: F401
 )
 
@@ -79,7 +80,6 @@ from deepagents_code._paths import (
     ensure_agent_dir,
     ensure_user_skills_dir,
     get_built_in_skills_dir,
-    get_project_agent_md_path,
     get_project_agent_skills_dir,
     get_project_agents_dir,
     get_project_claude_skills_dir,
@@ -2927,12 +2927,6 @@ def create_cli_agent(
     # Add memory middleware
     if enable_memory:
         memory_sources = [str(get_user_agent_md_path(assistant_id))]
-        project_agent_md_paths = (
-            project_context.project_agent_md_paths()
-            if project_context is not None
-            else get_project_agent_md_path(runtime_credentials.project_root)
-        )
-        memory_sources.extend(str(p) for p in project_agent_md_paths)
 
         # Loading memory stays on either way; a read-only prompt drops the
         # "proactively persist learnings" guidance when auto-save is disabled.
@@ -3161,6 +3155,36 @@ def create_cli_agent(
             routes={**extension_routes, **artifact_routes},
             artifacts_root=artifacts_root,
         )
+
+    project_root = (
+        project_context.project_root
+        if project_context is not None
+        else runtime_credentials.project_root
+    )
+    if sandbox is None and project_root is not None:
+        instructions_root = str(project_root)
+        instructions_cwd = str(effective_cwd or project_root)
+        agent_middleware.append(
+            ProjectInstructionsMiddleware(
+                backend=FilesystemBackend(
+                    root_dir=project_root,
+                    virtual_mode=True,
+                ),
+                project_root=instructions_root,
+                cwd=instructions_cwd,
+                backend_root="/",
+            )
+        )
+    elif sandbox is not None and sandbox_type is not None:
+        instructions_root = get_default_working_dir(sandbox_type)
+        agent_middleware.append(
+            ProjectInstructionsMiddleware(
+                backend=composite_backend,
+                project_root=instructions_root,
+                cwd=instructions_root,
+            )
+        )
+
     compaction_middleware = _create_cli_compaction_middleware(
         model,
         composite_backend,

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -168,7 +168,6 @@ def _patch_agent_paths(
     user_claude_skills_dir: Path | None = None,
     project_claude_skills_dir: Path | None = None,
     expected_project_claude_root: Path | None = None,
-    project_agent_md_paths: tuple[Path, ...] = (),
     user_agents_dir: Path | None = None,
     project_agents_dir: Path | None = None,
 ) -> Iterator[None]:
@@ -207,10 +206,6 @@ def _patch_agent_paths(
         patch(
             "deepagents_code.agent.get_user_agent_md_path",
             return_value=agent_dir / "AGENTS.md",
-        ),
-        patch(
-            "deepagents_code.agent.get_project_agent_md_path",
-            return_value=list(project_agent_md_paths),
         ),
         patch(
             "deepagents_code.agent.get_user_agents_dir",
@@ -2184,10 +2179,10 @@ class TestCreateCliAgentSkillsSources:
 
 
 class TestCreateCliAgentMemorySources:
-    """Test that `create_cli_agent` wires project AGENTS.md into memory sources."""
+    """Test that project instructions remain separate from explicit memory."""
 
     def test_project_agent_md_paths_in_memory_sources(self, tmp_path: Path) -> None:
-        """Project AGENTS.md paths should be passed to MemoryMiddleware sources."""
+        """Project AGENTS.md paths should not be passed as memory sources."""
         agent_dir = tmp_path / "agent"
         agent_dir.mkdir()
         skills_dir = tmp_path / "skills"
@@ -2231,7 +2226,6 @@ class TestCreateCliAgentMemorySources:
             _patch_agent_paths(
                 agent_dir=agent_dir,
                 skills_dir=skills_dir,
-                project_agent_md_paths=(project_inner, project_root),
                 user_agents_dir=tmp_path / "agents",
             ),
             patch("deepagents_code.agent.PluginSkillsMiddleware"),
@@ -2255,12 +2249,7 @@ class TestCreateCliAgentMemorySources:
 
         assert len(captured) == 1
         sources = captured[0]
-        # User AGENTS.md is always first
-        assert sources[0] == str(agent_dir / "AGENTS.md")
-        # Both project paths follow
-        assert sources[1] == str(project_inner)
-        assert sources[2] == str(project_root)
-        assert len(sources) == 3
+        assert sources == [str(agent_dir / "AGENTS.md")]
 
     def test_empty_project_paths_no_extra_sources(self, tmp_path: Path) -> None:
         """Empty project path list should not add extra memory sources."""
@@ -2517,7 +2506,7 @@ class TestCreateCliAgentProjectContext:
     def test_project_context_drives_project_agents_md_paths(
         self, tmp_path: Path
     ) -> None:
-        """Memory sources should use project AGENTS from explicit context."""
+        """Explicit context should keep project AGENTS out of memory sources."""
         project_root = tmp_path / "project"
         project_root.mkdir()
         (project_root / ".git").mkdir()
@@ -2585,10 +2574,7 @@ class TestCreateCliAgentProjectContext:
                 project_context=project_context,
             )
 
-        assert len(captured_sources) == 1
-        sources = captured_sources[0]
-        assert sources[0] == str(agent_dir / "AGENTS.md")
-        assert sources[1:] == [str(deepagents_md), str(root_md)]
+        assert captured_sources == [[str(agent_dir / "AGENTS.md")]]
 
     @staticmethod
     def _build_shell_agent(


### PR DESCRIPTION
Dcode now loads project instructions through the SDK middleware while retaining user `AGENTS.md` as explicit memory.

---

- wire `ProjectInstructionsMiddleware` to local and sandbox backends
- preserve `.deepagents/AGENTS.md` compatibility through SDK discovery
- keep project instructions separate from ordered user memory

Made by [Open SWE](https://openswe.vercel.app/agents/c68e2ecf-0fa1-5b54-9f13-bfc56488bb2f) · openai:gpt-5.6-sol (high)