### PR TITLE
fix(quickjs): preserve subagent identity across interrupt replays

### DIFF
--- a/libs/code/tests/unit_tests/tui/widgets/test_subagent_panel.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_subagent_panel.py
@@ -220,6 +220,80 @@ class TestReset:
             assert panel._phase_order == []
 
 
+class TestReplayStability:
+    """Replayed starts (hook interrupts + resumes) must not inflate counts.
+
+    A subagent's PostToolUse hook can raise `GraphInterrupt`; LangGraph then
+    replays the parent tool node on resume and the bridge re-emits `start`
+    events. Dispatch ids are replay-stable, so the panel must replace the
+    existing row rather than append a new one.
+    """
+
+    async def test_replayed_start_updates_row_instead_of_adding(self) -> None:
+        async with PanelApp().run_test(size=(200, 24)) as pilot:
+            panel = pilot.app.query_one("#panel", SubagentPanel)
+            for _ in range(6):  # original + five interrupt/resume replays
+                panel.on_subagent_event(_start("a", "E1", label="Validate outcomes"))
+                await pilot.pause()
+            phase = panel._phases["E1"]
+            assert len(phase.records) == 1
+            assert phase.order == ["a"]
+            done, total = phase.counts()
+            assert (done, total) == (0, 1)
+            header = _render(pilot.app.query_one("#subagent-header-summary", Static))
+            assert "0/1 done" in header
+
+    async def test_replayed_start_after_completion_resets_to_running(self) -> None:
+        # A replay that interrupts again after an earlier replay completed
+        # puts the row back in a running state — the latest attempt wins.
+        async with PanelApp().run_test(size=(200, 24)) as pilot:
+            panel = pilot.app.query_one("#panel", SubagentPanel)
+            panel.on_subagent_event(_start("a", "E1"))
+            panel.on_subagent_event(_complete("a", "E1"))
+            panel.on_subagent_event(_start("a", "E1"))  # replay interrupts again
+            await pilot.pause()
+            record = panel._find_record("a")
+            assert record is not None
+            assert record.status == "running"
+            assert record.duration_ms is None
+            done, total = panel._phases["E1"].counts()
+            assert (done, total) == (0, 1)
+
+    async def test_mixed_progress_one_completes_another_interrupts_then_resumes(
+        self,
+    ) -> None:
+        # Fan-out of two: `a` completes, `b`'s hook interrupts, then the
+        # resume replays both. Counts must stay 2 logical agents with `a`
+        # finished and `b` settled by the resume's terminal event.
+        async with PanelApp().run_test(size=(200, 24)) as pilot:
+            panel = pilot.app.query_one("#panel", SubagentPanel)
+
+            # Attempt 1: `a` completes; `b` starts, then interrupts.
+            panel.on_subagent_event(_start("a", "E1", label="Validate outcomes"))
+            panel.on_subagent_event(_complete("a", "E1"))
+            panel.on_subagent_event(_start("b", "E1", label="Validate reviewers"))
+            panel.finalize_running()  # the interrupt cancels in-flight rows
+            await pilot.pause()
+            assert panel._phases["E1"].counts() == (2, 2)
+
+            # Attempt 2 (resume): both dispatches replay; `b` completes.
+            panel.on_subagent_event(_start("a", "E1", label="Validate outcomes"))
+            panel.on_subagent_event(_start("b", "E1", label="Validate reviewers"))
+            panel.on_subagent_event(_complete("a", "E1"))
+            panel.on_subagent_event(_complete("b", "E1"))
+            await pilot.pause()
+
+            phase = panel._phases["E1"]
+            assert phase.order == ["a", "b"]
+            assert len(phase.records) == 2
+            assert phase.counts() == (2, 2)
+            assert not phase.any_running()
+            assert not phase.any_cancelled()
+            header = _render(pilot.app.query_one("#subagent-header-summary", Static))
+            assert "2/2 done" in header
+            assert "cancelled" not in header
+
+
 class TestSafety:
     async def test_strips_escapes_and_bounds_length(self) -> None:
         async with PanelApp().run_test(size=(200, 24)) as pilot:

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -131,6 +131,13 @@ class _PTCState:
     remaining_calls: int | None
     outer_runtime: ToolRuntime | None = None
     outer_loop: asyncio.AbstractEventLoop | None = None
