### PR TITLE
fix(sdk): treat ".." as a path component in FilesystemBackend

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -13,7 +13,7 @@ import threading
 import time
 from bisect import bisect_left, bisect_right
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from deepagents.backends.protocol import (
     ASYNC_GREP_TIMEOUT,
@@ -202,7 +202,9 @@ class FilesystemBackend(BackendProtocol):
         """
         if self.virtual_mode:
             vpath = key if key.startswith("/") else "/" + key
-            if ".." in vpath or vpath.startswith("~"):
+            # Check for traversal as a path component (not substring) to avoid
+            # false-positive rejection of legitimate names like "[...slug]"
+            if ".." in PurePosixPath(vpath).parts or vpath.startswith("~"):
                 msg = "Path traversal not allowed"
                 raise ValueError(msg)
             full = (self.cwd / vpath.lstrip("/")).resolve()

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -630,6 +630,29 @@ def test_filesystem_download_errors(tmp_path: Path):
     assert responses[0].content is None
 
 
+def test_filesystem_read_path_segment_containing_dots(tmp_path: Path):
+    """A name that merely contains "..", such as a Next.js catch-all route
+    segment, is not traversal and must remain readable."""
+    root = tmp_path
+    route = root / "src" / "app" / "feed" / "[...sections]"
+    route.mkdir(parents=True)
+    (route / "page.tsx").write_text("export default function Page() {}\n")
+
+    be = FilesystemBackend(root_dir=str(root), virtual_mode=True)
+
+    read_result = be.read("/src/app/feed/[...sections]/page.tsx")
+    assert isinstance(read_result, ReadResult) and read_result.file_data is not None
+    assert "export default" in read_result.file_data["content"]
+
+
+def test_filesystem_read_rejects_traversal_segment(tmp_path: Path):
+    """A ".." that is its own path segment still escapes the root and is refused."""
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    with pytest.raises(ValueError, match="Path traversal not allowed"):
+        be.read("/src/app/../../etc/passwd")
+
+
 def test_filesystem_upload_errors(tmp_path: Path):
     """Test upload error handling."""
     root = tmp_path


### PR DESCRIPTION
Fixes #6285

`FilesystemBackend` in `virtual_mode` can now read files whose path contains `..` inside a segment, such as Next.js catch-all routes (`/src/app/feed/[...sections]/page.tsx`).

---

`_resolve_path` tested `".." in vpath` as a substring, so any name merely containing two dots was refused with `Path traversal not allowed`. `backends/utils.py:706` already validates on path components for this exact reason ("to avoid false-positive rejection of legitimate filenames"), and the glob check at `utils.py:144` does the same — this aligns the third guard with the other two.

Escapes stay blocked: a `..` segment still fails the component check, and the `resolve()` / `relative_to(self.cwd)` containment check below it is untouched. Verified on 0.7.13:

```
REJECTED  /src/app/feed/[...sections]/page.tsx  -> ValueError: Path traversal not allowed   # before
READ OK   /src/app/feed/[...sections]/page.tsx                                              # after
REJECTED  /src/app/../../etc/passwd             -> ValueError: Path traversal not allowed   # both
```

Two tests added; the first fails without the change. `tests/unit_tests/backends/` is green (937 passed), as are the filesystem middleware and permissions suites.

Found in production: an automated code-review service using this backend logged 36 of 38 `read_file` failures on legitimate Next.js route paths, meaning those files were silently skipped during review.

Same root cause as #5789, which was closed as part of a bulk filing. Filing this one singly with the reproduction run, per the maintainer note there.

