### PR TITLE
fix(talon): fix local voice transcription and embedding retries

### DIFF
--- a/libs/talon/deepagents_talon/history_adapters.py
+++ b/libs/talon/deepagents_talon/history_adapters.py
@@ -266,7 +266,9 @@ class BoundedEmbeddings(Embeddings):
         return output
 
     async def _batch(self, texts: list[str]) -> list[list[float]]:
-        async with self.slots, asyncio.timeout(_REQUEST_TIMEOUT):
+        # CPU inference includes cold model loading; the Store batch deadline bounds it.
+        timeout = None if self.profile.adapter == "local" else _REQUEST_TIMEOUT
+        async with self.slots, asyncio.timeout(timeout):
             vectors = await self.embed.aembed_documents(texts)
         self._validate(vectors, len(texts))
         return vectors

--- a/libs/talon/deepagents_talon/history_embeddings.py
+++ b/libs/talon/deepagents_talon/history_embeddings.py
@@ -73,6 +73,7 @@ class HistoryEmbeddings(Embeddings):
         self._lock = threading.Lock()
         self._async_lock = asyncio.Lock()
         self._pending: asyncio.Task[list[list[float]]] | None = None
+        self._pending_texts: tuple[str, ...] = ()
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Embed archive chunks without a query instruction.
@@ -117,11 +118,26 @@ class HistoryEmbeddings(Embeddings):
             texts: Transcript chunks or prepared queries.
         """
         async with self._async_lock:
-            if self._pending is not None:
+            if self._pending is not None and self._pending_texts != tuple(texts):
                 await asyncio.shield(asyncio.gather(self._pending, return_exceptions=True))
-            self._pending = asyncio.create_task(asyncio.to_thread(self.embed_documents, texts))
-            self._pending.add_done_callback(_consume_exception)
-            return await asyncio.shield(self._pending)
+                self._pending = None
+            if self._pending is None:
+                self._pending_texts = tuple(texts)
+                self._pending = asyncio.create_task(
+                    asyncio.to_thread(self.embed_documents, list(texts))
+                )
+                self._pending.add_done_callback(_consume_exception)
+            cancelled = False
+            try:
+                return await asyncio.shield(self._pending)
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
+            finally:
+                # Cancellation leaves inference available for the next retry.
+                if not cancelled:
+                    self._pending = None
+                    self._pending_texts = ()
 
     async def aembed_query(self, text: str) -> list[float]:
         """Embed a query off-loop with the retrieval instruction.

--- a/libs/talon/deepagents_talon/speech.py
+++ b/libs/talon/deepagents_talon/speech.py
@@ -266,7 +266,7 @@ def _load_local_pipeline(model: str, device: str, config: TalonConfig) -> _Local
         model=snapshot,
         device=device,
         trust_remote_code=False,
-        model_kwargs={"local_files_only": True},
+        local_files_only=True,
     )
     _local_pipelines[key] = loaded
     logger.info("Local voice transcription model %s ready on device=%s", model, device)

--- a/libs/talon/deepagents_talon/speech.py
+++ b/libs/talon/deepagents_talon/speech.py
@@ -261,12 +261,18 @@ def _load_local_pipeline(model: str, device: str, config: TalonConfig) -> _Local
 
     logger.info("Loading local voice transcription model %s on device=%s", model, device)
     snapshot = hub.snapshot_download(repo_id=model, cache_dir=str(cache), token=False)
+    local_model = module.AutoModel.from_pretrained(
+        snapshot, local_files_only=True, trust_remote_code=False
+    )
+    processor = module.AutoProcessor.from_pretrained(
+        snapshot, local_files_only=True, trust_remote_code=False
+    )
     loaded = module.pipeline(
         "automatic-speech-recognition",
-        model=snapshot,
+        model=local_model,
+        tokenizer=processor.tokenizer,
+        feature_extractor=processor.feature_extractor,
         device=device,
-        trust_remote_code=False,
-        local_files_only=True,
     )
     _local_pipelines[key] = loaded
     logger.info("Local voice transcription model %s ready on device=%s", model, device)

