### PR TITLE
fix(code): open debug console at log bottom

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -267,6 +267,7 @@ class _DebugLogView(ScrollView, can_focus=True):
         self._wrap_prefix: list[int] = [0]
         self._total_visual = 0
         self._cached_width = 0
+        self._scroll_end_after_layout = False
         self._hover_index: int | None = None
         self._selected_index: int | None = None
         self._render_line_cache: LRUCache[
@@ -309,6 +310,7 @@ class _DebugLogView(ScrollView, can_focus=True):
         self._contents.extend(_record_to_content(record) for record in records)
         width = self._cached_width or self.size.width
         if width <= 0:
+            self._scroll_end_after_layout = self._scroll_end_after_layout or at_bottom
             # Not yet sized (e.g. first poll before layout). Assume one visual
             # line per new content so `_wrap_counts` stays 1:1 with `_contents`;
             # the first `on_resize` reflow recomputes real counts. Skipping this
@@ -500,6 +502,9 @@ class _DebugLogView(ScrollView, can_focus=True):
         """Re-wrap log entries when the view width changes."""
         if event.size.width != self._cached_width:
             self._reflow()
+        if self._scroll_end_after_layout:
+            self._scroll_end_after_layout = False
+            self.scroll_end(animate=False, immediate=True, x_axis=False)
 
     def on_mouse_move(self, event: events.MouseMove) -> None:
         """Highlight the logical log record under the pointer."""

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -21,6 +21,7 @@ from deepagents_code.tui.widgets.debug_console import (
 
 if TYPE_CHECKING:
     import pytest
+    from textual.strip import Strip
 
 
 logger = logging.getLogger("deepagents_code._test_console")
@@ -199,6 +200,38 @@ class TestDebugConsoleScreen:
             "debug2",
             "debug3",
         ]
+
+    async def test_first_populated_frame_starts_at_bottom(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The first frame containing logs renders at the newest records."""
+        states: list[tuple[int, int]] = []
+        records = [_log_record(f"marker-{index} {'x' * 100}") for index in range(100)]
+
+        class Buffer:
+            total_emitted = len(records)
+
+            @staticmethod
+            def snapshot_records_since(
+                _cursor: int,
+            ) -> tuple[list[InMemoryLogRecord], int]:
+                return records, len(records)
+
+        class CapturingLogView(_DebugLogView):
+            def render_line(self, y: int) -> Strip:
+                if self.virtual_size.height > self.size.height:
+                    states.append((self.scroll_offset.y, self.max_scroll_y))
+                return super().render_line(y)
+
+        monkeypatch.setattr(debug_console_mod, "_DebugLogView", CapturingLogView)
+        monkeypatch.setattr(debug_console_mod, "get_log_buffer", Buffer)
+        app = _Harness()
+        async with app.run_test(size=(80, 30)) as pilot:
+            app.push_screen(DebugConsoleScreen(_snapshot()))
+            await pilot.pause()
+
+        assert states
+        assert all(offset == maximum for offset, maximum in states)
 
     async def test_notice_replaced_by_incoming_records(self) -> None:
         app = _Harness()


### PR DESCRIPTION
The Debug Console now opens directly at the latest log records without visibly jumping from the top.

---

Records can arrive before Textual lays out the log viewport, when its scroll extent is still zero. Preserve the bottom-follow intent through that initial layout and apply it immediately during resize, before the first populated frame is painted.

Made by [Open SWE](https://openswe.vercel.app/agents/51849034-b8d3-53d0-992a-d36086eeb8e8) · openai:gpt-5.6-sol (high)