### PR TITLE
feat(code): copy model slug with Ctrl+click

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -33,6 +33,7 @@ _TIPS: dict[str, int] = {
     "Open /mcp and press Enter on a remote server to sign in again": 1,
     "Use /remember to save learnings from this conversation": 1,
     "Use /model to switch models mid-conversation": 2,
+    "Ctrl+click the footer model to copy its slug": 1,
     "Use /summarization-model to choose a model for compaction summaries": 1,
     "Use /uninstall to remove an optional integration": 1,
     "Use /effort to change the current model's reasoning effort": 1,

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -258,21 +258,28 @@ class ModelLabel(Widget):
         ):
             self.suppress_click()
 
-    async def on_click(self, event: events.Click) -> None:
-        """Open a picker for a left-click on a target span in the status bar.
+    def _copy_model_slug(self) -> None:
+        """Copy the unabridged model slug to the clipboard."""
+        from deepagents_code.clipboard import copy_text_with_feedback
 
-        Textual synthesizes `Click` for any button and posts one per release, so
-        filter on both: without the button check a right-click would open a picker,
-        and without the chain check a double-click would open two. A click that
-        restores terminal focus is consumed without opening anything.
-        """
+        slug = f"{self.provider}:{self.model}" if self.provider else self.model
+        copy_text_with_feedback(
+            self.app,
+            slug,
+            failure_noun="selection",
+            success_message="Model slug copied",
+        )
+
+    async def on_click(self, event: events.Click) -> None:
+        """Open a picker, or copy the model slug on Ctrl+left-click."""
         target = self._picker_target(event)
         if event.button != _LEFT_BUTTON or target is None:
             return
-        # Stop every target click so it cannot bubble to the app handler that
-        # refocuses the chat input behind a picker.
         event.stop()
         if event.chain > _SINGLE_CLICK_CHAIN:
+            return
+        if event.ctrl and target == "model":
+            self._copy_model_slug()
             return
         await self.run_action(_PICKER_ACTIONS[target])
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -434,6 +434,37 @@ class TestModelLabelClickTargets:
 
             assert app.opened_pickers == ["model"]
 
+    async def test_ctrl_click_copies_full_model_slug(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ctrl+click copies the raw slug instead of opening the model picker."""
+        from deepagents_code import clipboard as clipboard_module
+
+        copied: list[str] = []
+
+        def fake_copy(_app: App[None], text: str) -> tuple[bool, None]:
+            copied.append(text)
+            return True, None
+
+        monkeypatch.setattr(clipboard_module, "copy_text_to_clipboard", fake_copy)
+        app = StatusBarApp()
+        async with app.run_test(size=(150, 24)) as pilot:
+            label = pilot.app.query_one("#model-display", ModelLabel)
+            label.provider = "fireworks"
+            label.model = "accounts/fireworks/models/kimi-k2p6"
+            label.styles.width = 12
+            await pilot.pause()
+
+            await pilot.click(
+                label,
+                offset=self._offset_for_target(label, "model"),
+                control=True,
+            )
+            await pilot.pause()
+
+            assert copied == ["fireworks:accounts/fireworks/models/kimi-k2p6"]
+            assert app.opened_pickers == []
+
     @classmethod
     async def _move(
         cls,


### PR DESCRIPTION
Ctrl+clicking the model label in the dcode footer now copies its full model slug.

---

The model footer keeps its existing click-to-open behavior, while the Ctrl modifier routes the model target through the existing clipboard feedback helper. The copied value remains unabridged even when the footer display is truncated or strips a provider-specific prefix.

Made by [Open SWE](https://openswe.vercel.app/agents/e391525d-70b7-53d3-a143-4d070aec6205) · openai:gpt-5.6-sol (high)