### PR TITLE
feat(code): add Ollama Cloud web search/fetch backend alongside Tavily

### DIFF
--- a/libs/code/deepagents_code/_constants.py
+++ b/libs/code/deepagents_code/_constants.py
@@ -50,6 +50,9 @@ LANGSMITH_API_KEY_ENV: Final[str] = "LANGSMITH_API_KEY"
 LANGSMITH_API_KEY_FALLBACK_ENV_VARS: Final[tuple[str, ...]] = ("LANGCHAIN_API_KEY",)
 """Legacy env vars the LangSmith SDK accepts after `LANGSMITH_API_KEY_ENV`."""
 
+OLLAMA_API_KEY_ENV: Final[str] = "OLLAMA_API_KEY"
+"""Primary env var the Ollama Cloud web APIs read for their API key."""
+
 LANGSMITH_API_KEY_ENV_VARS: Final[tuple[str, ...]] = (
     LANGSMITH_API_KEY_ENV,
     *LANGSMITH_API_KEY_FALLBACK_ENV_VARS,

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1453,7 +1453,7 @@ _WEB_SEARCH_TOOL_GUIDANCE = (
     "The user only sees your text responses - not tool results. Always provide a "
     "complete, natural language answer after using web_search."
 )
-"""Usage guidance included only when the Tavily-backed tool is available."""
+"""Usage guidance included only when a web search tool is available."""
 
 
 def _build_fs_tool_prompt_guidance(fs_tools: list[FsToolName] | None) -> str:
@@ -1530,7 +1530,7 @@ def get_system_prompt(
     interactive: bool = True,
     cwd: str | Path | None = None,
     fs_tools: list[FsToolName] | None = None,
-    has_tavily: bool | None = None,
+    has_web_search: bool | None = None,
     model_result: ModelResult | None = None,
 ) -> str:
     """Get the base system prompt for the agent.
@@ -1550,7 +1550,7 @@ def get_system_prompt(
         cwd: Override the working directory shown in the prompt.
         fs_tools: Filesystem tool allowlist. Restricted prompts omit guidance
             for unavailable tools; `None` retains all guidance.
-        has_tavily: Workspace credential availability override.
+        has_web_search: Web search availability override.
         model_result: Workspace model metadata override.
 
     Returns:
@@ -1620,8 +1620,12 @@ def get_system_prompt(
             unsupported_modalities=runtime_state.model_unsupported_modalities,
         )
     filesystem_tool_guidance = _build_fs_tool_prompt_guidance(fs_tools)
-    tavily_available = credentials.has_tavily if has_tavily is None else has_tavily
-    web_search_tool_guidance = _WEB_SEARCH_TOOL_GUIDANCE if tavily_available else ""
+    web_search_available = (
+        credentials.has_tavily or credentials.has_ollama
+        if has_web_search is None
+        else has_web_search
+    )
+    web_search_tool_guidance = _WEB_SEARCH_TOOL_GUIDANCE if web_search_available else ""
 
     # Build working directory section (local vs sandbox)
     if sandbox_type:
@@ -1742,7 +1746,7 @@ def _format_web_search_description(
 
     return (
         f"Query: {query}\nMax results: {max_results}\n\n"
-        f"{get_glyphs().warning}  This will use Tavily API credits"
+        f"{get_glyphs().warning}  This will use web search API credits"
     )
 
 
@@ -3073,7 +3077,9 @@ def create_cli_agent(
             interactive=interactive,
             cwd=effective_cwd,
             fs_tools=fs_tools,
-            has_tavily=runtime_credentials.has_tavily,
+            has_web_search=(
+                runtime_credentials.has_tavily or runtime_credentials.has_ollama
+            ),
             model_result=model_result,
         )
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3599,20 +3599,24 @@ class DeepAgentsApp(App):
         """Whether a successful MCP login is waiting for reconnect."""
 
         self._pending_web_search_restart = False
-        """Whether a Tavily key saved via `/auth` is awaiting an offered restart.
+        """Whether a web-search key saved via `/auth` is awaiting an offered restart.
 
-        `web_search` is bound only when Tavily is configured at server spawn
-        time (see `server_graph._build_tools`), so a key added to a running
-        server takes effect only after a respawn. Set when the saved key gates
-        a tool the running server lacks; consumed when the `/auth` manager
+        `web_search` is bound only when Tavily or Ollama Cloud is configured at
+        server spawn time (see `server_graph._build_tools`), so a key added to a
+        running server takes effect only after a respawn. Set when the saved key
+        gates a tool the running server lacks; consumed when the `/auth` manager
         closes so the restart prompt never stacks over the still-open manager.
         """
 
-        self._auth_exported_tavily_original: str | None = None
-        """Original shell `TAVILY_API_KEY` value before `/auth` exported Tavily."""
+        self._auth_exported_web_search: dict[str, str | None] = {}
+        """Env originals for web-search keys `/auth` exported, per service.
 
-        self._auth_exported_tavily = False
-        """Whether this app process exported `TAVILY_API_KEY` from `/auth`."""
+        Maps the service name (e.g. `"tavily"`) to the `os.environ` value its
+        API-key var shadowed at export time (`None` when the var was absent), so
+        a later delete can restore exactly what was there before. Ownership of
+        the export is tracked separately from the offer flag so a later delete
+        can reliably undo it (see `_clear_web_search_restart_if_needed`).
+        """
 
         self._pending_mcp_disable_reconnect_servers: set[str] = set()
         """MCP servers with disable-state changes waiting for reconnect."""
@@ -23971,63 +23975,70 @@ class DeepAgentsApp(App):
     def _note_web_search_restart_if_needed(self, provider: str) -> None:
         """Flag an offered restart when a saved key enables `web_search`.
 
-        `web_search` is bound only when Tavily is configured at server spawn
-        time. A server that already spawned with Tavily has the tool bound, so
-        only a running server that lacks it needs a respawn. The stored key is
-        exported to the environment eagerly (as onboarding does) so a later
-        `/restart` — or the offered one — picks it up on reload. Ownership of
-        that export is tracked separately from the offer flag so a later delete
-        can reliably undo it (see `_clear_web_search_restart_if_needed`).
+        `web_search` is bound only when Tavily or Ollama Cloud is configured at
+        server spawn time. A server that already spawned with either has the
+        tool bound, so only a running server that lacks it needs a respawn. The
+        stored key is exported to the environment eagerly (as onboarding does)
+        so a later `/restart` — or the offered one — picks it up on reload.
+        Ownership of that export is tracked separately from the offer flag so a
+        later delete can reliably undo it (see `_clear_web_search_restart_if_needed`).
 
         Args:
             provider: The `/auth` config key that was just saved.
         """
-        from deepagents_code.model_config import TAVILY_SERVICE
+        from deepagents_code.model_config import (
+            OLLAMA_SERVICE,
+            SERVICE_API_KEY_ENV,
+            TAVILY_SERVICE,
+        )
 
-        if provider != TAVILY_SERVICE:
+        if provider not in (TAVILY_SERVICE, OLLAMA_SERVICE):
             return
         from deepagents_code.config import credentials
 
-        if credentials.has_tavily:
+        if credentials.has_tavily or credentials.has_ollama:
             return
         if self._server_proc is None or self._server_kwargs is None:
             return
         from deepagents_code.model_config import apply_stored_service_credentials
 
-        previous = os.environ.get("TAVILY_API_KEY")
+        env_var = SERVICE_API_KEY_ENV[provider]
+        previous = os.environ.get(env_var)
         apply_stored_service_credentials()
-        exported = os.environ.get("TAVILY_API_KEY")
+        exported = os.environ.get(env_var)
         if not exported:
             return
-        if not self._auth_exported_tavily and previous != exported:
-            self._auth_exported_tavily_original = previous
-            self._auth_exported_tavily = True
+        if provider not in self._auth_exported_web_search and previous != exported:
+            self._auth_exported_web_search[provider] = previous
         self._pending_web_search_restart = True
 
     def _clear_web_search_restart_if_needed(self, provider: str) -> None:
-        """Disarm a Tavily restart offer and undo its env export after a delete.
+        """Disarm a web-search restart offer and undo its env export after a delete.
 
-        Only touches `TAVILY_API_KEY` when *this* app exported it (tracked by
-        `_auth_exported_tavily`, set in `_note_web_search_restart_if_needed`) —
-        not the offer flag, which is consumed on manager close before a delete
-        can happen. That distinction is why a shell-provided key survives a
-        delete (the export flag was never set) while our own export is reverted
-        to whatever value it shadowed.
+        Only touches the deleted service's API-key var when *this* app exported
+        it (tracked by `_auth_exported_web_search`, set in
+        `_note_web_search_restart_if_needed`) — not the offer flag, which is
+        consumed on manager close before a delete can happen. That distinction
+        is why a shell-provided key survives a delete (the export was never
+        ours) while our own export is reverted to whatever value it shadowed.
 
         Args:
             provider: The `/auth` config key that was just deleted.
         """
-        from deepagents_code.model_config import TAVILY_SERVICE
+        from deepagents_code.model_config import (
+            OLLAMA_SERVICE,
+            SERVICE_API_KEY_ENV,
+            TAVILY_SERVICE,
+        )
 
-        if provider != TAVILY_SERVICE:
+        if provider not in (TAVILY_SERVICE, OLLAMA_SERVICE):
             return
-        if self._auth_exported_tavily:
-            if self._auth_exported_tavily_original is None:
-                os.environ.pop("TAVILY_API_KEY", None)
+        if provider in self._auth_exported_web_search:
+            original = self._auth_exported_web_search.pop(provider)
+            if original is None:
+                os.environ.pop(SERVICE_API_KEY_ENV[provider], None)
             else:
-                os.environ["TAVILY_API_KEY"] = self._auth_exported_tavily_original
-            self._auth_exported_tavily = False
-            self._auth_exported_tavily_original = None
+                os.environ[SERVICE_API_KEY_ENV[provider]] = original
         self._pending_web_search_restart = False
 
     def _maybe_offer_deferred_web_search_restart(self) -> None:
@@ -27428,29 +27439,29 @@ class DeepAgentsApp(App):
         )
 
     async def _offer_restart_for_web_search(self) -> None:
-        """Offer a restart so a Tavily key saved via `/auth` enables `web_search`.
+        """Offer a restart so a web-search key saved via `/auth` enables `web_search`.
 
-        The app-owned server binds `web_search` only when Tavily is configured
-        at spawn time (see `server_graph._build_tools`), so a key added
-        mid-session takes effect only after the server respawns. Mirrors the
-        post-install offer: same guards, watchdog, and fallback messaging, with
-        web-search-specific copy.
+        The app-owned server binds `web_search` only when Tavily or Ollama Cloud
+        is configured at spawn time (see `server_graph._build_tools`), so a key
+        added mid-session takes effect only after the server respawns. Mirrors
+        the post-install offer: same guards, watchdog, and fallback messaging,
+        with web-search-specific copy.
         """
         from deepagents_code.config import credentials
 
-        if credentials.has_tavily:
+        if credentials.has_tavily or credentials.has_ollama:
             # A respawn happened between arming the offer and now — e.g. an
             # install-on-select in the same `/auth` session auto-restarted the
             # server, which reloaded config and rebound `web_search`. The
             # restart is no longer needed, so don't offer a redundant one.
             return
         await self._offer_server_restart(
-            label="Tavily API key",
+            label="Web search API key",
             verb="Saved",
             prompt_body=(
                 "Restart the server to enable web search, or defer with `/restart`."
             ),
-            relaunch_hint="Relaunch dcode to enable web search with your Tavily key.",
+            relaunch_hint="Relaunch dcode to enable web search with your new key.",
             busy_hint=(
                 "Run `/restart` to enable web search once the current task finishes."
             ),

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -11582,7 +11582,7 @@ class DeepAgentsApp(App):
         """
         from deepagents_code.config import credentials
 
-        if credentials.has_tavily:
+        if credentials.has_tavily or credentials.has_ollama:
             return
 
         from deepagents_code.tui.widgets.auth import AuthPromptScreen, AuthResult

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3415,6 +3415,7 @@ _RELOADABLE_FIELDS = (
     "google_api_key",
     "nvidia_api_key",
     "tavily_api_key",
+    "ollama_api_key",
     "google_cloud_project",
     "google_cloud_location",
     "deepagents_langchain_project",
@@ -3625,6 +3626,9 @@ class CredentialsSnapshot:
     tavily_api_key: str | None
     """Tavily API key if available."""
 
+    ollama_api_key: str | None
+    """Ollama Cloud API key if available (backs web search/fetch)."""
+
     google_cloud_project: str | None
     """Google Cloud project ID for VertexAI authentication."""
 
@@ -3660,6 +3664,11 @@ class CredentialsSnapshot:
         """Check if Tavily API key is configured."""
         return self.tavily_api_key is not None
 
+    @property
+    def has_ollama(self) -> bool:
+        """Check if Ollama Cloud API key is configured."""
+        return self.ollama_api_key is not None
+
 
 _CREDENTIAL_FIELDS = frozenset(CredentialsSnapshot.__dataclass_fields__)
 
@@ -3677,6 +3686,7 @@ class Credentials:
     google_api_key: str | None
     nvidia_api_key: str | None
     tavily_api_key: str | None
+    ollama_api_key: str | None
     google_cloud_project: str | None
     google_cloud_location: str | None
     deepagents_langchain_project: str | None
@@ -3731,6 +3741,7 @@ class Credentials:
         google_key = _resolve_env_var_from(env, "GOOGLE_API_KEY")
         nvidia_key = _resolve_env_var_from(env, "NVIDIA_API_KEY")
         tavily_key = _resolve_env_var_from(env, "TAVILY_API_KEY")
+        ollama_key = _resolve_env_var_from(env, "OLLAMA_API_KEY")
         google_cloud_project = _resolve_env_var_from(env, "GOOGLE_CLOUD_PROJECT")
         google_cloud_location = _resolve_env_var_from(env, "GOOGLE_CLOUD_LOCATION")
         from deepagents_code._env_vars import LANGSMITH_PROJECT
@@ -3742,6 +3753,7 @@ class Credentials:
             google_api_key=google_key,
             nvidia_api_key=nvidia_key,
             tavily_api_key=tavily_key,
+            ollama_api_key=ollama_key,
             google_cloud_project=google_cloud_project,
             google_cloud_location=google_cloud_location,
             deepagents_langchain_project=_resolve_env_var_from(env, LANGSMITH_PROJECT),
@@ -3979,6 +3991,7 @@ class Credentials:
             "google_api_key": _resolve_env_var_from(env, "GOOGLE_API_KEY"),
             "nvidia_api_key": _resolve_env_var_from(env, "NVIDIA_API_KEY"),
             "tavily_api_key": _resolve_env_var_from(env, "TAVILY_API_KEY"),
+            "ollama_api_key": _resolve_env_var_from(env, "OLLAMA_API_KEY"),
             "google_cloud_project": _resolve_env_var_from(env, "GOOGLE_CLOUD_PROJECT"),
             "google_cloud_location": _resolve_env_var_from(
                 env, "GOOGLE_CLOUD_LOCATION"
@@ -4178,6 +4191,11 @@ class Credentials:
     def has_tavily(self) -> bool:
         """Check if Tavily API key is configured."""
         return self.active.has_tavily
+
+    @property
+    def has_ollama(self) -> bool:
+        """Check if Ollama Cloud API key is configured."""
+        return self.active.has_ollama
 
 
 DANGEROUS_SHELL_PATTERNS = (

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1832,7 +1832,10 @@ def check_optional_tools(*, config_path: Path | None = None) -> list[str]:
 
     from deepagents_code.config import credentials
 
-    if not credentials.has_tavily and not is_warning_suppressed("tavily", config_path):
+    if (
+        not (credentials.has_tavily or credentials.has_ollama)
+        and not is_warning_suppressed("tavily", config_path)
+    ):
         missing.append("tavily")
 
     return missing
@@ -1960,7 +1963,7 @@ def build_missing_tool_notification(tool: str) -> "PendingNotification":
         return PendingNotification(
             key="dep:tavily",
             title="Web search disabled",
-            body=("Add a Tavily API key to enable web search."),
+            body=("Add a Tavily or Ollama Cloud API key to enable web search."),
             actions=(
                 NotificationAction(
                     ActionId.ENTER_API_KEY, "Enter API key", primary=True
@@ -2007,7 +2010,8 @@ def format_tool_warning_cli(tool: str) -> str:
         url = "https://tavily.com"
         suppress = _suppress_hint_cli("tavily")
         return (
-            "Web search is disabled \u2014 TAVILY_API_KEY is not set.\n"
+            "Web search is disabled \u2014 neither TAVILY_API_KEY nor "
+            "OLLAMA_API_KEY is set.\n"
             f"Get a key at [link={url}]{url}[/link]\n\n"
             f"{suppress}\n"
         )
@@ -3538,7 +3542,7 @@ async def _run_acp_cli_async(
     ]
 
     tools: list[Any] = [fetch_url, get_current_thread_id]
-    if credentials.has_tavily:
+    if credentials.has_tavily or credentials.has_ollama:
         tools.append(web_search)
 
     mcp_session_manager = None

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -29,6 +29,7 @@ from deepagents_code import _env_vars, auth_store
 from deepagents_code._constants import (
     LANGSMITH_API_KEY_ENV,
     LANGSMITH_API_KEY_FALLBACK_ENV_VARS,
+    OLLAMA_API_KEY_ENV,
 )
 from deepagents_code._git import find_git_common_dir
 from deepagents_code._paths import PATHS
@@ -994,9 +995,19 @@ takes effect only after a respawn — the app offers that restart, and this
 constant is the single name its `/auth` handling compares against.
 """
 
+OLLAMA_SERVICE = "ollama"
+"""Service name for Ollama Cloud web search in `SERVICE_API_KEY_ENV`.
+
+Storing a key for this service via `/auth` gates the spawn-time `web_search`
+tool the same way `TAVILY_SERVICE` does (see `server_graph._build_tools`), so a
+key added to a running server takes effect only after a respawn — the app
+offers that restart, and its `/auth` handling compares against both constants.
+"""
+
 SERVICE_API_KEY_ENV: dict[str, str] = {
     LANGSMITH_SERVICE: LANGSMITH_API_KEY_ENV,
     TAVILY_SERVICE: "TAVILY_API_KEY",
+    OLLAMA_SERVICE: OLLAMA_API_KEY_ENV,
 }
 """Non-model services configurable via `/auth`, mapped to their API-key env var.
 

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -165,11 +165,12 @@ async def _build_tools(
     project_context: ProjectContext | None,
     *,
     tavily_api_key: str | None,
+    ollama_api_key: str | None = None,
 ) -> tuple[list[Any], list[Any] | None, list[Any], list[Any]]:
     """Assemble the tool list based on server config.
 
-    Loads built-in tools (conditionally including web search when Tavily is
-    available) and MCP tools when enabled.
+    Loads built-in tools (conditionally including web search when Tavily or
+    Ollama Cloud is available) and MCP tools when enabled.
 
     MCP discovery is awaited on the server's event loop: LangGraph invokes this
     async factory on its running loop, so discovery must use `await` rather than
@@ -186,6 +187,9 @@ async def _build_tools(
         tavily_api_key: Workspace Tavily key, or `None` when the workspace
             configures none. An empty string still binds the tool, which then
             reports the key as unconfigured.
+        ollama_api_key: Workspace Ollama Cloud key, or `None` when the
+            workspace configures none. Used only when `tavily_api_key` is
+            unset; Tavily keeps priority so existing workspaces are unaffected.
 
     Returns:
         Tuple of `(tools, mcp_server_info, mcp_tools, read_only_builtins)`. The
@@ -205,8 +209,17 @@ async def _build_tools(
 
     tools: list[Any] = [fetch_url, get_current_thread_id]
     read_only_builtins: list[Any] = [fetch_url]
-    if tavily_api_key is not None:
-        search_tool = create_web_search_tool(tavily_api_key)
+    if tavily_api_key or ollama_api_key:
+        # Tavily wins when both are configured; see the docstring.
+        provider = "tavily" if tavily_api_key else "ollama"
+        api_key = tavily_api_key if tavily_api_key else ollama_api_key
+        search_tool = create_web_search_tool(api_key or "", provider=provider)
+        tools.append(search_tool)
+        read_only_builtins.append(search_tool)
+    elif tavily_api_key is not None:
+        # An explicitly empty Tavily key still binds the tool so it can report
+        # itself as unconfigured (historical contract).
+        search_tool = create_web_search_tool("")
         tools.append(search_tool)
         read_only_builtins.append(search_tool)
 
@@ -453,6 +466,7 @@ async def _make_graphs_in_environment(
         config,
         project_context,
         tavily_api_key=workspace_credentials.tavily_api_key,
+        ollama_api_key=workspace_credentials.ollama_api_key,
     )
     read_only_context_tools = _criteria_context_tools(
         tools, mcp_tools, read_only_builtins

--- a/libs/code/deepagents_code/tool_catalog.py
+++ b/libs/code/deepagents_code/tool_catalog.py
@@ -206,7 +206,7 @@ def collect_built_in_tools(
     forwarded so agent-specific subagents are loaded from the same directory the
     normal launch path uses. The custom CLI tools are included the same way
     `server_graph._build_tools` adds them, so `web_search` appears only when
-    Tavily is configured.
+    Tavily or Ollama Cloud is configured.
 
     Args:
         assistant_id: Resolved dcode agent identifier to compile.
@@ -232,9 +232,10 @@ def collect_built_in_tools(
     from deepagents_code.tools import fetch_url, get_current_thread_id, web_search
 
     # Keep in sync with `server_graph._build_tools`: web_search is bound only
-    # when Tavily is configured, so it appears here only under the same gate.
+    # when Tavily or Ollama Cloud is configured, so it appears here only under
+    # the same gate.
     custom_tools: list[Any] = [fetch_url, get_current_thread_id]
-    if credentials.has_tavily:
+    if credentials.has_tavily or credentials.has_ollama:
         custom_tools.append(web_search)
 
     agent, _backend = create_cli_agent(

--- a/libs/code/deepagents_code/tools.py
+++ b/libs/code/deepagents_code/tools.py
@@ -27,6 +27,18 @@ logger = logging.getLogger(__name__)
 _UNSET = object()
 _tavily_client: TavilyClient | object | None = _UNSET
 
+_OLLAMA_WEB_SEARCH_URL = "https://ollama.com/api/web_search"
+"""Ollama Cloud web search endpoint (`Authorization: Bearer OLLAMA_API_KEY`)."""
+
+_OLLAMA_WEB_FETCH_URL = "https://ollama.com/api/web_fetch"
+"""Ollama Cloud web fetch endpoint (`Authorization: Bearer OLLAMA_API_KEY`)."""
+
+_OLLAMA_MAX_RESULTS = 10
+"""Hard cap the Ollama web search API accepts for `max_results`."""
+
+_TAVILY_PROVIDER = "tavily"
+_OLLAMA_PROVIDER = "ollama"
+
 _WEB_SEARCH_MARKER = "deepagents_web_search"
 """Tool-metadata key marking a workspace-bound `web_search` variant.
 
@@ -299,15 +311,45 @@ def _html_to_markdown_content(html: str, markdownify: Callable[[str], str]) -> s
     return parser.get_text()
 
 
-def _missing_tavily_key_error(query: object) -> dict[str, object]:
-    """Return the payload the model sees when no Tavily key is configured.
+def _active_web_provider() -> str | None:
+    """Return the provider backing the web tools, or `None` when unconfigured.
+
+    Tavily keeps priority so existing Tavily workspaces are unaffected; Ollama
+    Cloud (`OLLAMA_API_KEY`) is the fallback. The same Ollama key backs cloud
+    models and the web search/fetch APIs, so no separate credential is needed.
+
+    Returns:
+        `"tavily"`, `"ollama"`, or `None`.
+    """
+    from deepagents_code.config import credentials
+
+    if credentials.has_tavily:
+        return _TAVILY_PROVIDER
+    if credentials.has_ollama:
+        return _OLLAMA_PROVIDER
+    return None
+
+
+def _missing_key_error(provider: str | None, query: object) -> dict[str, object]:
+    """Return the payload the model sees when no web search key is configured.
 
     Shared by the built-in and workspace-bound variants: `is_web_search_tool`
     treats them as one tool, so they have to fail identically.
 
+    Args:
+        provider: Selected web provider, or `None` when no key is set. `None`
+            keeps the historical Tavily-only message because Tavily is still
+            the documented primary and existing deployments rely on it.
+
     Returns:
         Error payload naming the env var to set.
     """
+    if provider == _OLLAMA_PROVIDER:
+        return {
+            "error": "Ollama API key not configured. "
+            "Please set OLLAMA_API_KEY environment variable.",
+            "query": query,
+        }
     return {
         "error": "Tavily API key not configured. "
         "Please set TAVILY_API_KEY environment variable.",
@@ -345,7 +387,11 @@ def _get_tavily_client() -> TavilyClient | None:
     return _tavily_client
 
 
-def create_web_search_tool(api_key: str) -> BaseTool:
+def create_web_search_tool(
+    api_key: str,
+    *,
+    provider: str = _TAVILY_PROVIDER,
+) -> BaseTool:
     """Bind web search to one workspace credential.
 
     The schema is taken from `web_search` via `functools.wraps` so the built-in
@@ -353,6 +399,10 @@ def create_web_search_tool(api_key: str) -> BaseTool:
     also have to fail the same way: `is_web_search_tool` treats them as one, so
     a missing package or an unusable key must return the payload the model can
     act on rather than raising.
+
+    Args:
+        api_key: The workspace provider credential (`""` reports unconfigured).
+        provider: Which backend the key belongs to (`"tavily"` or `"ollama"`).
 
     Returns:
         Workspace-bound web search tool.
@@ -366,7 +416,13 @@ def create_web_search_tool(api_key: str) -> BaseTool:
     def workspace_web_search(**kwargs: Any) -> object:
         nonlocal client
         if not api_key:
-            return _missing_tavily_key_error(kwargs.get("query"))
+            return _missing_key_error(provider, kwargs.get("query"))
+        if provider == _OLLAMA_PROVIDER:
+            return _search_with_ollama(
+                api_key,
+                query=kwargs.get("query", ""),
+                max_results=kwargs.get("max_results", 5),
+            )
         if client is None:
             try:
                 from tavily import TavilyClient as _TavilyClient
@@ -438,12 +494,27 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
 ):
     """Search the web for current information.
 
+    Backed by Tavily when `TAVILY_API_KEY` is set, otherwise by Ollama Cloud
+    (`OLLAMA_API_KEY`). The `topic` and `include_raw_content` arguments only
+    apply to the Tavily backend; Ollama ignores them.
+
     Returns:
         Search hits with title, URL, snippet, and score.
     """
+    provider = _active_web_provider()
+    if provider is None:
+        return _missing_key_error(None, query)
+    if provider == _OLLAMA_PROVIDER:
+        from deepagents_code.config import credentials
+
+        return _search_with_ollama(
+            credentials.ollama_api_key or "",
+            query=query,
+            max_results=max_results,
+        )
     client = _get_tavily_client()
     if client is None:
-        return _missing_tavily_key_error(query)
+        return _missing_key_error(provider, query)
     return _search_with_tavily(
         client,
         query=query,
@@ -451,6 +522,49 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
         topic=topic,
         include_raw_content=include_raw_content,
     )
+
+
+def _search_with_ollama(
+    api_key: str,
+    *,
+    query: str,
+    max_results: int,
+) -> object:
+    """Execute an Ollama Cloud web search with the standard error translation.
+
+    Args:
+        api_key: Ollama Cloud API key (Bearer credential).
+        query: The search query.
+        max_results: Requested result count, capped at the API's own limit.
+
+    Returns:
+        Search hits (`{"query", "results"}` with `title`, `url`, and `content`
+        per hit) or a translated error payload.
+    """
+    if not api_key:
+        # Mirrors the workspace variant's contract: an empty key reports the
+        # configuration problem instead of sending an unusable request.
+        return _missing_key_error(_OLLAMA_PROVIDER, query)
+
+    try:
+        import requests
+    except ImportError as exc:
+        return _missing_package_error(exc)
+
+    try:
+        response = requests.post(
+            _OLLAMA_WEB_SEARCH_URL,
+            json={"query": query, "max_results": min(max_results, _OLLAMA_MAX_RESULTS)},
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=60,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.exceptions.RequestException, ValueError) as e:
+        return {"error": f"Web search error: {e!s}", "query": query}
+
+    results = payload.get("results", []) if isinstance(payload, dict) else []
+    return {"query": query, "results": results}
 
 
 def _search_with_tavily(
@@ -512,14 +626,25 @@ def fetch_url(
 ) -> dict[str, Any]:
     """Fetch a URL and return the page content as markdown.
 
+    Fetches directly unless Ollama Cloud is the active web provider (Tavily
+    unconfigured, `OLLAMA_API_KEY` set), in which case the Ollama web fetch
+    API retrieves the page server-side and no SSRF guard applies — the local
+    process never connects to the target host.
+
     Returns:
-        Fetched page markdown plus status metadata.
+        Fetched page markdown plus status metadata. The Ollama backend omits
+        `status_code` and adds `title` and `links`.
     """
     try:
         import requests
         from markdownify import markdownify
     except ImportError as exc:
         return _missing_package_error(exc)
+
+    if _active_web_provider() == _OLLAMA_PROVIDER:
+        from deepagents_code.config import credentials
+
+        return _fetch_with_ollama(url, credentials.ollama_api_key or "")
 
     try:
         response = _fetch_with_redirects(url, timeout=timeout)
@@ -547,6 +672,52 @@ def fetch_url(
         "status_code": response.status_code,
         "content_length": len(markdown_content),
     }
+
+
+def _fetch_with_ollama(url: str, api_key: str) -> dict[str, Any]:
+    """Fetch `url` through the Ollama Cloud web fetch API.
+
+    Args:
+        url: The URL Ollama should retrieve server-side.
+        api_key: Ollama Cloud API key (Bearer credential).
+
+    Returns:
+        Fetched page content and metadata, or an error payload using the same
+        shape the direct fetch path returns. No SSRF guard applies here: the
+        local process only connects to `ollama.com`, so fetching internal
+        addresses does not leak the network the agent runs in.
+    """
+    import requests
+
+    try:
+        response = requests.post(
+            _OLLAMA_WEB_FETCH_URL,
+            json={"url": url},
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=60,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.exceptions.RequestException, ValueError) as e:
+        return {"error": f"Fetch URL error: {e!s}", "url": url, "category": "network"}
+
+    content = ""
+    links: list[str] = []
+    if isinstance(payload, dict):
+        content = str(payload.get("content", ""))
+        raw_links = payload.get("links", [])
+        links = [str(link) for link in raw_links] if isinstance(raw_links, list) else []
+
+    result: dict[str, Any] = {
+        "url": url,
+        "markdown_content": content,
+        "content_length": len(content),
+    }
+    if isinstance(payload, dict) and payload.get("title"):
+        result["title"] = payload["title"]
+    if links:
+        result["links"] = links
+    return result
 
 
 def _fetch_with_redirects(url: str, *, timeout: int) -> Any:  # noqa: ANN401  # requests.Response, but kept dynamic to avoid eager import

--- a/libs/code/deepagents_code/tui/widgets/auth.py
+++ b/libs/code/deepagents_code/tui/widgets/auth.py
@@ -221,6 +221,7 @@ PROVIDER_API_KEY_URLS: dict[str, str] = {
     "meta": "https://dev.meta.ai/api-keys/",
     "mistralai": "https://console.mistral.ai/api-keys",
     "nvidia": "https://build.nvidia.com/settings/api-keys",
+    "ollama": "https://ollama.com/keys",
     "openai": "https://platform.openai.com/api-keys",
     "openrouter": "https://openrouter.ai/workspaces/default/keys",
     "perplexity": "https://www.perplexity.ai/settings/api",

--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -187,10 +187,15 @@ def _clear_tavily_env(monkeypatch: pytest.MonkeyPatch) -> None:
     a dev machine but runs it on CI, so a test that reaches the step passes
     locally yet hangs (real screen push) or writes a credential on CI.
 
-    Each test that *needs* a Tavily key should set it explicitly via
-    `monkeypatch.setenv` or patch `credentials.has_tavily`.
+    Each test that *needs* a Tavily or Ollama key should set it explicitly via
+    `monkeypatch.setenv` or patch `credentials.has_tavily` / `has_ollama`.
     """
-    for key in ("TAVILY_API_KEY", "DEEPAGENTS_CODE_TAVILY_API_KEY"):
+    for key in (
+        "TAVILY_API_KEY",
+        "DEEPAGENTS_CODE_TAVILY_API_KEY",
+        "OLLAMA_API_KEY",
+        "DEEPAGENTS_CODE_OLLAMA_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
 
 

--- a/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -153,6 +153,7 @@ def _mock_settings(tmp_path: Path) -> Generator[None, None, None]:
         mock_runtime_state.model_context_limit = _FIXED_CONTEXT_LIMIT
         mock_runtime_state.model_unsupported_modalities = frozenset()
         mock_s.has_tavily = False
+        mock_s.has_ollama = False
         mock_s.project_root = None
         mock_s.user_langchain_project = None
         mock_s.shell_allow_list = None

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -1186,13 +1186,13 @@ class TestWorkspacePromptCredentials:
         assert "workspace-provider" in prompt
         assert "12,345 tokens" in prompt
 
-    def test_has_tavily_override_controls_guidance(self) -> None:
+    def test_has_web_search_override_controls_guidance(self) -> None:
         """Prompt guidance does not consult process-global credentials."""
-        without = get_system_prompt("test-agent", has_tavily=False)
-        with_tavily = get_system_prompt("test-agent", has_tavily=True)
+        without = get_system_prompt("test-agent", has_web_search=False)
+        with_search = get_system_prompt("test-agent", has_web_search=True)
 
         assert "When you use the web_search tool" not in without
-        assert "When you use the web_search tool" in with_tavily
+        assert "When you use the web_search tool" in with_search
 
 
 class TestBuildModelIdentitySection:
@@ -1236,6 +1236,7 @@ class TestGetSystemPromptModelIdentity:
         mock_settings = Mock()
         runtime_state.model_name = None
         mock_settings.has_tavily = False
+        mock_settings.has_ollama = False
 
         with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1341,6 +1342,7 @@ class TestGetSystemPromptWebSearch:
         mock_settings = Mock()
         runtime_state.model_name = None
         mock_settings.has_tavily = False
+        mock_settings.has_ollama = False
 
         with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")
@@ -1352,6 +1354,7 @@ class TestGetSystemPromptWebSearch:
         mock_settings = Mock()
         runtime_state.model_name = None
         mock_settings.has_tavily = True
+        mock_settings.has_ollama = False
 
         with patch("deepagents_code.agent.credentials", mock_settings):
             prompt = get_system_prompt("test-agent")

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -1309,7 +1309,7 @@ class TestStartupSequence:
 
         with (
             patch(
-                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=False)
+                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=False, has_ollama=False)
             ),
             patch(
                 "deepagents_code.model_config.apply_stored_service_credentials"
@@ -1343,7 +1343,7 @@ class TestStartupSequence:
 
         with (
             patch(
-                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=False)
+                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=False, has_ollama=False)
             ),
             patch(
                 "deepagents_code.model_config.apply_stored_service_credentials"
@@ -1361,7 +1361,7 @@ class TestStartupSequence:
 
         with (
             patch(
-                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=True)
+                "deepagents_code.config.credentials", SimpleNamespace(has_tavily=True, has_ollama=False)
             ),
             patch("deepagents_code.auth_store.set_stored_key") as set_stored_key,
         ):

--- a/libs/code/tests/unit_tests/test_auth_web_search_restart.py
+++ b/libs/code/tests/unit_tests/test_auth_web_search_restart.py
@@ -129,8 +129,7 @@ class TestNoteWebSearchRestart:
 
         app = DeepAgentsApp()
         app._pending_web_search_restart = True
-        app._auth_exported_tavily = True
-        app._auth_exported_tavily_original = None
+        app._auth_exported_web_search = {"tavily": None}
 
         app._clear_web_search_restart_if_needed("tavily")
 
@@ -294,7 +293,7 @@ class TestOfferRestartForWebSearch:
         await app._offer_restart_for_web_search()
 
         app._restart_after_install.assert_awaited_once_with(  # ty: ignore
-            "Tavily API key"
+            "Web search API key"
         )
 
     async def test_restart_state_flip_surfaces_fallback(
@@ -469,8 +468,7 @@ class TestCredentialSavedHandler:
         async with app.run_test() as pilot:
             await pilot.pause()
             app._pending_web_search_restart = True
-            app._auth_exported_tavily = True
-            app._auth_exported_tavily_original = None
+            app._auth_exported_web_search = {"tavily": None}
 
             app.on_auth_manager_screen_credential_deleted(
                 AuthManagerScreen.CredentialDeleted("tavily")
@@ -607,3 +605,131 @@ class TestDeferredOfferAfterManagerCloses:
             assert app._pending_web_search_restart is True
             assert app._launch_web_search_restart_prompt not in scheduled
             app._install_provider_then_reopen_auth.assert_awaited_once()  # ty: ignore
+
+
+class TestOllamaWebSearchRestart:
+    """The restart offer covers Ollama Cloud alongside Tavily.
+
+    `web_search` gates on either provider (see `server_graph._build_tools`),
+    so saving an Ollama key via `/auth` arms the same deferred respawn offer.
+    """
+
+    @staticmethod
+    def _fake_ollama_export(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Make `apply_stored_service_credentials` export an Ollama key."""
+
+        def _apply() -> None:
+            monkeypatch.setenv("OLLAMA_API_KEY", "ollama-fake")
+
+        monkeypatch.setattr(
+            "deepagents_code.model_config.apply_stored_service_credentials",
+            _apply,
+        )
+
+    def test_flags_restart_when_running_server_lacks_ollama(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A saved Ollama key on a web-search-less running server arms the offer."""
+        from deepagents_code.config import credentials
+
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "ollama_api_key", None)
+        self._fake_ollama_export(monkeypatch)
+
+        app = DeepAgentsApp()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "anthropic:fake"}
+
+        app._note_web_search_restart_if_needed("ollama")
+
+        assert app._pending_web_search_restart is True
+
+    def test_skips_when_server_already_has_tavily(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A server spawned with Tavily already bound `web_search`, so no offer."""
+        from deepagents_code.config import credentials
+
+        monkeypatch.setattr(credentials, "tavily_api_key", "tvly-existing")
+        self._fake_ollama_export(monkeypatch)
+
+        app = DeepAgentsApp()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "anthropic:fake"}
+
+        app._note_web_search_restart_if_needed("ollama")
+
+        assert app._pending_web_search_restart is False
+
+    def test_skips_when_server_already_has_ollama(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A server spawned with Ollama Cloud already bound `web_search`."""
+        from deepagents_code.config import credentials
+
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "ollama_api_key", "ollama-existing")
+
+        app = DeepAgentsApp()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "anthropic:fake"}
+
+        app._note_web_search_restart_if_needed("ollama")
+
+        assert app._pending_web_search_restart is False
+
+    async def test_offer_gates_on_either_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The post-close offer skips when either key is already configured."""
+        from deepagents_code.config import credentials
+
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "ollama_api_key", "ollama-existing")
+
+        app = DeepAgentsApp()
+        app._offer_server_restart = AsyncMock()  # ty: ignore
+
+        app._pending_web_search_restart = True
+        app._maybe_offer_deferred_web_search_restart()
+        await app._offer_restart_for_web_search()
+
+        app._offer_server_restart.assert_not_awaited()  # ty: ignore
+
+    def test_deleted_ollama_key_clears_pending_restart_and_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Deleting Ollama disarms the deferred restart and removes its env bridge."""
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama-deleted")
+
+        app = DeepAgentsApp()
+        app._pending_web_search_restart = True
+        app._auth_exported_web_search = {"ollama": None}
+
+        app._clear_web_search_restart_if_needed("ollama")
+
+        assert app._pending_web_search_restart is False
+        assert "OLLAMA_API_KEY" not in os.environ
+
+    def test_deleted_ollama_key_restores_original_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Deleting Ollama restores a shell key that `/auth` temporarily replaced."""
+        from deepagents_code.config import credentials
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama-from-shell")
+        monkeypatch.setattr(credentials, "tavily_api_key", None)
+        monkeypatch.setattr(credentials, "ollama_api_key", None)
+        self._fake_ollama_export(monkeypatch)
+
+        app = DeepAgentsApp()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "anthropic:fake"}
+
+        app._note_web_search_restart_if_needed("ollama")
+        app._maybe_offer_deferred_web_search_restart()
+        app._clear_web_search_restart_if_needed("ollama")
+
+        assert app._pending_web_search_restart is False
+        assert os.environ["OLLAMA_API_KEY"] == "ollama-from-shell"

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -2514,7 +2514,7 @@ class TestCheckOptionalTools:
         """Patch credentials.has_tavily so ripgrep-only tests stay isolated."""
         with patch(
             "deepagents_code.config.credentials",
-            SimpleNamespace(has_tavily=True),
+            SimpleNamespace(has_tavily=True, has_ollama=False),
         ):
             yield
 
@@ -2545,7 +2545,7 @@ class TestCheckOptionalTools:
             patch("deepagents_code.main.shutil.which", return_value="/usr/bin/rg"),
             patch(
                 "deepagents_code.config.credentials",
-                SimpleNamespace(has_tavily=False),
+                SimpleNamespace(has_tavily=False, has_ollama=False),
             ),
         ):
             missing = check_optional_tools(config_path=config_path)
@@ -2561,7 +2561,7 @@ class TestCheckOptionalTools:
             patch("deepagents_code.main.shutil.which", return_value="/usr/bin/rg"),
             patch(
                 "deepagents_code.config.credentials",
-                SimpleNamespace(has_tavily=False),
+                SimpleNamespace(has_tavily=False, has_ollama=False),
             ),
         ):
             missing = check_optional_tools(config_path=config_path)

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -111,6 +111,7 @@ async def test_acp_defaults_classifier_after_provider_resolution(tmp_path) -> No
         patch("deepagents_code.acp.AgentServerACP", new=AgentServer),
     ):
         credentials.has_tavily = False
+        credentials.has_ollama = False
         exit_code = await _run_acp_cli_async(
             "agent",
             run_acp_agent=run_agent,

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -885,6 +885,31 @@ class TestServiceCredentials:
         assert status.env_var == "TAVILY_API_KEY"
         assert status.detail == "TAVILY_API_KEY is not set or is empty"
 
+    def test_ollama_is_configurable_service(self) -> None:
+        """`ollama` is a non-model service with an `/auth`-managed env var."""
+        from deepagents_code.model_config import (
+            OLLAMA_SERVICE,
+            SERVICE_API_KEY_ENV,
+            is_service,
+        )
+
+        assert is_service(OLLAMA_SERVICE)
+        assert SERVICE_API_KEY_ENV[OLLAMA_SERVICE] == "OLLAMA_API_KEY"
+
+    def test_ollama_status_configured_from_env(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An `OLLAMA_API_KEY` env var reports CONFIGURED from the env source."""
+        from deepagents_code.model_config import get_service_auth_status
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "from-env")
+        status = get_service_auth_status("ollama")
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.source is ProviderAuthSource.ENV
+        assert status.env_var == "OLLAMA_API_KEY"
+
     def test_status_configured_from_env(
         self,
         fake_state_dir: Path,  # noqa: ARG002

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -362,6 +362,7 @@ class TestSandboxTypeForwarding:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(
@@ -420,6 +421,7 @@ class TestSandboxTypeForwarding:
         ):
             mock_settings.return_value = SHELL_ALLOW_ALL
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(
@@ -469,6 +471,7 @@ class TestSandboxTypeForwarding:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(
@@ -523,6 +526,7 @@ class TestAllowFsToolsForwarding:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(
@@ -587,6 +591,7 @@ class TestQuietMode:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=True)
@@ -650,6 +655,7 @@ class TestQuietMode:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(
@@ -834,6 +840,7 @@ class TestNoStreamMode:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=True, stream=False)
@@ -903,6 +910,7 @@ class TestNoStreamMode:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=True, stream=True)
@@ -965,6 +973,7 @@ class TestFastFollowLangsmithLink:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=False)
@@ -1018,6 +1027,7 @@ class TestFastFollowLangsmithLink:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=False)
@@ -1064,6 +1074,7 @@ class TestFastFollowLangsmithLink:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(message="test", quiet=True)
@@ -1149,6 +1160,7 @@ class TestShellAllowListDecisionLogic:
         ):
             mock_settings.return_value = shell_allow_list
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(message="test task")
@@ -1205,6 +1217,7 @@ class TestNonInteractivePrompt:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(message="do the thing")
@@ -1264,6 +1277,7 @@ class TestNonInteractivePrompt:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(
@@ -1306,6 +1320,7 @@ class TestNonInteractivePrompt:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             result = await run_non_interactive(
@@ -1364,6 +1379,7 @@ class TestNonInteractivePrompt:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             result = await run_non_interactive(
@@ -1889,6 +1905,7 @@ class TestMaxTurns:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             await run_non_interactive(message="task", max_turns=7)
@@ -2036,6 +2053,7 @@ class TestMaxTurns:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             result = await run_non_interactive(message="task", max_turns=1)
@@ -3078,6 +3096,7 @@ class TestDrainWiring:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             result = await run_non_interactive(message="test", quiet=True)
@@ -3125,6 +3144,7 @@ class TestDrainWiring:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             result = await run_non_interactive(message="test", quiet=True)
@@ -3177,6 +3197,7 @@ class TestDrainWiring:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             result = await run_non_interactive(message="test", quiet=True)
@@ -3224,6 +3245,7 @@ class TestDrainWiring:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             result = await run_non_interactive(message="test", quiet=True)
@@ -3298,6 +3320,7 @@ class TestHeadlessUsageStats:
         ):
             mock_settings.return_value = None
             mock_settings.has_tavily = False
+            mock_settings.has_ollama = False
             runtime_state.model_name = None
 
             return_code = await run_non_interactive(message="test", quiet=quiet)

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -282,7 +282,7 @@ asyncio.run(main())
 
         assert read_only_builtins == [fetch_url, bound_tool]
         assert get_current_thread_id not in read_only_builtins
-        create.assert_called_once_with("workspace-key")
+        create.assert_called_once_with("workspace-key", provider="tavily")
 
     async def test_build_tools_read_only_allowlist_without_web_search(self) -> None:
         """With no Tavily key the allowlist holds `fetch_url` alone."""
@@ -359,7 +359,7 @@ asyncio.run(main())
             observed["auto_classifier_model"] = kwargs["auto_classifier_model"]
             return graph_obj, _backend_with_offload(object())
 
-        settings_obj = SimpleNamespace(has_tavily=False, tavily_api_key=None)
+        settings_obj = SimpleNamespace(has_tavily=False, tavily_api_key=None, ollama_api_key=None)
         environment = dict(os.environ)
         config_module = _module_with_attrs(
             "deepagents_code.config",
@@ -472,7 +472,7 @@ asyncio.run(main())
         registry.get_metadata.return_value = None
         registry.get_params.return_value = {}
 
-        settings_obj = SimpleNamespace(has_tavily=False, tavily_api_key=None)
+        settings_obj = SimpleNamespace(has_tavily=False, tavily_api_key=None, ollama_api_key=None)
         environment = dict(os.environ)
         config_module = _module_with_attrs(
             "deepagents_code.config",

--- a/libs/code/tests/unit_tests/test_tool_catalog.py
+++ b/libs/code/tests/unit_tests/test_tool_catalog.py
@@ -151,6 +151,18 @@ class TestCollectBuiltInTools:
             names = {tool.name for tool in collect_built_in_tools()}
         assert "web_search" not in names
 
+    def test_web_search_present_with_ollama(self) -> None:
+        with (
+            patch.object(
+                Credentials, "has_tavily", new_callable=PropertyMock, return_value=False
+            ),
+            patch.object(
+                Credentials, "has_ollama", new_callable=PropertyMock, return_value=True
+            ),
+        ):
+            names = {tool.name for tool in collect_built_in_tools()}
+        assert "web_search" in names
+
 
 class TestTodoToolNotBound:
     """Todos are opt-in in the SDK, so dcode binds no `write_todos` by default."""

--- a/libs/code/tests/unit_tests/tools/test_fetch_url.py
+++ b/libs/code/tests/unit_tests/tools/test_fetch_url.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import socket
 from typing import TYPE_CHECKING, Any
 from unittest import mock
@@ -530,3 +531,85 @@ def test_fetch_url_redirect_cap_exhausted(
     assert "error" in result
     assert "Exceeded" in result["error"]
     assert result["category"] == "redirects"
+
+
+class TestOllamaBackendRouting:
+    """`fetch_url` routes through Ollama Cloud only when Tavily is absent."""
+
+    @staticmethod
+    def _credentials(has_tavily: bool, has_ollama: bool, ollama_api_key: str = "k"):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            has_tavily=has_tavily,
+            has_ollama=has_ollama,
+            ollama_api_key=ollama_api_key,
+        )
+
+    def test_routes_to_ollama_when_only_ollama_configured(self) -> None:
+        from deepagents_code.tools import _OLLAMA_WEB_FETCH_URL
+
+        with responses.RequestsMock() as rsps, mock.patch(
+            "deepagents_code.config.credentials", self._credentials(False, True)
+        ):
+            rsps.add(
+                "POST",
+                _OLLAMA_WEB_FETCH_URL,
+                json={
+                    "title": "Example",
+                    "content": "# Example page",
+                    "links": ["https://example.com/next"],
+                },
+            )
+
+            result = fetch_url("https://example.com/article")
+            request = rsps.calls[0][0]
+        assert request.headers["Authorization"] == "Bearer k"
+        assert json.loads(request.body) == {"url": "https://example.com/article"}
+        assert result["markdown_content"] == "# Example page"
+        assert result["title"] == "Example"
+        assert result["links"] == ["https://example.com/next"]
+
+    def test_ollama_fetch_errors_are_translated(self) -> None:
+        from deepagents_code.tools import _OLLAMA_WEB_FETCH_URL
+
+        with responses.RequestsMock() as rsps, mock.patch(
+            "deepagents_code.config.credentials", self._credentials(False, True)
+        ):
+            rsps.add("POST", _OLLAMA_WEB_FETCH_URL, status=500)
+
+            result = fetch_url("https://example.com/article")
+
+        assert "Fetch URL error" in result["error"]
+        assert result["url"] == "https://example.com/article"
+        assert result["category"] == "network"
+
+    def test_direct_fetch_still_used_when_tavily_configured(self) -> None:
+        """Tavily keeps priority: no Ollama request and no bearer header."""
+        from deepagents_code import tools as tools_module
+
+        resolver, _ = _make_resolver("93.184.216.34")
+
+        class RecordingSession:
+            """Minimal `requests.Session` stand-in with a canned response."""
+
+            def get(self, url: str, **_kwargs: Any) -> requests.Response:
+                response = requests.Response()
+                response.status_code = 200
+                response.url = url
+                response._content = b"<html><body><p>direct</p></body></html>"
+                return response
+
+        with mock.patch(
+            "deepagents_code.config.credentials", self._credentials(True, True)
+        ), mock.patch.object(
+            tools_module, "_fetch_with_ollama"
+        ) as ollama_fetch, mock.patch.object(
+            socket, "getaddrinfo", resolver
+        ), mock.patch.object(
+            requests, "Session", RecordingSession
+        ):
+            result = fetch_url("http://example.com/direct")
+
+        ollama_fetch.assert_not_called()
+        assert result["status_code"] == 200

--- a/libs/code/tests/unit_tests/tools/test_web_search.py
+++ b/libs/code/tests/unit_tests/tools/test_web_search.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from typing import Any
+from unittest import mock
 from unittest.mock import patch
+
+import responses
 
 from langchain_core.tools import tool
 from langchain_core.utils.function_calling import convert_to_openai_tool
@@ -79,3 +83,106 @@ class TestWorkspaceErrorTranslation:
             result = search.invoke({"query": "anything"})
 
         assert "error" in result
+
+
+class TestOllamaProviderSelection:
+    """Tavily keeps priority; Ollama Cloud is the fallback."""
+
+    @staticmethod
+    def _credentials(has_tavily: bool, has_ollama: bool) -> Any:
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            has_tavily=has_tavily,
+            has_ollama=has_ollama,
+            ollama_api_key="k",
+        )
+
+    def test_tavily_wins_when_both_configured(self) -> None:
+        from deepagents_code.tools import _active_web_provider
+
+        with mock.patch(
+            "deepagents_code.config.credentials", self._credentials(True, True)
+        ):
+            assert _active_web_provider() == "tavily"
+
+    def test_ollama_when_only_ollama_configured(self) -> None:
+        from deepagents_code.tools import _active_web_provider
+
+        with mock.patch(
+            "deepagents_code.config.credentials", self._credentials(False, True)
+        ):
+            assert _active_web_provider() == "ollama"
+
+    def test_none_without_any_key(self) -> None:
+        from deepagents_code.tools import _active_web_provider
+
+        with mock.patch(
+            "deepagents_code.config.credentials", self._credentials(False, False)
+        ):
+            assert _active_web_provider() is None
+
+
+class TestOllamaSearch:
+    """The Ollama Cloud backend posts to `ollama.com` and normalizes hits."""
+
+    def test_posts_to_ollama_with_bearer_key_and_result_cap(self) -> None:
+        from types import SimpleNamespace
+
+        from deepagents_code.tools import _OLLAMA_WEB_SEARCH_URL
+
+        stub = SimpleNamespace(has_tavily=False, has_ollama=True, ollama_api_key="k")
+
+        with responses.RequestsMock() as rsps, mock.patch(
+            "deepagents_code.config.credentials", stub
+        ):
+            rsps.add(
+                "POST",
+                _OLLAMA_WEB_SEARCH_URL,
+                json={
+                    "results": [
+                        {"title": "T", "url": "https://x", "content": "c"},
+                    ]
+                },
+            )
+
+            result = web_search(query="q", max_results=25)
+            request = rsps.calls[0][0]
+        assert request.headers["Authorization"] == "Bearer k"
+        assert json.loads(request.body) == {"query": "q", "max_results": 10}
+        assert result == {"query": "q", "results": [{"title": "T", "url": "https://x", "content": "c"}]}
+
+    def test_request_errors_are_translated(self) -> None:
+        from types import SimpleNamespace
+
+        from deepagents_code.tools import _OLLAMA_WEB_SEARCH_URL
+
+        stub = SimpleNamespace(has_tavily=False, has_ollama=True, ollama_api_key="k")
+
+        with responses.RequestsMock() as rsps, mock.patch(
+            "deepagents_code.config.credentials", stub
+        ):
+            rsps.add("POST", _OLLAMA_WEB_SEARCH_URL, status=401)
+
+            result = web_search(query="q")
+
+        assert "Web search error" in result["error"]
+        assert result["query"] == "q"
+
+    def test_empty_ollama_key_reports_configuration(self) -> None:
+        from types import SimpleNamespace
+
+        stub = SimpleNamespace(has_tavily=False, has_ollama=True, ollama_api_key="")
+
+        with mock.patch("deepagents_code.config.credentials", stub):
+            result = web_search(query="q")
+
+        assert "Ollama API key not configured" in result["error"]
+        assert result["query"] == "q"
+
+    def test_workspace_variant_ollama_message_for_empty_key(self) -> None:
+        search = create_web_search_tool("", provider="ollama")
+
+        result = search.invoke({"query": "anything"})
+
+        assert "Ollama API key not configured" in result["error"]

--- a/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
@@ -2513,6 +2513,7 @@ api_key_env = "MY_GATEWAY_API_KEY"
             "anthropic",
             "tavily",
             "langsmith",
+            "ollama",
         }
 
     async def test_selecting_service_opens_prompt_for_its_env_var(


### PR DESCRIPTION
## Summary
Adds Ollama Cloud as a second web tool backend for deepagents-code, next to Tavily:

- `web_search` / `web_fetch` now route to Ollama Cloud (`POST https://ollama.com/api/web_search`, `.../api/web_fetch`) when `OLLAMA_API_KEY` is set and Tavily is not (Tavily keeps precedence). Keyed via `Authorization: Bearer`.
- Provider selection is centralized in `_active_web_provider()` with `create_web_search_tool(api_key, *, provider)`; gates across `server_graph`, `agent`, `tool_catalog`, and `main` now check `has_tavily or has_ollama`.
- `/auth` integration: `SERVICE_API_KEY_ENV` gains an `ollama` entry so the CLI and TUI credential managers list Ollama, status badges read `OLLAMA_API_KEY` (with `DEEPAGENTS_CODE_`-prefixed override winning), and stored keys export on startup like the other services. The Tavily-specific restart offer is generalized to both web-search providers, with per-service env-restore on delete-undo.

## Testing
- New unit tests for the Ollama search/fetch backends, provider selection, service-credential status/export, and the generalized restart offer (510 tests across the auth suites pass; `test_app.py` 1060 pass + 1 deselected timing flake that passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)