### PR TITLE
fix(sdk): bound compaction recovery and validate input budgets

### DIFF
--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -72,7 +72,7 @@ import uuid
 import warnings
 from collections.abc import Mapping
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, NotRequired, cast
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Never, NotRequired, cast
 
 from langchain.agents.middleware.summarization import (
     _DEFAULT_MESSAGES_TO_KEEP,
@@ -495,6 +495,29 @@ def _upload_response_error(responses: list[FileUploadResponse]) -> str | None:
     if error is None:
         return None
     return str(error)
+
+
+def _is_context_overflow(exc: Exception) -> bool:
+    """Recognize context errors without retrying unrelated bad requests."""
+    if isinstance(exc, ContextOverflowError):
+        return True
+    if getattr(exc, "status_code", None) not in {400, 413, 422}:
+        return False
+    text = str(exc).lower()
+    return any(
+        marker in text
+        for marker in (
+            "context_length_exceeded",
+            "contextwindowexceedederror",
+            "maximum context length",
+            "exceeds the context window",
+            "exceeds the available context size",
+            "context window exceeded",
+            "context limit exceeded",
+            "input tokens exceed the configured limit",
+            "prompt is too long",
+        )
+    )
 
 
 class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
@@ -1342,6 +1365,112 @@ A condensed summary follows:
             logger.debug("Offloaded %d messages to %s", len(filtered_messages), path)
             return path
 
+    @staticmethod
+    def _with_replacements(response: ModelResponse, replacements: list[AnyMessage]) -> ModelResponse | ExtendedModelResponse:
+        if replacements:
+            return ExtendedModelResponse(model_response=response, command=Command(update={"messages": replacements}))
+        return response
+
+    @staticmethod
+    def _raise_recovery_exhausted(error: Exception) -> Never:
+        """Expose a terminal model error instead of another retryable HTTP response."""
+        msg = "Model input still does not fit after recovery; reduce input, tools, or configured output tokens."
+        raise ContextOverflowError(msg) from error
+
+    def _input_budget(self, request: ModelRequest) -> int | None:
+        """Reserve configured output and 5% headroom from the advertised input limit."""
+        profile = request.model.profile
+        limit = profile.get("max_input_tokens") if isinstance(profile, dict) else None
+        if not isinstance(limit, int) or isinstance(limit, bool):
+            limit = self._get_profile_limits()
+        if limit is None:
+            return None
+        output = 0
+        for key in ("max_tokens", "max_completion_tokens", "max_output_tokens"):
+            value = request.model_settings.get(key, getattr(request.model, key, None))
+            if isinstance(value, int) and not isinstance(value, bool):
+                output = max(output, value)
+        return max(0, int(limit * 0.95) - output)
+
+    def _over_budget(self, request: ModelRequest, total_tokens: int | None = None) -> bool:
+        budget = self._input_budget(request)
+        if budget is None:
+            return False
+        count = total_tokens if total_tokens is not None else self._count_tokens(request.messages, request.system_message, request.tools)
+        return count > budget
+
+    def _check_reduction(self, original: ModelRequest, reduced: ModelRequest, error: Exception | None) -> None:
+        """Never resend an unchanged rejected request or a known oversized request."""
+        count = self._count_tokens(reduced.messages, reduced.system_message, reduced.tools)
+        if error is not None and count >= self._count_tokens(original.messages, original.system_message, original.tools):
+            self._raise_recovery_exhausted(error)
+        budget = self._input_budget(reduced)
+        if budget is not None and count > budget:
+            msg = "Context remains above the input budget after compaction; reduce input, tools, or configured output tokens."
+            raise ContextOverflowError(msg)
+
+    def _call_with_budget(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+        *,
+        error: Exception | None = None,
+        rejected: ModelRequest | None = None,
+    ) -> tuple[ModelResponse, list[AnyMessage]]:
+        """Check the complete request and allow one strictly smaller tail recovery."""
+        original = rejected if rejected is not None else request
+        replacements: list[AnyMessage] = []
+        if error is not None or self._over_budget(request):
+            messages, replacements = _clip_overflow_tail(
+                request.messages,
+                self._backend,
+                keep=("tokens", 1),
+                max_input_tokens=self._get_profile_limits(),
+                token_counter=self.token_counter,
+                large_tool_results_prefix=self._large_tool_results_prefix,
+            )
+            request = request.override(messages=messages)
+            self._check_reduction(original, request, error)
+        try:
+            return handler(request), replacements
+        except Exception as exc:
+            if not _is_context_overflow(exc):
+                raise
+            if error is not None or replacements:
+                self._raise_recovery_exhausted(exc)
+            return self._call_with_budget(request, handler, error=exc)
+
+    async def _acall_with_budget(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+        *,
+        error: Exception | None = None,
+        rejected: ModelRequest | None = None,
+    ) -> tuple[ModelResponse, list[AnyMessage]]:
+        """Check the complete request and allow one strictly smaller tail recovery."""
+        original = rejected if rejected is not None else request
+        replacements: list[AnyMessage] = []
+        if error is not None or self._over_budget(request):
+            messages, replacements = await _aclip_overflow_tail(
+                request.messages,
+                self._backend,
+                keep=("tokens", 1),
+                max_input_tokens=self._get_profile_limits(),
+                token_counter=self.token_counter,
+                large_tool_results_prefix=self._large_tool_results_prefix,
+            )
+            request = request.override(messages=messages)
+            self._check_reduction(original, request, error)
+        try:
+            return await handler(request), replacements
+        except Exception as exc:
+            if not _is_context_overflow(exc):
+                raise
+            if error is not None or replacements:
+                self._raise_recovery_exhausted(exc)
+            return await self._acall_with_budget(request, handler, error=exc)
+
     def wrap_model_call(
         self,
         request: ModelRequest,
@@ -1357,22 +1486,23 @@ A condensed summary follows:
 
         - If thresholds say "do not summarize", we still attempt one normal
             model call with the current effective/truncated messages.
-        - If that call raises `ContextOverflowError`, we immediately fall back to
-            the summarization path and retry the model call with
-            `summary_message + preserved_recent_messages`.
+        - Recognized provider context errors fall back to summarization and
+            offloading large trailing tool results. At most one smaller retry
+            is sent, including when the first request was already summarized.
+        - The complete request is checked against the input budget after
+            summarization. Irreducible input raises `ContextOverflowError`.
 
-        Unlike the legacy `before_model` approach, this does NOT modify the LangGraph state.
-        Instead, it tracks summarization events in middleware state and modifies the model
-        request directly.
+        History is condensed through a summary event rather than removing raw
+        messages. Offloaded tail results are persisted by message ID.
 
         Args:
             request: The model request to process.
             handler: The handler to call with the (possibly modified) request.
 
         Returns:
-            A plain `ModelResponse` when no summarization event is created, or
-                an `ExtendedModelResponse` that updates `_summarization_event`
-                with `cutoff_index`, `summary_message`, and `file_path`.
+            A plain `ModelResponse` when no state updates are needed, or an
+                `ExtendedModelResponse` with the summary event and/or offloaded
+                tool result replacements.
 
                 If `cutoff_index <= 0`, no compaction occurs and no
                 `_summarization_event` update is emitted.
@@ -1393,38 +1523,28 @@ A condensed summary follows:
         # Step 2: Check if summarization should happen
         if truncate_modified:
             total_tokens = self._count_tokens(truncated_messages, request.system_message, request.tools)
-        should_summarize = self._should_summarize(truncated_messages, total_tokens)
+        should_summarize = self._should_summarize(truncated_messages, total_tokens) or self._over_budget(request, total_tokens)
 
         # If no summarization needed, return with truncated messages
-        overflow_triggered = False
+        overflow_error: Exception | None = None
         if not should_summarize:
             try:
                 return handler(request.override(messages=truncated_messages))
-            except ContextOverflowError:
-                overflow_triggered = True
+            except Exception as exc:
+                if not _is_context_overflow(exc):
+                    raise
+                overflow_error = exc
                 # Fallback to summarization on context overflow
 
         # Step 3: Perform summarization
         cutoff_index = self._determine_cutoff_index(truncated_messages)
         if cutoff_index <= 0:
-            # Can't summarize, return truncated messages
-            return handler(request.override(messages=truncated_messages))
+            response, replacements = self._call_with_budget(request.override(messages=truncated_messages), handler, error=overflow_error)
+            return self._with_replacements(response, replacements)
 
         messages_to_summarize, preserved_messages = self._partition_messages(truncated_messages, cutoff_index)
 
         backend = self._backend
-        # On overflow, offload the large preserved tail TM batch to per-TM files.
-        new_state_tail: list[AnyMessage] = []
-        if overflow_triggered:
-            preserved_messages, new_state_tail = _clip_overflow_tail(
-                preserved_messages,
-                backend,
-                keep=self._lc_helper.keep,
-                max_input_tokens=self._get_profile_limits(),
-                token_counter=self.token_counter,
-                large_tool_results_prefix=self._large_tool_results_prefix,
-            )
-
         # Upload inline media once so both offload and summary see path references.
         offloaded_media_messages, failed_media = self._offload_inline_media(backend, messages_to_summarize)
 
@@ -1468,7 +1588,13 @@ A condensed summary follows:
 
         # Modify request to use summarized messages
         modified_messages = [*new_messages, *preserved_messages]
-        response = handler(request.override(messages=modified_messages))
+        modified_request = request.override(messages=modified_messages)
+        response, new_state_tail = self._call_with_budget(
+            modified_request,
+            handler,
+            error=overflow_error,
+            rejected=request.override(messages=truncated_messages),
+        )
 
         update: dict[str, Any] = {
             SUMMARIZATION_EVENT_KEY: new_event,
@@ -1498,22 +1624,23 @@ A condensed summary follows:
 
         - If thresholds say "do not summarize", we still attempt one normal
             model call with the current effective/truncated messages.
-        - If that call raises `ContextOverflowError`, we immediately fall back
-            to the summarization path and retry the model call with
-            `summary_message + preserved_recent_messages`.
+        - Recognized provider context errors fall back to summarization and
+            offloading large trailing tool results. At most one smaller retry
+            is sent, including when the first request was already summarized.
+        - The complete request is checked against the input budget after
+            summarization. Irreducible input raises `ContextOverflowError`.
 
-        Unlike the legacy `abefore_model` approach, this does NOT modify the LangGraph state.
-        Instead, it tracks summarization events in middleware state and modifies the model
-        request directly.
+        History is condensed through a summary event rather than removing raw
+        messages. Offloaded tail results are persisted by message ID.
 
         Args:
             request: The model request to process.
             handler: The handler to call with the (possibly modified) request.
 
         Returns:
-            A plain `ModelResponse` when no summarization event is created, or
-                an `ExtendedModelResponse` that updates `_summarization_event`
-                with `cutoff_index`, `summary_message`, and `file_path`.
+            A plain `ModelResponse` when no state updates are needed, or an
+                `ExtendedModelResponse` with the summary event and/or offloaded
+                tool result replacements.
 
                 If `cutoff_index <= 0`, no compaction occurs and no
                 `_summarization_event` update is emitted.
@@ -1534,38 +1661,28 @@ A condensed summary follows:
         # Step 2: Check if summarization should happen
         if truncate_modified:
             total_tokens = self._count_tokens(truncated_messages, request.system_message, request.tools)
-        should_summarize = self._should_summarize(truncated_messages, total_tokens)
+        should_summarize = self._should_summarize(truncated_messages, total_tokens) or self._over_budget(request, total_tokens)
 
         # If no summarization needed, return with truncated messages
-        overflow_triggered = False
+        overflow_error: Exception | None = None
         if not should_summarize:
             try:
                 return await handler(request.override(messages=truncated_messages))
-            except ContextOverflowError:
-                overflow_triggered = True
+            except Exception as exc:
+                if not _is_context_overflow(exc):
+                    raise
+                overflow_error = exc
                 # Fallback to summarization on context overflow
 
         # Step 3: Perform summarization
         cutoff_index = self._determine_cutoff_index(truncated_messages)
         if cutoff_index <= 0:
-            # Can't summarize, return truncated messages
-            return await handler(request.override(messages=truncated_messages))
+            response, replacements = await self._acall_with_budget(request.override(messages=truncated_messages), handler, error=overflow_error)
+            return self._with_replacements(response, replacements)
 
         messages_to_summarize, preserved_messages = self._partition_messages(truncated_messages, cutoff_index)
 
         backend = self._backend
-        # On overflow, offload the large preserved tail TM batch to per-TM files.
-        new_state_tail: list[AnyMessage] = []
-        if overflow_triggered:
-            preserved_messages, new_state_tail = await _aclip_overflow_tail(
-                preserved_messages,
-                backend,
-                keep=self._lc_helper.keep,
-                max_input_tokens=self._get_profile_limits(),
-                token_counter=self.token_counter,
-                large_tool_results_prefix=self._large_tool_results_prefix,
-            )
-
         # Upload inline media once so both offload and summary see path references.
         # This must complete before the gather since both methods consume the result.
         offloaded_media_messages, failed_media = await self._aoffload_inline_media(backend, messages_to_summarize)
@@ -1610,7 +1727,13 @@ A condensed summary follows:
 
         # Modify request to use summarized messages
         modified_messages = [*new_messages, *preserved_messages]
-        response = await handler(request.override(messages=modified_messages))
+        modified_request = request.override(messages=modified_messages)
+        response, new_state_tail = await self._acall_with_budget(
+            modified_request,
+            handler,
+            error=overflow_error,
+            rejected=request.override(messages=truncated_messages),
+        )
 
         update: dict[str, Any] = {
             SUMMARIZATION_EVENT_KEY: new_event,

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -1382,8 +1382,6 @@ A condensed summary follows:
         profile = request.model.profile
         limit = profile.get("max_input_tokens") if isinstance(profile, dict) else None
         if not isinstance(limit, int) or isinstance(limit, bool):
-            limit = self._get_profile_limits()
-        if limit is None:
             return None
         output = 0
         for key in ("max_tokens", "max_completion_tokens", "max_output_tokens"):

--- a/libs/deepagents/tests/unit_tests/middleware/test_compaction_recovery.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_compaction_recovery.py
@@ -1,0 +1,221 @@
+"""Context recovery must fit requests, preserve tool pairs, and stop making no progress."""
+
+from collections.abc import Callable
+from typing import cast
+
+import pytest
+from langchain.agents.middleware.types import AgentState, ExtendedModelResponse, ModelRequest, ModelResponse
+from langchain_core.exceptions import ContextOverflowError
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolMessage
+
+from deepagents.middleware.summarization import SummarizationMiddleware
+from tests.unit_tests.middleware.test_summarization_middleware import MockBackend, make_mock_model, make_mock_runtime
+
+
+class ProviderOverflowError(Exception):
+    """An OpenAI-compatible server's unclassified bad request."""
+
+    status_code = 400
+
+
+def _count(messages: list[AnyMessage], *, tools: list | None = None) -> int:
+    """Deterministic units, including system text and tool schemas."""
+    return sum(len(str(message.content)) for message in messages) + len(str(tools or ""))
+
+
+def _request(*, tail_size: int = 20000, limit: int = 100000) -> ModelRequest:
+    model = make_mock_model("summary")
+    model.profile = {"max_input_tokens": limit}
+    messages = [
+        HumanMessage(content="old context " * 1000, id="old"),
+        AIMessage(content="old answer", id="answer"),
+        HumanMessage(content="run the tool", id="user"),
+        AIMessage(content="", tool_calls=[{"id": "call", "name": "search", "args": {}}], id="ai"),
+        ToolMessage(content="x" * tail_size, tool_call_id="call", id="result"),
+    ]
+    return ModelRequest(model=model, messages=messages, state=cast("AgentState", {"messages": messages}), runtime=make_mock_runtime())
+
+
+def _middleware(request: ModelRequest, backend: MockBackend, *, trigger: int = 1, keep: int = 3) -> SummarizationMiddleware:
+    return SummarizationMiddleware(model=request.model, backend=backend, trigger=("messages", trigger), keep=("messages", keep), token_counter=_count)
+
+
+async def _invoke(
+    middleware: SummarizationMiddleware,
+    request: ModelRequest,
+    handler: Callable[[ModelRequest], ModelResponse],
+    *,
+    asynchronous: bool,
+) -> ModelResponse | ExtendedModelResponse:
+    if asynchronous:
+
+        async def async_handler(current: ModelRequest) -> ModelResponse:
+            return handler(current)
+
+        return await middleware.awrap_model_call(request, async_handler)
+    return middleware.wrap_model_call(request, handler)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("trigger", [1, 100])
+async def test_oversized_tail_fits_before_send(*, asynchronous: bool, trigger: int) -> None:
+    request = _request(limit=10000)
+    backend = MockBackend()
+    sent: list[ModelRequest] = []
+
+    def handler(current: ModelRequest) -> ModelResponse:
+        sent.append(current)
+        assert _count(current.messages) <= 9500
+        return ModelResponse(result=[AIMessage(content="done")])
+
+    result = await _invoke(_middleware(request, backend, trigger=trigger), request, handler, asynchronous=asynchronous)
+    assert len(sent) == 1
+    assert isinstance(result, ExtendedModelResponse)
+    replacements = result.command.update["messages"]
+    assert replacements[-1].id == "result"
+    assert replacements[-1].tool_call_id == sent[0].messages[-2].tool_calls[0]["id"]
+    assert any(content == "x" * 20000 for _, content in backend.write_calls)
+    assert request.messages[-1].content == "x" * 20000
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("trigger", [1, 100])
+async def test_provider_overflow_recovers_once(*, asynchronous: bool, trigger: int) -> None:
+    request = _request()
+    sent: list[int] = []
+
+    def handler(current: ModelRequest) -> ModelResponse:
+        sent.append(_count(current.messages))
+        if len(sent) == 1:
+            msg = "maximum context length exceeded"
+            raise ProviderOverflowError(msg)
+        return ModelResponse(result=[AIMessage(content="done")])
+
+    result = await _invoke(_middleware(request, MockBackend(), trigger=trigger), request, handler, asynchronous=asynchronous)
+    assert isinstance(result, ExtendedModelResponse)
+    assert len(sent) == 2
+    assert sent[1] < sent[0]
+    assert result.command.update["messages"][-1].id == "result"
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("trigger", [1, 100])
+async def test_repeated_overflow_stops_after_smaller_retry(*, asynchronous: bool, trigger: int) -> None:
+    request = _request()
+    sent: list[int] = []
+
+    def handler(current: ModelRequest) -> ModelResponse:
+        sent.append(_count(current.messages))
+        raise ContextOverflowError
+
+    with pytest.raises(ContextOverflowError):
+        await _invoke(_middleware(request, MockBackend(), trigger=trigger), request, handler, asynchronous=asynchronous)
+    assert len(sent) == 2
+    assert sent[1] < sent[0]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("failure", [False, True])
+async def test_no_cutoff_never_resends_unchanged_input(*, asynchronous: bool, failure: bool) -> None:
+    request = _request(tail_size=20000 if failure else 1)
+    backend = MockBackend(should_fail=failure)
+    calls = 0
+
+    def handler(_current: ModelRequest) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise ContextOverflowError
+
+    with pytest.raises(ContextOverflowError):
+        await _invoke(_middleware(request, backend, trigger=100, keep=100), request, handler, asynchronous=asynchronous)
+    assert calls == 1
+    assert request.messages[-1].content == "x" * (20000 if failure else 1)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("overhead", ["system", "tools", "output", "model_output"])
+async def test_irreducible_overhead_never_reaches_server(*, asynchronous: bool, overhead: str) -> None:
+    request = _request(limit=10000)
+    if overhead == "system":
+        request = request.override(system_message=SystemMessage(content="s" * 10000))
+    elif overhead == "tools":
+        request = request.override(tools=[{"name": "tool", "description": "s" * 10000}])
+    elif overhead == "output":
+        request = request.override(model_settings={"max_completion_tokens": 10000})
+    else:
+        request.model.max_tokens = 10000
+
+    def handler(_current: ModelRequest) -> ModelResponse:
+        pytest.fail("A known oversized request must not reach the server")
+
+    with pytest.raises(ContextOverflowError, match="above the input budget"):
+        await _invoke(_middleware(request, MockBackend()), request, handler, asynchronous=asynchronous)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_unrelated_bad_request_is_not_retried(*, asynchronous: bool) -> None:
+    request = _request()
+    backend = MockBackend()
+    error = ProviderOverflowError("invalid tool schema")
+
+    def handler(_current: ModelRequest) -> ModelResponse:
+        raise error
+
+    with pytest.raises(ProviderOverflowError) as caught:
+        await _invoke(_middleware(request, backend, trigger=100), request, handler, asynchronous=asynchronous)
+    assert caught.value is error
+    assert backend.write_calls == []
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_no_cutoff_recovers_and_persists_tool_result(*, asynchronous: bool) -> None:
+    request = _request()
+    backend = MockBackend()
+    sent: list[ModelRequest] = []
+
+    def handler(current: ModelRequest) -> ModelResponse:
+        sent.append(current)
+        if len(sent) == 1:
+            raise ContextOverflowError
+        return ModelResponse(result=[AIMessage(content="done")])
+
+    result = await _invoke(_middleware(request, backend, trigger=100, keep=100), request, handler, asynchronous=asynchronous)
+    assert len(sent) == 2
+    assert isinstance(result, ExtendedModelResponse)
+    assert "_summarization_event" not in result.command.update
+    assert result.command.update["messages"][-1].id == "result"
+    assert sent[-1].messages[-2].tool_calls == request.messages[-2].tool_calls
+    assert _count(sent[-1].messages) < _count(sent[0].messages)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_exhausted_provider_error_is_terminal(*, asynchronous: bool) -> None:
+    request = _request()
+    error = ProviderOverflowError("maximum context length exceeded")
+    calls = 0
+
+    def handler(_current: ModelRequest) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise error
+
+    with pytest.raises(ContextOverflowError, match="after recovery") as caught:
+        await _invoke(_middleware(request, MockBackend()), request, handler, asynchronous=asynchronous)
+    assert calls == 2
+    assert caught.value.__cause__ is error
+    assert not hasattr(caught.value, "status_code")
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_output_reservation_clips_an_otherwise_fitting_summary(*, asynchronous: bool) -> None:
+    request = _request(tail_size=6000, limit=30000).override(model_settings={"max_tokens": 24000})
+    sent: list[ModelRequest] = []
+
+    def handler(current: ModelRequest) -> ModelResponse:
+        sent.append(current)
+        assert _count(current.messages) <= 4500
+        return ModelResponse(result=[AIMessage(content="done")])
+
+    await _invoke(_middleware(request, MockBackend()), request, handler, asynchronous=asynchronous)
+    assert len(sent) == 1
+    assert len(sent[0].messages[-1].content) < 6000

--- a/libs/deepagents/tests/unit_tests/middleware/test_compaction_recovery.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_compaction_recovery.py
@@ -79,6 +79,37 @@ async def test_oversized_tail_fits_before_send(*, asynchronous: bool, trigger: i
 
 
 @pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("profile", [None, {}, {"max_input_tokens": True}])
+@pytest.mark.parametrize("trigger", [1, 100])
+@pytest.mark.parametrize("overflow", [False, True])
+async def test_unknown_agent_limit_does_not_use_summarizer_budget(
+    *, asynchronous: bool, profile: dict[str, int] | None, trigger: int, overflow: bool
+) -> None:
+    request = _request().override(system_message=SystemMessage(content="s" * 10000))
+    request.model.profile = profile
+    summarizer = make_mock_model("summary")
+    summarizer.profile = {"max_input_tokens": 10000}
+    middleware = SummarizationMiddleware(
+        model=summarizer, backend=MockBackend(), trigger=("messages", trigger), keep=("messages", 3), token_counter=_count
+    )
+    sent: list[int] = []
+
+    def handler(current: ModelRequest) -> ModelResponse:
+        assert current.system_message == request.system_message
+        sent.append(_count(current.messages))
+        if overflow and len(sent) == 1:
+            raise ContextOverflowError
+        return ModelResponse(result=[AIMessage(content="done")])
+
+    result = await _invoke(middleware, request, handler, asynchronous=asynchronous)
+    response = result.model_response if isinstance(result, ExtendedModelResponse) else result
+    assert response.result[0].content == "done"
+    assert len(sent) == (2 if overflow else 1)
+    if overflow:
+        assert sent[1] < sent[0]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
 @pytest.mark.parametrize("trigger", [1, 100])
 async def test_provider_overflow_recovers_once(*, asynchronous: bool, trigger: int) -> None:
     request = _request()


### PR DESCRIPTION
Agents now check input budgets after compaction and retry context overflows only with a smaller request.

---

Talon uses the SDK summarization middleware. Previously, proactive compaction could preserve an oversized tool-result tail, and unclassified provider errors could escape into Talon's unchanged-payload retry loop.

This change recognizes specific context errors from compatible servers, allows at most one smaller retry per middleware call, and checks the complete post-compaction request, including system text and tool schemas. The budget reserves configured output tokens and 5% headroom from the model's input limit. Oversized trailing tool results are offloaded with their call pairs and message IDs preserved; irreducible requests fail with a terminal `ContextOverflowError` rather than another retryable HTTP error.

Token counts remain estimates, and the configured model profile must reflect the server's limit. Unknown limits use reactive recovery. Manual compaction eligibility is unchanged.

Validation: 121 focused tests passed, covering sync/async recovery, proactive oversized tails, repeated errors, failed offloads, output reservations, and irreducible overhead. SDK `make lint` passed, including type checking.