+    task_dispatch_count: int = 0
+    """Count of `task()` dispatches made during this eval.
+
+    Seeds each dispatch's stable id; because the state is reset at eval
+    start, interrupted-and-resumed evals assign the same ordinals to the
+    same dispatches, keeping ids stable across replays.
+    """
 
     def consume_call_budget(
         self, *, function_name: str, max_ptc_calls: int | None
@@ -539,6 +546,14 @@ class _ThreadREPL:
         validated = self._validate_task_payload(payload)
         description, subagent_type, label, response_schema = validated
 
+        # Freeze this dispatch's ordinal before dispatching: consecutive
+        # task() calls in one eval get 0, 1, 2, ... Replays of an interrupted
+        # eval restart the count, so the same logical dispatch keeps the same
+        # stable id across interrupt/resume cycles.
+        state = replace(state, task_dispatch_count=state.task_dispatch_count + 1)
+        self._ptc_state = state
+        dispatch_ordinal = state.task_dispatch_count - 1
+
         async def _call() -> Any:
             runtime = state.outer_runtime
             if runtime is None:
@@ -555,6 +570,7 @@ class _ThreadREPL:
                 response_schema=response_schema,
                 runtime=runtime,
                 label=label,
+                dispatch_ordinal=dispatch_ordinal,
             )
 
         outer_loop = state.outer_loop

--- a/libs/partners/quickjs/langchain_quickjs/_subagent.py
+++ b/libs/partners/quickjs/langchain_quickjs/_subagent.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import time
-import uuid
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Final, Literal, NotRequired, TypedDict
 
@@ -50,6 +50,44 @@ _EVENT_LABEL_MAX_CHARS = 120
 
 _EVENT_LABEL_FALLBACK_MAX_CHARS = 60
 """Character cap on a label derived from the description fallback."""
+
+_DISPATCH_ID_SALT: Final = "langchain-quickjs-subagent-dispatch-v1"
+"""Domain-separation salt for derived dispatch ids."""
+
+
+def derive_dispatch_id(
+    *,
+    eval_id: str | None,
+    task_tool_name: str,
+    dispatch_ordinal: int,
+    description: str,
+    subagent_type: str,
+    label: str | None,
+) -> str:
+    """Derive a dispatch id that is stable across interrupt/resume replays.
+
+    When a subagent's hook raises `GraphInterrupt`, LangGraph replays the
+    parent tool node on resume, re-running the JavaScript and dispatching
+    the same `task()` calls again. A random per-invocation id would make
+    each replay look like a brand-new agent downstream (e.g. an inflated
+    fan-out panel). Hashing stable identity inputs — the parent eval's
+    tool-call id, the dispatch ordinal within that eval, and the payload —
+    keeps the id stable across replays while staying distinct for separate
+    `js_eval` calls and for identical-payload dispatches within one eval.
+    """
+    parts = [
+        _DISPATCH_ID_SALT,
+        task_tool_name,
+        str(dispatch_ordinal),
+        subagent_type,
+        description,
+        label or "",
+        eval_id or "",
+    ]
+    digest = hashlib.sha1(  # noqa: S324 — display identity, not security
+        "\x1f".join(parts).encode()
+    ).hexdigest()[:12]
+    return f"ptc_{task_tool_name}_{digest}"
 
 
 class SubagentStartEvent(TypedDict):
