### PR TITLE
fix(talon): keep results a discarded turn never reported

### DIFF
--- a/libs/talon/deepagents_talon/background.py
+++ b/libs/talon/deepagents_talon/background.py
@@ -21,7 +21,7 @@ from langgraph_sdk import get_client
 from deepagents_talon.authorization import set_authorization_handler
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Awaitable, Callable, Sequence
+    from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable, Sequence
 
     from deepagents import CompiledSubAgent, SubAgent
     from deepagents.middleware.async_subagents import AsyncSubAgent
@@ -298,6 +298,27 @@ class BackgroundSubagents(AgentMiddleware):
             dropped.append(key)
             logger.warning("Dropped undelivered background subagent result %s", key)
         return dropped
+
+    def requeue(self, results: Iterable[str]) -> None:
+        """Return acknowledged results to the pending set after an undelivered turn.
+
+        A turn that completed its model work acknowledges the results it consumed,
+        but the host may then discard its reply because a newer turn superseded it.
+        The user therefore never heard about work that is already marked delivered.
+        Clearing the flag offers it to the next turn instead; re-injection is
+        idempotent, because the result is carried as a message keyed by its own id.
+
+        Only the ids handed back are touched, so a result delivered by some earlier
+        turn is never resurrected. An id already pruned or cancelled is skipped:
+        there is nothing left to offer.
+
+        Args:
+            results: Result IDs whose turn produced a reply that was discarded.
+        """
+        for key in results:
+            job = self._jobs.get(key)
+            if job is not None and not job.cancelled:
+                job.notified = False
 
     def acknowledge(self, results: dict[str, str]) -> None:
         """Mark results processed only after the main agent completes a turn.

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -750,24 +750,59 @@ class TalonHost:
             with contextlib.suppress(asyncio.CancelledError):
                 await typing_task
             self._clear_authorization(agent_conversation_id)
+        await self._settle_agent_turn(
+            turn,
+            result,
+            channel=channel,
+            reply_conversation_id=message.conversation_id,
+            suppress_result=suppress_result,
+        )
+
+    async def _settle_agent_turn(
+        self,
+        turn: _Turn,
+        result: AgentResult,
+        *,
+        channel: ChannelAdapter,
+        reply_conversation_id: str,
+        suppress_result: bool,
+    ) -> None:
+        """Send a finished turn's reply, or return the work behind it to the queue.
+
+        Args:
+            turn: Turn whose model call has completed.
+            result: Output that turn produced.
+            channel: Channel that would carry the reply.
+            reply_conversation_id: Chat the reply is addressed to.
+            suppress_result: Whether the host is withholding this reply on purpose.
+        """
+        agent_conversation_id = turn.conversation_id
         try:
             async with self._conversation_lock(turn.conversation_root):
-                superseded = (
+                if suppress_result:
+                    # Withheld on purpose -- a terminal authorization, or a scheduled
+                    # run that chose silence. The model consumed these results and
+                    # nobody was waiting to hear about them, so they stay acknowledged
+                    # even if a newer turn has since taken the thread.
+                    return
+                if (
                     self._agent_conversation_id(turn.conversation_root) != agent_conversation_id
                     or self._generations[agent_conversation_id] != turn.generation
-                )
-                if superseded:
+                ):
                     # Not a deliberate silence: a newer turn took this thread, so a
                     # reply nobody asked for any more is dropped. The background work
                     # behind it was never reported, so it goes back to the queue.
                     self._requeue_background_results(result)
-                elif not suppress_result:
-                    await self._deliver_agent_result(channel, message.conversation_id, result)
+                    return
+                await self._deliver_agent_result(channel, reply_conversation_id, result)
         except asyncio.CancelledError:
             # Cancelled between the model finishing and this reply going out -- the
             # same loss, reached by the other route, and the reason this runs while
-            # the cancellation is in flight rather than after it.
-            self._requeue_background_results(result)
+            # the cancellation is in flight rather than after it. Suppression still
+            # wins: it was decided before the cancellation and does not become a loss
+            # because of one.
+            if not suppress_result:
+                self._requeue_background_results(result)
             raise
 
     def _requeue_background_results(self, result: AgentResult) -> None:

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -750,13 +750,40 @@ class TalonHost:
             with contextlib.suppress(asyncio.CancelledError):
                 await typing_task
             self._clear_authorization(agent_conversation_id)
-        async with self._conversation_lock(turn.conversation_root):
-            if (
-                self._agent_conversation_id(turn.conversation_root) == agent_conversation_id
-                and self._generations[agent_conversation_id] == turn.generation
-                and not suppress_result
-            ):
-                await self._deliver_agent_result(channel, message.conversation_id, result)
+        try:
+            async with self._conversation_lock(turn.conversation_root):
+                superseded = (
+                    self._agent_conversation_id(turn.conversation_root) != agent_conversation_id
+                    or self._generations[agent_conversation_id] != turn.generation
+                )
+                if superseded:
+                    # Not a deliberate silence: a newer turn took this thread, so a
+                    # reply nobody asked for any more is dropped. The background work
+                    # behind it was never reported, so it goes back to the queue.
+                    self._requeue_background_results(result)
+                elif not suppress_result:
+                    await self._deliver_agent_result(channel, message.conversation_id, result)
+        except asyncio.CancelledError:
+            # Cancelled between the model finishing and this reply going out -- the
+            # same loss, reached by the other route, and the reason this runs while
+            # the cancellation is in flight rather than after it.
+            self._requeue_background_results(result)
+            raise
+
+    def _requeue_background_results(self, result: AgentResult) -> None:
+        """Offer a discarded turn's background results to the next turn.
+
+        Args:
+            result: Turn output that never reached its conversation.
+        """
+        if not result.background_results or not isinstance(self.agent, BackgroundRuntime):
+            return
+        self.agent.background.requeue(result.background_results)
+        log_event(
+            logger,
+            "background.requeued",
+            result_count=len(result.background_results),
+        )
 
     async def run_scheduled_job(self, job: CronJob) -> str:
         """Invoke the agent for one scheduled job.

