### PR TITLE
fix(sdk): keep final status when `cancel_async_task` hits a finished run

### DIFF
--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -577,6 +577,69 @@ def _build_update_tool(
     )
 
 
+_FINISHED_BEFORE_CANCEL = frozenset({"success", "error", "timeout"})
+"""Run statuses showing the run ended on its own, so a cancel request had nothing to stop."""
+
+
+def _read_status_after_cancel(client: SyncLangGraphClient, task: AsyncTask) -> str | None:
+    """Read the run's status back after a cancel request, or `None` if the read fails."""
+    try:
+        run = client.runs.get(thread_id=task["thread_id"], run_id=task["run_id"])
+    except Exception:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        logger.warning("Failed to read run status after cancelling task %s", task["task_id"], exc_info=True)
+        return None
+    return run["status"]
+
+
+async def _aread_status_after_cancel(client: LangGraphClient, task: AsyncTask) -> str | None:
+    """Async version of `_read_status_after_cancel`."""
+    try:
+        run = await client.runs.get(thread_id=task["thread_id"], run_id=task["run_id"])
+    except Exception:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        logger.warning("Failed to read run status after cancelling task %s", task["task_id"], exc_info=True)
+        return None
+    return run["status"]
+
+
+def _build_cancel_command(
+    task: AsyncTask,
+    run_status: str | None,
+    tool_call_id: str | None,
+) -> Command:
+    """Build the `Command` update after a cancel request.
+
+    A run that finished before the cancel reached it keeps its real status, so
+    its outcome stays reachable through `check_async_task`. Any other status,
+    or a failed read (`run_status` is `None`), is recorded as `'cancelled'`.
+    """
+    if run_status is not None and run_status in _FINISHED_BEFORE_CANCEL:
+        status = run_status
+        msg = (
+            f"Async subagent task {task['task_id']} had already finished with status '{run_status}' "
+            "before the cancel request, so nothing was cancelled. Use check_async_task to see its outcome."
+        )
+    else:
+        status = "cancelled"
+        msg = f"Cancelled async subagent task: {task['task_id']}"
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    updated = AsyncTask(
+        task_id=task["task_id"],
+        agent_name=task["agent_name"],
+        thread_id=task["thread_id"],
+        run_id=task["run_id"],
+        status=status,
+        created_at=task["created_at"],
+        last_checked_at=now,
+        last_updated_at=now if status != task["status"] else task["last_updated_at"],
+    )
+    return Command(
+        update={
+            "messages": [ToolMessage(msg, tool_call_id=tool_call_id)],
+            "async_tasks": {task["task_id"]: updated},
+        }
+    )
+
+
 def _build_cancel_tool(
     clients: _ClientCache,
 ) -> StructuredTool:
@@ -595,24 +658,8 @@ def _build_cancel_tool(
             client.runs.cancel(thread_id=tracked["thread_id"], run_id=tracked["run_id"])
         except Exception as e:  # noqa: BLE001  # get_sync() may raise ValueError; SDK raises untyped errors
             return f"Failed to cancel run: {e}"
-        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        updated = AsyncTask(
-            task_id=tracked["task_id"],
-            agent_name=tracked["agent_name"],
-            thread_id=tracked["thread_id"],
-            run_id=tracked["run_id"],
-            status="cancelled",
-            created_at=tracked["created_at"],
-            last_checked_at=now,
-            last_updated_at=now,
-        )
-        msg = f"Cancelled async subagent task: {tracked['task_id']}"
-        return Command(
-            update={
-                "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_tasks": {tracked["task_id"]: updated},
-            }
-        )
+        run_status = _read_status_after_cancel(client, tracked)
+        return _build_cancel_command(tracked, run_status, runtime.tool_call_id)
 
     async def acancel_async_task(
         task_id: str,
@@ -627,24 +674,8 @@ def _build_cancel_tool(
             await client.runs.cancel(thread_id=tracked["thread_id"], run_id=tracked["run_id"])
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
-        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        updated = AsyncTask(
-            task_id=tracked["task_id"],
-            agent_name=tracked["agent_name"],
-            thread_id=tracked["thread_id"],
-            run_id=tracked["run_id"],
-            status="cancelled",
-            created_at=tracked["created_at"],
-            last_checked_at=now,
-            last_updated_at=now,
-        )
-        msg = f"Cancelled async subagent task: {tracked['task_id']}"
-        return Command(
-            update={
-                "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_tasks": {tracked["task_id"]: updated},
-            }
-        )
+        run_status = await _aread_status_after_cancel(client, tracked)
+        return _build_cancel_command(tracked, run_status, runtime.tool_call_id)
 
     return StructuredTool.from_function(
         name="cancel_async_task",

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -710,6 +710,7 @@ class TestAsyncTools:
     async def test_async_cancel_returns_command(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.runs.cancel = _async_return(None)
+        mock_client.runs.get = _async_return({"run_id": "run_xyz", "status": "running"})
         mock_get_client.return_value = mock_client
 
         tools = _build_async_subagent_tools([_make_spec()])
@@ -720,11 +721,28 @@ class TestAsyncTools:
         assert isinstance(result, Command)
         assert result.update["async_tasks"]["thread_abc"]["status"] == "cancelled"
 
+    @patch("deepagents.middleware.async_subagents.get_client")
+    async def test_async_cancel_after_run_finished_keeps_final_status(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.cancel = _async_return(None)
+        mock_client.runs.get = _async_return({"run_id": "run_xyz", "status": "success"})
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        cancel = _get_tool(tools, "cancel_async_task")
+        rt = _make_runtime_with_task(tool_call_id="tc_async_cancel")
+        result = await cancel.coroutine(task_id="thread_abc", runtime=rt)
+
+        assert isinstance(result, Command)
+        assert result.update["async_tasks"]["thread_abc"]["status"] == "success"
+        assert "already finished" in result.update["messages"][0].content
+
 
 class TestCancelTool:
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_cancel_returns_command_with_cancelled_status(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
+        mock_client.runs.get.return_value = {"run_id": "run_xyz", "status": "running"}
         mock_get_client.return_value = mock_client
 
         tools = _build_async_subagent_tools([_make_spec()])
@@ -766,6 +784,55 @@ class TestCancelTool:
         assert isinstance(result, str)
         assert "Failed to cancel run" in result
         assert "connection refused" in result
+
+    @pytest.mark.parametrize("run_status", ["success", "error", "timeout"])
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_cancel_after_run_finished_keeps_final_status(self, mock_get_client: MagicMock, run_status: str) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.return_value = {"run_id": "run_xyz", "status": run_status}
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        cancel = _get_tool(tools, "cancel_async_task")
+        rt = _make_runtime_with_task(tool_call_id="tc_cancel")
+        result = cancel.func(task_id="thread_abc", runtime=rt)
+
+        assert isinstance(result, Command)
+        assert result.update["async_tasks"]["thread_abc"]["status"] == run_status
+        content = result.update["messages"][0].content
+        assert "already finished" in content
+        assert f"'{run_status}'" in content
+        assert not content.startswith("Cancelled")
+
+    @pytest.mark.parametrize("run_status", ["pending", "running", "interrupted"])
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_cancel_of_unfinished_run_records_cancelled(self, mock_get_client: MagicMock, run_status: str) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.return_value = {"run_id": "run_xyz", "status": run_status}
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        cancel = _get_tool(tools, "cancel_async_task")
+        rt = _make_runtime_with_task(tool_call_id="tc_cancel")
+        result = cancel.func(task_id="thread_abc", runtime=rt)
+
+        assert isinstance(result, Command)
+        assert result.update["async_tasks"]["thread_abc"]["status"] == "cancelled"
+        assert result.update["messages"][0].content == "Cancelled async subagent task: thread_abc"
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_cancel_records_cancelled_when_status_read_fails(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.side_effect = RuntimeError("connection reset")
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        cancel = _get_tool(tools, "cancel_async_task")
+        rt = _make_runtime_with_task(tool_call_id="tc_cancel")
+        result = cancel.func(task_id="thread_abc", runtime=rt)
+
+        assert isinstance(result, Command)
+        assert result.update["async_tasks"]["thread_abc"]["status"] == "cancelled"
 
 
 class TestUnknownTaskId:


### PR DESCRIPTION
Fixes #6234

`cancel_async_task` no longer reports a cancellation, or records `cancelled`, for an async subagent run that had already finished; the task keeps its real `success`, `error`, or `timeout` status.

---

When a cancel reaches a run that has already finished, the LangGraph server treats it as a no-op: the dev server returns 202 and the run stays `success`. The cancel tool assumed the cancel took effect and stored `cancelled`. Because `cancelled` is terminal, `list_async_tasks` skips the live fetch for it, so the task stayed `cancelled` and the model never learned the run had finished.

After `runs.cancel`, the tool now reads the run back with `runs.get`. If the run ended on its own (`success`, `error`, `timeout`), that status is kept and the tool message says nothing was cancelled and points to `check_async_task`. Any other status, including `interrupted` (what the dev server records for a genuine cancel), is stored as `cancelled` as before, so the middleware's status vocabulary is unchanged. If the read-back fails, the tool falls back to `cancelled` and logs a warning. The sync and async tools share one `_build_cancel_command` helper.

Not addressed here: a run that is still `pending` or `running` when its status is read back can finish later while the cached task remains `cancelled`. This PR keeps cancellation non-blocking (`wait=False`) and does not wait for the run to settle. The example server's unconditional overwrite in `cancel_run` is related to #5401 and left out of this PR.

Tests cover cancel after `success`, `error`, and `timeout`; cancel of `pending`, `running`, and `interrupted` runs; a failed read-back; and the async path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
