### PR TITLE
fix(talon): report MCP protocol errors to the model

### DIFF
--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -23,6 +23,7 @@ from langchain_core.tools import InjectedToolCallId, tool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from mcp.client.auth import OAuthFlowError
 from mcp.shared.exceptions import McpError
+from mcp.types import CallToolResult, TextContent
 
 from deepagents_talon.authorization import (
     AuthorizationAttempt,
@@ -398,6 +399,10 @@ async def load_mcp_tools(config: TalonConfig) -> MCPTools:
             client = MultiServerMCPClient(
                 {name: connection},
                 tool_interceptors=[
+                    # Outermost: the authorization layer below still observes the
+                    # raw exception for its own failure bookkeeping, and only what
+                    # escapes it is converted into a model-visible tool error.
+                    _protocol_error_interceptor,
                     _authorization_interceptor,
                     partial(
                         _argument_normalization_interceptor,
@@ -560,6 +565,53 @@ async def _open_authenticated_session(
     client = MultiServerMCPClient({server_name: connection})
     await _open_mcp_session(client, server_name)
     return True
+
+
+async def _protocol_error_interceptor(
+    request: MCPToolCallRequest,
+    handler: Callable[[MCPToolCallRequest], Awaitable[MCPToolCallResult]],
+) -> MCPToolCallResult:
+    """Report MCP protocol errors to the model instead of failing the turn.
+
+    `handle_tool_errors=True` only covers execution errors the server reports as
+    `CallToolResult(isError=True)`; langchain-mcp-adapters deliberately raises its
+    `ToolException` subclass for those alone. A JSON-RPC protocol error such as
+    invalid-params instead raises `McpError`, which is a plain `Exception` and so
+    reaches LangGraph's `ToolNode`, whose default handler re-raises anything that
+    is not a `ToolInvocationError`. That aborts the whole agent turn -- and a
+    scheduled job records `last_status: error` -- without the model ever seeing
+    why, so it cannot retry without the rejected arguments.
+
+    Converting the error to an `isError=True` result puts it back on the path the
+    adapter already handles, producing a `ToolMessage` with `status="error"`.
+
+    Only the server's `code` and `message` are forwarded. The optional `data`
+    payload is dropped: it is unbounded server-controlled content that would be
+    injected into model context, and it carries no argument detail the model
+    needs to correct the call.
+    """
+    try:
+        return await handler(request)
+    except McpError as exc:
+        logger.debug(
+            "MCP protocol error from server %s calling %s",
+            request.server_name,
+            request.name,
+            exc_info=True,
+        )
+        return CallToolResult(
+            isError=True,
+            content=[
+                TextContent(
+                    type="text",
+                    text=(
+                        f"MCP server {request.server_name!r} rejected this call to "
+                        f"{request.name!r} with protocol error {exc.error.code}: "
+                        f"{exc.error.message}"
+                    ),
+                )
+            ],
+        )
 
 
 async def _authorization_interceptor(

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -12,7 +12,8 @@ import pytest
 from langchain_mcp_adapters.interceptors import MCPToolCallRequest
 from mcp.client.auth import OAuthFlowError
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
-from mcp.types import CallToolResult
+from mcp.shared.exceptions import McpError
+from mcp.types import CallToolResult, ErrorData
 from pydantic import SecretStr
 
 from deepagents_talon.authorization import (
@@ -37,6 +38,7 @@ from deepagents_talon.mcp import (
     _authorization_interceptor,
     _connection,
     _normalize_mcp_arguments,
+    _protocol_error_interceptor,
     _run_authorized,
     load_mcp_tools,
     login_mcp_server,
@@ -339,6 +341,88 @@ def test_normalize_mcp_arguments_omits_only_optional_empty_strings() -> None:
     )
 
     assert arguments == {"query": "", "fetchMode": {}}
+
+
+async def test_protocol_error_interceptor_reports_error_to_model() -> None:
+    """An McpError becomes a failed result instead of aborting the agent turn."""
+    request = MCPToolCallRequest(
+        name="listVulnerabilities",
+        args={"severity": "NOPE"},
+        server_name="vanta",
+    )
+
+    async def execute(_request: MCPToolCallRequest) -> CallToolResult:
+        raise McpError(
+            ErrorData(
+                code=-32602,
+                message="severity must be one of CRITICAL, HIGH, MEDIUM, LOW",
+                data={"internal_trace": "/srv/vanta/handler.py:81", "token": "do-not-leak-this-fixture"},
+            )
+        )
+
+    result = await _protocol_error_interceptor(request, execute)
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    text = "".join(block.text for block in result.content if block.type == "text")
+    assert "severity must be one of CRITICAL, HIGH, MEDIUM, LOW" in text
+    assert "-32602" in text
+    assert "listVulnerabilities" in text
+    # The unbounded server-controlled `data` payload is never fed to the model.
+    assert "internal_trace" not in text
+    assert "do-not-leak-this-fixture" not in text
+    assert "handler.py" not in text
+
+
+async def test_protocol_error_interceptor_passes_success_through_unchanged() -> None:
+    request = MCPToolCallRequest(name="listVulnerabilities", args={}, server_name="vanta")
+    expected = CallToolResult(content=[])
+
+    async def execute(_request: MCPToolCallRequest) -> CallToolResult:
+        return expected
+
+    assert await _protocol_error_interceptor(request, execute) is expected
+
+
+async def test_protocol_error_interceptor_lets_cancellation_propagate() -> None:
+    """Cancellation must not be converted into a tool result."""
+    request = MCPToolCallRequest(name="listVulnerabilities", args={}, server_name="vanta")
+
+    async def execute(_request: MCPToolCallRequest) -> CallToolResult:
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await _protocol_error_interceptor(request, execute)
+
+
+async def test_protocol_error_interceptor_keeps_authorization_bookkeeping() -> None:
+    """Nesting order leaves the authorization layer observing the raw McpError.
+
+    `_protocol_error_interceptor` is registered outermost so `_authorization_interceptor`
+    still sees the failure and reports it, rather than being handed a successful-looking
+    result.
+    """
+    request = MCPToolCallRequest(name="listVulnerabilities", args={}, server_name="vanta")
+    events: list[AuthorizationEvent] = []
+
+    async def handler(event: AuthorizationEvent) -> None:
+        events.append(event)
+
+    async def execute(_request: MCPToolCallRequest) -> CallToolResult:
+        raise McpError(ErrorData(code=-32602, message="invalid params"))
+
+    async def authorized(inner: MCPToolCallRequest) -> CallToolResult:
+        return await _authorization_interceptor(inner, execute)
+
+    token = set_authorization_handler(handler)
+    try:
+        result = await _protocol_error_interceptor(request, authorized)
+    finally:
+        reset_authorization_handler(token)
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert not any(isinstance(event, AuthorizationCompleted) for event in events)
 
 
 async def test_argument_normalization_interceptor_overrides_request_arguments() -> None:

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -356,7 +356,10 @@ async def test_protocol_error_interceptor_reports_error_to_model() -> None:
             ErrorData(
                 code=-32602,
                 message="severity must be one of CRITICAL, HIGH, MEDIUM, LOW",
-                data={"internal_trace": "/srv/vanta/handler.py:81", "token": "do-not-leak-this-fixture"},
+                data={
+                    "internal_trace": "/srv/vanta/handler.py:81",
+                    "token": "do-not-leak-this-fixture",
+                },
             )
         )
 


### PR DESCRIPTION
## Problem

`load_mcp_tools` loads MCP tools with `handle_tool_errors=True` (`libs/talon/deepagents_talon/mcp.py`), but that flag is narrower than it looks. langchain-mcp-adapters only converts `CallToolResult(isError=True)` into a `ToolException` subclass (`_MCPToolExecutionError`) — deliberately, per its own docstring.

A JSON-RPC **protocol** error such as invalid-params instead raises `mcp.shared.exceptions.McpError`, whose MRO is `(McpError, Exception)`. Nothing converts it:

- It is not a `ToolException`, so the adapter's `handle_tool_error` callback never sees it.
- LangGraph's `ToolNode` is constructed without `handle_tool_errors` (`langchain/agents/factory.py`), so it falls back to `_default_handle_tool_errors` — which returns a message only for `ToolInvocationError` and **re-raises everything else**.

So the error propagates out of the tool call and fails the entire agent turn. For a scheduled job, `CronScheduler._run_due_job`'s `except Exception` then records `last_status: error`. The model never sees the error and gets no chance to retry without the rejected arguments.

## Fix

Add `_protocol_error_interceptor`, which catches `McpError` and returns `CallToolResult(isError=True, ...)`. That puts the failure back onto the path the adapter already handles, producing a `ToolMessage` with `status="error"` that the model can read and act on.

**Placement is load-bearing.** It is registered *outermost*, ahead of `_authorization_interceptor`. Interceptors compose as an onion, so the authorization layer below still observes the raw exception for its `_authorization_failure_reason` / `_finish_authorization` bookkeeping, and only what escapes it is converted. Registering it innermost would hide `McpError` from that layer and make a failed call look successful to the OAuth attempt tracking.

Two deliberate constraints:

- Only the server's `code` and `message` are forwarded. The optional `data` payload is dropped — it is unbounded, server-controlled content that would be injected straight into model context, and it carries no argument detail the model needs to correct the call.
- `McpError` is caught specifically rather than via a broad `except Exception`, so `CancelledError` still propagates and cancellation/shutdown semantics are unchanged.

## Tests

Four tests in `libs/talon/tests/test_mcp.py`, following the existing interceptor test style:

- an `McpError` becomes an `isError=True` result carrying the server's code and message, and **not** the `data` payload
- a successful call passes through unchanged
- `CancelledError` propagates rather than becoming a tool result
- nesting order leaves the authorization layer observing the raw error

Verified the tests can actually fail: with the interceptor neutered to a pass-through, the two substantive tests fail with exactly the reported symptom (`McpError` propagating out of the call). With the fix in place, the full talon unit suite is **921 passed, 3 skipped**; `ruff check`, `ruff format --diff`, and `ty check` are clean.

## Not addressed here

Two adjacent cases share this shape and are left for a follow-up rather than silently widened into this PR:

- `MCPAuthorizationError` (raised by `_run_authorized`) is also a plain `Exception` and kills the turn identically — notable because talon has a dedicated `authenticate_mcp_server` tool the model could otherwise call in response.
- Transport failures (`HTTPError`, `OSError` from a dead stdio server) propagate the same way. Arguably you *want* the turn to fail there, so this one deserves a deliberate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
