### PR TITLE
fix(code): expose unknown reasoning effort

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2039,6 +2039,8 @@ Shared by every such command -- `/effort`, `/summarization-model` -- so the
 habit transfers and the accepted spellings cannot drift apart.
 """
 
+_UNKNOWN_EFFORT_LABEL = "effort?"
+
 
 def _parse_reconnect_args(rest: str) -> tuple[bool, bool]:
     """Parse the argument tail of `/mcp reconnect [force]`.
@@ -18208,7 +18210,13 @@ class DeepAgentsApp(App):
             effort = (
                 current_effort_from_model_params(spec, self._model_params_override)
                 or default_effort_for_model(spec, cli_override=self._profile_override)
-                or ""
+                or (
+                    _UNKNOWN_EFFORT_LABEL
+                    if supported_efforts_for_model(
+                        spec, cli_override=self._profile_override
+                    )
+                    else ""
+                )
             )
         self._status_bar.set_model(provider=provider, model=model, effort=effort)
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2039,7 +2039,7 @@ Shared by every such command -- `/effort`, `/summarization-model` -- so the
 habit transfers and the accepted spellings cannot drift apart.
 """
 
-_UNKNOWN_EFFORT_LABEL = "effort?"
+_UNKNOWN_EFFORT_LABEL = "effort"
 
 
 def _parse_reconnect_args(rest: str) -> tuple[bool, bool]:

--- a/libs/code/deepagents_code/tui/widgets/effort_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/effort_selector.py
@@ -116,9 +116,12 @@ class EffortSelectorScreen(ModalScreen[str | None]):
             f" {glyphs.bullet} Enter select"
             f" {glyphs.bullet} Esc cancel"
         )
+        subtitle = self._model_spec
+        if self._current_effort is None and self._default_effort is None:
+            subtitle += "\nProvider default unknown — select an explicit effort"
         with Vertical():
             yield Static("Select Reasoning Effort", classes="effort-selector-title")
-            yield Static(self._model_spec, classes="effort-selector-subtitle")
+            yield Static(subtitle, classes="effort-selector-subtitle")
             option_list = OptionList(*options, id="effort-options")
             option_list.highlighted = highlighted
             yield option_list

--- a/libs/code/deepagents_code/tui/widgets/effort_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/effort_selector.py
@@ -118,7 +118,7 @@ class EffortSelectorScreen(ModalScreen[str | None]):
         )
         subtitle = self._model_spec
         if self._current_effort is None and self._default_effort is None:
-            subtitle += "\nProvider default unknown — select an explicit effort"
+            subtitle = "Provider default unknown — select an explicit effort"
         with Vertical():
             yield Static("Select Reasoning Effort", classes="effort-selector-title")
             yield Static(subtitle, classes="effort-selector-subtitle")

--- a/libs/code/tests/unit_tests/test_reasoning_effort.py
+++ b/libs/code/tests/unit_tests/test_reasoning_effort.py
@@ -7,10 +7,11 @@ Support data comes from LangChain model profiles, so most tests mock
 import logging
 from collections.abc import Iterator
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from textual.app import App
+from textual.widgets import OptionList, Static
 
 from deepagents_code import model_config, reasoning_effort
 from deepagents_code.app import DeepAgentsApp
@@ -63,6 +64,24 @@ def test_fireworks_duplicate_forms_fail_closed(
 
 
 # app.py integration (uses real profile data for openai/anthropic)
+
+
+def test_status_exposes_effort_when_default_is_unknown() -> None:
+    app = DeepAgentsApp(
+        profile_override={
+            "reasoning_output": True,
+            "reasoning_effort_levels": ["low", "medium", "high"],
+        }
+    )
+    app._status_bar = Mock()
+    runtime_state.model_provider = "openai"
+    runtime_state.model_name = "gpt-6-astra"
+
+    app._sync_status_model()
+
+    app._status_bar.set_model.assert_called_once_with(
+        provider="openai", model="gpt-6-astra", effort="effort?"
+    )
 
 
 async def test_profile_override_controls_persisted_restoration() -> None:
@@ -152,6 +171,26 @@ async def test_effort_selector_escape_cancels() -> None:
         await pilot.press("escape")
         await pilot.pause()
         assert results == [None]
+
+
+async def test_effort_selector_explains_unknown_default() -> None:
+    app = _EffortSelectorHost()
+    async with app.run_test() as pilot:
+        await app.push_screen(
+            EffortSelectorScreen(
+                model_spec="openai:gpt-6-astra",
+                efforts=("low", "medium", "high"),
+            )
+        )
+        await pilot.pause()
+
+        subtitle = app.screen.query_one(".effort-selector-subtitle", Static)
+        options = app.screen.query_one("#effort-options", OptionList)
+        assert "Provider default unknown" in str(subtitle.render())
+        assert all(
+            "default" not in str(options.get_option_at_index(index).prompt)
+            for index in range(options.option_count)
+        )
 
 
 async def test_effort_selector_dims_underlying_content() -> None:

--- a/libs/code/tests/unit_tests/test_reasoning_effort.py
+++ b/libs/code/tests/unit_tests/test_reasoning_effort.py
@@ -80,7 +80,7 @@ def test_status_exposes_effort_when_default_is_unknown() -> None:
     app._sync_status_model()
 
     app._status_bar.set_model.assert_called_once_with(
-        provider="openai", model="gpt-6-astra", effort="effort?"
+        provider="openai", model="gpt-6-astra", effort="effort"
     )
 
 


### PR DESCRIPTION
Models with configurable reasoning now keep an effort control visible even when their provider profile does not document a default.

---

- Show `effort` in the status bar when supported effort levels exist but neither an override nor a documented default is available.
- Explain in the selector that the provider default is unknown, without labeling the first supported level as the default.
- Preserve existing rendering for explicit efforts, documented defaults, and models without configurable effort.

### Preview

![GPT-6 Astra reasoning effort selector](https://github.com/langchain-ai/deepagents/releases/download/deepagents-code%3D%3D0.1.68/gpt-6-astra-effort-v2.png)

Made by [Open SWE](https://openswe.vercel.app/agents/e088ac20-f9c3-5fea-bb63-2d6964057543) · openai:gpt-5.6-sol (high)

