### PR TITLE
fix(code): silence absent themes config warning

### DIFF
--- a/libs/code/deepagents_code/theme.py
+++ b/libs/code/deepagents_code/theme.py
@@ -613,8 +613,9 @@ def _load_user_themes(
     if themes_section is None:
         return
     if not isinstance(themes_section, dict):
-        # A malformed top-level value makes every user theme inert, and this
-        # reader emits no ranked diagnostics to report it elsewhere.
+        # Not merely absent: the table resolved to something that is not a
+        # table, which means every user theme is inert. This reader emits no
+        # ranked diagnostics, so nothing else reports it.
         logger.warning("Ignoring [themes]: expected a table, got %r", themes_section)
         return
     if not themes_section:

--- a/libs/code/deepagents_code/theme.py
+++ b/libs/code/deepagents_code/theme.py
@@ -610,10 +610,11 @@ def _load_user_themes(
         .get(option)
         .value
     )
+    if themes_section is None:
+        return
     if not isinstance(themes_section, dict):
-        # Not merely absent: the table resolved to something that is not a
-        # table, which means every user theme is inert. This reader emits no
-        # ranked diagnostics, so nothing else reports it.
+        # A malformed top-level value makes every user theme inert, and this
+        # reader emits no ranked diagnostics to report it elsewhere.
         logger.warning("Ignoring [themes]: expected a table, got %r", themes_section)
         return
     if not themes_section:

--- a/libs/code/tests/unit_tests/test_theme.py
+++ b/libs/code/tests/unit_tests/test_theme.py
@@ -242,49 +242,11 @@ class TestLoadUserThemes:
     def test_absent_themes_is_silent(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """An absent optional themes table emits no warning."""
         config = tmp_path / "config.toml"
         _write_config(config, "[ui]\ncursor_blink = true\n")
-        builtins: dict[str, ThemeEntry] = {}
-        with caplog.at_level("WARNING", logger="deepagents_code.theme"):
-            _load_user_themes(builtins, config_path=config)
-        assert builtins == {}
-        assert not caplog.records
-
-    def test_scalar_themes_warns(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A malformed scalar themes value still emits a warning."""
-        config = tmp_path / "config.toml"
-        _write_config(config, 'themes = "foo"\n')
-        with caplog.at_level("WARNING", logger="deepagents_code.theme"):
-            _load_user_themes({}, config_path=config)
-        assert any(
-            "Ignoring [themes]" in record.getMessage() for record in caplog.records
-        )
-
-    def test_empty_themes_is_silent(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """An empty themes table emits no warning."""
-        config = tmp_path / "config.toml"
-        _write_config(config, "[themes]\n")
         with caplog.at_level("WARNING", logger="deepagents_code.theme"):
             _load_user_themes({}, config_path=config)
         assert not caplog.records
-
-    def test_custom_theme_loads(self, tmp_path: Path) -> None:
-        """A valid custom theme is added to the registry."""
-        config = tmp_path / "config.toml"
-        _write_config(
-            config,
-            '[themes.custom]\nlabel = "Custom"\ndark = true\nprimary = "#123456"\n',
-        )
-        builtins: dict[str, ThemeEntry] = {}
-        _load_user_themes(builtins, config_path=config)
-        assert "custom" in builtins
-        assert builtins["custom"].label == "Custom"
-        assert builtins["custom"].custom is True
 
 
 # ---------------------------------------------------------------------------

--- a/libs/code/tests/unit_tests/test_theme.py
+++ b/libs/code/tests/unit_tests/test_theme.py
@@ -239,6 +239,53 @@ class TestLoadUserThemes:
         _load_user_themes(builtins, config_path=config)
         assert builtins == {}
 
+    def test_absent_themes_is_silent(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An absent optional themes table emits no warning."""
+        config = tmp_path / "config.toml"
+        _write_config(config, "[ui]\ncursor_blink = true\n")
+        builtins: dict[str, ThemeEntry] = {}
+        with caplog.at_level("WARNING", logger="deepagents_code.theme"):
+            _load_user_themes(builtins, config_path=config)
+        assert builtins == {}
+        assert not caplog.records
+
+    def test_scalar_themes_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A malformed scalar themes value still emits a warning."""
+        config = tmp_path / "config.toml"
+        _write_config(config, 'themes = "foo"\n')
+        with caplog.at_level("WARNING", logger="deepagents_code.theme"):
+            _load_user_themes({}, config_path=config)
+        assert any(
+            "Ignoring [themes]" in record.getMessage() for record in caplog.records
+        )
+
+    def test_empty_themes_is_silent(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An empty themes table emits no warning."""
+        config = tmp_path / "config.toml"
+        _write_config(config, "[themes]\n")
+        with caplog.at_level("WARNING", logger="deepagents_code.theme"):
+            _load_user_themes({}, config_path=config)
+        assert not caplog.records
+
+    def test_custom_theme_loads(self, tmp_path: Path) -> None:
+        """A valid custom theme is added to the registry."""
+        config = tmp_path / "config.toml"
+        _write_config(
+            config,
+            '[themes.custom]\nlabel = "Custom"\ndark = true\nprimary = "#123456"\n',
+        )
+        builtins: dict[str, ThemeEntry] = {}
+        _load_user_themes(builtins, config_path=config)
+        assert "custom" in builtins
+        assert builtins["custom"].label == "Custom"
+        assert builtins["custom"].custom is True
+
 
 # ---------------------------------------------------------------------------
 # _build_registry with user themes


### PR DESCRIPTION
Starting `dcode` without a `[themes]` table no longer logs a misleading warning.

---

Treat the resolved `None` value as an absent optional section while preserving warnings for malformed non-table values. A focused regression test covers the absent optional section while existing behavior for other values remains unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/4c90195a-2658-5f50-8aec-9c60b8f9e3dd) · openai:gpt-5.6-sol (high)
