### PR TITLE
fix(sdk): restore default summarization trim limit

### DIFF
--- a/libs/code/tests/unit_tests/test_end_to_end.py
+++ b/libs/code/tests/unit_tests/test_end_to_end.py
@@ -202,7 +202,7 @@ class TestDeepAgentsCLIEndToEnd:
                     ]
                 )
             )
-            model.profile = {"max_input_tokens": 200_000}
+            model.profile = {"max_input_tokens": 10_000}
 
             # Create a CLI agent with the fake model
             agent, backend = create_cli_agent(
@@ -214,22 +214,20 @@ class TestDeepAgentsCLIEndToEnd:
 
             # Invoke the agent
             thread_id = str(uuid.uuid4())
-            text_10_000_tokens = "x" * 10_000 * 4
-            text_50_000_tokens = "x" * 50_000 * 4
+            text_500_tokens = "x" * 500 * 4
             input_messages = [
-                HumanMessage(content=text_10_000_tokens),
-                AIMessage(content=text_50_000_tokens),  # 60,000 tokens
-                HumanMessage(content=text_10_000_tokens),
-                AIMessage(content=text_50_000_tokens),  # 120,000 tokens
-                HumanMessage(content=text_10_000_tokens),
-                AIMessage(content=text_50_000_tokens),  # 180,000 tokens (summarizes)
-                HumanMessage(content="query"),
-            ]
+                message
+                for _ in range(9)
+                for message in (
+                    HumanMessage(content=text_500_tokens),
+                    AIMessage(content=text_500_tokens),
+                )
+            ] + [HumanMessage(content="query")]
             result = await agent.ainvoke(
                 {"messages": input_messages},
                 {"configurable": {"thread_id": thread_id}},
             )
-            assert len(result["messages"]) == 8  # 7 inputs + response
+            assert len(result["messages"]) == len(input_messages) + 1
             assert result["messages"][-1].content == "response"
 
             # two calls: one to summarize, one for response

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -1759,7 +1759,7 @@ def create_summarization_middleware(
     backend: BackendProtocol,
     *,
     summary_prompt: str = DEEPAGENTS_DEFAULT_SUMMARY_PROMPT,
-    trim_tokens_to_summarize: int | None = None,
+    trim_tokens_to_summarize: int | None = _DEFAULT_TRIM_TOKEN_LIMIT,
     token_counter: TokenCounter = count_tokens_approximately,
 ) -> _DeepAgentsSummarizationMiddleware:
     """Create a Deep Agents `SummarizationMiddleware` with model-aware defaults.

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_factory.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_factory.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
+from langchain.agents.middleware.summarization import _DEFAULT_TRIM_TOKEN_LIMIT
 from langchain_core.messages import AIMessage, MessageLikeRepresentation
 
 from deepagents.middleware.summarization import create_summarization_middleware
@@ -42,6 +43,26 @@ def test_factory_uses_fallback_defaults_without_profile() -> None:
     assert middleware._lc_helper.keep == ("messages", 6)
     assert middleware._truncate_args_trigger == ("messages", 20)
     assert middleware._truncate_args_keep == ("messages", 20)
+
+
+def test_factory_uses_default_summary_trim_limit() -> None:
+    """Keeps the summary request within the middleware's default token limit."""
+    model = _make_model(with_profile_limit=120_000)
+    middleware = create_summarization_middleware(model, cast("Any", MagicMock()))
+
+    assert middleware._lc_helper.trim_tokens_to_summarize == _DEFAULT_TRIM_TOKEN_LIMIT
+
+
+def test_factory_allows_disabling_summary_trimming() -> None:
+    """Preserves `None` as an explicit opt-out from summary input trimming."""
+    model = _make_model(with_profile_limit=120_000)
+    middleware = create_summarization_middleware(
+        model,
+        cast("Any", MagicMock()),
+        trim_tokens_to_summarize=None,
+    )
+
+    assert middleware._lc_helper.trim_tokens_to_summarize is None
 
 
 def test_factory_default_prompt_explains_media_references() -> None:

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -2410,29 +2410,27 @@ class TestSummarizationOffloadToState:
                 ]
             )
         )
-        fake_model.profile = {"max_input_tokens": 200_000}
+        fake_model.profile = {"max_input_tokens": 20_000}
 
         agent = create_deep_agent(
             model=fake_model,
             checkpointer=InMemorySaver(),
         )
 
