### PR TITLE
fix(code): price Fireworks GLM-5.3 Flash usage

### DIFF
--- a/libs/code/deepagents_code/bundled_prices.json
+++ b/libs/code/deepagents_code/bundled_prices.json
@@ -32,7 +32,8 @@
     "name": "Fireworks",
     "api_pattern": "https://api\\.fireworks\\.ai",
     "models": [
-      { "id": "glm-5p3", "match": { "equals": "accounts/fireworks/models/glm-5p3" }, "price_comments": "Fireworks deployment omitted from pydantic/genai-prices#617", "prices": { "input_mtok": 1.4, "cache_read_mtok": 0.26, "output_mtok": 4.4 } }
+      { "id": "glm-5p3", "match": { "equals": "accounts/fireworks/models/glm-5p3" }, "price_comments": "Fireworks deployment omitted from pydantic/genai-prices#617", "prices": { "input_mtok": 1.4, "cache_read_mtok": 0.26, "output_mtok": 4.4 } },
+      { "id": "glm-5p3-flash", "match": { "equals": "accounts/fireworks/models/glm-5p3-flash" }, "price_comments": "Fireworks deployment omitted from pydantic/genai-prices#617", "prices": { "input_mtok": 0.15, "cache_read_mtok": 0.03, "output_mtok": 0.5 } }
     ]
   }
 ]


### PR DESCRIPTION
Deep Agents Code now reports costs for Fireworks GLM-5.3 Flash instead of treating its usage as unpriced.

---

The Fireworks GLM-5.3 fallback merged without its Flash sibling, which is also absent from `genai-prices`. Add an exact-match fallback for `accounts/fireworks/models/glm-5p3-flash` using Fireworks' published standard rates: $0.15 input, $0.03 cached input, and $0.50 output per million tokens. Upstream remains authoritative when coverage lands.

Made by [Open SWE](https://openswe.vercel.app/agents/f57cbaaa-a9f3-5479-9b4f-b70ff9ce5e93) · openai:gpt-5.6-sol (high)