### PR TITLE
fix(code): order debug console log filters

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -153,9 +153,15 @@ def _filter_options() -> tuple[tuple[str, FilterValue], ...]:
     """Return level filter options valid for the current logging configuration."""
     if not _debug_records_enabled():
         return _BASE_FILTER_OPTIONS
-    all_option = _BASE_FILTER_OPTIONS[:1]
-    rest = _BASE_FILTER_OPTIONS[1:]
-    return (*all_option, *_DEBUG_FILTER_OPTIONS, *rest)
+    minimum_options = _BASE_FILTER_OPTIONS[:5]
+    only_options = _BASE_FILTER_OPTIONS[5:]
+    return (
+        minimum_options[0],
+        _DEBUG_FILTER_OPTIONS[0],
+        *minimum_options[1:],
+        _DEBUG_FILTER_OPTIONS[1],
+        *only_options,
+    )
 
 
 def _record_matches_filter(

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -62,6 +62,25 @@ def _snapshot() -> list[SnapshotField]:
 
 
 class TestDebugConsoleScreen:
+    def test_level_filters_group_thresholds_before_exact_levels(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(debug_console_mod, "_debug_records_enabled", lambda: True)
+
+        assert [label for label, _ in debug_console_mod._filter_options()] == [
+            "All",
+            "DEBUG",
+            "INFO",
+            "WARNING",
+            "ERROR",
+            "CRITICAL",
+            "Only DEBUG",
+            "Only INFO",
+            "Only WARNING",
+            "Only ERROR",
+            "Only CRITICAL",
+        ]
+
     async def test_wrapped_snapshot_values_align_to_value_column(self) -> None:
         fields = [
             SnapshotField(


### PR DESCRIPTION
The Debug Console now lists minimum-level filters together before the exact-level filters.

---

The DEBUG entries were inserted as a pair after `All`, leaving `Only DEBUG` detached from the other exact-level choices. Split the existing choices into minimum and exact-level groups, then place the optional DEBUG choice in its corresponding group.

Made by [Open SWE](https://openswe.vercel.app/agents/8a44f464-9421-508c-9183-cceafd168a42) · openai:gpt-5.6-sol (high)