### PR TITLE
fix(code): attribute dotenv config sources

### DIFF
--- a/libs/code/deepagents_code/client/commands/config.py
+++ b/libs/code/deepagents_code/client/commands/config.py
@@ -353,6 +353,27 @@ def _resolve(
     return source != "default", source, resolved.value
 
 
+def _resolve_for_display(
+    option: ConfigOption[object],
+    toml_data: dict[str, Any],
+    *,
+    stored: _StoredCredentialView | None = None,
+    managed_toml_data: dict[str, Any],
+) -> tuple[bool, str, object]:
+    """Resolve an option and add display-only dotenv source attribution.
+
+    Returns:
+        The effective set state, attributed source, and value.
+    """
+    is_set, source, value = _resolve(
+        option,
+        toml_data,
+        stored=stored,
+        managed_toml_data=managed_toml_data,
+    )
+    return is_set, _attribute_env_source(source), value
+
+
 def _has_prefixed_env_override(option: ConfigOption[object]) -> bool:
     """Return whether an option's `DEEPAGENTS_CODE_` env var is present."""
     if option.env_var is None:
@@ -416,6 +437,36 @@ def _source_label(source: str, *, option: ConfigOption[object] | None = None) ->
         if env is not None and env.startswith("DEEPAGENTS_CODE_"):
             return f"{source}; session override"
     return source
+
+
+def _attribute_env_source(source: str) -> str:
+    """Append the dotenv path for an environment value loaded by dcode.
+
+    Returns:
+        The attributed source, or `source` when it was not dotenv-injected.
+    """
+    from deepagents_code.config import (
+        _dotenv_loaded_values,
+        _dotenv_provenance,
+        _environment_key,
+        active_environment,
+    )
+
+    if active_environment() is not os.environ:
+        return source
+    suffix = "; invalid"
+    core = source.removesuffix(suffix)
+    name = _env_source_name(core)
+    if name is None:
+        return source
+    key = _environment_key(name)
+    if os.environ.get(key) != _dotenv_loaded_values.get(key):
+        return source
+    path = _dotenv_provenance.get(key)
+    if path is None:
+        return source
+    attributed = f"{core[:-1]}, {path})"
+    return f"{attributed}{suffix}" if source.endswith(suffix) else attributed
 
 
 def _env_source_name(source: str) -> str | None:
@@ -645,7 +696,7 @@ def _run_config(output_format: OutputFormat, *, verbose: bool) -> int:
     resolved = [
         ResolvedOption(
             opt,
-            *_resolve(
+            *_resolve_for_display(
                 opt,
                 toml_data,
                 stored=stored,
@@ -965,7 +1016,7 @@ def _run_get_section(
     resolved = [
         ResolvedOption(
             opt,
-            *_resolve(
+            *_resolve_for_display(
                 opt,
                 toml_data,
                 stored=stored,
@@ -1041,7 +1092,7 @@ def _run_get(
     # Only credential options consult the store, so skip the read (and its
     # warning) for everything else.
     stored = _load_stored_credentials() if option.group == "Credentials" else None
-    is_set, source, value = _resolve(
+    is_set, source, value = _resolve_for_display(
         option,
         toml_data,
         stored=stored,

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -122,6 +122,9 @@ _singleton_lock = threading.Lock()
 _dotenv_loaded_values: dict[str, str] = {}
 """Environment values injected by our dotenv loader and safe to refresh later."""
 
+_dotenv_provenance: dict[str, Path] = {}
+"""Dotenv file that supplied each value injected into the process environment."""
+
 _reconciled_tracing_values: dict[str, tuple[str | None, str | None]] = {}
 """Original and published tracing values, kept out of later workspace baselines."""
 
@@ -633,6 +636,7 @@ def _dotenv_environment(
     include_global: bool = True,
     unreadable: list[Path] | None = None,
     project_layer: dict[str, str] | None = None,
+    provenance: dict[str, Path] | None = None,
 ) -> dict[str, str]:
     """Apply the project/global dotenv stack to an explicit environment mapping.
 
@@ -649,6 +653,7 @@ def _dotenv_environment(
             `.env` contributes, i.e. what `include_global=False` would return.
             Lets a caller that needs both layers get them from one pass instead
             of re-walking and re-parsing the whole stack.
+        provenance: Filled with the dotenv path that supplied each applied key.
 
     Returns:
         A new effective environment mapping.
@@ -696,6 +701,8 @@ def _dotenv_environment(
             if key in env:
                 continue
             env[key] = value
+            if provenance is not None:
+                provenance[key] = dotenv_path
 
     discovery_root = start_path or Path.cwd()
     try:
@@ -864,6 +871,7 @@ def _load_dotenv(
     if refresh_loaded:
         _strip_dotenv_loaded_values(os.environ)
         _dotenv_loaded_values.clear()
+        _dotenv_provenance.clear()
 
     baseline = dict(os.environ)
     # The project layer alone, because the global profile `.env` configures the
@@ -874,13 +882,18 @@ def _load_dotenv(
     project: dict[str, str] | None = {} if capture_user_langsmith else None
     if capture_user_langsmith:
         _initialize_launch_langsmith_env(baseline)
+    provenance: dict[str, Path] = {}
     effective = _dotenv_environment(
-        start_path=start_path, environ=baseline, project_layer=project
+        start_path=start_path,
+        environ=baseline,
+        project_layer=project,
+        provenance=provenance,
     )
     for key, value in effective.items():
         if key not in baseline:
             os.environ[key] = value
             _dotenv_loaded_values[key] = value
+            _dotenv_provenance[key] = provenance[key]
     if project is not None:
         _bootstrap_state.user_langsmith_env = _langsmith_selectors_from(project)
     return bool(effective.keys() - baseline.keys())

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -373,6 +373,157 @@ class TestRuntimeDotenvReload:
             config_mod._dotenv_loaded_values.clear()
 
 
+class TestDotenvProvenance:
+    """Dotenv-injected config values identify the file that supplied them."""
+
+    def test_global_dotenv_source_is_rendered_in_text(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Text output names the global file without printing its value."""
+        from deepagents_code.client.commands.config import _run_get
+
+        name = "DEEPAGENTS_CODE_LANGSMITH_REDACT"
+        global_dotenv = tmp_path / "global.env"
+        global_dotenv.write_text(f"{name}=0\n", encoding="utf-8")
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.setattr(config_module, "_GLOBAL_DOTENV_PATH", global_dotenv)
+        monkeypatch.setattr(config_module, "_dotenv_loaded_values", {})
+        monkeypatch.setattr(config_module, "_dotenv_provenance", {})
+
+        config_module._load_dotenv(start_path=tmp_path)
+
+        assert _run_get("tracing.langsmith_redact", "text") == 0
+        output = capsys.readouterr().out
+        compact = "".join(output.splitlines())
+        assert f"env ({name}, {global_dotenv})" in compact
+        assert f"{name}=0" not in output
+
+    def test_project_dotenv_source_is_rendered_in_json(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """JSON output carries the project dotenv path in its source field."""
+        from deepagents_code.client.commands.config import _run_get
+
+        name = "DEEPAGENTS_CODE_SHOW_HEADER"
+        project = tmp_path / "project"
+        project.mkdir()
+        dotenv = project / ".env"
+        dotenv.write_text(f"{name}=false\n", encoding="utf-8")
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.setattr(config_module, "_dotenv_loaded_values", {})
+        monkeypatch.setattr(config_module, "_dotenv_provenance", {})
+
+        config_module._load_dotenv(start_path=project)
+
+        assert _run_get("display.show_header", "json") == 0
+        payload = json.loads(capsys.readouterr().out)["data"]
+        assert payload["source"] == f"env ({name}, {dotenv})"
+
+    def test_shell_env_source_stays_unattributed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A launch environment value remains a bare env source."""
+        from deepagents_code.client.commands.config import _attribute_env_source
+
+        name = "DEEPAGENTS_CODE_SHOW_HEADER"
+        global_dotenv = tmp_path / "global.env"
+        global_dotenv.write_text(f"{name}=false\n", encoding="utf-8")
+        monkeypatch.setenv(name, "true")
+        monkeypatch.setattr(config_module, "_GLOBAL_DOTENV_PATH", global_dotenv)
+        monkeypatch.setattr(config_module, "_dotenv_loaded_values", {})
+        monkeypatch.setattr(config_module, "_dotenv_provenance", {})
+
+        config_module._load_dotenv(start_path=tmp_path)
+
+        assert _attribute_env_source(f"env ({name})") == f"env ({name})"
+        assert name not in config_module._dotenv_provenance
+
+    def test_project_dotenv_provenance_wins_over_global(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """First-file-wins records the project file rather than the global file."""
+        name = "DEEPAGENTS_CODE_SHOW_HEADER"
+        project = tmp_path / "project"
+        project.mkdir()
+        project_dotenv = project / ".env"
+        project_dotenv.write_text(f"{name}=false\n", encoding="utf-8")
+        global_dotenv = tmp_path / "global.env"
+        global_dotenv.write_text(f"{name}=true\n", encoding="utf-8")
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.setattr(config_module, "_GLOBAL_DOTENV_PATH", global_dotenv)
+        monkeypatch.setattr(config_module, "_dotenv_loaded_values", {})
+        monkeypatch.setattr(config_module, "_dotenv_provenance", {})
+
+        config_module._load_dotenv(start_path=project)
+
+        assert config_module._dotenv_provenance[name] == project_dotenv
+
+    def test_denied_dotenv_key_has_no_provenance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Denied values are neither injected nor attributed."""
+        name = "PYTHONPATH"
+        dotenv = tmp_path / ".env"
+        dotenv.write_text(f"{name}=/tmp/forbidden\n", encoding="utf-8")
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.setattr(config_module, "_dotenv_loaded_values", {})
+        monkeypatch.setattr(config_module, "_dotenv_provenance", {})
+
+        config_module._load_dotenv(start_path=tmp_path)
+
+        assert name not in config_module._dotenv_loaded_values
+        assert name not in config_module._dotenv_provenance
+
+    def test_whitespace_only_dotenv_value_is_attributed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An injected whitespace-only value retains its source path."""
+        name = "DEEPAGENTS_CODE_SHOW_HEADER"
+        (tmp_path / ".env").write_text(f"{name}=   \n", encoding="utf-8")
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.setattr(config_module, "_dotenv_loaded_values", {})
+        monkeypatch.setattr(config_module, "_dotenv_provenance", {})
+
+        config_module._load_dotenv(start_path=tmp_path)
+
+        assert config_module._dotenv_loaded_values.get(name) == ""
+        assert config_module._dotenv_provenance[name] == tmp_path / ".env"
+
+    def test_preview_does_not_replace_process_provenance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Workspace previews leave process-level attribution untouched."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".env").write_text(
+            "DEEPAGENTS_CODE_SHOW_HEADER=false\n", encoding="utf-8"
+        )
+        existing = {"EXISTING": tmp_path / "existing.env"}
+        monkeypatch.setattr(config_module, "_dotenv_provenance", existing)
+
+        config_module._preview_dotenv_environ(start_path=project)
+
+        assert config_module._dotenv_provenance == existing
+
+    def test_missing_dotenv_leaves_source_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty provenance map preserves source labels byte-for-byte."""
+        from deepagents_code.client.commands.config import _attribute_env_source
+
+        monkeypatch.setattr(config_module, "_dotenv_loaded_values", {})
+        monkeypatch.setattr(config_module, "_dotenv_provenance", {})
+
+        source = "env (DEEPAGENTS_CODE_SHOW_HEADER)"
+        assert _attribute_env_source(source) == source
+
+
 class TestWorkspaceDotenvEnvironment:
     """Workspace previews stay isolated without replacing the process environment."""
 
@@ -500,9 +651,11 @@ class TestWorkspaceDotenvEnvironment:
         )
         monkeypatch.setattr(manifest, "resolve_read_project_dotenv", lambda **_: True)
 
+        provenance: dict[str, Path] = {}
         from_dotenv = config_mod._dotenv_environment(
             start_path=tmp_path,
             environ={},
+            provenance=provenance,
         )
         from_shell = config_mod._dotenv_environment(
             start_path=tmp_path,
@@ -510,6 +663,7 @@ class TestWorkspaceDotenvEnvironment:
         )
 
         assert from_dotenv["OPENAI_API_KEY"] == "dotenv-key"
+        assert provenance["OPENAI_API_KEY"] == tmp_path / ".env"
         assert "openai_api_key" not in from_dotenv
         assert from_shell["OPENAI_API_KEY"] == "shell-key"
 


### PR DESCRIPTION
`dcode config` now identifies the dotenv file that supplied an effective environment value, while process-environment values retain the existing `env (NAME)` source.

---

Dotenv injection previously erased file provenance before configuration resolution, making project and global overrides indistinguishable from shell exports. This records only the supplying path during dotenv loading, then enriches source labels at the display boundary for text and JSON output. Resolver precedence, workspace previews, `doctor`, `config path`, and secret redaction remain unchanged.

### Before / after

With `DEEPAGENTS_CODE_SHOW_HEADER=false` supplied only by a project `.env`:

**Before** — a dotenv-supplied value is indistinguishable from a shell export, in text and JSON output:

```
$ dcode config get display.show_header
display.show_header = False  (env (DEEPAGENTS_CODE_SHOW_HEADER))

$ dcode config get display.show_header --json
{"schema_version": 1, "command": "config get", "data": {"key": "display.show_header", "source": "env (DEEPAGENTS_CODE_SHOW_HEADER)", "set": true, "redacted": false, "value": false}}
```

**After** — the source label names the file that injected the value:

```
$ dcode config get display.show_header
display.show_header = False  (env (DEEPAGENTS_CODE_SHOW_HEADER, /home/me/project/.env))

$ dcode config get display.show_header --json
{"schema_version": 1, "command": "config get", "data": {"key": "display.show_header", "source": "env (DEEPAGENTS_CODE_SHOW_HEADER, /home/me/project/.env)", "set": true, "redacted": false, "value": false}}
```

A value genuinely exported by the shell keeps the bare `env (NAME)` label, so attribution appears only for values `dcode` itself injected. When both the project and global profile dotenv files define a key, the project file wins, matching first-file-wins resolution.

Made by [Open SWE](https://openswe.vercel.app/agents/284da657-1445-5bfd-8b3f-110768656224) · fireworks:accounts/fireworks/models/glm-5p3-flash (max)