### PR TITLE
fix(code): demote no-output hint suppression to debug

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -19523,13 +19523,7 @@ class DeepAgentsApp(App):
             return False
 
         if not had_agent_output:
-            # `debug`, not `info`: the always-on ring buffer behind the Debug
-            # Console captures INFO and above, but a suppressed hint is normal
-            # operation for a thread that never produced output, not a
-            # condition worth surfacing. Deliberately does not report a store
-            # count — by the time `_resume_thread` reaches here the store holds
-            # the *incoming* thread's history, so any count would describe the
-            # wrong thread.
+            # A thread with no output is normal and not worth surfacing at INFO.
             logger.debug(
                 "Suppressing previous-thread hint for %s: no server-backed "
                 "output was recorded in it",
@@ -19548,12 +19542,7 @@ class DeepAgentsApp(App):
             resumable = await thread_exists(previous_thread_id)
             owner = await get_thread_agent(previous_thread_id) if resumable else None
         except (sqlite3.Error, OSError):
-            # `info`, not `debug`: the always-on ring buffer behind the Debug
-            # Console captures INFO and above, and a store failure here is
-            # suspicious — callers have usually just read the same store
-            # successfully. At `debug` a vanished hint leaves no trace; here
-            # losing that trace would hide a real failure, so this stays at
-            # `info` while the routine no-output suppression above is `debug`.
+            # Keep store failures visible because they are not routine suppression.
             logger.info(
                 "Could not check whether previous thread %s is resumable",
                 previous_thread_id,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -19523,13 +19523,14 @@ class DeepAgentsApp(App):
             return False
 
         if not had_agent_output:
-            # `info`, not `debug`, for the same reason as the store-failure
-            # branch below: the always-on ring buffer behind the Debug Console
-            # captures INFO and above, and at `debug` a vanished hint leaves no
-            # trace. Deliberately does not report a store count — by the time
-            # `_resume_thread` reaches here the store holds the *incoming*
-            # thread's history, so any count would describe the wrong thread.
-            logger.info(
+            # `debug`, not `info`: the always-on ring buffer behind the Debug
+            # Console captures INFO and above, but a suppressed hint is normal
+            # operation for a thread that never produced output, not a
+            # condition worth surfacing. Deliberately does not report a store
+            # count — by the time `_resume_thread` reaches here the store holds
+            # the *incoming* thread's history, so any count would describe the
+            # wrong thread.
+            logger.debug(
                 "Suppressing previous-thread hint for %s: no server-backed "
                 "output was recorded in it",
                 previous_thread_id,
@@ -19550,7 +19551,9 @@ class DeepAgentsApp(App):
             # `info`, not `debug`: the always-on ring buffer behind the Debug
             # Console captures INFO and above, and a store failure here is
             # suspicious — callers have usually just read the same store
-            # successfully. At `debug` a vanished hint leaves no trace.
+            # successfully. At `debug` a vanished hint leaves no trace; here
+            # losing that trace would hide a real failure, so this stays at
+            # `info` while the routine no-output suppression above is `debug`.
             logger.info(
                 "Could not check whether previous thread %s is resumable",
                 previous_thread_id,


### PR DESCRIPTION
One plain-English sentence on the user-visible change: the `Suppressing previous-thread hint ... no server-backed output` record in the `dcode` Debug Console is now emitted at `debug` instead of `info`.

---

Suppression of a previous-thread hint is normal operation for a thread that never produced server-backed output, so its log record was noise in the always-on ring buffer behind the Debug Console, which captures `INFO` and above. `_mount_previous_thread_hint` now logs that case at `debug`.

The store-failure branch in the same method stays at `info` — its comment now explains the split, since losing that trace would hide a real problem.

Made by [Open SWE](https://openswe.vercel.app/agents/c7643029-3064-5bd7-99ca-ffe03e65877f) · openai:gpt-5.6-sol (high)