-        text_10_000_tokens = "x" * 10_000 * NUM_CHARS_PER_TOKEN
-        text_50_000_tokens = "x" * 50_000 * NUM_CHARS_PER_TOKEN
+        text_1_000_tokens = "x" * 1_000 * NUM_CHARS_PER_TOKEN
         input_messages = [
-            HumanMessage(content=text_10_000_tokens),
-            AIMessage(content=text_50_000_tokens),  # 60,000 tokens
-            HumanMessage(content=text_10_000_tokens),
-            AIMessage(content=text_50_000_tokens),  # 120,000 tokens
-            HumanMessage(content=text_10_000_tokens),
-            AIMessage(content=text_50_000_tokens),  # 180,000 tokens (summarizes)
-            HumanMessage(content="query"),
-        ]
+            message
+            for _ in range(9)
+            for message in (
+                HumanMessage(content=text_1_000_tokens),
+                AIMessage(content=text_1_000_tokens),
+            )
+        ] + [HumanMessage(content="query")]
 
         config = {"configurable": {"thread_id": "summarization-state-test"}}
         result = agent.invoke({"messages": input_messages}, config)
 
-        assert len(result["messages"]) == 8  # 7 inputs + response
+        assert len(result["messages"]) == len(input_messages) + 1
         assert result["messages"][-1].content == "response"
 
         # two calls: one to summarize, one for response
@@ -3138,7 +3136,7 @@ class TestArtifactsRoot:
                 ]
             )
         )
-        fake_model.profile = {"max_input_tokens": 200_000}
+        fake_model.profile = {"max_input_tokens": 20_000}
 
         agent = create_deep_agent(
             model=fake_model,
@@ -3146,17 +3144,15 @@ class TestArtifactsRoot:
             checkpointer=InMemorySaver(),
         )
 
-        text_10_000_tokens = "x" * 10_000 * NUM_CHARS_PER_TOKEN
-        text_50_000_tokens = "x" * 50_000 * NUM_CHARS_PER_TOKEN
+        text_1_000_tokens = "x" * 1_000 * NUM_CHARS_PER_TOKEN
         input_messages = [
-            HumanMessage(content=text_10_000_tokens),
-            AIMessage(content=text_50_000_tokens),
-            HumanMessage(content=text_10_000_tokens),
-            AIMessage(content=text_50_000_tokens),
-            HumanMessage(content=text_10_000_tokens),
-            AIMessage(content=text_50_000_tokens),
-            HumanMessage(content="query"),
-        ]
+            message
+            for _ in range(9)
+            for message in (
+                HumanMessage(content=text_1_000_tokens),
+                AIMessage(content=text_1_000_tokens),
+            )
+        ] + [HumanMessage(content="query")]
 
         config = {"configurable": {"thread_id": "artifacts-root-summarization-test"}}
         result = agent.invoke({"messages": input_messages}, config)


### PR DESCRIPTION
Fixes #5913

Summarization requests created through `create_deep_agent` are trimmed to the 4,000-token default again, while callers can still pass `trim_tokens_to_summarize=None` to opt out.

---

`create_summarization_middleware` defaulted `trim_tokens_to_summarize` to `None`, overriding the underlying middleware default and allowing an entire oversized conversation to reach the summarization model. This aligns the factory default with `_DeepAgentsSummarizationMiddleware` and adds regressions for both the safe default and explicit opt-out.

The SDK and coding-agent end-to-end summarization fixtures now use smaller individual messages so the restored trim budget can produce a valid summary batch while continuing to exercise state and artifact offloading.

## Test plan

- `libs/deepagents`: full test suite — 2,862 passed, 101 skipped, 4 xfailed
- `libs/deepagents`: Ruff check/format and ty — passed
- `libs/code`: `test_cli_agent_summarizes` — 1 passed
- `libs/code`: Ruff check/format and ty for the changed test — passed
- `libs/`: lockfile check — passed

## AI Disclosure

This fix and its tests were developed with AI assistance and manually reviewed and validated.

Co-authored-by: @RafaelMaier94 via #6281

Made by [Open SWE](https://openswe.vercel.app/agents/97575f12-7cef-5346-9d6d-bacbae2cced0) · openai:gpt-5.6-sol (medium)
