### PR TITLE
fix(code): read and write packaged text as UTF-8

### DIFF
--- a/libs/code/deepagents_code/_testing_models.py
+++ b/libs/code/deepagents_code/_testing_models.py
@@ -156,7 +156,7 @@ class DeterministicIntegrationChatModel(_ToolBindingFakeModel):
         if not gate_dir:
             return
         gate = Path(gate_dir)
-        (gate / "entered").write_text("1")
+        (gate / "entered").write_text("1", encoding="utf-8")
         deadline = time.monotonic() + 120
         while not (gate / "release").exists():
             if time.monotonic() > deadline:

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1374,7 +1374,7 @@ def reset_agent(
             )
             raise SystemExit(1)
 
-        source_content = source_md.read_text()
+        source_content = source_md.read_text(encoding="utf-8")
         action_desc = f"contents of agent '{source_agent}'"
     else:
         source_content = get_default_coding_instructions()
@@ -1408,7 +1408,7 @@ def reset_agent(
 
     agent_dir.mkdir(parents=True, exist_ok=True)
     agent_md = agent_dir / "AGENTS.md"
-    agent_md.write_text(source_content)
+    agent_md.write_text(source_content, encoding="utf-8")
 
     if output_format == "json":
         from deepagents_code.output import write_json
@@ -1566,7 +1566,7 @@ def get_system_prompt(
         ```
     """
     prompt_dir = Path(__file__).parent
-    template = (prompt_dir / "system_prompt.md").read_text()
+    template = (prompt_dir / "system_prompt.md").read_text(encoding="utf-8")
 
     skills_path = PATHS.display(PATHS.profile.agent_skills_dir(assistant_id))
 

--- a/libs/code/deepagents_code/built_in_skills/skill-creator/scripts/init_skill.py
+++ b/libs/code/deepagents_code/built_in_skills/skill-creator/scripts/init_skill.py
@@ -274,7 +274,7 @@ def init_skill(skill_name, path):
 
     skill_md_path = skill_dir / "SKILL.md"
     try:
-        skill_md_path.write_text(skill_content)
+        skill_md_path.write_text(skill_content, encoding="utf-8")
         print("Created SKILL.md")
     except Exception as e:
         print(f"Error creating SKILL.md: {e}")
@@ -286,7 +286,9 @@ def init_skill(skill_name, path):
         scripts_dir = skill_dir / "scripts"
         scripts_dir.mkdir(exist_ok=True)
         example_script = scripts_dir / "example.py"
-        example_script.write_text(EXAMPLE_SCRIPT.format(skill_name=skill_name))
+        example_script.write_text(
+            EXAMPLE_SCRIPT.format(skill_name=skill_name), encoding="utf-8"
+        )
         example_script.chmod(0o755)
         print("Created scripts/example.py")
 
@@ -294,14 +296,16 @@ def init_skill(skill_name, path):
         references_dir = skill_dir / "references"
         references_dir.mkdir(exist_ok=True)
         example_reference = references_dir / "api_reference.md"
-        example_reference.write_text(EXAMPLE_REFERENCE.format(skill_title=skill_title))
+        example_reference.write_text(
+            EXAMPLE_REFERENCE.format(skill_title=skill_title), encoding="utf-8"
+        )
         print("Created references/api_reference.md")
 
         # Create assets/ directory with example asset placeholder
         assets_dir = skill_dir / "assets"
         assets_dir.mkdir(exist_ok=True)
         example_asset = assets_dir / "example_asset.txt"
-        example_asset.write_text(EXAMPLE_ASSET)
+        example_asset.write_text(EXAMPLE_ASSET, encoding="utf-8")
         print("Created assets/example_asset.txt")
     except Exception as e:
         print(f"Error creating resource directories: {e}")

--- a/libs/code/deepagents_code/built_in_skills/skill-creator/scripts/quick_validate.py
+++ b/libs/code/deepagents_code/built_in_skills/skill-creator/scripts/quick_validate.py
@@ -32,7 +32,7 @@ def validate_skill(skill_path):
         return False, "SKILL.md not found"
 
     # Read and validate frontmatter
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding="utf-8")
     if not content.startswith("---"):
         return False, "No YAML frontmatter found"
 

--- a/libs/code/deepagents_code/client/launch/server.py
+++ b/libs/code/deepagents_code/client/launch/server.py
@@ -248,7 +248,7 @@ def generate_langgraph_json(
         config["checkpointer"] = {"path": checkpointer_path}
 
     output_path = Path(output_dir) / "langgraph.json"
-    output_path.write_text(json.dumps(config, indent=2))
+    output_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
     return output_path
 
 

--- a/libs/code/deepagents_code/client/launch/server_manager.py
+++ b/libs/code/deepagents_code/client/launch/server_manager.py
@@ -160,7 +160,7 @@ async def create_checkpointer():
     async with AsyncSqliteSaver.from_conn_string(db_path) as saver:
         yield saver
 '''
-    (work_dir / "checkpointer.py").write_text(content)
+    (work_dir / "checkpointer.py").write_text(content, encoding="utf-8")
 
 
 def _write_pyproject(work_dir: Path) -> None:
@@ -184,7 +184,7 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 """
-    (work_dir / "pyproject.toml").write_text(content)
+    (work_dir / "pyproject.toml").write_text(content, encoding="utf-8")
 
 
 def _default_package_project_root() -> Path | None:

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -5474,7 +5474,7 @@ def get_default_coding_instructions() -> str:
         The default agent instructions as a string.
     """
     default_prompt_path = Path(__file__).parent / "default_agent_prompt.md"
-    return default_prompt_path.read_text()
+    return default_prompt_path.read_text(encoding="utf-8")
 
 
 _BEDROCK_REGION_PREFIXES = ("us.", "eu.", "apac.", "us-gov.")

--- a/libs/code/deepagents_code/hooks/legacy.py
+++ b/libs/code/deepagents_code/hooks/legacy.py
@@ -146,7 +146,7 @@ def _load_hooks() -> list[dict[str, Any]]:
         return _hooks_config
 
     try:
-        data = json.loads(hooks_path.read_text())
+        data = json.loads(hooks_path.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
             logger.warning(
                 "Hooks config at %s must be a JSON object, got %s",
@@ -165,7 +165,7 @@ def _load_hooks() -> list[dict[str, Any]]:
             _hooks_config = []
             return _hooks_config
         _hooks_config = hooks
-    except (json.JSONDecodeError, OSError) as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError, OSError) as exc:
         logger.warning("Failed to load hooks config from %s: %s", hooks_path, exc)
         _hooks_config = []
 

--- a/libs/code/deepagents_code/skills/commands.py
+++ b/libs/code/deepagents_code/skills/commands.py
@@ -488,7 +488,7 @@ def _create(
 
     template = _generate_template(skill_name)
     skill_md = skill_dir / "SKILL.md"
-    skill_md.write_text(template)
+    skill_md.write_text(template, encoding="utf-8")
 
     if output_format == "json":
         from deepagents_code.output import write_json

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -1195,6 +1195,36 @@ class TestWorkspacePromptCredentials:
         assert "When you use the web_search tool" in with_tavily
 
 
+class TestSystemPromptEncoding:
+    """The packaged prompt template decodes independently of the host locale."""
+
+    def test_template_is_read_as_utf8(self) -> None:
+        """`system_prompt.md` is read with an explicit encoding.
+
+        The template holds em dashes, arrows and a not-equal sign. Without an
+        explicit encoding `Path.read_text` uses `locale.getpreferredencoding`,
+        which is the ANSI code page on Windows: cp936/cp932/cp949/cp950/cp874
+        raise, and cp1252/cp1251/cp1250/cp1253 decode to mojibake. It round-trips
+        either way on a UTF-8 host, so this asserts the encoding reaches the call.
+        """
+        recorded: list[dict[str, Any]] = []
+        real_read_text = Path.read_text
+
+        def _record(self: Path, *args: Any, **kwargs: Any) -> str:
+            if self.name == "system_prompt.md":
+                recorded.append(kwargs)
+            return real_read_text(self, *args, **kwargs)
+
+        with patch.object(Path, "read_text", _record):
+            prompt = get_system_prompt("test-agent")
+
+        assert recorded, "system_prompt.md was not read"
+        assert all(kwargs.get("encoding") == "utf-8" for kwargs in recorded)
+        # Guard the guard: a template that turned pure ASCII would make the
+        # assertion above vacuous.
+        assert any(ord(char) > 127 for char in prompt)
+
+
 class TestBuildModelIdentitySection:
     """Direct tests for build_model_identity_section."""
 

--- a/libs/code/tests/unit_tests/test_hooks.py
+++ b/libs/code/tests/unit_tests/test_hooks.py
@@ -45,6 +45,26 @@ class TestLoadHooks:
 
         assert result == []
 
+    def test_unicode_decode_error(self, tmp_path):
+        """Returns empty list when the hooks file is not valid UTF-8.
+
+        Reading with an explicit `encoding="utf-8"` is what makes this
+        reachable: a hooks file saved in the host's ANSI code page now raises
+        `UnicodeDecodeError`, which is neither `json.JSONDecodeError` nor
+        `OSError`, so it has to be caught for the documented "never
+        interrupted" behavior to hold.
+        """
+        (tmp_path / "hooks.json").write_text("{}")
+        invalid_utf8 = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+        with (
+            patch("deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path),
+            patch("pathlib.Path.read_text", side_effect=invalid_utf8),
+        ):
+            result = hooks_mod._load_hooks()
+
+        assert result == []
+
 
 # ---------------------------------------------------------------------------
 # dispatch_hook


### PR DESCRIPTION
Fixes #6229

`agent.get_system_prompt` loads the packaged prompt template with
`(prompt_dir / "system_prompt.md").read_text()` and no `encoding`, so on Windows
it decodes with the ANSI code page. The file holds 27 non-ASCII characters
(U+2014 x21, U+2260 x3, U+2192 x3): the read raises on cp936/cp932/cp949/cp950/cp874
and mojibakes on cp1252/cp1251/cp1250/cp1253. It sits in `create_cli_agent`'s
`if system_prompt is None:` branch, which the default `dcode` run reaches through
`server_graph.py:528`, so the first group gets a `DEEPAGENTS_STARTUP_ERROR` exit
and the second silently feeds a corrupted system prompt to the model.

The write side inverts that set: `init_skill.py:277` writes a template holding 22
`→` and raises `UnicodeEncodeError` on cp874/cp1252/cp1251/cp1250/cp1253, and
`skills/commands.py:491` writes one `—` and raises on cp932/cp949 — while its
sibling read at line 601 already passes `encoding="utf-8"`, so a generated
SKILL.md was written in the locale encoding and read back as UTF-8.

An AST sweep finds 18 unencoded `read_text`/`write_text`; 3 are
`importlib.metadata.Distribution.read_text`, a different API taking no
`encoding`. This passes it at the remaining 15, matching the 57 sites in this
package that already do. Five of the 15 cannot currently fail (fixed ASCII, or
`json.dumps` whose `ensure_ascii` defaults true) and are hardening rather than
live defects.

One hunk is not mechanical. `hooks/legacy.py` documents that a malformed hooks
file "is never interrupted" and catches `(json.JSONDecodeError, OSError)`.
Reading with an explicit encoding is exactly what makes `UnicodeDecodeError`
reachable there — a user-authored `hooks.json` saved in the host ANSI page — and
it is neither of those, so the tuple gains it and the documented behavior holds.

Two behavioral tests, both failing on main:
`TestSystemPromptEncoding::test_template_is_read_as_utf8` records the kwargs
reaching `Path.read_text` (mirroring `test_dotenv_is_read_as_utf8_regardless_of_locale`),
and `TestLoadHooks::test_unicode_decode_error` proves the escape from the except
tuple. No source-tree-walking guard — ruff `PLW1514` covers the shape when it
can infer a `Path` receiver, and a change-detector would not.

Verified on macOS with Python 3.13: `make lint` clean, `make test` 7918 passed
/ 1 skipped. CPython's `EncodingWarning` (PEP 597) reports one call site in
`get_system_prompt` before and zero after.
