### PR TITLE
fix(code): price nested usage with its own model and honor completions

### DIFF
--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -149,6 +149,14 @@ class RecordedUsage:
     request_tokens: int
     """Running token total for the request after applying this message."""
 
+    request_id: str | None = None
+    """Bare message ID of the request this delta belongs to, when known.
+
+    Lets the provisional-cost accumulator key corrections to the request that
+    earned them, so a late revision cannot subtract spend a backend total has
+    already replaced with other requests' contributions.
+    """
+
 
 UsageLedgerKey = str | tuple[Hashable, str]
 """Key of the recorded-request ledger: a message ID, optionally scoped.
@@ -460,6 +468,15 @@ def finalize_recorded_requests(
             recorded_requests[request_id[1]] = closed
 
 
+def _bare_request_id(request_id: UsageLedgerKey | None) -> str | None:
+    """Return a ledger key's bare message ID, dropping any attempt scope."""
+    if request_id is None:
+        return None
+    if isinstance(request_id, tuple):
+        return request_id[1]
+    return request_id
+
+
 def _names_a_model(message: object) -> bool:
     """Report whether a message's own metadata names the model that served it.
 
@@ -630,21 +647,24 @@ def _resolve_usage_model(
         The `(model_name, provider)` pair to record and price under.
     """
     from deepagents_code.cost_tracking import (
+        _CONFIGURED_MODEL_METADATA_KEY,
         _CONFIGURED_PROVIDER_METADATA_KEY,
         resolve_message_model,
     )
 
-    configured_provider = (
-        request_metadata.get(_CONFIGURED_PROVIDER_METADATA_KEY)
-        if request_metadata is not None
-        else None
-    )
+    request_metadata = request_metadata or {}
+    configured_provider = request_metadata.get(_CONFIGURED_PROVIDER_METADATA_KEY)
     has_request_provider = isinstance(configured_provider, str) and bool(
         configured_provider
     )