--- a/libs/talon/deepagents_talon/interfaces.py
+++ b/libs/talon/deepagents_talon/interfaces.py
@@ -161,10 +161,15 @@ class AgentResult:
         text: Text to deliver to the triggering channel. Empty text means the
             runtime has no message to send.
         metadata: Runtime metadata for future observability integrations.
+        background_results: Background result ids this turn consumed, which the
+            runtime has already acknowledged. A host that then discards the turn's
+            reply hands these back through `BackgroundSubagents.requeue`, so work
+            the user never heard about is offered to the next turn instead.
     """
 
     text: str
     metadata: Mapping[str, object] = field(default_factory=dict)
+    background_results: tuple[str, ...] = ()
 
 
 MessageHandler = Callable[[ChannelMessage], Awaitable[None]]

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -522,7 +522,10 @@ class DeepAgentRuntime:
         if activity is not None:
             activity.run_completed(text)
         self.background.acknowledge(pending)
-        return AgentResult(text=text)
+        # The ids travel with the result because acknowledgement records that the
+        # model consumed them, not that the user heard about them. Only the host
+        # knows whether the reply it is holding actually gets delivered.
+        return AgentResult(text=text, background_results=tuple(pending))
 
     @property
     def history_enabled(self) -> bool:

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from typing import TYPE_CHECKING, cast
@@ -93,6 +94,7 @@ class FailingStopAgent(BlockingAgent):
 class StubBackground:
     def __init__(self) -> None:
         self.pending: set[str] = set()
+        self.requeued: list[str] = []
 
     def owners(self) -> set[str]:
         return set(self.pending)
@@ -103,6 +105,9 @@ class StubBackground:
     async def cancel(self, owner: str | None = None) -> bool:
         self.pending.discard(owner) if owner else self.pending.clear()
         return True
+
+    def requeue(self, results: object) -> None:
+        self.requeued.extend(results)  # type: ignore[arg-type]
 
 
 class ArchiveAgent(BlockingAgent):
@@ -1183,6 +1188,149 @@ async def test_channel_background_turn_keeps_its_operator_context(tmp_path: Path
         assert "trigger" not in follow_up.metadata
         assert follow_up.approval_handler is not None
         assert follow_up.authorization_handler is not None
+    finally:
+        await host.stop()
+
+
+class BackgroundResultAgent(BlockingAgent):
+    """Agent whose turn reports the background results it consumed."""
+
+    def __init__(self, *, text: str | None = None) -> None:
+        super().__init__()
+        self.background = StubBackground()
+        self.text = text
+
+    async def invoke(self, request: AgentRequest) -> AgentResult:
+        self.requests.append(request)
+        if request.text == "block":
+            await self.released.wait()
+        return AgentResult(
+            text=self.text if self.text is not None else f"reply:{request.text}",
+            background_results=("subagent-1",),
+        )
+
+
+async def _park_turn_at_delivery(agent: BlockingAgent) -> None:
+    """Let a blocked turn finish its model work while the delivery lock is held."""
+    agent.released.set()
+    for _ in range(50):
+        await asyncio.sleep(0)
+
+
+async def test_superseded_turn_requeues_its_background_results(tmp_path: Path) -> None:
+    """A newer turn takes the thread while the previous reply waits to go out.
+
+    The runtime acknowledged those results when the model consumed them, but the
+    reply carrying them is dropped by the generation check, so nobody was told. The
+    ids go back to the queue rather than counting as delivered.
+    """
+    channel = RecordingChannel()
+    agent = BackgroundResultAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+        await _wait_for_request(agent, "block")
+        turn = host._tasks["test:chat"]
+
+        async with host._conversation_lock("test:chat"):
+            await _park_turn_at_delivery(agent)
+            # Exactly what `_cancel_active` records before it cancels.
+            host._generations["test:chat"] += 1
+
+        await asyncio.wait_for(turn, 2)
+
+        assert agent.background.requeued == ["subagent-1"]
+        assert channel.sent == []
+    finally:
+        await host.stop()
+
+
+async def test_turn_cancelled_awaiting_delivery_requeues_its_background_results(
+    tmp_path: Path,
+) -> None:
+    """The same loss reached by cancellation instead of the generation check.
+
+    A scheduled run preempts a follow-up turn by cancelling it, and the turn can
+    already be past the model call and parked on the conversation lock the run
+    holds. Re-queueing has to happen while that cancellation is in flight.
+    """
+    channel = RecordingChannel()
+    agent = BackgroundResultAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+        await _wait_for_request(agent, "block")
+        turn = host._tasks["test:chat"]
+
+        async with host._conversation_lock("test:chat"):
+            await _park_turn_at_delivery(agent)
+            turn.cancel()
+            for _ in range(50):
+                await asyncio.sleep(0)
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.wait_for(turn, 2)
+
+        assert agent.background.requeued == ["subagent-1"]
+        assert channel.sent == []
+    finally:
+        await host.stop()
+
+
+async def test_delivered_turn_does_not_requeue_its_background_results(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = BackgroundResultAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="hello"))
+        await asyncio.wait_for(host._tasks["test:chat"], 2)
+
+        assert channel.sent == [("chat", "reply:hello")]
+        assert agent.background.requeued == []
+    finally:
+        await host.stop()
+
+
+async def test_deliberately_suppressed_turn_does_not_requeue(tmp_path: Path) -> None:
+    """Suppression the host chose is not a lost result.
+
+    A terminal authorization withholds the reply on purpose, and a silent scheduled
+    run does the same. The model still consumed the results, so they stay
+    acknowledged; re-queueing them would replay work the conversation has handled.
+    """
+    channel = RecordingChannel()
+    agent = BackgroundResultAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        host._terminal_authorizations.add("test:chat")
+        await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="hello"))
+        await asyncio.wait_for(host._tasks["test:chat"], 2)
+
+        assert channel.sent == []
+        assert agent.background.requeued == []
+    finally:
+        await host.stop()
+
+
+async def test_silent_scheduled_turn_does_not_requeue(tmp_path: Path) -> None:
+    channel = RecordingChannel()
+    agent = BackgroundResultAgent(text="[SILENT]")
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    job = _cron_job(tmp_path)
+    cron_id = f"{job.id}:talon-cron"
+    await host.start()
+    try:
+        agent.background.pending.add(cron_id)
+        await host.run_scheduled_job(job)
+        await host._dispatch_background_results()
+        await asyncio.wait_for(host._tasks[cron_id], 2)
+
+        assert channel.sent == []
+        assert agent.background.requeued == []
     finally:
         await host.stop()
 

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -1210,6 +1210,17 @@ class BackgroundResultAgent(BlockingAgent):
         )
 
 
+class SilentFollowUpAgent(BackgroundResultAgent):
+    """Scheduled agent whose background follow-up turn blocks, then chooses silence."""
+
+    async def invoke(self, request: AgentRequest) -> AgentResult:
+        self.requests.append(request)
+        if request.text.startswith(_BACKGROUND_FOLLOW_UP):
+            await self.released.wait()
+            return AgentResult(text="[SILENT]", background_results=("subagent-1",))
+        return AgentResult(text="[SILENT]")
+
+
 async def _park_turn_at_delivery(agent: BlockingAgent) -> None:
     """Let a blocked turn finish its model work while the delivery lock is held."""
     agent.released.set()
@@ -1312,6 +1323,81 @@ async def test_deliberately_suppressed_turn_does_not_requeue(tmp_path: Path) -> 
 
         assert channel.sent == []
         assert agent.background.requeued == []
+    finally:
+        await host.stop()
+
+
+@pytest.mark.parametrize("discard", ["superseded", "cancelled"])
+async def test_suppressed_turn_does_not_requeue_when_also_discarded(
+    tmp_path: Path, discard: str
+) -> None:
+    """Supersession does not turn a deliberate silence into a lost result.
+
+    A terminal authorization withholds the reply, and that turn can still be
+    superseded or cancelled while parked on the conversation lock. The suppression
+    was decided before either happened, so the results stay acknowledged; re-queueing
+    them would make a later turn report work the host meant to keep quiet about.
+    """
+    channel = RecordingChannel()
+    agent = BackgroundResultAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+    try:
+        host._terminal_authorizations.add("test:chat")
+        await host.receive_message(channel, ChannelMessage(conversation_id="chat", text="block"))
+        await _wait_for_request(agent, "block")
+        turn = host._tasks["test:chat"]
+
+        async with host._conversation_lock("test:chat"):
+            await _park_turn_at_delivery(agent)
+            if discard == "superseded":
+                host._generations["test:chat"] += 1
+            else:
+                turn.cancel()
+                for _ in range(50):
+                    await asyncio.sleep(0)
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.wait_for(turn, 2)
+
+        assert agent.background.requeued == []
+        assert channel.sent == []
+    finally:
+        await host.stop()
+
+
+@pytest.mark.parametrize("discard", ["superseded", "cancelled"])
+async def test_silent_scheduled_turn_does_not_requeue_when_also_discarded(
+    tmp_path: Path, discard: str
+) -> None:
+    """The same for a scheduled follow-up that answered with the silent sentinel."""
+    channel = RecordingChannel()
+    agent = SilentFollowUpAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    job = _cron_job(tmp_path)
+    cron_id = f"{job.id}:talon-cron"
+    await host.start()
+    try:
+        agent.background.pending.add(cron_id)
+        await host.run_scheduled_job(job)
+        await host._dispatch_background_results()
+        await _wait_for_request(agent, _SCHEDULED_FOLLOW_UP)
+        turn = host._tasks[cron_id]
+
+        async with host._conversation_lock(cron_id):
+            await _park_turn_at_delivery(agent)
+            if discard == "superseded":
+                host._generations[cron_id] += 1
+            else:
+                turn.cancel()
+                for _ in range(50):
+                    await asyncio.sleep(0)
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.wait_for(turn, 2)
+
+        assert agent.background.requeued == []
+        assert channel.sent == []
     finally:
         await host.stop()
 

--- a/libs/talon/tests/unit_tests/test_background.py
+++ b/libs/talon/tests/unit_tests/test_background.py
@@ -230,6 +230,106 @@ async def test_cancel_finished_subagent_preserves_result():
     assert not background.owners()
 
 
+async def test_invoke_reports_the_results_it_acknowledged(monkeypatch):
+    """The runtime hands back what it acknowledged so a host can undo it.
+
+    Acknowledgement records that the model consumed a result, which the runtime
+    knows; whether the user was told depends on the reply being delivered, which
+    only the host knows. The ids travel so the two can be reconciled.
+    """
+
+    async def child(_state):
+        return {"messages": [AIMessage(content="research result")]}
+
+    runtime = _runtime(
+        monkeypatch,
+        child,
+        [
+            _delegate(),
+            AIMessage(content="Working on it"),
+            AIMessage(content="Processed research"),
+        ],
+    )
+    await runtime.start()
+    try:
+        launched = await runtime.invoke(AgentRequest(conversation_id="chat", text="research"))
+        assert launched.background_results == ()
+
+        await asyncio.gather(*(job.worker for job in runtime.background._jobs.values()))
+        pending = set(runtime.background.results("chat"))
+        assert pending
+
+        processed = await runtime.invoke(AgentRequest(conversation_id="chat", text="anything else"))
+
+        assert set(processed.background_results) == pending
+        assert not runtime.background.results("chat")
+
+        runtime.background.requeue(processed.background_results)
+
+        assert set(runtime.background.results("chat")) == pending
+    finally:
+        await runtime.stop()
+
+
+async def test_requeue_returns_only_the_results_it_is_given():
+    """Re-queueing is scoped to one turn's ids, not to everything acknowledged.
+
+    A conversation can hold results from several turns. Only the turn whose reply
+    was discarded goes back to the queue; anything an earlier turn delivered stays
+    acknowledged, so it is never reported to the user twice.
+    """
+
+    @tool
+    async def task() -> str:
+        """Return completed research."""
+        return "completed research"
+
+    background = BackgroundSubagents()
+    for thread in ("one", "two"):
+        await background.awrap_tool_call(_request(thread, task), _unused_handler)
+    await asyncio.gather(*(job.worker for job in background._jobs.values()))
+    first = background.results("one")
+    second = background.results("two")
+    background.acknowledge(first)
+    background.acknowledge(second)
+    assert not background.results("one")
+    assert not background.results("two")
+    assert not background.owners()
+
+    background.requeue(first)
+
+    assert background.results("one") == first
+    assert not background.results("two")
+    assert background.owners() == {"one"}
+
+
+async def test_requeue_skips_cancelled_and_unknown_results():
+    """Nothing is resurrected that the conversation has no use for.
+
+    `/stop` discards a thread's results deliberately, and a result already pruned
+    is gone. Re-queueing either would be an undelivered turn reviving work the user
+    stopped, so both are left alone.
+    """
+
+    @tool
+    async def task() -> str:
+        """Return completed research."""
+        return "completed research"
+
+    background = BackgroundSubagents()
+    await background.awrap_tool_call(_request("one", task), _unused_handler)
+    await asyncio.gather(*(job.worker for job in background._jobs.values()))
+    results = background.results("one")
+    background.acknowledge(results)
+    assert await background.cancel("one")
+
+    background.requeue(results)
+    background.requeue(["subagent-never-existed"])
+
+    assert not background.results("one")
+    assert not background.owners()
+
+
 @pytest.mark.parametrize("owner", ["one", None])
 async def test_conversation_cancel_discards_finished_results(owner):
     @tool


### PR DESCRIPTION
Follow-up to #6228, from an Open SWE review comment on it. Based on `main`, so this is not a stacked PR.

### The defect

`DeepAgentRuntime.invoke` acknowledges the background results a turn consumed as soon as the graph returns (`runtime.py`), and `TalonHost._run_agent_turn` delivers the reply afterwards, under the conversation lock. `_cancel_active` bumps `self._generations[conversation_id]` **and then** cancels, so a turn superseded in that window either fails the delivery guard or is cancelled while awaiting the lock.

Dropping the reply is correct — that is what supersession means, and it is what the generation check is for. The bug is the other half: the results that turn consumed are already `notified`, so they leave `results()` and `owners()` and are never offered to another turn. The user is never told what the subagent found.

Reachable two ways, both now covered:
- a second scheduled run preempting a background follow-up turn parked on the lock it holds (the path #6228 introduced);
- a user's next message superseding a turn in the same window, which has been reachable on the channel path all along.

### The fix

Acknowledgement answers a question the runtime can settle — *did the model consume this result?* Whether anyone heard about it is a different question, and only the host can settle it, because only the host knows whether the reply went out.

So the runtime keeps acknowledging exactly as before (a library embedder using `DeepAgentRuntime` without `TalonHost` is unaffected) and additionally reports the ids it acknowledged on `AgentResult.background_results`. The host hands precisely those back through a new `BackgroundSubagents.requeue` when it discards the reply carrying them.

**Re-queueing is safe rather than merely tempting.** A pending result travels as a message keyed by its own task id, and LangGraph's `add_messages` replaces a message with a matching id — so offering one to a thread that already contains it cannot duplicate it. I verified this against the installed version rather than assuming it.

Three things keep the scope honest:

- **Scoped to the turn's own ids**, not to the conversation. A thread can hold results from several turns, and one an earlier turn delivered must stay acknowledged.
- **Pruned and cancelled ids are skipped.** `/stop` discards a thread's results deliberately; an undelivered turn must not revive work the user stopped.
- **Deliberate suppression does not re-queue.** A terminal authorization withholds the reply on purpose, and a silent scheduled run does the same. The model consumed those results either way.

The re-queue on the cancellation path is synchronous so it completes while the cancellation is in flight.

### Tests

Eight new tests. To show they pin behaviour rather than the new field, I ran them with everything in place *except* the host's re-queue: exactly the two behavioural tests fail, with `assert [] == ['subagent-1']`, and the six guards still pass.

- superseded turn re-queues; turn cancelled awaiting delivery re-queues;
- delivered turn does not; terminal-authorization suppression does not; silent scheduled run does not;
- `requeue` touches only the ids it is given, and skips cancelled and unknown ones;
- `invoke` reports the ids it acknowledged, and re-queueing them restores `results()`.

905 pass locally, `ruff` and `ty` clean.

### Note on the review comment

The finding was real in mechanism. Two of its claims were not, and this PR does not act on them: it was not introduced by #6228 (the identical window exists on the channel path, where `receive_message` holds the root lock across `_replace_agent_turn`), and the background output is not *permanently lost* — the results are injected as graph messages and checkpointed before `acknowledge` runs, so the content survives in the thread. What was lost is the outbound message and the chance to offer the results again, which is what this fixes.