--- a/libs/talon/tests/test_speech.py
+++ b/libs/talon/tests/test_speech.py
@@ -146,7 +146,7 @@ def test_local_pipeline_uses_talon_home_cache(tmp_path: Path, monkeypatch) -> No
     pipeline = Mock()
     modules = {
         "huggingface_hub": SimpleNamespace(snapshot_download=download),
-        "transformers": SimpleNamespace(pipeline=pipeline),
+        "transformers": SimpleNamespace(pipeline=pipeline, AutoModel=Mock(), AutoProcessor=Mock()),
     }
     monkeypatch.setattr(speech.importlib, "import_module", modules.__getitem__)
     monkeypatch.setattr(speech, "_local_pipelines", {})
@@ -158,4 +158,7 @@ def test_local_pipeline_uses_talon_home_cache(tmp_path: Path, monkeypatch) -> No
         cache_dir=str(tmp_path / "cache" / "models" / "huggingface"),
         token=False,
     )
-    assert pipeline.call_args.kwargs["model"] == download.return_value
+    for loader in (modules["transformers"].AutoModel, modules["transformers"].AutoProcessor):
+        loader.from_pretrained.assert_called_once_with(
+            download.return_value, local_files_only=True, trust_remote_code=False
+        )

--- a/libs/talon/tests/unit_tests/test_history_embeddings.py
+++ b/libs/talon/tests/unit_tests/test_history_embeddings.py
@@ -1,15 +1,18 @@
 """Local embedding model cache coverage."""
 
+import asyncio
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 
-from deepagents_talon import history_embeddings, speech
+from deepagents_talon import history_adapters, history_embeddings, speech
 from deepagents_talon.config import TalonConfig
-from deepagents_talon.history_adapters import open_profile
+from deepagents_talon.history_adapters import BoundedEmbeddings, open_profile
 from deepagents_talon.history_embeddings import HistoryEmbeddings
+from deepagents_talon.history_profiles import EmbeddingProfile
 from deepagents_talon.speech import DEFAULT_LOCAL_VOICE_TRANSCRIPTION_MODEL
 
 
@@ -60,3 +63,67 @@ def test_embeddings_default_to_environment_cache(tmp_path: Path, monkeypatch) ->
     assert constructor.call_args.kwargs["cache_folder"] == str(
         tmp_path / "cache" / "models" / "huggingface"
     )
+
+
+@pytest.mark.parametrize("completed", [False, True])
+async def test_cancelled_embedding_retry_reuses_inference(monkeypatch, *, completed: bool) -> None:
+    started = asyncio.Event()
+    release = threading.Event()
+    loop = asyncio.get_running_loop()
+    calls: list[list[str]] = []
+
+    def encode(texts: list[str]) -> list[list[float]]:
+        calls.append(texts)
+        loop.call_soon_threadsafe(started.set)
+        assert release.wait(timeout=3)
+        return [[1.0]]
+
+    embeddings = HistoryEmbeddings()
+    monkeypatch.setattr(embeddings, "embed_documents", encode)
+    try:
+        first = asyncio.create_task(embeddings.aembed_documents(["hello"]))
+        await asyncio.wait_for(started.wait(), 2)
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        if completed:
+            release.set()
+            await embeddings.aclose()
+        retry = asyncio.create_task(embeddings.aembed_documents(["hello"]))
+        await asyncio.sleep(0)
+        release.set()
+        assert await retry == [[1.0]]
+        assert calls == [["hello"]]
+        assert await embeddings.aembed_documents(["different"]) == [[1.0]]
+        assert calls == [["hello"], ["different"]]
+    finally:
+        release.set()
+        await embeddings.aclose()
+
+
+async def test_failed_embedding_can_retry(monkeypatch) -> None:
+    embeddings = HistoryEmbeddings()
+    monkeypatch.setattr(
+        embeddings, "embed_documents", Mock(side_effect=[RuntimeError("inference failed"), [[1.0]]])
+    )
+    with pytest.raises(RuntimeError, match="inference failed"):
+        await embeddings.aembed_documents(["hello"])
+    assert await embeddings.aembed_documents(["hello"]) == [[1.0]]
+
+
+@pytest.mark.parametrize("adapter", ["local", "openai-compatible"])
+async def test_document_deadline_depends_on_adapter(monkeypatch, adapter: str) -> None:
+    async def encode(texts: list[str]) -> list[list[float]]:
+        await asyncio.sleep(0)
+        return [[1.0] for _ in texts]
+
+    embeddings = HistoryEmbeddings()
+    monkeypatch.setattr(embeddings, "aembed_documents", encode)
+    monkeypatch.setattr(history_adapters, "_REQUEST_TIMEOUT", 0)
+    bounded = BoundedEmbeddings(embeddings, EmbeddingProfile(adapter=adapter, dims=1))
+    if adapter == "local":
+        assert await bounded.aembed_documents(["hello"]) == [[1.0]]
+    else:
+        with pytest.raises(ExceptionGroup) as error:
+            await bounded.aembed_documents(["hello"])
+        assert isinstance(error.value.exceptions[0], TimeoutError)