+    configured_model = request_metadata.get(_CONFIGURED_MODEL_METADATA_KEY)
+    has_request_model = isinstance(configured_model, str) and bool(configured_model)
     return resolve_message_model(
         message,
-        fallback_model=fallback_model,
+        # The request's own configured model describes this very call, so unlike
+        # the caller's fallback it is valid for nested calls too; it only
+        # replaces the parent-fallback step, ahead of the existing chain.
+        fallback_model=configured_model if has_request_model else fallback_model,
         fallback_provider=(
             configured_provider if has_request_provider else fallback_provider
         ),
@@ -733,6 +753,93 @@ def _move_request_to_named_model(
     )
 
 
+def _finalize_from_completed(
+    stats: SessionStats,
+    message: object,
+    previous: RecordedRequest,
+    *,
+    usage: Mapping[str, Any],
+    recorded_requests: dict[UsageLedgerKey, RecordedRequest],
+    request_id: UsageLedgerKey,
+    fallback_model: str,
+    fallback_provider: str,
+    request_metadata: Mapping[str, Any] | None,
+    kind: UsageKind,
+) -> RecordedUsage | None:
+    """Replace a chunk-built request record with a completed message's usage.
+
+    Chunks report incremental deltas, so a request recorded mid-stream holds
+    partial tokens priced under whatever model was known then. The completed
+    message carries the whole usage; it must replace the partial record rather
+    than join it, or corrected token counts, cache details, and model
+    attribution never reach the stats.
+
+    Args:
+        stats: Accumulator holding the partial request.
+        message: The completed message with the request's whole usage.
+        previous: The partial ledger entry to supersede.
+        usage: The completed message's whole usage metadata.
+        recorded_requests: Ledger to update in place.
+        request_id: Message ID keying the ledger entry.
+        fallback_model: Model to use when response metadata does not name one.
+        fallback_provider: Provider to use when response metadata omits it.
+        request_metadata: Stream metadata for this specific request, if any.
+        kind: Request class used by the type breakdown.
+
+    Returns:
+        The signed cost change the replacement applied, for the caller's
+            provisional display, or `None` when nothing changed.
+    """
+    from deepagents_code.cost_tracking import cache_token_counts, estimate_cost
+
+    model_name, provider = _resolve_usage_model(
+        message,
+        fallback_model=fallback_model,
+        fallback_provider=fallback_provider,
+        request_metadata=request_metadata,
+        kind=kind,
+    )
+    input_count, output_count = _display_token_counts(usage)
+    cost_usd = estimate_cost(usage, model_name, provider)
+    cache_reads, cache_writes = cache_token_counts(usage)
+
+    stats.retract_request(previous)
+    stats.record_request(
+        model_name,
+        input_count,
+        output_count,
+        provider,
+        cost_usd=cost_usd,
+        kind=kind,
+        cache_read_tokens=cache_reads,
+        cache_write_tokens=sum(cache_writes),
+    )
+    recorded_requests[request_id] = RecordedRequest(
+        model_name=model_name,
+        provider=provider,
+        kind=kind,
+        input_tokens=input_count,
+        output_tokens=output_count,
+        cache_read_tokens=cache_reads,
+        cache_write_tokens=sum(cache_writes),
+        cost_usd=cost_usd,
+        usage_metadata=usage,
+        finalized=True,
+    )
+    return RecordedUsage(
+        input_tokens=input_count - previous.input_tokens,
+        output_tokens=output_count - previous.output_tokens,
+        cost_usd=_cost_delta(
+            previous.cost_usd,
+            cost_usd,
+            model_name=model_name,
+            previous_model_name=previous.model_name,
+        ),
+        request_tokens=input_count + output_count,
+        request_id=_bare_request_id(request_id),
+    )
+
+
 def record_message_usage(
     stats: SessionStats,
     message: object,
@@ -810,10 +917,28 @@ def record_message_usage(
         request_id = (attempt_scope, request_id)
     is_chunk = isinstance(message, AIMessageChunk)
     if request_id is not None and request_id in recorded_requests and not is_chunk:
-        # A completed message repeats the whole request. Whether the request was
-        # built from chunks or from an identical earlier replay, it is already
-        # accounted for.
-        return None
+        previous = recorded_requests[request_id]
+        if previous.finalized:
+            # A completed message repeats the whole request, and a completed
+            # record already holds it in full. Whether this entry was built
+            # from an identical earlier completion or re-records one, it is
+            # already accounted for.
+            return None
+        # A partial ledger entry was built only from incremental chunks; this
+        # completion carries the request's whole usage and must *replace* it.
+        # Retry-attempt scoping keeps this keyed to its own attempt's entry.
+        return _finalize_from_completed(
+            stats,
+            message,
+            previous,
+            usage=usage,
+            recorded_requests=recorded_requests,
+            request_id=request_id,
+            fallback_model=fallback_model,
+            fallback_provider=fallback_provider,
+            request_metadata=request_metadata,
+            kind=kind,
+        )
 
     input_count, output_count = _display_token_counts(usage)
     previous = recorded_requests.get(request_id) if request_id is not None else None
@@ -850,6 +975,7 @@ def record_message_usage(
                     output_tokens=0,
                     cost_usd=reprice_delta,
                     request_tokens=previous.input_tokens + previous.output_tokens,
+                    request_id=_bare_request_id(request_id),
                 )
         return None
 
@@ -925,6 +1051,7 @@ def record_message_usage(
             previous_model_name=previous.model_name if previous else model_name,
         ),
         request_tokens=input_count + output_count,
+        request_id=_bare_request_id(request_id),
     )
 
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4449,6 +4449,11 @@ class DeepAgentsApp(App):
         reset whenever a server total arrives.
         """
 
+        self._provisional_cost_by_request: dict[str, float] = {}
+        """Which request each provisional dollar came from, so a correction to
+        one request cannot subtract spend the last server total already
+        replaced. Cleared with `_provisional_cost_usd` on every reset."""
+
         self._server_pricing_ok: bool | None = None
         """Whether price data loaded in the process that does the pricing.
 
@@ -8829,6 +8834,7 @@ class DeepAgentsApp(App):
             self._server_pricing_ok = pricing_ok
         self._session_cost_usd = _coerce_session_cost_usd(cost_usd)
         self._provisional_cost_usd = 0.0
+        self._provisional_cost_by_request.clear()
         self._refresh_session_cost_display()
         threshold = self._session_cost_warning_threshold_usd
         if (
@@ -8887,7 +8893,21 @@ class DeepAgentsApp(App):
         if self._inflight_thread_id == self._lc_thread_id:
             self._thread_has_completed_turn = True
 
-    def _add_provisional_cost(self, cost_usd: float, /) -> None:
+    def _apply_provisional_delta(self, delta_usd: float) -> None:
+        """Move the running provisional figure and refresh the display.
+
+        Clamps the running total, not the increment: dropping a negative delta
+        would strand the display at the estimate the correction supersedes.
+        """
+        self._provisional_cost_usd = max(self._provisional_cost_usd + delta_usd, 0.0)
+        self._refresh_session_cost_display()
+
+    def _add_provisional_cost(
+        self,
+        cost_usd: float,
+        /,
+        request_id: str | None = None,
+    ) -> None:
         """Show one streamed request's estimate ahead of the graph's total.
 
         The graph checkpoints this same request and streams the total that
@@ -8898,14 +8918,33 @@ class DeepAgentsApp(App):
         Args:
             cost_usd: Estimated cost this message contributed, in US dollars.
                 Negative when a later chunk re-prices its request downward.
+            request_id: Message ID of the request the delta belongs to, when
+                known. A correction to a request the last backend total already
+                covered must not subtract other requests' newer provisional
+                spend, so a keyed delta is only applied while its own
+                contribution is still held.
         """
         delta_usd = _coerce_provisional_cost_delta_usd(cost_usd)
         if delta_usd is None or delta_usd == 0:
             return
-        # Clamp the running total, not the increment: dropping a negative delta
-        # would strand the display at the estimate the correction supersedes.
-        self._provisional_cost_usd = max(self._provisional_cost_usd + delta_usd, 0.0)
-        self._refresh_session_cost_display()
+        if request_id is None:
+            # Legacy callers without request identity cannot be reconciled; the
+            # running total is all they can adjust.
+            self._apply_provisional_delta(delta_usd)
+            return
+        held = self._provisional_cost_by_request.get(request_id, 0.0)
+        if held <= 0 and delta_usd < 0:
+            # A backend total already folded this request's contribution into
+            # the durable figure and cleared the provisional pool; its
+            # correction is stale and must not claw back other spend.
+            return
+        # Clamp a retraction to what this request still holds. A correction
+        # larger than its own contribution -- a partial reset, or an estimate
+        # that fell further than the pool it is drawn from -- would otherwise
+        # subtract spend that other in-flight children put there.
+        applied_usd = max(delta_usd, -held) if delta_usd < 0 else delta_usd
+        self._provisional_cost_by_request[request_id] = held + applied_usd
+        self._apply_provisional_delta(applied_usd)
 
     def _pricing_is_broken(self) -> bool:
         """Report whether price data failed to load where pricing happens.

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -79,7 +79,12 @@ if TYPE_CHECKING:
         Positional-only for the same reason as `_SessionCostCallback`.
         """
 
-        def __call__(self, cost_usd: float, /) -> None: ...
+        def __call__(
+            self,
+            cost_usd: float,
+            /,
+            request_id: str | None = None,
+        ) -> None: ...
 
 
 from deepagents_code import _session_stats
@@ -916,6 +921,8 @@ class TextualUIAdapter:
         Keeps the status bar moving during work whose cost the graph has not
         checkpointed yet — a long subagent run, say — without making the client
         a second authority: every server total replaces what this accumulated.
+        `request_id` names the request the delta belongs to so a late
+        correction only retracts its own contribution.
         """
 
         self._on_usage_update: Callable[[], None] | None = None
@@ -1512,10 +1519,19 @@ def _apply_recorded_usage(
         adapter._on_usage_update()
     if recorded_usage.cost_usd is None or not adapter._on_provisional_cost:
         return
+    if recorded_usage.cost_usd == 0:
+        # A zero delta moves nothing; the app already ignores it, so skip the
+        # call rather than waking the display for a no-op.
+        return
     # Display-only: the graph checkpoints the same spend and streams the
-    # authoritative total, which supersedes this estimate.
+    # authoritative total, which supersedes this estimate. The request ID lets
+    # the app reconcile a later correction with its own contribution rather
+    # than the whole running provisional total.
     try:
-        adapter._on_provisional_cost(recorded_usage.cost_usd)
+        adapter._on_provisional_cost(
+            recorded_usage.cost_usd,
+            request_id=recorded_usage.request_id,
+        )
     except Exception:
         logger.warning("on_provisional_cost callback failed", exc_info=True)
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -30325,3 +30325,122 @@ class TestPromptClipboard:
                 setattr(app, attribute, None)
 
             assert app._prompt_clipboard_block_reason() is None
+
+
+class TestProvisionalCostReconciliation:
+    """Request-keyed provisional deltas survive backend resets correctly."""
+
+    async def test_a_late_correction_only_retracts_its_own_contribution(
+        self,
+    ) -> None:
+        """A child's completion correcting it down must not subtract spend.
+
+        Other children added spend after a backend total cleared the pool; the
+        correction must leave theirs alone.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._add_provisional_cost(0.5, request_id="child-1")
+            # A backend total arrives and clears all provisional spend.
+            app._set_session_cost(2.0)
+            assert app._displayed_cost_usd == pytest.approx(2.0)
+
+            # A second child adds new provisional spend after the reset.
+            app._add_provisional_cost(0.7, request_id="child-2")
+
+            # child-1's late correction arrives: its own $0.50 is no longer
+            # held, so the correction must not touch child-2's contribution.
+            app._add_provisional_cost(-0.5, request_id="child-1")
+
+            assert app._displayed_cost_usd == pytest.approx(2.7)
+
+    async def test_a_correction_applies_while_its_contribution_is_still_held(
+        self,
+    ) -> None:
+        """Before any backend reset, a correction adjusts the total.
+
+        The request's contribution is retracted by the signed delta only.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._set_session_cost(1.0)
+            app._add_provisional_cost(0.5, request_id="child-1")
+            app._add_provisional_cost(0.7, request_id="child-2")
+
+            app._add_provisional_cost(-0.45, request_id="child-1")
+
+            assert app._displayed_cost_usd == pytest.approx(1.75)
+
+    async def test_chunk_revisions_accumulate_per_request(self) -> None:
+        """A request priced across several chunks reconciles correctly.
+
+        The retraction matches the running total, not just the last delta.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._set_session_cost(1.0)
+            app._add_provisional_cost(0.3, request_id="child-1")
+            app._add_provisional_cost(0.2, request_id="child-1")
+
+            app._add_provisional_cost(-0.1, request_id="child-1")
+
+            assert app._displayed_cost_usd == pytest.approx(1.4)
+
+    async def test_a_backend_reset_clears_keyed_contributions(self) -> None:
+        """After `_set_session_cost`, no keyed contribution can be retracted."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._set_session_cost(1.0)
+            app._add_provisional_cost(0.5, request_id="child-1")
+            app._set_session_cost(1.5)
+
+            app._add_provisional_cost(-0.5, request_id="child-1")
+
+            assert app._displayed_cost_usd == pytest.approx(1.5)
+
+    async def test_unkeyed_deltas_keep_the_legacy_behavior(self) -> None:
+        """Deltas without request identity still adjust the running total."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._set_session_cost(1.0)
+
+            app._add_provisional_cost(0.5)
+            app._add_provisional_cost(-0.2)
+
+            assert app._displayed_cost_usd == pytest.approx(1.3)
+
+    async def test_a_correction_never_drives_the_display_negative(self) -> None:
+        """Clamping still applies to a keyed retraction."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._set_session_cost(0.0)
+            app._add_provisional_cost(0.01, request_id="child-1")
+
+            app._add_provisional_cost(-0.5, request_id="child-1")
+
+            assert app._displayed_cost_usd == pytest.approx(0.0)
+
+    async def test_an_oversized_retraction_spares_other_children(self) -> None:
+        """A correction may only give back what its own request contributed.
+
+        Applying the whole signed delta would take a sibling's provisional
+        spend with it, which the next backend total would then have to add
+        back — the drop the display is meant to avoid.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._set_session_cost(1.0)
+            app._add_provisional_cost(0.1, request_id="child-1")
+            app._add_provisional_cost(0.7, request_id="child-2")
+
+            # Larger than child-1's own contribution.
+            app._add_provisional_cost(-0.5, request_id="child-1")
+
+            assert app._displayed_cost_usd == pytest.approx(1.7)

--- a/libs/code/tests/unit_tests/test_session_stats.py
+++ b/libs/code/tests/unit_tests/test_session_stats.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, cast
 
 import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk
@@ -107,6 +108,550 @@ class TestRecordMessageUsage:
         assert second is None
         assert stats.request_count == 1
         assert stats.output_tokens == 100
+
+    def test_completion_replaces_a_partial_chunk_record(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A completed message corrects a request built from partial chunks.
+
+        The chunks priced the request under the fallback model; the completion
+        names the real one and carries the whole usage. The partial record must
+        be replaced, not added to, and the reported delta must be signed so the
+        provisional display can follow the correction down.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.cost_tracking.estimate_cost",
+            lambda _usage, model, _provider="": (
+                0.5 if model == "fallback-model" else 0.05
+            ),
+        )
+        stats = SessionStats()
+        ledger: dict[UsageLedgerKey, RecordedRequest] = {}
+        chunk = AIMessageChunk(
+            content="",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 900,
+                "output_tokens": 10,
+                "total_tokens": 910,
+            },
+            response_metadata={"model_provider": "openai"},
+        )
+        completion = AIMessage(
+            content="done",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 5,
+                "total_tokens": 105,
+                "input_token_details": {"cache_read": 80},
+            },
+            response_metadata={"model_name": "real-model", "model_provider": "openai"},
+        )
+
+        chunk_usage = record_message_usage(
+            stats,
+            chunk,
+            fallback_model="fallback-model",
+            fallback_provider="openai",
+            recorded_requests=ledger,
+        )
+        completion_usage = record_message_usage(
+            stats,
+            completion,
+            fallback_model="fallback-model",
+            fallback_provider="openai",
+            recorded_requests=ledger,
+        )
+
+        assert chunk_usage is not None
+        assert chunk_usage.cost_usd == pytest.approx(0.5)
+        assert completion_usage is not None
+        assert completion_usage.cost_usd == pytest.approx(-0.45)
+        assert completion_usage.request_tokens == 105
+        assert completion_usage.request_id == "child-1"
+        assert stats.request_count == 1
+        assert stats.total_cost_usd == pytest.approx(0.05)
+        assert stats.input_tokens == 100
+        assert stats.output_tokens == 5
+        assert stats.cache_read_tokens == 80
+        assert stats.per_model["openai", "real-model"].request_count == 1
+        assert stats.per_kind["assistant"].request_count == 1
+        assert ledger["child-1"].finalized is True
+
+    def test_replaying_a_completion_after_partial_chunks_is_a_no_op(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The completed event arrives twice; the second must not re-count.
+
+        Once from the message stream and once as a nested event.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.cost_tracking.estimate_cost",
+            lambda _usage, _model, _provider="": 0.05,
+        )
+        stats = SessionStats()
+        ledger: dict[UsageLedgerKey, RecordedRequest] = {}
+        chunk = AIMessageChunk(
+            content="",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 900,
+                "output_tokens": 10,
+                "total_tokens": 910,
+            },
+            response_metadata={"model_provider": "openai"},
+        )
+        completion = AIMessage(
+            content="done",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 5,
+                "total_tokens": 105,
+            },
+            response_metadata={"model_name": "real-model", "model_provider": "openai"},
+        )
+        record_message_usage(stats, chunk, recorded_requests=ledger)
+        first = record_message_usage(stats, completion, recorded_requests=ledger)
+        replay = record_message_usage(stats, completion, recorded_requests=ledger)
+
+        assert first is not None
+        assert replay is None
+        assert stats.request_count == 1
+        assert stats.input_tokens == 100
+        assert stats.total_cost_usd == pytest.approx(0.05)
+
+    def test_chunks_after_a_completion_cannot_reopen_the_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A finalization closes the ledger entry against later chunk deltas."""
+        monkeypatch.setattr(
+            "deepagents_code.cost_tracking.estimate_cost",
+            lambda _usage, _model, _provider="": 0.05,
+        )
+        stats = SessionStats()
+        ledger: dict[UsageLedgerKey, RecordedRequest] = {}
+        completion = AIMessage(
+            content="done",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 5,
+                "total_tokens": 105,
+            },
+            response_metadata={"model_name": "real-model", "model_provider": "openai"},
+        )
+        record_message_usage(stats, completion, recorded_requests=ledger)
+        stray = record_message_usage(
+            stats,
+            AIMessageChunk(
+                content="",
+                id="child-1",
+                usage_metadata={
+                    "input_tokens": 50,
+                    "output_tokens": 2,
+                    "total_tokens": 52,
+                },
+                response_metadata={"model_provider": "openai"},
+            ),
+            recorded_requests=ledger,
+        )
+
+        assert stray is None
+        assert stats.request_count == 1
+        assert stats.input_tokens == 100
+        assert stats.total_cost_usd == pytest.approx(0.05)
+
+    def test_completion_before_any_chunks_opens_the_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A completion with no prior partial record opens the request.
+
+        It is an ordinary first record, not a correction.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.cost_tracking.estimate_cost",
+            lambda _usage, _model, _provider="": 0.05,
+        )
+        stats = SessionStats()
+        ledger: dict[UsageLedgerKey, RecordedRequest] = {}
+        completion = AIMessage(
+            content="done",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 5,
+                "total_tokens": 105,
+            },
+            response_metadata={"model_name": "real-model", "model_provider": "openai"},
+        )
+
+        recorded = record_message_usage(stats, completion, recorded_requests=ledger)
+
+        assert recorded is not None
+        assert recorded.cost_usd == pytest.approx(0.05)
+        assert recorded.request_id == "child-1"
+        assert stats.request_count == 1
+
+    def test_retry_attempt_scoping_separates_completions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two attempts reusing one message ID are distinct requests.
+
+        A completion finalizes only its own attempt's entry.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.cost_tracking.estimate_cost",
+            lambda _usage, _model, _provider="": 0.1,
+        )
+        stats = SessionStats()
+        ledger: dict[UsageLedgerKey, RecordedRequest] = {}
+        chunk = AIMessageChunk(
+            content="",
+            id="run-1",
+            usage_metadata={
+                "input_tokens": 900,
+                "output_tokens": 10,
+                "total_tokens": 910,
+            },
+            response_metadata={"model_provider": "openai"},
+        )
+        completion = AIMessage(
+            content="done",
+            id="run-1",
+            usage_metadata={
+                "input_tokens": 1_000,
+                "output_tokens": 20,
+                "total_tokens": 1_020,
+            },
+            response_metadata={"model_provider": "openai"},
+        )
+
+        record_message_usage(stats, chunk, recorded_requests=ledger, attempt_scope=1)
+        finalized = record_message_usage(
+            stats, completion, recorded_requests=ledger, attempt_scope=1
+        )
+        retry = record_message_usage(
+            stats, chunk, recorded_requests=ledger, attempt_scope=2
+        )
+
+        assert finalized is not None
+        assert finalized.request_id == "run-1"
+        assert retry is not None
+        assert stats.request_count == 2
+        assert stats.input_tokens == 1_900
+        assert stats.output_tokens == 30
+        assert ledger[1, "run-1"].finalized is True
+        assert ledger[2, "run-1"].finalized is False
+
+    def test_missing_response_model_uses_request_specific_configured_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A child's configured model beats the main agent's fallback.
+
+        The request metadata describes this very call, so it must win over the
+        caller's `runtime_state` fallback, which describes the parent.
+        """
+        priced_models: list[str] = []
+
+        def fake_price(_usage: object, model: str, _provider: str = "") -> float | None:
+            priced_models.append(model)
+            return 0.25 if model == "child-model" else 9.99
+
+        monkeypatch.setattr("deepagents_code.cost_tracking.estimate_cost", fake_price)
+        stats = SessionStats()
+        ledger: dict[UsageLedgerKey, RecordedRequest] = {}
+        chunk = AIMessageChunk(
+            content="",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 10,
+                "total_tokens": 110,
+            },
+            response_metadata={"model_provider": "openai"},
+        )
+
+        recorded = record_message_usage(
+            stats,
+            chunk,
+            fallback_model="main-model",
+            fallback_provider="openai",
+            request_metadata={
+                "deepagents_code_configured_model": "child-model",
+                "deepagents_code_configured_provider": "openai",
+            },
+            kind="subagent",
+            recorded_requests=ledger,
+        )
+
+        assert recorded is not None
+        assert recorded.cost_usd == pytest.approx(0.25)
+        assert stats.per_model["openai", "child-model"].request_count == 1
+        assert ("openai", "main-model") not in stats.per_model
+        assert priced_models == ["child-model"]
+
+    def test_explicit_response_model_still_beats_configured_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A response that names its model keeps precedence over request metadata.
+
+        The configured model only fills in when the response omits one; the
+        existing response-first chain must not be inverted.
+        """
+        priced_models: list[str] = []
+
+        def fake_price(_usage: object, model: str, _provider: str = "") -> float | None:
+            priced_models.append(model)
+            return 0.25
+
+        monkeypatch.setattr("deepagents_code.cost_tracking.estimate_cost", fake_price)
+        stats = SessionStats()
+        ledger: dict[UsageLedgerKey, RecordedRequest] = {}
+        chunk = AIMessageChunk(
+            content="",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 10,
+                "total_tokens": 110,
+            },
+            response_metadata={
+                "model_name": "response-model",
+                "model_provider": "openai",
+            },
+        )
+
+        record_message_usage(
+            stats,
+            chunk,
+            fallback_model="main-model",
+            fallback_provider="openai",
+            request_metadata={
+                "deepagents_code_configured_model": "child-model",
+                "deepagents_code_configured_provider": "openai",
+            },
+            kind="subagent",
+            recorded_requests=ledger,
+        )
+
+        assert stats.per_model["openai", "response-model"].request_count == 1
+        assert ("openai", "child-model") not in stats.per_model
+        assert priced_models == ["response-model"]
+
+    def test_configured_provider_alias_wins_over_generic_response_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An aliased configured provider still replaces a generic response one.
+
+        `azure_openai` maps to the `genai-prices` identifier the catalog knows;
+        pricing under the response's bare `openai` would use the wrong rates.
+        """
+        priced_providers: list[str] = []
+
+        def fake_price(_usage: object, _model: str, provider: str = "") -> float | None:
+            priced_providers.append(provider)
+            return 0.25
+
+        monkeypatch.setattr("deepagents_code.cost_tracking.estimate_cost", fake_price)
+        stats = SessionStats()
+        chunk = AIMessageChunk(
+            content="",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 10,
+                "total_tokens": 110,
+            },
+            response_metadata={"model_name": "gpt-5.5", "model_provider": "openai"},
+        )
+
+        record_message_usage(
+            stats,
+            chunk,
+            fallback_model="main-model",
+            fallback_provider="openai",
+            request_metadata={
+                "deepagents_code_configured_model": "gpt-5.5",
+                "deepagents_code_configured_provider": "azure_openai",
+            },
+            kind="subagent",
+            recorded_requests={},
+        )
+
+        assert priced_providers == ["azure_openai"]
+        assert stats.per_model["azure_openai", "gpt-5.5"].request_count == 1
+
+    def test_without_request_metadata_the_parent_fallback_stays_subagent_shy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No request metadata and a nested call keeps prior behavior.
+
+        The parent fallback must not silently price the child as the parent's
+        model when the response names nothing.
+        """
+        priced_models: list[str] = []
+
+        def fake_price(_usage: object, model: str, _provider: str = "") -> float | None:
+            priced_models.append(model)
+            return 0.25
+
+        monkeypatch.setattr("deepagents_code.cost_tracking.estimate_cost", fake_price)
+        stats = SessionStats()
+        chunk = AIMessageChunk(
+            content="",
+            id="child-1",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 10,
+                "total_tokens": 110,
+            },
+            response_metadata={},
+        )
+
+        record_message_usage(
+            stats,
+            chunk,
+            fallback_model="main-model",
+            fallback_provider="openai",
+            kind="subagent",
+            recorded_requests={},
+        )
+
+        # Pre-existing behavior: an unnamed nested response is priced under the
+        # caller's fallback because nothing request-specific is known.
+        assert stats.per_model["openai", "main-model"].request_count == 1
+        assert priced_models == ["main-model"]
+
+
+class TestParallelChildrenAndLateCorrections:
+    """Interleaved children, backend totals, and late usage corrections."""
+
+    @staticmethod
+    def _chunk(
+        message_id: str,
+        input_tokens: int,
+        *,
+        names_model: bool = True,
+    ) -> AIMessageChunk:
+        return AIMessageChunk(
+            content="",
+            id=message_id,
+            usage_metadata={
+                "input_tokens": input_tokens,
+                "output_tokens": 10,
+                "total_tokens": input_tokens + 10,
+            },
+            response_metadata=(
+                {"model_name": "expensive-model", "model_provider": "openai"}
+                if names_model
+                else {"model_provider": "openai"}
+            ),
+        )
+
+    def test_a_late_correction_reports_a_negative_delta_for_its_own_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two children recorded provisionally, then a completion corrects.
+
+        The second child's completion corrects it down after the first's
+        backend total already reset the display.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.cost_tracking.estimate_cost",
+            lambda _usage, model, _provider="": 0.05 if model == "real-model" else 0.5,
+        )
+        stats = SessionStats()
+        ledger: dict[UsageLedgerKey, RecordedRequest] = {}
+        record_message_usage(
+            stats, self._chunk("child-1", 900), recorded_requests=ledger
+        )
+        record_message_usage(
+            stats, self._chunk("child-2", 900), recorded_requests=ledger
+        )
+
+        completion = AIMessage(
+            content="done",
+            id="child-2",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 5,
+                "total_tokens": 105,
+            },
+            response_metadata={"model_name": "real-model", "model_provider": "openai"},
+        )
+        correction = record_message_usage(stats, completion, recorded_requests=ledger)
+
+        assert correction is not None
+        assert correction.request_id == "child-2"
+        # Signed so the caller can reconcile request-keyed provisional spend;
+        # applying it to the whole accumulator would subtract child-1's $0.50.
+        assert correction.cost_usd == pytest.approx(-0.45)
+        assert stats.request_count == 2
+
+    def test_event_with_changed_model_replaces_the_partial_record(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A nested event correcting model and tokens re-files its request."""
+        priced: dict[str, float] = {}
+
+        def fake_price(usage: object, model: str, _provider: str = "") -> float | None:
+            rates = {"expensive-model": 1.0, "cheap-model": 0.01, "": 0.0}
+            priced[model] = rates[model]
+            input_tokens = cast("dict[str, Any]", usage)["input_tokens"]
+            return input_tokens / 1000 * rates[model]
+
+        monkeypatch.setattr("deepagents_code.cost_tracking.estimate_cost", fake_price)
+        stats = SessionStats()
+        ledger: dict[UsageLedgerKey, RecordedRequest] = {}
+        partial = {
+            "type": "model_usage",
+            "version": 1,
+            "request_id": "child-1",
+            "usage_metadata": {
+                "input_tokens": 1_000,
+                "output_tokens": 100,
+                "total_tokens": 1_100,
+            },
+            "model_name": "expensive-model",
+            "provider": "openai",
+            "thread_id": "thread-1",
+            "scope": "tools:task",
+        }
+        # A nested event arrives complete by construction, but the message
+        # stream can have recorded partial chunks for the same request first.
+        record_message_usage(
+            stats, self._chunk("child-1", 1_000), recorded_requests=ledger
+        )
+
+        corrected = record_model_usage_event(
+            stats,
+            partial
+            | {
+                "model_name": "cheap-model",
+                "usage_metadata": {
+                    "input_tokens": 500,
+                    "output_tokens": 50,
+                    "total_tokens": 550,
+                    "input_token_details": {"cache_read": 400},
+                },
+            },
+            active_thread_id="thread-1",
+            recorded_requests=ledger,
+        )
+
+        assert corrected is not None
+        assert corrected.cost_usd == pytest.approx(
+            500 / 1000 * 0.01 - 1_000 / 1000 * 1.0
+        )
+        assert corrected.request_id == "child-1"
+        assert stats.request_count == 1
+        assert stats.total_cost_usd == pytest.approx(500 / 1000 * 0.01)
+        assert stats.input_tokens == 500
+        assert stats.cache_read_tokens == 400
+        assert ("openai", "cheap-model") in stats.per_model
+        assert ("openai", "expensive-model") not in stats.per_model
 
 
 class TestRecordModelUsageEvent:

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -2086,7 +2086,15 @@ class TestSessionCostEvents:
             request_approval=_mock_approval,
         )
         adapter._on_usage_update = lambda: None
