### PR TITLE
fix(code): price Fireworks GLM-5.3 usage

### DIFF
--- a/libs/code/deepagents_code/bundled_prices.json
+++ b/libs/code/deepagents_code/bundled_prices.json
@@ -26,5 +26,13 @@
       { "id": "thinkingmachines/inkling", "match": { "equals": "inkling" }, "price_comments": "Bare alias omitted from pydantic/genai-prices#660", "prices": { "input_mtok": 1.0, "cache_read_mtok": 0.17, "output_mtok": 4.05 } },
       { "id": "thinkingmachines/inkling-small", "match": { "equals": "inkling-small" }, "price_comments": "Bare alias omitted from pydantic/genai-prices#660", "prices": { "input_mtok": 0.5, "cache_read_mtok": 0.1, "output_mtok": 1.2 } }
     ]
+  },
+  {
+    "id": "fireworks",
+    "name": "Fireworks",
+    "api_pattern": "https://api\\.fireworks\\.ai",
+    "models": [
+      { "id": "glm-5p3", "match": { "equals": "accounts/fireworks/models/glm-5p3" }, "price_comments": "Fireworks deployment omitted from pydantic/genai-prices#617", "prices": { "input_mtok": 1.4, "cache_read_mtok": 0.26, "output_mtok": 4.4 } }
+    ]
   }
 ]


### PR DESCRIPTION
Deep Agents Code now reports costs for Fireworks GLM-5.3 instead of treating its usage as unpriced.

---

`genai-prices` includes GLM-5.3 for other providers but omits Fireworks' `accounts/fireworks/models/glm-5p3` deployment. Add an exact-match fallback using Fireworks' published standard rates: $1.40 input, $0.26 cached input, and $4.40 output per million tokens. The override becomes inert when upstream adds coverage.

Made by [Open SWE](https://openswe.vercel.app/agents/f57cbaaa-a9f3-5479-9b4f-b70ff9ce5e93) · openai:gpt-5.6-sol (high)