### PR TITLE
fix(evals): log tool-call efficiency expectations

### DIFF
--- a/libs/evals/tests/evals/utils.py
+++ b/libs/evals/tests/evals/utils.py
@@ -1333,7 +1333,25 @@ def _log_efficiency(
 
     expected_steps: int | None = None
     expected_tool_calls: int | None = None
-    for assertion in scorer._expectations:
+    for index, assertion in enumerate(scorer._expectations, start=1):
+        feedback_name = {
+            AgentSteps: "agent_steps",
+            ToolCallRequests: "tool_call_requests",
+            MaxToolCallRequests: "max_tool_call_requests",
+            ToolCall: "tool_call",
+        }.get(type(assertion), "assertion")
+        feedback_key = f"efficiency_{feedback_name}_{index}"
+        passed = assertion.check(trajectory)
+        if passed:
+            t.log_feedback(key=feedback_key, score=True, value=repr(assertion))
+        else:
+            t.log_feedback(
+                key=feedback_key,
+                score=False,
+                value=repr(assertion),
+                comment=assertion.describe_failure(trajectory),
+            )
+
         if isinstance(assertion, AgentSteps):
             expected_steps = assertion.n
         elif isinstance(assertion, ToolCallRequests):
@@ -1344,7 +1362,7 @@ def _log_efficiency(
     if expected_tool_calls is not None:
         t.log_feedback(key="expected_tool_call_requests", value=expected_tool_calls)
 
-    if expected_steps is None and expected_tool_calls is None:
+    if not scorer._expectations:
         return None
 
     return EfficiencyResult(

--- a/libs/evals/tests/unit_tests/test_assertions.py
+++ b/libs/evals/tests/unit_tests/test_assertions.py
@@ -12,12 +12,15 @@ from __future__ import annotations
 import pytest
 from langchain_core.messages import AIMessage
 
+import tests.evals.utils as eval_utils
 from tests.evals.utils import (
     AgentStep,
     AgentTrajectory,
     ToolCall,
     ToolCalled,
     ToolNotCalled,
+    TrajectoryScorer,
+    max_tool_call_requests,
     tool_call,
     tool_called,
     tool_not_called,
@@ -191,6 +194,64 @@ class TestToolCall:
             args_equals={"a": 1, "b": 2},
         )
         assert assertion.check(traj)
+
+
+class TestEfficiencyLogging:
+    def test_logs_tool_call_expectations_and_returns_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feedback: list[dict[str, object]] = []
+        monkeypatch.setattr(
+            eval_utils.t,
+            "log_feedback",
+            lambda **kwargs: feedback.append(kwargs),
+        )
+        trajectory = _traj(_step(1, _tc("fetch_page")))
+        matching = tool_call(name="fetch_page")
+        missing = tool_call(name="lookup_population", step=1)
+        scorer = TrajectoryScorer().expect(tool_calls=[matching, missing])
+
+        result = eval_utils._log_efficiency(trajectory, scorer)
+
+        assert result is not None
+        assert result.expected_steps is None
+        assert result.expected_tool_calls is None
+        assert feedback[-2:] == [
+            {
+                "key": "efficiency_tool_call_1",
+                "score": True,
+                "value": repr(matching),
+            },
+            {
+                "key": "efficiency_tool_call_2",
+                "score": False,
+                "value": repr(missing),
+                "comment": missing.describe_failure(trajectory),
+            },
+        ]
+
+    def test_logs_other_efficiency_assertions_polymorphically(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feedback: list[dict[str, object]] = []
+        monkeypatch.setattr(
+            eval_utils.t,
+            "log_feedback",
+            lambda **kwargs: feedback.append(kwargs),
+        )
+        trajectory = _traj(_step(1, _tc("fetch_page")))
+        assertion = max_tool_call_requests(0)
+        scorer = TrajectoryScorer(_expectations=(assertion,))
+
+        result = eval_utils._log_efficiency(trajectory, scorer)
+
+        assert result is not None
+        assert {
+            "key": "efficiency_max_tool_call_requests_1",
+            "score": False,
+            "value": repr(assertion),
+            "comment": assertion.describe_failure(trajectory),
+        } in feedback
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
TrajectoryScorer now logs per-tool efficiency assertions and preserves tool-only efficiency results.

---

Fixes #6048.

Adds deterministic coverage for matching and missing tool-call expectations.