### PR TITLE
feat(code): list DeepSeek V4.1 Flash in picker

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -78,6 +78,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "anthropic:claude-opus-5": "Claude Opus 5",
     "anthropic:claude-sonnet-5": "Claude Sonnet 5",
     "baseten:deepseek-ai/DeepSeek-V4-Flash-0731": "DeepSeek V4 Flash 0731",
+    "baseten:deepseek-ai/DeepSeek-V4.1-Flash": "DeepSeek V4.1 Flash",
     "baseten:deepseek-ai/DeepSeek-V4-Pro": "DeepSeek V4 Pro",
     "baseten:deepseek-ai/DeepSeek-V4-Pro-0813": "DeepSeek V4 Pro 0813",
     "baseten:moonshotai/Kimi-K3": "Kimi K3",
@@ -87,6 +88,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "fireworks:accounts/fireworks/models/deepseek-v4-flash-0731": (
         "DeepSeek V4 Flash 0731"
     ),
+    "fireworks:accounts/fireworks/models/deepseek-v4p1-flash": "DeepSeek V4.1 Flash",
     "fireworks:accounts/fireworks/models/deepseek-v4-pro": "DeepSeek V4 Pro",
     "fireworks:accounts/fireworks/models/deepseek-v4-pro-0813": "DeepSeek V4 Pro 0813",
     "fireworks:accounts/fireworks/models/glm-5p3": "GLM 5.3",
@@ -97,6 +99,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "google_genai:gemini-3.7-flash": "Gemini 3.7 Flash",
     "meta:muse-spark-1.2": "Muse Spark 1.2",
     "ollama:deepseek-v4-flash:cloud": "DeepSeek V4 Flash",
+    "ollama:deepseek-v4.1-flash:cloud": "DeepSeek V4.1 Flash",
     "ollama:deepseek-v4-pro:cloud": "DeepSeek V4 Pro",
     "ollama:glm-5.3:cloud": "GLM 5.3",
     "ollama:glm-5.3-flash:cloud": "GLM 5.3 Flash",
@@ -112,6 +115,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "openrouter:anthropic/claude-sonnet-5": "Claude Sonnet 5",
     "openrouter:deepseek/deepseek-v4-flash-0731": "DeepSeek V4 Flash 0731",
     "openrouter:deepseek/deepseek-v4-flash:free": "DeepSeek V4 Flash (free)",
+    "openrouter:deepseek/deepseek-v4.1-flash": "DeepSeek V4.1 Flash",
     "openrouter:deepseek/deepseek-v4-pro": "DeepSeek V4 Pro",
     "openrouter:deepseek/deepseek-v4-pro-0813": "DeepSeek V4 Pro 0813",
     "openrouter:google/gemini-3.7-flash": "Gemini 3.7 Flash",


### PR DESCRIPTION
Adds `deepseek-ai/DeepSeek-V4.1-Flash` to the curated recommended-models mapping in the dcode model picker, across all four providers that carry it:

- **Baseten**: `deepseek-ai/DeepSeek-V4.1-Flash`
- **Fireworks**: `accounts/fireworks/models/deepseek-v4p1-flash`
- **Ollama (cloud)**: `deepseek-v4.1-flash:cloud`
- **OpenRouter**: `deepseek/deepseek-v4.1-flash`

Each ID was verified against the provider's published model library (Baseten model page, Fireworks model page, Ollama library page, OpenRouter `/api/v1/models`). V4-Flash and V4-Pro entries are left in place for now — DeepSeek is retiring them server-side, but the IDs still resolve.

---

`_RECOMMENDED_MODELS` is a safety net behind provider profiles; these entries ensure the new model surfaces in onboarding and the "Recommended only" toggle even for users without the provider package installed, matching the existing pattern for other DeepSeek models.

Made by [Open SWE](https://openswe.vercel.app/agents/f1f4d6f6-57b6-5b61-9606-c164db94241a) · openai:gpt-5.6-sol (high)