--- a/libs/talon/tests/unit_tests/test_history_embeddings.py
+++ b/libs/talon/tests/unit_tests/test_history_embeddings.py
@@ -33,7 +33,7 @@ async def test_local_models_share_cache(tmp_path: Path, monkeypatch, assistant_i
     modules = {
         "sentence_transformers": SimpleNamespace(SentenceTransformer=constructor),
         "huggingface_hub": SimpleNamespace(snapshot_download=download),
-        "transformers": SimpleNamespace(pipeline=Mock()),
+        "transformers": SimpleNamespace(pipeline=Mock(), AutoModel=Mock(), AutoProcessor=Mock()),
     }
     monkeypatch.setattr(history_embeddings.importlib, "import_module", modules.__getitem__)
     monkeypatch.setattr(speech, "_local_pipelines", {})

--- a/libs/talon/tests/unit_tests/test_speech.py
+++ b/libs/talon/tests/unit_tests/test_speech.py
@@ -1,0 +1,62 @@
+"""Exercise local speech loading and generation without downloading a model."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from deepagents_talon import speech
+from deepagents_talon.config import TalonConfig
+
+
+def test_local_pipeline_transcribes_with_local_only_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    transformers = pytest.importorskip("transformers")
+    torch = pytest.importorskip("torch")
+    np = pytest.importorskip("numpy")
+    tokenizers = pytest.importorskip("tokenizers")
+    pytest.importorskip("librosa")
+    hub = pytest.importorskip("huggingface_hub")
+    config = transformers.ParakeetTDTConfig(
+        encoder_config={
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 2,
+            "subsampling_conv_channels": 4,
+        },
+        vocab_size=4,
+        blank_token_id=3,
+        decoder_start_token_id=3,
+        decoder_hidden_size=8,
+        num_decoder_layers=1,
+        max_symbols_per_step=1,
+    )
+    with torch.random.fork_rng():
+        torch.manual_seed(0)
+        model = transformers.AutoModel.from_config(config)
+    model.generation_config.num_beams = 1
+    model.generation_config.max_new_tokens = 2
+    tokenizer = transformers.PreTrainedTokenizerFast(
+        tokenizer_object=tokenizers.Tokenizer(
+            tokenizers.models.WordLevel({"hello": 0, "world": 1, "<pad>": 2, "<blank>": 3})
+        ),
+        pad_token="<pad>",  # noqa: S106  # tokenizer symbol, not a password
+    )
+    processor = transformers.ParakeetProcessor(transformers.ParakeetFeatureExtractor(), tokenizer)
+    snapshot = tmp_path / "snapshot"
+    model.save_pretrained(snapshot)
+    processor.save_pretrained(snapshot)
+    monkeypatch.setattr(hub, "snapshot_download", Mock(return_value=str(snapshot)))
+    monkeypatch.setattr(speech, "_local_pipelines", {})
+
+    pipeline = speech._load_local_pipeline(
+        speech.DEFAULT_LOCAL_VOICE_TRANSCRIPTION_MODEL,
+        "cpu",
+        TalonConfig.from_env({"DEEPAGENTS_TALON_HOME": str(tmp_path)}),
+    )
+    result = pipeline(np.zeros(1600, dtype=np.float32))
+
+    assert isinstance(result["text"], str)


### PR DESCRIPTION
Talon fixes local voice transcription model loading and avoids restarting local history embeddings after a timeout.

---

Load the speech model and processor explicitly with local-only options, keeping those options out of the pipeline generation arguments. Let local document embeddings use the Store batch deadline so cold model loading can finish, and reuse pending inference when the same batch is retried after cancellation. Remote embedding request timeouts remain enforced.

Validation: 145 focused speech/history tests passed, 3 skipped; 17 WhatsApp bridge tests passed; Talon lint, formatting, and type checks passed. The speech regression loads a tiny local Parakeet model and invokes the real Transformers pipeline with networking disabled.