@@ -196,11 +234,15 @@ async def call_subagent_task_tool(
     response_schema: dict[str, Any] | None,
     runtime: Any,
     label: str | None = None,
+    dispatch_ordinal: int = 0,
 ) -> Any:
     """Call the Deep Agents task tool and return a JavaScript-friendly value.
 
     This also emits `start` then `complete`/`error` subagent lifecycle
-    events on the custom stream.
+    events on the custom stream. `dispatch_ordinal` is the 0-based position
+    of this dispatch within its parent eval; together with the eval's
+    tool-call id it yields a per-dispatch id that survives the replays a
+    hook-driven `GraphInterrupt` causes on resume.
     """
     if runtime is None:
         msg = "task() requires an active ToolRuntime"
@@ -214,7 +256,14 @@ async def call_subagent_task_tool(
 
     eval_id = getattr(runtime, "tool_call_id", None)
     stream_writer = getattr(runtime, "stream_writer", None)
-    subagent_id = f"ptc_{task_tool.name}_{uuid.uuid4().hex[:8]}"
+    subagent_id = derive_dispatch_id(
+        eval_id=eval_id,
+        task_tool_name=task_tool.name,
+        dispatch_ordinal=dispatch_ordinal,
+        description=description,
+        subagent_type=subagent_type,
+        label=label,
+    )
 
     runtime = _runtime_with_tool_call_id(runtime, subagent_id)
 

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -978,6 +978,111 @@ async def test_async_task_global_propagates_graph_interrupt(repl: _ThreadREPL) -
     assert exc_info.value is interrupt
 
 
+class _IntermittentInterruptRunnable:
+    """Runnable whose async path raises `GraphInterrupt` until told to stop.
+
+    Stands in for a subagent whose PostToolUse hook fires an approval
+    interrupt: the parent eval replays on resume and re-dispatches the
+    same `task()` calls.
+    """
+
+    def __init__(self) -> None:
+        self.interrupt = GraphInterrupt([Interrupt(value={"action_requests": []})])
+        self.interrupts_remaining = 1
+        self.starts = 0
+
+    async def _afail(self, _state: Any, _config: Any) -> dict[str, Any]:
+        raise self.interrupt
+
+    async def _aok(self, _state: Any, _config: Any) -> dict[str, Any]:
+        return {"messages": [AIMessage(content="subagent done")]}
+
+    def __call__(self, state: dict[str, Any], config: Any) -> dict[str, Any]:
+        raise NotImplementedError  # sync path not exercised
+
+    @property
+    def afunc(self) -> Any:
+        # RunnableLambda inspects afunc on the callable.
+        return self._aafunc
+
+    async def _aafunc(self, state: Any, config: Any) -> Any:
+        self.starts += 1
+        if self.interrupts_remaining > 0:
+            self.interrupts_remaining -= 1
+            return await self._afail(state, config)
+        return await self._aok(state, config)
+
+
+async def test_task_dispatch_ids_stable_across_interrupt_resume_replays() -> None:
+    """Resumed evals re-dispatch with the same ids; no duplicate agents.
+
+    Mirrors the field report: a subagent's PostToolUse hook raises
+    `GraphInterrupt` mid-eval, LangGraph replays the parent tool node on
+    resume, and the JavaScript re-runs its fan-out. Every replayed start
+    must carry the id the previous replay used.
+    """
+    captured: list[dict[str, Any]] = []
+    interrupting = _IntermittentInterruptRunnable()
+
+    def _recording_writer(chunk: Any) -> None:
+        if isinstance(chunk, dict) and chunk.get("type") == "subagent":
+            captured.append(chunk)
+
+    repl = _ThreadREPL(
+        ThreadWorker(),
+        Runtime(),
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
+    try:
+        task_tool = _task_tool_for_runnable(
+            RunnableLambda(interrupting, afunc=interrupting.afunc)
+        )
+        runtime = _subagent_runtime_from_task_tool(task_tool)
+        runtime = ToolRuntime(
+            state=runtime.state,
+            context=runtime.context,
+            config=runtime.config,
+            stream_writer=_recording_writer,
+            tools=[task_tool],
+            tool_call_id=runtime.tool_call_id,
+            store=runtime.store,
+        )
+
+        js = (
+            "(async () => {"
+            "const results = await Promise.all(["
+            "task({description: 'Validate outcomes', subagentType: 'worker'}),"
+            "task({description: 'Validate reviewers', subagentType: 'worker'}),"
+            "task({description: 'Validate costs', subagentType: 'worker'})"
+            "]); return results.length; })()"
+        )
+
+        # First attempt: all three dispatches interrupt.
+        with pytest.raises(GraphInterrupt):
+            await repl.eval_async(js, outer_runtime=runtime)
+        # Resume: the replays complete.
+        outcome = await repl.eval_async(js, outer_runtime=runtime)
+        assert outcome.error_type is None
+        assert outcome.result == "3"
+    finally:
+        repl.close()
+
+    starts = [e for e in captured if e["phase"] == "start"]
+    completes = [e for e in captured if e["phase"] == "complete"]
+    # Promise.all drives all three dispatches; whichever finishes last
+    # raises the hook's interrupt, so its already-completed siblings emit
+    # start+complete on the interrupting run, and all three emit
+    # start+complete again on the resume — always under the same stable
+    # ids. The interrupting task itself completes only on the resume, so
+    # completions total 5, not 6.
+    assert len({e["id"] for e in starts}) == 3  # three logical agents
+    assert len(completes) == 5
+    # Every terminal event matches a start id — nothing orphaned.
+    assert {e["id"] for e in completes} <= {e["id"] for e in starts}
+
+
 def test_runtime_with_response_format_uses_configurable() -> None:
     runtime = _subagent_runtime(
         RunnableLambda(lambda _state, _config: {"messages": [AIMessage(content="ok")]})

--- a/libs/partners/quickjs/tests/unit_tests/test_subagent_events.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_subagent_events.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import pytest
+from langgraph.errors import GraphInterrupt
 
 from langchain_quickjs._subagent import call_subagent_task_tool
 
@@ -227,3 +228,124 @@ async def test_structured_output_path_still_emits_events() -> None:
     assert out == {"answer": 42}
     assert [e["phase"] for e in rec.events] == ["start", "complete"]
     assert rec.events[0]["eval_id"] == "eval_call_123"
+
+
+class TestReplayStableDispatchIds:
+    """Dispatch ids survive the replays a hook-driven interrupt causes.
+
+    When a subagent's PostToolUse hook raises `GraphInterrupt`, LangGraph
+    replays the parent tool node on resume, re-running the JavaScript and
+    re-dispatching the same `task()` calls. Ids must stay stable across
+    replays (so a UI updates one row) yet differ between distinct dispatches.
+    """
+
+    async def _dispatch(
+        self,
+        rec: _Recorder,
+        tool: _FakeTaskTool,
+        *,
+        description: str = "Validate outcomes",
+        ordinal: int = 0,
+        eval_id: str = "call_abc",
+    ) -> bool:
+        """Run one dispatch attempt; True when it completed without raising."""
+        runtime = _FakeRuntime(tool_call_id=eval_id, stream_writer=rec)
+        try:
+            await call_subagent_task_tool(
+                tool,
+                description=description,
+                subagent_type="reviewer",
+                label=description,
+                response_schema=None,
+                runtime=runtime,
+                dispatch_ordinal=ordinal,
+            )
+        except GraphInterrupt:
+            return False
+        return True
+
+    async def test_replayed_dispatch_keeps_same_id(self) -> None:
+        rec = _Recorder()
+        tool = _FakeTaskTool()
+
+        for _ in range(3):  # original run + two interrupt/resume replays
+            await self._dispatch(rec, tool)
+
+        starts = [e for e in rec.events if e["phase"] == "start"]
+        assert len(starts) == 3  # one start per replay
+        assert len({e["id"] for e in starts}) == 1
+
+    async def test_replayed_complete_matches_replayed_start_id(self) -> None:
+        # A resumed eval that gets far enough to finish must emit a
+        # complete event carrying the same id as every replayed start,
+        # so the terminal event lands on the existing row.
+        rec = _Recorder()
+        interrupting = _FakeTaskTool(raise_exc=GraphInterrupt())
+        finishing = _FakeTaskTool("done")
+
+        await self._dispatch(rec, interrupting)  # interrupted attempt
+        await self._dispatch(rec, finishing)  # resumed attempt completes
+
+        phases = [e["phase"] for e in rec.events]
+        assert phases == ["start", "start", "complete"]
+        ids = {e["id"] for e in rec.events}
+        assert len(ids) == 1
+
+    async def test_parallel_dispatches_get_distinct_ids(self) -> None:
+        # The three-task fan-out from the field report: one js_eval call,
+        # three task() calls at ordinals 0/1/2 — three ids, not one.
+        rec = _Recorder()
+        tool = _FakeTaskTool("ok")
+
+        for ordinal in range(3):
+            await self._dispatch(rec, tool, ordinal=ordinal)
+
+        starts = [e for e in rec.events if e["phase"] == "start"]
+        assert len({e["id"] for e in starts}) == 3
+
+    async def test_identical_payloads_at_same_ordinal_in_different_evals_differ(
+        self,
+    ) -> None:
+        # Distinct js_eval calls must never collide, even dispatching the
+        # exact same payload at the same ordinal.
+        rec = _Recorder()
+        tool = _FakeTaskTool("ok")
+
+        await self._dispatch(rec, tool, eval_id="call_one")
+        await self._dispatch(rec, tool, eval_id="call_two")
+
+        starts = [e for e in rec.events if e["phase"] == "start"]
+        assert len({e["id"] for e in starts}) == 2
+
+    async def test_identical_payloads_at_different_ordinals_differ(self) -> None:
+        # Two identical task() calls inside one eval are separate agents.
+        rec = _Recorder()
+        tool = _FakeTaskTool("ok")
+
+        await self._dispatch(rec, tool, ordinal=0)
+        await self._dispatch(rec, tool, ordinal=1)
+
+        starts = [e for e in rec.events if e["phase"] == "start"]
+        assert len({e["id"] for e in starts}) == 2
+
+    async def test_no_eval_id_still_yields_stable_replay_ids(self) -> None:
+        # Runtimes without a parent tool-call id still need replay-stable
+        # ids (payload + ordinal identify the dispatch).
+        rec = _Recorder()
+        tool = _FakeTaskTool()
+
+        for _ in range(2):
+            await self._dispatch(rec, tool, eval_id="")
+
+        starts = [e for e in rec.events if e["phase"] == "start"]
+        assert len({e["id"] for e in starts}) == 1
+
+    async def test_interrupt_preserves_no_terminal_event(self) -> None:
+        # An interrupted dispatch must not emit complete/error — the row
+        # stays in its pre-interrupt state until a replay settles it.
+        rec = _Recorder()
+        tool = _FakeTaskTool(raise_exc=GraphInterrupt())
+
+        await self._dispatch(rec, tool)
+
+        assert [e["phase"] for e in rec.events] == ["start"]


### PR DESCRIPTION
JavaScript-dispatched subagents keep the same identity after hook interrupts, so resuming a fan-out no longer adds duplicate agents to the dcode panel.

---

A child hook can interrupt `js_eval`, causing LangGraph to replay the parent tool node on resume. The child checkpoints survive, but each replay generated new dispatch IDs. Three tasks replayed 18 times therefore appeared as 54 subagents.

- Derive identity from the parent tool-call ID, dispatch position, and task payload. Replays identify the same task; identical assignments at different positions remain separate. Calls without a parent ID retain fresh IDs.
- Reserve each dispatch position before waiting for a concurrency slot, without restoring an older tool-call budget when queued tasks start.
- Preserve hook execution and checkpoint resumption rather than caching task results or suppressing interrupts.

This fixes dispatch identity and inflated counts. Panel duration and terminal-state handling across replays are unchanged.
