### PR TITLE
feat(code): condense status bar cwd from the middle, tail intact

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/_condense_path.py
+++ b/libs/code/deepagents_code/tui/widgets/_condense_path.py
@@ -1,0 +1,94 @@
+"""Width-aware condensation of paths for single-line display."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+from rich.cells import cell_len
+from textual.content import Content
+
+from deepagents_code.config import get_glyphs
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+
+def condense_path(path: str, width: int, prefix: str = "") -> str:
+    """Condense `path` so it renders within `width` terminal cells.
+
+    Directory components are replaced by a single ellipsis, growing outward
+    from the middle of the component list, because the tail of a path — the
+    directory or file the user is actually looking at — is the part worth
+    keeping. The last component is only end-truncated once every directory
+    component has already been dropped.
+
+    Args:
+        path: Path to display, already home-substituted where wanted.
+        width: Cells available for `prefix` and the path together.
+        prefix: Text rendered immediately before the path; it is returned as
+            part of the result and counted against `width`.
+
+    Returns:
+        `prefix` followed by as much of the path as fits in `width`.
+    """
+    return _condense(path, width, prefix, get_glyphs().ellipsis)
+
+
+@lru_cache(maxsize=512)
+def _condense(path: str, width: int, prefix: str, ellipsis: str) -> str:
+    """Condense `path` for one specific ellipsis glyph.
+
+    The glyph is an explicit argument so that the cache is keyed by it and a
+    charset switch cannot serve a result built from the other glyph set.
+
+    Returns:
+        `prefix` followed by the condensed path.
+    """
+    budget = width - cell_len(prefix)
+    if cell_len(path) <= budget:
+        return prefix + path
+    components = [part for part in path.split("/") if part]
+    if not components:
+        return prefix + _truncate(path, budget, ellipsis)
+    root = "/" if path.startswith("/") else ""
+    for candidate in _candidates(root, components, ellipsis):
+        if cell_len(candidate) <= budget:
+            return prefix + candidate
+    return prefix + _truncate(components[-1], budget, ellipsis)
+
+
+def _candidates(root: str, components: Sequence[str], ellipsis: str) -> Iterator[str]:
+    """Yield progressively shorter renderings of a component list.
+
+    Args:
+        root: `'/'` for an absolute path, otherwise the empty string.
+        components: Path components, with the displayed one last.
+        ellipsis: Glyph standing in for the dropped components.
+
+    Yields:
+        The path with a growing run of middle directory components collapsed
+            into one ellipsis, and finally the bare last component.
+    """
+    *directories, last = components
+    for dropped in range(1, len(directories) + 1):
+        start = (len(directories) - dropped) // 2
+        kept = [*directories[:start], ellipsis, *directories[start + dropped :], last]
+        yield root + "/".join(kept)
+    yield last
+
+
+def _truncate(text: str, width: int, ellipsis: str) -> str:
+    """End-truncate `text` to `width` cells, marking the cut with `ellipsis`.
+
+    Returns:
+        The leading cells of `text` followed by `ellipsis`, or as much of
+            `ellipsis` alone as fits when there is no room for both.
+    """
+    if width <= 0:
+        return ""
+    marker = cell_len(ellipsis)
+    if width <= marker:
+        return Content(ellipsis).truncate(width).plain
+    # `truncate` pads with a space when the cut splits a double-width cell.
+    return Content(text).truncate(width - marker).plain.rstrip() + ellipsis

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -7,6 +7,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
+from rich.cells import cell_len
 from textual import events
 from textual.containers import Horizontal, Vertical
 from textual.content import Content
@@ -21,6 +22,7 @@ from deepagents_code._constants import FIREWORKS_MODEL_ID_PREFIXES
 from deepagents_code._env_vars import HIDE_CWD, HIDE_GIT_BRANCH, is_env_truthy
 from deepagents_code._session_stats import format_cost, format_token_count
 from deepagents_code.config import get_glyphs
+from deepagents_code.tui.widgets._condense_path import condense_path
 from deepagents_code.tui.widgets.loading import Spinner
 
 logger = logging.getLogger(__name__)
@@ -335,6 +337,79 @@ class ModelLabel(Widget):
         return self._clickable_content(ellipsis[:width])
 
 
+_CWD_MAX_FRACTION = 0.45
+"""Share of the status row `.status-cwd` may claim (its CSS `max-width`)."""
+
+
+def _home_relative(path: str) -> str:
+    """Substitute `~` for the user's home directory.
+
+    Returns:
+        The path with a leading `~` when it lives under the home directory,
+            otherwise the path unchanged.
+    """
+    try:
+        candidate = Path(path)
+        home = Path.home()
+        if candidate.is_relative_to(home):
+            relative = candidate.relative_to(home).as_posix()
+            return "~" if relative == "." else f"~/{relative}"
+    except (ValueError, RuntimeError):
+        pass
+    return path
+
+
+class CwdLabel(Widget):
+    """A label that displays the working directory, condensed to fit.
+
+    The tail of a path is the part users read, so directory components are
+    collapsed from the middle outward (see :func:`condense_path`) rather than
+    clipping the end the way CSS `text-overflow: ellipsis` does. The widget
+    sizes to the full path but is capped by `.status-cwd`'s `max-width`, so
+    `render` always sees the real budget in `content_size`. The untruncated
+    path is always available as the widget's tooltip.
+    """
+
+    path: reactive[str] = reactive("", layout=True)
+
+    def get_content_width(self, container: Size, viewport: Size) -> int:  # noqa: ARG002
+        """Return the intrinsic width so the widget participates in flex layout.
+
+        Args:
+            container: Size of the container.
+            viewport: Size of the viewport.
+
+        Returns:
+            Cell width of the full home-relative path. Returning the full path
+                (not the condensed form) keeps the label's size independent of
+                its own output and lets the CSS `max-width` provide the budget
+                `render` condenses against.
+        """
+        if not self.path:
+            return 0
+        return cell_len(_home_relative(self.path))
+
+    def watch_path(self, path: str) -> None:
+        """Expose the untruncated path as the widget's tooltip."""
+        self.tooltip = path or None
+
+    def render(self) -> RenderResult:
+        """Render the path condensed to the available width.
+
+        Returns:
+            The home-relative path, condensed when it overflows, or the empty
+                string when no path is set.
+        """
+        if not self.path:
+            return Content("")
+        display = _home_relative(self.path)
+        width = self.content_size.width
+        # Before the first layout there is no width to condense against.
+        if width <= 0:
+            return Content(display)
+        return Content(condense_path(display, width))
+
+
 class BranchLabel(Widget):
     """A label that displays the git branch with glyph-aware truncation.
 
@@ -527,7 +602,6 @@ class StatusBar(Vertical):
         padding: 0 1 0 0;
         color: $text-muted;
         overflow-x: hidden;
-        text-overflow: ellipsis;
         text-wrap: nowrap;
     }
 
@@ -625,7 +699,7 @@ class StatusBar(Vertical):
                 classes="status-auto-approve manual",
                 id="auto-approve-indicator",
             )
-            yield Static("", classes="status-cwd", id="cwd-display")
+            yield CwdLabel(classes="status-cwd", id="cwd-display")
             yield BranchLabel(classes="status-branch", id="branch-display")
             yield Static("", classes="status-rubric", id="rubric-display")
             yield ModelLabel(id="model-display")
@@ -651,7 +725,7 @@ class StatusBar(Vertical):
     def _set_cwd_visible(self, visible: bool) -> None:
         """Show or hide the cwd."""
         with suppress(NoMatches):
-            self.query_one("#cwd-display", Static).display = visible
+            self.query_one("#cwd-display", CwdLabel).display = visible
 
     def on_unmount(self) -> None:
         """Stop the spinner timer so it can't tick on a detached widget."""
