### PR TITLE
feat(sdk): expose execute truncation metadata

### DIFF
--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -846,6 +846,9 @@ class ExecuteArtifact(TypedDict):
     Omitted when the exit code could not be determined.
     """
 
+    truncated: bool
+    """Whether the backend truncated the command output."""
+
 
 @dataclass(frozen=True, slots=True)
 class ExecuteOffloadResult:

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -2856,12 +2856,14 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
     def _execute_artifact(response: ExecuteResponse) -> ExecuteArtifact:
         """Build the `ExecuteArtifact` for an execute result.
 
-        See `ExecuteArtifact` for why an unknown exit code is omitted rather
-        than published as `None`.
+        `truncated` is always present so callers can distinguish incomplete
+        output without parsing the model-facing status text. An unknown exit
+        code remains omitted rather than published as `None`.
         """
-        if response.exit_code is None:
-            return {}
-        return {"exit_code": response.exit_code}
+        artifact: ExecuteArtifact = {"truncated": response.truncated}
+        if response.exit_code is not None:
+            artifact["exit_code"] = response.exit_code
+        return artifact
 
     def _interpret_capture_output(self, offload: ExecuteOffloadResult, capture_path: str, tool_call_id: str) -> str:
         """Build `ToolMessage` content from an `execute_with_offload` result."""

--- a/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
+++ b/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
@@ -1708,7 +1708,7 @@ class TestExecuteCaptureOffload:
 
         assert "oops" in result.content
         assert "exit code 3" in result.content
-        assert result.artifact == {"exit_code": 3}
+        assert result.artifact == {"exit_code": 3, "truncated": False}
 
     async def test_offloaded_result_carries_exit_code_artifact(self, tools: tuple, invoke: Callable) -> None:
         # When the output is offloaded, `_interpret_capture_output` replaces the
@@ -1718,7 +1718,7 @@ class TestExecuteCaptureOffload:
         result = await invoke(execute_tool, {"command": f"{_BIG_OUTPUT_CMD}; exit 3", "runtime": self._runtime("c_off_ec")})
 
         assert self._capture_path("c_off_ec") in result.content  # actually offloaded
-        assert result.artifact == {"exit_code": 3}
+        assert result.artifact == {"exit_code": 3, "truncated": False}
 
     async def test_runaway_output_is_capped_and_flagged(
         self,
@@ -1742,7 +1742,7 @@ class TestExecuteCaptureOffload:
 
         assert "exceeded the capture size limit" in result.content
         assert "succeeded with exit code 0" in result.content
-        assert result.artifact == {"exit_code": 0}
+        assert result.artifact == {"exit_code": 0, "truncated": True}
         # The on-disk capture file is bounded at the cap regardless of total output.
         size = sandbox.execute(f"wc -c < {self._capture_path('c_cap')}").output.strip()
         assert size == str(cap)

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -3017,7 +3017,7 @@ class TestFilesystemMiddleware:
         assert "Hello world\nLine 2" in result.content
         assert "succeeded" in result.content
         assert "exit code 0" in result.content
-        assert result.artifact == {"exit_code": 0}
+        assert result.artifact == {"exit_code": 0, "truncated": False}
 
     def test_execute_tool_output_formatting_with_failure(self):
         """Test execute tool formats failure output correctly."""
@@ -3054,7 +3054,7 @@ class TestFilesystemMiddleware:
         assert "Error: command not found" in result.content
         assert "failed" in result.content
         assert "exit code 127" in result.content
-        assert result.artifact == {"exit_code": 127}
+        assert result.artifact == {"exit_code": 127, "truncated": False}
 
     def test_execute_tool_omits_artifact_exit_code_when_unknown(self):
         """Test execute tool omits `exit_code` when the backend reports none."""
@@ -3087,7 +3087,7 @@ class TestFilesystemMiddleware:
         # The content omits the status line entirely for an unknown exit code, so the
         # artifact must not imply one either.
         assert "exit code" not in result.content
-        assert result.artifact == {}
+        assert result.artifact == {"truncated": False}
 
     def test_execute_tool_error_paths_carry_no_artifact(self):
         """Test execute tool returns no artifact when no command ran."""
@@ -3161,6 +3161,7 @@ class TestFilesystemMiddleware:
 
         assert "Very long output..." in result.content
         assert "truncated" in result.content
+        assert result.artifact == {"exit_code": 0, "truncated": True}
 
     def testsupports_execution_helper_with_composite_backend(self):
         """Test supports_execution correctly identifies CompositeBackend capabilities."""

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -941,7 +941,7 @@ class TestFilesystemMiddlewareAsync:
         assert "Async Hello world\nAsync Line 2" in result.content
         assert "succeeded" in result.content
         assert "exit code 0" in result.content
-        assert result.artifact == {"exit_code": 0}
+        assert result.artifact == {"exit_code": 0, "truncated": False}
 
     async def test_aexecute_tool_output_formatting_with_failure(self):
         """Test async execute tool formats failure output correctly."""
@@ -985,7 +985,7 @@ class TestFilesystemMiddlewareAsync:
         assert "Async Error: command not found" in result.content
         assert "failed" in result.content
         assert "exit code 127" in result.content
-        assert result.artifact == {"exit_code": 127}
+        assert result.artifact == {"exit_code": 127, "truncated": False}
 
     async def test_aexecute_tool_omits_artifact_exit_code_when_unknown(self):
         """Test async execute tool omits `exit_code` when the backend reports none."""
@@ -1018,7 +1018,7 @@ class TestFilesystemMiddlewareAsync:
 
         assert "async output" in result.content
         assert "exit code" not in result.content
-        assert result.artifact == {}
+        assert result.artifact == {"truncated": False}
 
     async def test_aexecute_tool_error_paths_carry_no_artifact(self):
         """Test async execute tool returns no artifact when no command ran."""
@@ -1097,3 +1097,4 @@ class TestFilesystemMiddlewareAsync:
 
         assert "Async Very long output..." in result.content
         assert "truncated" in result.content
+        assert result.artifact == {"exit_code": 0, "truncated": True}


### PR DESCRIPTION
Execute results now expose whether their output was truncated through structured metadata.

---

The `execute` tool currently publishes truncation only in model-facing display text. Downstream middleware that needs to distinguish complete output from partial output must parse that text.

Add an always-present `truncated` boolean to `ExecuteArtifact`, alongside the existing optional exit code. The model-facing output is unchanged.

Tests cover normal, truncated, unknown-exit, synchronous, asynchronous, and offloaded execute results.

Verified: targeted unit tests (242 passed; 101 skipped) and `make lint`.