### PR TITLE
fix(sdk): report UTF-8 byte sizes

### DIFF
--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -156,7 +156,7 @@ class StateBackend(BackendProtocol):
                 continue
 
             # This is a file directly in the current directory
-            size = len(file_data_to_string(fd))
+            size = len(file_data_to_string(fd).encode("utf-8"))
             infos.append(
                 {
                     "path": k,
@@ -308,7 +308,7 @@ class StateBackend(BackendProtocol):
         infos: list[FileInfo] = []
         for p in paths:
             fd = files.get(p)
-            size = len(file_data_to_string(fd)) if fd else 0
+            size = len(file_data_to_string(fd).encode("utf-8")) if fd else 0
             infos.append(
                 {
                     "path": p,

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -347,7 +347,7 @@ class StoreBackend(BackendProtocol):
                 fd = self._convert_store_item_to_file_data(item)
             except ValueError:
                 continue
-            size = len(file_data_to_string(fd))
+            size = len(file_data_to_string(fd).encode("utf-8"))
             infos.append(
                 {
                     "path": item.key,
@@ -641,7 +641,7 @@ class StoreBackend(BackendProtocol):
         infos: list[FileInfo] = []
         for p in paths:
             fd = files.get(p)
-            size = len(file_data_to_string(fd)) if fd else 0
+            size = len(file_data_to_string(fd).encode("utf-8")) if fd else 0
             infos.append(
                 {
                     "path": p,

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
@@ -83,6 +83,22 @@ def test_state_backend_reads_legacy_list_content(monkeypatch: pytest.MonkeyPatch
     assert files["/legacy.txt"]["content"] == legacy_content
 
 
+def test_state_backend_reports_utf8_byte_sizes(monkeypatch: pytest.MonkeyPatch) -> None:
+    content = "hello 😀 €"
+    files = {"/unicode.txt": {"content": content, "encoding": "utf-8"}}
+    monkeypatch.setattr(StateBackend, "_read_files", lambda _self: files)
+    backend = StateBackend()
+    expected_size = len(content.encode("utf-8"))
+
+    listing = backend.ls("/").entries
+    assert listing is not None
+    assert listing[0]["size"] == expected_size
+
+    matches = backend.glob("*.txt", path="/").matches
+    assert matches is not None
+    assert matches[0]["size"] == expected_size
+
+
 def test_state_backend_reads_legacy_list_content_for_non_text_path(monkeypatch: pytest.MonkeyPatch) -> None:
     backend = StateBackend()
     legacy_content = ["aGVsbG8="]

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -150,6 +150,22 @@ def test_store_backend_reads_legacy_list_content() -> None:
     assert "encoding" not in stored.value
 
 
+def test_store_backend_reports_utf8_byte_sizes() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    content = "hello 😀 €"
+    be.write("/unicode.txt", content)
+    expected_size = len(content.encode("utf-8"))
+
+    listing = be.ls("/").entries
+    assert listing is not None
+    assert listing[0]["size"] == expected_size
+
+    matches = be.glob("*.txt", path="/").matches
+    assert matches is not None
+    assert matches[0]["size"] == expected_size
+
+
 def test_store_backend_rejects_legacy_lists_with_non_string_items() -> None:
     mem_store = InMemoryStore()
     be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))


### PR DESCRIPTION
Fixes #6042

## Summary

Fix `FileInfo.size` reporting character counts instead of UTF-8 byte
sizes in `StateBackend` and `StoreBackend`.

## Changes

- Report file sizes in UTF-8 bytes.
- Add regression tests for non-ASCII content.
- Cover `ls()` and `glob()` behavior.