### PR TITLE
fix(code): wrap debug logs before the scrollbar

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -307,7 +307,7 @@ class _DebugLogView(ScrollView, can_focus=True):
         start = len(self._contents)
         self._records.extend(records)
         self._contents.extend(_record_to_content(record) for record in records)
-        width = self._cached_width or self.size.width
+        width = self._cached_width or self.scrollable_content_region.width
         if width <= 0:
             # Not yet sized (e.g. first poll before layout). Assume one visual
             # line per new content so `_wrap_counts` stays 1:1 with `_contents`;
@@ -341,7 +341,7 @@ class _DebugLogView(ScrollView, can_focus=True):
         self._hover_index = None
         self._selected_index = None
         self._render_line_cache.clear()
-        self.virtual_size = Size(self.size.width, 0)
+        self.virtual_size = Size(self.scrollable_content_region.width, 0)
         self.refresh()
 
     def show_notice(self, message: str) -> None:
@@ -372,7 +372,7 @@ class _DebugLogView(ScrollView, can_focus=True):
         self._total_visual = self._wrap_prefix[-1]
 
     def _reflow(self) -> None:
-        width = self.size.width
+        width = self.scrollable_content_region.width
         if width <= 0:
             width = self._cached_width
         if width <= 0:
@@ -444,7 +444,7 @@ class _DebugLogView(ScrollView, can_focus=True):
     def render_line(self, y: int) -> Strip:
         _scroll_x, scroll_y = self.scroll_offset
         abs_y = scroll_y + y
-        width = self.size.width
+        width = self.scrollable_content_region.width
         key = (
             abs_y,
             width,
@@ -496,9 +496,9 @@ class _DebugLogView(ScrollView, can_focus=True):
         super().notify_style_update()
         self._render_line_cache.clear()
 
-    def on_resize(self, event: events.Resize) -> None:
+    def on_resize(self, _event: events.Resize) -> None:
         """Re-wrap log entries when the view width changes."""
-        if event.size.width != self._cached_width:
+        if self.scrollable_content_region.width != self._cached_width:
             self._reflow()
 
     def on_mouse_move(self, event: events.MouseMove) -> None:

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -17,6 +17,7 @@ from deepagents_code.tui.widgets.debug_console import (
     DebugConsoleScreen,
     SnapshotField,
     _DebugLogView,
+    _record_to_content,
 )
 
 if TYPE_CHECKING:
@@ -199,6 +200,22 @@ class TestDebugConsoleScreen:
             "debug2",
             "debug3",
         ]
+
+    async def test_log_wraps_at_scrollbar_edge_without_truncating(self) -> None:
+        app = _Harness()
+        async with app.run_test(size=(50, 30)) as pilot:
+            screen = DebugConsoleScreen(_snapshot())
+            app.push_screen(screen)
+            await pilot.pause()
+            log = screen.query_one("#debug-log", _DebugLogView)
+            prefix_width = _record_to_content(_log_record("")).cell_length
+            message = "x" * (log.scrollable_content_region.width - prefix_width) + "Z"
+
+            log.set_records([_log_record(message)], scroll_end=False)
+            await pilot.pause()
+
+            assert log.line_count == 2
+            assert "Z" in log.render_line(1).text
 
     async def test_notice_replaced_by_incoming_records(self) -> None:
         app = _Harness()


### PR DESCRIPTION
Debug Console log lines now wrap at the visible edge instead of losing their final character behind the scrollbar.

---

The log view measured its full content width while Textual reserved two cells for the stable vertical scrollbar gutter. Use the scrollable content region consistently for wrapping, virtual sizing, rendering, and resize reflow.

Made by [Open SWE](https://openswe.vercel.app/agents/869f4472-f82b-506b-bf51-ffb170565db8) · openai:gpt-5.6-luna (high)