@@ -715,10 +789,10 @@ class StatusBar(Vertical):
     def watch_cwd(self, new_value: str) -> None:
         """Update cwd display when it changes."""
         try:
-            display = self.query_one("#cwd-display", Static)
+            display = self.query_one("#cwd-display", CwdLabel)
         except NoMatches:
             return
-        display.update(self._format_cwd(new_value))
+        display.path = new_value or self.cwd or self._initial_cwd
 
     def watch_branch(self, new_value: str) -> None:
         """Update branch display when it changes."""
@@ -875,22 +949,6 @@ class StatusBar(Vertical):
             count: Count of queued messages (negative values clamp to `0`).
         """
         self.queued_count = max(count, 0)
-
-    def _format_cwd(self, cwd_path: str = "") -> str:
-        """Format the current working directory for display.
-
-        Returns:
-            Formatted path string, using ~ for home directory when possible.
-        """
-        path = Path(cwd_path or self.cwd or self._initial_cwd)
-        try:
-            # Try to use ~ for home directory
-            home = Path.home()
-            if path.is_relative_to(home):
-                return "~/" + path.relative_to(home).as_posix()
-        except (ValueError, RuntimeError):
-            pass
-        return str(path)
 
     def set_mode(self, mode: str) -> None:
         """Set the current input mode.

