### PR TITLE
fix(talon): deliver background subagents launched by a scheduled job

### DIFF
--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -238,7 +238,7 @@ async def _run_host_with_agent(
         host.scheduler = PersistentCronScheduler(
             store=cron_store,
             run_job=host.run_scheduled_job,
-            deliver_result=lambda job, text: _deliver_cron_result(host, channels, job, text),
+            deliver_result=lambda job, text: _deliver_cron_result(host, job, text),
         )
     if args.once:
         await _run_once(host)
@@ -351,16 +351,12 @@ def _runtime_env(config: TalonConfig) -> dict[str, str]:
     return values
 
 
-async def _deliver_cron_result(
-    host: TalonHost,
-    channels: Sequence[ChannelAdapter],
-    job: CronJob,
-    text: str,
-) -> None:
-    for channel in channels:
-        if job.origin.channel is None or (await channel.status()).provider == job.origin.channel:
-            await host.deliver_scheduled_result(channel, job, text)
-            return
+async def _deliver_cron_result(host: TalonHost, job: CronJob, text: str) -> None:
+    channel = await host.origin_channel(job.origin)
+    if channel is None:
+        logger.warning("No channel serves cron job %s; dropping its result", job.id)
+        return
+    await host.deliver_scheduled_result(channel, job, text)
 
 
 if __name__ == "__main__":

--- a/libs/talon/deepagents_talon/cron/__init__.py
+++ b/libs/talon/deepagents_talon/cron/__init__.py
@@ -11,10 +11,15 @@ from deepagents_talon.cron.jobs import (
     CronRepeat,
     CronSchedule,
 )
-from deepagents_talon.cron.scheduler import PersistentCronScheduler
+from deepagents_talon.cron.scheduler import (
+    SILENT_SENTINEL,
+    PersistentCronScheduler,
+    is_silent,
+)
 from deepagents_talon.cron.tools import CronTools
 
 __all__ = [
+    "SILENT_SENTINEL",
     "CronJob",
     "CronJobError",
     "CronJobStore",
@@ -23,4 +28,5 @@ __all__ = [
     "CronSchedule",
     "CronTools",
     "PersistentCronScheduler",
+    "is_silent",
 ]

--- a/libs/talon/deepagents_talon/cron/scheduler.py
+++ b/libs/talon/deepagents_talon/cron/scheduler.py
@@ -149,10 +149,10 @@ class PersistentCronScheduler:
             "cron.success",
             job_id=claimed.id,
             job_name=claimed.name,
-            silent=_is_silent(text),
-            has_delivery=bool(text and not _is_silent(text)),
+            silent=is_silent(text),
+            has_delivery=bool(text and not is_silent(text)),
         )
-        if _is_silent(text):
+        if is_silent(text):
             log_event(
                 logger,
                 "cron.delivery_suppressed",
@@ -188,6 +188,14 @@ class PersistentCronScheduler:
             )
 
 
-def _is_silent(text: str) -> bool:
+def is_silent(text: str) -> bool:
+    """Whether a scheduled result asks to be withheld from the chat.
+
+    Args:
+        text: Agent output produced for a scheduled job.
+
+    Returns:
+        Whether the text carries the silent sentinel at either end.
+    """
     stripped = text.strip()
     return stripped.startswith(SILENT_SENTINEL) or stripped.endswith(SILENT_SENTINEL)

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -15,7 +15,7 @@ import tempfile
 from collections import defaultdict
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from pathlib import Path
 from types import FrameType
@@ -31,6 +31,7 @@ from deepagents_talon.authorization import (
     DeviceCode,
 )
 from deepagents_talon.channels.base import outbound_media_root_from_env, send_with_retry
+from deepagents_talon.cron.scheduler import SILENT_SENTINEL, is_silent
 from deepagents_talon.interfaces import (
     AgentRequest,
     AgentResult,
@@ -62,7 +63,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from deepagents_talon.config import TalonConfig
-    from deepagents_talon.cron.jobs import CronJob
+    from deepagents_talon.cron.jobs import CronJob, CronOrigin
     from deepagents_talon.speech import VoiceTranscriber
 
 SignalHandler = Callable[[int, FrameType | None], object] | int | None
@@ -107,6 +108,14 @@ _CANCEL_TIMEOUT_MESSAGE = (
     "Restart Talon to recover."
 )
 _AGENT_FAILURE_MESSAGE = "Something went wrong while working on that. Check Talon logs."
+_SCHEDULED_PREEMPT_FAILURE = (
+    "Could not stop the previous run on this job's thread; restart Talon to recover."
+)
+_BACKGROUND_FOLLOW_UP = "Process the completed background subagent results."
+_SCHEDULED_FOLLOW_UP = (
+    f"{_BACKGROUND_FOLLOW_UP} Report what the user needs to know, or reply "
+    f"{SILENT_SENTINEL} if there is nothing worth sending."
+)
 _BACKGROUND_RETRY_BASE_SECONDS = 2.0
 _BACKGROUND_RETRY_MAX_SECONDS = 60.0
 _EMOJI_VARIATION_SELECTOR = "\ufe0f"
@@ -149,10 +158,30 @@ class _BackgroundRetry:
     deadline: float
 
 
-@dataclass(slots=True)
-class _CronControl:
-    lock: asyncio.Lock
-    users: int = 0
+@dataclass(frozen=True, slots=True)
+class _BackgroundRoute:
+    """Everything needed to start another main-agent turn for one conversation.
+
+    `metadata` is carried here rather than on `message` because a route is stored
+    before the inbound message is prepared, so a channel message's own metadata
+    still describes its media and voice attachments. The dispatcher drops that when
+    it synthesizes the follow-up message; host-set turn metadata has to survive it.
+
+    Args:
+        channel: Channel that receives this conversation's replies.
+        message: Message identifying the reply conversation and its sender.
+        conversation_root: Lock key shared by every turn of this conversation.
+        conversation_id: Agent thread that owns the background workers.
+        provider: Channel provider name, when the adapter reports one.
+        metadata: Turn metadata; a scheduled turn pins its cron identity here.
+    """
+
+    channel: ChannelAdapter
+    message: ChannelMessage
+    conversation_root: str
+    conversation_id: str
+    provider: str | None
+    metadata: Mapping[str, object] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -219,7 +248,6 @@ class TalonHost:
         self.scheduler = scheduler
         self.voice_transcriber = voice_transcriber
         self._locks: dict[str, _ConversationLock] = {}
-        self._cron_controls: dict[str, _CronControl] = {}
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._conversation_tasks: defaultdict[str, set[asyncio.Task[None]]] = defaultdict(set)
         self._generations: defaultdict[str, int] = defaultdict(int)
@@ -230,9 +258,7 @@ class TalonHost:
         self._authorization_flows: dict[str, _AuthorizationFlow] = {}
         self._terminal_authorizations: set[str] = set()
         self._background_loop: asyncio.Task[None] | None = None
-        self._background_routes: dict[
-            str, tuple[ChannelAdapter, ChannelMessage, str, str | None]
-        ] = {}
+        self._background_routes: dict[str, _BackgroundRoute] = {}
         self._background_retries: dict[str, _BackgroundRetry] = {}
         self._stopped = asyncio.Event()
         self._running = False
@@ -439,11 +465,13 @@ class TalonHost:
                 return
 
             await self._replace_agent_turn(
-                channel,
-                message,
-                conversation_root,
-                agent_conversation_id,
-                provider,
+                _BackgroundRoute(
+                    channel=channel,
+                    message=message,
+                    conversation_root=conversation_root,
+                    conversation_id=agent_conversation_id,
+                    provider=provider,
+                ),
             )
 
     async def _handle_conversation_command(
@@ -529,14 +557,10 @@ class TalonHost:
             env=self.config.env,
         )
 
-    async def _replace_agent_turn(
-        self,
-        channel: ChannelAdapter,
-        message: ChannelMessage,
-        conversation_root: str,
-        conversation_id: str,
-        provider: str | None,
-    ) -> None:
+    async def _replace_agent_turn(self, route: _BackgroundRoute) -> None:
+        conversation_id = route.conversation_id
+        channel = route.channel
+        message = route.message
         if conversation_id in self._blocked:
             await send_with_retry(
                 lambda: channel.send_message(message.conversation_id, _CANCEL_TIMEOUT_MESSAGE)
@@ -553,22 +577,16 @@ class TalonHost:
                 return
             recovery_degraded = outcome is _CancelOutcome.DEGRADED
         if isinstance(self.agent, BackgroundRuntime):
-            self._background_routes[conversation_id] = (
-                channel,
-                message,
-                conversation_root,
-                provider,
-            )
+            self._background_routes[conversation_id] = route
         generation = self._generations[conversation_id] + 1
         self._generations[conversation_id] = generation
         task = asyncio.create_task(
             self._run_agent_turn(
-                channel,
-                message,
+                route,
                 _Turn(
-                    conversation_root,
+                    route.conversation_root,
                     conversation_id,
-                    provider,
+                    route.provider,
                     generation,
                     recovery_degraded,
                 ),
@@ -589,8 +607,13 @@ class TalonHost:
     async def _dispatch_background_results(self) -> None:
         if not isinstance(self.agent, BackgroundRuntime):
             return
-        for owner, (channel, message, root, provider) in list(self._background_routes.items()):
+        for owner, route in list(self._background_routes.items()):
+            root = route.conversation_root
             control = self._locks.get(root)
+            # Nothing may await between this check and the acquire below. A scheduled
+            # job holds its conversation lock for the whole of a run that can last
+            # minutes, so a suspension point here would let this sequential loop block
+            # on that lock and stall delivery for every other conversation.
             if control is not None and control.lock.locked():
                 # A turn or a command owns this conversation, and cancelling one can
                 # take 30 seconds. Leave it and retry on the next tick.
@@ -610,15 +633,14 @@ class TalonHost:
                     continue
                 if self._claim_background_turn(owner):
                     await self._replace_agent_turn(
-                        channel,
-                        ChannelMessage(
-                            message.conversation_id,
-                            "Process the completed background subagent results.",
-                            sender_id=message.sender_id,
+                        replace(
+                            route,
+                            message=ChannelMessage(
+                                route.message.conversation_id,
+                                _follow_up_prompt(route),
+                                sender_id=route.message.sender_id,
+                            ),
                         ),
-                        root,
-                        owner,
-                        provider,
                     )
 
     def _claim_background_turn(self, owner: str) -> bool:
@@ -642,20 +664,28 @@ class TalonHost:
 
     async def _run_agent_turn(
         self,
-        channel: ChannelAdapter,
-        message: ChannelMessage,
+        route: _BackgroundRoute,
         turn: _Turn,
     ) -> None:
+        channel = route.channel
         agent_conversation_id = turn.conversation_id
-        message = await transcribe_voice_message(self.voice_transcriber, message)
+        message = await transcribe_voice_message(self.voice_transcriber, route.message)
         message = _prepare_inbound_message(message)
         metadata: dict[str, object] = {
             "channel": turn.provider,
             "sender_id": message.sender_id,
             "message_id": message.message_id,
             **message.metadata,
+            # Last, so channel-supplied inbound metadata can never restate a field the
+            # host sets. A scheduled turn's cron identity is what its tools scope by.
+            **route.metadata,
         }
-        if isinstance(self.agent, ConversationHistoryRuntime) and self.agent.history_enabled:
+        scheduled = metadata.get("trigger") == "cron"
+        if (
+            isinstance(self.agent, ConversationHistoryRuntime)
+            and self.agent.history_enabled
+            and not scheduled
+        ):
             metadata["history_channel"] = _channel_key(channel, turn.provider)
             metadata["history_chat"] = message.conversation_id
         if turn.recovery_degraded:
@@ -676,23 +706,43 @@ class TalonHost:
                 conversation_id=agent_conversation_id,
                 text=message.text,
                 metadata=metadata,
-                approval_handler=lambda approval: self._request_tool_approval(
-                    channel,
-                    approval,
-                    provider=_channel_key(channel, turn.provider),
-                    reply_conversation_id=message.conversation_id,
-                    sender_id=message.sender_id,
+                # A scheduled turn has no operator to ask. Approvals are auto-denied
+                # upstream for `trigger: cron`, and an authorization prompt raises on
+                # the absent sender rather than reaching anyone, so both are withheld
+                # exactly as `run_scheduled_job` withholds them.
+                approval_handler=None
+                if scheduled
+                else (
+                    lambda approval: self._request_tool_approval(
+                        channel,
+                        approval,
+                        provider=_channel_key(channel, turn.provider),
+                        reply_conversation_id=message.conversation_id,
+                        sender_id=message.sender_id,
+                    )
                 ),
-                authorization_handler=lambda event: self._handle_authorization_event(
-                    channel,
-                    event,
-                    provider=_channel_key(channel, turn.provider),
-                    reply_conversation_id=message.conversation_id,
-                    agent_conversation_id=agent_conversation_id,
-                    sender_id=message.sender_id,
+                authorization_handler=None
+                if scheduled
+                else (
+                    lambda event: self._handle_authorization_event(
+                        channel,
+                        event,
+                        provider=_channel_key(channel, turn.provider),
+                        reply_conversation_id=message.conversation_id,
+                        agent_conversation_id=agent_conversation_id,
+                        sender_id=message.sender_id,
+                    )
                 ),
             )
             suppress_result = agent_conversation_id in self._terminal_authorizations
+            if scheduled and is_silent(result.text):
+                log_event(
+                    logger,
+                    "cron.background_suppressed",
+                    job_id=metadata.get("cron_job_id"),
+                    job_name=metadata.get("cron_job_name"),
+                )
+                suppress_result = True
         except Exception:  # noqa: BLE001  # _invoke_agent logged the traceback for operators
             result = AgentResult(text=_AGENT_FAILURE_MESSAGE)
         finally:
@@ -716,29 +766,103 @@ class TalonHost:
 
         Returns:
             Agent text output for scheduler delivery handling.
+
+        Raises:
+            RuntimeError: If a turn already running on this job's thread could not be
+                stopped first.
         """
         conversation_id = f"{job.id}{_CRON_THREAD_SUFFIX}"
-        control = self._cron_controls.setdefault(job.id, _CronControl(asyncio.Lock()))
-        control.users += 1
-        try:
-            async with control.lock:
-                result = await self._invoke_agent(
-                    conversation_id=conversation_id,
-                    text=job.prompt,
-                    metadata={
-                        "channel": job.origin.channel,
-                        "cron_job_id": job.id,
-                        "cron_job_name": job.name,
-                        "origin_conversation_id": job.origin.conversation_id,
-                        "cron_origin_message_id": job.origin.message_id,
-                        "trigger": "cron",
-                    },
-                )
-                return result.text
-        finally:
-            control.users -= 1
-            if control.users == 0 and self._cron_controls.get(job.id) is control:
-                del self._cron_controls[job.id]
+        # Held across the whole run, as the per-job lock it replaces was. It keeps two
+        # fires off one graph thread, and it keeps the background dispatcher from
+        # popping this job's route before the run has had a chance to delegate.
+        async with self._conversation_lock(conversation_id):
+            await self._preempt_scheduled_turn(conversation_id)
+            self._route_scheduled_background(
+                job,
+                conversation_id,
+                await self.origin_channel(job.origin),
+            )
+            result = await self._invoke_agent(
+                conversation_id=conversation_id,
+                text=job.prompt,
+                metadata=_scheduled_metadata(job),
+            )
+            return result.text
+
+    async def _preempt_scheduled_turn(self, conversation_id: str) -> None:
+        """Clear a background follow-up turn before a new run writes the same thread.
+
+        Args:
+            conversation_id: Scheduled job thread about to be invoked.
+
+        Raises:
+            RuntimeError: If a turn already on this thread could not be stopped, so
+                the scheduler records the run as failed instead of writing the thread
+                underneath a live one.
+        """
+        if conversation_id in self._blocked:
+            raise RuntimeError(_SCHEDULED_PREEMPT_FAILURE)
+        active = self._tasks.get(conversation_id)
+        if active is None or active.done():
+            return
+        # Deliberately not `_cancel_conversation_tasks`: that also cancels this
+        # thread's workers and drops its route, discarding the very results the turn
+        # was consuming. Cancelling the turn alone leaves them unacknowledged -- the
+        # runtime skips `record_delivery_failure` for a cancellation -- so the
+        # dispatcher delivers them again once this run releases the thread.
+        if await self._cancel_active(conversation_id, active, recover=True) is (
+            _CancelOutcome.TIMEOUT
+        ):
+            raise RuntimeError(_SCHEDULED_PREEMPT_FAILURE)
+
+    def _route_scheduled_background(
+        self,
+        job: CronJob,
+        conversation_id: str,
+        channel: ChannelAdapter | None,
+    ) -> None:
+        """Point a scheduled job's background results at its origin conversation.
+
+        Registered before the run, not after: the scheduler swallows whatever
+        `run_scheduled_job` raises, so a run that fails after delegating would
+        otherwise strand its subagent with nothing to deliver it. A route for a job
+        that delegates nothing is dropped by the dispatcher on its next tick.
+
+        Args:
+            job: Claimed cron job about to run.
+            conversation_id: Thread the job runs on, which owns its background work.
+            channel: Channel serving the job's origin, if one does.
+        """
+        if not isinstance(self.agent, BackgroundRuntime):
+            return
+        if channel is None:
+            logger.warning(
+                "No channel serves cron job %s; its background results cannot be delivered",
+                job.id,
+            )
+            return
+        self._background_routes[conversation_id] = _BackgroundRoute(
+            channel=channel,
+            message=ChannelMessage(job.origin.conversation_id, job.prompt),
+            conversation_root=conversation_id,
+            conversation_id=conversation_id,
+            provider=job.origin.channel,
+            metadata=_scheduled_metadata(job),
+        )
+
+    async def origin_channel(self, origin: CronOrigin) -> ChannelAdapter | None:
+        """Return the channel serving a scheduled job's origin conversation.
+
+        Args:
+            origin: Conversation that receives a job's results.
+
+        Returns:
+            First channel matching the origin, or `None` when no channel does.
+        """
+        for channel in self.channels:
+            if origin.channel is None or await _channel_provider(channel) == origin.channel:
+                return channel
+        return None
 
     async def deliver_scheduled_result(
         self,
@@ -1522,6 +1646,44 @@ def _outbound_media_from_refs(
             path = getattr(ref, "path", None)
             failed.append(getattr(ref, "alt", "") or getattr(path, "name", "attachment"))
     return media, failed
+
+
+def _scheduled_metadata(job: CronJob) -> dict[str, object]:
+    """Return the turn metadata identifying one scheduled job's thread.
+
+    One source for both a job's own run and any later background follow-up turn on
+    the same thread, so the two agree on every field the runtime reads from them --
+    `trigger`, which auto-denies tool approvals a scheduled turn has no operator to
+    answer, and `channel`, which the cron tools scope a job's own edits by.
+
+    Args:
+        job: Cron job whose thread the turn runs on.
+
+    Returns:
+        Turn metadata for a scheduled run.
+    """
+    return {
+        "channel": job.origin.channel,
+        "cron_job_id": job.id,
+        "cron_job_name": job.name,
+        "origin_conversation_id": job.origin.conversation_id,
+        "cron_origin_message_id": job.origin.message_id,
+        "trigger": "cron",
+    }
+
+
+def _follow_up_prompt(route: _BackgroundRoute) -> str:
+    """Return the prompt that asks a conversation to process finished background work.
+
+    Args:
+        route: Conversation whose background results are ready.
+
+    Returns:
+        Prompt text; a scheduled conversation is also told how to stay silent.
+    """
+    if route.metadata.get("trigger") == "cron":
+        return _SCHEDULED_FOLLOW_UP
+    return _BACKGROUND_FOLLOW_UP
 
 
 def _conversation_key(provider: str, conversation_id: str) -> str:

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -1103,6 +1103,45 @@ async def test_second_cron_run_preempts_a_pending_background_turn(tmp_path: Path
         await host.stop()
 
 
+async def test_preempting_a_turn_blocked_on_the_conversation_lock_completes(
+    tmp_path: Path,
+) -> None:
+    """A run preempts a follow-up turn while holding the lock that turn is awaiting.
+
+    `_run_agent_turn` takes the conversation lock only to deliver, so a follow-up
+    turn can be parked on it at the moment a scheduled run acquires it and preempts.
+    Cancellation has to be what releases it; anything that waited for the turn to
+    make progress instead would deadlock the scheduler against its own thread.
+    """
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    cron_id = "job:talon-cron"
+    await host.start()
+    try:
+        parked = asyncio.Event()
+
+        async def blocked_turn() -> None:
+            parked.set()
+            async with host._conversation_lock(cron_id):
+                pass
+
+        async with host._conversation_lock(cron_id):
+            turn = asyncio.create_task(blocked_turn())
+            host._tasks[cron_id] = turn
+            await asyncio.wait_for(parked.wait(), 2)
+            for _ in range(10):
+                await asyncio.sleep(0)
+
+            await asyncio.wait_for(host._preempt_scheduled_turn(cron_id), 2)
+
+        assert turn.cancelled()
+        assert agent.recoveries == [cron_id]
+        assert cron_id not in host._blocked
+    finally:
+        await host.stop()
+
+
 async def test_two_runs_of_one_job_never_overlap(tmp_path: Path) -> None:
     channel = RecordingChannel()
     agent = BlockingAgent()

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -8,7 +8,13 @@ from typing import TYPE_CHECKING, cast
 from deepagents_talon.background import BackgroundSubagents
 from deepagents_talon.config import TalonConfig
 from deepagents_talon.cron import CronJobStore, CronOrigin, CronSchedule
-from deepagents_talon.host import TalonHost, _save_conversation_resets
+from deepagents_talon.host import (
+    _BACKGROUND_FOLLOW_UP,
+    _SCHEDULED_FOLLOW_UP,
+    TalonHost,
+    _BackgroundRoute,
+    _save_conversation_resets,
+)
 from deepagents_talon.interfaces import (
     AgentRequest,
     AgentResult,
@@ -847,6 +853,301 @@ async def test_cancellation_timeout_blocks_until_host_restart(
     await host.stop()
 
 
+class DelegatingCronAgent(BlockingAgent):
+    """Agent that delegates on a scheduled run and answers the follow-up turn."""
+
+    def __init__(self, *, follow_up: str = "digest", history: bool = False) -> None:
+        super().__init__()
+        self.background = StubBackground()
+        self.follow_up = follow_up
+        self.history_enabled = history
+        self.fires = 0
+
+    async def invoke(self, request: AgentRequest) -> AgentResult:
+        self.requests.append(request)
+        if request.text.startswith(_BACKGROUND_FOLLOW_UP):
+            self.background.pending.discard(request.conversation_id)
+            return AgentResult(text=self.follow_up)
+        self.fires += 1
+        if self.fires == 1:
+            self.background.pending.add(request.conversation_id)
+        return AgentResult(text="[SILENT]")
+
+
+class BlockingFollowUpCronAgent(DelegatingCronAgent):
+    """Agent whose background follow-up turn blocks until released."""
+
+    async def invoke(self, request: AgentRequest) -> AgentResult:
+        if request.text.startswith(_BACKGROUND_FOLLOW_UP):
+            self.requests.append(request)
+            await self.released.wait()
+            return AgentResult(text=self.follow_up)
+        return await super().invoke(request)
+
+
+class RouteAssertingCronAgent(BlockingAgent):
+    """Agent that records whether its route existed, then fails the run."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.background = StubBackground()
+        self.host: TalonHost | None = None
+        self.routed_at_invoke: list[bool] = []
+
+    async def invoke(self, request: AgentRequest) -> AgentResult:
+        self.requests.append(request)
+        assert self.host is not None
+        self.routed_at_invoke.append(request.conversation_id in self.host._background_routes)
+        self.background.pending.add(request.conversation_id)
+        message = "scheduled run exploded"
+        raise RuntimeError(message)
+
+
+def _cron_job(tmp_path: Path, *, prompt: str = "scan the market", channel: str | None = None):
+    store = CronJobStore(assistant_id="test", cron_dir=tmp_path / "test" / "cron")
+    return store.create_job(
+        prompt=prompt,
+        schedule=CronSchedule.parse("in 5m"),
+        origin=CronOrigin(conversation_id="chat", channel=channel),
+    )
+
+
+async def test_cron_background_result_reaches_the_job_origin_chat(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = DelegatingCronAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    job = _cron_job(tmp_path)
+    cron_id = f"{job.id}:talon-cron"
+    await host.start()
+    try:
+        assert await host.run_scheduled_job(job) == "[SILENT]"
+        assert channel.sent == []
+
+        await host._dispatch_background_results()
+        await asyncio.wait_for(host._tasks[cron_id], 2)
+
+        assert channel.sent == [("chat", "digest")]
+        assert agent.requests[-1].conversation_id == cron_id
+        assert agent.requests[-1].text.startswith(_BACKGROUND_FOLLOW_UP)
+    finally:
+        await host.stop()
+
+
+@pytest.mark.parametrize("origin_channel", [None, "test"])
+async def test_cron_background_turn_keeps_the_job_identity(
+    tmp_path: Path, origin_channel: str | None
+) -> None:
+    channel = RecordingChannel()
+    agent = DelegatingCronAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    job = _cron_job(tmp_path, channel=origin_channel)
+    await host.start()
+    try:
+        await host.run_scheduled_job(job)
+        await host._dispatch_background_results()
+        await asyncio.wait_for(host._tasks[f"{job.id}:talon-cron"], 2)
+
+        metadata = agent.requests[-1].metadata
+        assert metadata["trigger"] == "cron"
+        assert metadata["cron_job_id"] == job.id
+        assert metadata["origin_conversation_id"] == "chat"
+        # `_same_origin_scope` compares the channel too, so a follow-up turn that
+        # reported the resolved provider here could not find its own job.
+        assert metadata["channel"] == origin_channel
+        # Identical to the run's own metadata in every field the runtime reads, so
+        # the follow-up turn cannot behave as a different kind of turn.
+        run_metadata = agent.requests[0].metadata
+        assert {key: metadata[key] for key in run_metadata} == dict(run_metadata)
+    finally:
+        await host.stop()
+
+
+async def test_cron_background_turn_gets_no_operator_handlers(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = DelegatingCronAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    job = _cron_job(tmp_path)
+    await host.start()
+    try:
+        await host.run_scheduled_job(job)
+        await host._dispatch_background_results()
+        await asyncio.wait_for(host._tasks[f"{job.id}:talon-cron"], 2)
+
+        # An approval prompt would be keyed by the cron thread but answered in the
+        # chat thread, and the wait on it has no timeout.
+        assert agent.requests[-1].approval_handler is None
+        assert agent.requests[-1].authorization_handler is None
+    finally:
+        await host.stop()
+
+
+async def test_cron_background_turn_is_not_archived_into_the_chat(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = DelegatingCronAgent(history=True)
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    job = _cron_job(tmp_path)
+    await host.start()
+    try:
+        await host.run_scheduled_job(job)
+        await host._dispatch_background_results()
+        await asyncio.wait_for(host._tasks[f"{job.id}:talon-cron"], 2)
+
+        assert "history_chat" not in agent.requests[-1].metadata
+        assert "history_channel" not in agent.requests[-1].metadata
+    finally:
+        await host.stop()
+
+
+@pytest.mark.parametrize("reply", ["[SILENT]", "nothing moved [SILENT]"])
+async def test_cron_background_reply_is_suppressed_when_silent(
+    tmp_path: Path, reply: str, caplog
+) -> None:
+    channel = RecordingChannel()
+    agent = DelegatingCronAgent(follow_up=reply)
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    job = _cron_job(tmp_path)
+    await host.start()
+    try:
+        with caplog.at_level(logging.INFO, logger="deepagents_talon.host"):
+            await host.run_scheduled_job(job)
+            await host._dispatch_background_results()
+            await asyncio.wait_for(host._tasks[f"{job.id}:talon-cron"], 2)
+
+        assert channel.sent == []
+        events = _talon_events(caplog, "cron.background_suppressed")
+        assert [event["job_id"] for event in events] == [job.id]
+    finally:
+        await host.stop()
+
+
+async def test_cron_route_is_registered_before_the_run(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = RouteAssertingCronAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    agent.host = host
+    job = _cron_job(tmp_path)
+    await host.start()
+    try:
+        with pytest.raises(RuntimeError, match="scheduled run exploded"):
+            await host.run_scheduled_job(job)
+
+        # The scheduler swallows this raise, so a run that fails after delegating
+        # still needs the route its subagent will be delivered through.
+        assert agent.routed_at_invoke == [True]
+        assert f"{job.id}:talon-cron" in host._background_routes
+    finally:
+        await host.stop()
+
+
+async def test_cron_route_is_dropped_when_the_job_delegates_nothing(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = RoutedAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    job = _cron_job(tmp_path)
+    await host.start()
+    try:
+        assert await host.run_scheduled_job(job) == "reply:scan the market"
+        assert f"{job.id}:talon-cron" in host._background_routes
+
+        await host._dispatch_background_results()
+
+        assert host._background_routes == {}
+        assert host._locks == {}
+        assert dict(host._generations) == {}
+    finally:
+        await host.stop()
+
+
+async def test_cron_route_addresses_the_channel_matching_the_job_origin(tmp_path: Path) -> None:
+    first = RecordingChannel(provider="whatsapp")
+    second = RecordingChannel(provider="telegram")
+    agent = DelegatingCronAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[first, second])
+    job = _cron_job(tmp_path, channel="telegram")
+    await host.start()
+    try:
+        await host.run_scheduled_job(job)
+        await host._dispatch_background_results()
+        await asyncio.wait_for(host._tasks[f"{job.id}:talon-cron"], 2)
+
+        assert first.sent == []
+        assert second.sent == [("chat", "digest")]
+    finally:
+        await host.stop()
+
+
+async def test_second_cron_run_preempts_a_pending_background_turn(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = BlockingFollowUpCronAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    job = _cron_job(tmp_path)
+    cron_id = f"{job.id}:talon-cron"
+    await host.start()
+    try:
+        await host.run_scheduled_job(job)
+        await host._dispatch_background_results()
+        await _wait_for_request(agent, _SCHEDULED_FOLLOW_UP)
+        follow_up = host._tasks[cron_id]
+
+        await host.run_scheduled_job(job)
+
+        assert follow_up.cancelled()
+        assert agent.recoveries == [cron_id]
+        # The turn was cancelled, not the workers: the results it was consuming are
+        # still pending, so the dispatcher delivers them again.
+        assert agent.background.pending == {cron_id}
+        assert cron_id in host._background_routes
+        assert channel.sent == []
+    finally:
+        agent.released.set()
+        await host.stop()
+
+
+async def test_two_runs_of_one_job_never_overlap(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    job = _cron_job(tmp_path, prompt="block")
+    await host.start()
+    try:
+        first = asyncio.create_task(host.run_scheduled_job(job))
+        await _wait_for_request(agent, "block")
+        second = asyncio.create_task(host.run_scheduled_job(job))
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+        assert len(agent.requests) == 1
+
+        agent.released.set()
+        assert await asyncio.wait_for(first, 2) == "reply:block"
+        assert await asyncio.wait_for(second, 2) == "reply:block"
+        assert len(agent.requests) == 2
+    finally:
+        await host.stop()
+
+
+async def test_channel_background_turn_keeps_its_operator_context(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = RoutedAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        agent.background.pending.add("test:chat")
+        await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="hello"))
+        await asyncio.wait_for(host._tasks["test:chat"], 2)
+
+        await host._dispatch_background_results()
+        await asyncio.wait_for(host._tasks["test:chat"], 2)
+
+        follow_up = agent.requests[-1]
+        assert follow_up.text == _BACKGROUND_FOLLOW_UP
+        assert "trigger" not in follow_up.metadata
+        assert follow_up.approval_handler is not None
+        assert follow_up.authorization_handler is not None
+    finally:
+        await host.stop()
+
+
 async def test_host_sends_markdown_media_refs_as_channel_media(tmp_path: Path) -> None:
     channel = RecordingChannel()
     workspace = tmp_path / "workspace"
@@ -1621,11 +1922,12 @@ async def test_one_locked_conversation_does_not_stall_delivery_for_others(
     try:
         for owner in ("stuck", "waiting"):
             agent.background.pending.add(owner)
-            host._background_routes[owner] = (
-                channel,
-                ChannelMessage(owner, "research"),
-                owner,
-                "test",
+            host._background_routes[owner] = _BackgroundRoute(
+                channel=channel,
+                message=ChannelMessage(owner, "research"),
+                conversation_root=owner,
+                conversation_id=owner,
+                provider="test",
             )
         held = asyncio.Event()
         release = asyncio.Event()


### PR DESCRIPTION
**Stack 5 of 5 — scheduled-job background delivery.** Based on `linted/talon/lifecycle-4-review-fixes` (#6169). Review levels 1–4 first.

From a bug report of six defects. Five did not survive checking against the stack tip, so only this one is fixed here; the triage is at the bottom so they are not re-reported.

### The defect

`run_scheduled_job` runs a job on a thread of its own, `{job.id}:talon-cron`, but `_replace_agent_turn` was the only place that ever wrote `_background_routes` — and `_dispatch_background_results` walks nothing else. A subagent delegated during a cron turn was invisible to delivery: it finished, set its result, and sat in `BackgroundSubagents._jobs` forever. It was not even counted as a *failed* delivery, because `record_delivery_failure` only sees results a turn actually picked up — so those jobs also accumulated against the global `_MAX_TASKS` until delegation wedged for every conversation. That second effect was reported separately as a job-table leak; it is the same defect, and it drains once this one is fixed.

### The fix

A scheduled job now registers a route, so the existing machinery applies unchanged: when the subagent finishes, the host runs a follow-up main-agent turn on the cron thread with the results injected, and delivers *that turn's reply*. **No subagent output reaches the user directly** — the conversation that delegated the work is the one that decides what to say, and `[SILENT]` lets it decide to say nothing, exactly as it can for the run itself.

Three things this required, each load-bearing:

- **The route is registered before the run, not after.** The scheduler swallows whatever `run_scheduled_job` raises, so a run that fails *after* delegating is precisely the case that needs a route. That is only safe because the run now holds the shared `_conversation_lock` for its whole duration, which is what stops the dispatcher popping the route before the run has delegated anything.
- **That lock replaces `_CronControl`** — an identical refcounted lock the cron path kept for itself — but it is not sufficient alone, because `_run_agent_turn` takes the lock only to *deliver*. A second run therefore preempts a pending follow-up turn explicitly, cancelling the turn alone rather than going through `_cancel_conversation_tasks`, which would discard the very results it was consuming.
- **The follow-up turn has to be a scheduled turn**, not a chat turn that happens to run on a cron thread, so the route carries the run's own metadata and merges it last. Without `trigger: cron` the turn bypasses the upstream approval auto-deny and reaches `_request_tool_approval`, which keys the pending approval by the cron thread while prompting in the chat thread — the reply looks up a different key, and the wait on it has no timeout. Without `channel` taken from the job's origin rather than the resolved provider, `_same_origin_scope` compares a provider name against the origin's `None` and the agent's own cron tools stop finding the job they are running under. For the same reason the turn is given neither handler and is kept out of chat history: its transcript belongs to the schedule, not to the user's conversation.

`__main__._deliver_cron_result` now shares the host's channel resolution rather than keeping a second copy of the rule — two independent answers to "which channel does this job talk to" is the drift that produced this defect.

### On the dispatcher's check-then-acquire

`_dispatch_background_results` tests `self._locks.get(root)` and then acquires, with no await between. That was always true; it becomes load-bearing here, because a scheduled run can now hold that lock for minutes rather than milliseconds, and a suspension point inserted between those two lines would let the sequential loop block and stall delivery for every other conversation — reintroducing what `e29bd9c32` fixed. There is a comment on it now.

### Tests

Eleven new tests, all of which fail on `b826f1b48`. The headline one fails there with `KeyError: '…:talon-cron'` — no turn is ever started for the cron thread. Also covered: the run's and the follow-up's metadata agreeing field-for-field, both handlers withheld, history suppression, `[SILENT]` in leading and trailing form, the route surviving a run that raises, the route being dropped when a job delegates nothing, channel matching across two providers, and two runs of one job never overlapping (which `_CronControl` had no test for at all).

One test exists for the deadlock specifically: a follow-up turn parked on the conversation lock, preempted by a run holding that same lock. Cancellation is what releases it, and a preempt that waited for progress instead would deadlock the scheduler against its own thread.

### Triage of the other five reported items

| # | Claim | Verdict |
|---|---|---|
| 2 | "Silent 1-hour collapse; no logging anywhere in `background.py`" | **Already fixed on this stack.** `background.py` logs the failure and distinguishes `_TIMED_OUT_RESULT` from `_FAILED_RESULT` via `timeout.expired()`. Written against `main`, where neither exists. |
| 3 | "Global 4-slot cap starves later delegations" | The cap **is** global. The stated cause is not: nothing in the package prompts for 4-wide fan-out, and `_INSTRUCTIONS` says the opposite. Left alone deliberately. |
| 4 | "Job-table leak" | Real, and a consequence of this defect — fixed here by routing those results into the existing three-strike drop. |
| 5 | "Post-cancel destruction + hard block" | Both halves are deliberate and asserted, by `test_conversation_cancel_discards_finished_results` and `test_cancellation_timeout_blocks_until_host_restart`. |
| 6 | "Ack-regardless race" | Mechanism does not hold: `acknowledge(pending)` receives the snapshot taken at turn start, so a result landing mid-turn is never acknowledged. It waits for the next turn, as intended. |

Rejected alternative, for the record: routing cron subagent results into the *origin chat's* thread. `BackgroundSubagents` keys jobs by the spawning turn's `thread_id` and `invoke` pulls `results(request.conversation_id)`, so that needs an owner→delivery-thread indirection inside the runtime, and it splices a scheduled job's internal transcript into the user's own conversation.

Adjacent defect found while tracing and **not** fixed here: `host.stop()` never calls `background.cancel()`, so background workers survive host shutdown until the loop dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)