-        adapter._on_provisional_cost = updates.append
+
+        def _record_provisional(
+            cost_usd: float,
+            /,
+            request_id: str | None = None,  # noqa: ARG001  # Protocol conformance.
+        ) -> None:
+            updates.append(cost_usd)
+
+        adapter._on_provisional_cost = _record_provisional
         chunks = [
             (
                 ("tools:task",),
@@ -2144,7 +2152,15 @@ class TestSessionCostEvents:
             update_status=_noop_status,
             request_approval=_mock_approval,
         )
-        adapter._on_provisional_cost = updates.append
+
+        def _record_provisional(
+            cost_usd: float,
+            /,
+            request_id: str | None = None,  # noqa: ARG001  # Protocol conformance.
+        ) -> None:
+            updates.append(cost_usd)
+
+        adapter._on_provisional_cost = _record_provisional
         usage = {
             "input_tokens": 1_000,
             "output_tokens": 100,
@@ -2195,6 +2211,97 @@ class TestSessionCostEvents:
         assert updates == [pytest.approx(0.42)]
         assert turn_stats.per_kind["subagent"].request_count == 1
         assert turn_stats.total_cost_usd == pytest.approx(0.42)
+
+    async def test_a_completion_after_partial_chunks_reports_a_negative_delta(
+        self,
+    ) -> None:
+        """A nested usage event correcting a chunk-built request flows on.
+
+        The provisional callback receives a signed, request-keyed delta.
+        """
+        from langchain_core.messages import AIMessageChunk
+
+        async def mount_message(_: object) -> bool:
+            await asyncio.sleep(0)
+            return True
+
+        updates: list[tuple[float, str | None]] = []
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+        adapter._on_usage_update = lambda: None
+        adapter._on_provisional_cost = lambda cost_usd, /, request_id=None: (
+            updates.append((cost_usd, request_id))
+        )
+        partial = {
+            "input_tokens": 1_000,
+            "output_tokens": 100,
+            "total_tokens": 1_100,
+        }
+        corrected = {
+            "input_tokens": 100,
+            "output_tokens": 5,
+            "total_tokens": 105,
+        }
+        chunks = [
+            (
+                ("tools:task",),
+                "messages",
+                (
+                    AIMessageChunk(  # ty: ignore[invalid-argument-type]
+                        content="",
+                        id="child-1",
+                        usage_metadata=partial,
+                        response_metadata={"model_provider": "openai"},
+                    ),
+                    {},
+                ),
+            ),
+            (
+                ("tools:task",),
+                "custom",
+                {
+                    "type": "model_usage",
+                    "version": 1,
+                    "request_id": "child-1",
+                    "usage_metadata": corrected,
+                    "model_name": "real-model",
+                    "provider": "openai",
+                    "thread_id": "thread-1",
+                    "scope": "tools:task",
+                },
+            ),
+            ((), "messages", (_text_message("Done."), {})),
+        ]
+        turn_stats = SessionStats()
+
+        def price(_usage: object, model: str, _provider: str = "") -> float | None:
+            return 0.5 if model == "gpt-5.5" else 0.05
+
+        with (
+            patch("deepagents_code.config.runtime_state") as mock_runtime_state,
+            patch("deepagents_code.cost_tracking.estimate_cost", price),
+        ):
+            mock_runtime_state.model_name = "gpt-5.5"
+            mock_runtime_state.model_provider = "openai"
+            await execute_task_textual(
+                user_input="hello",
+                agent=_FakeAgent(chunks),
+                assistant_id="assistant",
+                session_state=_session_state(auto_approve=False),
+                adapter=adapter,
+                turn_stats=turn_stats,
+            )
+
+        assert updates == [
+            (pytest.approx(0.5), "child-1"),
+            (pytest.approx(-0.45), "child-1"),
+        ]
+        assert turn_stats.request_count == 1
+        assert turn_stats.total_cost_usd == pytest.approx(0.05)
+        assert turn_stats.input_tokens == 100
 
 
 class TestExecuteTaskTextualAutoModeClassifier:


### PR DESCRIPTION
Nested agent costs no longer spike during streaming and drop when the backend reports its final total.

---

Two gaps inflated provisional cost: nested responses without model names inherited parent pricing, and final usage events could not correct chunk-built records.

Use request model metadata before the parent fallback, replace provisional records with final usage, and track provisional cost per request so corrections cannot subtract another request's spend.

Made by [Open SWE](https://openswe.vercel.app/agents/2029a02d-bc43-50b5-936d-3025b65a5bb3) · openai:gpt-5.6-sol (medium)