--- a/libs/code/tests/unit_tests/tui/widgets/test_condense_path.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_condense_path.py
@@ -1,0 +1,123 @@
+"""Unit tests for width-aware path condensation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from rich.cells import cell_len
+
+from deepagents_code.config import reset_glyphs_cache
+from deepagents_code.tui.widgets._condense_path import condense_path
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+LONG = "/home/user/projects/deepagents/libs/code/deepagents_code/tui/widgets"
+
+
+@pytest.fixture(autouse=True)
+def unicode_glyphs(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the ellipsis glyph so widths are independent of the environment."""
+    monkeypatch.setenv("UI_CHARSET_MODE", "unicode")
+    reset_glyphs_cache()
+    yield
+    reset_glyphs_cache()
+
+
+class TestFitting:
+    """Paths that already fit are returned verbatim."""
+
+    def test_short_path_unchanged(self) -> None:
+        """A path narrower than the budget is untouched."""
+        assert condense_path("/usr/local/bin", 40) == "/usr/local/bin"
+
+    def test_exact_width_fit_unchanged(self) -> None:
+        """A path exactly as wide as the budget is untouched."""
+        path = "/usr/local/bin"
+        assert condense_path(path, len(path)) == path
+
+    def test_trailing_slash_preserved_when_it_fits(self) -> None:
+        """Nothing is normalized away while the path fits."""
+        assert condense_path("/usr/local/bin/", 40) == "/usr/local/bin/"
+
+    def test_filesystem_root(self) -> None:
+        """The root has no components to condense."""
+        assert condense_path("/", 10) == "/"
+
+    def test_prefix_counts_against_width(self) -> None:
+        """The prefix is returned with the path and shares the budget."""
+        assert (
+            condense_path("/usr/local/bin", 20, prefix="cwd: ") == "cwd: /usr/local/bin"
+        )
+        assert cell_len(condense_path(LONG, 20, prefix="cwd: ")) <= 20
+
+
+class TestCondensation:
+    """Directory components collapse from the middle outward."""
+
+    def test_middle_component_goes_first(self) -> None:
+        """The first component dropped is the middle one, not the tail."""
+        assert condense_path("/usr/local/share/foo/bar", 22) == "/usr/…/share/foo/bar"
+
+    def test_condenses_progressively_toward_the_tail(self) -> None:
+        """Narrower budgets keep dropping components nearer the front."""
+        widths = [50, 40, 30, 20, 12]
+        results = [condense_path(LONG, width) for width in widths]
+        assert results == [
+            "/home/user/…/code/deepagents_code/tui/widgets",
+            "/home/user/…/deepagents_code/tui/widgets",
+            "/home/…/tui/widgets",
+            "/home/…/tui/widgets",
+            "/…/widgets",
+        ]
+        for width, result in zip(widths, results, strict=True):
+            assert cell_len(result) <= width
+
+    def test_trailing_slash_condenses(self) -> None:
+        """A trailing slash does not produce an empty component."""
+        assert condense_path("/usr/local/share/foo/bar/", 22) == "/usr/…/share/foo/bar"
+
+    def test_home_relative_path(self) -> None:
+        """`~` is an ordinary leading component."""
+        assert condense_path("~/projects/deepagents/libs/code", 20) == "~/…/libs/code"
+
+    def test_relative_path_keeps_no_root(self) -> None:
+        """A relative path never grows a leading slash."""
+        assert condense_path("projects/deepagents/libs/code", 16) == "…/libs/code"
+
+
+class TestNarrowWidths:
+    """The last component survives longest, then degrades gracefully."""
+
+    def test_last_component_survives_alone(self) -> None:
+        """Once every directory is dropped, the bare tail is shown."""
+        assert condense_path(LONG, 8) == "widgets"
+
+    def test_last_component_truncates_only_at_the_end(self) -> None:
+        """Below the tail's own width the tail itself is end-truncated."""
+        assert condense_path(LONG, 5) == "widg…"
+
+    def test_very_narrow_width(self) -> None:
+        """A single cell leaves room for the ellipsis alone."""
+        assert condense_path(LONG, 1) == "…"
+
+    def test_zero_width_is_empty(self) -> None:
+        """Nothing is rendered when there is no room at all."""
+        assert condense_path(LONG, 0) == ""
+        assert condense_path(LONG, -3) == ""
+
+    def test_single_component_path(self) -> None:
+        """A one-component path drops its root before truncating."""
+        assert condense_path("/deepagents_code", 12) == "deepagents_…"
+
+    def test_ascii_charset_uses_ascii_ellipsis(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In ASCII mode the wider `"..."` marker is used and still fits."""
+        monkeypatch.setenv("UI_CHARSET_MODE", "ascii")
+        reset_glyphs_cache()
+        result = condense_path(LONG, 20)
+        assert "\u2026" not in result
+        assert "..." in result
+        assert cell_len(result) <= 20

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -15,6 +15,7 @@ from deepagents_code.config import ASCII_GLYPHS, reset_glyphs_cache
 from deepagents_code.tui.widgets.status import (
     _PICKER_TARGET_META,
     BranchLabel,
+    CwdLabel,
     ModelLabel,
     StatusBar,
 )
@@ -67,6 +68,70 @@ class TestApprovalModeDisplay:
 
 class TestCwdDisplay:
     """Tests for the cwd display in the status bar."""
+
+    LONG_CWD = "/home/user/projects/deepagents/libs/code/deepagents_code/tui/widgets"
+
+    async def test_tooltip_is_full_path(self) -> None:
+        """The widget's tooltip always carries the untruncated path."""
+        async with StatusBarApp().run_test(size=(90, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.cwd = self.LONG_CWD
+            await pilot.pause()
+            display = pilot.app.query_one("#cwd-display", CwdLabel)
+            assert display.tooltip == self.LONG_CWD
+            bar.cwd = "/short/dir"
+            await pilot.pause()
+            assert display.tooltip == "/short/dir"
+
+    async def test_condensed_render_keeps_the_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A long path renders condensed with the last component intact."""
+        monkeypatch.setenv("UI_CHARSET_MODE", "unicode")
+        reset_glyphs_cache()
+        async with StatusBarApp().run_test(size=(90, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.cwd = self.LONG_CWD
+            await pilot.pause()
+            display = pilot.app.query_one("#cwd-display", CwdLabel)
+            rendered = str(display.render())
+            assert "…" in rendered
+            assert rendered.endswith("widgets")
+            assert rendered != self.LONG_CWD
+
+    async def test_short_path_renders_verbatim(self) -> None:
+        """A path that fits is not condensed and still gets a tooltip."""
+        async with StatusBarApp().run_test(size=(90, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.cwd = "/short/dir"
+            await pilot.pause()
+            display = pilot.app.query_one("#cwd-display", CwdLabel)
+            assert str(display.render()) == "/short/dir"
+
+    async def test_resize_recomputes_condensation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Growing the terminal condenses less; hiding still wins below 70."""
+        monkeypatch.setenv("UI_CHARSET_MODE", "unicode")
+        reset_glyphs_cache()
+        async with StatusBarApp().run_test(size=(90, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.cwd = self.LONG_CWD
+            await pilot.pause()
+            display = pilot.app.query_one("#cwd-display", CwdLabel)
+            condensed = str(display.render())
+            assert condensed.endswith("widgets")
+
+            await pilot.resize_terminal(120, 24)
+            await pilot.pause()
+            wider = str(display.render())
+            assert wider != condensed
+            assert wider.startswith("/home/user/")
+
+            # Below the hide threshold the display is dropped outright.
+            await pilot.resize_terminal(60, 24)
+            await pilot.pause()
+            assert display.display is False
 
 
 class TestBranchDisplay:


### PR DESCRIPTION
The status bar cwd now condenses from the middle outward — collapsing directory components into a single `…` while keeping the last component (the filename users are actually looking for) visible as long as possible — instead of CSS-clipping the end of the path.

---

The cwd previously relied on `text-overflow: ellipsis` on `.status-cwd`, which hides the tail of the path first, the opposite of what users want. The behavior now lives in:

- `condense_path(path, width, prefix="")` — a pure, `lru_cache`d helper in `tui/widgets/_condense_path.py` that abbreviates directory components from the middle of the component list outward and only end-truncates the last component once every directory has been dropped. Measurement is cell-accurate via Rich's `cell_len`, and the ellipsis glyph comes from `get_glyphs()` so ASCII mode gets `...` like the other status-bar labels.
- A new `CwdLabel` widget in `status.py` that owns the home-substitution (extracted from the removed `_format_cwd`), renders against its laid-out width, and always exposes the untruncated path as its stock Textual tooltip. The `.status-cwd` `max-width: 45%` cap is what supplies the condensation budget; the `text-overflow: ellipsis` reliance is removed.

`_CWD_WIDTH_THRESHOLD` (hide below 70 cols) is unchanged, and `tool_display.py`'s `abbreviate_path` is untouched.

Made by [Open SWE](https://openswe.vercel.app/agents/dc0bc11c-71af-5d22-abc4-e5fbb77c75be) · openai:gpt-5.6-sol (medium)