### PR TITLE
fix(code): isolate user shell tracing credentials

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12694,11 +12694,16 @@ class DeepAgentsApp(App):
 
         refresh_started = False
         try:
+            from deepagents_code.config import restore_user_langsmith_env
+
+            shell_env = os.environ.copy()
+            restore_user_langsmith_env(shell_env, start_path=Path(self._cwd))
             proc = await asyncio.create_subprocess_shell(
                 command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=self._cwd,
+                env=shell_env,
                 start_new_session=(sys.platform != "win32"),
             )
             self._shell_process = proc

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -2510,16 +2510,23 @@ async def _run_startup_command(
         asyncio.CancelledError: If the caller cancels while the startup command
             is running.
     """
+    import os
     import sys
+    from pathlib import Path
+
+    from deepagents_code.config import restore_user_langsmith_env
 
     if not quiet:
         console.print(Text(f"Running startup command: {command}", style="dim"))
 
     try:
+        shell_env = os.environ.copy()
+        restore_user_langsmith_env(shell_env, start_path=Path.cwd())
         proc = await asyncio.create_subprocess_shell(
             command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=shell_env,
             start_new_session=(sys.platform != "win32"),
         )
     except OSError as e:

--- a/libs/code/scripts/check_process_cwd.py
+++ b/libs/code/scripts/check_process_cwd.py
@@ -88,6 +88,9 @@ _ALLOWLIST: dict[CallSite, str] = {
         "2956b508",
     ): "The client captures the directory used to launch or bind the server.",
     CallSite(
+        "client/non_interactive.py", "_run_startup_command", "Path.cwd", "c745df8c"
+    ): "The headless client runs startup commands in its active local workspace.",
+    CallSite(
         "client/non_interactive.py", "_run_agent_loop", "Path.cwd", "8826e907"
     ): "The headless client records its local working directory.",
     CallSite(

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -12135,6 +12135,110 @@ class TestPasteRouting:
 class TestShellCommandInterrupt:
     """Tests for interruptible shell commands (! prefix) using worker pattern."""
 
+    @pytest.mark.parametrize("incognito", [False, True], ids=["shell", "incognito"])
+    async def test_shell_command_uses_user_langsmith_environment(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        incognito: bool,
+    ) -> None:
+        """User shell commands keep dcode tracing credentials isolated."""
+        import json
+
+        import deepagents_code.config as config_mod
+
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".env").write_text(
+            "LANGSMITH_API_KEY=project-key\nLANGSMITH_PROJECT=project-name\n"
+        )
+        monkeypatch.setattr(
+            config_mod,
+            "_GLOBAL_DOTENV_PATH",
+            tmp_path / "missing-global.env",
+        )
+        launch = dict.fromkeys(config_mod._USER_LANGSMITH_ENV_VARS)
+        launch["LANGSMITH_API_KEY"] = "shell-key"
+        carrier = json.dumps({"launch": launch, "user": dict(launch)})
+        monkeypatch.setenv("LANGSMITH_API_KEY", "dcode-key")
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "prefixed-key")
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_PROFILE", "dcode-profile")
+        monkeypatch.setenv(config_mod._USER_LANGSMITH_ENV_CARRIER, carrier)
+        monkeypatch.setenv("SHELL_TEST_UNRELATED", "preserved")
+        monkeypatch.setenv("DEEPAGENTS_CODE_SUPPRESS_ENV_OVERRIDE_WARNING", "1")
+        config_mod._apply_prefixed_langsmith_env()
+        assert os.environ["LANGSMITH_API_KEY"] == "prefixed-key"
+
+        app = DeepAgentsApp(cwd=project)
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"visible-output\n", b""))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._schedule_git_branch_refresh = MagicMock()  # ty: ignore
+            app._maybe_drain_deferred = AsyncMock()  # ty: ignore
+            app._process_next_from_queue = AsyncMock()  # ty: ignore
+            with patch(
+                "asyncio.create_subprocess_shell",
+                return_value=mock_proc,
+            ) as create_shell:
+                await app._run_shell_task("echo visible-output", incognito=incognito)
+                await pilot.pause()
+
+        child_env = create_shell.call_args.kwargs["env"]
+        assert child_env["LANGSMITH_API_KEY"] == "shell-key"
+        assert child_env["LANGSMITH_PROJECT"] == "project-name"
+        assert child_env["SHELL_TEST_UNRELATED"] == "preserved"
+        assert config_mod._USER_LANGSMITH_ENV_CARRIER not in child_env
+        assert not any(
+            key.startswith("DEEPAGENTS_CODE_LANGSMITH_") for key in child_env
+        )
+        assert os.environ["LANGSMITH_API_KEY"] == "prefixed-key"
+        assert os.environ["DEEPAGENTS_CODE_LANGSMITH_API_KEY"] == "prefixed-key"
+        if incognito:
+            assert app._pending_shell_messages == []
+        else:
+            assert "visible-output" in app._pending_shell_messages[0].content
+
+    async def test_shell_command_does_not_inherit_app_only_credentials(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """App-only LangSmith credentials are absent from user commands."""
+        import json
+
+        import deepagents_code.config as config_mod
+
+        launch = dict.fromkeys(config_mod._USER_LANGSMITH_ENV_VARS)
+        carrier = json.dumps({"launch": launch, "user": dict(launch)})
+        monkeypatch.setenv("LANGSMITH_API_KEY", "dcode-only-key")
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "prefixed-key")
+        monkeypatch.setenv(config_mod._USER_LANGSMITH_ENV_CARRIER, carrier)
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+
+        app = DeepAgentsApp(cwd=tmp_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._schedule_git_branch_refresh = MagicMock()  # ty: ignore
+            app._maybe_drain_deferred = AsyncMock()  # ty: ignore
+            app._process_next_from_queue = AsyncMock()  # ty: ignore
+            with patch(
+                "asyncio.create_subprocess_shell",
+                return_value=mock_proc,
+            ) as create_shell:
+                await app._run_shell_task("true", incognito=True)
+
+        child_env = create_shell.call_args.kwargs["env"]
+        assert "LANGSMITH_API_KEY" not in child_env
+        assert "DEEPAGENTS_CODE_LANGSMITH_API_KEY" not in child_env
+        assert os.environ["LANGSMITH_API_KEY"] == "dcode-only-key"
+
     @staticmethod
     def _shell_context_message(
         command: str, output: str, returncode: int = 0

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -3,6 +3,7 @@
 import asyncio
 import io
 import logging
+import os
 import signal
 import sys
 from collections.abc import AsyncIterator, Iterator, Sequence
@@ -2045,6 +2046,52 @@ class TestMaxTurns:
 
 class TestRunStartupCommand:
     """Tests for `_run_startup_command` (`--startup-cmd`)."""
+
+    async def test_uses_project_langsmith_environment_when_launch_value_absent(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Headless startup commands receive project values, not dcode values."""
+        import json
+
+        import deepagents_code.config as config_mod
+
+        (tmp_path / ".env").write_text("LANGSMITH_API_KEY=project-key\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            config_mod,
+            "_GLOBAL_DOTENV_PATH",
+            tmp_path / "missing-global.env",
+        )
+        launch = dict.fromkeys(config_mod._USER_LANGSMITH_ENV_VARS)
+        carrier = json.dumps({"launch": launch, "user": dict(launch)})
+        monkeypatch.setenv("LANGSMITH_API_KEY", "dcode-key")
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "prefixed-key")
+        monkeypatch.setenv(config_mod._USER_LANGSMITH_ENV_CARRIER, carrier)
+        monkeypatch.setenv("STARTUP_TEST_UNRELATED", "preserved")
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"startup-output\n", b""))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        with patch(
+            "asyncio.create_subprocess_shell",
+            return_value=mock_proc,
+        ) as create_shell:
+            await _run_startup_command("echo startup-output", console, quiet=False)
+
+        child_env = create_shell.call_args.kwargs["env"]
+        assert child_env["LANGSMITH_API_KEY"] == "project-key"
+        assert child_env["STARTUP_TEST_UNRELATED"] == "preserved"
+        assert config_mod._USER_LANGSMITH_ENV_CARRIER not in child_env
+        assert not any(
+            key.startswith("DEEPAGENTS_CODE_LANGSMITH_") for key in child_env
+        )
+        assert os.environ["LANGSMITH_API_KEY"] == "dcode-key"
+        assert "startup-output" in buf.getvalue()
 
     async def test_cancellation_kills_process_group_on_posix(self) -> None:
         """Outer cancellation should still clean up the startup process group."""


### PR DESCRIPTION
User shell commands now receive the launch-shell or active project LangSmith credentials instead of dcode's tracing credentials.

---

Interactive `!` and `!!` commands now pass a copied, restored environment to their subprocess. Interactive and headless `--startup-cmd` execution follows the same isolation path while preserving unrelated environment variables, existing output rendering, and model-context behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/c08bc89f-bf2e-5959-8107-dd0baeb9e91a) · openai:gpt-5.6-sol (high)